### PR TITLE
[#259] Prototyping: new AbstractApplication for multiple servers.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/HonoBeanNameGenerator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/HonoBeanNameGenerator.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.service;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+
+/**
+ * Generates bean names that are identical to the class name.
+ */
+public class HonoBeanNameGenerator implements BeanNameGenerator {
+
+    @Override
+    public String generateBeanName(BeanDefinition beanDefinition, BeanDefinitionRegistry beanDefinitionRegistry) {
+        return beanDefinition.getBeanClassName();
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/NewAbstractApplication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/NewAbstractApplication.java
@@ -1,0 +1,276 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.service;
+
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.util.ConfigurationSupportingVerticle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.vertx.core.*;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+
+/**
+ * TODO: fix me.
+ *
+ *
+ * A base class for implementing Spring Boot applications.
+ * <p>
+ * This class supports the configuration of an {@code ObjectFactory} for creating instances of the service
+ * implementation that this application exposes.
+ */
+public class NewAbstractApplication {
+
+    /**
+     * A logger to be shared with subclasses.
+     */
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final Set<ObjectFactory<? extends ConfigurationSupportingVerticle>> serviceFactories = new HashSet<>();
+
+    private Vertx vertx;
+
+    /**
+     * Sets the Vert.x instance to deploy the service to.
+     *
+     * @param vertx The vertx instance.
+     * @throws NullPointerException if vertx is {@code null}.
+     */
+    @Autowired
+    public final void setVertx(final Vertx vertx) {
+        this.vertx = Objects.requireNonNull(vertx);
+    }
+
+    /**
+     * Gets the Vert.x instance the service gets deployed to.
+     *
+     * @return The vertx instance.
+     */
+    protected Vertx getVertx() {
+        return vertx;
+    }
+
+    /**
+     * Adds multiple serviceFactories to this server.
+     *
+     * @param definedServiceFactories The serviceFactories.
+     */
+    @Autowired(required = false)
+    public final void addServiceFactories(final List<ObjectFactory<? extends ConfigurationSupportingVerticle>> definedServiceFactories) {
+        Objects.requireNonNull(definedServiceFactories);
+        serviceFactories.addAll(definedServiceFactories);
+        log.debug("added {} service factories", definedServiceFactories.size());
+    }
+
+    /**
+     * Starts up this application.
+     */
+    @PostConstruct
+    public final void startup() {
+
+        if (vertx == null) {
+            throw new IllegalStateException("no Vert.x instance has been configured");
+        } else if (serviceFactories.isEmpty()) {
+            throw new IllegalStateException("no service factory has been configured");
+        }
+
+        final CountDownLatch startupLatch = new CountDownLatch(1);
+
+        Future<Void> startFuture = deployRequiredVerticles();
+
+        Future<Void> started = Future.future();
+        started.setHandler(s -> {
+            if (s.failed()) {
+                log.error("cannot start up application", s.cause());
+            } else {
+                startupLatch.countDown();
+            }
+        });
+
+        final int startupTimeoutSeconds = 20; // TODO: how to determine timeout? Really configurable per service?
+
+        for (ObjectFactory<? extends ConfigurationSupportingVerticle> serviceFactory : serviceFactories) {
+
+
+            final ConfigurationSupportingVerticle firstServiceInstance = serviceFactory.getObject();
+            final ServiceConfigProperties config = (ServiceConfigProperties) firstServiceInstance.getConfig();
+            final int maxInstances = config == null ? 1 : config.getMaxInstances();
+//            final int startupTimeoutSeconds = config == null ? 20 : config.getStartupTimeout();
+
+            startFuture = startFuture
+                    .compose(s -> deployServiceVerticles(firstServiceInstance, serviceFactory, maxInstances - 1));
+
+
+        }
+
+        startFuture
+                .compose(s -> postRegisterServiceVerticles())
+                .compose(s -> started.complete(), started);
+
+        try {
+            if (startupLatch.await(startupTimeoutSeconds, TimeUnit.SECONDS)) {
+                log.info("application startup completed successfully");
+            } else {
+                log.error("startup timed out after {} seconds, shutting down ...", startupTimeoutSeconds);
+                shutdown();
+            }
+        } catch (InterruptedException e) {
+            log.error("startup process has been interrupted, shutting down ...");
+            Thread.currentThread().interrupt();
+            shutdown();
+        }
+    }
+
+    /**
+     * Invoked before the service instances are being deployed.
+     * <p>
+     * May be overridden to prepare the environment for the service instances,
+     * e.g. deploying additional (prerequisite) verticles.
+     * <p>
+     * This default implementation simply returns a succeeded future.
+     *
+     * @param maxInstances The number of service verticle instances to deploy.
+     * @return A future indicating success. Application start-up fails if the
+     *         returned future fails.
+     */
+    protected Future<Void> deployRequiredVerticles(
+//            final int maxInstances // TODO: how can we determine this number? Do we even need it? Per service?
+    ) {
+        return Future.succeededFuture();
+    }
+
+    final Future<Void> deployServiceVerticles(final ConfigurationSupportingVerticle firstServiceInstance,
+                                              ObjectFactory<? extends ConfigurationSupportingVerticle> serviceFactory, final int maxInstances) {
+
+        Objects.requireNonNull(firstServiceInstance);
+        final Future<Void> result = Future.future();
+        @SuppressWarnings("rawtypes")
+        final List<Future> deploymentTracker = new ArrayList<>();
+        final Future<String> deployTracker = Future.future();
+        vertx.deployVerticle(firstServiceInstance, deployTracker.completer());
+        deploymentTracker.add(deployTracker);
+
+        for (int i = 0; i < maxInstances; i++) {
+            final ConfigurationSupportingVerticle serviceInstance = serviceFactory.getObject();
+            log.debug("created new instance of service: " + serviceInstance);
+            final Future<String> tracker = Future.future();
+            vertx.deployVerticle(serviceInstance, tracker.completer());
+            deploymentTracker.add(tracker);
+        }
+
+        CompositeFuture.all(deploymentTracker).setHandler(s -> {
+            if (s.succeeded()) {
+                result.complete();
+            } else {
+                result.fail(s.cause());
+            }
+        });
+
+        return result;
+    }
+
+    /**
+     * Stops this application in a controlled fashion.
+     */
+    @PreDestroy
+    public final void shutdown() {
+//        final int shutdownTimeoutSeconds = config == null ? 20 : config.getStartupTimeout();
+        final int shutdownTimeoutSeconds = 20; // TODO: how to determine timeout? Really configurable per service?
+        shutdown(shutdownTimeoutSeconds, succeeded -> {
+            // do nothing
+        });
+    }
+
+    /**
+     * Stops this application in a controlled fashion.
+     *
+     * @param maxWaitTime The maximum time to wait for the server to shut down (in seconds).
+     * @param shutdownHandler The handler to invoke with the result of the shutdown attempt.
+     */
+    public final void shutdown(final long maxWaitTime, final Handler<Boolean> shutdownHandler) {
+
+        try {
+            preShutdown();
+            final CountDownLatch latch = new CountDownLatch(1);
+            if (vertx != null) {
+                log.debug("shutting down application...");
+                vertx.close(r -> {
+                    if (r.failed()) {
+                        log.error("could not shut down application cleanly", r.cause());
+                    }
+                    latch.countDown();
+                });
+            }
+            if (latch.await(maxWaitTime, TimeUnit.SECONDS)) {
+                log.info("application has been shut down successfully");
+                shutdownHandler.handle(Boolean.TRUE);
+            } else {
+                log.error("shut down timed out, aborting...");
+                shutdownHandler.handle(Boolean.FALSE);
+            }
+        } catch (InterruptedException e) {
+            log.error("shut down has been interrupted, aborting...");
+            Thread.currentThread().interrupt();
+            shutdownHandler.handle(Boolean.FALSE);
+        }
+    }
+
+    // TODO: How could we provide this?
+//    /**
+//     * Invoked with each created service instance.
+//     * <p>
+//     * Subclasses may override this method in order to customize
+//     * the service instance before it gets deployed to the Vert.x
+//     * container.
+//     *
+//     * @param instance The service instance.
+//     */
+//    protected void customizeServiceInstance(final S instance) {
+//        // empty
+//    }
+
+    /**
+     * Invoked after the service instances have been deployed successfully.
+     * <p>
+     * May be overridden to provide additional startup logic, e.g. deploying
+     * additional verticles.
+     * <p>
+     * This default implementation simply returns a succeeded future.
+     *
+     * @return A future indicating success. Application start-up fails if the
+     *         returned future fails.
+     */
+    protected Future<Void> postRegisterServiceVerticles() {
+        return Future.succeededFuture();
+    }
+
+    /**
+     * Invoked before application shutdown is initiated.
+     * <p>
+     * May be overridden to provide additional shutdown handling, e.g.
+     * releasing resources.
+     */
+    protected void preShutdown() {
+        // empty
+    }
+}

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
@@ -12,18 +12,22 @@
 
 package org.eclipse.hono.deviceregistry;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Verticle;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractApplication;
+import org.eclipse.hono.service.HonoBeanNameGenerator;
+import org.eclipse.hono.service.NewAbstractApplication;
 import org.eclipse.hono.service.auth.AuthenticationService;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.registration.RegistrationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,10 +40,10 @@ import io.vertx.core.Future;
  * and <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
  * </p>
  */
-@ComponentScan(basePackages = { "org.eclipse.hono.service", "org.eclipse.hono.deviceregistry" })
+@ComponentScan(basePackages = { "org.eclipse.hono.service", "org.eclipse.hono.deviceregistry" }, nameGenerator = HonoBeanNameGenerator.class)
 @Configuration
 @EnableAutoConfiguration
-public class Application extends AbstractApplication<DeviceRegistryAmqpServer, ServiceConfigProperties> {
+public class Application extends NewAbstractApplication {
 
     private AuthenticationService authenticationService;
     private CredentialsService credentialsService;
@@ -78,12 +82,13 @@ public class Application extends AbstractApplication<DeviceRegistryAmqpServer, S
         this.authenticationService = Objects.requireNonNull(authenticationService);
     }
 
-    @Override
-    protected final void customizeServiceInstance(final DeviceRegistryAmqpServer instance) {
-    }
+    // TODO: How could we provide this?
+//    @Override
+//    protected final void customizeServiceInstance(final DeviceRegistryAmqpServer instance) {
+//    }
 
     @Override
-    protected final Future<Void> deployRequiredVerticles(int maxInstances) {
+    protected final Future<Void> deployRequiredVerticles() {
 
         Future<Void> result = Future.future();
         CompositeFuture.all(

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DeviceRegistryRestServer.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DeviceRegistryRestServer.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016 Bosch Software Innovations GmbH.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * Contributors:
+ * Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.deviceregistry;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.eclipse.hono.util.RegistrationConstants.ACTION_GET;
+
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.service.http.HttpServiceBase;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.http.*;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * A server that provides a REST interface to register devices. It's parent additionally provides the
+ * <a href="https://www.eclipse.org/hono/api/Device-Registration-API/">Device Registration API</a> and
+ * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a> by means of AMQP.
+ * <p>
+ * It contains code copied from {@code VertxBasedRestProtocolAdapter}.
+ * This is only a transition step to keep changes small.
+ * Currently only the "GET" operation is implemented.
+ *
+ * TODO: add all operations of the Registration API.
+ */
+@Component
+@Scope("prototype")
+public class DeviceRegistryRestServer extends HttpServiceBase<ServiceConfigProperties> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceRegistryRestServer.class);
+
+    private static final String PARAM_TENANT    = "tenant";
+    private static final String PARAM_DEVICE_ID = "device_id";
+
+
+    @Autowired
+    @Qualifier("rest")
+    @Override
+    public void setConfig(final ServiceConfigProperties configuration) {
+        setSpecificConfig(configuration);
+    }
+
+    @Override
+    protected void addRoutes(Router router) {
+        addRegistrationApiRoutes(router);
+    }
+
+    private void addRegistrationApiRoutes(final Router router) {
+        router.route(HttpMethod.GET, String.format("/registration/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
+                .handler(this::doGetDevice);
+    }
+
+    private static String getTenantParam(final RoutingContext ctx) {
+        return ctx.request().getParam(PARAM_TENANT);
+    }
+
+    private static String getDeviceIdParam(final RoutingContext ctx) {
+        return ctx.request().getParam(PARAM_DEVICE_ID);
+    }
+
+    private void doGetDevice(final RoutingContext ctx) {
+
+        final String deviceId = getDeviceIdParam(ctx);
+        final String tenantId = getTenantParam(ctx);
+
+        final JsonObject requestMsg = RegistrationConstants.getServiceRequestAsJson(ACTION_GET, tenantId, deviceId);
+
+        vertx.eventBus().send(RegistrationConstants.EVENT_BUS_ADDRESS_REGISTRATION_IN, requestMsg,
+                result -> {
+                    HttpServerResponse response = ctx.response();
+                    if (result.failed()) {
+                        internalServerError(response, "could not get device");
+                    } else {
+                        JsonObject registrationResult = (JsonObject) result.result().body();
+                        Integer status = Integer.valueOf(registrationResult.getString("status"));
+                        response.setStatusCode(status);
+                        switch (status) {
+                            case HTTP_OK:
+                                String msg = registrationResult.encodePrettily();
+                                response
+                                        .putHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_JSON_UFT8)
+                                        .putHeader(HttpHeaders.CONTENT_LENGTH, String.valueOf(msg.length()))
+                                        .write(msg);
+                            default:
+                                response.end();
+                        }
+                    }
+                });
+    }
+}
+
+
+
+
+


### PR DESCRIPTION
Added class NewAbstractApplication to show how AbstractApplication could
be modified to support multiple servers per application (added as a
copy only for this prototype, should be renamed to AbstractApplication
and replace it).
Device registry is used as an example to show how it could be used.

Signed-off-by: Abel Buechner <Abel.Buechner@bosch-si.com>