### PR TITLE
[#261] Credentials validation architecture for protocol adapters.

### DIFF
--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Application.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Application.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * The Hono MQTT adapter main application class.
  */
-@ComponentScan(basePackages = "org.eclipse.hono.adapter.mqtt")
+@ComponentScan(basePackages = {"org.eclipse.hono.adapter.mqtt", "org.eclipse.hono.service.credentials"})
 @Configuration
 @EnableAutoConfiguration
 public class Application extends AbstractApplication<VertxBasedMqttProtocolAdapter, ServiceConfigProperties> {

--- a/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
@@ -40,6 +40,9 @@ public final class CredentialsConstants extends RequestResponseApiConstants {
 
     public static final String CREDENTIALS_ENDPOINT              = "credentials";
 
+    public static final String SECRETS_TYPE_HASHED_PASSWORD      = "hashed-password";
+    public static final String SECRETS_TYPE_PRESHARED_KEY        = "psk";
+
     private static final List<String> OPERATIONS = Arrays.asList(OPERATION_GET, OPERATION_ADD, OPERATION_UPDATE, OPERATION_REMOVE);
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsSecretsValidator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsSecretsValidator.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.credentials;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Interface that all credentials validators need to implement.
+ * <p>
+ * Any mechanism to authenticate a device is based on credentials secrets that are defined in the
+ * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+ * This interface defines the methods necessary to provide an algorithm for validating any of these secrets.
+ * <p>
+ * Validators that implement this interface and are implemented as Spring beans in the package
+ * {@link org.eclipse.hono.service.credentials.validators} will be automatically found during startup and are used
+ * during authentication.
+ * This makes adding of own validators very easy.
+ * <p>See the provided validators (e.g. {@link org.eclipse.hono.service.credentials.validators.CredentialsValidatorHashedPassword})
+ * as a blueprint for how to write own validators.
+ * See {@link org.eclipse.hono.service.credentials.validators.AbstractCredentialsValidator} as the base class for such
+ * implementations.
+ *
+ * @param <T> The type of what has to be validated (called item below): this can be String in case of password validation, a certificate
+ *           class in case of a client certificate, etc.
+ */
+
+public interface CredentialsSecretsValidator<T> {
+    /**
+     * Get the type of credentials secrets this validator is responsible for.
+     * <p>This can be freely defined, but there are some predefined types in the
+     * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     *
+     * @return The type of credentials secrets.
+     */
+    String getSecretsType();
+
+    /**
+     * Validate  an instance of T (e.g. a password) against credentials secrets (as JsonObject as defined in the
+     * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>).
+     * <p>
+     *
+     * @param payload The payload as returned from the credentials API get operation.
+     * @param itemToValidate The item that has to be validated, e.g. a password String, a certificate, etc.
+     *
+     * @return True if the item could be validated, false otherwise.
+     */
+    boolean validate(final JsonObject payload, T itemToValidate);
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsUtils.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.credentials;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+/**
+ * Utility class as Spring bean that is used by protocol adapters to find matching implementations for the
+ * validation of authentication objects.
+ */
+@Component
+@Scope("prototype")
+public final class CredentialsUtils {
+    private final Map<String, Set<CredentialsSecretsValidator>> secretsValidators = new HashMap<>();
+
+    @Autowired(required = false)
+    public final void addValidators(final List<CredentialsSecretsValidator> definedValidators) {
+        Objects.requireNonNull(definedValidators);
+        for (CredentialsSecretsValidator secretsValidator : definedValidators) {
+            addSecretsValidator(secretsValidator);
+        }
+    }
+
+    private void addSecretsValidator(final CredentialsSecretsValidator secretsValidator) {
+        Set<CredentialsSecretsValidator> validatorsSet;
+        if (secretsValidators.containsKey(secretsValidator.getSecretsType())) {
+            validatorsSet = secretsValidators.get(secretsValidator.getSecretsType());
+        } else {
+            validatorsSet = new HashSet<CredentialsSecretsValidator>();
+        }
+        validatorsSet.add(secretsValidator);
+        secretsValidators.put(secretsValidator.getSecretsType(), validatorsSet);
+    }
+
+    public Set<CredentialsSecretsValidator> findAppropriateValidators(final String secretsType) {
+        return secretsValidators.get(secretsType);
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/validators/AbstractCredentialsValidator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/validators/AbstractCredentialsValidator.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.credentials.validators;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.eclipse.hono.service.credentials.CredentialsSecretsValidator;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Abstract validator class from which concrete validators are derived that are specialized to a specific type of
+ * credential secrets.
+ * <p>
+ * The class implements the validation steps that are common to all types of credentials. This e.g. includes the enabled
+ * flag of credential entries, the iteration over several valid credential entries (until one is successfully validated
+ * or none is left), etc.
+ * <p>
+ * The detailed algorithm to validate a single credential entry is delegated to the implementing subclass and so supports
+ * a specified small implementation class per credentials type..
+ *
+ * @param <T> The type of what has to be validated (called item below): this can be String in case of password validation, a certificate
+ *           class in case of a client certificate, etc.
+ */
+public abstract class AbstractCredentialsValidator<T> implements CredentialsSecretsValidator<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractCredentialsValidator.class);
+
+    /**
+     * Get the type of credentials secrets this validator is responsible for.
+     * <p>This can be freely defined, but there are some predefined types in the
+     * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     *
+     * @return The type of credentials secrets.
+     */
+    @Override
+    public abstract String getSecretsType();
+
+    /**
+     * Validate an instance of T (e.g. a password) against a single credentials secret (as JsonObject).
+     * <p>
+     * Subclasses need to implement their specified algorithm for validation in this method.
+     *
+     * @param itemToValidate The item to validate.
+     * @param aSecret The secret record as JsonObject (as returned by the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * @return The result of the validation as boolean.
+     */
+    protected abstract boolean validateSingleSecret(final T itemToValidate, final JsonObject aSecret);
+
+    /**
+     * Validate  an instance of T (e.g. a password) against credentials secrets (as JsonObject as defined in the
+     * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>).
+     * <p>
+     * The payload from the get operation of the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>
+     * is parsed and splitted into single secrets entries in this method. The single entries are then delegated to the
+     * {@link #validateSingleSecret(Object, JsonObject)} method of the implementing subclass where the detailed
+     * validation is processed. If one entry was successfully validated, the validation is considered
+     * successful and the result is completed. If no secret could be validated, the validation fails and thus the result
+     * is set to failed.
+     *
+     * @param credentialsGetPayload The payload as returned from the credentials get operation.
+     * @param authenticationObject The object to authenticate.
+     *
+     * @return boolean True if the authenticationObject could be validated, false otherwise.
+     */
+    @Override
+    public final boolean validate(final JsonObject credentialsGetPayload, final T authenticationObject) {
+
+        if (!checkMandatoryFields(credentialsGetPayload)) {
+            return false;
+        }
+
+        if (credentialsGetPayload.containsKey(CredentialsConstants.FIELD_ENABLED) && !credentialsGetPayload.getBoolean(CredentialsConstants.FIELD_ENABLED)) {
+            // if not found : default is enabled
+            LOG.debug("Credentials not validated - device disabled");
+            return false;
+        }
+
+        JsonArray secrets = credentialsGetPayload.getJsonArray(CredentialsConstants.FIELD_SECRETS);
+
+        if (secrets == null) {
+            LOG.debug("Credentials not validated - mandatory field {} is null", CredentialsConstants.FIELD_SECRETS);
+            return false;
+        }
+
+        if (secrets.size() == 0) {
+            LOG.debug("Credentials not validated - mandatory field {} is empty", CredentialsConstants.FIELD_SECRETS);
+            return false;
+        }
+
+        // find any validated secret -> validation was successful
+        Predicate<Object> validationPred = secret -> validateSingleSecret(authenticationObject, (JsonObject) secret);
+        Optional<Object> validationSecret = secrets.stream().filter(validationPred).findAny();
+
+        if (!validationSecret.isPresent()) {
+            LOG.debug("Credentials not validated - invalid");
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean checkMandatoryFields(final JsonObject payload) {
+
+        if (!payload.containsKey(CredentialsConstants.FIELD_SECRETS)) {
+            LOG.debug("Credentials not validated - mandatory field {} not found", CredentialsConstants.FIELD_SECRETS);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/validators/CredentialsValidatorHashedPassword.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/validators/CredentialsValidatorHashedPassword.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.credentials.validators;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+
+import org.eclipse.hono.util.CredentialsConstants;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Validator to validate credentials of type {@link CredentialsConstants#SECRETS_TYPE_HASHED_PASSWORD} for a given password.
+ */
+@Component
+@Scope("prototype")
+public final class CredentialsValidatorHashedPassword extends AbstractCredentialsValidator<String> {
+
+    /**
+     * Get the type of credentials secrets this validator is responsible for.
+     *
+     * @return The type of credentials secrets.
+     */
+    @Override
+    public String getSecretsType() {
+        return CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD;
+    }
+
+    /**
+     * Approve a single secret (as JsonObject) against a given password.
+     * If the password matches against it, the approval is considered successful.
+     * <p>This involves the hash-function found in the credentials secrets record to hash the given password before the
+     * comparison against the password in the credentials secrets record is done.
+     * <p>If a salt is contained in the credentials record (in base64 encoding), the hash function will be salted first.
+     *
+     * @param password The password to validate.
+     * @param aSecret The secret record as JsonObject (as returned by the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * @return The result of the approval as boolean.
+     */
+    @Override
+    protected boolean validateSingleSecret(final String password, final JsonObject aSecret) {
+        String hashFunction = aSecret.getString(CredentialsConstants.FIELD_SECRETS_HASH_FUNCTION);
+        if (hashFunction == null) {
+            return false;
+        }
+
+        return checkPasswordAgainstSecret(aSecret, hashFunction, password);
+    }
+
+    private boolean checkPasswordAgainstSecret(final JsonObject secret, final String hashFunction, final String protocolAdapterPassword) {
+
+        String pwdHash = secret.getString(CredentialsConstants.FIELD_SECRETS_PWD_HASH);
+        if (pwdHash == null) {
+            return false;
+        }
+
+        byte[] password = Base64.getDecoder().decode(pwdHash);
+
+        // TODO: performance - always decode salts is terrible
+        final String salt = secret.getString(CredentialsConstants.FIELD_SECRETS_SALT);
+        final byte[] decodedSalt = Base64.getDecoder().decode(salt);
+        final String decodedSaltStr = new String(decodedSalt);
+
+        try {
+            byte[] hashedPassword = hashPassword(hashFunction, decodedSaltStr, protocolAdapterPassword);
+            if (!Arrays.equals(password, hashedPassword)) {
+                return false;
+            }
+        } catch (NoSuchAlgorithmException e) {
+            return false;
+        } catch (UnsupportedEncodingException e) {
+            return false;
+        }
+        // check if the password is the hashed version of the protocol adapter password
+        return true;
+    }
+
+    private byte[] hashPassword(final String hashFunction,final String hashSalt, final String passwordToHash) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        MessageDigest messageDigest = MessageDigest.getInstance(hashFunction);
+        messageDigest.update(hashSalt.getBytes("UTF-8"));
+        byte[] theHashedPassword = messageDigest.digest(passwordToHash.getBytes());
+        return theHashedPassword;
+    }
+}


### PR DESCRIPTION
Starting with the mqtt protocol adapter this commit implements the
username/password authentication for devices against the credentials
type "hashed-password". The algorithms for validation are plugged into
Hono via Spring beans that implement the CredentialsSecretsValidator interface.

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>