### PR TITLE
Allow all credentials api operations in subclasses of BaseCredentialsService

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
@@ -24,11 +24,16 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RequestResponseApiConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 import java.net.HttpURLConnection;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static org.eclipse.hono.util.CredentialsConstants.*;
+import static org.eclipse.hono.util.RequestResponseApiConstants.FIELD_DEVICE_ID;
+import static org.eclipse.hono.util.RequestResponseApiConstants.FIELD_ENABLED;
 
 /**
  * Base class for implementing {@code CredentialsService}s.
@@ -141,6 +146,15 @@ public abstract class BaseCredentialsService<T> extends ConfigurationSupportingV
             case OPERATION_GET:
                 processCredentialsMessageGetOperation(regMsg, tenantId, payload);
                 break;
+            case OPERATION_ADD:
+                processCredentialsMessageAddOperation(regMsg, tenantId, payload);
+                break;
+            case OPERATION_UPDATE:
+                processCredentialsMessageUpdateOperation(regMsg, tenantId, payload);
+                break;
+            case OPERATION_REMOVE:
+                processCredentialsMessageRemoveOperation(regMsg, tenantId, payload);
+                break;
             default:
                 log.debug("operation [{}] not supported", subject);
                 reply(regMsg, CredentialsResult.from(HTTP_BAD_REQUEST));
@@ -165,6 +179,109 @@ public abstract class BaseCredentialsService<T> extends ConfigurationSupportingV
         getCredentials(tenantId, type, authId, result -> reply(regMsg, result));
     }
 
+    private void processCredentialsMessageAddOperation(final Message<JsonObject> regMsg, final String tenantId, final JsonObject payload) {
+        if (!isValidCredentialsObject(payload)) {
+            reply(regMsg, CredentialsResult.from(HTTP_BAD_REQUEST));
+            return;
+        }
+        addCredentials(tenantId, payload, result -> reply(regMsg, result));
+    }
+    
+    private void processCredentialsMessageUpdateOperation(final Message<JsonObject> regMsg, final String tenantId, final JsonObject payload) {
+        if (!isValidCredentialsObject(payload)) {
+            reply(regMsg, CredentialsResult.from(HTTP_BAD_REQUEST));
+            return;
+        }
+        updateCredentials(tenantId, payload, result -> reply(regMsg, result)); 
+    }
+    
+    private void processCredentialsMessageRemoveOperation(final Message<JsonObject> regMsg, final String tenantId, final JsonObject payload) {
+        final String deviceId = payload.getString(FIELD_DEVICE_ID);
+        if (deviceId == null) {
+            log.debug("credentials remove request did not contain device-id in payload - not supported");
+            reply(regMsg, CredentialsResult.from(HTTP_BAD_REQUEST));
+            return;
+        }
+        
+        final String type = payload.getString(FIELD_TYPE);
+        if (type == null) {
+            log.debug("credentials remove request did not contain type in payload - not supported");
+            reply(regMsg, CredentialsResult.from(HTTP_BAD_REQUEST));
+            return;
+        }
+
+        final String authId = payload.getString(FIELD_AUTH_ID);
+        
+        removeCredentials(tenantId, deviceId, type, authId, result -> reply(regMsg, result));
+    }
+
+    private boolean isValidCredentialsObject(final JsonObject credentials) {
+        return containsStringValueForField(credentials, RequestResponseApiConstants.FIELD_DEVICE_ID)
+                && containsStringValueForField(credentials, FIELD_TYPE)
+                && containsStringValueForField(credentials, FIELD_AUTH_ID)
+                && containsValidSecretValue(credentials);
+    }
+
+    private boolean containsValidSecretValue(final JsonObject credentials) {
+        final JsonArray secrets = credentials.getJsonArray(FIELD_SECRETS);
+        
+        if (secrets == null) {
+            log.debug("credentials request did not contain {} in payload - not supported", FIELD_SECRETS);
+            return false;
+        }
+
+        if (secrets.isEmpty()) {
+            log.debug("credentials request contains empty {} object in payload - not supported", FIELD_SECRETS);
+            return false;
+        }
+
+        for (int i = 0; i < secrets.size(); i++) {
+            JsonObject currentSecret = secrets.getJsonObject(i);
+            if (!containsValidTimestampIfPresentForField(currentSecret, FIELD_SECRETS_NOT_BEFORE)
+                    || !containsValidTimestampIfPresentForField(currentSecret, FIELD_SECRETS_NOT_AFTER)) {
+                log.debug("credentials request did contain invalid timestamp values in payload");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean containsStringValueForField(final JsonObject payload, final String field) {
+        final String value = payload.getString(field);
+
+        if (StringUtils.isEmpty(value)) {
+            log.debug("credentials request did not contain {} in payload - not supported", field);
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean containsValidTimestampIfPresentForField(final JsonObject payload, final String field) {
+        final String timeStamp = payload.getString(field);
+
+        if (timeStamp != null) {
+            return isValidTimestampForField(payload, field);
+        }
+        else {
+            return true;
+        }
+    }
+
+    private boolean isValidTimestampForField(final JsonObject payload, final String field) {
+        final String dateTime = payload.getString(field);
+
+        try {
+            final DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_DATE_TIME;
+            timeFormatter.parse(dateTime);
+
+            return true;
+        }
+        catch (DateTimeParseException e) {
+            log.debug("credentials request did contain invalid timestamp in payload");
+            return false;
+        }
+    }
 
     private void reply(final Message<JsonObject> request, final AsyncResult<CredentialsResult> result) {
 

--- a/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.credentials;
+
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.eclipse.hono.util.CredentialsResult;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RequestResponseApiConstants;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Unit tests for BaseCredentialsService
+ */
+public class BaseCredentialsServiceTest {
+
+    private BaseCredentialsService<ServiceConfigProperties> service;
+
+    private static final String TEST_FIELD = "test";
+    private static final String TEST_TENANT = "dummy";
+
+    @Before
+    public void setUp() {
+        this.service = createBaseCredentialsService();
+    }
+    
+    @Test
+    public void testCredentialsAddWithValidMinimalData() {
+        final JsonObject testData = createValidCredentialsObject();
+        
+        final Message<JsonObject> msg = createMessageMockForPayload(testData);
+        service.processCredentialsMessage(msg);
+
+        verify(msg).reply(resultWithStatusCode(HTTP_CREATED));
+    }
+    
+    @Test
+    public void testCredentialsAddWithLongTimestamp() {
+        final String iso8601TimeStamp = "2007-04-05T12:30-02:00";
+
+        final JsonObject testData = createValidCredentialsObject();
+        final JsonObject firstSecret = testData.getJsonArray(CredentialsConstants.FIELD_SECRETS).getJsonObject(0);
+        firstSecret.put(CredentialsConstants.FIELD_SECRETS_NOT_BEFORE, iso8601TimeStamp);
+        
+        final Message<JsonObject> msg = createMessageMockForPayload(testData);
+        service.processCredentialsMessage(msg);
+
+        verify(msg).reply(resultWithStatusCode(HTTP_CREATED));
+    }
+    
+    @Test
+    public void testCredentialsAddWithShortTimestamp() {
+        final String iso8601TimeStamp = "2007-04-05T14:30";
+
+        final JsonObject testData = createValidCredentialsObject();
+        final JsonObject firstSecret = testData.getJsonArray(CredentialsConstants.FIELD_SECRETS).getJsonObject(0);
+        firstSecret.put(CredentialsConstants.FIELD_SECRETS_NOT_BEFORE, iso8601TimeStamp);
+        
+        final Message<JsonObject> msg = createMessageMockForPayload(testData);
+        service.processCredentialsMessage(msg);
+
+        verify(msg).reply(resultWithStatusCode(HTTP_CREATED));
+    }
+
+    @Test
+    public void testCredentialsAddWithInvalidTimestamp() {
+        final String invalidTimestamp = "yakshaver";
+
+        final JsonObject testData = createValidCredentialsObject();
+        final JsonObject firstSecret = testData.getJsonArray(CredentialsConstants.FIELD_SECRETS).getJsonObject(0);
+        firstSecret.put(CredentialsConstants.FIELD_SECRETS_NOT_BEFORE, invalidTimestamp);
+        
+        final Message<JsonObject> msg = createMessageMockForPayload(testData);
+        service.processCredentialsMessage(msg);
+        
+        verify(msg).reply(resultWithStatusCode(HTTP_BAD_REQUEST));
+    }
+
+    @Test
+    public void testCredentialsAddWithMissingSecrets() {
+        final JsonObject testData = createValidCredentialsObject();
+
+        testData.remove(CredentialsConstants.FIELD_SECRETS);
+        
+        final Message<JsonObject> msg = createMessageMockForPayload(testData);
+        service.processCredentialsMessage(msg);
+        
+        verify(msg).reply(resultWithStatusCode(HTTP_BAD_REQUEST));
+    }
+
+    @Test
+    public void testCredentialsAddWithNoSecrets() {
+        final JsonObject testData = createValidCredentialsObject();
+        testData.put(CredentialsConstants.FIELD_SECRETS, new JsonArray());
+
+        final Message<JsonObject> msg = createMessageMockForPayload(testData);
+        service.processCredentialsMessage(msg);
+        
+        verify(msg).reply(resultWithStatusCode(HTTP_BAD_REQUEST));
+    }
+
+    @Test
+    public void testCredentialsAddWithEmptySecret() {
+        final JsonObject testData = createValidCredentialsObject();
+        
+        JsonArray secrets = new JsonArray();
+        secrets.add(new JsonObject());
+        
+        testData.put(CredentialsConstants.FIELD_SECRETS, secrets);
+
+        final Message<JsonObject> msg = createMessageMockForPayload(testData);
+        service.processCredentialsMessage(msg);
+        
+        verify(msg).reply(resultWithStatusCode(HTTP_CREATED));
+    }
+
+    private JsonObject resultWithStatusCode(int statusCode) {
+        final JsonObject result = new JsonObject();
+        result.put(RequestResponseApiConstants.FIELD_TENANT_ID, TEST_TENANT);
+        result.put(MessageHelper.APP_PROPERTY_STATUS, String.valueOf(statusCode));
+        
+        return result;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private Message<JsonObject> createMessageMockForPayload(JsonObject payload) {
+        Message<JsonObject> msg = mock(Message.class);
+        
+        JsonObject requestBody = new JsonObject();
+        requestBody.put(RequestResponseApiConstants.FIELD_TENANT_ID, TEST_TENANT);
+        requestBody.put(MessageHelper.SYS_PROPERTY_SUBJECT, CredentialsConstants.OPERATION_ADD);
+        requestBody.put(CredentialsConstants.FIELD_PAYLOAD, payload);
+        
+        when(msg.body()).thenReturn(requestBody);
+        
+        return msg;
+    }
+    
+    private JsonObject createValidCredentialsObject() {
+        final JsonObject testData = new JsonObject();
+        testData.put(RequestResponseApiConstants.FIELD_DEVICE_ID, "dummy");
+        testData.put(CredentialsConstants.FIELD_TYPE, "dummy");
+        testData.put(CredentialsConstants.FIELD_AUTH_ID, "dummy");
+        
+        final JsonArray secrets = new JsonArray();
+
+        final JsonObject secret = new JsonObject();
+        secret.put(TEST_FIELD, "dummy");
+        
+        secrets.add(secret);
+        
+        testData.put(CredentialsConstants.FIELD_SECRETS, secrets);
+        
+        return testData;
+    }
+
+    private BaseCredentialsService<ServiceConfigProperties> createBaseCredentialsService() {
+        return new BaseCredentialsService<ServiceConfigProperties>() {
+            @Override
+            public void updateCredentials(String tenantId, JsonObject credentialsObject,
+                    Handler<AsyncResult<CredentialsResult>> resultHandler) {
+            }
+            @Override
+            public void removeCredentials(String tenantId, String deviceId, String type, String authId,
+                    Handler<AsyncResult<CredentialsResult>> resultHandler) {
+            }
+            @Override
+            public void getCredentials(String tenantId, String type, String authId,
+                    Handler<AsyncResult<CredentialsResult>> resultHandler) {
+            }
+            @Override
+            public void addCredentials(String tenantId, JsonObject credentialsObject,
+                    Handler<AsyncResult<CredentialsResult>> resultHandler) {
+                resultHandler.handle(Future.succeededFuture(CredentialsResult.from(HTTP_CREATED)));
+            }
+            @Override
+            public void setConfig(ServiceConfigProperties configuration) {
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR allows the usage of all the methods defined in the Credential API  (`Add` / `Get` / `Update` / `Remove`) in subclasses of `BaseCredentialsService`. Until now it was just possible to use mandatory operations (`Get`).

See issue https://github.com/eclipse/hono/issues/321

Signed-off-by: Christian Schmid <Christian.Schmid3@bosch-si.com>