### PR TITLE
Prevent REST adapter startup failure if no active profiles are set

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -64,7 +64,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter extends AbstractVert
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractVertxBasedHttpProtocolAdapter.class);
 
-    @Value("${spring.profiles.active}")
+    @Value("${spring.profiles.active:}")
     private String activeProfiles;
 
     private HttpServer server;


### PR DESCRIPTION
Use an empty string as default value for "spring.profiles.active" to prevent startup failure of REST adapter if no active profiles are set.
