### PR TITLE
[#203] Device registry as separate microservice :auth-server,registra…

### DIFF
--- a/example/docker/docker-compose.yml
+++ b/example/docker/docker-compose.yml
@@ -96,6 +96,28 @@ services:
     volumes:
       - /home/hono/registration
 
+  device-registry:
+    image: eclipsehono/hono-service-device-registry:${project.version}
+    networks:
+      hono-net:
+        aliases:
+          - device-registry.hono
+    ports:
+      - "25671:5671"
+    environment:
+      - HONO_AUTH_HOST=auth-server.hono
+      - HONO_AUTH_TRUST_STORE_PATH=/etc/hono/certs/trusted-certs.pem
+      - HONO_AUTH_NAME=device-registry
+      - HONO_AUTH_VALIDATION_CERT_PATH=/etc/hono/certs/auth-server-cert.pem
+      - HONO_DEVICE_REGISTRY_BIND_ADDRESS=0.0.0.0
+      - HONO_DEVICE_REGISTRY_KEY_PATH=/etc/hono/certs/device-registry-key.pem
+      - HONO_DEVICE_REGISTRY_CERT_PATH=/etc/hono/certs/device-registry-cert.pem
+      - HONO_DEVICE_REGISTRY_INSECURE_PORT_ENABLED=false
+      - HONO_DEVICE_REGISTRY_MAX_INSTANCES=1
+      - HONO_DEVICE_REGISTRY_REGISTRATION_ASSERTION_SHARED_SECRET="g#aWO!BUm7aj*#%X*VGXKFhxkhNrMNj0"
+      - LOGGING_CONFIG=classpath:logback-spring.xml
+      - SPRING_PROFILES_ACTIVE=default,dev
+
   rest-adapter:
     image: eclipsehono/hono-adapter-rest-vertx:${project.version}
     networks:

--- a/services/device-registry/pom.xml
+++ b/services/device-registry/pom.xml
@@ -127,7 +127,7 @@
                       <inline>
                         <fileSets>
                           <fileSet>
-                            <directory>${project.build.directory}}/certs</directory>
+                            <directory>${project.build.directory}/certs</directory>
                             <outputDirectory>etc/hono/certs</outputDirectory>
                             <includes>
                               <include>device-registry-*.pem</include>

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
@@ -14,8 +14,13 @@ package org.eclipse.hono.deviceregistry;
 
 import java.util.Objects;
 
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Verticle;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractApplication;
+import org.eclipse.hono.service.auth.AuthenticationService;
+import org.eclipse.hono.service.credentials.CredentialsService;
+import org.eclipse.hono.service.registration.RegistrationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -25,25 +30,52 @@ import org.springframework.context.annotation.Configuration;
 import io.vertx.core.Future;
 
 /**
- * A Spring Boot application exposing an AMQP based endpoint that implements Hono's Credentials API.
- *
+ * A Spring Boot application exposing an AMQP based endpoint that implements Hono's device registry.
+ * <p>
+ * The application implements Hono's <a href="https://www.eclipse.org/hono/api/Device-Registration-API/">Device Registration API</a>
+ * and <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+ * </p>
  */
-@ComponentScan(basePackages = {"org.eclipse.hono.deviceregistry","org.eclipse.hono.service.credentials"})
+@ComponentScan(basePackages = {"org.eclipse.hono.service","org.eclipse.hono.deviceregistry"})
 @Configuration
 @EnableAutoConfiguration
 public class Application extends AbstractApplication<SimpleDeviceRegistryServer, ServiceConfigProperties> {
 
-    private FileBasedCredentialsService credentialsService;
+    private AuthenticationService authenticationService;
+    private CredentialsService credentialsService;
+    private RegistrationService registrationService;
 
     /**
-     * Sets the authentication service implementation this server is based on.
+     * Sets the credentials service implementation this server is based on.
      * 
      * @param credentialsService The service implementation.
      * @throws NullPointerException if service is {@code null}.
      */
     @Autowired
-    public void setCredentialsService(final FileBasedCredentialsService credentialsService) {
+    public final void setCredentialsService(final CredentialsService credentialsService) {
         this.credentialsService = Objects.requireNonNull(credentialsService);
+    }
+
+    /**
+     * Sets the registration service implementation this server is based on.
+     *
+     * @param registrationService the registrationService to set
+     * @throws NullPointerException if service is {@code null}.
+     */
+    @Autowired
+    public final void setRegistrationService(final RegistrationService registrationService) {
+        this.registrationService = Objects.requireNonNull(registrationService);
+    }
+
+    /**
+     * Sets the authentication service implementation this server is based on.
+     *
+     * @param authenticationService the authenticationService to set
+     * @throws NullPointerException if service is {@code null}.
+     */
+    @Autowired
+    public final void setAuthenticationService(final AuthenticationService authenticationService) {
+        this.authenticationService = Objects.requireNonNull(authenticationService);
     }
 
     @Override
@@ -53,23 +85,45 @@ public class Application extends AbstractApplication<SimpleDeviceRegistryServer,
     @Override
     protected Future<Void> postRegisterServiceVerticles() {
         Future<Void> result = Future.future();
-        if (credentialsService == null) {
-            result.fail("no authentication service implementation configured");
+        CompositeFuture.all(
+                deployAuthenticationService(), // we only need 1 authentication service
+                deployRegistrationService(),
+                deployCredentialsService()).setHandler(ar -> {
+            if (ar.succeeded()) {
+                result.complete();
+            } else {
+                result.fail(ar.cause());
+            }
+        });
+        return result;
+    }
+
+    private Future<String> deployCredentialsService() {
+        log.info("Starting credentials service {}", credentialsService);
+        Future<String> result = Future.future();
+        getVertx().deployVerticle(credentialsService, result.completer());
+        return result;
+    }
+
+    private Future<String> deployAuthenticationService() {
+        Future<String> result = Future.future();
+        if (!Verticle.class.isInstance(authenticationService)) {
+            result.fail("authentication service is not a verticle");
         } else {
-            log.debug("deploying {}", credentialsService);
-            getVertx().deployVerticle(credentialsService, s -> {
-                if (s.succeeded()) {
-                    result.complete();
-                } else {
-                    result.fail(s.cause());
-                }
-            });
+            log.info("Starting authentication service {}", authenticationService);
+            getVertx().deployVerticle((Verticle) authenticationService, result.completer());
         }
         return result;
     }
 
+    private Future<String> deployRegistrationService() {
+        log.info("Starting registration service {}", registrationService);
+        Future<String> result = Future.future();
+        getVertx().deployVerticle(registrationService, result.completer());
+        return result;
+    }
     /**
-     * Starts the Authentication Server.
+     * Starts the Device Registry Server.
      * 
      * @param args command line arguments to pass to the server.
      */

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DeviceRegistryConfigProperties.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DeviceRegistryConfigProperties.java
@@ -15,12 +15,13 @@ package org.eclipse.hono.deviceregistry;
 import java.util.Objects;
 
 import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.config.SignatureSupportingConfigProperties;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
 
 /**
- * Configuration properties for the device registry as own server.
+ * Configuration properties for the Hono's device registry as own server.
  *
  */
 public final class DeviceRegistryConfigProperties extends ServiceConfigProperties {
@@ -28,7 +29,16 @@ public final class DeviceRegistryConfigProperties extends ServiceConfigPropertie
     private static final Resource DEFAULT_CREDENTIALS_RESOURCE = new ClassPathResource("credentials.json");
     private Resource credentialsResource = DEFAULT_CREDENTIALS_RESOURCE;
     private boolean saveToFile;
+    private final SignatureSupportingConfigProperties registrationAssertionProperties = new SignatureSupportingConfigProperties();
 
+    /**
+     * Gets the properties for determining key material for creating/validation registration assertion tokens.
+     *
+     * @return The properties.
+     */
+    public SignatureSupportingConfigProperties getRegistrationAssertion() {
+        return registrationAssertionProperties;
+    }
 
     /**
      * Get the resource that the credentials should be loaded from.
@@ -37,7 +47,7 @@ public final class DeviceRegistryConfigProperties extends ServiceConfigPropertie
      * 
      * @return The resource.
      */
-    public final Resource getCredentialsPath() {
+    public Resource getCredentialsPath() {
         return credentialsResource;
     }
 
@@ -49,7 +59,7 @@ public final class DeviceRegistryConfigProperties extends ServiceConfigPropertie
      * @param credentialsResource The resource.
      * @throws NullPointerException if the resource is {@code null}.
      */
-    public final void setCredentialsPath(final Resource credentialsResource) {
+    public void setCredentialsPath(final Resource credentialsResource) {
         this.credentialsResource = Objects.requireNonNull(credentialsResource);
     }
 

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
@@ -1,0 +1,369 @@
+/**
+ * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.deviceregistry;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.FileSystem;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.eclipse.hono.service.registration.BaseRegistrationService;
+import org.eclipse.hono.util.RegistrationResult;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.net.HttpURLConnection.*;
+import static org.eclipse.hono.util.RegistrationConstants.*;
+
+/**
+ * A registration service that keeps all data in memory but is backed by a file.
+ * <p>
+ * On startup this adapter loads all registered devices from a file. On shutdown all
+ * devices kept in memory are written to the file.
+ */
+@Repository
+@ConfigurationProperties(prefix = "hono.registration")
+@Profile({"default", "registration-file"})
+public final class FileBasedRegistrationService extends BaseRegistrationService {
+
+    /**
+     * The default number of devices that can be registered for each tenant.
+     */
+    public static final int DEFAULT_MAX_DEVICES_PER_TENANT = 100;
+    private static final String ARRAY_DEVICES = "devices";
+    private static final String FIELD_TENANT = "tenant";
+
+    // <tenantId, <deviceId, registrationData>>
+    private Map<String, Map<String, JsonObject>> identities = new HashMap<>();
+    // the name of the file used to persist the registry content
+    private String filename = "device-identities.json";
+    private boolean saveToFile = false;
+    private boolean isModificationEnabled = true;
+    private int maxDevicesPerTenant = DEFAULT_MAX_DEVICES_PER_TENANT;
+    private boolean running = false;
+    private boolean dirty = false;
+
+    /**
+     * Sets the path to the file that the content of the registry should be persisted
+     * periodically.
+     * <p>
+     * Default value is <em>device-identities.json</em>.
+     * 
+     * @param filename The name of the file to persist to (can be a relative or absolute path).
+     * @throws IllegalStateException if this registry is already running.
+     */
+    public void setFilename(final String filename) {
+        if (running) {
+            throw new IllegalStateException("registry already started");
+        }
+        this.filename = filename;
+    }
+
+    /**
+     * Sets whether the content of the registry should be persisted to the file system
+     * periodically.
+     * <p>
+     * Default value is {@code true}.
+     * 
+     * @param enabled {@code true} if registry content should be persisted.
+     * @throws IllegalStateException if this registry is already running.
+     */
+    public void setSaveToFile(final boolean enabled) {
+        if (running) {
+            throw new IllegalStateException("registry already started");
+        }
+        this.saveToFile = enabled;
+    }
+
+    /**
+     * Sets whether this registry allows modification and removal of registered devices.
+     * <p>
+     * If set to {@code false} then the methods {@link #updateDevice(String, String, JsonObject, Handler)}
+     * and {@link #removeDevice(String, String, Handler)} always return a <em>403 Forbidden</em> response.
+     * <p>
+     * The default value of this property is {@code true}.
+     * 
+     * @param flag The flag.
+     */
+    public void setModificationEnabled(final boolean flag) {
+        isModificationEnabled = flag;
+    }
+
+    /**
+     * Sets the maximum nubmer of devices that can be registered for each tenant.
+     * <p>
+     * The default value of this property is {@link #DEFAULT_MAX_DEVICES_PER_TENANT}.
+     * 
+     * @param maxDevices The maximum number of devices.
+     * @throws IllegalArgumentException if the number of devices is &lt;= 0.
+     */
+    public void setMaxDevicesPerTenant(final int maxDevices) {
+        if (maxDevices <= 0) {
+            throw new IllegalArgumentException("max devices must be > 0");
+        }
+        this.maxDevicesPerTenant = maxDevices;
+    }
+
+    @Override
+    protected void doStart(Future<Void> startFuture) {
+
+        if (!running) {
+            if (!isModificationEnabled) {
+                log.info("modification of registered devices has been disabled");
+            }
+            if (filename != null) {
+                loadRegistrationData();
+                if (saveToFile) {
+                    log.info("saving device identities to file every 3 seconds");
+                    vertx.setPeriodic(3000, saveIdentities -> {
+                        saveToFile(Future.future());
+                    });
+                } else {
+                    log.info("persistence is disabled, will not safe device identities to file");
+                }
+            }
+        }
+        running = true;
+        startFuture.complete();
+    }
+
+    private void loadRegistrationData() {
+        if (filename != null) {
+            final FileSystem fs = vertx.fileSystem();
+            log.debug("trying to load device registration information from file {}", filename);
+            if (fs.existsBlocking(filename)) {
+                final AtomicInteger deviceCount = new AtomicInteger();
+                fs.readFile(filename, readAttempt -> {
+                   if (readAttempt.succeeded()) {
+                       JsonArray allObjects = new JsonArray(new String(readAttempt.result().getBytes()));
+                       for (Object obj : allObjects) {
+                           JsonObject tenant = (JsonObject) obj;
+                           String tenantId = tenant.getString(FIELD_TENANT);
+                           Map<String, JsonObject> deviceMap = new HashMap<>();
+                           for (Object deviceObj : tenant.getJsonArray(ARRAY_DEVICES)) {
+                               JsonObject device = (JsonObject) deviceObj;
+                               deviceMap.put(device.getString(FIELD_DEVICE_ID), device.getJsonObject(FIELD_DATA));
+                               deviceCount.incrementAndGet();
+                           }
+                           identities.put(tenantId, deviceMap);
+                       }
+                       log.info("successfully loaded {} device identities from file [{}]", deviceCount.get(), filename);
+                   } else {
+                       log.warn("could not load device identities from file [{}]", filename, readAttempt.cause());
+                   }
+                });
+            } else {
+                log.debug("device identity file {} does not exist (yet)", filename);
+            }
+        }
+    }
+
+    @Override
+    protected void doStop(final Future<Void> stopFuture) {
+
+        if (running) {
+            Future<Void> stopTracker = Future.future();
+            stopTracker.setHandler(stopAttempt -> {
+                running = false;
+                stopFuture.complete();
+            });
+
+            if (saveToFile) {
+                saveToFile(stopTracker);
+            } else {
+                stopTracker.complete();
+            }
+        } else {
+            stopFuture.complete();
+        }
+    }
+
+    private void saveToFile(final Future<Void> writeResult) {
+
+        if (!dirty) {
+            log.trace("registry does not need to be persisted");
+            return;
+        }
+
+        final FileSystem fs = vertx.fileSystem();
+        if (!fs.existsBlocking(filename)) {
+            fs.createFileBlocking(filename);
+        }
+        final AtomicInteger idCount = new AtomicInteger();
+        JsonArray tenants = new JsonArray();
+        for (Entry<String, Map<String, JsonObject>> entry : identities.entrySet()) {
+            JsonArray devices = new JsonArray();
+            for (Entry<String, JsonObject> deviceEntry : entry.getValue().entrySet()) {
+                devices.add(
+                        new JsonObject()
+                            .put(FIELD_DEVICE_ID, deviceEntry.getKey())
+                            .put(FIELD_DATA, deviceEntry.getValue()));
+                idCount.incrementAndGet();
+            }
+            tenants.add(
+                    new JsonObject()
+                        .put(FIELD_TENANT, entry.getKey())
+                        .put(ARRAY_DEVICES, devices));
+        }
+        fs.writeFile(filename, Buffer.factory.buffer(tenants.encodePrettily()), writeAttempt -> {
+            if (writeAttempt.succeeded()) {
+                dirty = false;
+                log.trace("successfully wrote {} device identities to file {}", idCount.get(), filename);
+                writeResult.complete();
+            } else {
+                log.warn("could not write device identities to file {}", filename, writeAttempt.cause());
+                writeResult.fail(writeAttempt.cause());
+            }
+        });
+    }
+
+    @Override
+    public void getDevice(final String tenantId, final String deviceId, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+        resultHandler.handle(Future.succeededFuture(getDevice(tenantId, deviceId)));
+    }
+
+    RegistrationResult getDevice(final String tenantId, final String deviceId) {
+        JsonObject data = getRegistrationData(tenantId, deviceId);
+        if (data != null) {
+            return RegistrationResult.from(HTTP_OK, getResultPayload(deviceId, data));
+        } else {
+            return RegistrationResult.from(HTTP_NOT_FOUND);
+        }
+    }
+
+    private JsonObject getRegistrationData(final String tenantId, final String deviceId) {
+
+        final Map<String, JsonObject> devices = identities.get(tenantId);
+        if (devices != null) {
+            return devices.get(deviceId);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void findDevice(final String tenantId, final String key, final String value, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+        resultHandler.handle(Future.succeededFuture(findDevice(tenantId, key, value)));
+    }
+
+    RegistrationResult findDevice(final String tenantId, final String key, final String value) {
+        final Map<String, JsonObject> devices = identities.get(tenantId);
+        if (devices != null) {
+            for (Entry<String, JsonObject> entry : devices.entrySet()) {
+                if (value.equals(entry.getValue().getString(key))) {
+                    return RegistrationResult.from(HTTP_OK, getResultPayload(entry.getKey(), entry.getValue()));
+                }
+            }
+        }
+        return RegistrationResult.from(HTTP_NOT_FOUND);
+    }
+
+    @Override
+    public void removeDevice(final String tenantId, final String deviceId, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+
+        resultHandler.handle(Future.succeededFuture(removeDevice(tenantId, deviceId)));
+    }
+
+    RegistrationResult removeDevice(final String tenantId, final String deviceId) {
+
+        if (isModificationEnabled) {
+            final Map<String, JsonObject> devices = identities.get(tenantId);
+            if (devices != null && devices.containsKey(deviceId)) {
+                dirty = true;
+                return RegistrationResult.from(HTTP_OK, getResultPayload(deviceId, devices.remove(deviceId)));
+            } else {
+                return RegistrationResult.from(HTTP_NOT_FOUND);
+            }
+        } else {
+            return RegistrationResult.from(HTTP_FORBIDDEN);
+        }
+    }
+
+    @Override
+    public void addDevice(final String tenantId, final String deviceId, final JsonObject data, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+
+        resultHandler.handle(Future.succeededFuture(addDevice(tenantId, deviceId, data)));
+    }
+
+    /**
+     * Adds a device to this registry.
+     * 
+     * @param tenantId The tenant the device belongs to.
+     * @param deviceId The ID of the device to add.
+     * @param data Additional data to register with the device (may be {@code null}).
+     * @return The outcome of the operation indicating success or failure.
+     */
+    public RegistrationResult addDevice(final String tenantId, final String deviceId, final JsonObject data) {
+
+        JsonObject obj = data != null ? data : new JsonObject().put(FIELD_ENABLED, Boolean.TRUE);
+        Map<String, JsonObject> devices = getDevicesForTenant(tenantId);
+        if (devices.size() < maxDevicesPerTenant) {
+            if (devices.putIfAbsent(deviceId, obj) == null) {
+                dirty = true;
+                return RegistrationResult.from(HTTP_CREATED);
+            } else {
+                return RegistrationResult.from(HTTP_CONFLICT);
+            }
+        } else {
+            return RegistrationResult.from(HTTP_FORBIDDEN);
+        }
+    }
+
+    @Override
+    public void updateDevice(final String tenantId, final String deviceId, final JsonObject data, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+
+        resultHandler.handle(Future.succeededFuture(updateDevice(tenantId, deviceId, data)));
+    }
+
+    RegistrationResult updateDevice(final String tenantId, final String deviceId, final JsonObject data) {
+
+        if (isModificationEnabled) {
+            JsonObject obj = data != null ? data : new JsonObject().put(FIELD_ENABLED, Boolean.TRUE);
+            final Map<String, JsonObject> devices = identities.get(tenantId);
+            if (devices != null && devices.containsKey(deviceId)) {
+                dirty = true;
+                return RegistrationResult.from(HTTP_OK, getResultPayload(deviceId, devices.put(deviceId, obj)));
+            } else {
+                return RegistrationResult.from(HTTP_NOT_FOUND);
+            }
+        } else {
+            return RegistrationResult.from(HTTP_FORBIDDEN);
+        }
+    }
+
+    private Map<String, JsonObject> getDevicesForTenant(final String tenantId) {
+        return identities.computeIfAbsent(tenantId, id -> new ConcurrentHashMap<>());
+    }
+
+    /**
+     * Removes all devices from the registry.
+     */
+    public void clear() {
+        dirty = true;
+        identities.clear();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s[filename=%s]", FileBasedRegistrationService.class.getSimpleName(), filename);
+    }
+}

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/SimpleDeviceRegistryServer.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/SimpleDeviceRegistryServer.java
@@ -30,9 +30,9 @@ import java.util.UUID;
 
 
 /**
- * A server that implements Hono's Credentials and Registration APIs as the default implementation of Hono's device registry.
+ * A server that implements Hono's <a href="https://www.eclipse.org/hono/api/Device-Registration-API/">Device Registration API</a> and
+ * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a> as the default implementation of Hono's device registry.
  *
- * TODO: Currently only implements the Credentials API. Registration API implementation to be added.
  * TODO: add metrics.
  */
 @Component

--- a/services/device-registry/src/main/resources/device-identities.json
+++ b/services/device-registry/src/main/resources/device-identities.json
@@ -1,0 +1,7 @@
+[ {
+  "tenant" : "DEFAULT_TENANT",
+  "devices" : [ {
+    "id" : "4711",
+    "data" : { }
+  } ]
+} ]

--- a/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationServiceTest.java
+++ b/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationServiceTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.deviceregistry;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.file.FileSystem;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.eclipse.hono.util.RegistrationResult;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static java.net.HttpURLConnection.*;
+import static org.eclipse.hono.util.RegistrationConstants.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link FileBasedRegistrationService}.
+ */
+@RunWith(VertxUnitRunner.class)
+public class FileBasedRegistrationServiceTest
+{
+   private static final String TENANT = "tenant";
+   private static final String DEVICE = "device";
+   private FileBasedRegistrationService registrationService;
+   Vertx vertx;
+   EventBus eventBus;
+
+   @Before
+   public void setUp() throws Exception {
+      vertx = mock(Vertx.class);
+      Context ctx = mock(Context.class);
+      eventBus = mock(EventBus.class);
+      when(vertx.eventBus()).thenReturn(eventBus);
+
+      registrationService = new FileBasedRegistrationService();
+      registrationService.init(vertx, ctx);
+   }
+
+   /**
+    * Removes all devices from the registry.
+    */
+   @After
+   public void clear() {
+       registrationService.clear();
+   }
+
+   /**
+    * Verifies that the registry enforces the maximum devices per tenant limit.
+    */
+   @Test
+   public void testAddDeviceFailsIfDeviceLimitIsReached() {
+
+       // GIVEN a registry whose devices-per-tenant limit has been reached
+       registrationService.setMaxDevicesPerTenant(1);
+       registrationService.addDevice(TENANT, DEVICE, null);
+
+       // WHEN registering an additional device for the tenant
+       RegistrationResult result = registrationService.addDevice(TENANT, "newDevice", null);
+
+       // THEN the result contains a FORBIDDEN status code and the device has not been added to the registry
+       assertThat(result.getStatus(), is(HTTP_FORBIDDEN));
+       assertThat(registrationService.getDevice(TENANT, "newDevice").getStatus(), is(HTTP_NOT_FOUND));
+   }
+
+   /**
+    * Verifies that the <em>modificationEnabled</em> property prevents updating an existing entry.
+    */
+   @Test
+   public void testUpdateDeviceFailsIfModificationIsDisabled() {
+
+       // GIVEN a registry that has been configured to not allow modification of entries
+       // which contains a device
+       registrationService.setModificationEnabled(false);
+       registrationService.addDevice(TENANT, DEVICE, null);
+
+       // WHEN trying to update the device
+       RegistrationResult result = registrationService.updateDevice(TENANT, DEVICE, new JsonObject().put("updated", true));
+
+       // THEN the result contains a FORBIDDEN status code and the device has not been updated
+       assertThat(result.getStatus(), is(HTTP_FORBIDDEN));
+       assertFalse(registrationService.getDevice(TENANT, DEVICE).getPayload().containsKey("updated"));
+   }
+
+   /**
+    * Verifies that the <em>modificationEnabled</em> property prevents removing an existing entry.
+    */
+   @Test
+   public void testRemoveDeviceFailsIfModificationIsDisabled() {
+
+       // GIVEN a registry that has been configured to not allow modification of entries
+       // which contains a device
+       registrationService.setModificationEnabled(false);
+       registrationService.addDevice(TENANT, DEVICE, null);
+
+       // WHEN trying to remove the device
+       RegistrationResult result = registrationService.removeDevice(TENANT, DEVICE);
+
+       // THEN the result contains a FORBIDDEN status code and the device has not been removed
+       assertThat(result.getStatus(), is(HTTP_FORBIDDEN));
+       assertThat(registrationService.getDevice(TENANT, DEVICE).getStatus(), is(HTTP_OK));
+   }
+
+   @Test
+   public void testGetUnknownDeviceReturnsNotFound() {
+       processMessageAndExpectResponse(mockMsg(ACTION_GET), getServiceReplyAsJson(HTTP_NOT_FOUND, TENANT, DEVICE));
+   }
+
+   @Test
+   public void testDeregisterUnknownDeviceReturnsNotFound() {
+       processMessageAndExpectResponse(mockMsg(ACTION_DEREGISTER), getServiceReplyAsJson(HTTP_NOT_FOUND, TENANT, DEVICE));
+   }
+
+   @Test
+   public void testProcessRegisterMessageDetectsUnsupportedAction() {
+       processMessageAndExpectResponse(mockMsg("bumlux"), getServiceReplyAsJson(HTTP_BAD_REQUEST, TENANT, DEVICE));
+   }
+
+   @Test
+   public void testDuplicateRegistrationFails() {
+       processMessageAndExpectResponse(mockMsg(ACTION_REGISTER), getServiceReplyAsJson(HTTP_CREATED, TENANT, DEVICE));
+       processMessageAndExpectResponse(mockMsg(ACTION_REGISTER), getServiceReplyAsJson(HTTP_CONFLICT, TENANT, DEVICE));
+   }
+
+   @Test
+   public void testGetSucceedsForRegisteredDevice() {
+       processMessageAndExpectResponse(mockMsg(ACTION_REGISTER), getServiceReplyAsJson(HTTP_CREATED, TENANT, DEVICE));
+       processMessageAndExpectResponse(mockMsg(ACTION_GET), getServiceReplyAsJson(HTTP_OK, TENANT, DEVICE, expectedMessage(DEVICE)));
+   }
+
+   @Test
+   public void testGetFailsForDeregisteredDevice() {
+       processMessageAndExpectResponse(mockMsg(ACTION_REGISTER), getServiceReplyAsJson(HTTP_CREATED, TENANT, DEVICE));
+       processMessageAndExpectResponse(mockMsg(ACTION_DEREGISTER), getServiceReplyAsJson(HTTP_OK, TENANT, DEVICE, expectedMessage(DEVICE)));
+       processMessageAndExpectResponse(mockMsg(ACTION_GET), getServiceReplyAsJson(HTTP_NOT_FOUND, TENANT, DEVICE));
+   }
+
+   @Test
+   public void testPeriodicSafeJobIsNotScheduledIfSavingIfDisabled(final TestContext ctx) throws Exception {
+
+       FileSystem fs = mock(FileSystem.class);
+       when(fs.existsBlocking(anyString())).thenReturn(Boolean.FALSE);
+       when(vertx.fileSystem()).thenReturn(fs);
+
+       Future<Void> startupTracker = Future.future();
+       startupTracker.setHandler(ctx.asyncAssertSuccess(done -> {
+           verify(vertx, never()).setPeriodic(anyLong(), any(Handler.class));
+       }));
+
+       registrationService.setSaveToFile(false);
+       registrationService.doStart(startupTracker);
+   }
+
+   @Test
+   public void testContentsNotSavedOnShutdownIfSavingIfDisabled(final TestContext ctx) throws Exception {
+
+       FileSystem fs = mock(FileSystem.class);
+       when(fs.existsBlocking(anyString())).thenReturn(Boolean.FALSE);
+       when(vertx.fileSystem()).thenReturn(fs);
+
+       Future<Void> shutdownTracker = Future.future();
+       shutdownTracker.setHandler(ctx.asyncAssertSuccess(done -> {
+           verify(vertx, times(1)).fileSystem();
+       }));
+
+       registrationService.setSaveToFile(false);
+       Future<Void> startupTracker = Future.future();
+       registrationService.doStart(startupTracker);
+       startupTracker.compose(started -> {
+           registrationService.addDevice(TENANT, DEVICE, new JsonObject());
+           registrationService.doStop(shutdownTracker);
+       }, shutdownTracker);
+   }
+
+   private static JsonObject expectedMessage(final String id) {
+       return new JsonObject()
+               .put(FIELD_DEVICE_ID, id)
+               .put(FIELD_DATA, new JsonObject().put(FIELD_ENABLED, Boolean.TRUE));
+   }
+
+   private static Message<JsonObject> mockMsg(final String action) {
+       return mockMsg(action, TENANT);
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Message<JsonObject> mockMsg(final String action, final String tenant) {
+       final JsonObject registrationJson = getServiceRequestAsJson(action, tenant, DEVICE);
+       final Message<JsonObject> message = mock(Message.class);
+       when(message.body()).thenReturn(registrationJson);
+       return message;
+   }
+
+   private void processMessageAndExpectResponse(final Message<JsonObject> request, final JsonObject expectedResponse) {
+       registrationService.processRegistrationMessage(request);
+       verify(request).reply(expectedResponse);
+   }
+}

--- a/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/StandaloneCredentialsApiTest.java
+++ b/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/StandaloneCredentialsApiTest.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests validating Hono's Credentials API using a stand alone server.
+ * Tests validating {@link FileBasedCredentialsService} using a stand alone server.
  */
 @RunWith(VertxUnitRunner.class)
 public class StandaloneCredentialsApiTest {

--- a/services/device-registry/src/test/resources/logback-test.xml
+++ b/services/device-registry/src/test/resources/logback-test.xml
@@ -17,7 +17,7 @@
   <logger name="org.eclipse.hono.service" level="INFO"/>
   <logger name="org.eclipse.hono.service.amqp" level="INFO"/>
   <logger name="org.eclipse.hono.service.auth" level="INFO"/>
-  <logger name="org.eclipse.hono.service.deviceregistry.impl" level="INFO"/>
+  <logger name="org.eclipse.hono.deviceregistry" level="INFO"/>
   <logger name="org.eclipse.hono.service.auth.delegating" level="INFO"/>
 
   <logger name="io.vertx.proton.impl" level="INFO"/>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -119,6 +119,48 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </log>
                   </run>
                 </image>
+                <!-- ##### Device registry server ##### -->
+                <image>
+                  <name>eclipsehono/hono-service-device-registry</name>
+                  <build>
+                    <from>eclipsehono/hono-service-device-registry:${project.version}</from>
+                    <assembly>
+                      <mode>dir</mode>
+                      <basedir>/etc/hono</basedir>
+                      <inline>
+                        <id>config</id>
+                        <fileSets>
+                          <fileSet>
+                            <directory>${project.basedir}/src/test/resources/deviceregistry</directory>
+                            <outputDirectory>.</outputDirectory>
+                            <includes>
+                              <include>*</include>
+                            </includes>
+                          </fileSet>
+                        </fileSets>
+                      </inline>
+                    </assembly>
+                  </build>
+                  <run>
+                    <ports>
+                      <port>+deviceregistry.ip:deviceregistry.amqp.port:5672</port>
+                    </ports>
+                    <network>
+                      <mode>custom</mode>
+                      <name>hono</name>
+                      <alias>device-registry.hono</alias>
+                    </network>
+                    <env>
+                      <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SPRING_PROFILES_ACTIVE>credentials-file,registration-file,prod</SPRING_PROFILES_ACTIVE>
+                    </env>
+                    <log>
+                      <prefix>REGISTRY</prefix>
+                      <color>yellow</color>
+                    </log>
+                  </run>
+                </image>
                 <!-- ##### ActiveMQ Artemis message broker ##### -->
                 <image>
                   <name>eclipsehono/broker:${project.version}</name>
@@ -257,6 +299,8 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 <hono.amqp.port>${hono.amqp.port}</hono.amqp.port>
                 <downstream.host>${qpid.ip}</downstream.host>
                 <downstream.amqp.port>${qpid.amqp.port}</downstream.amqp.port>
+                <deviceregistry.host>${deviceregistry.ip}</deviceregistry.host>
+                <deviceregistry.amqp.port>${deviceregistry.amqp.port}</deviceregistry.amqp.port>
               </systemProperties>
               <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
               <test>*IT</test>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -19,6 +19,7 @@ Run the tests by executing the following command from the `tests` directory (add
 This starts the following Docker containers and runs the test cases against them
 
 * hono-server
+* hono-device-registry
 * Qpid Dispatch Router
 * ActiveMQ Artemis Broker
 * test-config (a volume image that contains configuration files for the Hono server)

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -22,6 +22,8 @@ public final class IntegrationTestSupport {
     public static final String PROPERTY_HONO_PORT = "hono.amqp.port";
     public static final String PROPERTY_HONO_USERNAME = "hono.username";
     public static final String PROPERTY_HONO_PASSWORD = "hono.password";
+    public static final String PROPERTY_DEVICEREGISTRY_HOST = "deviceregistry.host";
+    public static final String PROPERTY_DEVICEREGISTRY_PORT = "deviceregistry.amqp.port";
     public static final String PROPERTY_DOWNSTREAM_HOST = "downstream.host";
     public static final String PROPERTY_DOWNSTREAM_PORT = "downstream.amqp.port";
     public static final String PROPERTY_DOWNSTREAM_USERNAME = "downstream.username";

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/DeviceRegistrationIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/DeviceRegistrationIT.java
@@ -46,8 +46,8 @@ public class DeviceRegistrationIT {
     private RegistrationTestSupport registration;
 
     @BeforeClass
-    public static void connectToHono() throws JMSException, NamingException {
-        client = JmsIntegrationTestSupport.newClient("hono", HONO_USER, HONO_PASSWORD);
+    public static void connectToDeviceRegistry() throws JMSException, NamingException {
+        client = JmsIntegrationTestSupport.newClient(HONO_DEVICEREGISTRY, HONO_USER, HONO_PASSWORD);
     }
 
     @Before

--- a/tests/src/test/resources/auth/permissions.json
+++ b/tests/src/test/resources/auth/permissions.json
@@ -41,6 +41,11 @@
       "password": "secret",
       "authorities": [ "DEFAULT_TENANT-manager" ]
     },
+    "honodr-client": {
+      "mechanism": "PLAIN",
+      "password": "secret",
+      "authorities": [ "DEFAULT_TENANT-manager" ]
+    },
     "connector-client": {
       "mechanism": "PLAIN",
       "password": "connector-secret",

--- a/tests/src/test/resources/deviceregistry/application.yml
+++ b/tests/src/test/resources/deviceregistry/application.yml
@@ -1,0 +1,16 @@
+hono:
+  auth:
+    host: auth-server.hono
+    port: 5672
+    name: device-registry
+    validation:
+      certPath: /etc/hono/certs/auth-server-cert.pem
+  device:
+    registry:
+      insecurePortEnabled: true
+      insecurePortBindAddress: 0.0.0.0
+      maxInstances: 1
+      registrationAssertion:
+        sharedSecret: sdgfsdafazufgsdafjhfgsdajfgwhriojsdafjlksdhfgsa8fg452368gdf
+      startupTimeout: 65
+

--- a/tests/src/test/resources/deviceregistry/logback-spring.xml
+++ b/tests/src/test/resources/deviceregistry/logback-spring.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <!-- 
+    This is the logging configuration that is used by the
+    Hono Device Registry Docker image while executing the integration tests.
+
+    Any changes made here will be reflected on the next start
+    of the Hono Device Registry Docker image only, i.e. the next time
+
+    mvn -Prun-tests verify
+
+    is invoked.
+   -->
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <springProfile name="dev">
+    <logger name="org.eclipse.hono" level="DEBUG"/>
+    <logger name="org.eclipse.hono.auth" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.connection" level="DEBUG"/>
+    <logger name="org.eclipse.hono.server" level="DEBUG"/>
+    <logger name="org.eclipse.hono.service.credentials.impl" level="DEBUG"/>
+    <logger name="org.eclipse.hono.service.registration.impl" level="DEBUG"/>
+    <logger name="org.eclipse.hono.telemetry.impl" level="DEBUG"/>
+
+    <logger name="io.netty.handler.logging.LoggingHandler" level="DEBUG"/>
+
+    <logger name="io.vertx.proton.impl" level="INFO"/>
+    <logger name="io.vertx.core.net.impl" level="INFO"/>
+  </springProfile>
+
+  <springProfile name="prod">
+    <logger name="org.eclipse.hono" level="INFO"/>
+    <logger name="org.eclipse.hono.auth" level="INFO"/>
+    <logger name="org.eclipse.hono.server" level="INFO"/>
+    <logger name="org.eclipse.hono.service.credentials.impl" level="INFO"/>
+    <logger name="org.eclipse.hono.service.registration.impl" level="INFO"/>
+    <logger name="org.eclipse.hono.telemetry.impl" level="INFO"/>
+
+    <logger name="io.netty.handler.logging.LoggingHandler" level="INFO"/>
+
+    <logger name="io.vertx.proton.impl" level="INFO"/>
+    <logger name="io.vertx.core.net.impl" level="INFO"/>
+  </springProfile>
+
+</configuration>


### PR DESCRIPTION
…tion endpoint and credentials endpoint; integration tests changed to only use the device registry instead of Hono server for all registration calls.

Remarks:
- the FileBasedRegistrationService and the FileBasedCredentialsService currently have some dissimilarities that should be eliminated in a followup PR (not relevant for functionality though)
- Hono server for now still has the full registration API implemented. This will be removed in a followup directly after this PR.

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>