### PR TITLE
Configurable RegistrationServiceClient in protocol adapters

### DIFF
--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Config.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Config.java
@@ -17,6 +17,9 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.impl.HonoClientImpl;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.connection.ConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ServiceLocatorFactoryBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +32,10 @@ import org.springframework.context.annotation.Scope;
 @Configuration
 public class Config extends AdapterConfig {
 
+    @Autowired(required = false)
+    @Qualifier("registration")
+    private ConnectionFactory registrationServiceConnectionFactory;
+    
     @Override
     protected void customizeClientConfigProperties(ClientConfigProperties props) {
         if (props.getName() == null) {
@@ -52,6 +59,34 @@ public class Config extends AdapterConfig {
         return new HonoClientImpl(getVertx(), honoConnectionFactory());
     }
 
+    @Override
+    protected void customizeRegistrationServiceClientConfigProperties(ClientConfigProperties props) {
+        if (props.getName() == null) {
+            props.setName("Hono REST Adapter");
+        }
+        if (props.getAmqpHostname() == null) {
+            props.setAmqpHostname("hono-device-registry");
+        }
+    }
+
+    /**
+     * Exposes a registration service client as a Spring bean.
+     * <p>
+     * The client is configured with the properties provided by {@link #registrationServiceClientConfig()}.
+     * If no such properties are set, null is returned here.
+     *
+     * @return The client or null.
+     */
+    @Bean
+    @Qualifier("registration")
+    @Scope("prototype")
+    public HonoClient registrationServiceClient() {
+        if (registrationServiceConnectionFactory == null) {
+            return null;
+        }
+        return new HonoClientImpl(getVertx(), registrationServiceConnectionFactory);
+    }
+
     /**
      * Exposes the REST adapter's configuration properties as a Spring bean.
      * 
@@ -63,6 +98,11 @@ public class Config extends AdapterConfig {
         return new ServiceConfigProperties();
     }
 
+    /**
+     * Exposes a factory for creating REST adapter instances.
+     * 
+     * @return The factory bean.
+     */
     @Bean
     public ServiceLocatorFactoryBean serviceLocator() {
         ServiceLocatorFactoryBean bean = new ServiceLocatorFactoryBean();

--- a/application/src/main/java/org/eclipse/hono/application/ApplicationConfig.java
+++ b/application/src/main/java/org/eclipse/hono/application/ApplicationConfig.java
@@ -88,11 +88,12 @@ public class ApplicationConfig {
      * Exposes a factory for connections to the downstream AMQP container
      * as a Spring bean.
      * 
+     * @param config configuration properties
      * @return The connection factory.
      */
     @Bean
-    public ConnectionFactory downstreamConnectionFactory() {
-        return new ConnectionFactoryImpl();
+    public ConnectionFactory downstreamConnectionFactory(final ClientConfigProperties config) {
+        return new ConnectionFactoryImpl(vertx, config);
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/adapter/AdapterConfig.java
+++ b/core/src/main/java/org/eclipse/hono/adapter/AdapterConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 Red Hat
+ * Copyright (c) 2016, 2017 Red Hat and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Red Hat - initial creation
+ *    Bosch Software Innovations GmbH
  */
 
 package org.eclipse.hono.adapter;
@@ -15,6 +16,9 @@ package org.eclipse.hono.adapter;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.connection.ConnectionFactory;
 import org.eclipse.hono.connection.ConnectionFactoryImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -27,6 +31,10 @@ public abstract class AdapterConfig {
 
     private final Vertx vertx = Vertx.vertx();
 
+    @Autowired(required = false)
+    @Qualifier("registration")
+    private ClientConfigProperties registrationServiceClientConfig;
+    
     /**
      * Exposes a Vert.x instance as a Spring bean.
      * 
@@ -71,6 +79,50 @@ public abstract class AdapterConfig {
      */
     @Bean
     public ConnectionFactory honoConnectionFactory() {
-        return new ConnectionFactoryImpl();
+        return new ConnectionFactoryImpl(vertx, honoClientConfig());
+    }
+
+    /**
+     * Exposes configuration properties for accessing the registration service as a Spring bean.
+     *
+     * @return The properties.
+     */
+    @Qualifier("registration")
+    @ConfigurationProperties(prefix = "hono.registration")
+    @ConditionalOnProperty(prefix = "hono.registration", name = "host")
+    @Bean
+    public ClientConfigProperties registrationServiceClientConfig() {
+        ClientConfigProperties config = new ClientConfigProperties();
+        customizeRegistrationServiceClientConfigProperties(config);
+        return config;
+    }
+
+    /**
+     * Further customizes the properties provided by the {@link #registrationServiceClientConfig()}
+     * method.
+     * <p>
+     * This method does nothing by default. Subclasses may override this method to set additional
+     * properties programmatically.
+     *
+     * @param config The configuration to customize.
+     */
+    protected void customizeRegistrationServiceClientConfigProperties(final ClientConfigProperties config) {
+        // empty by default
+    }
+
+    /**
+     * Exposes a factory for connections to the registration service 
+     * as a Spring bean. Returns null if no ClientConfigProperties for accessing the 
+     * registration service have been set.
+     *
+     * @return The connection factory or null.
+     */
+    @Qualifier("registration")
+    @Bean
+    public ConnectionFactory registrationServiceConnectionFactory() {
+        if (registrationServiceClientConfig == null) {
+            return null;
+        }
+        return new ConnectionFactoryImpl(vertx, registrationServiceClientConfig);
     }
 }

--- a/core/src/main/java/org/eclipse/hono/connection/ConnectionFactoryImpl.java
+++ b/core/src/main/java/org/eclipse/hono/connection/ConnectionFactoryImpl.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -38,31 +37,22 @@ import io.vertx.proton.sasl.impl.ProtonSaslPlainImpl;
 public class ConnectionFactoryImpl implements ConnectionFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(ConnectionFactoryImpl.class);
-    private Vertx                      vertx;
-    private ClientConfigProperties config;
+    private final Vertx vertx;
+    private final ClientConfigProperties config;
 
     /**
-     * Sets the Vert.x instance to use.
-     * 
-     * @param vertx The Vert.x instance.
-     * @throws NullPointerException if the instance is {@code null}.
-     */
-    @Autowired
-    public final void setVertx(final Vertx vertx) {
-        this.vertx = Objects.requireNonNull(vertx);
-    }
-
-    /**
-     * Sets the configuration parameters for connecting to the AMQP server.
+     * Constructor with the Vert.x instance to use and the configuration 
+     * parameters for connecting to the AMQP server as parameters.
      * <p>
      * The <em>name</em> property of the configuration is used as the basis
      * for the local container name which is then appended with a UUID.
-     *  
+     * 
+     * @param vertx The Vert.x instance.
      * @param config The configuration parameters.
      * @throws NullPointerException if the parameters are {@code null}.
      */
-    @Autowired
-    public final void setClientConfig(final ClientConfigProperties config) {
+    public ConnectionFactoryImpl(final Vertx vertx, final ClientConfigProperties config) {
+        this.vertx = Objects.requireNonNull(vertx);
         this.config = Objects.requireNonNull(config);
     }
 
@@ -329,10 +319,7 @@ public class ConnectionFactoryImpl implements ConnectionFactory {
             if (vertx == null) {
                 vertx = Vertx.vertx();
             }
-            ConnectionFactoryImpl impl = new ConnectionFactoryImpl();
-            impl.setVertx(vertx);
-            impl.setClientConfig(properties);
-            return impl;
+            return new ConnectionFactoryImpl(vertx, properties);
         }
     }
 }

--- a/core/src/test/java/org/eclipse/hono/connection/ConnectionFactoryImplTest.java
+++ b/core/src/test/java/org/eclipse/hono/connection/ConnectionFactoryImplTest.java
@@ -34,14 +34,11 @@ import io.vertx.proton.ProtonConnection;
  */
 public class ConnectionFactoryImplTest {
 
-    ConnectionFactoryImpl factory;
     Vertx vertx;
 
     @Before
     public void setup() {
         vertx = Vertx.vertx();
-        factory = new ConnectionFactoryImpl();
-        factory.setVertx(vertx);
     }
 
     /**
@@ -58,7 +55,7 @@ public class ConnectionFactoryImplTest {
         props.setPort(12000); // no server running on port
         props.setAmqpHostname("hono");
         props.setName("client");
-        factory.setClientConfig(props);
+        ConnectionFactoryImpl factory = new ConnectionFactoryImpl(vertx, props);
 
         // WHEN trying to connect to the server
         final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
Use "hono.registration.*" properties to configure the RegistrationServiceClient in protocol adapters.

If no such properties are configured (or to be exact, if no "hono.registration.host" property is set), the honoClient will be used as RegistrationServiceClient.

Adding information about this in the protocol adapter documentation is not included here - to be done in a follow-up commit.