### PR TITLE
Increase test timeout to prevent build failures

### DIFF
--- a/core/src/test/java/org/eclipse/hono/connection/ConnectionFactoryImplTest.java
+++ b/core/src/test/java/org/eclipse/hono/connection/ConnectionFactoryImplTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonClientOptions;
 import io.vertx.proton.ProtonConnection;
 
 /**
@@ -69,7 +70,8 @@ public class ConnectionFactoryImplTest {
             }
         };
 
-        factory.connect(null, null, null, connectionHandler);
+        ProtonClientOptions options = new ProtonClientOptions().setConnectTimeout(100);
+        factory.connect(options, null, null, connectionHandler);
 
         // THEN the connection attempt fails and the given handler is invoked
         assertTrue(latch.await(200, TimeUnit.MILLISECONDS));


### PR DESCRIPTION
Hi,

me and all my colleagues that use windows get an error with this test. However if we increase the timeout all works fine. Perhaps an issue with different networking behavior on windows and linux.

This test lasts up to 2 seconds on my machine. Do you think this is still OK for a unit test? Or should we try to test this without real network operations (which could be hard in this case without mocking everything)? Do you have any hard limits on execution times for a single unit test? Perhaps this is already an integration test because it tries to connect to another component.

Signed-off-by: Daniel Maier <Daniel.Maier@bosch-si.com>