### PR TITLE
#129: introduce IANA port numbers for AMQP 1.0 for both secure and in…

### DIFF
--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -1,13 +1,16 @@
 hono:
   downstream:
     host: localhost
-    port: 5672
+    port: 5671
     name: hono-server
   server:
     bindAddress: 127.0.0.1
-    port: 5672
+    port: 5671
     maxInstances: 0
     singleTenant: false
+    insecurePortEnabled: false
+    bindAddressInsecurePort: 127.0.0.1
+    insecurePort: 5672
 spring:
   profiles:
     active: default

--- a/core/src/main/java/org/eclipse/hono/config/HonoConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/HonoConfigProperties.java
@@ -22,7 +22,7 @@ import org.eclipse.hono.util.Constants;
  */
 public final class HonoConfigProperties extends AbstractHonoConfig {
 
-    private static final int MIN_PAYLOAD_SIZE = 128; // bytes
+    private static final int MIN_PAYLOAD_SIZE  = 128; // bytes
 
     private int maxInstances = 0;
     private int startupTimeout = 20;
@@ -30,12 +30,15 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
     private boolean networkDebugLogging = false;
     private boolean waitForDownstreamConnection = false;
     private String bindAddress = "127.0.0.1";
-    private int port = 0;
+    private int port = Constants.PORT_UNCONFIGURED;
+    private boolean insecurePortEnabled = false;
+    private String insecurePortBindAddress = "127.0.0.1";
+    private int insecurePort = Constants.PORT_UNCONFIGURED;
     private int maxPayloadSize = 2048;
 
     /**
      * Gets the host name or literal IP address of the network interface that this server is bound to.
-     * 
+     *
      * @return The host name.
      */
     public String getBindAddress() {
@@ -46,7 +49,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * Sets the host name or literal IP address of the network interface that this server should bind to.
      * <p>
      * The default value of this property is <em>127.0.0.1</em> (the loop back device) on IPv4 stacks.
-     * 
+     *
      * @param address  The host name or IP address.
      * @throws NullPointerException if host is {@code null}.
      */
@@ -60,7 +63,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * If the port has been set to 0 this server will bind to an arbitrary free port chosen by the
      * operating system during startup. Once Hono is up and running this method returns the
      * <em>actual port</em> the server has bound to.
-     * 
+     *
      * @return The port number.
      */
     public int getPort() {
@@ -68,11 +71,35 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
     }
 
     /**
+     * Gets the port this server is bound to/listens on. If the port is not configured, it returns the defaultPort.
+     * <p>
+     * @see #getPort() for more information.
+     *
+     * @param defaultPort The default port to use if it was not configured so far.
+     * @return The port number.
+     */
+    public int getPort(final int defaultPort) {
+        if (getPort() == Constants.PORT_UNCONFIGURED) {
+            return defaultPort;
+        }
+        return port;
+    }
+
+    /**
+     * Returns if the secure port is unconfigured.
+     *
+     * @return If the secure port is unconfigured.
+     */
+    public boolean isPortUnconfigured() {
+        return getPort() == Constants.PORT_UNCONFIGURED;
+    }
+
+    /**
      * Sets the port that this server should bind to/listen on.
      * <p>
      * If the port is set to 0 (the default value), then this server will bind to an arbitrary free
      * port chosen by the operating system during startup.
-     * 
+     *
      * @param port The port number.
      * @throws IllegalArgumentException if port &lt; 0 or port &gt; 65535.
      */
@@ -85,8 +112,99 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
     }
 
     /**
+     * Checks if this server should support insecure AMQP 1.0 ports (i.e. without TLS) at all.
+     * If false, it is guaranteed by the server that no opened port is insecure.
+     * If true, it enables the definition of an insecure port (as the only port <u>or</u> additionally to the secure port).
+     *
+     * @return {@code true} if the server guarantees that no opened port is insecure.
+     */
+    public boolean isInsecurePortEnabled() {
+        return insecurePortEnabled;
+    }
+
+    /**
+     * Sets if this server should support insecure AMQP 1.0 ports (i.e. without TLS) at all.
+     * If false, it is guaranteed by the server that no opened port is insecure.
+     * If true, it enables the definition of an insecure port (as the only port <u>or</u> additionally to the secure port).
+     *
+     * @param insecurePortEnabled {@code true} if the server shall guarantee that no opened port is insecure.
+     */
+    public void setInsecurePortEnabled(final boolean insecurePortEnabled) {
+        this.insecurePortEnabled = insecurePortEnabled;
+    }
+
+    /**
+     * Gets the host name or literal IP address of the network interface that the insecure port of this server is bound to.
+     *
+     * @return The host name.
+     */
+    public String getInsecurePortBindAddress() {
+        return insecurePortBindAddress;
+    }
+
+    /**
+     * Sets the host name or literal IP address of the network interface that the insecure port of this server should bind to.
+     * <p>
+     * The default value of this property is <em>127.0.0.1</em> (the loop back device) on IPv4 stacks.
+     *
+     * @param address  The host name or IP address.
+     * @throws NullPointerException if host is {@code null}.
+     */
+    public void setInsecurePortBindAddress(final String address) {
+        this.insecurePortBindAddress = Objects.requireNonNull(address);
+    }
+
+    /**
+     * Gets the insecure port this server is bound to/listens on (if enabled by @see #insecurePortEnabled).
+     * <p>
+     *
+     * @return The port number.
+     */
+    public int getInsecurePort() {
+        return insecurePort;
+    }
+
+    /**
+     * Gets the insecure port this server is bound to/listens on. If the port is not configured, it returns the defaultPort.
+     * <p>
+     * @see #getInsecurePort() for more information.
+     *
+     * @param defaultPort The default port to use if it was not configured so far.
+     * @return The port number.
+     */
+    public int getInsecurePort(final int defaultPort) {
+        if (isInsecurePortUnconfigured()) {
+            return defaultPort;
+        }
+        return insecurePort;
+    }
+
+    /**
+     * Returns if the insecure port is unconfigured.
+     *
+     * @return If the insecure port is unconfigured.
+     */
+    public boolean isInsecurePortUnconfigured() {
+        return getInsecurePort() == Constants.PORT_UNCONFIGURED;
+    }
+
+    /**
+     * Sets the insecure port this server is bound to/listens on (if enabled by @see #insecurePortEnabled).
+     * <p>
+     *
+     * @param insecurePort The insecure port number.
+     * <p>
+     * In contrast to the secure port, there is no support for the automatic selection of a port - it needs to be set to
+     * an explicit value.
+     * @throws IllegalArgumentException if port &lt;= 0 or port &gt; 65535.
+     */
+    public void setInsecurePort(final int insecurePort) {
+        this.insecurePort = insecurePort;
+    }
+
+    /**
      * Sets the maximum size of a message payload this server accepts from clients.
-     * 
+     *
      * @param bytes The maximum number of bytes.
      * @throws IllegalArgumentException if bytes is &lt; 128.
      */
@@ -99,7 +217,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
 
     /**
      * Gets the maximum size of a message payload this server accepts from clients.
-     * 
+     *
      * @return The maximum number of bytes.
      */
     public int getMaxPayloadSize() {
@@ -108,7 +226,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
 
     /**
      * Gets the maximum time to wait for Hono to start up.
-     * 
+     *
      * @return The number of seconds to wait.
      */
     public int getStartupTimeout() {
@@ -119,7 +237,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * Sets the maximum time to wait for Hono to start up.
      * <p>
      * The default value of this property is 20 (seconds).
-     * 
+     *
      * @param seconds The maximum number of seconds to wait.
      * @return This instance for setter chaining.
      * @throws IllegalArgumentException if <em>seconds</em> &lt; 1.
@@ -140,7 +258,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * <li>if 0 &lt; <em>maxInstances</em> &lt; #processors, then return <em>maxInstances</em></li>
      * <li>else return {@code Runtime.getRuntime().availableProcessors()}</li>
      * </ol>
-     * 
+     *
      * @return the number of verticles to deploy.
      */
     public int getMaxInstances() {
@@ -155,7 +273,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * Sets the number of verticle instances to deploy.
      * <p>
      * The default value of this property is 0.
-     * 
+     *
      * @param maxVerticleInstances The number of verticles to deploy.
      * @return This instance for setter chaining.
      * @throws IllegalArgumentException if the number is &lt; 0.
@@ -174,7 +292,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * In this mode clients do not need to specify a <em>tenant</em>
      * component in resource addresses. Hono will use the
      * {@link Constants#DEFAULT_TENANT} instead.
-     * 
+     *
      * @return {@code true} if Hono runs in single-tenant mode.
      */
     public boolean isSingleTenant() {
@@ -189,7 +307,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * {@link Constants#DEFAULT_TENANT} instead.
      * <p>
      * The default value of this property is {@code false}.
-     * 
+     *
      * @param singleTenant {@code true} if this Hono server should support a single tenant only.
      * @return This instance for setter chaining.
      */
@@ -200,7 +318,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
 
     /**
      * Checks whether Hono should log TCP traffic.
-     * 
+     *
      * @return {@code true} if TCP traffic gets logged.
      */
     public boolean isNetworkDebugLoggingEnabled() {
@@ -211,7 +329,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * Sets whether Hono should log TCP traffic.
      * <p>
      * The default value of this property is {@code false}.
-     * 
+     *
      * @param networkDebugLogging {@code true} if TCP traffic should be logged.
      * @return This instance for setter chaining.
      */
@@ -228,7 +346,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * time out if the downstream container to connect to is not (yet) available.
      * <p>
      * The default value of this property is {@code false}.
-     * 
+     *
      * @return {@code true} if Hono waits for downstream connection to be established during startup.
      */
     public boolean isWaitForDownstreamConnectionEnabled() {
@@ -243,7 +361,7 @@ public final class HonoConfigProperties extends AbstractHonoConfig {
      * time out if the downstream container to connect to is not (yet) available.
      * <p>
      * The default value of this property is {@code false}.
-     * 
+     *
      * @param waitForConnection {@code true} if Hono should wait for downstream connections to be established during startup.
      * @return This instance for setter chaining.
      */

--- a/core/src/main/java/org/eclipse/hono/util/Constants.java
+++ b/core/src/main/java/org/eclipse/hono/util/Constants.java
@@ -45,6 +45,21 @@ public final class Constants {
      */
     public static final String DEFAULT_PATH_SEPARATOR = "/";
 
+    /**
+     * The AMQP 1.0 port defined by IANA for TLS encrypted connections.
+     */
+    public static final int PORT_AMQP = 5671;
+
+    /**
+     * The AMQP 1.0 port defined by IANA for unencrypted connections.
+     */
+    public static final int PORT_AMQP_INSECURE = 5672;
+
+    /**
+     * Default value for a port that is not explicitly configured.
+     */
+    public static final int PORT_UNCONFIGURED = -1;
+
     private Constants() {
     }
 

--- a/example/docker/docker-compose.yml
+++ b/example/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     networks:
       - hono-net
     ports:
-      - "5672:5672"
+      - "5671:5671"
     environment:
       - HONO_DOWNSTREAM_HOST=qdrouter
       - HONO_DOWNSTREAM_PORT=5673
@@ -30,6 +30,7 @@ services:
       - HONO_SERVER_BIND_ADDRESS=0.0.0.0
       - HONO_SERVER_KEY_STORE_PATH=/etc/hono/certs/honoKeyStore.p12
       - HONO_SERVER_KEY_STORE_PASSWORD=honokeys
+      - HONO_SERVER_INSECURE_PORT_ENABLED=false
       - HONO_SERVER_MAX_INSTANCES=1
       - LOGGING_CONFIG=classpath:logback-spring.xml
       - SPRING_PROFILES_ACTIVE=default,dev
@@ -45,7 +46,7 @@ services:
     environment:
       - HONO_CLIENT_NAME=Hono REST Adapter
       - HONO_CLIENT_HOST=hono
-      - HONO_CLIENT_PORT=5672
+      - HONO_CLIENT_PORT=5671
       - HONO_CLIENT_USERNAME=rest-adapter
       - HONO_CLIENT_PASSWORD=secret
       - HONO_CLIENT_TRUST_STORE_PATH=/etc/hono/certs/trusted-certs.pem
@@ -62,7 +63,7 @@ services:
     environment:
       - HONO_CLIENT_NAME=Hono MQTT Adapter
       - HONO_CLIENT_HOST=hono
-      - HONO_CLIENT_PORT=5672
+      - HONO_CLIENT_PORT=5671
       - HONO_CLIENT_USERNAME=mqtt-adapter
       - HONO_CLIENT_PASSWORD=secret
       - HONO_CLIENT_TRUST_STORE_PATH=/etc/hono/certs/trusted-certs.pem

--- a/server/src/test/java/org/eclipse/hono/server/StandaloneRegistrationApiTest.java
+++ b/server/src/test/java/org/eclipse/hono/server/StandaloneRegistrationApiTest.java
@@ -21,6 +21,7 @@ import org.eclipse.hono.authorization.impl.InMemoryAuthorizationService;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.impl.HonoClientImpl;
+import org.eclipse.hono.config.HonoConfigProperties;
 import org.eclipse.hono.connection.ConnectionFactoryImpl.ConnectionFactoryBuilder;
 import org.eclipse.hono.registration.impl.FileBasedRegistrationService;
 import org.eclipse.hono.registration.impl.RegistrationEndpoint;
@@ -66,6 +67,10 @@ public class StandaloneRegistrationApiTest {
     public static void prepareHonoServer(final TestContext ctx) throws Exception {
 
         server = new HonoServer().setSaslAuthenticatorFactory(new HonoSaslAuthenticatorFactory(vertx));
+        HonoConfigProperties configProperties = new HonoConfigProperties();
+        configProperties.setInsecurePortEnabled(true);
+        configProperties.setInsecurePort(0);
+        server.setHonoConfiguration(configProperties);
         server.addEndpoint(new RegistrationEndpoint(vertx));
         registrationAdapter = new FileBasedRegistrationService();
 
@@ -91,8 +96,8 @@ public class StandaloneRegistrationApiTest {
             client = new HonoClientImpl(vertx, ConnectionFactoryBuilder.newBuilder()
                     .vertx(vertx)
                     .name("test")
-                    .host(server.getBindAddress())
-                    .port(server.getPort())
+                    .host(server.getInsecurePortBindAddress())
+                    .port(server.getInsecurePort())
                     .user(USER)
                     .password(PWD)
                     .build());

--- a/server/src/test/java/org/eclipse/hono/server/StandaloneTelemetryApiTest.java
+++ b/server/src/test/java/org/eclipse/hono/server/StandaloneTelemetryApiTest.java
@@ -21,6 +21,7 @@ import org.eclipse.hono.authorization.impl.InMemoryAuthorizationService;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.impl.HonoClientImpl;
+import org.eclipse.hono.config.HonoConfigProperties;
 import org.eclipse.hono.connection.ConnectionFactoryImpl.ConnectionFactoryBuilder;
 import org.eclipse.hono.registration.impl.FileBasedRegistrationService;
 import org.eclipse.hono.telemetry.impl.MessageDiscardingTelemetryDownstreamAdapter;
@@ -68,6 +69,10 @@ public class StandaloneTelemetryApiTest {
 
         telemetryAdapter = new MessageDiscardingTelemetryDownstreamAdapter(vertx);
         server = new HonoServer().setSaslAuthenticatorFactory(new HonoSaslAuthenticatorFactory(vertx));
+        HonoConfigProperties configProperties = new HonoConfigProperties();
+        configProperties.setInsecurePortEnabled(true);
+        configProperties.setInsecurePort(0);
+        server.setHonoConfiguration(configProperties);
         TelemetryEndpoint telemetryEndpoint = new TelemetryEndpoint(vertx);
         telemetryEndpoint.setTelemetryAdapter(telemetryAdapter);
         server.addEndpoint(telemetryEndpoint);
@@ -93,8 +98,8 @@ public class StandaloneTelemetryApiTest {
             client = new HonoClientImpl(vertx, ConnectionFactoryBuilder.newBuilder()
                     .vertx(vertx)
                     .name("test")
-                    .host(server.getBindAddress())
-                    .port(server.getPort())
+                    .host(server.getInsecurePortBindAddress())
+                    .port(server.getInsecurePort())
                     .user(USER)
                     .password(PWD)
                     .build());


### PR DESCRIPTION
…secure connections. Insecure port must be explicitly allowed (not allowed by default). Both ports can coexist, both port numbers can (but do not need to) be configured. Illegal combinations are checked and Hono refuses to start with explicit error message.

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>