### PR TITLE
Hono JMeter Plugin uses username and password only when provided by the user.

### DIFF
--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
@@ -54,17 +54,28 @@ public class HonoReceiver {
     public HonoReceiver(final HonoReceiverSampler sampler) throws InterruptedException {
         this.sampler = sampler;
 
-        // amqp network config
-        amqpNetworkConnectionFactory = ConnectionFactoryImpl.ConnectionFactoryBuilder.newBuilder()
-                .disableHostnameVerification()
-                .host(sampler.getHost())
-                .name(sampler.getContainer())
-                .user(sampler.getUser())
-                .password(sampler.getPwd())
-                .port(Integer.parseInt(sampler.getPort()))
-                .trustStorePath(sampler.getTrustStorePath())
-                .vertx(vertx)
-                .build();
+        if (sampler.getUser() != null && sampler.getPwd() != null) {
+            // amqp network config
+            amqpNetworkConnectionFactory = ConnectionFactoryImpl.ConnectionFactoryBuilder.newBuilder()
+                    .disableHostnameVerification()
+                    .host(sampler.getHost())
+                    .name(sampler.getContainer())
+                    .user(sampler.getUser()).password(sampler.getPwd())
+                    .port(Integer.parseInt(sampler.getPort()))
+                    .trustStorePath(sampler.getTrustStorePath())
+                    .vertx(vertx)
+                    .build();
+        } else {
+            // amqp network config without user/pw
+            amqpNetworkConnectionFactory = ConnectionFactoryImpl.ConnectionFactoryBuilder.newBuilder()
+                    .disableHostnameVerification()
+                    .host(sampler.getHost())
+                    .name(sampler.getContainer())
+                    .port(Integer.parseInt(sampler.getPort()))
+                    .trustStorePath(sampler.getTrustStorePath())
+                    .vertx(vertx)
+                    .build();
+        }
 
         connect();
         createConsumer();


### PR DESCRIPTION
Customized jmeter plugin to use user and pwd only when provided by the user. If it is always set by default, then we get "Could not find a suitable SASL mechanism for the remote peer using the available credentials" error. 

Also when the the AMQP Connection Factory could not open a connection, it was giving out the error message in Debug level. It is now set to WARN.

Signed-off-by: Balasubramanian Azhagappan <balasubramanian.azhagappan@bosch-si.com>