### PR TITLE
Fix certificate paths in commands in the documentation

### DIFF
--- a/site/content/component/auth-server.md
+++ b/site/content/component/auth-server.md
@@ -121,14 +121,14 @@ In order to do so, the server can be started using the `spring-boot:run` maven g
 The corresponding command to start up the server with the configuration used in the Docker example above looks like this:
 
 ~~~sh
-~/hono/services/auth$ mvn spring-boot:run -Drun.arguments=\
+~/hono/services/auth$ mvn spring-boot:run -Drun.profiles=authentication-impl -Drun.arguments=\
 > --hono.auth.amqp.bindAddress=0.0.0.0,\
-> --hono.auth.amqp.keyPath=target/certs/auth-server-key.pem,\
-> --hono.auth.amqp.certPath=target/certs/auth-server-cert.pem,\
-> --hono.auth.amqp.trustStorePath=target/certs/trusted-certs.pem
+> --hono.auth.amqp.keyPath=../../demo-certs/certs/auth-server-key.pem,\
+> --hono.auth.amqp.certPath=../../demo-certs/certs/auth-server-cert.pem,\
+> --hono.auth.amqp.trustStorePath=../../demo-certs/certs/trusted-certs.pem
 ~~~
 
 {{% note %}}
 You may want to make logging of the server a little more verbose by enabling the *dev* Spring profile.
-To do so, append *-Drun.profiles=authentication-impl,dev* to the command line.
+To do so, change the above command line to contain *-Drun.profiles=authentication-impl,dev*.
 {{% /note %}}

--- a/site/content/component/device-registry.md
+++ b/site/content/component/device-registry.md
@@ -159,13 +159,13 @@ The corresponding command to start up the server with the configuration used in 
 ~~~sh
 ~/hono/services/device-registry $ mvn spring-boot:run -Drun.arguments=\
 > --hono.registry.amqp.bindAddress=0.0.0.0,\
-> --hono.registry.amqp.keyPath=target/certs/device-registry-key.pem,\
-> --hono.registry.amqp.certPath=target/certs/device-registry-cert.pem,\
-> --hono.registry.amqp.trustStorePath=target/certs/trusted-certs.pem,\
+> --hono.registry.amqp.keyPath=../../demo-certs/certs/device-registry-key.pem,\
+> --hono.registry.amqp.certPath=../../demo-certs/certs/device-registry-cert.pem,\
+> --hono.registry.amqp.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
 > --hono.auth.host=localhost,\
 > --hono.auth.name='device-registry',\
-> --hono.auth.validation.certPath=target/certs/auth-server-cert.pem,\
-> --hono.auth.trustStorePath=target/certs/trusted-certs.pem
+> --hono.auth.validation.certPath=../../demo-certs/certs/auth-server-cert.pem,\
+> --hono.auth.trustStorePath=../../demo-certs/certs/trusted-certs.pem
 ~~~
 
 {{% note %}}

--- a/site/content/component/hono-messaging.md
+++ b/site/content/component/hono-messaging.md
@@ -172,21 +172,21 @@ In order to do so, the service can be started using the `spring-boot:run` maven 
 The corresponding command to start up the service with the configuration used in the Docker example above looks like this:
 
 ~~~sh
-~/hono/services/messaging$ mvn spring-boot:run -Drun.arguments= \
+~/hono/services/messaging$ mvn spring-boot:run -Drun.arguments=\
 > --hono.auth.host=auth-server.hono,\
-> --hono.auth.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.auth.validation.certPath=target/certs/auth-server-cert.pem,\
+> --hono.auth.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+> --hono.auth.validation.certPath=../../demo-certs/certs/auth-server-cert.pem,\
 > --hono.auth.hostnameVerificationRequired=false,\
 > --hono.downstream.host=qdrouter.hono,\
 > --hono.downstream.port=5673,\
 > --hono.downstream.hostnameVerificationRequired=false,\
-> --hono.downstream.keyPath=target/certs/hono-messaging-key.pem,\
-> --hono.downstream.certPath=target/certs/hono-messaging-cert.pem,\
-> --hono.downstream.trustStorePath=target/certs/trusted-certs.pem,\
+> --hono.downstream.keyPath=../../demo-certs/certs/hono-messaging-key.pem,\
+> --hono.downstream.certPath=../../demo-certs/certs/hono-messaging-cert.pem,\
+> --hono.downstream.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
 > --hono.messaging.validation.sharedSecret=asharedsecretforvalidatingassertions,\
-> --hono.messaging.keyPath=target/certs/hono-messaging-key.pem,\
-> --hono.messaging.certPath=target/certs/hono-messaging-cert.pem,\
-> --hono.messaging.trustStorePath=target/certs/trusted-certs.pem,\
+> --hono.messaging.keyPath=../../demo-certs/certs/hono-messaging-key.pem,\
+> --hono.messaging.certPath=../../demo-certs/certs/hono-messaging-cert.pem,\
+> --hono.messaging.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
 > --hono.messaging.insecurePortEnabled=true,\
 > --hono.messaging.insecurePortBindAddress=0.0.0.0
 ~~~

--- a/site/content/component/mqtt-adapter.md
+++ b/site/content/component/mqtt-adapter.md
@@ -177,12 +177,12 @@ The corresponding command to start up the adapter with the configuration used in
 > --hono.messaging.host=hono-service-messaging.hono,\
 > --hono.messaging.username=mqtt-adapter@HONO,\
 > --hono.messaging.password=mqtt-secret,\
-> --hono.messaging.trustStorePath=target/certs/trusted-certs.pem \
+> --hono.messaging.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
 > --hono.registration.host=hono-service-device-registry.hono,\
 > --hono.registration.username=mqtt-adapter@HONO,\
 > --hono.registration.password=mqtt-secret,\
-> --hono.registration.trustStorePath=target/certs/trusted-certs.pem \
-> --hono.mqtt.bindAddress=0.0.0.0 \
+> --hono.registration.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+> --hono.mqtt.bindAddress=0.0.0.0,\
 > --hono.mqtt.insecurePortEnabled=true,\
 > --hono.mqtt.insecurePortBindAddress=0.0.0.0
 ~~~

--- a/site/content/component/rest-adapter.md
+++ b/site/content/component/rest-adapter.md
@@ -176,12 +176,12 @@ The corresponding command to start up the adapter with the configuration used in
 > --hono.messaging.host=hono-service-messaging.hono,\
 > --hono.messaging.username=rest-adapter@HONO,\
 > --hono.messaging.password=rest-secret,\
-> --hono.messaging.trustStorePath=target/certs/trusted-certs.pem \
+> --hono.messaging.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
 > --hono.registration.host=hono-service-device-registry.hono,\
 > --hono.registration.username=rest-adapter@HONO,\
 > --hono.registration.password=rest-secret,\
-> --hono.registration.trustStorePath=target/certs/trusted-certs.pem \
-> --hono.http.bindAddress=0.0.0.0 \
+> --hono.registration.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+> --hono.http.bindAddress=0.0.0.0,\
 > --hono.http.insecurePortEnabled=true,\
 > --hono.http.insecurePortBindAddress=0.0.0.0
 ~~~


### PR DESCRIPTION
- Certificates were referenced in "target/certs" but that folder doesn't exist relative to the given base directories.
- Added "authentication-impl" profile to auth service invocation - otherwise it won't start.