### PR TITLE
[#259] Add support for multiple protocols per application.

### DIFF
--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Application.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Application.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.hono.adapter.mqtt;
 
-import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -26,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 @ComponentScan(basePackages = "org.eclipse.hono.adapter.mqtt")
 @Configuration
 @EnableAutoConfiguration
-public class Application extends AbstractApplication<VertxBasedMqttProtocolAdapter, ServiceConfigProperties> {
+public class Application extends AbstractApplication {
 
     /**
      * Starts the MQTT Adapter application.

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Config.java
@@ -21,12 +21,21 @@ import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 
 /**
  * Configuration class
  */
 @Configuration
 public class Config extends AbstractAdapterConfig {
+
+    private static final String BEAN_NAME_VERTX_BASED_MQTT_PROTOCOL_ADAPTER = "vertxBasedMqttProtocolAdapter";
+
+    @Bean(name = BEAN_NAME_VERTX_BASED_MQTT_PROTOCOL_ADAPTER)
+    @Scope("prototype")
+    public VertxBasedMqttProtocolAdapter vertxBasedMqttProtocolAdapter(){
+        return new VertxBasedMqttProtocolAdapter();
+    }
 
     @Override
     protected void customizeMessagingClientConfigProperties(final ClientConfigProperties props) {
@@ -72,7 +81,7 @@ public class Config extends AbstractAdapterConfig {
     @Bean
     public ObjectFactoryCreatingFactoryBean serviceFactory() {
         ObjectFactoryCreatingFactoryBean factory = new ObjectFactoryCreatingFactoryBean();
-        factory.setTargetBeanName(VertxBasedMqttProtocolAdapter.class.getName());
+        factory.setTargetBeanName(BEAN_NAME_VERTX_BASED_MQTT_PROTOCOL_ADAPTER);
         return factory;
     }
 }

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
@@ -25,8 +25,6 @@ import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
 import io.netty.handler.codec.mqtt.MqttQoS;
@@ -40,8 +38,6 @@ import io.vertx.mqtt.messages.MqttPublishMessage;
 /**
  * A Vert.x based Hono protocol adapter for accessing Hono's Telemetry API using MQTT.
  */
-@Component
-@Scope("prototype")
 public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<ServiceConfigProperties> {
 
     private static final Logger LOG = LoggerFactory.getLogger(VertxBasedMqttProtocolAdapter.class);

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Application.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Application.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.hono.adapter.rest;
 
-import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -24,7 +23,7 @@ import org.springframework.context.annotation.Configuration;
 @ComponentScan(basePackages = "org.eclipse.hono.adapter.rest")
 @Configuration
 @EnableAutoConfiguration
-public class Application extends AbstractApplication<VertxBasedRestProtocolAdapter, ServiceConfigProperties> {
+public class Application extends AbstractApplication {
 
     /**
      * Starts the REST Adapter application.

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Config.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Config.java
@@ -20,12 +20,21 @@ import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 
 /**
  * Spring Beans used by the Hono REST protocol adapter.
  */
 @Configuration
 public class Config extends AbstractAdapterConfig {
+
+    private static final String BEAN_NAME_VERTX_BASED_REST_PROTOCOL_ADAPTER = "vertxBasedRestProtocolAdapter";
+
+    @Bean(name = BEAN_NAME_VERTX_BASED_REST_PROTOCOL_ADAPTER)
+    @Scope("prototype")
+    public VertxBasedRestProtocolAdapter vertxBasedRestProtocolAdapter(){
+        return new VertxBasedRestProtocolAdapter();
+    }
 
     @Override
     protected void customizeMessagingClientConfigProperties(final ClientConfigProperties props) {
@@ -71,7 +80,7 @@ public class Config extends AbstractAdapterConfig {
     @Bean
     public ObjectFactoryCreatingFactoryBean serviceFactory() {
         ObjectFactoryCreatingFactoryBean factory = new ObjectFactoryCreatingFactoryBean();
-        factory.setTargetBeanName(VertxBasedRestProtocolAdapter.class.getName());
+        factory.setTargetBeanName(BEAN_NAME_VERTX_BASED_REST_PROTOCOL_ADAPTER);
         return factory;
     }
 }

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapter.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapter.java
@@ -24,8 +24,6 @@ import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.util.RegistrationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -39,8 +37,6 @@ import io.vertx.ext.web.RoutingContext;
 /**
  * A Vert.x based Hono protocol adapter for accessing Hono's Telemetry &amp; Registration API using REST.
  */
-@Component
-@Scope("prototype")
 public class VertxBasedRestProtocolAdapter extends AbstractVertxBasedHttpProtocolAdapter<ServiceConfigProperties> {
 
     private static final Logger LOG = LoggerFactory.getLogger(VertxBasedRestProtocolAdapter.class);

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/Application.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/Application.java
@@ -14,7 +14,6 @@ package org.eclipse.hono.service.auth.impl;
 
 import java.util.Objects;
 
-import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractApplication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
@@ -32,7 +31,7 @@ import io.vertx.core.Future;
 @ComponentScan(basePackages = "org.eclipse.hono.service.auth")
 @Configuration
 @EnableAutoConfiguration
-public class Application extends AbstractApplication<SimpleAuthenticationServer, ServiceConfigProperties> {
+public class Application extends AbstractApplication {
 
     private FileBasedAuthenticationService authenticationService;
 

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/ApplicationConfig.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/ApplicationConfig.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Configuration;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.dns.AddressResolverOptions;
+import org.springframework.context.annotation.Scope;
 
 /**
  * Spring Boot configuration for the simple authentication server application.
@@ -33,6 +34,8 @@ import io.vertx.core.dns.AddressResolverOptions;
  */
 @Configuration
 public class ApplicationConfig {
+
+    private static final String BEAN_NAME_SIMPLE_AUTHENTICATION_SERVER = "simpleAuthenticationServer";
 
     /**
      * Gets the singleton Vert.x instance to be used by Hono.
@@ -50,6 +53,12 @@ public class ApplicationConfig {
         return Vertx.vertx(options);
     }
 
+    @Bean(name = BEAN_NAME_SIMPLE_AUTHENTICATION_SERVER)
+    @Scope("prototype")
+    public SimpleAuthenticationServer simpleAuthenticationServer(){
+        return new SimpleAuthenticationServer();
+    }
+
     /**
      * Exposes a factory for creating service instances as a Spring bean.
      * 
@@ -58,7 +67,7 @@ public class ApplicationConfig {
     @Bean
     public ObjectFactoryCreatingFactoryBean authServerFactory() {
         ObjectFactoryCreatingFactoryBean factory = new ObjectFactoryCreatingFactoryBean();
-        factory.setTargetBeanName(SimpleAuthenticationServer.class.getName());
+        factory.setTargetBeanName(BEAN_NAME_SIMPLE_AUTHENTICATION_SERVER);
         return factory;
     }
 

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
@@ -21,8 +21,6 @@ import org.eclipse.hono.service.amqp.Endpoint;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
 import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.ProtonHelper;
@@ -34,8 +32,6 @@ import io.vertx.proton.ProtonSender;
  * An authentication server serving JSON Web Tokens to clients that have been authenticated using SASL.
  *
  */
-@Component
-@Scope("prototype")
 public final class SimpleAuthenticationServer extends AmqpServiceBase<ServiceConfigProperties> {
 
     @Autowired

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
@@ -16,7 +16,6 @@ import java.util.Objects;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Verticle;
-import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractApplication;
 import org.eclipse.hono.service.auth.AuthenticationService;
 import org.eclipse.hono.service.credentials.CredentialsService;
@@ -39,7 +38,7 @@ import io.vertx.core.Future;
 @ComponentScan(basePackages = { "org.eclipse.hono.service", "org.eclipse.hono.deviceregistry" })
 @Configuration
 @EnableAutoConfiguration
-public class Application extends AbstractApplication<DeviceRegistryAmqpServer, ServiceConfigProperties> {
+public class Application extends AbstractApplication {
 
     private AuthenticationService authenticationService;
     private CredentialsService credentialsService;
@@ -76,10 +75,6 @@ public class Application extends AbstractApplication<DeviceRegistryAmqpServer, S
     @Autowired
     public final void setAuthenticationService(final AuthenticationService authenticationService) {
         this.authenticationService = Objects.requireNonNull(authenticationService);
-    }
-
-    @Override
-    protected final void customizeServiceInstance(final DeviceRegistryAmqpServer instance) {
     }
 
     @Override

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -37,6 +37,8 @@ import org.springframework.context.annotation.Scope;
 @Configuration
 public class ApplicationConfig {
 
+    private static final String BEAN_NAME_DEVICE_REGISTRY_AMQP_SERVER = "deviceRegistryAmqpServer";
+
     /**
      * Gets the singleton Vert.x instance to be used by Hono.
      * 
@@ -51,6 +53,12 @@ public class ApplicationConfig {
                         .setCacheMaxTimeToLive(0) // support DNS based service resolution
                         .setQueryTimeout(1000));
         return Vertx.vertx(options);
+    }
+
+    @Bean(BEAN_NAME_DEVICE_REGISTRY_AMQP_SERVER)
+    @Scope("prototype")
+    public DeviceRegistryAmqpServer deviceRegistryAmqpServer(){
+        return new DeviceRegistryAmqpServer();
     }
 
     /**
@@ -72,7 +80,7 @@ public class ApplicationConfig {
     @Bean
     public ObjectFactoryCreatingFactoryBean deviceRegistryServerFactory() {
         ObjectFactoryCreatingFactoryBean factory = new ObjectFactoryCreatingFactoryBean();
-        factory.setTargetBeanName(DeviceRegistryAmqpServer.class.getName());
+        factory.setTargetBeanName(BEAN_NAME_DEVICE_REGISTRY_AMQP_SERVER);
         return factory;
     }
 

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DeviceRegistryAmqpServer.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DeviceRegistryAmqpServer.java
@@ -22,8 +22,6 @@ import org.eclipse.hono.service.auth.AuthenticationConstants;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
 import java.util.Objects;
 
@@ -34,8 +32,6 @@ import java.util.Objects;
  * It implements Hono's <a href="https://www.eclipse.org/hono/api/Device-Registration-API/">Device Registration API</a> and
  * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
  */
-@Component
-@Scope("prototype")
 public final class DeviceRegistryAmqpServer extends AmqpServiceBase<ServiceConfigProperties> {
 
     private ConnectionFactory authenticationService;

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessaging.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessaging.java
@@ -25,8 +25,6 @@ import org.eclipse.hono.telemetry.TelemetryConstants;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
 import io.vertx.core.Future;
 
@@ -36,8 +34,6 @@ import java.util.Objects;
  * Hono Messaging is an AMQP 1.0 container that provides nodes for uploading <em>Telemetry</em> and
  * <em>Event</em> messages.
  */
-@Component
-@Scope("prototype")
 public final class HonoMessaging extends AmqpServiceBase<HonoMessagingConfigProperties> {
 
     private ConnectionFactory authenticationService;

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplication.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplication.java
@@ -32,7 +32,7 @@ import io.vertx.core.Verticle;
 @ComponentScan(basePackages = "org.eclipse.hono")
 @Configuration
 @EnableAutoConfiguration
-public class HonoMessagingApplication extends AbstractApplication<HonoMessaging, HonoMessagingConfigProperties> {
+public class HonoMessagingApplication extends AbstractApplication {
 
     private static final Logger LOG = LoggerFactory.getLogger(HonoMessagingApplication.class);
 

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplicationConfig.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplicationConfig.java
@@ -29,12 +29,15 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.metrics.MetricsOptions;
+import org.springframework.context.annotation.Scope;
 
 /**
  * Spring bean definitions required by the Hono application.
  */
 @Configuration
 public class HonoMessagingApplicationConfig {
+
+    private static final String BEAN_NAME_HONO_MESSAGING = "honoMessaging";
 
     private MetricsOptions metricsOptions;
 
@@ -68,6 +71,12 @@ public class HonoMessagingApplicationConfig {
         return Vertx.vertx(options);
     }
 
+    @Bean(name = BEAN_NAME_HONO_MESSAGING)
+    @Scope("prototype")
+    public HonoMessaging honoMessaging() {
+        return new HonoMessaging();
+    }
+
     /**
      * Exposes a factory for {@code HonoServer} instances as a Spring bean.
      * 
@@ -76,7 +85,7 @@ public class HonoMessagingApplicationConfig {
     @Bean
     public ObjectFactoryCreatingFactoryBean honoServerFactory() {
         ObjectFactoryCreatingFactoryBean factory = new ObjectFactoryCreatingFactoryBean();
-        factory.setTargetBeanName(HonoMessaging.class.getName());
+        factory.setTargetBeanName(BEAN_NAME_HONO_MESSAGING);
         return factory;
     }
 


### PR DESCRIPTION
Class AbstractApplication is no longer parametrized with service type
and configuration type. Services are now picked up dynamically at
startup if corresponding ObjectFactories are provided. The
targetBeanName now needs to be the name of an existing bean.
For discussion see #287.

Signed-off-by: Abel Buechner <Abel.Buechner@bosch-si.com>