### PR TITLE
Pr/rest basic auth

### DIFF
--- a/adapters/mqtt-vertx/pom.xml
+++ b/adapters/mqtt-vertx/pom.xml
@@ -21,6 +21,10 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Application.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Application.java
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * The Hono MQTT adapter main application class.
  */
-@ComponentScan(basePackages = "org.eclipse.hono.adapter.mqtt")
+@ComponentScan(basePackages = {"org.eclipse.hono.adapter.mqtt", "org.eclipse.hono.service.credentials"})
 @Configuration
 @EnableAutoConfiguration
 public class Application extends AbstractApplication {

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Config.java
@@ -69,8 +69,8 @@ public class Config extends AbstractAdapterConfig {
      */
     @Bean
     @ConfigurationProperties(prefix = "hono.mqtt")
-    public ServiceConfigProperties adapterProperties() {
-        return new ServiceConfigProperties();
+    public MqttProtocolAdapterProperties adapterProperties() {
+        return new MqttProtocolAdapterProperties();
     }
 
     /**

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/MqttProtocolAdapterProperties.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/MqttProtocolAdapterProperties.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.adapter.mqtt;
+
+import org.eclipse.hono.config.ServiceConfigProperties;
+
+/**
+ * Configuration properties for the MQTT protocol adapter of Hono.
+ *
+ */
+public class MqttProtocolAdapterProperties extends ServiceConfigProperties {
+
+    private boolean authenticateDevices = true;
+
+    /**
+     * Checks whether the MQTT protocol adapter always authenticates devices using their provided credentials as defined
+     * in the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * <p>
+     * If this property is {@code false} then devices are always allowed to publish data without providing
+     * credentials. This should only be set to false in test setups.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @return {@code true} if the MQTT protocol adapter demands the authentication of devices to allow the publishing of data.
+     */
+
+    public final boolean isAuthenticateDevices() {
+        return authenticateDevices;
+    }
+
+    /**
+     * Sets whether the MQTT protocol adapter always authenticates devices using their provided credentials as defined
+     * in the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * <p>
+     * If this property is set to {@code false} then devices are always allowed to publish data without providing
+     * credentials. This should only be set to false in test setups.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @param authenticateDevices {@code true} if the server should wait for downstream connections to be established during startup.
+     * @return {@code true} if the MQTT protocol adapter demands the authentication of devices to allow the publishing of data.
+     */
+    public final MqttProtocolAdapterProperties setAuthenticateDevices(final boolean authenticateDevices) {
+        this.authenticateDevices = authenticateDevices;
+        return this;
+    }
+}

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/MqttProtocolAdapterProperties.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/MqttProtocolAdapterProperties.java
@@ -20,7 +20,7 @@ import org.eclipse.hono.config.ServiceConfigProperties;
  */
 public class MqttProtocolAdapterProperties extends ServiceConfigProperties {
 
-    private boolean authenticateDevices = true;
+    private boolean authenticationRequired = true;
 
     /**
      * Checks whether the MQTT protocol adapter always authenticates devices using their provided credentials as defined
@@ -33,9 +33,8 @@ public class MqttProtocolAdapterProperties extends ServiceConfigProperties {
      *
      * @return {@code true} if the MQTT protocol adapter demands the authentication of devices to allow the publishing of data.
      */
-
-    public final boolean isAuthenticateDevices() {
-        return authenticateDevices;
+    public final boolean isAuthenticationRequired() {
+        return authenticationRequired;
     }
 
     /**
@@ -47,11 +46,9 @@ public class MqttProtocolAdapterProperties extends ServiceConfigProperties {
      * <p>
      * The default value of this property is {@code true}.
      *
-     * @param authenticateDevices {@code true} if the server should wait for downstream connections to be established during startup.
-     * @return {@code true} if the MQTT protocol adapter demands the authentication of devices to allow the publishing of data.
+     * @param authenticationRequired {@code true} if the server should wait for downstream connections to be established during startup.
      */
-    public final MqttProtocolAdapterProperties setAuthenticateDevices(final boolean authenticateDevices) {
-        this.authenticateDevices = authenticateDevices;
-        return this;
+    public final void setAuthenticationRequired(final boolean authenticationRequired) {
+        this.authenticationRequired = authenticationRequired;
     }
 }

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
@@ -16,11 +16,9 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.vertx.core.Handler;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.eclipse.hono.adapter.mqtt.credentials.MqttUsernamePassword;
 import org.eclipse.hono.client.MessageSender;
-import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.util.Constants;
@@ -185,7 +183,7 @@ public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<M
             endpoint.reject(MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
 
         } else {
-            endpoint.publishHandler(createMqttPublishMessageHandler(endpoint));
+            endpoint.publishHandler(message -> publishMessage(endpoint, message));
 
             endpoint.closeHandler(v -> {
                 LOG.debug("connection closed with client [{}]", endpoint.clientIdentifier());
@@ -193,87 +191,88 @@ public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<M
                     LOG.trace("removed registration assertion for client [{}]", endpoint.clientIdentifier());
             });
 
-            if (getConfig().isAuthenticateDevices()) {
+            if (getConfig().isAuthenticationRequired()) {
 
                 // check credentials for valid authentication
                 // so far, only hashed-password supported, more to follow
-                try {
-
-                    MqttUsernamePassword authObject = MqttUsernamePassword.create(endpoint,
-                            getConfig().isSingleTenant());
-
-                    Future<Void> validationTracker = Future.future();
-                    validationTracker.setHandler(result -> {
-                        if (result.failed()) {
-                            endpoint.reject(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED);
-                        }
-                    });
-                    validateCredentialsForDevice(authObject.getTenantId(), authObject.getType(), authObject.getAuthId(),
-                            authObject.getPassword()).compose(
-                            deviceId -> {
-                                LOG.trace("successfully authenticated device id <{}>", deviceId);
-                                endpoint.accept(false);
-                            }, validationTracker);
-                } catch (IllegalArgumentException e) {
-                    LOG.warn(e.getMessage());
+                if (endpoint.auth() == null) {
+                    LOG.trace("no auth information in endpoint found");
                     endpoint.reject(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
                 }
+
+                MqttUsernamePassword authObject = MqttUsernamePassword.create(endpoint.auth().userName(),
+                        endpoint.auth().password(), getConfig().isSingleTenant());
+
+                if (authObject == null) {
+                    endpoint.reject(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
+                }
+
+                validateCredentialsForDevice(authObject.getTenantId(), authObject.getType(), authObject.getAuthId(),
+                        authObject.getPassword()).setHandler(attempt -> {
+                            if (attempt.succeeded()) {
+                                String deviceId = attempt.result();
+                                LOG.trace("successfully authenticated device id <{}>", deviceId);
+                                endpoint.accept(false);
+                            } else {
+                                endpoint.reject(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED);
+                            }
+                        });
             } else {
                 endpoint.accept(false);
             }
         }
     }
 
-    private Handler<MqttPublishMessage> createMqttPublishMessageHandler(final MqttEndpoint endpoint) {
-        return message -> {
+    private void publishMessage(final MqttEndpoint endpoint, final MqttPublishMessage message) {
+        LOG.trace("received message [client ID: {}, topic: {}, QoS: {}, payload {}]", endpoint.clientIdentifier(),
+                message.topicName(),
+                message.qosLevel(), message.payload().toString(Charset.defaultCharset()));
 
-            LOG.trace("received message [client ID: {}, topic: {}, QoS: {}, payload {}]", endpoint.clientIdentifier(), message.topicName(),
-                    message.qosLevel(), message.payload().toString(Charset.defaultCharset()));
+        try {
 
-            try {
+            final ResourceIdentifier resource = ResourceIdentifier.fromString(message.topicName());
 
-                final ResourceIdentifier resource = ResourceIdentifier.fromString(message.topicName());
-
-                // if MQTT client doesn't specify device_id then closing connection (MQTT has now way for errors)
-                if (resource.getResourceId() == null) {
-                    close(endpoint);
-                } else {
-
-                    Future<Void> messageTracker = Future.future();
-                    messageTracker.setHandler(s -> {
-                        if (s.failed()) {
-                            LOG.debug("cannot process message [client ID: {}, topic: {}, QoS: {}]: {}", endpoint.clientIdentifier(),
-                                    resource, message.qosLevel(), s.cause().getMessage());
-                            close(endpoint);
-                        } else {
-                            LOG.trace("successfully processed message [client ID: {}, topic: {}, QoS: {}]", endpoint.clientIdentifier(),
-                                    resource, message.qosLevel());
-                        }
-                    });
-
-                    // check that MQTT client tries to publish on topic with device_id same as on connection
-                    if (resource.getResourceId().equals(endpoint.clientIdentifier())) {
-
-                        Future<String> assertionTracker = getRegistrationAssertion(endpoint, resource);
-                        Future<MessageSender> senderTracker = getSenderTracker(message, resource);
-
-                        CompositeFuture.all(assertionTracker, senderTracker).compose(ok -> {
-                            doUploadMessage(resource.getTenantId(), assertionTracker.result(), endpoint, message,
-                                    senderTracker.result(), messageTracker);
-                        }, messageTracker);
-                    } else {
-                        // MQTT client is trying to publish on a different device_id used on connection (MQTT has no way for errors)
-                        messageTracker.fail("client not authorized");
-                    }
-                }
-
-            } catch (IllegalArgumentException e) {
-
-                // MQTT client is trying to publish on invalid topic; it does not contain at least two segments
-                LOG.debug("client [ID: {}] tries to publish on unsupported topic", endpoint.clientIdentifier());
+            // if MQTT client doesn't specify device_id then closing connection (MQTT has now way for errors)
+            if (resource.getResourceId() == null) {
                 close(endpoint);
+            } else {
+
+                Future<Void> messageTracker = Future.future();
+                messageTracker.setHandler(s -> {
+                    if (s.failed()) {
+                        LOG.debug("cannot process message [client ID: {}, topic: {}, QoS: {}]: {}",
+                                endpoint.clientIdentifier(),
+                                resource, message.qosLevel(), s.cause().getMessage());
+                        close(endpoint);
+                    } else {
+                        LOG.trace("successfully processed message [client ID: {}, topic: {}, QoS: {}]",
+                                endpoint.clientIdentifier(),
+                                resource, message.qosLevel());
+                    }
+                });
+
+                // check that MQTT client tries to publish on topic with device_id same as on connection
+                if (!getConfig().isAuthenticationRequired() && !resource.getResourceId().equals(endpoint.clientIdentifier())) {
+                    // MQTT client is trying to publish on a different device_id used on connection (MQTT has no way for
+                    // errors)
+                    messageTracker.fail("client not authorized");
+                } else {
+                    Future<String> assertionTracker = getRegistrationAssertion(endpoint, resource);
+                    Future<MessageSender> senderTracker = getSenderTracker(message, resource);
+
+                    CompositeFuture.all(assertionTracker, senderTracker).compose(ok -> {
+                        doUploadMessage(resource.getTenantId(), assertionTracker.result(), endpoint, message,
+                                senderTracker.result(), messageTracker);
+                    }, messageTracker);
+                }
             }
-        };
+
+        } catch (IllegalArgumentException e) {
+
+            // MQTT client is trying to publish on invalid topic; it does not contain at least two segments
+            LOG.debug("client [ID: {}] tries to publish on unsupported topic", endpoint.clientIdentifier());
+            close(endpoint);
+        }
     }
 
     private Future<MessageSender> getSenderTracker(final MqttPublishMessage message, final ResourceIdentifier resource) {

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
@@ -22,6 +22,7 @@ import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -211,15 +212,24 @@ public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<S
 
                         // check that MQTT client tries to publish on topic with device_id same as on connection
                         if (resource.getResourceId().equals(endpoint.clientIdentifier())) {
+                            // check credentials for valid authentication
+                            // so far, only hashed-password supported, more to follow
+                            final String type = CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD;
+                            final String user = (endpoint.auth() == null ? null : endpoint.auth().userName());
+                            final String protocolAdapterPassword = (endpoint.auth() == null ? null : endpoint.auth().password());
 
-                            Future<String> assertionTracker = getRegistrationAssertion(endpoint, resource);
-                            Future<MessageSender> senderTracker = getSenderTracker(message, resource);
+                            validateCredentialsForDevice(resource.getTenantId(), type, user, protocolAdapterPassword).compose(deviceId -> {
+                                LOG.trace("successfully authenticated device id <{}>", deviceId);
 
-                            CompositeFuture.all(assertionTracker, senderTracker).compose(ok -> {
-                                doUploadMessage(resource.getTenantId(), assertionTracker.result(), endpoint, message, senderTracker.result(), messageTracker);
+                                Future<Void> messageResult = Future.future();
+
+                                Future<String> assertionTracker = getRegistrationAssertion(endpoint, resource);
+                                Future<MessageSender> senderTracker = getSenderTracker(message, resource);
+
+                                CompositeFuture.all(assertionTracker, senderTracker).compose(ok -> {
+                                    doUploadMessage(resource.getTenantId(), assertionTracker.result(), endpoint, message, senderTracker.result(), messageTracker);
+                                }, messageResult);
                             }, messageTracker);
-
-
                         } else {
                             // MQTT client is trying to publish on a different device_id used on connection (MQTT has no way for errors)
                             messageTracker.fail("client not authorized");
@@ -241,6 +251,7 @@ public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<S
                     LOG.trace("removed registration assertion for client [{}]", endpoint.clientIdentifier());
             });
 
+            // TODO : check credentials here
             endpoint.accept(false);
         }
     }

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
@@ -16,13 +16,14 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.vertx.core.Handler;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.eclipse.hono.adapter.mqtt.credentials.MqttUsernamePassword;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -184,66 +185,7 @@ public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<S
             endpoint.reject(MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
 
         } else {
-            endpoint.publishHandler(message -> {
-
-                LOG.trace("received message [client ID: {}, topic: {}, QoS: {}, payload {}]", endpoint.clientIdentifier(), message.topicName(),
-                        message.qosLevel(), message.payload().toString(Charset.defaultCharset()));
-
-                try {
-
-                    final ResourceIdentifier resource = ResourceIdentifier.fromString(message.topicName());
-
-                    // if MQTT client doesn't specify device_id then closing connection (MQTT has now way for errors)
-                    if (resource.getResourceId() == null) {
-                        close(endpoint);
-                    } else {
-
-                        Future<Void> messageTracker = Future.future();
-                        messageTracker.setHandler(s -> {
-                            if (s.failed()) {
-                                LOG.debug("cannot process message [client ID: {}, topic: {}, QoS: {}]: {}", endpoint.clientIdentifier(),
-                                        resource, message.qosLevel(), s.cause().getMessage());
-                                close(endpoint);
-                            } else {
-                                LOG.trace("successfully processed message [client ID: {}, topic: {}, QoS: {}]", endpoint.clientIdentifier(),
-                                        resource, message.qosLevel());
-                            }
-                        });
-
-                        // check that MQTT client tries to publish on topic with device_id same as on connection
-                        if (resource.getResourceId().equals(endpoint.clientIdentifier())) {
-                            // check credentials for valid authentication
-                            // so far, only hashed-password supported, more to follow
-                            final String type = CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD;
-                            final String user = (endpoint.auth() == null ? null : endpoint.auth().userName());
-                            final String protocolAdapterPassword = (endpoint.auth() == null ? null : endpoint.auth().password());
-
-                            validateCredentialsForDevice(resource.getTenantId(), type, user, protocolAdapterPassword).compose(deviceId -> {
-                                LOG.trace("successfully authenticated device id <{}>", deviceId);
-
-                                Future<Void> messageResult = Future.future();
-
-                                Future<String> assertionTracker = getRegistrationAssertion(endpoint, resource);
-                                Future<MessageSender> senderTracker = getSenderTracker(message, resource);
-
-                                CompositeFuture.all(assertionTracker, senderTracker).compose(ok -> {
-                                    doUploadMessage(resource.getTenantId(), assertionTracker.result(), endpoint, message, senderTracker.result(), messageTracker);
-                                }, messageResult);
-                            }, messageTracker);
-                        } else {
-                            // MQTT client is trying to publish on a different device_id used on connection (MQTT has no way for errors)
-                            messageTracker.fail("client not authorized");
-                        }
-
-                    }
-
-                } catch (IllegalArgumentException e) {
-
-                    // MQTT client is trying to publish on invalid topic; it does not contain at least two segments
-                    LOG.debug("client [ID: {}] tries to publish on unsupported topic", endpoint.clientIdentifier());
-                    close(endpoint);
-                }
-            });
+            endpoint.publishHandler(createMqttPublishMessageHandler(endpoint));
 
             endpoint.closeHandler(v -> {
                 LOG.debug("connection closed with client [{}]", endpoint.clientIdentifier());
@@ -251,9 +193,82 @@ public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<S
                     LOG.trace("removed registration assertion for client [{}]", endpoint.clientIdentifier());
             });
 
-            // TODO : check credentials here
-            endpoint.accept(false);
+            // check credentials for valid authentication
+            // so far, only hashed-password supported, more to follow
+            try {
+
+                MqttUsernamePassword authObject = MqttUsernamePassword.create(endpoint,
+                        getConfig().isSingleTenant());
+
+                Future<Void> validationTracker = Future.future();
+                validationTracker.setHandler(result -> {
+                    if (result.failed()) {
+                        endpoint.reject(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED);
+                    }
+                });
+                validateCredentialsForDevice(authObject.getTenantId(), authObject.getType(), authObject.getAuthId(),
+                        authObject.getPassword()).compose(
+                                deviceId -> {
+                                    LOG.trace("successfully authenticated device id <{}>", deviceId);
+                                    endpoint.accept(false);
+                                }, validationTracker);
+            } catch (IllegalArgumentException e) {
+                LOG.warn(e.getMessage());
+                endpoint.reject(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
+            }
         }
+    }
+
+    private Handler<MqttPublishMessage> createMqttPublishMessageHandler(final MqttEndpoint endpoint) {
+        return message -> {
+
+            LOG.trace("received message [client ID: {}, topic: {}, QoS: {}, payload {}]", endpoint.clientIdentifier(), message.topicName(),
+                    message.qosLevel(), message.payload().toString(Charset.defaultCharset()));
+
+            try {
+
+                final ResourceIdentifier resource = ResourceIdentifier.fromString(message.topicName());
+
+                // if MQTT client doesn't specify device_id then closing connection (MQTT has now way for errors)
+                if (resource.getResourceId() == null) {
+                    close(endpoint);
+                } else {
+
+                    Future<Void> messageTracker = Future.future();
+                    messageTracker.setHandler(s -> {
+                        if (s.failed()) {
+                            LOG.debug("cannot process message [client ID: {}, topic: {}, QoS: {}]: {}", endpoint.clientIdentifier(),
+                                    resource, message.qosLevel(), s.cause().getMessage());
+                            close(endpoint);
+                        } else {
+                            LOG.trace("successfully processed message [client ID: {}, topic: {}, QoS: {}]", endpoint.clientIdentifier(),
+                                    resource, message.qosLevel());
+                        }
+                    });
+
+                    // check that MQTT client tries to publish on topic with device_id same as on connection
+                    if (resource.getResourceId().equals(endpoint.clientIdentifier())) {
+
+                        Future<String> assertionTracker = getRegistrationAssertion(endpoint, resource);
+                        Future<MessageSender> senderTracker = getSenderTracker(message, resource);
+
+                        CompositeFuture.all(assertionTracker, senderTracker).compose(ok -> {
+                            doUploadMessage(resource.getTenantId(), assertionTracker.result(), endpoint, message,
+                                    senderTracker.result(), messageTracker);
+                        }, messageTracker);
+                    } else {
+                        // MQTT client is trying to publish on a different device_id used on connection (MQTT has no way for errors)
+                        messageTracker.fail("client not authorized");
+                    }
+                }
+
+            } catch (IllegalArgumentException e) {
+
+                // MQTT client is trying to publish on invalid topic; it does not contain at least two segments
+                LOG.debug("client [ID: {}] tries to publish on unsupported topic", endpoint.clientIdentifier());
+                close(endpoint);
+            }
+        };
     }
 
     private Future<MessageSender> getSenderTracker(final MqttPublishMessage message, final ResourceIdentifier resource) {

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/credentials/MqttUsernamePassword.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/credentials/MqttUsernamePassword.java
@@ -11,31 +11,32 @@
  */
 package org.eclipse.hono.adapter.mqtt.credentials;
 
-import io.vertx.mqtt.MqttEndpoint;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
-
-import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper class to handle mqtt username/password authentication in CONNECT messages.
  * <p>
- * During connect messages, the tenant of a device can only be determined as part of the mqtt username.
- * Thus the following convention is realized inside this class:
+ * During connect messages, the tenant of a device can only be determined as part of the mqtt username. Thus the
+ * following convention is realized inside this class:
  * <p>
  * <ul>
  * <li>If the adapter runs in single tenant mode, the tenant is set to {@link Constants#DEFAULT_TENANT}.
  * <li>If the adapter runs in multiple tenant mode, the tenant must be part of the mqtt username, which must comply to
  * the structure authId@tenantId.
  * </ul>
-  */
+ */
 public class MqttUsernamePassword {
-    private final String type = CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD;
-    private String authId;
-    private String password;
-    private String tenantId;
 
-    public final  String getType() {
+    private static final Logger LOG  = LoggerFactory.getLogger(MqttUsernamePassword.class);
+    private static final String type = CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD;
+    private String              authId;
+    private String              password;
+    private String              tenantId;
+
+    public final String getType() {
         return type;
     }
 
@@ -52,49 +53,47 @@ public class MqttUsernamePassword {
     }
 
     /**
-     * Create an instance of this class from the MqttEndpoint.
+     * Create an instance of this class. The tenant is derived from the passed parameters (see class description).
      *
-     * @param endpoint The mqtt endpoint from the adapter that is available during CONNECT. The auth information is taken
-     *                 from it to obtain the username and password.
+     * @param userName The userName that shall be stored in the instance.
+     * @param password The password that shall be stored in the instance.
      * @param singleTenant If true the tenant is set to the {@link Constants#DEFAULT_TENANT}, otherwise it is taken from
-     *                     the endpoint.
+     *            the endpoint.
      *
-     * @return The instance of the created object.
-     *
-     * @throws IllegalArgumentException If the auth information is null, or the username in the auth object is null,
-     * or the username does not comply to the structure authId@tenantId.
+     * @return The instance of the created object. Will be null if the userName is null,  or the
+     *             username does not comply to the structure userName@tenantId.
      */
-    public static final MqttUsernamePassword create(final MqttEndpoint endpoint,
-                                                    final boolean singleTenant) throws IllegalArgumentException {
-        MqttUsernamePassword credentials = new MqttUsernamePassword();
-        if (endpoint.auth() == null) {
-            throw new IllegalArgumentException("no auth information in endpoint found");
+    public static final MqttUsernamePassword create(final String userName, final String password,
+            final boolean singleTenant) {
+        MqttUsernamePassword credentials = fillAuthIdAndTenantId(userName, singleTenant);
+        if (credentials != null) {
+            credentials.password = password;
         }
-        fillAuthIdAndTenantId(credentials, endpoint.auth().userName(), singleTenant);
-        credentials.password = endpoint.auth().password();
         return credentials;
     }
 
-    private static void fillAuthIdAndTenantId(final MqttUsernamePassword credentials, final String userFromMqtt,
-                                              final boolean singleTenant) throws IllegalArgumentException {
+    private static MqttUsernamePassword fillAuthIdAndTenantId(final String userFromMqtt, final boolean singleTenant) {
         if (userFromMqtt == null) {
-            throw new IllegalArgumentException("auth object in endpoint found, but username must not be null");
+            LOG.trace("auth object in endpoint found, but username must not be null");
+            return null;
         }
-        Objects.requireNonNull(userFromMqtt);
+
+        MqttUsernamePassword credentials = new MqttUsernamePassword();
         if (singleTenant) {
             credentials.authId = userFromMqtt;
             credentials.tenantId = Constants.DEFAULT_TENANT;
-            return;
-        }
-
-        // multi tenantId -> <userId>@<tenantId>
-        String[] userComponents = userFromMqtt.split("@");
-        if (userComponents.length != 2) {
-            throw new IllegalArgumentException(
-                    String.format("User {} in mqtt CONNECT message has not  structure, must fulfil the pattern '<authId>@<tenantId>'", userFromMqtt));
         } else {
-            credentials.authId = userComponents[0];
-            credentials.tenantId = userComponents[1];
+            // multi tenantId -> <userId>@<tenantId>
+            String[] userComponents = userFromMqtt.split("@");
+            if (userComponents.length != 2) {
+                LOG.trace("User {} in mqtt CONNECT message does not comply with the defined structure, must fulfil the pattern '<authId>@<tenantId>'",
+                        userFromMqtt);
+                return null;
+            } else {
+                credentials.authId = userComponents[0];
+                credentials.tenantId = userComponents[1];
+            }
         }
+        return credentials;
     }
 }

--- a/adapters/mqtt-vertx/src/test/java/org/eclipse/hono/adapter/mqtt/MqttUsernamePasswordTest.java
+++ b/adapters/mqtt-vertx/src/test/java/org/eclipse/hono/adapter/mqtt/MqttUsernamePasswordTest.java
@@ -41,13 +41,12 @@ public class MqttUsernamePasswordTest {
      * Verifies that in multi tenant mode, a username containing userId@tenantId leads to a correctly filled instance.
      */
     @Test
-    public void testTenantFromUserMultiTenant() throws Exception {
+    public void testTenantFromUserMultiTenant() {
         MqttAuth auth = mock(MqttAuth.class);
         when(auth.userName()).thenReturn(TEST_USER_OTHER_TENANT);
         when(auth.password()).thenReturn(TEST_PASSWORD);
-        MqttEndpoint mqttEndpoint = mockMqttEndpoint(auth);
 
-        MqttUsernamePassword mqttUsernamePassword = MqttUsernamePassword.create(mqttEndpoint, false);
+        MqttUsernamePassword mqttUsernamePassword = MqttUsernamePassword.create(TEST_USER_OTHER_TENANT, TEST_PASSWORD, false);
 
         assertEquals(mqttUsernamePassword.getType(), CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD);
         assertEquals(mqttUsernamePassword.getTenantId(), TEST_OTHER_TENANT);
@@ -56,37 +55,37 @@ public class MqttUsernamePasswordTest {
     }
 
     /**
-     * Verifies that if no tenantId is present in the username, an IllegalArgumentException is thrown for multi tenant mode.
+     * Verifies that if no tenantId is present in the username, the created object for multi tenant mode is null.
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void testTenantFromUserMultiTenantWrongUsername() throws Exception {
+    @Test
+    public void testTenantFromUserMultiTenantWrongUsername() {
         MqttAuth auth = mockMqttAuthWithoutTenantIdInUsername();
 
-        MqttEndpoint mqttEndpoint = mockMqttEndpoint(auth);
-        MqttUsernamePassword.create(mqttEndpoint, false);
+        MqttUsernamePassword mqttUserNamePassword = MqttUsernamePassword.create(auth.userName(), auth.password(), false);
+        assertNull(mqttUserNamePassword);
     }
 
     /**
-     * Verifies that if username is null, an IllegalArgumentException is thrown for multi tenant mode.
+     * Verifies that if username is null, the created object for multi tenant mode is null.
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void testTenantFromUserMultiTenantNullUsername() throws Exception {
+    @Test
+    public void testTenantFromUserMultiTenantNullUsername() {
         MqttAuth auth = mock(MqttAuth.class);
         when(auth.userName()).thenReturn(null); // null user
 
-        MqttEndpoint mqttEndpoint = mockMqttEndpoint(auth);
-        MqttUsernamePassword.create(mqttEndpoint, false);
+        MqttUsernamePassword mqttUserNamePassword = MqttUsernamePassword.create(auth.userName(), auth.password(), false);
+        assertNull(mqttUserNamePassword);
     }
 
     /**
-     * Verifies that if username does not comply to the structure authId@tenantId, an IllegalArgumentException is thrown for multi tenant mode.
+     * Verifies that if username does not comply to the structure authId@tenantId, the created object for multi tenant mode is null.
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void testTenantFromUserMultiTenantWrongUsernameStructure() throws Exception {
+    @Test
+    public void testTenantFromUserMultiTenantWrongUsernameStructure() {
         MqttAuth auth = mockMqttAuthWithoutTenantIdInUsername();
 
-        MqttEndpoint mqttEndpoint = mockMqttEndpoint(auth);
-        MqttUsernamePassword.create(mqttEndpoint, false);
+        MqttUsernamePassword mqttUserNamePassword = MqttUsernamePassword.create(auth.userName(), auth.password(), false);
+        assertNull(mqttUserNamePassword);
     }
 
     /**
@@ -95,9 +94,8 @@ public class MqttUsernamePasswordTest {
     @Test
     public void testTenantFromUserSingleTenant() throws Exception {
         MqttAuth auth = mockMqttAuthWithoutTenantIdInUsername();
-        MqttEndpoint mqttEndpoint = mockMqttEndpoint(auth);
 
-        MqttUsernamePassword mqttUsernamePassword = MqttUsernamePassword.create(mqttEndpoint, true);
+        MqttUsernamePassword mqttUsernamePassword = MqttUsernamePassword.create(auth.userName(), auth.password(), true);
 
         assertEquals(mqttUsernamePassword.getType(), CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD);
         assertEquals(mqttUsernamePassword.getTenantId(), Constants.DEFAULT_TENANT);

--- a/adapters/mqtt-vertx/src/test/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx/src/test/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapterTest.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.adapter.mqtt;
+
+import static org.mockito.Mockito.*;
+
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
+import io.vertx.core.*;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.mqtt.MqttAuth;
+import io.vertx.mqtt.MqttEndpoint;
+import io.vertx.mqtt.MqttServer;
+import org.eclipse.hono.adapter.mqtt.credentials.MqttUsernamePassword;
+import org.eclipse.hono.client.CredentialsClient;
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.util.Constants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.Router;
+import io.vertx.proton.ProtonClientOptions;
+import org.mockito.Mock;
+
+/**
+ * Verifies behavior of {@link VertxBasedMqttProtocolAdapter}.
+ * 
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxBasedMqttProtocolAdapterTest {
+    private static final int IANA_MQTT_PORT = 1883;
+    private static final int IANA_SECURE_MQTT_PORT = 8883;
+
+    HonoClient messagingClient;
+    HonoClient registrationClient;
+    HonoClient credentialsClient;
+
+    MqttProtocolAdapterProperties config;
+
+    private Vertx vertx;
+
+    /**
+     * Cleans up fixture.
+     */
+    @After
+    public void shutDown() {
+        vertx.close();
+    }
+
+    /**
+     * Creates a 
+     */
+    @Before
+    public void setup() {
+
+        vertx = Vertx.vertx();
+
+        messagingClient = mock(HonoClient.class);
+        registrationClient = mock(HonoClient.class);
+        credentialsClient = mock(HonoClient.class);
+        config = new MqttProtocolAdapterProperties();
+        config.setInsecurePortEnabled(true);
+    }
+
+    /**
+     * TODO:
+     * Verifies that a client provided http server is started instead of creating and starting a new http server.
+     * 
+     * @param ctx The helper to use for running async tests on vertx.
+     * @throws Exception if the test fails.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testStartup(final TestContext ctx) throws Exception {
+
+        MqttServer server = getMqttServer(false);
+        VertxBasedMqttProtocolAdapter adapter = getAdapter(server);
+
+        Async startup = ctx.async();
+
+        Future<Void> startupTracker = Future.future();
+        startupTracker.setHandler(ctx.asyncAssertSuccess(s -> {
+            startup.complete();
+        }));
+        adapter.start(startupTracker);
+
+        startup.await(1000);
+
+        verify(server).listen(any(Handler.class));
+        verify(server).endpointHandler(any(Handler.class));
+        verify(messagingClient).connect(any(ProtonClientOptions.class), any(Handler.class), any(Handler.class));
+        verify(registrationClient).connect(any(ProtonClientOptions.class), any(Handler.class), any(Handler.class));
+        verify(credentialsClient).connect(any(ProtonClientOptions.class), any(Handler.class), any(Handler.class));
+    }
+
+    // TODO: startup fail test
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEndpointHandlerFailsWithoutConnect(final TestContext ctx) throws Exception {
+
+        // GIVEN an endpoint
+        MqttEndpoint endpoint = mock(MqttEndpoint.class);
+
+        MqttServer server = getMqttServer(false);
+        VertxBasedMqttProtocolAdapter adapter = getAdapter(server);
+
+        adapter.handleEndpointConnection(endpoint);
+        verify(endpoint).reject(MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEndpointHandlerSetsPublishAndCloseHandlers(final TestContext ctx) throws Exception {
+
+        // GIVEN an endpoint
+        MqttEndpoint endpoint = mock(MqttEndpoint.class);
+        when(endpoint.auth()).thenReturn(new MqttAuth() {
+            @Override
+            public String userName() {
+                return "billie";
+            }
+
+            @Override
+            public String password() {
+                return "test";
+            }
+        });
+
+        MqttServer server = getMqttServer(false);
+        VertxBasedMqttProtocolAdapter adapter = getAdapter(server);
+
+        forceClientMocksToConnected();
+
+        adapter.handleEndpointConnection(endpoint);
+        verify(endpoint).publishHandler(any(Handler.class));
+        verify(endpoint).closeHandler(any(Handler.class));
+    }
+
+    private void forceClientMocksToConnected() {
+        when(messagingClient.isConnected()).thenReturn(true);
+        when(registrationClient.isConnected()).thenReturn(true);
+        when(credentialsClient.isConnected()).thenReturn(true);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEndpointHandlerVerifiesCredentialsIfNotConfigured(final TestContext ctx) throws Exception {
+
+        // GIVEN an endpoint
+        MqttEndpoint endpoint = mock(MqttEndpoint.class);
+
+        MqttServer server = getMqttServer(false);
+        config.setAuthenticationRequired(false);
+        VertxBasedMqttProtocolAdapter adapter = getAdapter(server);
+
+        forceClientMocksToConnected();
+
+        adapter.handleEndpointConnection(endpoint);
+        verify(endpoint).accept(false);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEndpointHandlerVerifiesCredentialsIfConfigured(final TestContext ctx) throws Exception {
+
+        // GIVEN an endpoint
+        MqttEndpoint endpoint = mock(MqttEndpoint.class);
+        when(endpoint.auth()).thenReturn(new MqttAuth() {
+            @Override
+            public String userName() {
+                return "billie";
+            }
+
+            @Override
+            public String password() {
+                return "test";
+            }
+        });
+
+        MqttServer server = getMqttServer(false);
+        config.setAuthenticationRequired(true);
+        config.setSingleTenant(true);
+        VertxBasedMqttProtocolAdapter adapter = getAdapter(server);
+
+        forceClientMocksToConnected();
+
+        adapter.handleEndpointConnection(endpoint);
+        verify(credentialsClient).getOrCreateCredentialsClient(matches(Constants.DEFAULT_TENANT), any(Handler.class));
+    }
+
+    private MqttServer getMqttServer(final boolean startupShouldFail) {
+
+        MqttServer server = mock(MqttServer.class);
+        when(server.actualPort()).thenReturn(0, 1883);
+        when(server.endpointHandler(any(Handler.class))).thenReturn(server);
+        when(server.listen(any(Handler.class))).then(invocation -> {
+            Handler<AsyncResult<MqttServer>> handler = (Handler<AsyncResult<MqttServer>>) invocation.getArgumentAt(0, Handler.class);
+            if (startupShouldFail) {
+                handler.handle(Future.failedFuture("mqtt server intentionally failed to start"));
+            } else {
+                handler.handle(Future.succeededFuture(server));
+            }
+            return server;
+        });
+
+        return server;
+    }
+
+    private VertxBasedMqttProtocolAdapter getAdapter(final MqttServer server) {
+        VertxBasedMqttProtocolAdapter adapter = new VertxBasedMqttProtocolAdapter() {
+            @Override
+            public void setConfig(final MqttProtocolAdapterProperties configuration) {
+                setSpecificConfig(configuration);
+            }
+        };
+        adapter.setMqttInsecureServer(server);
+        adapter.setConfig(config);
+        adapter.setHonoMessagingClient(messagingClient);
+        adapter.setRegistrationServiceClient(registrationClient);
+        adapter.setCredentialsServiceClient(credentialsClient);
+        adapter.init(vertx, mock(Context.class));
+        return adapter;
+    }
+}

--- a/adapters/rest-vertx/pom.xml
+++ b/adapters/rest-vertx/pom.xml
@@ -21,6 +21,18 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Config.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Config.java
@@ -14,7 +14,6 @@ package org.eclipse.hono.adapter.rest;
 
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -68,8 +67,8 @@ public class Config extends AbstractAdapterConfig {
      */
     @Bean
     @ConfigurationProperties(prefix = "hono.http")
-    public ServiceConfigProperties honoServerProperties() {
-        return new ServiceConfigProperties();
+    public RestProtocolAdapterProperties honoServerProperties() {
+        return new RestProtocolAdapterProperties();
     }
 
     /**

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/RestProtocolAdapterProperties.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/RestProtocolAdapterProperties.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.adapter.rest;
+
+import org.eclipse.hono.config.ServiceConfigProperties;
+
+/**
+ * Configuration properties for the REST adapter of Hono.
+ *
+ */
+public class RestProtocolAdapterProperties extends ServiceConfigProperties {
+
+    private boolean authenticationRequired = true;
+
+    /**
+     * Checks whether the REST adapter always authenticates devices using their provided credentials as defined
+     * in the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * <p>
+     * If this property is {@code false} then devices are always allowed to publish data without providing
+     * credentials. This should only be set to false in test setups.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @return {@code true} if the REST adapter demands the authentication of devices to allow the publishing of data.
+     */
+    public final boolean isAuthenticationRequired() {
+        return authenticationRequired;
+    }
+
+    /**
+     * Sets whether the REST adapter always authenticates devices using their provided credentials as defined
+     * in the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * <p>
+     * If this property is set to {@code false} then devices are always allowed to publish data without providing
+     * credentials. This should only be set to false in test setups.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @param authenticationRequired {@code true} if the server should wait for downstream connections to be established during startup.
+     */
+    public final void setAuthenticationRequired(final boolean authenticationRequired) {
+        this.authenticationRequired = authenticationRequired;
+    }
+}

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapter.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapter.java
@@ -12,39 +12,52 @@
 
 package org.eclipse.hono.adapter.rest;
 
+import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BasicAuthHandler;
 import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
-import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.adapter.rest.credentials.BasicAuthProvider;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Vert.x based Hono protocol adapter for accessing Hono's Telemetry &amp; Event API using REST.
  */
-public final class VertxBasedRestProtocolAdapter extends AbstractVertxBasedHttpProtocolAdapter<ServiceConfigProperties> {
+public class VertxBasedRestProtocolAdapter
+        extends AbstractVertxBasedHttpProtocolAdapter<RestProtocolAdapterProperties> {
 
-    private static final String PARAM_TENANT = "tenant";
+    private static final Logger LOG             = LoggerFactory.getLogger(VertxBasedRestProtocolAdapter.class);
+    private static final String PARAM_TENANT    = "tenant";
     private static final String PARAM_DEVICE_ID = "device_id";
 
     @Override
     protected void addRoutes(final Router router) {
+        if (getConfig().isAuthenticationRequired()) {
+            LOG.debug("Enabled Basic Authentication for all routes");
+            setupBasicAuth(router);
+        }
         addTelemetryApiRoutes(router);
         addEventApiRoutes(router);
     }
 
-    private void addTelemetryApiRoutes(final Router router) {
+    private void setupBasicAuth(final Router router) {
+        AuthProvider authProvider = BasicAuthProvider.create(this);
+        router.route().handler(BasicAuthHandler.create(authProvider));
+    }
 
+    private void addTelemetryApiRoutes(final Router router) {
         // route for uploading telemetry data
         router.route(HttpMethod.PUT, String.format("/telemetry/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
-            .handler(ctx -> uploadTelemetryMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
+                .handler(ctx -> uploadTelemetryMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
     }
 
     private void addEventApiRoutes(final Router router) {
-
         // route for sending event messages
         router.route(HttpMethod.PUT, String.format("/event/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
-            .handler(ctx -> uploadEventMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
+                .handler(ctx -> uploadEventMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
     }
 
     private static String getTenantParam(final RoutingContext ctx) {

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/credentials/BasicAuthProvider.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/credentials/BasicAuthProvider.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.adapter.rest.credentials;
+
+import io.vertx.core.*;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
+import org.eclipse.hono.adapter.rest.VertxBasedRestProtocolAdapter;
+
+/**
+ * Helper class implementing {@link AuthProvider}. The Vertx components handle the header extraction and return the
+ * appropriate error codes if the user authorization fails.
+ */
+public class BasicAuthProvider implements AuthProvider {
+
+    private VertxBasedRestProtocolAdapter adapter;
+
+    public BasicAuthProvider(VertxBasedRestProtocolAdapter adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public void authenticate(JsonObject authInfo, Handler<AsyncResult<User>> resultHandler) {
+        String username = authInfo.getString("username");
+        String password = authInfo.getString("password");
+        VertxRestUser user = VertxRestUser.create(username, password, adapter.getConfig().isSingleTenant());
+        if (user == null) {
+            resultHandler.handle(Future.failedFuture("login failed"));
+        } else {
+            adapter.validateCredentialsForDevice(user.getTenantId(), user.getType(), user.getAuthId(),
+                    user.getPassword()).setHandler(attempt -> {
+                        if (attempt.succeeded()) {
+                            resultHandler.handle(Future.succeededFuture(user));
+                        } else {
+                            resultHandler.handle(Future.failedFuture("login failed"));
+                        }
+                    });
+        }
+    }
+
+    public static BasicAuthProvider create(VertxBasedRestProtocolAdapter adapter) {
+        return new BasicAuthProvider(adapter);
+    }
+}

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/credentials/VertxRestUser.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/credentials/VertxRestUser.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.adapter.rest.credentials;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.AbstractUser;
+import io.vertx.ext.auth.AuthProvider;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class to handle http basic authentication.
+ * <p>
+ * The tenant is transferred as part of the username in the basic authentication header similar to the MQTT
+ * username/password implementation.
+ * <p>
+ * <ul>
+ * <li>If the adapter runs in single tenant mode, the tenant is set to {@link Constants#DEFAULT_TENANT}.
+ * <li>If the adapter runs in multiple tenant mode, the tenant must be part of the basic auth username, which must comply to
+ * the structure authId@tenantId.
+ * </ul>
+ */
+public class VertxRestUser extends AbstractUser {
+
+    private static final Logger LOG  = LoggerFactory.getLogger(VertxRestUser.class);
+    private static final String type = CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD;
+    private String              authId;
+    private String              password;
+    private String              tenantId;
+    private String              userFromBasicAuth;
+    private JsonObject          principal;
+
+    public final String getType() {
+        return type;
+    }
+
+    public final String getAuthId() {
+        return authId;
+    }
+
+    public final String getPassword() {
+        return password;
+    }
+
+    public final String getTenantId() {
+        return tenantId;
+    }
+
+    public static final VertxRestUser create(final String userName, final String password,
+            final boolean singleTenant) {
+        VertxRestUser credentials = fillAuthIdAndTenantId(userName, singleTenant);
+        if (credentials != null) {
+            credentials.password = password;
+        }
+        return credentials;
+    }
+
+    private static VertxRestUser fillAuthIdAndTenantId(final String userFromBasicAuth, final boolean singleTenant) {
+        if (userFromBasicAuth == null) {
+            LOG.trace("auth object in endpoint found, but username must not be null");
+            return null;
+        }
+        VertxRestUser credentials = new VertxRestUser();
+        credentials.userFromBasicAuth = userFromBasicAuth;
+        if (singleTenant) {
+            credentials.authId = userFromBasicAuth;
+            credentials.tenantId = Constants.DEFAULT_TENANT;
+        } else {
+            // multi tenantId -> <userId>@<tenantId>
+            String[] userComponents = userFromBasicAuth.split("@");
+            if (userComponents.length != 2) {
+                LOG.trace(
+                        "User {} in Basic Auth does not comply with the defined structure, must fulfil the pattern '<authId>@<tenantId>'",
+                        userFromBasicAuth);
+                return null;
+            } else {
+                credentials.authId = userComponents[0];
+                credentials.tenantId = userComponents[1];
+            }
+        }
+        return credentials;
+    }
+
+    @Override
+    protected void doIsPermitted(String s, Handler<AsyncResult<Boolean>> handler) {
+        LOG.debug("No authorization supported at the moment");
+        handler.handle(Future.succeededFuture());
+    }
+
+    @Override
+    public JsonObject principal() {
+        if (principal == null) {
+            principal = new JsonObject().put("username", userFromBasicAuth);
+        }
+        return principal;
+    }
+
+    @Override
+    public void setAuthProvider(AuthProvider authProvider) {
+    }
+}

--- a/adapters/rest-vertx/src/test/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapterTest.java
+++ b/adapters/rest-vertx/src/test/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapterTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.adapter.rest;
+
+import static org.mockito.Mockito.*;
+
+import io.vertx.core.*;
+import org.eclipse.hono.client.HonoClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import java.util.Base64;
+
+import static org.eclipse.hono.service.http.HttpEndpointUtils.CONTENT_TYPE_JSON;
+
+/**
+ * Verifies behavior of {@link VertxBasedRestProtocolAdapter}.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxBasedRestProtocolAdapterTest {
+
+    private static final String HOST                 = "localhost";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private static HonoClient messagingClient;
+    private static HonoClient registrationClient;
+    private static HonoClient credentialsClient;
+
+    private static RestProtocolAdapterProperties config;
+    private static VertxBasedRestProtocolAdapter restAdapter;
+
+    private static Vertx vertx;
+
+    @After
+    public void shutDown() {
+        vertx.close();
+    }
+
+    @Before
+    public void setup(TestContext context) {
+        vertx = Vertx.vertx();
+
+        Future<String> setupTracker = Future.future();
+        setupTracker.setHandler(context.asyncAssertSuccess());
+
+        messagingClient = mock(HonoClient.class);
+        registrationClient = mock(HonoClient.class);
+        credentialsClient = mock(HonoClient.class);
+        config = new RestProtocolAdapterProperties();
+        config.setInsecurePortEnabled(true);
+        config.setAuthenticationRequired(true);
+        restAdapter = spy(VertxBasedRestProtocolAdapter.class);
+        restAdapter.setConfig(config);
+        restAdapter.setHonoMessagingClient(messagingClient);
+        restAdapter.setRegistrationServiceClient(registrationClient);
+        restAdapter.setCredentialsServiceClient(credentialsClient);
+
+        Future<String> restServerDeploymentTracker = Future.future();
+        vertx.deployVerticle(restAdapter, restServerDeploymentTracker.completer());
+        restServerDeploymentTracker.compose(c -> setupTracker.complete(), setupTracker);
+    }
+
+    @Test
+    public void testBasicAuthFailsEmptyHeader(final TestContext context) throws Exception {
+        final Async async = context.async();
+
+        vertx.createHttpClient().get(restAdapter.getInsecurePort(), HOST, "/somenonexistingroute")
+                .putHeader("content-type", CONTENT_TYPE_JSON).handler(response -> {
+                    context.assertEquals(401, response.statusCode());
+                    response.bodyHandler(totalBuffer -> {
+                        async.complete();
+                    });
+                }).exceptionHandler(context::fail).end();
+    }
+
+    @Test
+    public void testBasicAuthFailsWrongCredentials(final TestContext context) throws Exception {
+        final Async async = context.async();
+        final String encodedUserPass = Base64.getEncoder()
+                .encodeToString("testuser@DEFAULT_TENANT:password123".getBytes("utf-8"));
+
+        Future<String> validationResult = Future.future();
+        validationResult.fail("");
+
+        doReturn(validationResult).when(restAdapter).validateCredentialsForDevice(anyObject(), anyObject(), anyObject(),
+                anyObject());
+
+        vertx.createHttpClient().put(restAdapter.getInsecurePort(), HOST, "/somenonexistingroute")
+                .putHeader("content-type", CONTENT_TYPE_JSON)
+                .putHeader(AUTHORIZATION_HEADER, "Basic " + encodedUserPass).handler(response -> {
+                    context.assertEquals(401, response.statusCode());
+                    response.bodyHandler(totalBuffer -> {
+                        async.complete();
+                    });
+                }).exceptionHandler(context::fail).end();
+    }
+
+    @Test
+    public void testBasicAuthSuccess(final TestContext context) throws Exception {
+        final Async async = context.async();
+        final String encodedUserPass = Base64.getEncoder()
+                .encodeToString("existinguser@DEFAULT_TENANT:password123".getBytes("utf-8"));
+
+        Future<String> validationResult = Future.future();
+        validationResult.complete("device_1");
+
+        doReturn(validationResult).when(restAdapter).validateCredentialsForDevice(anyObject(), anyObject(), anyObject(),
+                anyObject());
+
+        vertx.createHttpClient().get(restAdapter.getInsecurePort(), HOST, "/somenonexistingroute")
+                .putHeader("content-type", CONTENT_TYPE_JSON)
+                .putHeader(AUTHORIZATION_HEADER, "Basic " + encodedUserPass).handler(response -> {
+                    context.assertEquals(404, response.statusCode());
+                    response.bodyHandler(totalBuffer -> {
+                        async.complete();
+                    });
+                }).exceptionHandler(context::fail).end();
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/CredentialsClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/CredentialsClient.java
@@ -14,6 +14,7 @@ package org.eclipse.hono.client;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import org.eclipse.hono.util.CredentialsObject;
 import org.eclipse.hono.util.CredentialsResult;
 
 import java.net.HttpURLConnection;
@@ -42,5 +43,5 @@ public interface CredentialsClient extends RequestResponseClient {
      *         Otherwise the status will be {@link HttpURLConnection#HTTP_NOT_FOUND}.
 
      */
-    void get(String type, String authId,  Handler<AsyncResult<CredentialsResult>> resultHandler);
+    void get(String type, String authId,  Handler<AsyncResult<CredentialsResult<CredentialsObject>>> resultHandler);
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -74,10 +74,10 @@ public abstract class AbstractRequestResponseClient<C extends RequestResponseCli
      * Creates a result object from the status and payload of a response received from the endpoint.
      *
      * @param status The status of the response.
-     * @param payload The json payload of the response.
+     * @param payload The json payload of the response as String.
      * @return The result object.
      */
-    protected abstract R getResult(final int status, final JsonObject payload);
+    protected abstract R getResult(final int status, final String payload);
 
     /**
      * Creates a client for a vert.x context.
@@ -166,7 +166,7 @@ public abstract class AbstractRequestResponseClient<C extends RequestResponseCli
                 message.getApplicationProperties(),
                 MessageHelper.APP_PROPERTY_STATUS,
                 String.class);
-        final JsonObject payload = MessageHelper.getJsonPayload(message);
+        final String payload = MessageHelper.getPayload(message);
         return getResult(Integer.valueOf(status), payload);
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
@@ -12,34 +12,30 @@
 
 package org.eclipse.hono.client.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.proton.*;
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
-import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
-import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.CredentialsClient;
-import org.eclipse.hono.client.RequestResponseClient;
 import org.eclipse.hono.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
+import java.io.IOException;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.eclipse.hono.util.CredentialsConstants.OPERATION_GET;
-import static org.eclipse.hono.util.MessageHelper.APP_PROPERTY_STATUS;
 
 /**
  * A Vertx-Proton based client for Hono's Credentials API.
  *
  */
-public final class CredentialsClientImpl extends AbstractRequestResponseClient<CredentialsClient, CredentialsResult> implements CredentialsClient {
+public final class CredentialsClientImpl extends AbstractRequestResponseClient<CredentialsClient, CredentialsResult<CredentialsObject>> implements CredentialsClient {
 
     private static final String                  CREDENTIALS_NAME = "credentials";
 
@@ -63,9 +59,16 @@ public final class CredentialsClientImpl extends AbstractRequestResponseClient<C
     }
 
     @Override
-    protected CredentialsResult getResult(final int status, final JsonObject payload) {
-
-        return CredentialsResult.from(status, payload);
+    protected CredentialsResult<CredentialsObject> getResult(final int status, final String payload) {
+        try {
+            if (status == HTTP_OK) {
+                ObjectMapper om = new ObjectMapper();
+                return CredentialsResult.from(status, om.readValue(payload, CredentialsObject.class));
+            }
+        } catch (IOException e) {
+            return CredentialsResult.from(HTTP_INTERNAL_ERROR, null);
+        }
+        return CredentialsResult.from(status, null);
     }
 
     /**
@@ -87,7 +90,7 @@ public final class CredentialsClientImpl extends AbstractRequestResponseClient<C
     }
 
     @Override
-    public final void get(final String type, final String authId, final Handler<AsyncResult<CredentialsResult>> resultHandler) {
+    public final void get(final String type, final String authId, final Handler<AsyncResult<CredentialsResult<CredentialsObject>>> resultHandler) {
         JsonObject specification = new JsonObject().put(CredentialsConstants.FIELD_TYPE, type).put(CredentialsConstants.FIELD_AUTH_ID, authId);
         createAndSendRequest(OPERATION_GET, specification, resultHandler);
     }

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
@@ -41,6 +41,8 @@ public final class CredentialsClientImpl extends AbstractRequestResponseClient<C
 
     private static final Logger                  LOG = LoggerFactory.getLogger(CredentialsClientImpl.class);
 
+    private static final ObjectMapper            objectMapper = new ObjectMapper();
+
     private CredentialsClientImpl(final Context context, final ProtonConnection con, final String tenantId,
                                   final Handler<AsyncResult<CredentialsClient>> creationHandler) {
         super(context, con, tenantId, creationHandler);
@@ -62,13 +64,13 @@ public final class CredentialsClientImpl extends AbstractRequestResponseClient<C
     protected CredentialsResult<CredentialsObject> getResult(final int status, final String payload) {
         try {
             if (status == HTTP_OK) {
-                ObjectMapper om = new ObjectMapper();
-                return CredentialsResult.from(status, om.readValue(payload, CredentialsObject.class));
+                return CredentialsResult.from(status, objectMapper.readValue(payload, CredentialsObject.class));
+            } else {
+                return CredentialsResult.from(status, null);
             }
         } catch (IOException e) {
             return CredentialsResult.from(HTTP_INTERNAL_ERROR, null);
         }
-        return CredentialsResult.from(status, null);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
@@ -63,9 +63,9 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
     }
 
     @Override
-    protected RegistrationResult getResult(final int status, final JsonObject payload) {
+    protected RegistrationResult getResult(final int status, final String payload) {
 
-        return RegistrationResult.from(status,payload);
+        return RegistrationResult.from(status, payload);
     }
 
     /**

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -111,7 +111,6 @@
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-databind</artifactId>
      <version>${jackson.version}</version>
-     <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
@@ -67,10 +67,10 @@ public final class CredentialsConstants extends RequestResponseApiConstants {
      *
      * @param tenantId The tenant for which the message was processed.
      * @param deviceId The device that the message relates to.
-     * @param result The {@link RegistrationResult} object with the payload for the reply object.
+     * @param result The {@link RegistrationResult} object with the payload as JsonObject for the reply object.
      * @return JsonObject The json reply object that is to be sent back via the vert.x event bus.
      */
-    public static JsonObject getServiceReplyAsJson(final String tenantId, final String deviceId, final CredentialsResult result) {
+    public static JsonObject getServiceReplyAsJson(final String tenantId, final String deviceId, final CredentialsResult<JsonObject> result) {
         return getServiceReplyAsJson(result.getStatus(), tenantId, deviceId, result.getPayload());
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/CredentialsObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsObject.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.util;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Encapsulates the credentials information for a device that was found by the get operation of the
+ * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+ * <p>
+ * Is mapped internally from json representation by jackson-databind.
+ */
+public final class CredentialsObject {
+    @JsonProperty(CredentialsConstants.FIELD_DEVICE_ID)
+    private String deviceId;
+    @JsonProperty(CredentialsConstants.FIELD_TYPE)
+    private String type;
+    @JsonProperty(CredentialsConstants.FIELD_AUTH_ID)
+    private String authId;
+    @JsonProperty(CredentialsConstants.FIELD_ENABLED)
+    private Boolean enabled;
+    /*
+     * Since the format of the secrets field is not determined by the Credentials API, they are best represented as
+     * key-value maps with key and value both of type String.
+     * The further processing of secrets is part of the validator for the specific type.
+     */
+    @JsonProperty(CredentialsConstants.FIELD_SECRETS)
+    private List<Map<String,String>> secrets;
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getAuthId() {
+        return authId;
+    }
+
+    public void setAuthId(String authId) {
+        this.authId = authId;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public List<Map<String, String>> getSecrets() {
+        return secrets;
+    }
+
+    public void setSecrets(List<Map<String, String>> secrets) {
+        this.secrets = secrets;
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/CredentialsResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsResult.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.util;
 /**
  * A container for the result returned by Hono's credentials API.
  *
+ * @param <T> denotes the concrete type of the payload that is part of the result
  */
 public final class CredentialsResult<T> extends RequestResponseResult<T> {
     private CredentialsResult(final int status, final T payload) {

--- a/core/src/main/java/org/eclipse/hono/util/CredentialsResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsResult.java
@@ -12,14 +12,12 @@
 
 package org.eclipse.hono.util;
 
-import io.vertx.core.json.JsonObject;
-
 /**
  * A container for the result returned by Hono's credentials API.
  *
  */
-public final class CredentialsResult extends RequestResponseResult {
-    private CredentialsResult(final int status, final JsonObject payload) {
+public final class CredentialsResult<T> extends RequestResponseResult<T> {
+    private CredentialsResult(final int status, final T payload) {
         super(status, payload);
     }
 
@@ -27,7 +25,7 @@ public final class CredentialsResult extends RequestResponseResult {
         return new CredentialsResult(status, null);
     }
 
-    public static CredentialsResult from(final int status, final JsonObject payload) {
-        return new CredentialsResult(status, payload);
+    public static <T> CredentialsResult<T> from(final int status, final T payload) {
+        return new CredentialsResult<>(status, payload);
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/RegistrationResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistrationResult.java
@@ -18,7 +18,7 @@ import io.vertx.core.json.JsonObject;
  * A container for the result returned by Hono's registration API.
  *
  */
-public final class RegistrationResult extends RequestResponseResult {
+public final class RegistrationResult extends RequestResponseResult<JsonObject> {
     private RegistrationResult(final int status, final JsonObject payload) {
         super(status, payload);
     }
@@ -29,5 +29,13 @@ public final class RegistrationResult extends RequestResponseResult {
 
     public static RegistrationResult from(final int status, final JsonObject payload) {
         return new RegistrationResult(status, payload);
+    }
+
+    public static RegistrationResult from(final int status, final String payloadString) {
+        if (payloadString != null) {
+            return new RegistrationResult(status, new JsonObject(payloadString));
+        } else {
+            return new RegistrationResult(status, null);
+        }
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseResult.java
@@ -18,12 +18,12 @@ import io.vertx.core.json.JsonObject;
  * A container for the result returned by a Hono API that implements the request response pattern.
  *
  */
-public class RequestResponseResult {
+public class RequestResponseResult<T> {
 
     private final int status;
-    private final JsonObject payload;
+    private final T payload;
 
-    protected RequestResponseResult(final int status, final JsonObject payload) {
+    protected RequestResponseResult(final int status, final T payload) {
         this.status = status;
         this.payload = payload;
     }
@@ -38,7 +38,7 @@ public class RequestResponseResult {
     /**
      * @return the payload
      */
-    public final JsonObject getPayload() {
+    public final T getPayload() {
         return payload;
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseResult.java
@@ -12,11 +12,10 @@
 package org.eclipse.hono.util;
 
 
-import io.vertx.core.json.JsonObject;
-
 /**
  * A container for the result returned by a Hono API that implements the request response pattern.
  *
+ * @param <T> denotes the concrete type of the payload that is part of the result
  */
 public class RequestResponseResult<T> {
 

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -14,14 +14,13 @@ package org.eclipse.hono.service;
 import java.net.HttpURLConnection;
 import java.util.Objects;
 
-import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonConnection;
 import org.eclipse.hono.client.CredentialsClient;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.config.ServiceConfigProperties;
-import org.eclipse.hono.service.credentials.CredentialsSecretsValidator;
+import org.eclipse.hono.service.credentials.SecretsValidator;
 import org.eclipse.hono.service.credentials.CredentialsUtils;
 import org.eclipse.hono.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -494,7 +493,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ServiceConfigPropert
                 CredentialsObject payload = credResult.getPayload();
                 result.complete(payload);
             } else if (credResult.getStatus() == HttpURLConnection.HTTP_NOT_FOUND) {
-                result.fail(String.format("cannot retrieve credentials (not found for type <%s>, authId <%s>)",type,authId));
+                result.fail(String.format("cannot retrieve credentials (not found for type <%s>, authId <%s>)", type, authId));
             } else {
                 result.fail("cannot retrieve credentials");
             }
@@ -521,7 +520,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ServiceConfigPropert
                                                               final Object authenticationObject) {
         return getCredentialsForDevice(tenantId, type, authId).compose(payload -> {
             Future<String> resultDeviceId = Future.future();
-            CredentialsSecretsValidator validator = CredentialsUtils.findAppropriateValidators(type);
+            SecretsValidator validator = CredentialsUtils.findAppropriateValidators(type);
             try {
                 if (validator != null && validator.validate(payload, authenticationObject)) {
                     resultDeviceId.complete(payload.getDeviceId());
@@ -532,7 +531,6 @@ public abstract class AbstractProtocolAdapterBase<T extends ServiceConfigPropert
             catch (IllegalArgumentException e) {
                 resultDeviceId.fail(String.format("credentials invalid : %s", e.getMessage()));
             }
-
             return resultDeviceId;
         });
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -14,16 +14,16 @@ package org.eclipse.hono.service;
 import java.net.HttpURLConnection;
 import java.util.Objects;
 
+import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonConnection;
 import org.eclipse.hono.client.CredentialsClient;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.config.ServiceConfigProperties;
-import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.CredentialsConstants;
-import org.eclipse.hono.util.RegistrationConstants;
-import org.eclipse.hono.util.RegistrationResult;
+import org.eclipse.hono.service.credentials.CredentialsSecretsValidator;
+import org.eclipse.hono.service.credentials.CredentialsUtils;
+import org.eclipse.hono.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -480,6 +480,60 @@ public abstract class AbstractProtocolAdapterBase<T extends ServiceConfigPropert
     public void registerLivenessChecks(final HealthCheckHandler handler) {
         handler.register("ping", status -> {
             status.complete(Status.OK());
+        });
+    }
+    private Future<CredentialsObject> getCredentialsForDevice(final String tenantId, final String type, final String authId) {
+
+        Future<CredentialsObject> result = Future.future();
+        getCredentialsClient(tenantId).compose(client -> {
+            Future<CredentialsResult<CredentialsObject>> credResultFuture = Future.future();
+            client.get(type, authId, credResultFuture.completer());
+            return credResultFuture;
+        }).compose(credResult -> {
+            if (credResult.getStatus() == HttpURLConnection.HTTP_OK) {
+                CredentialsObject payload = credResult.getPayload();
+                result.complete(payload);
+            } else if (credResult.getStatus() == HttpURLConnection.HTTP_NOT_FOUND) {
+                result.fail(String.format("cannot retrieve credentials (not found for type <%s>, authId <%s>)",type,authId));
+            } else {
+                result.fail("cannot retrieve credentials");
+            }
+        }, result);
+
+        return result;
+    }
+
+    /**
+     * Validates an authentication object against credentials secrets available by the get operation of the
+     *  <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * <p>The credentials are first retrieved from the credentials service, and then all matching validators are
+     * invoked until one is successful or all failed. The authentication object is validated iff at least
+     * one validator was successful.
+     *
+     * @param tenantId The tenantId to which the device belongs.
+     * @param type The type of credentials that are to be used for validation.
+     * @param authId The authId of the credentials that are to be used for validation.
+     * @param authenticationObject The authentication object to be validated, e.g. a password, a preshared-key, etc.
+
+     * @return Future The future object carrying the payload of the credentials get operation, if successful.
+     */
+    protected Future<String> validateCredentialsForDevice(final String tenantId, final String type, final String authId,
+                                                              final Object authenticationObject) {
+        return getCredentialsForDevice(tenantId, type, authId).compose(payload -> {
+            Future<String> resultDeviceId = Future.future();
+            CredentialsSecretsValidator validator = CredentialsUtils.findAppropriateValidators(type);
+            try {
+                if (validator != null && validator.validate(payload, authenticationObject)) {
+                    resultDeviceId.complete(payload.getDeviceId());
+                } else {
+                    resultDeviceId.fail("credentials invalid - not validated");
+                }
+            }
+            catch (IllegalArgumentException e) {
+                resultDeviceId.fail(String.format("credentials invalid : %s", e.getMessage()));
+            }
+
+            return resultDeviceId;
         });
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -516,7 +516,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ServiceConfigPropert
 
      * @return Future The future object carrying the payload of the credentials get operation, if successful.
      */
-    protected Future<String> validateCredentialsForDevice(final String tenantId, final String type, final String authId,
+    public Future<String> validateCredentialsForDevice(final String tenantId, final String type, final String authId,
                                                               final Object authenticationObject) {
         return getCredentialsForDevice(tenantId, type, authId).compose(payload -> {
             Future<String> resultDeviceId = Future.future();

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
@@ -218,8 +218,8 @@ public abstract class BaseCredentialsService<T> extends ConfigurationSupportingV
     }
 
     /**
-     * Wraps a given device ID and registration data into a JSON structure suitable
-     * to be returned to clients as the result of a registration operation.
+     * Wraps a given device ID and credentials data into a JSON structure suitable
+     * to be returned to clients as the result of a credentials operation.
      * 
      * @param deviceId The identifier of the device.
      * @param type The type of credentials returned.

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsSecretsValidator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsSecretsValidator.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.credentials;
+
+import org.eclipse.hono.util.CredentialsObject;
+
+/**
+ * Interface that all credentials validators need to implement.
+ * <p>
+ * Any mechanism to authenticate a device is based on credentials secrets that are defined in the
+ * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+ * This interface defines the methods necessary to provide an algorithm for validating any of these secrets.
+ * <p>
+ * Validators that implement this interface and are implemented as Spring beans in the package
+ * {@link org.eclipse.hono.service.credentials.validators} will be automatically found during startup and are used
+ * during authentication.
+ * This makes adding of own validators very easy.
+ * <p>See the provided validators (e.g. {@link org.eclipse.hono.service.credentials.validators.CredentialsValidatorHashedPassword})
+ * as a blueprint for how to write own validators.
+ * See {@link org.eclipse.hono.service.credentials.validators.AbstractCredentialsValidator} as the base class for such
+ * implementations.
+ *
+ * @param <T> The type of what has to be validated (called item below): this can be String in case of password validation, a certificate
+ *           class in case of a client certificate, etc.
+ */
+
+public interface CredentialsSecretsValidator<T> {
+    /**
+     * Get the type of credentials secrets this validator is responsible for.
+     * <p>This can be freely defined, but there are some predefined types in the
+     * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     *
+     * @return The type of credentials secrets.
+     */
+    String getSecretsType();
+
+    /**
+     * Validate  an instance of T (e.g. a password) against credentials secrets (as JsonObject as defined in the
+     * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>).
+     * <p>
+     *
+     * @param credentialsGetPayload The payload as returned from the credentials API get operation.
+     * @param itemToValidate The item that has to be validated, e.g. a password String, a certificate, etc.
+     *
+     * @return True if the item could be validated, false otherwise.
+     * @throws IllegalArgumentException If the payload is not correct.
+     */
+    boolean validate(final CredentialsObject credentialsGetPayload, T itemToValidate) throws IllegalArgumentException;
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsUtils.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.credentials;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+/**
+ * Utility class as Spring bean that is used by protocol adapters to find matching implementations for the
+ * validation of authentication objects.
+ */
+@Component
+public final class CredentialsUtils {
+    private static final Map<String, CredentialsSecretsValidator> secretsValidators = new HashMap<>();
+
+    @Autowired(required = false)
+    public final void addValidators(final Set<CredentialsSecretsValidator> definedValidators) throws BeanCreationException {
+        Objects.requireNonNull(definedValidators);
+        for (CredentialsSecretsValidator secretsValidator : definedValidators) {
+            addSecretsValidator(secretsValidator);
+        }
+    }
+
+    private void addSecretsValidator(final CredentialsSecretsValidator secretsValidator) throws IllegalArgumentException {
+        if (secretsValidators.containsKey(secretsValidator.getSecretsType())) {
+            throw new IllegalArgumentException(String.format("multiple credentials validators for type <%s> found - not supported.",
+                    secretsValidator.getSecretsType()));
+        }
+        secretsValidators.put(secretsValidator.getSecretsType(), secretsValidator);
+    }
+
+    public static CredentialsSecretsValidator findAppropriateValidators(final String secretsType) {
+        return secretsValidators.get(secretsType);
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsUtils.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.hono.service.credentials;
 
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -23,25 +22,33 @@ import java.util.*;
  */
 @Component
 public final class CredentialsUtils {
-    private static final Map<String, CredentialsSecretsValidator> secretsValidators = new HashMap<>();
+    private static final Map<String, SecretsValidator> secretsValidators = new HashMap<>();
 
     @Autowired(required = false)
-    public final void addValidators(final Set<CredentialsSecretsValidator> definedValidators) throws BeanCreationException {
+    public final void addValidators(final Set<SecretsValidator> definedValidators) {
         Objects.requireNonNull(definedValidators);
-        for (CredentialsSecretsValidator secretsValidator : definedValidators) {
+        for (SecretsValidator secretsValidator : definedValidators) {
             addSecretsValidator(secretsValidator);
         }
     }
 
-    private void addSecretsValidator(final CredentialsSecretsValidator secretsValidator) throws IllegalArgumentException {
-        if (secretsValidators.containsKey(secretsValidator.getSecretsType())) {
+    /**
+     * Add validator bean to the internal map that keeps track of a single validator per type.
+     *
+     * @param secretsValidator The validator bean to add to the map.
+     *
+     * @throws IllegalArgumentException If there was a validator for this type already (which is considered conceptually
+     * illegal).
+     */
+    private void addSecretsValidator(final SecretsValidator secretsValidator) {
+        if (secretsValidators.containsKey(secretsValidator.getSupportedType())) {
             throw new IllegalArgumentException(String.format("multiple credentials validators for type <%s> found - not supported.",
-                    secretsValidator.getSecretsType()));
+                    secretsValidator.getSupportedType()));
         }
-        secretsValidators.put(secretsValidator.getSecretsType(), secretsValidator);
+        secretsValidators.put(secretsValidator.getSupportedType(), secretsValidator);
     }
 
-    public static CredentialsSecretsValidator findAppropriateValidators(final String secretsType) {
+    public static SecretsValidator findAppropriateValidators(final String secretsType) {
         return secretsValidators.get(secretsType);
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/SecretsValidator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/SecretsValidator.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.hono.service.credentials;
 
+import org.eclipse.hono.service.credentials.validators.AbstractSecretValidator;
 import org.eclipse.hono.util.CredentialsObject;
 
 /**
@@ -24,24 +25,24 @@ import org.eclipse.hono.util.CredentialsObject;
  * {@link org.eclipse.hono.service.credentials.validators} will be automatically found during startup and are used
  * during authentication.
  * This makes adding of own validators very easy.
- * <p>See the provided validators (e.g. {@link org.eclipse.hono.service.credentials.validators.CredentialsValidatorHashedPassword})
+ * <p>See the provided validators (e.g. {@link org.eclipse.hono.service.credentials.validators.HashedPasswordValidator})
  * as a blueprint for how to write own validators.
- * See {@link org.eclipse.hono.service.credentials.validators.AbstractCredentialsValidator} as the base class for such
+ * See {@link AbstractSecretValidator} as the base class for such
  * implementations.
  *
- * @param <T> The type of what has to be validated (called item below): this can be String in case of password validation, a certificate
+ * @param <T> The type of secret that is validated: this can be String in case of password validation, a certificate
  *           class in case of a client certificate, etc.
  */
 
-public interface CredentialsSecretsValidator<T> {
+public interface SecretsValidator<T> {
     /**
      * Get the type of credentials secrets this validator is responsible for.
      * <p>This can be freely defined, but there are some predefined types in the
      * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
      *
-     * @return The type of credentials secrets.
+     * @return The type of credentials secrets that are handled by the implementor.
      */
-    String getSecretsType();
+    String getSupportedType();
 
     /**
      * Validate  an instance of T (e.g. a password) against credentials secrets (as JsonObject as defined in the
@@ -49,10 +50,10 @@ public interface CredentialsSecretsValidator<T> {
      * <p>
      *
      * @param credentialsGetPayload The payload as returned from the credentials API get operation.
-     * @param itemToValidate The item that has to be validated, e.g. a password String, a certificate, etc.
+     * @param secret The secret that has to be validated, e.g. a password String, a certificate, etc.
      *
      * @return True if the item could be validated, false otherwise.
      * @throws IllegalArgumentException If the payload is not correct.
      */
-    boolean validate(final CredentialsObject credentialsGetPayload, T itemToValidate) throws IllegalArgumentException;
+    boolean validate(final CredentialsObject credentialsGetPayload, T secret);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/validators/AbstractCredentialsValidator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/validators/AbstractCredentialsValidator.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.credentials.validators;
+
+import org.eclipse.hono.service.credentials.CredentialsSecretsValidator;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.eclipse.hono.util.CredentialsObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Abstract validator class from which concrete validators are derived that are specialized to a specific type of
+ * credential secrets.
+ * <p>
+ * The class implements the validation steps that are common to all types of credentials. This e.g. includes the enabled
+ * flag of credential entries, the iteration over several valid credential entries (until one is successfully validated
+ * or none is left), etc.
+ * <p>
+ * The detailed algorithm to validate a single credential entry is delegated to the implementing subclass and so supports
+ * a specified small implementation class per credentials type..
+ *
+ * @param <T> The type of what has to be validated (called item below): this can be String in case of password validation, a certificate
+ *           class in case of a client certificate, etc.
+ */
+public abstract class AbstractCredentialsValidator<T> implements CredentialsSecretsValidator<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractCredentialsValidator.class);
+
+    /**
+     * Get the type of credentials secrets this validator is responsible for.
+     * <p>This can be freely defined, but there are some predefined types in the
+     * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     *
+     * @return The type of credentials secrets.
+     */
+    @Override
+    public abstract String getSecretsType();
+
+    /**
+     * Validate an instance of T (e.g. a password) against a single credentials secret (as JsonObject).
+     * <p>
+     * Subclasses need to implement their specified algorithm for validation in this method.
+     *
+     * @param itemToValidate The item to validate.
+     * @param aSecret The secret record as JsonObject (as returned by the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * @return The result of the validation as boolean.
+     */
+    protected abstract boolean validateSingleSecret(final T itemToValidate, final Map<String, String> aSecret);
+
+    /**
+     * Validate  an instance of T (e.g. a password) against credentials secrets (as JsonObject as defined in the
+     * <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>).
+     * <p>
+     * The payload from the get operation of the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>
+     * is parsed and splitted into single secrets entries in this method. The single entries are then delegated to the
+     * {@link #validateSingleSecret} method of the implementing subclass where the detailed
+     * validation is processed. If one entry was successfully validated, the validation is considered
+     * successful and the result is completed. If no secret could be validated, the validation fails and thus the result
+     * is set to failed.
+     *
+     * @param credentialsObject The credentials that were returned from the credentials get operation.
+     * @param authenticationObject The object to authenticate.
+     *
+     * @return boolean True if the authenticationObject could be validated, false otherwise.
+     * @throws IllegalArgumentException If the payload is not correct.
+     */
+    @Override
+    public final boolean validate(final CredentialsObject credentialsObject, final T authenticationObject) throws IllegalArgumentException {
+
+        if (!credentialsObject.getEnabled()) {
+            // if not found : default is enabled
+            LOG.debug("credentials not validated - device disabled");
+            return false;
+        }
+
+        List<Map<String, String>> secrets = credentialsObject.getSecrets();
+
+        if (secrets == null) {
+            throw new IllegalArgumentException(String.format("credentials not validated - mandatory field %s is null", CredentialsConstants.FIELD_SECRETS));
+        }
+
+        if (secrets.size() == 0) {
+            throw new IllegalArgumentException(String.format("credentials not validated - mandatory field %s is empty", CredentialsConstants.FIELD_SECRETS));
+        }
+
+        try {
+            // find any validated secret -> validation was successful
+            Predicate<Object> validationPred = secret -> validateSingleSecret(authenticationObject, (Map<String, String>) secret);
+            Optional<Map<String, String>> validationSecret = secrets.stream().filter(validationPred).findAny();
+
+            if (!validationSecret.isPresent()) {
+                LOG.debug("credentials not validated - invalid");
+                return false;
+            }
+        }
+        catch(ClassCastException e) {
+            throw new IllegalArgumentException(String.format("validator for type <%s> does not match with passed class %s", getSecretsType(),
+                    authenticationObject.getClass().getName()));
+        }
+
+        return true;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/validators/CredentialsValidatorHashedPassword.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/validators/CredentialsValidatorHashedPassword.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.credentials.validators;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+
+import org.eclipse.hono.util.CredentialsConstants;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validator to validate credentials of type {@link CredentialsConstants#SECRETS_TYPE_HASHED_PASSWORD} for a given password.
+ */
+@Component
+public final class CredentialsValidatorHashedPassword extends AbstractCredentialsValidator<String> {
+
+    /**
+     * Get the type of credentials secrets this validator is responsible for.
+     *
+     * @return The type of credentials secrets.
+     */
+    @Override
+    public String getSecretsType() {
+        return CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD;
+    }
+
+    /**
+     * Approve a single secret (as JsonObject) against a given password.
+     * If the password matches against it, the approval is considered successful.
+     * <p>This involves the hash-function found in the credentials secrets record to hash the given password before the
+     * comparison against the password in the credentials secrets record is done.
+     * <p>If a salt is contained in the credentials record (in base64 encoding), the hash function will be salted first.
+     *
+     * @param password The password to validate.
+     * @param aSecret The secret record as JsonObject (as returned by the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * @return The result of the approval as boolean.
+     */
+    @Override
+    protected boolean validateSingleSecret(final String password, final Map<String, String> aSecret) {
+        String hashFunction = aSecret.get(CredentialsConstants.FIELD_SECRETS_HASH_FUNCTION);
+        if (hashFunction == null) {
+            return false;
+        }
+
+        return checkPasswordAgainstSecret(aSecret, hashFunction, password);
+    }
+
+    private boolean checkPasswordAgainstSecret(final Map<String, String> secret, final String hashFunction, final String protocolAdapterPassword) {
+
+        String pwdHash = secret.get(CredentialsConstants.FIELD_SECRETS_PWD_HASH);
+        if (pwdHash == null) {
+            return false;
+        }
+
+        byte[] password = Base64.getDecoder().decode(pwdHash);
+
+        final String salt = secret.get(CredentialsConstants.FIELD_SECRETS_SALT);
+        byte[] decodedSalt = null;
+        // the salt is optional so decodedSalt may stay null if salt was not found
+        if (salt != null) {
+            decodedSalt = Base64.getDecoder().decode(salt);
+        }
+
+        try {
+            byte[] hashedPassword = hashPassword(hashFunction, decodedSalt, protocolAdapterPassword);
+            if (!Arrays.equals(password, hashedPassword)) {
+                return false;
+            }
+        } catch (NoSuchAlgorithmException e) {
+            return false;
+        } catch (UnsupportedEncodingException e) {
+            return false;
+        }
+        // check if the password is the hashed version of the protocol adapter password
+        return true;
+    }
+
+    private byte[] hashPassword(final String hashFunction, final byte[] hashSalt, final String passwordToHash) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        MessageDigest messageDigest = MessageDigest.getInstance(hashFunction);
+        if (hashSalt != null) {
+            messageDigest.update(hashSalt);
+        }
+        byte[] theHashedPassword = messageDigest.digest(passwordToHash.getBytes());
+        return theHashedPassword;
+    }
+}

--- a/site/content/component/mqtt-adapter.md
+++ b/site/content/component/mqtt-adapter.md
@@ -82,6 +82,7 @@ The following table provides an overview of the configuration variables and corr
 | `HONO_MQTT_KEY_STORE_PATH`<br>`--hono.mqtt.keyStorePath` | no | - | The absolute path to the Java key store containing the private key and certificate that the protocol adapter should use for authenticating to clients. Either this option or the `HONO_MQTT_KEY_PATH` and `HONO_MQTT_CERT_PATH` options need to be set in order to enable TLS secured connections with clients. The key store format can be either `JKS` or `PKCS12` indicated by a `.jks` or `.p12` file suffix respectively. |
 | `HONO_MQTT_MAX_PAYLOAD_SIZE`<br>`--hono.mqtt.maxPayloadSize` | no | `2048` | The maximum allowed size of an incoming MQTT message's payload in bytes. When a client sends a message with a larger payload, the message is discarded and the connection to the client gets closed. |
 | `HONO_MQTT_PORT`<br>`--hono.mqtt.port` | no | `8883` | The secure port that the protocol adapter should listen on.<br>See [Port Configuration]({{< relref "#port-configuration" >}}) below for details. |
+| `HONO_MQTT_AUTHENTICATE_DEVICES`<br>`--hono.mqtt.authenticateDevices` | no | `true` | If set to `true` the protocol adapter demands the authentication of devices by using the [Credentials Service]({{< relref "#credentials-service-configuration" >}}) before they are allowed to publish messages. |
 
 The variables only need to be set if the default values do not match your environment.
 

--- a/site/content/component/mqtt-adapter.md
+++ b/site/content/component/mqtt-adapter.md
@@ -82,7 +82,7 @@ The following table provides an overview of the configuration variables and corr
 | `HONO_MQTT_KEY_STORE_PATH`<br>`--hono.mqtt.keyStorePath` | no | - | The absolute path to the Java key store containing the private key and certificate that the protocol adapter should use for authenticating to clients. Either this option or the `HONO_MQTT_KEY_PATH` and `HONO_MQTT_CERT_PATH` options need to be set in order to enable TLS secured connections with clients. The key store format can be either `JKS` or `PKCS12` indicated by a `.jks` or `.p12` file suffix respectively. |
 | `HONO_MQTT_MAX_PAYLOAD_SIZE`<br>`--hono.mqtt.maxPayloadSize` | no | `2048` | The maximum allowed size of an incoming MQTT message's payload in bytes. When a client sends a message with a larger payload, the message is discarded and the connection to the client gets closed. |
 | `HONO_MQTT_PORT`<br>`--hono.mqtt.port` | no | `8883` | The secure port that the protocol adapter should listen on.<br>See [Port Configuration]({{< relref "#port-configuration" >}}) below for details. |
-| `HONO_MQTT_AUTHENTICATE_DEVICES`<br>`--hono.mqtt.authenticateDevices` | no | `true` | If set to `true` the protocol adapter demands the authentication of devices by using the [Credentials Service]({{< relref "#credentials-service-configuration" >}}) before they are allowed to publish messages. |
+| `HONO_MQTT_AUTHENTICATE_DEVICES`<br>`--hono.mqtt.authenticationRequired` | no | `true` | If set to `true` the protocol adapter demands the authentication of devices by using the [Credentials Service]({{< relref "#credentials-service-configuration" >}}) before they are allowed to publish messages. |
 
 The variables only need to be set if the default values do not match your environment.
 


### PR DESCRIPTION
This is an implementation of Basic Auth for the REST Adapter similar to the currently discussed MQTT adapter authentication, see [PR 307](https://github.com/eclipse/hono/pull/307).

**Description:**

Username/password authentication using standard HTTP Basic Auth mechanism. Vertx provides the boiler plate code for the handling of the HTTP header and the proper 4XX error codes on authentication failure.
The hono side of things is taken from the MQTT adapter. The same single/multi-tenant logic is used as in the aforementioned pull request. It is probably a good idea to 

**Open points:**

- Resolve the conflicts once PR 307 is accepted and adjust changes if there are any to the PR
- Merge adapter/mqtt/credentials/MqttUsernamePassword.java and hono/adapter/rest/credentials/VertxRestUser.java they are almost identical but was not sure wether the REST authentication approach is the way to go so wanted to discuss it first

**Questions:**
- Approach ok?
- merge two user models (from the REST and MQTT adapters) or do it some other way?
