### PR TITLE
Changed device registration API

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
@@ -203,7 +203,7 @@ public class RegistrationClientImpl extends AbstractHonoClient implements Regist
     public void find(final String key, final String value, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
 
         final Map<String, Object> properties = new HashMap<>();
-        properties.put(APP_PROPERTY_DEVICE_ID, value);
+        properties.put(APP_PROPERTY_VALUE, value);
         properties.put(APP_PROPERTY_ACTION, ACTION_FIND);
         properties.put(APP_PROPERTY_KEY, key);
         sendMessage(createMessage(properties), resultHandler);

--- a/core/src/main/java/org/eclipse/hono/util/RegistrationConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistrationConstants.java
@@ -46,6 +46,7 @@ public final class RegistrationConstants {
     public static final String APP_PROPERTY_CORRELATION_ID       = "correlation-id";
     public static final String APP_PROPERTY_ACTION               = "action";
     public static final String APP_PROPERTY_KEY                  = "key";
+    public static final String APP_PROPERTY_VALUE                = "value";
     public static final String APP_PROPERTY_STATUS               = "status";
     public static final String FIELD_PAYLOAD                     = "payload";
 
@@ -91,9 +92,10 @@ public final class RegistrationConstants {
         final String deviceId = MessageHelper.getDeviceIdAnnotation(message);
         final String tenantId = MessageHelper.getTenantIdAnnotation(message);
         final String key = getKey(message);
+        final String value = getValue(message);
         final String action = getAction(message);
         final JsonObject payload = MessageHelper.getJsonPayload(message);
-        return getRegistrationJson(action, tenantId, deviceId, key, payload);
+        return getRegistrationJson(action, tenantId, deviceId, key, value, payload);
     }
 
     public static JsonObject getReply(final int status, final String tenantId, final String deviceId) {
@@ -158,16 +160,19 @@ public final class RegistrationConstants {
     }
 
     public static JsonObject getRegistrationJson(final String action, final String tenantId, final String deviceId, final JsonObject payload) {
-        return getRegistrationJson(action, tenantId, deviceId, null, payload);
+        return getRegistrationJson(action, tenantId, deviceId, null, null, payload);
     }
 
-    public static JsonObject getRegistrationJson(final String action, final String tenantId, final String deviceId, final String key, final JsonObject payload) {
+    public static JsonObject getRegistrationJson(final String action, final String tenantId, final String deviceId, final String key, final String value, final JsonObject payload) {
         final JsonObject msg = new JsonObject();
         msg.put(APP_PROPERTY_ACTION, action);
         msg.put(APP_PROPERTY_DEVICE_ID, deviceId);
         msg.put(APP_PROPERTY_TENANT_ID, tenantId);
         if (key != null) {
             msg.put(APP_PROPERTY_KEY, key);
+        }
+        if (value != null) {
+            msg.put(APP_PROPERTY_VALUE, value);
         }
         if (payload != null) {
             msg.put(FIELD_PAYLOAD, payload);
@@ -184,4 +189,10 @@ public final class RegistrationConstants {
         Objects.requireNonNull(msg);
         return getApplicationProperty(msg.getApplicationProperties(), APP_PROPERTY_KEY, String.class);
     }
+
+    private static String getValue(final Message msg) {
+        Objects.requireNonNull(msg);
+        return getApplicationProperty(msg.getApplicationProperties(), APP_PROPERTY_VALUE, String.class);
+    }
+
 }

--- a/server/src/main/java/org/eclipse/hono/registration/impl/BaseRegistrationService.java
+++ b/server/src/main/java/org/eclipse/hono/registration/impl/BaseRegistrationService.java
@@ -103,6 +103,7 @@ public abstract class BaseRegistrationService extends AbstractVerticle implement
         final String tenantId = body.getString(MessageHelper.APP_PROPERTY_TENANT_ID);
         final String deviceId = body.getString(MessageHelper.APP_PROPERTY_DEVICE_ID);
         final String key = body.getString(RegistrationConstants.APP_PROPERTY_KEY);
+        final String value = body.getString(RegistrationConstants.APP_PROPERTY_VALUE);
         final String action = body.getString(RegistrationConstants.APP_PROPERTY_ACTION);
         final JsonObject payload = body.getJsonObject(RegistrationConstants.FIELD_PAYLOAD, new JsonObject());
 
@@ -112,8 +113,8 @@ public abstract class BaseRegistrationService extends AbstractVerticle implement
             reply(regMsg, getDevice(tenantId, deviceId));
             break;
         case ACTION_FIND:
-            LOG.debug("looking up device [key: {}, value: {}] of tenant [{}]", key, deviceId, tenantId);
-            reply(regMsg, findDevice(tenantId, key, deviceId));
+            LOG.debug("looking up device [key: {}, value: {}] of tenant [{}]", key, value, tenantId);
+            reply(regMsg, findDevice(tenantId, key, value));
             break;
         case ACTION_REGISTER:
             LOG.debug("registering device [{}] of tenant [{}] with data {}", deviceId, tenantId, payload.encode());


### PR DESCRIPTION
#90 

Instead of "device_id" property for the value of the find command there is now the "value" property in the AMQP device registration API. So device_id is not needed in the find operation. This means that the verifyStandardProperties method could not be used for this specific operation.