### PR TITLE
[#278] Move handle(Sender|Receiver)Open methods to base class.

### DIFF
--- a/service-base/src/test/java/org/eclipse/hono/service/amqp/AmqpServiceBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/amqp/AmqpServiceBaseTest.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ *
+ */
+package org.eclipse.hono.service.amqp;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonReceiver;
+import org.apache.qpid.proton.amqp.transport.Target;
+import org.apache.qpid.proton.engine.Record;
+import org.apache.qpid.proton.engine.impl.RecordImpl;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.auth.Activity;
+import org.eclipse.hono.auth.HonoUser;
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.service.auth.AuthorizationService;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests verifying behavior of {@link AmqpServiceBase}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AmqpServiceBaseTest {
+    private static final String CON_ID = "connection-id";
+    private static final String ENDPOINT = "anEndpoint";
+
+    private Vertx vertx;
+    private EventBus eventBus;
+
+    /**
+     * Sets up common mock objects used by the test cases.
+     */
+    @Before
+    public void initMocks() {
+        eventBus = mock(EventBus.class);
+        vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(eventBus);
+    }
+
+    private AmqpServiceBase<ServiceConfigProperties> createServer(final Endpoint amqpEndpoint) {
+
+        AmqpServiceBase<ServiceConfigProperties> server = new AmqpServiceBase<ServiceConfigProperties>() {
+            @Override
+            protected void onRemoteConnectionOpen(ProtonConnection connection) {
+            }
+
+            @Override
+            protected void onRemoteConnectionOpenInsecurePort(ProtonConnection connection) {
+            }
+        };
+        server.setConfig(new ServiceConfigProperties());
+        if (amqpEndpoint != null) {
+            server.addEndpoint(amqpEndpoint);
+        }
+        server.init(vertx, mock(Context.class));
+        return server;
+    }
+
+    @Test
+    public void testHandleReceiverOpenForwardsToEndpoint() throws InterruptedException {
+
+        // GIVEN a server with an endpoint
+        final ResourceIdentifier targetAddress = ResourceIdentifier.from(ENDPOINT, Constants.DEFAULT_TENANT, null);
+        final CountDownLatch linkEstablished = new CountDownLatch(1);
+        final Endpoint endpoint = new BaseEndpoint<ServiceConfigProperties>(vertx) {
+
+            @Override
+            public String getName() {
+                return ENDPOINT;
+            }
+
+            @Override
+            public void onLinkAttach(final ProtonConnection con, final ProtonReceiver receiver, final ResourceIdentifier targetResource) {
+                linkEstablished.countDown();
+            }
+
+            @Override
+            protected boolean passesFormalVerification(ResourceIdentifier targetAddress, Message message) {
+                return true;
+            }
+        };
+        AuthorizationService authService = mock(AuthorizationService.class);
+        when(authService.isAuthorized(Constants.PRINCIPAL_ANONYMOUS, targetAddress, Activity.WRITE)).thenReturn(Future.succeededFuture(Boolean.TRUE));
+        AmqpServiceBase<ServiceConfigProperties> server = createServer(endpoint);
+        server.setAuthorizationService(authService);
+
+        // WHEN a client connects to the server using this endpoint
+        final Target target = getTarget(targetAddress);
+        final ProtonReceiver receiver = mock(ProtonReceiver.class);
+        when(receiver.getRemoteTarget()).thenReturn(target);
+        when(receiver.attachments()).thenReturn(mock(Record.class));
+        server.handleReceiverOpen(newConnection(Constants.PRINCIPAL_ANONYMOUS), receiver);
+
+        // THEN the server delegates link establishment to the endpoint
+        assertTrue(linkEstablished.await(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testHandleReceiverOpenRejectsUnauthorizedClient() throws InterruptedException {
+
+        // GIVEN a server with a endpoint
+        final ResourceIdentifier restrictedTargetAddress = ResourceIdentifier.from(ENDPOINT, "RESTRICTED_TENANT", null);
+        final Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.getName()).thenReturn(ENDPOINT);
+        AuthorizationService authService = mock(AuthorizationService.class);
+        when(authService.isAuthorized(Constants.PRINCIPAL_ANONYMOUS, restrictedTargetAddress, Activity.WRITE)).thenReturn(Future.succeededFuture(Boolean.FALSE));
+        AmqpServiceBase<ServiceConfigProperties> server = createServer(endpoint);
+        server.setAuthorizationService(authService);
+
+        // WHEN a client connects to the server using a address for a tenant it is not authorized to write to
+        final CountDownLatch linkClosed = new CountDownLatch(1);
+        final Target target = getTarget(restrictedTargetAddress);
+        final ProtonReceiver receiver = mock(ProtonReceiver.class);
+        when(receiver.getRemoteTarget()).thenReturn(target);
+        when(receiver.setCondition(any())).thenReturn(receiver);
+        when(receiver.close()).thenAnswer(invocation -> {
+            linkClosed.countDown();
+            return receiver;
+        });
+        server.handleReceiverOpen(newConnection(Constants.PRINCIPAL_ANONYMOUS), receiver);
+
+        // THEN the server closes the link with the client
+        assertTrue(linkClosed.await(1, TimeUnit.SECONDS));
+    }
+
+    private static Target getTarget(final ResourceIdentifier targetAddress) {
+        Target result = mock(Target.class);
+        when(result.getAddress()).thenReturn(targetAddress.toString());
+        return result;
+    }
+
+    private static ProtonConnection newConnection(final HonoUser user) {
+        final Record attachments = new RecordImpl();
+        attachments.set(Constants.KEY_CONNECTION_ID, String.class, CON_ID);
+        attachments.set(Constants.KEY_CLIENT_PRINCIPAL, HonoUser.class, user);
+        final ProtonConnection con = mock(ProtonConnection.class);
+        when(con.attachments()).thenReturn(attachments);
+        when(con.getRemoteContainer()).thenReturn("test-client");
+        return con;
+    }
+
+}

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
@@ -99,7 +99,7 @@ public class SimpleAuthenticationServer extends AmqpServiceBase<AuthenticationSe
      * @param con the connection to the client.
      * @param sender the sender created for the link.
      */
-    void handleSenderOpen(final ProtonConnection con, final ProtonSender sender) {
+    protected void handleSenderOpen(final ProtonConnection con, final ProtonSender sender) {
 
         final Source remoteSource = sender.getRemoteSource();
         LOG.debug("client [{}] wants to open a link for receiving messages [address: {}]",


### PR DESCRIPTION
Eliminate identical implementations that are part of HonoMessaging and
SimpleDeviceRegistrationService.

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>