### PR TITLE
[#259] Provide device registry AMQP API in hono-service-base.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/registration/DeviceRegistryAmqpServerBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/DeviceRegistryAmqpServerBase.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.service.registration;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.connection.ConnectionFactory;
+import org.eclipse.hono.service.amqp.AmqpServiceBase;
+import org.eclipse.hono.service.amqp.Endpoint;
+import org.eclipse.hono.service.auth.AuthenticationConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.util.Objects;
+
+/**
+ * Abstract base class that provides APIs which can be used to implement a device registry.
+ * 
+ * Beans of it's subclasses could be used to expose Hono's
+ * <a href="https://www.eclipse.org/hono/api/Device-Registration-API/">Device Registration API</a> and
+ * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+ */
+public abstract class DeviceRegistryAmqpServerBase extends AmqpServiceBase<ServiceConfigProperties> {
+
+    public static final String CONFIGURATION_QUALIFIER_AMQP = "amqp";
+
+    private ConnectionFactory authenticationService;
+
+    @Autowired
+    @Qualifier(CONFIGURATION_QUALIFIER_AMQP)
+    @Override
+    public void setConfig(final ServiceConfigProperties configuration) {
+        setSpecificConfig(configuration);
+    }
+
+    /**
+     * Sets the factory to use for creating an AMQP 1.0 connection to
+     * the Authentication service.
+     *
+     * @param factory The factory.
+     * @throws NullPointerException if factory is {@code null}.
+     */
+    @Autowired
+    @Qualifier(AuthenticationConstants.QUALIFIER_AUTHENTICATION)
+    public void setAuthenticationServiceConnectionFactory(final ConnectionFactory factory) {
+        authenticationService = Objects.requireNonNull(factory);
+    }
+
+    /**
+     * Registers this service's endpoints' readiness checks.
+     * <p>
+     * This invokes {@link Endpoint#registerReadinessChecks(HealthCheckHandler)} for all registered endpoints
+     * and it checks if the <em>Authentication Service</em> is connected.
+     * <p>
+     * Subclasses should override this method to register more specific checks.
+     *
+     * @param handler The health check handler to register the checks with.
+     */
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler handler) {
+        for (Endpoint ep : endpoints()) {
+            ep.registerReadinessChecks(handler);
+        }
+        handler.register("authentication-service-connection", status -> {
+            if (authenticationService == null) {
+                status.complete(Status.KO(new JsonObject().put("error", "no connection factory set for Authentication service")));
+            } else {
+                LOG.debug("checking connection to Authentication service");
+                authenticationService.connect(null, null, null, s -> {
+                    if (s.succeeded()) {
+                        s.result().close();
+                        status.complete(Status.OK());
+                    } else {
+                        status.complete(Status.KO(new JsonObject().put("error", "cannot connect to Authentication service")));
+                    }
+                });
+            }
+        });
+    }
+}

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -18,6 +18,7 @@ import io.vertx.core.dns.AddressResolverOptions;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.credentials.CredentialsEndpoint;
+import org.eclipse.hono.service.registration.DeviceRegistryAmqpServerBase;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.service.registration.RegistrationEndpoint;
@@ -89,7 +90,7 @@ public class ApplicationConfig {
      * 
      * @return The properties.
      */
-    @Qualifier("amqp")
+    @Qualifier(DeviceRegistryAmqpServerBase.CONFIGURATION_QUALIFIER_AMQP)
     @Bean
     @ConfigurationProperties(prefix = "hono.registry.amqp")
     public ServiceConfigProperties amqpProperties() {

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DeviceRegistryAmqpServer.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DeviceRegistryAmqpServer.java
@@ -12,82 +12,17 @@
 
 package org.eclipse.hono.deviceregistry;
 
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.healthchecks.HealthCheckHandler;
-import io.vertx.ext.healthchecks.Status;
-import org.eclipse.hono.connection.ConnectionFactory;
-import org.eclipse.hono.service.amqp.AmqpServiceBase;
-import org.eclipse.hono.service.amqp.Endpoint;
-import org.eclipse.hono.service.auth.AuthenticationConstants;
-import org.eclipse.hono.config.ServiceConfigProperties;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
-import java.util.Objects;
-
+import org.eclipse.hono.service.registration.DeviceRegistryAmqpServerBase;
 
 /**
- * Spring component that serves as the default implementation of Hono's device registry.
- * <p>
- * It implements Hono's <a href="https://www.eclipse.org/hono/api/Device-Registration-API/">Device Registration API</a> and
- * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+ * Default AQMP server for Hono's example device registry.
  */
-public final class DeviceRegistryAmqpServer extends AmqpServiceBase<ServiceConfigProperties> {
-
-    private ConnectionFactory authenticationService;
+public final class DeviceRegistryAmqpServer extends DeviceRegistryAmqpServerBase {
 
     @Override
     protected String getServiceName() {
         return "Hono-DeviceRegistry";
     }
 
-    @Autowired
-    @Qualifier("amqp")
-    @Override
-    public void setConfig(final ServiceConfigProperties configuration) {
-        setSpecificConfig(configuration);
-    }
-
-    /**
-     * Sets the factory to use for creating an AMQP 1.0 connection to
-     * the Authentication service.
-     *
-     * @param factory The factory.
-     * @throws NullPointerException if factory is {@code null}.
-     */
-    @Autowired
-    @Qualifier(AuthenticationConstants.QUALIFIER_AUTHENTICATION)
-    public void setAuthenticationServiceConnectionFactory(final ConnectionFactory factory) {
-        authenticationService = Objects.requireNonNull(factory);
-    }
-
-    /**
-     * Registers this service's endpoints' readiness checks.
-     * <p>
-     * This invokes {@link Endpoint#registerReadinessChecks(HealthCheckHandler)} for all registered endpoints
-     * and it checks if the <em>Authentication Service</em> is connected.
-     *
-     * @param handler The health check handler to register the checks with.
-     */
-    @Override
-    public void registerReadinessChecks(final HealthCheckHandler handler) {
-        for (Endpoint ep : endpoints()) {
-            ep.registerReadinessChecks(handler);
-        }
-        handler.register("authentication-service-connection", status -> {
-            if (authenticationService == null) {
-                status.complete(Status.KO(new JsonObject().put("error", "no connection factory set for Authentication service")));
-            } else {
-                LOG.debug("checking connection to Authentication service");
-                authenticationService.connect(null, null, null, s -> {
-                    if (s.succeeded()) {
-                        s.result().close();
-                        status.complete(Status.OK());
-                    } else {
-                        status.complete(Status.KO(new JsonObject().put("error", "cannot connect to Authentication service")));
-                    }
-                });
-            }
-        });
-    }
 }


### PR DESCRIPTION
Introduced base class DeviceRegistryAmqpServerBase and moved logic to there.

Signed-off-by: Abel Buechner <Abel.Buechner@bosch-si.com>