### PR TITLE
Use correct 'device-id' field in Device Registry REST API documentation

### DIFF
--- a/site/content/component/device-registry.md
+++ b/site/content/component/device-registry.md
@@ -248,7 +248,7 @@ The response will look similar to this:
          "enabled": true,
          "ep": "IMEI4711"
       },
-      "id" : "4711"
+      "device-id" : "4711"
     }
 
 ### Update Registration
@@ -279,7 +279,7 @@ The response will look similar to this:
          "enabled": true,
          "ep": "IMEI4711"
       },
-      "id" : "4711"
+      "device-id" : "4711"
     }
 
 ### Delete Registration
@@ -306,5 +306,5 @@ The response will look similar to this:
          "ep": "IMEI4711",
          "psk-id": "psk4711"
       },
-      "id" : "4711"
+      "device-id" : "4711"
     }

--- a/site/content/getting-started.md
+++ b/site/content/getting-started.md
@@ -154,7 +154,7 @@ Content-Length: 35
   "data" : {
       "enabled": true
   },
-  "id" : "4711"
+  "device-id" : "4711"
 }
 ~~~
 


### PR DESCRIPTION
The JSON structure returned by GET, PUT and DELETE requests to the device registry looks like this
`
    {
      "data" : {
         "enabled": true,
         "ep": "IMEI4711"
      },
      "device-id" : "4711"
    }
`
, with the field name "device-id" (see `BaseRegistrationService#getResultPayload()`).

In the documentation, there was still the field name "id" being used.