### PR TITLE
Added "latest" tag to Docker images and increased maxSessions for internal router connection

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -78,7 +78,9 @@
                   <build>
                     <from>tianon/true</from>
                     <tags>
+                      <tag>latest</tag>
                       <tag>${project.version}</tag>
+                      <tag>${timestamp}</tag>
                     </tags>
                     <volumes>
                       <volume>/etc/qpid-dispatch</volume>
@@ -107,7 +109,9 @@
                   <build>
                     <from>tianon/true</from>
                     <tags>
+                      <tag>latest</tag>
                       <tag>${project.version}</tag>
+                      <tag>${timestamp}</tag>
                     </tags>
                     <volumes>
                       <volume>/var/lib/qdrouterd</volume>

--- a/config/qpid/policy/policies.json
+++ b/config/qpid/policy/policies.json
@@ -58,6 +58,7 @@
       "connectionAllowDefault": false,
       "settings": {
         "anonymous": {
+          "maxSessions": 50,
           "allowDynamicSrc": false,
           "allowAnonymousSender": false,
           "sources": "telemetry/*",

--- a/example/readme.md
+++ b/example/readme.md
@@ -57,21 +57,21 @@ you can also use plain *Docker* to run and wire up the images manually from the 
 In order to start a broker using [Gordon Sim's Qpid Dispatch Router image](https://hub.docker.com/r/gordons/qpid-dispatch/) with the required configuration run the following from the
 command line
 
-    $ docker run -d --name qdrouter-config eclipsehono/qpid-default-config:0.5-SNAPSHOT
-    $ docker run -d --name qdrouter-sasldb eclipsehono/qpid-sasldb:0.5-SNAPSHOT
+    $ docker run -d --name qdrouter-config eclipsehono/qpid-default-config:latest
+    $ docker run -d --name qdrouter-sasldb eclipsehono/qpid-sasldb:latest
     $ docker run -d --name qdrouter -p 15672:5672 -h qdrouter --volumes-from="qdrouter-config" --volumes-from="qdrouter-sasldb" gordons/qpid-dispatch:0.6.0
  
 ##### Example Configuration
 
 Start volume container to provide required configuration
     
-    $ docker run -d --name example-config eclipsehono/hono-default-config:0.5-SNAPSHOT
+    $ docker run -d --name example-config eclipsehono/hono-default-config:latest
 
 ##### Start Hono Server
 
 Once the *Dispatch Router* Docker image has been started using the command above the *Hono Server* image can be run as follows
 
-    $ docker run -d --name hono --link qdrouter -p 5672:5672 --volumes-from="example-config" eclipsehono/hono-server:0.5-SNAPSHOT
+    $ docker run -d --name hono --link qdrouter -p 5672:5672 --volumes-from="example-config" eclipsehono/hono-server:latest
 
 ### Run Client
 


### PR DESCRIPTION
Added the "latest" tag for the qpid-default-config and qpid-sasldb Docker images during the build
Updated example readme in order to use the "latest" tag for the images started manually on the command line
Updated the policies.json with maxSessions (50) parameter in order to have more channels for the internal connection with the router

Signed-off-by: ppatierno <ppatierno@live.com>