### PR TITLE
Openshift deployments with enabled hostname verification for TLS conn…

### DIFF
--- a/adapters/mqtt-vertx/src/main/fabric8/hono-adapter-mqtt-vertx-dc.yml
+++ b/adapters/mqtt-vertx/src/main/fabric8/hono-adapter-mqtt-vertx-dc.yml
@@ -27,31 +27,27 @@ spec:
         - name: HONO_CLIENT_NAME
           value: Hono MQTT Adapter
         - name: HONO_CLIENT_HOST
-          value: ${HONO_SERVICE_MESSAGING_SERVICE_HOST}
+          value: hono-service-messaging
         - name: HONO_CLIENT_PORT
-          value: ${HONO_SERVICE_MESSAGING_SERVICE_PORT}
+          value: "5671"
         - name: HONO_CLIENT_USERNAME
           value: mqtt-adapter@HONO
         - name: HONO_CLIENT_PASSWORD
           value: mqtt-secret
         - name: HONO_CLIENT_TRUST_STORE_PATH
           value: /etc/hono/certs/trusted-certs.pem
-        - name: HONO_CLIENT_HOSTNAME_VERIFICATION_REQUIRED
-          value: "false"
         - name: HONO_REGISTRATION_NAME
           value: Hono MQTT Adapter
         - name: HONO_REGISTRATION_HOST
-          value: ${HONO_SERVICE_DEVICE_REGISTRY_SERVICE_HOST}
+          value: hono-service-device-registry
         - name: HONO_REGISTRATION_PORT
-          value: ${HONO_SERVICE_DEVICE_REGISTRY_SERVICE_PORT_AMQPS}
+          value: "26671"
         - name: HONO_REGISTRATION_USERNAME
           value: mqtt-adapter@HONO
         - name: HONO_REGISTRATION_PASSWORD
           value: mqtt-secret
         - name: HONO_REGISTRATION_TRUST_STORE_PATH
           value: /etc/hono/certs/trusted-certs.pem
-        - name: HONO_REGISTRATION_HOSTNAME_VERIFICATION_REQUIRED
-          value: "false"
         - name: HONO_MQTT_BIND_ADDRESS
           value: 0.0.0.0
         - name: HONO_MQTT_INSECURE_PORT_BIND_ADDRESS

--- a/adapters/rest-vertx/src/main/fabric8/hono-adapter-rest-vertx-dc.yml
+++ b/adapters/rest-vertx/src/main/fabric8/hono-adapter-rest-vertx-dc.yml
@@ -27,31 +27,27 @@ spec:
         - name: HONO_CLIENT_NAME
           value: Hono REST Adapter
         - name: HONO_CLIENT_HOST
-          value: ${HONO_SERVICE_MESSAGING_SERVICE_HOST}
+          value: hono-service-messaging
         - name: HONO_CLIENT_PORT
-          value: ${HONO_SERVICE_MESSAGING_SERVICE_PORT}
+          value: "5671"
         - name: HONO_CLIENT_USERNAME
           value: rest-adapter@HONO
         - name: HONO_CLIENT_PASSWORD
           value: rest-secret
         - name: HONO_CLIENT_TRUST_STORE_PATH
           value: /etc/hono/certs/trusted-certs.pem
-        - name: HONO_CLIENT_HOSTNAME_VERIFICATION_REQUIRED
-          value: "false"
         - name: HONO_REGISTRATION_NAME
           value: Hono REST Adapter
         - name: HONO_REGISTRATION_HOST
-          value: ${HONO_SERVICE_DEVICE_REGISTRY_SERVICE_HOST}
+          value: hono-service-device-registry
         - name: HONO_REGISTRATION_PORT
-          value: ${HONO_SERVICE_DEVICE_REGISTRY_SERVICE_PORT_AMQPS}
+          value: "26671"
         - name: HONO_REGISTRATION_USERNAME
           value: rest-adapter@HONO
         - name: HONO_REGISTRATION_PASSWORD
           value: rest-secret
         - name: HONO_REGISTRATION_TRUST_STORE_PATH
           value: /etc/hono/certs/trusted-certs.pem
-        - name: HONO_REGISTRATION_HOSTNAME_VERIFICATION_REQUIRED
-          value: "false"
         - name: HONO_HTTP_BIND_ADDRESS
           value: 0.0.0.0
         - name: HONO_HTTP_INSECURE_PORT_BIND_ADDRESS

--- a/example/openshift/openshift_deploy.sh
+++ b/example/openshift/openshift_deploy.sh
@@ -33,6 +33,11 @@ oc create -f ../../services/device-registry/target/fabric8/hono-device-registry-
 oc create -f ../../services/device-registry/target/fabric8/hono-device-registry-route.yml
 echo ... done
 
+echo Deploying Apache ActiveMQ Artemis Broker ...
+oc create -f ../../broker/target/fabric8/artemis-svc.yml
+oc create -f ../../broker/target/fabric8/artemis-dc.yml
+echo ... done
+
 echo Deploying Qpid Dispatch Router ...
 oc create -f ../../dispatchrouter/target/fabric8/dispatch-router-svc.yml
 oc create -f ../../dispatchrouter/target/fabric8/dispatch-router-external-svc.yml
@@ -40,10 +45,6 @@ oc create -f ../../dispatchrouter/target/fabric8/dispatch-router-dc.yml
 oc create -f ../../dispatchrouter/target/fabric8/dispatch-router-route.yml
 echo ... done
 
-echo Deploying Apache ActiveMQ Artemis Broker ...
-oc create -f ../../broker/target/fabric8/artemis-svc.yml
-oc create -f ../../broker/target/fabric8/artemis-dc.yml
-echo ... done
 
 echo Deploying Hono Messaging ...
 oc create -f ../../services/messaging/target/fabric8/hono-messaging-svc.yml

--- a/services/device-registry/src/main/fabric8/hono-device-registry-dc.yml
+++ b/services/device-registry/src/main/fabric8/hono-device-registry-dc.yml
@@ -25,17 +25,15 @@ spec:
           protocol: TCP
         env:
         - name: HONO_AUTH_HOST
-          value: ${HONO_SERVICE_AUTH_SERVICE_HOST}
+          value: hono-service-auth
         - name: HONO_AUTH_PORT
-          value: ${HONO_SERVICE_AUTH_SERVICE_PORT_AMQPS}
+          value: "25671"
         - name: HONO_AUTH_NAME
           value: Hono Device Registry
         - name: HONO_AUTH_VALIDATION_CERT_PATH
           value: /etc/hono/certs/auth-server-cert.pem
         - name: HONO_AUTH_TRUST_STORE_PATH
           value: /etc/hono/certs/trusted-certs.pem
-        - name: HONO_AUTH_HOSTNAME_VERIFICATION_REQUIRED
-          value: "false"
         - name: HONO_DEVICE_REGISTRY_KEY_PATH
           value: /etc/hono/certs/device-registry-key.pem
         - name: HONO_DEVICE_REGISTRY_CERT_PATH

--- a/services/messaging/src/main/fabric8/hono-messaging-dc.yml
+++ b/services/messaging/src/main/fabric8/hono-messaging-dc.yml
@@ -25,17 +25,15 @@ spec:
           protocol: TCP
         env:
         - name: HONO_AUTH_HOST
-          value: ${HONO_SERVICE_AUTH_SERVICE_HOST}
+          value: hono-service-auth
         - name: HONO_AUTH_PORT
-          value: ${HONO_SERVICE_AUTH_SERVICE_PORT_AMQPS}
+          value: "25671"
         - name: HONO_AUTH_NAME
           value: Hono Messaging
         - name: HONO_AUTH_CERT_PATH
           value: /etc/hono/certs/auth-server-cert.pem
         - name: HONO_AUTH_TRUST_STORE_PATH
           value: /etc/hono/certs/trusted-certs.pem
-        - name: HONO_AUTH_HOSTNAME_VERIFICATION_REQUIRED
-          value: "false"
         - name: HONO_DOWNSTREAM_HOST
           value: ${HONO_DISPATCH_ROUTER_SERVICE_HOST}
         - name: HONO_DOWNSTREAM_PORT


### PR DESCRIPTION
…ections.

For that purpose, the real names of the openshift services are used instead
of the variables that are substituted by the IP address during startup.
This does not match with the certificates and would let the hostname verification
fail.

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>