### PR TITLE
Hono adapters dual port configuration 140

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -129,6 +129,11 @@
       	<version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-service-base</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
       	<groupId>org.eclipse.hono</groupId>
       	<artifactId>hono-core</artifactId>
       	<version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
     <module>example</module>
     <module>legal</module>
     <module>server</module>
+    <module>service-base</module>
     <module>tests</module>
     <module>site</module>
   </modules>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -71,6 +71,10 @@
     	<artifactId>hono-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-service-base</artifactId>
+    </dependency>
+    <dependency>
     	<groupId>org.eclipse.hono</groupId>
     	<artifactId>hono-legal</artifactId>
     </dependency>

--- a/server/src/test/java/org/eclipse/hono/server/HonoServerTest.java
+++ b/server/src/test/java/org/eclipse/hono/server/HonoServerTest.java
@@ -20,14 +20,12 @@ import java.security.Principal;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import io.vertx.core.Future;
 import org.apache.qpid.proton.amqp.transport.Target;
 import org.apache.qpid.proton.engine.Record;
 import org.apache.qpid.proton.engine.impl.RecordImpl;
 import org.eclipse.hono.TestSupport;
 import org.eclipse.hono.authorization.AuthorizationConstants;
 import org.eclipse.hono.authorization.Permission;
-import org.eclipse.hono.config.HonoConfigProperties;
 import org.eclipse.hono.telemetry.TelemetryConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.ResourceIdentifier;
@@ -157,177 +155,15 @@ public class HonoServerTest {
     }
 
     /**
-     * Verifies that a Hono server will bind to the default AMQPS port only
-     * when using a default configuration with only the key store property being set.
+     * Verifies that a Hono server defines AMQP and AMQPS as it's default ports.
      */
     @Test
-    public void checkSecurePortAutoSelect() {
-
-        // GIVEN a configuration with a key store set
-        HonoConfigProperties configProperties = new HonoConfigProperties();
-        configProperties.setKeyStorePath("/etc/hono/certs/honoKeyStore.p12");
-
-        // WHEN using this configuration to determine the server's port configuration
-        // secure port config: no port set -> secure IANA port selected
-        Future<Void> portConfigurationTracker = Future.future();
+    public void verifyHonoDefaultPortNumbers() {
         HonoServer server = createServer(null);
-        server.setHonoConfiguration(configProperties);
-        server.determinePortConfigurations(portConfigurationTracker);
-
-        // THEN the default AMQPS port is selected and no insecure port will be opened
-        assertTrue(portConfigurationTracker.succeeded());
-        assertTrue(server.isOpenSecurePort());
-        assertThat(server.getPort(), is(Constants.PORT_AMQPS));
-        assertFalse(server.isOpenInsecurePort());
+        assertThat(server.getPortDefaultValue(), is(Constants.PORT_AMQPS));
+        assertThat(server.getInsecurePortDefaultValue(), is(Constants.PORT_AMQP));
     }
 
-    /**
-     * Verifies that a Hono server will bind to the configured secure port only
-     * when using a default configuration with only the key store and the port property being set.
-     */
-    @Test
-    public void checkSecurePortExplicitlySet() {
-
-        // GIVEN a configuration with a key store and a secure port being set
-        HonoConfigProperties configProperties = new HonoConfigProperties();
-        configProperties.setKeyStorePath("/etc/hono/certs/honoKeyStore.p12");
-        configProperties.setPort(8989);
-
-        // WHEN using this configuration to determine the server's port configuration
-        // secure port config: explicit port set -> port used
-        Future<Void> portConfigurationTracker = Future.future();
-        HonoServer server = createServer(null);
-        server.setHonoConfiguration(configProperties);
-        server.determinePortConfigurations(portConfigurationTracker);
-
-        // THEN the configured port is used and no insecure port will be opened
-        assertTrue(portConfigurationTracker.succeeded());
-        assertTrue(server.isOpenSecurePort());
-        assertThat(server.getPort(), is(8989));
-        assertFalse(server.isOpenInsecurePort());
-    }
-
-    /**
-     * Verifies that a Hono server will not be able to start
-     * when using a default configuration with not key store being set.
-     */
-    @Test
-    public void checkNoPortsSet() {
-
-        // GIVEN a default configuration with no key store being set
-        HonoConfigProperties configProperties = new HonoConfigProperties();
-
-        // WHEN using this configuration to determine the server's port configuration
-        Future<Void> portConfigurationTracker = Future.future();
-        HonoServer server = createServer(null);
-        server.setHonoConfiguration(configProperties);
-        server.determinePortConfigurations(portConfigurationTracker);
-
-        // THEN the port configuration fails
-        assertTrue(portConfigurationTracker.failed());
-    }
-
-    /**
-     * Verifies that a Hono server will bind to the default AMQP port only
-     * when using a default configuration with the insecure port being enabled.
-     */
-    @Test
-    public void checkInsecureOnlyPort() {
-
-        // GIVEN a default configuration with insecure port being enabled but no key store being set
-        HonoConfigProperties configProperties = new HonoConfigProperties();
-        configProperties.setInsecurePortEnabled(true);
-
-        // WHEN using this configuration to determine the server's port configuration
-        Future<Void> portConfigurationTracker = Future.future();
-        HonoServer server = createServer(null);
-        server.setHonoConfiguration(configProperties);
-        server.determinePortConfigurations(portConfigurationTracker);
-
-        // THEN the server will bind to the default AMQP port only
-        assertTrue(portConfigurationTracker.succeeded());
-        assertFalse(server.isOpenSecurePort());
-        assertTrue(server.isOpenInsecurePort());
-        assertThat(server.getInsecurePort(), is(Constants.PORT_AMQP));
-    }
-
-    /**
-     * Verifies that a Hono server will bind to a configured insecure port only
-     * when using a default configuration with the insecure port property being set.
-     */
-    @Test
-    public void checkInsecureOnlyPortExplicitlySet() {
-
-        // GIVEN a default configuration with insecure port being set to a specific port.
-        HonoConfigProperties configProperties = new HonoConfigProperties();
-        configProperties.setInsecurePortEnabled(false);
-        configProperties.setInsecurePort(8888);
-
-        // WHEN using this configuration to determine the server's port configuration
-        Future<Void> portConfigurationTracker = Future.future();
-        HonoServer server = createServer(null);
-        server.setHonoConfiguration(configProperties);
-        server.determinePortConfigurations(portConfigurationTracker);
-
-        // THEN the server will bind to the configured insecure port only
-        assertTrue(portConfigurationTracker.succeeded());
-        assertFalse(server.isOpenSecurePort());
-        assertTrue(server.isOpenInsecurePort());
-        assertThat(server.getInsecurePort(), is(8888));
-    }
-
-    /**
-     * Verifies that a Hono server will bind to both the default AMQP and AMQPS ports
-     * when using a default configuration with the insecure port being enabled and the
-     * key store property being set.
-     */
-    @Test
-    public void checkBothPortsOpen() {
-
-        // GIVEN a default configuration with insecure port being enabled and a key store being set.
-        HonoConfigProperties configProperties = new HonoConfigProperties();
-        configProperties.setInsecurePortEnabled(true);
-        configProperties.setKeyStorePath("/etc/hono/certs/honoKeyStore.p12");
-
-        // WHEN using this configuration to determine the server's port configuration
-        Future<Void> portConfigurationTracker = Future.future();
-        HonoServer server = createServer(null);
-        server.setHonoConfiguration(configProperties);
-        server.determinePortConfigurations(portConfigurationTracker);
-
-        // THEN the server will bind to both the default AMQP and AMQPS ports
-        assertTrue(portConfigurationTracker.succeeded());
-        assertTrue(server.isOpenSecurePort());
-        assertThat(server.getPort(), is(Constants.PORT_AMQPS));
-        assertTrue(server.isOpenInsecurePort());
-        assertThat(server.getInsecurePort(), is(Constants.PORT_AMQP));
-    }
-
-    /**
-     * Verifies that a Hono server will not start
-     * when using a default configuration with both secure and insecure ports being enabled and
-     * set to the same port number.
-     */
-    @Test
-    public void checkBothPortsSetToSame() {
-
-        // GIVEN a default configuration with both the insecure port and the secure port
-        // being set to the same value.
-        HonoConfigProperties configProperties = new HonoConfigProperties();
-        configProperties.setInsecurePortEnabled(true);
-        configProperties.setKeyStorePath("/etc/hono/certs/honoKeyStore.p12");
-        configProperties.setInsecurePort(8888);
-        configProperties.setPort(8888);
-
-        // WHEN using this configuration to determine the server's port configuration
-        Future<Void> portConfigurationTracker = Future.future();
-        HonoServer server = createServer(null);
-        server.setHonoConfiguration(configProperties);
-        server.determinePortConfigurations(portConfigurationTracker);
-
-        // THEN port configuration fails
-        assertTrue(portConfigurationTracker.failed());
-    }
 
     private static Target getTarget(final String targetAddress) {
         Target result = mock(Target.class);

--- a/server/src/test/java/org/eclipse/hono/server/StandaloneRegistrationApiTest.java
+++ b/server/src/test/java/org/eclipse/hono/server/StandaloneRegistrationApiTest.java
@@ -70,7 +70,7 @@ public class StandaloneRegistrationApiTest {
         HonoConfigProperties configProperties = new HonoConfigProperties();
         configProperties.setInsecurePortEnabled(true);
         configProperties.setInsecurePort(0);
-        server.setHonoConfiguration(configProperties);
+        server.setConfig(configProperties);
         server.addEndpoint(new RegistrationEndpoint(vertx));
         registrationAdapter = new FileBasedRegistrationService();
 

--- a/server/src/test/java/org/eclipse/hono/server/StandaloneTelemetryApiTest.java
+++ b/server/src/test/java/org/eclipse/hono/server/StandaloneTelemetryApiTest.java
@@ -72,7 +72,7 @@ public class StandaloneTelemetryApiTest {
         HonoConfigProperties configProperties = new HonoConfigProperties();
         configProperties.setInsecurePortEnabled(true);
         configProperties.setInsecurePort(0);
-        server.setHonoConfiguration(configProperties);
+        server.setConfig(configProperties);
         TelemetryEndpoint telemetryEndpoint = new TelemetryEndpoint(vertx);
         telemetryEndpoint.setTelemetryAdapter(telemetryAdapter);
         server.addEndpoint(telemetryEndpoint);

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-bom</artifactId>
+    <version>0.5-M6-SNAPSHOT</version>
+    <relativePath>../bom</relativePath>
+  </parent>
+  <artifactId>hono-service-base</artifactId>
+  <name>Hono Service base</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
@@ -1,0 +1,184 @@
+package org.eclipse.hono.service;
+
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import org.eclipse.hono.config.HonoConfigProperties;
+import org.eclipse.hono.util.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Objects;
+
+public abstract class AbstractServiceBase extends AbstractVerticle {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractServiceBase.class);
+
+    protected HonoConfigProperties config = new HonoConfigProperties();
+
+    protected int port         = Constants.PORT_UNCONFIGURED;
+    protected int insecurePort = Constants.PORT_UNCONFIGURED;
+
+    /**
+     * Define the default value for the TLS port number in the implementing server class (e.g. 5671 for AMQPS 1.0).
+     * @return The default value for the TLS port.
+     */
+    protected abstract int getPortDefaultValue();
+    /**
+     * Define the default value for the unencrypted port number in the implementing server class (e.g. 5672 for AMQP 1.0).
+     * @return The default value for the unencrypted port.
+     */
+    protected abstract int getInsecurePortDefaultValue();
+
+    /**
+     * Return the port number of the TLS port. If the implementing service determined the port during startup
+     * (ephemeral port configuration), return this port number.
+     * @return The port number of the TLS port.
+     */
+    public abstract int getPort();
+
+    /**
+     * Return the port number of the unencrypted port. If the implementing service determined the port during startup
+     * (ephemeral port configuration), return this port number.
+     * @return The port number of the unencrypted port.
+     */
+    public abstract int getInsecurePort();
+
+    /**
+     * Set the configuration for the Hono service.
+     * @param props The configuration properties.
+     * @throws NullPointerException if props is {@code null}.
+     */
+    @Autowired(required = false)
+    public final void setConfig(final HonoConfigProperties props) {
+        this.config = Objects.requireNonNull(props);
+    }
+
+    /**
+     * Either one secure, one insecure or one secure AND insecure ports are supported for servers in Hono.
+     *
+     * @param portConfigurationTracker The future to continue or fail (in case of configuration errors).
+     * @throws NullPointerException if portConfigurationTracker is null.
+     */
+    protected final void determinePortConfigurations(Future<Void> portConfigurationTracker) {
+
+        Objects.requireNonNull(portConfigurationTracker);
+
+        // secure port first
+        determineSecurePortConfiguration();
+        determineInsecurePortConfiguration();
+
+        if (isPortNumberUnconfigured(port) && isPortNumberUnconfigured(insecurePort)) {
+            final String message = "cannot start up Server - no listening ports found.";
+            portConfigurationTracker.fail(message);
+        } else if (isPortNumberExplicitlySet(port) && isPortNumberExplicitlySet(insecurePort) && port == insecurePort) {
+            final String message = String.format("cannot start up Server - secure and insecure ports configured to same port number %s.",
+                    port);
+            portConfigurationTracker.fail(message);
+        } else {
+            portConfigurationTracker.complete();
+        }
+    }
+
+    private void determineSecurePortConfiguration() {
+
+        if (config.getKeyCertOptions() == null) {
+            if (config.getPort() >= 0) {
+                LOG.warn("Secure port number configured, but the certificate setup is not correct. No secure port will be opened - please check your configuration!");
+            }
+            return;
+        }
+
+        port = config.getPort(getPortDefaultValue());
+
+        if (port == getPortDefaultValue()) {
+            LOG.info("Server uses secure standard port {}", getPortDefaultValue());
+        } else if (config.getPort() == 0) {
+            LOG.info("Server found secure port number configured for ephemeral port selection (port chosen automatically).");
+        }
+    }
+
+    private void determineInsecurePortConfiguration() {
+
+        if (config.isInsecurePortUnconfigured() && !config.isInsecurePortEnabled())
+            return;
+
+        insecurePort = config.getInsecurePort(getInsecurePortDefaultValue());
+
+        if (insecurePort == 0) {
+            LOG.info("Server found insecure port number configured for ephemeral port selection (port chosen automatically).");
+        } else if (insecurePort == getInsecurePortDefaultValue()) {
+            LOG.info("Server uses standard insecure port {}", getInsecurePortDefaultValue());
+        } else if (insecurePort == getPortDefaultValue()) {
+            LOG.warn("Server found insecure port number configured to standard port for secure connections {}", config.getInsecurePort());
+            LOG.warn("Possibly misconfigured?");
+        }
+    }
+
+    /**
+     * Gets if Hono service opens a secure port.
+     *
+     * @return The flag value for opening a secure port.
+     */
+    public final boolean isOpenSecurePort() {
+        return (port >= 0);
+    }
+
+    /**
+     * Gets if Hono service opens an insecure port.
+     *
+     * @return The flag value for opening an insecure port.
+     */
+    public final boolean isOpenInsecurePort() {
+        return (insecurePort >= 0);
+    }
+
+    /**
+     * Gets the IP address Hono is bound to.
+     *
+     * @return The IP address.
+     */
+    public final String getBindAddress() {
+        return config.getBindAddress();
+    }
+
+    /**
+     * Gets the IP address Hono's insecure port is bound to.
+     *
+     * @return The IP address.
+     */
+    public final String getInsecurePortBindAddress() {
+        return config.getInsecurePortBindAddress();
+    }
+
+    /**
+     * Checks if the given port number represents an unconfigured port.
+     * @param portToCheck The port number to check.
+     * @return True if the port number if unconfigured.
+     */
+    public static final boolean isPortNumberUnconfigured(int portToCheck) {
+        return (portToCheck == Constants.PORT_UNCONFIGURED);
+    }
+
+    /**
+     * Checks if the given port number represents an explicitly configured port.
+     * @param portToCheck The port number to check.
+     * @return True if the port number was configured explicitly.
+     */
+    public static final boolean isPortNumberExplicitlySet(int portToCheck) {
+        return (portToCheck != Constants.PORT_UNCONFIGURED && portToCheck != 0);
+    }
+
+}

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractServiceBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractServiceBaseTest.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import org.eclipse.hono.config.HonoConfigProperties;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for Hono Server Base class.
+ *
+ */
+public class AbstractServiceBaseTest {
+
+    private static final int PORT_NR          = 4711;
+    private static final int INSECURE_PORT_NR = 4712;
+
+    private Vertx vertx;
+    private EventBus eventBus;
+
+    /**
+     * Sets up common mock objects used by the test cases.
+     */
+    @Before
+    public void initMocks() {
+        eventBus = mock(EventBus.class);
+        vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(eventBus);
+    }
+
+    private AbstractServiceBase createServer() {
+        AbstractServiceBase server = new AbstractServiceBase() {
+            @Override
+            public int getPortDefaultValue() {
+                return PORT_NR;
+            }
+
+            @Override
+            public int getInsecurePortDefaultValue() {
+                return INSECURE_PORT_NR;
+            }
+
+            @Override
+            public int getPort() {
+                return port;
+            }
+
+            @Override
+            public int getInsecurePort() {
+                return insecurePort;
+            }
+        };
+        return server;
+    }
+
+    /**
+     * Verifies that a Hono server will bind to the default port only
+     * when using a default configuration with only the key store property being set.
+     */
+    @Test
+    public void checkSecurePortAutoSelect() {
+
+        // GIVEN a configuration with a key store set
+        HonoConfigProperties configProperties = new HonoConfigProperties();
+        configProperties.setKeyStorePath("/etc/hono/certs/honoKeyStore.p12");
+
+        // WHEN using this configuration to determine the server's port configuration
+        // secure port config: no port set -> secure IANA port selected
+        Future<Void> portConfigurationTracker = Future.future();
+        AbstractServiceBase server = createServer();
+        server.setConfig(configProperties);
+        server.determinePortConfigurations(portConfigurationTracker);
+
+        // THEN the default secure port is selected and no insecure port will be opened
+        assertTrue(portConfigurationTracker.succeeded());
+        assertTrue(server.isOpenSecurePort());
+        assertThat(server.getPort(), is(PORT_NR));
+        assertFalse(server.isOpenInsecurePort());
+    }
+
+    /**
+     * Verifies that a Hono server will bind to the configured secure port only
+     * when using a default configuration with only the key store and the port property being set.
+     */
+    @Test
+    public void checkSecurePortExplicitlySet() {
+
+        // GIVEN a configuration with a key store and a secure port being set
+        HonoConfigProperties configProperties = new HonoConfigProperties();
+        configProperties.setKeyStorePath("/etc/hono/certs/honoKeyStore.p12");
+        configProperties.setPort(8989);
+
+        // WHEN using this configuration to determine the server's port configuration
+        // secure port config: explicit port set -> port used
+        Future<Void> portConfigurationTracker = Future.future();
+        AbstractServiceBase server = createServer();
+        server.setConfig(configProperties);
+        server.determinePortConfigurations(portConfigurationTracker);
+
+        // THEN the configured port is used and no insecure port will be opened
+        assertTrue(portConfigurationTracker.succeeded());
+        assertTrue(server.isOpenSecurePort());
+        assertThat(server.getPort(), is(8989));
+        assertFalse(server.isOpenInsecurePort());
+    }
+
+    /**
+     * Verifies that a Hono server will not be able to start
+     * when using a default configuration with not key store being set.
+     */
+    @Test
+    public void checkNoPortsSet() {
+
+        // GIVEN a default configuration with no key store being set
+        HonoConfigProperties configProperties = new HonoConfigProperties();
+
+        // WHEN using this configuration to determine the server's port configuration
+        Future<Void> portConfigurationTracker = Future.future();
+        AbstractServiceBase server = createServer();
+        server.setConfig(configProperties);
+        server.determinePortConfigurations(portConfigurationTracker);
+
+        // THEN the port configuration fails
+        assertTrue(portConfigurationTracker.failed());
+    }
+
+    /**
+     * Verifies that a Hono server will bind to the default insecure port only
+     * when using a default configuration with the insecure port being enabled.
+     */
+    @Test
+    public void checkInsecureOnlyPort() {
+
+        // GIVEN a default configuration with insecure port being enabled but no key store being set
+        HonoConfigProperties configProperties = new HonoConfigProperties();
+        configProperties.setInsecurePortEnabled(true);
+
+        // WHEN using this configuration to determine the server's port configuration
+        Future<Void> portConfigurationTracker = Future.future();
+        AbstractServiceBase server = createServer();
+        server.setConfig(configProperties);
+        server.determinePortConfigurations(portConfigurationTracker);
+
+        // THEN the server will bind to the default insecure port only
+        assertTrue(portConfigurationTracker.succeeded());
+        assertFalse(server.isOpenSecurePort());
+        assertTrue(server.isOpenInsecurePort());
+        assertThat(server.getInsecurePort(), is(INSECURE_PORT_NR));
+    }
+
+    /**
+     * Verifies that a Hono server will bind to a configured insecure port only
+     * when using a default configuration with the insecure port property being set.
+     */
+    @Test
+    public void checkInsecureOnlyPortExplicitlySet() {
+
+        // GIVEN a default configuration with insecure port being set to a specific port.
+        HonoConfigProperties configProperties = new HonoConfigProperties();
+        configProperties.setInsecurePortEnabled(true);
+        configProperties.setInsecurePort(8888);
+
+        // WHEN using this configuration to determine the server's port configuration
+        Future<Void> portConfigurationTracker = Future.future();
+        AbstractServiceBase server = createServer();
+        server.setConfig(configProperties);
+        server.determinePortConfigurations(portConfigurationTracker);
+
+        // THEN the server will bind to the configured insecure port only
+        assertTrue(portConfigurationTracker.succeeded());
+        assertFalse(server.isOpenSecurePort());
+        assertTrue(server.isOpenInsecurePort());
+        assertThat(server.getInsecurePort(), is(8888));
+    }
+
+    /**
+     * Verifies that a Hono server will bind to both the default insecure and secure ports
+     * when using a default configuration with the insecure port being enabled and the
+     * key store property being set.
+     */
+    @Test
+    public void checkBothPortsOpen() {
+
+        // GIVEN a default configuration with insecure port being enabled and a key store being set.
+        HonoConfigProperties configProperties = new HonoConfigProperties();
+        configProperties.setInsecurePortEnabled(true);
+        configProperties.setKeyStorePath("/etc/hono/certs/honoKeyStore.p12");
+
+        // WHEN using this configuration to determine the server's port configuration
+        Future<Void> portConfigurationTracker = Future.future();
+        AbstractServiceBase server = createServer();
+        server.setConfig(configProperties);
+        server.determinePortConfigurations(portConfigurationTracker);
+
+        // THEN the server will bind to both the default insecure and secure ports
+        assertTrue(portConfigurationTracker.succeeded());
+        assertTrue(server.isOpenSecurePort());
+        assertThat(server.getPort(), is(PORT_NR));
+        assertTrue(server.isOpenInsecurePort());
+        assertThat(server.getInsecurePort(), is(INSECURE_PORT_NR));
+    }
+
+    /**
+     * Verifies that a Hono server will not start
+     * when using a default configuration with both secure and insecure ports being enabled and
+     * set to the same port number.
+     */
+    @Test
+    public void checkBothPortsSetToSame() {
+
+        // GIVEN a default configuration with both the insecure port and the secure port
+        // being set to the same value.
+        HonoConfigProperties configProperties = new HonoConfigProperties();
+        configProperties.setInsecurePortEnabled(true);
+        configProperties.setKeyStorePath("/etc/hono/certs/honoKeyStore.p12");
+        configProperties.setInsecurePort(8888);
+        configProperties.setPort(8888);
+
+        // WHEN using this configuration to determine the server's port configuration
+        Future<Void> portConfigurationTracker = Future.future();
+        AbstractServiceBase server = createServer();
+        server.setConfig(configProperties);
+        server.determinePortConfigurations(portConfigurationTracker);
+
+        // THEN port configuration fails
+        assertTrue(portConfigurationTracker.failed());
+    }
+
+
+
+
+}


### PR DESCRIPTION
This PR consists of a new maven module "server-base" that contains the common functionality for implementing servers that listen on a secure and/or insecure port.
Applied to HonoServer only currently, but intended to serve as base for the protocol adapters as well.

Existing tests for the port determination are mainly moved to the new maven module and only a few AMQP(s) port checks remain in the "server" module. This would be similar in the protocol adapters in the future (not part of this PR).

Looking forward to comments, improvements, thoughts on the way I implemented it now.