### PR TITLE
[#203] Add Openshift deployment for device registry.

### DIFF
--- a/adapters/mqtt-vertx/src/main/fabric8/hono-adapter-mqtt-vertx-dc.yml
+++ b/adapters/mqtt-vertx/src/main/fabric8/hono-adapter-mqtt-vertx-dc.yml
@@ -38,6 +38,20 @@ spec:
           value: /etc/hono/certs/trusted-certs.pem
         - name: HONO_CLIENT_HOSTNAME_VERIFICATION_REQUIRED
           value: "false"
+        - name: HONO_REGISTRATION_NAME
+          value: Hono MQTT Adapter
+        - name: HONO_REGISTRATION_HOST
+          value: ${HONO_SERVICE_DEVICE_REGISTRY_SERVICE_HOST}
+        - name: HONO_REGISTRATION_PORT
+          value: ${HONO_SERVICE_DEVICE_REGISTRY_SERVICE_PORT_AMQPS}
+        - name: HONO_REGISTRATION_USERNAME
+          value: mqtt-adapter@HONO
+        - name: HONO_REGISTRATION_PASSWORD
+          value: mqtt-secret
+        - name: HONO_REGISTRATION_TRUST_STORE_PATH
+          value: /etc/hono/certs/trusted-certs.pem
+        - name: HONO_REGISTRATION_HOSTNAME_VERIFICATION_REQUIRED
+          value: "false"
         - name: HONO_MQTT_BIND_ADDRESS
           value: 0.0.0.0
         - name: HONO_MQTT_INSECURE_PORT_BIND_ADDRESS

--- a/adapters/rest-vertx/src/main/fabric8/hono-adapter-rest-vertx-dc.yml
+++ b/adapters/rest-vertx/src/main/fabric8/hono-adapter-rest-vertx-dc.yml
@@ -36,6 +36,22 @@ spec:
           value: rest-secret
         - name: HONO_CLIENT_TRUST_STORE_PATH
           value: /etc/hono/certs/trusted-certs.pem
+        - name: HONO_CLIENT_HOSTNAME_VERIFICATION_REQUIRED
+          value: "false"
+        - name: HONO_REGISTRATION_NAME
+          value: Hono REST Adapter
+        - name: HONO_REGISTRATION_HOST
+          value: ${HONO_SERVICE_DEVICE_REGISTRY_SERVICE_HOST}
+        - name: HONO_REGISTRATION_PORT
+          value: ${HONO_SERVICE_DEVICE_REGISTRY_SERVICE_PORT_AMQPS}
+        - name: HONO_REGISTRATION_USERNAME
+          value: rest-adapter@HONO
+        - name: HONO_REGISTRATION_PASSWORD
+          value: rest-secret
+        - name: HONO_REGISTRATION_TRUST_STORE_PATH
+          value: /etc/hono/certs/trusted-certs.pem
+        - name: HONO_REGISTRATION_HOSTNAME_VERIFICATION_REQUIRED
+          value: "false"
         - name: HONO_HTTP_BIND_ADDRESS
           value: 0.0.0.0
         - name: HONO_HTTP_INSECURE_PORT_BIND_ADDRESS
@@ -50,8 +66,6 @@ spec:
           value: "1"
         - name: SPRING_PROFILES_ACTIVE
           value: dev
-        - name: HONO_CLIENT_HOSTNAME_VERIFICATION_REQUIRED
-          value: "false"
         livenessProbe:
           httpGet:
             path: "/status"

--- a/application/src/main/fabric8/hono-app-dc.yml
+++ b/application/src/main/fabric8/hono-app-dc.yml
@@ -25,9 +25,9 @@ spec:
           protocol: TCP
         env:
         - name: HONO_AUTH_HOST
-          value: ${HONO_SERVICE_AUTH_HOST}
+          value: ${HONO_SERVICE_AUTH_SERVICE_HOST}
         - name: HONO_AUTH_PORT
-          value: ${HONO_SERVICE_AUTH_PORT_AMQPS}
+          value: ${HONO_SERVICE_AUTH_SERVICE_PORT_AMQPS}
         - name: HONO_AUTH_NAME
           value: hono-server
         - name: HONO_AUTH_CERT_PATH
@@ -60,7 +60,7 @@ spec:
           value: "true"
         - name: HONO_SERVER_INSECURE_PORT_BIND_ADDRESS
           value: 0.0.0.0
-        - name: HONO_SERVER_REGISTRATION_ASSERTION_SHARED_SECRET
+        - name: HONO_SERVER_VALIDATION_SHARED_SECRET
           value: "g#aWO!BUm7aj*#%X*VGXKFhxkhNrMNj0"
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml

--- a/example/docker/docker-compose.yml
+++ b/example/docker/docker-compose.yml
@@ -103,7 +103,7 @@ services:
         aliases:
           - device-registry.hono
     ports:
-      - "25671:5671"
+      - "26671:5671"
     environment:
       - HONO_AUTH_HOST=auth-server.hono
       - HONO_AUTH_TRUST_STORE_PATH=/etc/hono/certs/trusted-certs.pem

--- a/example/openshift/openshift_deploy.sh
+++ b/example/openshift/openshift_deploy.sh
@@ -27,6 +27,12 @@ oc create -f ../../services/auth/target/fabric8/hono-auth-dc.yml
 oc create -f ../../services/auth/target/fabric8/hono-auth-route.yml
 echo ... done
 
+echo Deploying Device Registry ...
+oc create -f ../../services/device-registry/target/fabric8/hono-device-registry-svc.yml
+oc create -f ../../services/device-registry/target/fabric8/hono-device-registry-dc.yml
+oc create -f ../../services/device-registry/target/fabric8/hono-device-registry-route.yml
+echo ... done
+
 echo Deploying Qpid Dispatch Router ...
 oc create -f ../../dispatchrouter/target/fabric8/dispatch-router-svc.yml
 oc create -f ../../dispatchrouter/target/fabric8/dispatch-router-dc.yml

--- a/services/device-registry/pom.xml
+++ b/services/device-registry/pom.xml
@@ -115,6 +115,7 @@
                     <cmd>
                       <exec>
                         <arg>java</arg>
+                        <arg>-Dvertx.cacheDirBase=/tmp</arg>
                         <arg>-jar</arg>
                         <arg>
                           /opt/hono/${project.artifactId}-${project.version}.jar

--- a/services/device-registry/src/main/fabric8/hono-device-registry-dc.yml
+++ b/services/device-registry/src/main/fabric8/hono-device-registry-dc.yml
@@ -1,0 +1,59 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: hono
+    name: ${project.artifactId}
+  name: ${project.artifactId}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hono
+        name: ${project.artifactId}
+    spec:
+      containers:
+      - image: eclipsehono/hono-service-device-registry:${project.version}
+        name: ${project.artifactId}
+        ports:
+        - containerPort: 5671
+          name: amqps
+          protocol: TCP
+        - containerPort: 5672
+          name: amqp
+          protocol: TCP
+        env:
+        - name: HONO_AUTH_HOST
+          value: ${HONO_SERVICE_AUTH_SERVICE_HOST}
+        - name: HONO_AUTH_PORT
+          value: ${HONO_SERVICE_AUTH_SERVICE_PORT_AMQPS}
+        - name: HONO_AUTH_NAME
+          value: device-registry
+        - name: HONO_AUTH_VALIDATION_CERT_PATH
+          value: /etc/hono/certs/auth-server-cert.pem
+        - name: HONO_AUTH_TRUST_STORE_PATH
+          value: /etc/hono/certs/trusted-certs.pem
+        - name: HONO_AUTH_HOSTNAME_VERIFICATION_REQUIRED
+          value: "false"
+        - name: HONO_DEVICE_REGISTRY_KEY_PATH
+          value: /etc/hono/certs/device-registry-key.pem
+        - name: HONO_DEVICE_REGISTRY_CERT_PATH
+          value: /etc/hono/certs/device-registry-cert.pem
+        - name: HONO_DEVICE_REGISTRY_BIND_ADDRESS
+          value: 0.0.0.0
+        - name: HONO_DEVICE_REGISTRY_INSECURE_PORT_ENABLED
+          value: "true"
+        - name: HONO_DEVICE_REGISTRY_INSECURE_PORT_BIND_ADDRESS
+          value: 0.0.0.0
+        - name: HONO_DEVICE_REGISTRY_MAX_INSTANCES
+          value: "1"
+        - name: HONO_DEVICE_REGISTRY_SIGNING_SHARED_SECRET
+          value: "g#aWO!BUm7aj*#%X*VGXKFhxkhNrMNj0"
+        - name: LOGGING_CONFIG
+          value: classpath:logback-spring.xml
+        - name: SPRING_PROFILES_ACTIVE
+          value: default,dev
+        livenessProbe:
+          tcpSocket:
+            port: 5672

--- a/services/device-registry/src/main/fabric8/hono-device-registry-route.yml
+++ b/services/device-registry/src/main/fabric8/hono-device-registry-route.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Route
+metadata:
+  labels:
+    app: hono
+    name: ${project.artifactId}
+  name: ${project.artifactId}
+spec:
+  to:
+    kind: Service
+    name: ${project.artifactId}
+  port:
+    targetPort: 5671
+  tls:
+    termination: passthrough

--- a/services/device-registry/src/main/fabric8/hono-device-registry-svc.yml
+++ b/services/device-registry/src/main/fabric8/hono-device-registry-svc.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hono
+    name: ${project.artifactId}
+  name: ${project.artifactId}
+spec:
+  ports:
+  - name: amqps
+    port: 26671
+    protocol: TCP
+    targetPort: 5671
+  - name: amqp
+    port: 26672
+    protocol: TCP
+    targetPort: 5672
+  selector:
+    name: ${project.artifactId}

--- a/site/content/deployment/openshift.md
+++ b/site/content/deployment/openshift.md
@@ -71,6 +71,8 @@ $ oc login -u developer
 Using the `developer` user, it's now possible to deploy all the other OpenShift resources related to :
 
 * Qpid Dispatch Router (service and deployment)
+* Auth Server (service and deployment)
+* Device Registry (service and deployment)
 * Hono Server (persistent volume claim, service and deployment)
 * HTTP REST adapter (service and deployment)
 * MQTT adapter (service and deployment)
@@ -80,6 +82,20 @@ In order to start deploy the Qpid Dispath Router, the following resources needs 
 ~~~sh
 $ oc create -f <path-to-repo>/hono/dispatchrouter/target/fabric8/dispatch-router-svc.yml
 $ oc create -f <path-to-repo>/hono/dispatchrouter/target/fabric8/dispatch-router-dc.yml
+~~~
+
+Then the Auth Server.
+
+~~~sh
+$ oc create -f <path-to-repo>/hono/services/auth/target/fabric8/hono-auth-svc.yml
+$ oc create -f <path-to-repo>/hono/services/auth/target/fabric8/hono-auth-dc.yml
+~~~
+
+Then the Device Registry.
+
+~~~sh
+$ oc create -f <path-to-repo>/hono/services/device-registry/target/fabric8/hono-device-registry-svc.yml
+$ oc create -f <path-to-repo>/hono/services/device-registry/target/fabric8/hono-device-registry-dc.yml
 ~~~
 
 Then the Hono Server, which needs a _claim_ on the persistent volume already provisioned other than a _deployment_ and _service_.


### PR DESCRIPTION
Since for Openshift the auth server already uses the port 25671, the device registry now always binds
to port 26671 (openshift and docker swarm).

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>