### PR TITLE
REST adapter Basic Auth

### DIFF
--- a/adapters/rest-vertx/pom.xml
+++ b/adapters/rest-vertx/pom.xml
@@ -21,6 +21,18 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Config.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/Config.java
@@ -14,7 +14,7 @@ package org.eclipse.hono.adapter.rest;
 
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -63,18 +63,18 @@ public class Config extends AbstractAdapterConfig {
 
     /**
      * Exposes the REST adapter's configuration properties as a Spring bean.
-     * 
+     *
      * @return The configuration properties.
      */
     @Bean
     @ConfigurationProperties(prefix = "hono.http")
-    public ServiceConfigProperties honoServerProperties() {
-        return new ServiceConfigProperties();
+    public ProtocolAdapterProperties honoServerProperties() {
+        return new ProtocolAdapterProperties();
     }
 
     /**
      * Exposes a factory for creating REST adapter instances.
-     * 
+     *
      * @return The factory bean.
      */
     @Bean

--- a/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapter.java
+++ b/adapters/rest-vertx/src/main/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapter.java
@@ -12,39 +12,60 @@
 
 package org.eclipse.hono.adapter.rest;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BasicAuthHandler;
 import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
-import org.eclipse.hono.config.ServiceConfigProperties;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
+import org.eclipse.hono.auth.UsernamePasswordCredentials;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Vert.x based Hono protocol adapter for accessing Hono's Telemetry &amp; Event API using REST.
  */
-public final class VertxBasedRestProtocolAdapter extends AbstractVertxBasedHttpProtocolAdapter<ServiceConfigProperties> {
+public class VertxBasedRestProtocolAdapter
+        extends AbstractVertxBasedHttpProtocolAdapter<ProtocolAdapterProperties> implements AuthProvider {
 
+    private static final Logger LOG = LoggerFactory.getLogger(VertxBasedRestProtocolAdapter.class);
     private static final String PARAM_TENANT = "tenant";
     private static final String PARAM_DEVICE_ID = "device_id";
+    private static final String USERNAME_PROPERTY = "username";
+    private static final String PASSWORD_PROPERTY = "password";
 
     @Override
-    protected void addRoutes(final Router router) {
+    protected final void addRoutes(final Router router) {
+        if (!getConfig().isAuthenticationRequired()) {
+            LOG.warn("authentication of devices switched off");
+        } else {
+            setupBasicAuth(router);
+        }
         addTelemetryApiRoutes(router);
         addEventApiRoutes(router);
     }
 
-    private void addTelemetryApiRoutes(final Router router) {
+    private void setupBasicAuth(final Router router) {
+        router.route().handler(BasicAuthHandler.create(this));
+    }
 
+    private void addTelemetryApiRoutes(final Router router) {
         // route for uploading telemetry data
         router.route(HttpMethod.PUT, String.format("/telemetry/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
-            .handler(ctx -> uploadTelemetryMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
+                .handler(ctx -> uploadTelemetryMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
     }
 
     private void addEventApiRoutes(final Router router) {
-
         // route for sending event messages
         router.route(HttpMethod.PUT, String.format("/event/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
-            .handler(ctx -> uploadEventMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
+                .handler(ctx -> uploadEventMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
     }
 
     private static String getTenantParam(final RoutingContext ctx) {
@@ -59,7 +80,28 @@ public final class VertxBasedRestProtocolAdapter extends AbstractVertxBasedHttpP
      * Returns {@code null} to disable status resource.
      */
     @Override
-    protected String getStatusResourcePath() {
+    protected final String getStatusResourcePath() {
         return null;
+    }
+
+    @Override
+    public final void authenticate(final JsonObject authInfo, final Handler<AsyncResult<User>> resultHandler) {
+        String username = authInfo.getString(USERNAME_PROPERTY);
+        String password = authInfo.getString(PASSWORD_PROPERTY);
+        UsernamePasswordCredentials credentials = UsernamePasswordCredentials.create(username,
+                password, getConfig().isSingleTenant());
+        if (credentials == null) {
+            LOG.debug("authentication failed for device [authId: {}]", username);
+            resultHandler.handle(Future.failedFuture("authentication failed"));
+        } else {
+            this.validateCredentialsForDevice(credentials).setHandler(attempt -> {
+                if (attempt.succeeded()) {
+                    resultHandler.handle(Future.succeededFuture(null));
+                } else {
+                    LOG.debug("authentication failed for device [tenantId: {}, authId: {}]", credentials.getTenantId(), credentials.getAuthId());
+                    resultHandler.handle(Future.failedFuture("authentication failed"));
+                }
+            });
+        }
     }
 }

--- a/adapters/rest-vertx/src/test/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapterTest.java
+++ b/adapters/rest-vertx/src/test/java/org/eclipse/hono/adapter/rest/VertxBasedRestProtocolAdapterTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+
+package org.eclipse.hono.adapter.rest;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static org.mockito.Mockito.*;
+
+import io.vertx.core.*;
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.junit.*;
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import java.util.*;
+
+import static org.eclipse.hono.service.http.HttpEndpointUtils.CONTENT_TYPE_JSON;
+
+/**
+ * Verifies behavior of {@link VertxBasedRestProtocolAdapter}.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxBasedRestProtocolAdapterTest {
+
+    private static final String HOST = "localhost";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private static HonoClient messagingClient;
+    private static HonoClient registrationClient;
+    private static HonoClient credentialsClient;
+
+    private static ProtocolAdapterProperties config;
+    private static VertxBasedRestProtocolAdapter restAdapter;
+
+    private static Vertx vertx;
+
+    @AfterClass
+    public final static void shutDown() {
+        vertx.close();
+    }
+
+    @BeforeClass
+    public final static void setup(TestContext context) {
+        vertx = Vertx.vertx();
+
+        Future<String> setupTracker = Future.future();
+        setupTracker.setHandler(context.asyncAssertSuccess());
+
+        messagingClient = mock(HonoClient.class);
+        registrationClient = mock(HonoClient.class);
+        credentialsClient = mock(HonoClient.class);
+        config = new ProtocolAdapterProperties();
+        config.setInsecurePortEnabled(true);
+        config.setAuthenticationRequired(true);
+        restAdapter = spy(VertxBasedRestProtocolAdapter.class);
+        restAdapter.setConfig(config);
+        restAdapter.setHonoMessagingClient(messagingClient);
+        restAdapter.setRegistrationServiceClient(registrationClient);
+        restAdapter.setCredentialsServiceClient(credentialsClient);
+
+        Future<String> restServerDeploymentTracker = Future.future();
+        vertx.deployVerticle(restAdapter, restServerDeploymentTracker.completer());
+        restServerDeploymentTracker.compose(c -> setupTracker.complete(), setupTracker);
+    }
+
+    @Test
+    public final void testBasicAuthFailsEmptyHeader(final TestContext context) throws Exception {
+        final Async async = context.async();
+
+        vertx.createHttpClient().get(restAdapter.getInsecurePort(), HOST, "/somenonexistingroute")
+                .putHeader("content-type", CONTENT_TYPE_JSON).handler(response -> {
+            context.assertEquals(HTTP_UNAUTHORIZED, response.statusCode());
+            response.bodyHandler(totalBuffer -> {
+                async.complete();
+            });
+        }).exceptionHandler(context::fail).end();
+    }
+
+    @Test
+    public final void testBasicAuthFailsWrongCredentials(final TestContext context) throws Exception {
+        final Async async = context.async();
+        final String encodedUserPass = Base64.getEncoder()
+                .encodeToString("testuser@DEFAULT_TENANT:password123".getBytes("utf-8"));
+
+        Future<String> validationResult = Future.future();
+        validationResult.fail("");
+        doReturn(validationResult).when(restAdapter).validateCredentialsForDevice(anyObject());
+
+        vertx.createHttpClient().put(restAdapter.getInsecurePort(), HOST, "/somenonexistingroute")
+                .putHeader("content-type", CONTENT_TYPE_JSON)
+                .putHeader(AUTHORIZATION_HEADER, "Basic " + encodedUserPass).handler(response -> {
+            context.assertEquals(HTTP_UNAUTHORIZED, response.statusCode());
+            response.bodyHandler(totalBuffer -> {
+                async.complete();
+            });
+        }).exceptionHandler(context::fail).end();
+    }
+
+    @Test
+    public final void testBasicAuthSuccess(final TestContext context) throws Exception {
+        final Async async = context.async();
+        final String encodedUserPass = Base64.getEncoder()
+                .encodeToString("existinguser@DEFAULT_TENANT:password123".getBytes("utf-8"));
+
+        Future<String> validationResult = Future.future();
+        validationResult.complete("device_1");
+
+        doReturn(validationResult).when(restAdapter).validateCredentialsForDevice(anyObject());
+
+        vertx.createHttpClient().get(restAdapter.getInsecurePort(), HOST, "/somenonexistingroute")
+                .putHeader("content-type", CONTENT_TYPE_JSON)
+                .putHeader(AUTHORIZATION_HEADER, "Basic " + encodedUserPass).handler(response -> {
+            context.assertEquals(HTTP_NOT_FOUND, response.statusCode());
+            response.bodyHandler(totalBuffer -> {
+                async.complete();
+            });
+        }).exceptionHandler(context::fail).end();
+    }
+}
+


### PR DESCRIPTION
Ok here is the rebased Pull Request #329 this should make it easier to discuss the changes.

The descriptions is unchanged, so here it is again:

This is an implementation of Basic Auth for the REST Adapter similar to the MQTT adapter authentication.

**Description:**

Username/password authentication using standard HTTP Basic Auth mechanism. Vertx provides the boiler plate code for the handling of the HTTP header and the proper 4XX error codes on authentication failure.
The hono side of things is taken from the MQTT adapter. The same single/multi-tenant logic is used as in the aforementioned pull request. It is probably a good idea to

**Open points:**

hono/adapter/rest/credentials/VertxRestUser.java they are almost identical but was not sure wether the REST authentication approach is the way to go so wanted to discuss it first

**Questions:**

Approach ok?
merge two user models (from the REST and MQTT adapters) or do it some other way?