### PR TITLE
[#271] Getters for secure and insecure port in common base class.

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -93,25 +93,13 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends ServiceCon
     }
 
     @Override
-    public int getPort() {
-        if (server != null) {
-            return server.actualPort();
-        } else if (isSecurePortEnabled()) {
-            return getConfig().getPort(getPortDefaultValue());
-        } else {
-            return Constants.PORT_UNCONFIGURED;
-        }
+    protected final int getActualPort() {
+        return (server != null ? server.actualPort() : Constants.PORT_UNCONFIGURED);
     }
 
     @Override
-    public int getInsecurePort() {
-        if (insecureServer != null) {
-            return insecureServer.actualPort();
-        } else if (isInsecurePortEnabled()) {
-            return getConfig().getInsecurePort(getInsecurePortDefaultValue());
-        } else {
-            return Constants.PORT_UNCONFIGURED;
-        }
+    protected final int getActualInsecurePort() {
+        return (insecureServer != null ? insecureServer.actualPort() : Constants.PORT_UNCONFIGURED);
     }
 
     /**

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
@@ -61,30 +61,19 @@ public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<S
         return IANA_SECURE_MQTT_PORT;
     }
 
+    @Override
     public int getInsecurePortDefaultValue() {
         return IANA_MQTT_PORT;
     }
 
     @Override
-    public int getPort() {
-        if (server != null) {
-            return server.actualPort();
-        } else if (isSecurePortEnabled()) {
-            return getConfig().getPort(getPortDefaultValue());
-        } else {
-            return Constants.PORT_UNCONFIGURED;
-        }
+    protected final int getActualPort() {
+        return (server != null ? server.actualPort() : Constants.PORT_UNCONFIGURED);
     }
 
     @Override
-    public int getInsecurePort() {
-        if (insecureServer != null) {
-            return insecureServer.actualPort();
-        } else if (isInsecurePortEnabled()) {
-            return getConfig().getInsecurePort(getInsecurePortDefaultValue());
-        } else {
-            return Constants.PORT_UNCONFIGURED;
-        }
+    protected final int getActualInsecurePort() {
+        return (insecureServer != null ? insecureServer.actualPort() : Constants.PORT_UNCONFIGURED);
     }
 
     private Future<MqttServer> bindSecureMqttServer() {

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
@@ -175,6 +175,24 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
     public abstract int getInsecurePortDefaultValue();
 
     /**
+     * Gets the port number from a running secure server if it is listening on the corresponding socket already.
+     * <p>
+     * If no server is listening, {@link Constants#PORT_UNCONFIGURED} is returned.
+     *
+     * @return The port number.
+     */
+    protected abstract int getActualPort();
+
+    /**
+     * Gets the port number from a running insecure server if it is listening on the corresponding socket already.
+     * <p>
+     * If no server is listening, {@link Constants#PORT_UNCONFIGURED} is returned.
+     *
+     * @return The port number.
+     */
+    protected abstract int getActualInsecurePort();
+
+    /**
      * Gets the secure port number that this service has bound to.
      * <p>
      * The port number is determined as follows:
@@ -186,7 +204,15 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
      * 
      * @return The port number.
      */
-    public abstract int getPort();
+    public final int getPort() {
+        if (getActualPort() != Constants.PORT_UNCONFIGURED) {
+            return getActualPort();
+        } else if (isSecurePortEnabled()) {
+            return getConfig().getPort(getPortDefaultValue());
+        } else {
+            return Constants.PORT_UNCONFIGURED;
+        }
+    };
 
     /**
      * Gets the insecure port number that this service has bound to.
@@ -200,7 +226,15 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
      * 
      * @return The port number.
      */
-    public abstract int getInsecurePort();
+    public final int getInsecurePort() {
+        if (getActualInsecurePort() != Constants.PORT_UNCONFIGURED) {
+            return getActualInsecurePort();
+        } else if (isInsecurePortEnabled()) {
+            return getConfig().getInsecurePort(getInsecurePortDefaultValue());
+        } else {
+            return Constants.PORT_UNCONFIGURED;
+        }
+    }
 
     /**
      * Verifies that this service is properly configured to bind to at least one of the secure or insecure ports.

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
@@ -326,25 +326,13 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
     }
 
     @Override
-    public final int getPort() {
-        if (server != null) {
-            return server.actualPort();
-        } else if (isSecurePortEnabled()) {
-            return getConfig().getPort(getPortDefaultValue());
-        } else {
-            return Constants.PORT_UNCONFIGURED;
-        }
+    protected final int getActualPort() {
+        return (server != null ? server.actualPort() : Constants.PORT_UNCONFIGURED);
     }
 
     @Override
-    public final int getInsecurePort() {
-        if (insecureServer != null) {
-            return insecureServer.actualPort();
-        } else if (isInsecurePortEnabled()) {
-            return getConfig().getInsecurePort(getInsecurePortDefaultValue());
-        } else {
-            return Constants.PORT_UNCONFIGURED;
-        }
+    protected final int getActualInsecurePort() {
+        return (insecureServer != null ? insecureServer.actualPort() : Constants.PORT_UNCONFIGURED);
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractServiceBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractServiceBaseTest.java
@@ -15,6 +15,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.util.Constants;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,13 +61,13 @@ public class AbstractServiceBaseTest {
             }
 
             @Override
-            public int getPort() {
-                return config.getPort(PORT_NR);
+            protected int getActualPort() {
+                return Constants.PORT_UNCONFIGURED;
             }
 
             @Override
-            public int getInsecurePort() {
-                return config.getInsecurePort(INSECURE_PORT_NR);
+            protected int getActualInsecurePort() {
+                return Constants.PORT_UNCONFIGURED;
             }
         };
         server.setConfig(config);

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -252,7 +252,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </log>
                     <wait>
                       <log>^.*(Started \w*Application in).*$</log>
-                      <time>30000</time>
+                      <time>40000</time>
                     </wait>
                   </run>
                 </image>


### PR DESCRIPTION
Eliminate code duplication from implementing the getters for each
specific vertx server (to only cover the ephemeral port determination).

Increase startup time for Hono Messaging in integration tests to 40 seconds.

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>