### PR TITLE
[#259] Make REST API of device registry available.

### DIFF
--- a/example/src/main/config/hono-service-device-registry-config.yml
+++ b/example/src/main/config/hono-service-device-registry-config.yml
@@ -17,6 +17,10 @@ hono:
       bindAddress: 0.0.0.0
       keyPath: /run/secrets/device-registry-key.pem
       certPath: /run/secrets/device-registry-cert.pem
+    rest:
+      bindAddress: 0.0.0.0
+      keyPath: /run/secrets/device-registry-key.pem
+      certPath: /run/secrets/device-registry-cert.pem
     svc:
       signing:
         sharedSecret: ${hono.regAssertion.sharedSecret}

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/BaseEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/BaseEndpoint.java
@@ -74,7 +74,6 @@ public abstract class BaseEndpoint<T> implements Endpoint, HealthCheckProvider {
      * @param props The properties.
      * @throws NullPointerException if props is {@code null}.
      */
-    @Autowired(required = false)
     public final void setConfiguration(final T props) {
         this.config = Objects.requireNonNull(props);
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/DeviceRegistryRestServerBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/DeviceRegistryRestServerBase.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.service.registration;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.eclipse.hono.util.RegistrationConstants.ACTION_GET;
 
+import io.vertx.ext.healthchecks.HealthCheckHandler;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.http.HttpServiceBase;
 import org.eclipse.hono.util.RegistrationConstants;

--- a/services/device-registry/pom.xml
+++ b/services/device-registry/pom.xml
@@ -57,6 +57,8 @@
                     <ports>
                       <port>5671</port>
                       <port>5672</port>
+                      <port>8080</port>
+                      <port>8443</port>
                       <port>${vertx.health.port}</port>
                     </ports>
                     <runCmds>

--- a/services/device-registry/src/main/fabric8/service.yml
+++ b/services/device-registry/src/main/fabric8/service.yml
@@ -1,0 +1,11 @@
+spec:
+  type: NodePort
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+    nodePort: 31080
+  - port: 8443
+    protocol: TCP
+    targetPort: 8443
+    nodePort: 31443


### PR DESCRIPTION
Add configuration to use the REST interface of the device registry:
Beans are now instantiated, Docker image configured and
Kubernetes service added. BaseEndpoint.setConfiguration() is no longer
autowired.

Signed-off-by: Abel Buechner <Abel.Buechner@bosch-si.com>