### PR TITLE
[#147] Explicitly allowed insecure port 5672 in integration test setu…

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/client/ClientTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/client/ClientTestBase.java
@@ -263,7 +263,7 @@ public abstract class ClientTestBase {
             latch.await();
         });
 
-        long timeToWait = Math.min(5000, Math.round(MSG_COUNT * 1.2));
+        long timeToWait = Math.max(5000, Math.round(MSG_COUNT * 1.2));
         received.await(timeToWait);
         accepted.await(timeToWait);
         LOGGER.info("sent {} and received {} messages after {} milliseconds",

--- a/tests/src/test/resources/server/application.yml
+++ b/tests/src/test/resources/server/application.yml
@@ -6,7 +6,8 @@ hono:
   registration:
     saveToFile: false
   server:
-    bindAddress: 0.0.0.0
+    insecurePortEnabled: true
+    insecurePortBindAddress: 0.0.0.0
     maxInstances: 1
     waitForDownstreamConnectionEnabled: true
 


### PR DESCRIPTION
…p; changed timeout calculation of message send method to allow at least 5 seconds waiting time (support for slower environments)

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>