### PR TITLE
[#269] Ability to set prefetch on client consumer (and also own flow control)

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoClient.java
@@ -154,11 +154,29 @@ public interface HonoClient {
             Handler<AsyncResult<MessageConsumer>> creationHandler);
 
     /**
+     * Creates a new consumer of telemetry data for a tenant.
+     *
+     * @param tenantId The tenant to consume data for.
+     * @param prefetch the number of message credits the consumer grants and replenishes automatically as messages are
+     *                 delivered. To manage credit manually, you can instead set prefetch to 0.
+     * @param telemetryConsumer The handler to invoke with every message received.
+     * @param creationHandler The handler to invoke with the outcome of the operation.
+     * @return This client for command chaining.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    HonoClient createTelemetryConsumer(
+            String tenantId,
+            int prefetch,
+            Consumer<Message> telemetryConsumer,
+            Handler<AsyncResult<MessageConsumer>> creationHandler);
+
+    /**
      * Creates a new consumer of events for a tenant.
      * <p>
      * The events passed in to the registered eventConsumer will be settled
-     * automatically if the consumer does not throw an exception.
-     * 
+     * automatically if the consumer does not throw an exception and does not
+     * manually handle the message disposition using the passed in delivery.
+     *
      * @param tenantId The tenant to consume events for.
      * @param eventConsumer The handler to invoke with every event received.
      * @param creationHandler The handler to invoke with the outcome of the operation.
@@ -172,11 +190,28 @@ public interface HonoClient {
 
     /**
      * Creates a new consumer of events for a tenant.
+     *
+     * @param tenantId The tenant to consume events for.
+     * @param prefetch the number of message credits the consumer grants and replenishes automatically as messages are
+     *                 delivered. To manage credit manually, you can instead set prefetch to 0.
+     * @param eventConsumer The handler to invoke with every event received.
+     * @param creationHandler The handler to invoke with the outcome of the operation.
+     * @return This client for command chaining.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    HonoClient createEventConsumer(
+            String tenantId,
+            int prefetch,
+            Consumer<Message> eventConsumer,
+            Handler<AsyncResult<MessageConsumer>> creationHandler);
+
+    /**
+     * Creates a new consumer of events for a tenant.
      * <p>
      * The events passed in to the registered eventConsumer will be settled
      * automatically if the consumer does not throw an exception and does not
      * manually handle the message disposition using the passed in delivery.
-     * 
+     *
      * @param tenantId The tenant to consume events for.
      * @param eventConsumer The handler to invoke with every event received.
      * @param creationHandler The handler to invoke with the outcome of the operation.
@@ -185,6 +220,23 @@ public interface HonoClient {
      */
     HonoClient createEventConsumer(
             String tenantId,
+            BiConsumer<ProtonDelivery, Message> eventConsumer,
+            Handler<AsyncResult<MessageConsumer>> creationHandler);
+
+    /**
+     * Creates a new consumer of events for a tenant.
+     *
+     * @param tenantId The tenant to consume events for.
+     * @param prefetch the number of message credits the consumer grants and replenishes automatically as messages are
+     *                 delivered. To manage credit manually, you can instead set prefetch to 0.
+     * @param eventConsumer The handler to invoke with every event received.
+     * @param creationHandler The handler to invoke with the outcome of the operation.
+     * @return This client for command chaining.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    HonoClient createEventConsumer(
+            String tenantId,
+            int prefetch,
             BiConsumer<ProtonDelivery, Message> eventConsumer,
             Handler<AsyncResult<MessageConsumer>> creationHandler);
 

--- a/client/src/main/java/org/eclipse/hono/client/MessageConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/MessageConsumer.java
@@ -30,4 +30,14 @@ public interface MessageConsumer {
      * @param closeHandler A handler that is called back with the result of the attempt to close the links.
      */
     void close(Handler<AsyncResult<Void>> closeHandler);
+
+    /**
+     * Grants the given number of message credits to the sender.
+     *
+     * For use when created with 0 prefetch in consumer creation
+     *
+     * @param credits the credits to flow
+     * @throws IllegalStateException if prefetch is non-zero, or an existing drain operation is not yet complete
+     */
+    void flow(int credits) throws IllegalStateException;
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractConsumer.java
@@ -1,0 +1,74 @@
+package org.eclipse.hono.client.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonReceiver;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.MessageConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Abstract client for consuming messages from a Hono server.
+ */
+abstract class AbstractConsumer extends AbstractHonoClient implements MessageConsumer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractConsumer.class);
+
+    AbstractConsumer(final Context context, final ProtonReceiver receiver) {
+        super(context);
+        this.receiver = receiver;
+    }
+
+    @Override
+    public void flow(final int credits) throws IllegalStateException {
+        receiver.flow(credits);
+    }
+
+    @Override
+    public void close(final Handler<AsyncResult<Void>> closeHandler) {
+        closeLinks(closeHandler);
+    }
+
+    static Future<ProtonReceiver> createConsumer(
+            final Context context,
+            final ProtonConnection con,
+            final String tenantId,
+            final String pathSeparator,
+            final String address,
+            final int prefetch,
+            final BiConsumer<ProtonDelivery, Message> consumer) {
+
+        Future<ProtonReceiver> result = Future.future();
+        final String targetAddress = String.format(address, pathSeparator, tenantId);
+
+        context.runOnContext(open -> {
+            final ProtonReceiver receiver = con.createReceiver(targetAddress);
+            receiver.setAutoAccept(true);
+            receiver.setPrefetch(prefetch);
+            receiver.openHandler(receiverOpen -> {
+                if (receiverOpen.succeeded()) {
+                    LOG.debug("{} receiver for [{}] open", address, receiverOpen.result().getRemoteSource());
+                    result.complete(receiverOpen.result());
+                } else {
+                    result.fail(receiverOpen.cause());
+                }
+            });
+            receiver.handler((delivery, message) -> {
+                if (consumer != null) {
+                    consumer.accept(delivery, message);
+                }
+            });
+            receiver.open();
+        });
+        return result;
+    }
+
+}

--- a/client/src/main/java/org/eclipse/hono/client/impl/EventConsumerImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/EventConsumerImpl.java
@@ -33,14 +33,13 @@ import io.vertx.proton.ProtonReceiver;
 /**
  * A Vertx-Proton based client for consuming event messages from a Hono server.
  */
-public class EventConsumerImpl extends AbstractHonoClient implements MessageConsumer {
+public class EventConsumerImpl extends AbstractConsumer implements MessageConsumer {
 
     private static final String EVENT_ADDRESS_TEMPLATE = "event%s%s";
     private static final Logger LOG = LoggerFactory.getLogger(EventConsumerImpl.class);
 
     private EventConsumerImpl(final Context context, final ProtonReceiver receiver) {
-        super(context);
-        this.receiver = receiver;
+        super(context, receiver);
     }
 
     /**
@@ -49,6 +48,8 @@ public class EventConsumerImpl extends AbstractHonoClient implements MessageCons
      * @param context The vert.x context to run all interactions with the server on.
      * @param con The AMQP connection to the server.
      * @param tenantId The tenant to consumer events for.
+     * @param prefetch the number of message credits the consumer grants and replenishes automatically as messages are
+     *                 delivered. To manage credit manually, you can instead set prefetch to 0.
      * @param eventConsumer The consumer to invoke with each event received.
      * @param creationHandler The handler to invoke with the outcome of the creation attempt.
      * @throws NullPointerException if any of the parameters is {@code null}.
@@ -57,10 +58,11 @@ public class EventConsumerImpl extends AbstractHonoClient implements MessageCons
             final Context context,
             final ProtonConnection con,
             final String tenantId,
+            final int prefetch,
             final BiConsumer<ProtonDelivery, Message> eventConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler) {
 
-        create(context, con, tenantId, Constants.DEFAULT_PATH_SEPARATOR, eventConsumer, creationHandler);
+        create(context, con, tenantId, Constants.DEFAULT_PATH_SEPARATOR, prefetch, eventConsumer, creationHandler);
     }
 
     /**
@@ -70,6 +72,8 @@ public class EventConsumerImpl extends AbstractHonoClient implements MessageCons
      * @param con The AMQP connection to the server.
      * @param tenantId The tenant to consumer events for.
      * @param pathSeparator The address path separator character used by the server.
+     * @param prefetch the number of message credits the consumer grants and replenishes automatically as messages are
+     *                 delivered. To manage credit manually, you can instead set prefetch to 0.
      * @param eventConsumer The consumer to invoke with each event received.
      * @param creationHandler The handler to invoke with the outcome of the creation attempt.
      * @throws NullPointerException if any of the parameters is {@code null}.
@@ -79,6 +83,7 @@ public class EventConsumerImpl extends AbstractHonoClient implements MessageCons
             final ProtonConnection con,
             final String tenantId,
             final String pathSeparator,
+            final int prefetch,
             final BiConsumer<ProtonDelivery, Message> eventConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler) {
 
@@ -88,7 +93,7 @@ public class EventConsumerImpl extends AbstractHonoClient implements MessageCons
         Objects.requireNonNull(pathSeparator);
         Objects.requireNonNull(eventConsumer);
         Objects.requireNonNull(creationHandler);
-        createConsumer(context, con, tenantId, pathSeparator, eventConsumer).setHandler(created -> {
+        createConsumer(context, con, tenantId, pathSeparator, EVENT_ADDRESS_TEMPLATE, prefetch, eventConsumer).setHandler(created -> {
             if (created.succeeded()) {
                 creationHandler.handle(Future.succeededFuture(
                         new EventConsumerImpl(context, created.result())));
@@ -98,40 +103,4 @@ public class EventConsumerImpl extends AbstractHonoClient implements MessageCons
         });
     }
 
-    private static Future<ProtonReceiver> createConsumer(
-            final Context context,
-            final ProtonConnection con,
-            final String tenantId,
-            final String pathSeparator,
-            final BiConsumer<ProtonDelivery, Message> consumer) {
-
-        Future<ProtonReceiver> result = Future.future();
-        final String targetAddress = String.format(EVENT_ADDRESS_TEMPLATE, pathSeparator, tenantId);
-
-        context.runOnContext(open -> {
-            final ProtonReceiver receiver = con.createReceiver(targetAddress);
-            receiver.setAutoAccept(true);
-            receiver.setPrefetch(DEFAULT_SENDER_CREDITS);
-            receiver.openHandler(receiverOpen -> {
-                if (receiverOpen.succeeded()) {
-                    LOG.debug("event receiver for [{}] open", receiverOpen.result().getRemoteSource());
-                    result.complete(receiverOpen.result());
-                } else {
-                    result.fail(receiverOpen.cause());
-                }
-            });
-            receiver.handler((delivery, message) -> {
-                if (consumer != null) {
-                    consumer.accept(delivery, message);
-                }
-            });
-            receiver.open();
-        });
-        return result;
-    }
-
-    @Override
-    public void close(final Handler<AsyncResult<Void>> closeHandler) {
-        closeLinks(closeHandler);
-    }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/EventConsumerImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/EventConsumerImplTest.java
@@ -88,7 +88,7 @@ public class EventConsumerImplTest {
             return receiver;
         });
         Async consumerCreation = ctx.async();
-        EventConsumerImpl.create(vertx.getOrCreateContext(), con, "tenant", eventConsumer, ctx.asyncAssertSuccess(s -> {
+        EventConsumerImpl.create(vertx.getOrCreateContext(), con, "tenant", AbstractHonoClient.DEFAULT_SENDER_CREDITS, eventConsumer, ctx.asyncAssertSuccess(s -> {
             consumerCreation.complete();
         }));
         consumerCreation.await(500);

--- a/jmeter/src/jmeter/hono_jmeter_runtime.jmx
+++ b/jmeter/src/jmeter/hono_jmeter_runtime.jmx
@@ -71,6 +71,7 @@
             <stringProp name="tenant">DEFAULT_TENANT</stringProp>
             <boolProp name="useSenderTime">true</boolProp>
             <stringProp name="endpoint">telemetry</stringProp>
+            <stringProp name="prefetch">50</stringProp>
           </org.eclipse.hono.jmeter.HonoReceiverSampler>
           <hashTree/>
           <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoReceiverSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoReceiverSampler.java
@@ -34,6 +34,7 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
     private static final Logger LOGGER = LoggerFactory.getLogger(HonoReceiverSampler.class);
 
     private static final String USE_SENDER_TIME = "useSenderTime";
+    private static final String PREFETCH = "prefetch";
 
     private HonoReceiver honoReceiver;
 
@@ -43,6 +44,14 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
 
     public void setUseSenderTime(final Boolean useSenderTime) {
         setProperty(USE_SENDER_TIME, useSenderTime);
+    }
+
+    public String getPrefetch() {
+        return getPropertyAsString(PREFETCH);
+    }
+
+    public void setPrefetch(final String prefetch) {
+        setProperty(PREFETCH, prefetch);
     }
 
     @Override

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.impl.HonoClientImpl;
 import org.eclipse.hono.connection.ConnectionFactory;
 import org.eclipse.hono.connection.ConnectionFactoryImpl;
+import org.eclipse.hono.jmeter.HonoReceiverSampler;
 import org.eclipse.hono.jmeter.HonoSampler;
 import org.slf4j.LoggerFactory;
 
@@ -38,19 +39,19 @@ public class HonoReceiver {
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(HonoReceiver.class);
 
-    private ConnectionFactory amqpNetworkConnectionFactory;
-    private HonoClient        amqpNetworkClient;
-    private Vertx             vertx = Vertx.vertx();
+    private ConnectionFactory   amqpNetworkConnectionFactory;
+    private HonoClient          amqpNetworkClient;
+    private Vertx               vertx = Vertx.vertx();
 
-    private int          messageCount;
-    private long         messageSize;
-    private double       avgElapsed;
-    private StringBuffer messages = new StringBuffer();
-    private HonoSampler  sampler;
+    private int                 messageCount;
+    private long                messageSize;
+    private double              avgElapsed;
+    private StringBuffer        messages = new StringBuffer();
+    private HonoReceiverSampler sampler;
 
     private final transient Object lock = new Object();
 
-    public HonoReceiver(final HonoSampler sampler) throws InterruptedException {
+    public HonoReceiver(final HonoReceiverSampler sampler) throws InterruptedException {
         this.sampler = sampler;
 
         // amqp network config
@@ -90,14 +91,14 @@ public class HonoReceiver {
             connect();
         }
         if (sampler.getEndpoint().equals(HonoSampler.Endpoint.telemetry.toString())) {
-            amqpNetworkClient.createTelemetryConsumer(sampler.getTenant(), this::messageReceived, creationHandler -> {
+            amqpNetworkClient.createTelemetryConsumer(sampler.getTenant(), Integer.parseInt(sampler.getPrefetch()), this::messageReceived, creationHandler -> {
                 if (creationHandler.failed()) {
                     LOGGER.error("HonoClient.createTelemetryConsumer() failed", creationHandler.cause());
                 }
                 receiverLatch.countDown();
             });
         } else {
-            amqpNetworkClient.createEventConsumer(sampler.getTenant(), this::messageReceived, creationHandler -> {
+            amqpNetworkClient.createEventConsumer(sampler.getTenant(), Integer.parseInt(sampler.getPrefetch()), this::messageReceived, creationHandler -> {
                 if (creationHandler.failed()) {
                     LOGGER.error("HonoClient.createEventConsumer() failed", creationHandler.cause());
                 }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
@@ -135,7 +135,7 @@ public class HonoSender {
             connect();
         }
         if(sampler.getEndpoint().equals(HonoSampler.Endpoint.telemetry.toString())) {
-            honoClient.getOrCreateTelemetrySender(sampler.getTenant(), sampler.getDeviceId(), resultHandler -> {
+            honoClient.getOrCreateTelemetrySender(sampler.getTenant(), resultHandler -> {
                 if (resultHandler.failed()) {
                     LOGGER.error("HonoClient.getOrCreateTelemetrySender() failed", resultHandler.cause());
                 } else {
@@ -145,7 +145,7 @@ public class HonoSender {
             });
         }
         else {
-            honoClient.getOrCreateEventSender(sampler.getTenant(), sampler.getDeviceId(), resultHandler -> {
+            honoClient.getOrCreateEventSender(sampler.getTenant(), resultHandler -> {
                 if (resultHandler.failed()) {
                     LOGGER.error("HonoClient.getOrCreateEventSender() failed", resultHandler.cause());
                 } else {

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoReceiverSamplerUI.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoReceiverSamplerUI.java
@@ -15,6 +15,8 @@ package org.eclipse.hono.jmeter.ui;
 import javax.swing.*;
 
 import org.apache.jmeter.testelement.TestElement;
+import org.apache.jorphan.gui.JLabeledTextField;
+import org.eclipse.hono.client.impl.AbstractHonoClient;
 import org.eclipse.hono.jmeter.HonoReceiverSampler;
 
 /**
@@ -22,11 +24,13 @@ import org.eclipse.hono.jmeter.HonoReceiverSampler;
  */
 public class HonoReceiverSamplerUI extends HonoSamplerUI {
 
-    private final JCheckBox useSenderTime = new JCheckBox("Use sender time");
+    private final JCheckBox         useSenderTime = new JCheckBox("Use sender time");
+    private final JLabeledTextField prefetch      = new JLabeledTextField("Prefetch");
 
     public HonoReceiverSamplerUI() {
         super("Qpid Dispatch Router");
         addDefaultOptions();
+        addOption(prefetch);
         addOption(useSenderTime);
     }
 
@@ -46,6 +50,7 @@ public class HonoReceiverSamplerUI extends HonoSamplerUI {
     public void modifyTestElement(final TestElement testElement) {
         super.modifyTestElement(testElement);
         HonoReceiverSampler sampler = (HonoReceiverSampler) testElement;
+        sampler.setPrefetch(prefetch.getText());
         sampler.setUseSenderTime(useSenderTime.isSelected());
     }
 
@@ -53,12 +58,14 @@ public class HonoReceiverSamplerUI extends HonoSamplerUI {
     public void configure(final TestElement element) {
         super.configure(element);
         HonoReceiverSampler sampler = (HonoReceiverSampler) element;
+        prefetch.setText(sampler.getPrefetch());
         useSenderTime.setSelected(sampler.isUseSenderTime());
     }
 
     @Override
     public void clearGui() {
         super.clearGui();
+        prefetch.setText("50");
         useSenderTime.setSelected(false);
     }
 


### PR DESCRIPTION
- created AbstractConsumer
- moved methods to AbstractConsumer
- added variants with prefetch to factories and HonoClient
- added flow() to Consumer
- added prefetch property to JMeter consumer
