### PR TITLE
#106: Call connectionResultHandler in case of failed connection attempt.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/connection/ConnectionFactoryImpl.java
+++ b/core/src/main/java/org/eclipse/hono/connection/ConnectionFactoryImpl.java
@@ -125,6 +125,7 @@ public class ConnectionFactoryImpl implements ConnectionFactory {
         if (conAttempt.failed()) {
             logger.warn("can't connect to AMQP 1.0 container [{}://{}:{}]", clientOptions.isSsl() ? "amqps" : "amqp",
                     config.getHost(), config.getPort(), conAttempt.cause());
+            connectionResultHandler.handle(Future.failedFuture(conAttempt.cause()));
         } else {
             logger.info("connected to AMQP 1.0 container [{}://{}:{}], opening connection ...",
                     clientOptions.isSsl() ? "amqps" : "amqp", config.getHost(), config.getPort());


### PR DESCRIPTION
Fix for issue #106 : callback handler now called in case of connection failures as well.

Signed-off-by: kf <Karsten.Frank@bosch-si.com>