### PR TITLE
[#169] Credentials API client (so far only get operation)

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/CredentialsClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/CredentialsClient.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.client;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import org.eclipse.hono.util.CredentialsResult;
+
+import java.net.HttpURLConnection;
+
+/**
+ * A client for accessing Hono's Credentials API.
+ * <p>
+ * An instance of this interface is always scoped to a specific tenant.
+ * </p>
+ * <p>
+ * See Hono's <a href="https://www.eclipse.org/hono/api/Credentials-API">
+ * Credentials API specification</a> for a description of the result codes returned.
+ * </p>
+ */
+public interface CredentialsClient {
+
+    /**
+     * Gets credentials data of a specific type by authId of a device.
+     *
+     * @param type The type of the credentials record.
+     * @param authId The auth-id of the device.
+     * @param resultHandler The handler to invoke with the result of the operation. If credentials are existing for the
+     *         given type and authId, the <em>status</em> will be {@link HttpURLConnection#HTTP_OK}
+     *         and the <em>payload</em> contains the details as defined
+     *         here <a href="https://www.eclipse.org/hono/api/Credentials-API/#credentials-format">Credentials Format</a>.
+     *         Otherwise the status will be {@link HttpURLConnection#HTTP_NOT_FOUND}.
+
+     */
+    void get(String type, String authId,  Handler<AsyncResult<CredentialsResult>> resultHandler);
+
+    /**
+     * Closes the AMQP link(s) with the Hono server this client is configured to use.
+     * <p>
+     * The underlying AMQP connection to the server is not affected by this operation.
+     * </p>
+     * 
+     * @param closeHandler A handler that is called back with the result of the attempt to close the links.
+     */
+    void close(Handler<AsyncResult<Void>> closeHandler);
+
+    /**
+     * Checks if this client's sender and receiver are (locally) open.
+     * 
+     * @return {@code true} if this client can be used to exchange messages with the peer.
+     */
+    boolean isOpen();
+}

--- a/client/src/main/java/org/eclipse/hono/client/HonoClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016,2017 Bosch Software Innovations GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -186,6 +186,30 @@ public interface HonoClient {
     HonoClient createRegistrationClient(
             String tenantId,
             Handler<AsyncResult<RegistrationClient>> creationHandler);
+
+    /**
+     * Gets a client for interacting with Hono's <em>Credentials</em> API.
+     *
+     * @param tenantId The tenant to manage device credentials data for.
+     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return This client for command chaining.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    HonoClient getOrCreateCredentialsClient(
+            String tenantId,
+            Handler<AsyncResult<CredentialsClient>> resultHandler);
+
+    /**
+     * Creates a new client for interacting with Hono's <em>Credentials</em> API.
+     *
+     * @param tenantId The tenant to manage device credentials data for.
+     * @param creationHandler The handler to invoke with the result of the operation.
+     * @return This client for command chaining.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    HonoClient createCredentialsClient(
+            String tenantId,
+            Handler<AsyncResult<CredentialsClient>> creationHandler);
 
     /**
      * Closes this client's connection to the Hono server.

--- a/client/src/main/java/org/eclipse/hono/client/RegistrationClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/RegistrationClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016,2017 Bosch Software Innovations GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -26,7 +26,7 @@ import io.vertx.core.json.JsonObject;
  * An instance of this interface is always scoped to a specific tenant.
  * </p>
  * <p>
- * See Hono's <a href="https://github.com/eclipse/hono/wiki/Device-Registration-API">
+ * See Hono's <a href="https://www.eclipse.org/hono/api/Device-Registration-API">
  * Registration API specification</a> for a description of the result codes returned.
  * </p>
  */

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * Contributors:
+ * Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.client.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.proton.*;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.CredentialsClient;
+import org.eclipse.hono.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.eclipse.hono.util.CredentialsConstants.OPERATION_GET;
+import static org.eclipse.hono.util.MessageHelper.APP_PROPERTY_STATUS;
+
+/**
+ * A Vertx-Proton based client for Hono's Credentials API.
+ *
+ */
+public final class CredentialsClientImpl extends AbstractHonoClient implements CredentialsClient {
+
+    private static final Logger                  LOG = LoggerFactory.getLogger(CredentialsClientImpl.class);
+    private static final String                  CREDENTIALS_ADDRESS_TEMPLATE = "credentials/%s";
+    private static final String                  CREDENTIALS_REPLY_TO_ADDRESS_TEMPLATE = "credentials/%s/%s";
+
+    private final Map<String, Handler<AsyncResult<CredentialsResult>>> replyMap = new ConcurrentHashMap<>();
+    private final String                         credentialsReplyToAddress;
+
+    private CredentialsClientImpl(final Context context, final ProtonConnection con, final String tenantId,
+                                  final Handler<AsyncResult<CredentialsClient>> creationHandler) {
+
+        super(context);
+        this.credentialsReplyToAddress = String.format(
+                CREDENTIALS_REPLY_TO_ADDRESS_TEMPLATE,
+                Objects.requireNonNull(tenantId),
+                UUID.randomUUID());
+
+        final Future<ProtonSender> senderTracker = Future.future();
+        senderTracker.setHandler(r -> {
+            if (r.succeeded()) {
+                LOG.debug("credentials client created");
+                this.sender = r.result();
+                creationHandler.handle(Future.succeededFuture(this));
+            } else {
+                creationHandler.handle(Future.failedFuture(r.cause()));
+            }
+        });
+
+        final Future<ProtonReceiver> receiverTracker = Future.future();
+        context.runOnContext(create -> {
+            final ProtonReceiver receiver = con.createReceiver(credentialsReplyToAddress);
+            receiver
+                    .setAutoAccept(true)
+                    .setPrefetch(DEFAULT_SENDER_CREDITS)
+                    .handler((delivery, message) -> {
+                        final Handler<AsyncResult<CredentialsResult>> handler = replyMap.remove(message.getCorrelationId());
+                        if (handler != null) {
+                            CredentialsResult result = getCredentialsResult(message);
+                            LOG.debug("received response [correlation ID: {}, status: {}]",
+                                    message.getCorrelationId(), result.getStatus());
+                            handler.handle(Future.succeededFuture(result));
+                        } else {
+                            LOG.info("discarding unexpected response [correlation ID: {}]",
+                                    message.getCorrelationId());
+                        }
+                    }).openHandler(receiverTracker.completer())
+                    .open();
+
+            receiverTracker.compose(openReceiver -> {
+                this.receiver = openReceiver;
+                ProtonSender sender = con.createSender(String.format(CREDENTIALS_ADDRESS_TEMPLATE, tenantId));
+                sender
+                        .setQoS(ProtonQoS.AT_LEAST_ONCE)
+                        .openHandler(senderTracker.completer())
+                        .open();
+            }, senderTracker);
+        });
+    }
+
+    private static CredentialsResult getCredentialsResult(final Message message) {
+        final String status = MessageHelper.getApplicationProperty(
+                                                message.getApplicationProperties(),
+                                                APP_PROPERTY_STATUS,
+                                                String.class);
+        final JsonObject payload = MessageHelper.getJsonPayload(message);
+        return CredentialsResult.from(Integer.valueOf(status), payload);
+    }
+
+    /**
+     * Creates a new credentials client for a tenant.
+     *
+     * @param context The vert.x context to run all interactions with the server on.
+     * @param con The AMQP connection to the server.
+     * @param tenantId The tenant for which credentials are handled.
+     * @param creationHandler The handler to invoke with the outcome of the creation attempt.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static void create(final Context context, final ProtonConnection con, final String tenantId,
+                              final Handler<AsyncResult<CredentialsClient>> creationHandler) {
+        new CredentialsClientImpl(
+                Objects.requireNonNull(context),
+                Objects.requireNonNull(con),
+                Objects.requireNonNull(tenantId),
+                Objects.requireNonNull(creationHandler));
+    }
+
+    @Override
+    public boolean isOpen() {
+        return sender != null && sender.isOpen() && receiver != null && receiver.isOpen();
+    }
+
+
+    @Override
+    public void close(final Handler<AsyncResult<Void>> closeHandler) {
+
+        Objects.requireNonNull(closeHandler);
+        LOG.info("closing credentials client ...");
+        closeLinks(closeHandler);
+    }
+
+    private void createAndSendRequest(final String action, final JsonObject payload,
+                                      final Handler<AsyncResult<CredentialsResult>> resultHandler) {
+
+        final Message request = createMessage(null);
+        request.setSubject(action);
+        if (payload != null) {
+            request.setContentType("application/json; charset=utf-8");
+            request.setBody(new AmqpValue(payload.encode()));
+        }
+        sendMessage(request, resultHandler);
+    }
+
+    private void sendMessage(final Message request, final Handler<AsyncResult<CredentialsResult>> resultHandler) {
+
+        context.runOnContext(req -> {
+            replyMap.put((String) request.getMessageId(), resultHandler);
+            sender.send(request);
+        });
+    }
+
+    private Message createMessage(final Map<String, Object> appProperties) {
+        final Message msg = ProtonHelper.message();
+        final String messageId = createMessageId();
+        if (appProperties != null) {
+            msg.setApplicationProperties(new ApplicationProperties(appProperties));
+        }
+        msg.setReplyTo(credentialsReplyToAddress);
+        msg.setMessageId(messageId);
+        return msg;
+    }
+
+    private String createMessageId() {
+        return String.format("cred-client-%s", UUID.randomUUID());
+    }
+
+    @Override
+    public final void get(final String type, final String authId, final Handler<AsyncResult<CredentialsResult>> resultHandler) {
+        JsonObject specification = new JsonObject().put(CredentialsConstants.FIELD_TYPE, type).put(CredentialsConstants.FIELD_AUTH_ID, authId);
+        createAndSendRequest(OPERATION_GET, specification, resultHandler);
+    }
+}

--- a/server/src/test/java/org/eclipse/hono/server/StandaloneCredentialsApiTest.java
+++ b/server/src/test/java/org/eclipse/hono/server/StandaloneCredentialsApiTest.java
@@ -1,0 +1,363 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.server;
+
+import io.vertx.core.*;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.proton.ProtonClientOptions;
+import org.eclipse.hono.authentication.impl.AcceptAllPlainAuthenticationService;
+import org.eclipse.hono.authorization.impl.InMemoryAuthorizationService;
+import org.eclipse.hono.client.CredentialsClient;
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.impl.HonoClientImpl;
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.connection.ConnectionFactoryImpl.ConnectionFactoryBuilder;
+import org.eclipse.hono.service.credentials.CredentialsEndpoint;
+import org.eclipse.hono.service.credentials.impl.FileBasedCredentialsService;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.net.HttpURLConnection.*;
+import static org.eclipse.hono.util.Constants.DEFAULT_TENANT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests validating Hono's Credentials API using a stand alone server.
+ */
+@RunWith(VertxUnitRunner.class)
+public class StandaloneCredentialsApiTest {
+
+    private static final int                   TIMEOUT = 5000; // milliseconds
+    private static final String                USER    = "hono-client";
+    private static final String                PWD     = "secret";
+    public static final  String                CREDENTIALS_USER = "billie";
+    public static final  String                CREDENTIALS_TYPE = "hashed-password";
+    public static final  String                CREDENTIALS_USER_PASSWORD = "hono-secret";
+    public static final  String                CREDENTIALS_PASSWORD_SALT = "hono";
+    public static final  String                DEFAULT_DEVICE_ID = "4711";
+
+    private static Vertx                       vertx = Vertx.vertx();
+    private static HonoServer                  server;
+    private static FileBasedCredentialsService credentialsAdapter;
+    private static HonoClient                  client;
+    private static CredentialsClient           credentialsClient;
+
+    @BeforeClass
+    public static void prepareHonoServer(final TestContext ctx) throws Exception {
+
+        server = new HonoServer();
+        server.setSaslAuthenticatorFactory(new HonoSaslAuthenticatorFactory(vertx));
+        ServiceConfigProperties configProperties = new ServiceConfigProperties();
+        configProperties.setInsecurePortEnabled(true);
+        configProperties.setInsecurePort(0);
+        server.setConfig(configProperties);
+        server.addEndpoint(new CredentialsEndpoint(vertx));
+        credentialsAdapter = new FileBasedCredentialsService();
+
+        Future<CredentialsClient> setupTracker = Future.future();
+        setupTracker.setHandler(ctx.asyncAssertSuccess(r -> {
+            credentialsClient = r;
+        }));
+
+        Future<String> credentialsTracker = Future.future();
+        Future<String> authenticationTracker = Future.future();
+        Future<String> authTracker = Future.future();
+
+        vertx.deployVerticle(credentialsAdapter, credentialsTracker.completer());
+        vertx.deployVerticle(AcceptAllPlainAuthenticationService.class.getName(), authenticationTracker.completer());
+        vertx.deployVerticle(InMemoryAuthorizationService.class.getName(), authTracker.completer());
+
+        CompositeFuture.all(credentialsTracker, authTracker)
+        .compose(r -> {
+            Future<String> serverTracker = Future.future();
+            vertx.deployVerticle(server, serverTracker.completer());
+            return serverTracker;
+        }).compose(s -> {
+            client = new HonoClientImpl(vertx, ConnectionFactoryBuilder.newBuilder()
+                    .vertx(vertx)
+                    .name("test")
+                    .host(server.getInsecurePortBindAddress())
+                    .port(server.getInsecurePort())
+                    .user(USER)
+                    .password(PWD)
+                    .build());
+
+            Future<HonoClient> clientTracker = Future.future();
+            client.connect(new ProtonClientOptions(), clientTracker.completer());
+            return clientTracker;
+        }).compose(c -> {
+            c.createCredentialsClient(DEFAULT_TENANT, setupTracker.completer());
+        }, setupTracker);
+    }
+
+    @AfterClass
+    public static void shutdown(final TestContext ctx) {
+
+        Future<Void> done = Future.future();
+        done.setHandler(ctx.asyncAssertSuccess());
+
+        if (client != null) {
+            Future<Void> closeTracker = Future.future();
+            if (credentialsClient != null) {
+                credentialsClient.close(closeTracker.completer());
+            } else {
+                closeTracker.complete();
+            }
+            closeTracker.compose(c -> {
+                client.shutdown(done.completer());
+            }, done);
+        }
+    }
+
+    /**
+     * Verify that a not existing authId is responded with HTTP_NOT_FOUND.
+     */
+    @Test(timeout = TIMEOUT)
+    public void testGetCredentialsNotExistingAuthId(final TestContext ctx) {
+        final Async ok = ctx.async();
+
+        credentialsClient.get(CREDENTIALS_TYPE, "notExisting", s -> {
+            ctx.assertTrue(s.succeeded());
+            ctx.assertEquals(s.result().getStatus(), HTTP_NOT_FOUND);
+            ok.complete();
+        });
+    }
+
+    /**
+     * Verify that a null type is responded with HTTP_BAD_REQUEST.
+     */
+    @Test(timeout = TIMEOUT)
+    public void testGetCredentialsNullType(final TestContext ctx) {
+        final Async ok = ctx.async();
+
+        credentialsClient.get(null, "notExisting", s -> {
+            ctx.assertTrue(s.succeeded());
+            ctx.assertEquals(s.result().getStatus(), HTTP_BAD_REQUEST);
+            ok.complete();
+        });
+    }
+
+    /**
+     * Verify that a null authId is responded with HTTP_BAD_REQUEST.
+     */
+    @Test(timeout = TIMEOUT)
+    public void testGetCredentialsNullAuthId(final TestContext ctx) {
+        final Async ok = ctx.async();
+
+        credentialsClient.get(CREDENTIALS_TYPE, null, s -> {
+            ctx.assertTrue(s.succeeded());
+            ctx.assertEquals(s.result().getStatus(), HTTP_BAD_REQUEST);
+            ok.complete();
+        });
+    }
+
+    /**
+     * Verify that setting authId and type to existing credentials is responded with HTTP_OK.
+     * Check that the payload contains exactly the given type and authId afterwards.
+     */
+    @Test(timeout = TIMEOUT)
+    public void testGetCredentialsReturnsCredentialsTypeAndAuthId(final TestContext ctx) {
+        final Async ok = ctx.async();
+
+        credentialsClient.get(CREDENTIALS_TYPE, CREDENTIALS_USER, s -> {
+            ctx.assertTrue(s.succeeded());
+            ctx.assertEquals(s.result().getStatus(), HTTP_OK);
+            JsonObject payload = s.result().getPayload();
+
+            checkPayloadGetCredentialsContainsAuthIdAndType(payload);
+            ok.complete();
+        });
+    }
+
+    /**
+     * Verify that setting authId and type to existing credentials is responded with HTTP_OK.
+     * Check that the payload contains the default deviceId and is enabled.
+     */
+    @Test(timeout = TIMEOUT)
+    public void testGetCredentialsReturnsCredentialsDefaultDeviceIdAndIsEnabled(final TestContext ctx) {
+        final Async ok = ctx.async();
+
+        credentialsClient.get(CREDENTIALS_TYPE, CREDENTIALS_USER, s -> {
+            ctx.assertTrue(s.succeeded());
+            ctx.assertEquals(s.result().getStatus(), HTTP_OK);
+            JsonObject payload = s.result().getPayload();
+
+            checkPayloadGetCredentialsContainsDefaultDeviceIdAndIsEnabled(payload);
+            ok.complete();
+        });
+    }
+
+    /**
+     * Verify that setting authId and type to existing credentials is responded with HTTP_OK.
+     * Check that the payload contains multiple secrets (more than one).
+     */
+    @Test(timeout = TIMEOUT)
+    public void testGetCredentialsReturnsMultipleSecrets(final TestContext ctx) {
+        final Async ok = ctx.async();
+
+        credentialsClient.get(CREDENTIALS_TYPE, CREDENTIALS_USER, s -> {
+            ctx.assertTrue(s.succeeded());
+            ctx.assertEquals(s.result().getStatus(), HTTP_OK);
+            JsonObject payload = s.result().getPayload();
+
+            checkPayloadGetCredentialsReturnsMultipleSecrets(payload);
+            ok.complete();
+        });
+    }
+
+    /**
+     * Verify that setting authId and type to existing credentials is responded with HTTP_OK.
+     * Check that the payload contains the exepected hash-function,salt and encrypted password.
+     */
+    @Test(timeout = TIMEOUT)
+    public void testGetCredentialsFirstSecretCorrectPassword(final TestContext ctx) throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        final Async ok = ctx.async();
+
+        final AtomicReference<JsonObject> payloadRef = new AtomicReference<>();
+
+        credentialsClient.get(CREDENTIALS_TYPE, CREDENTIALS_USER, s -> {
+            ctx.assertTrue(s.succeeded());
+            ctx.assertEquals(s.result().getStatus(), HTTP_OK);
+            payloadRef.set(s.result().getPayload());
+            ok.complete();
+        });
+        ok.await(200);
+        checkPayloadGetCredentialsReturnsFirstSecretWithCorrectPassword(payloadRef.get());
+    }
+
+    /**
+     * Verify that setting authId and type to existing credentials is responded with HTTP_OK.
+     * Check that the payload contains NOT_BEFORE and NOT_AFTER entries which denote a currently active time interval.
+     */
+    @Test(timeout = TIMEOUT)
+    public void testGetCredentialsFirstSecretCurrentlyActiveTimeInterval(final TestContext ctx) {
+        final Async ok = ctx.async();
+
+        credentialsClient.get(CREDENTIALS_TYPE, CREDENTIALS_USER, s -> {
+            ctx.assertTrue(s.succeeded());
+            ctx.assertEquals(s.result().getStatus(), HTTP_OK);
+            JsonObject payload = s.result().getPayload();
+
+            checkPayloadGetCredentialsReturnsFirstSecretWithCurrentlyActiveTimeInterval(payload);
+            ok.complete();
+        });
+    }
+
+
+    private JsonObject pickFirstSecretFromPayload(final JsonObject payload) {
+        // secrets: first entry is expected to be valid, second entry may have timestamps not yet active (not checked), more entries may be avail
+        assertTrue(payload.containsKey(CredentialsConstants.FIELD_SECRETS));
+        JsonArray secrets = payload.getJsonArray(CredentialsConstants.FIELD_SECRETS);
+        assertNotNull(secrets);
+        assertTrue(secrets.size() > 0);
+
+        JsonObject firstSecret = secrets.getJsonObject(0);
+        assertNotNull(firstSecret);
+        return firstSecret;
+    }
+
+    private void checkPayloadGetCredentialsReturnsFirstSecretWithCorrectPassword(final JsonObject payload) throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        assertNotNull(payload);
+        JsonObject firstSecret = pickFirstSecretFromPayload(payload);
+        assertNotNull(firstSecret);
+
+        String hashFunction = firstSecret.getString(CredentialsConstants.FIELD_SECRETS_HASH_FUNCTION);
+        assertNotNull(hashFunction);
+        assertEquals(hashFunction,firstSecret.getString(CredentialsConstants.FIELD_SECRETS_HASH_FUNCTION));
+
+        String salt = firstSecret.getString(CredentialsConstants.FIELD_SECRETS_SALT);
+        assertNotNull(salt);
+        byte[] decodedSalt = Base64.getDecoder().decode(salt);
+        assertEquals(new String(decodedSalt), CREDENTIALS_PASSWORD_SALT);  // see file, this should be the salt
+
+        String pwdHash = firstSecret.getString(CredentialsConstants.FIELD_SECRETS_PWD_HASH);
+        assertNotNull(pwdHash);
+        byte[] password = Base64.getDecoder().decode(pwdHash);
+        assertNotNull(password);
+
+        byte[] hashedPassword = hashPassword(hashFunction,new String(decodedSalt), CREDENTIALS_USER_PASSWORD);
+        // check if the password is the hashed version of "hono-secret"
+        assertTrue(Arrays.equals(password,hashedPassword));
+    }
+
+    private void checkPayloadGetCredentialsReturnsFirstSecretWithCurrentlyActiveTimeInterval(final JsonObject payload) {
+        assertNotNull(payload);
+        JsonObject firstSecret = pickFirstSecretFromPayload(payload);
+        assertNotNull(firstSecret);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        assertTrue(firstSecret.containsKey(CredentialsConstants.FIELD_SECRETS_NOT_BEFORE));
+        String notBefore = firstSecret.getString(CredentialsConstants.FIELD_SECRETS_NOT_BEFORE);
+        LocalDateTime notBeforeLocalDate = LocalDateTime.parse(notBefore, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        assertTrue(now.compareTo(notBeforeLocalDate) >= 0);
+
+        assertTrue(firstSecret.containsKey(CredentialsConstants.FIELD_SECRETS_NOT_AFTER));
+        String notAfter = firstSecret.getString(CredentialsConstants.FIELD_SECRETS_NOT_AFTER);
+        LocalDateTime notAfterLocalDate = LocalDateTime.parse(notAfter, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        assertTrue(now.compareTo(notAfterLocalDate) <= 0);
+    }
+
+    private void checkPayloadGetCredentialsReturnsMultipleSecrets(final JsonObject payload) {
+        assertNotNull(payload);
+
+        // secrets: first entry is expected to be valid, second entry may have timestamps not yet active (not checked), more entries may be avail
+        assertTrue(payload.containsKey(CredentialsConstants.FIELD_SECRETS));
+        JsonArray secrets = payload.getJsonArray(CredentialsConstants.FIELD_SECRETS);
+        assertNotNull(secrets);
+        assertTrue(secrets.size() > 1); // at least 2 entries to test multiple entries
+    }
+
+    private void checkPayloadGetCredentialsContainsAuthIdAndType(final JsonObject payload) {
+        assertNotNull(payload);
+
+        assertTrue(payload.containsKey(CredentialsConstants.FIELD_AUTH_ID));
+        assertEquals(payload.getString(CredentialsConstants.FIELD_AUTH_ID), CREDENTIALS_USER);
+
+        assertTrue(payload.containsKey(CredentialsConstants.FIELD_TYPE));
+        assertEquals(payload.getString(CredentialsConstants.FIELD_TYPE),CREDENTIALS_TYPE);
+    }
+
+    private void checkPayloadGetCredentialsContainsDefaultDeviceIdAndIsEnabled(final JsonObject payload) {
+        assertNotNull(payload);
+
+        assertTrue(payload.containsKey(CredentialsConstants.FIELD_DEVICE_ID));
+        assertEquals(payload.getString(CredentialsConstants.FIELD_DEVICE_ID), DEFAULT_DEVICE_ID);
+
+        assertTrue(payload.getBoolean(CredentialsConstants.FIELD_ENABLED));
+    }
+
+    private byte[] hashPassword(final String hashFunction,final String hashSalt,final String passwordToHash) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+            MessageDigest messageDigest = MessageDigest.getInstance(hashFunction);
+            messageDigest.update(hashSalt.getBytes("UTF-8"));
+            byte[] theHashedPassword = messageDigest.digest(passwordToHash.getBytes());
+            return theHashedPassword;
+    }
+}


### PR DESCRIPTION
Last step (out of 4) to provide the get operation of the credentials API.
Includes the client plus tests.

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>