### PR TITLE
#296: implemented cache for token validation

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -52,6 +52,7 @@
     <truth.version>0.28</truth.version>
     <vertx.version>3.4.1</vertx.version>
     <jmeter.version>3.2</jmeter.version>
+    <guava.version>21.0</guava.version>
   </properties>
 
   <dependencyManagement>
@@ -282,6 +283,11 @@
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-dispatch-router</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/core/src/main/java/org/eclipse/hono/config/SignatureSupportingConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/SignatureSupportingConfigProperties.java
@@ -24,6 +24,7 @@ public class SignatureSupportingConfigProperties {
     private String keyPath;
     private long tokenExpirationSeconds = 600L;
     private String certificatePath;
+    private long validationCacheMaxSize = 100_000L;
 
     /**
      * Gets the secret used for creating and validating HmacSHA256 based signatures.
@@ -134,6 +135,16 @@ public class SignatureSupportingConfigProperties {
      */
     public final boolean isAppropriateForValidating() {
         return sharedSecret != null || certificatePath != null;
+    }
+
+    /**
+     * Gets the maximum number of entries the validation cache may contain.
+     * This directly reflects the performance of registration token validation.
+     *
+     * @return number of maximum entries the validation cache can store
+     */
+    public long getValidationCacheMaxSize() {
+        return validationCacheMaxSize;
     }
 
 }

--- a/core/src/main/java/org/eclipse/hono/util/JwtHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/JwtHelper.java
@@ -23,7 +23,13 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.eclipse.hono.config.KeyLoader;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SigningKeyResolverAdapter;
 import io.vertx.core.Vertx;
 
 /**
@@ -47,6 +53,17 @@ public abstract class JwtHelper {
      * The lifetime of created tokens.
      */
     protected Duration tokenLifetime;
+
+    /**
+     * see {@link JwtParser#setAllowedClockSkewSeconds}
+     */
+    protected int allowedClockSkew = 10;
+
+    /**
+     * Specifies the maximum number of entries the validation cache may contain.
+     * This directly reflects the performance of registration token validation.
+     */
+    protected Long validationCacheMaxSize;
 
     /**
      * Creates a new helper for a vertx instance.
@@ -198,5 +215,20 @@ public abstract class JwtHelper {
         } else {
             return result.get();
         }
+    }
+
+    /**
+     * Sets the maximum number of entries the validation cache may contain.
+     * This directly reflects the performance of registration token validation.
+     *
+     * @param validationCacheMaxSize number of cache entries
+     * @throws IllegalArgumentException if the given max cache size is negative
+     */
+    public void setValidationCacheMaxSize(final Long validationCacheMaxSize) {
+        Objects.requireNonNull(validationCacheMaxSize);
+        if (validationCacheMaxSize < 0L) {
+            throw new IllegalArgumentException("Validation cache size must not be negative.");
+        }
+        this.validationCacheMaxSize = validationCacheMaxSize;
     }
 }

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -92,6 +92,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/AuthTokenHelperImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/AuthTokenHelperImpl.java
@@ -62,6 +62,7 @@ public class AuthTokenHelperImpl extends JwtHelper implements AuthTokenHelper {
         } else {
             AuthTokenHelperImpl result = new AuthTokenHelperImpl(vertx);
             result.tokenLifetime = Duration.ofSeconds(config.getTokenExpiration());
+            result.setValidationCacheMaxSize(config.getValidationCacheMaxSize());
             if (config.getSharedSecret() != null) {
                 byte[] secret = getBytes(config.getSharedSecret());
                 result.setSharedSecret(secret);
@@ -89,6 +90,7 @@ public class AuthTokenHelperImpl extends JwtHelper implements AuthTokenHelper {
             throw new IllegalArgumentException("configuration does not specify any key material for validating signatures");
         } else {
             AuthTokenHelperImpl result = new AuthTokenHelperImpl(vertx);
+            result.setValidationCacheMaxSize(config.getValidationCacheMaxSize());
             if (config.getSharedSecret() != null) {
                 byte[] secret = getBytes(config.getSharedSecret());
                 result.setSharedSecret(secret);

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAssertionCacheKey.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAssertionCacheKey.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.registration;
+
+/**
+ * A utility class for creating cache keys
+ */
+public final class RegistrationAssertionCacheKey {
+
+    /**
+     * The token representing the asserted status.
+     */
+    private final String token;
+
+    /**
+     * The tenant that the device is expected to belong to.
+     */
+    private final String tenantId;
+
+    /**
+     * The device that is expected to be the subject of the assertion.
+     */
+    private final String deviceId;
+
+    /**
+     * Key for validation cache (which is used to improve registration assertion validations) consisting of token,
+     * tenantId and deviceId
+     * @param token token, which is part of the cache key
+     * @param tenantId tenantId, which is part of the cache key
+     * @param deviceId deviceId, which is part of the cache key
+     */
+    RegistrationAssertionCacheKey(final String token, final String tenantId, final String deviceId) {
+        this.token = token;
+        this.tenantId = tenantId;
+        this.deviceId = deviceId;
+    }
+
+    /**
+     * Getter method for token
+     *
+     * @return token
+     */
+    public String getToken() {
+        return token;
+    }
+
+    /**
+     * Getter method for tenantId
+     *
+     * @return tenantId
+     */
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Getter method for deviceId
+     *
+     * @return deviceId
+     */
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RegistrationAssertionCacheKey that = (RegistrationAssertionCacheKey) o;
+
+        return token.equals(that.token) && tenantId.equals(that.tenantId) && deviceId.equals(that.deviceId);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = token.hashCode();
+        result = 31 * result + tenantId.hashCode();
+        result = 31 * result + deviceId.hashCode();
+        return result;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImpl.java
@@ -15,12 +15,20 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.config.SignatureSupportingConfigProperties;
 import org.eclipse.hono.util.JwtHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.vertx.core.Vertx;
@@ -33,6 +41,8 @@ public final class RegistrationAssertionHelperImpl extends JwtHelper implements 
 
     private static final Logger LOG = LoggerFactory.getLogger(RegistrationAssertionHelperImpl.class);
 
+    private LoadingCache<RegistrationAssertionCacheKey, Instant> validationCache;
+
     private RegistrationAssertionHelperImpl() {
         this(null);
     }
@@ -43,7 +53,7 @@ public final class RegistrationAssertionHelperImpl extends JwtHelper implements 
 
     /**
      * Creates a helper for creating registration assertions.
-     * 
+     *
      * @param vertx The vertx instance to use for accessing the file system.
      * @param config The configuration properties to determine the signing key material from.
      * @return The helper.
@@ -56,7 +66,8 @@ public final class RegistrationAssertionHelperImpl extends JwtHelper implements 
             throw new IllegalArgumentException("configuration does not specify any signing key material");
         } else {
             RegistrationAssertionHelperImpl result = new RegistrationAssertionHelperImpl(vertx);
-            result.tokenLifetime = Duration.ofMinutes(config.getTokenExpiration());
+            result.tokenLifetime = Duration.ofSeconds(config.getTokenExpiration());
+            result.setValidationCacheMaxSize(config.getValidationCacheMaxSize());
             if (config.getSharedSecret() != null) {
                 byte[] secret = getBytes(config.getSharedSecret());
                 result.setSharedSecret(secret);
@@ -71,7 +82,7 @@ public final class RegistrationAssertionHelperImpl extends JwtHelper implements 
 
     /**
      * Creates a helper for validating registration assertions.
-     * 
+     *
      * @param vertx The vertx instance to use for accessing the file system.
      * @param config The configuration properties to determine the signing key material from.
      * @return The helper.
@@ -84,6 +95,8 @@ public final class RegistrationAssertionHelperImpl extends JwtHelper implements 
             throw new IllegalArgumentException("configuration does not specify any key material for validating signatures");
         } else {
             RegistrationAssertionHelperImpl result = new RegistrationAssertionHelperImpl(vertx);
+            result.tokenLifetime = Duration.ofSeconds(config.getTokenExpiration());
+            result.setValidationCacheMaxSize(config.getValidationCacheMaxSize());
             if (config.getSharedSecret() != null) {
                 byte[] secret = getBytes(config.getSharedSecret());
                 result.setSharedSecret(secret);
@@ -98,17 +111,19 @@ public final class RegistrationAssertionHelperImpl extends JwtHelper implements 
 
     /**
      * Creates a helper for creating/validating HmacSHA256 based registration assertions.
-     * 
+     *
      * @param sharedSecret The shared secret.
      * @param tokenExpiration The number of minutes after which tokens expire.
+     * @param validationCacheMaxSize max size for validation cache holding the registration assertions requests
      * @return The helper.
      * @throws NullPointerException if sharedSecret is {@code null}.
      */
-    public static RegistrationAssertionHelper forSharedSecret(final String sharedSecret, final long tokenExpiration) {
+    public static RegistrationAssertionHelper forSharedSecret(final String sharedSecret, final long tokenExpiration, final long validationCacheMaxSize) {
         Objects.requireNonNull(sharedSecret);
         RegistrationAssertionHelperImpl result = new RegistrationAssertionHelperImpl();
         result.setSharedSecret(getBytes(sharedSecret));
         result.tokenLifetime = Duration.ofMinutes(tokenExpiration);
+        result.setValidationCacheMaxSize(validationCacheMaxSize);
         return result;
     }
 
@@ -129,18 +144,55 @@ public final class RegistrationAssertionHelperImpl extends JwtHelper implements 
     @Override
     public boolean isValid(final String token, final String tenantId, final String deviceId) {
 
+        if (validationCache == null) {
+            initValidationCache();
+        }
+
         try {
-            Jwts.parser()
-                .setSigningKey(key)
-                .requireSubject(Objects.requireNonNull(deviceId))
-                .require("ten", Objects.requireNonNull(tenantId))
-                .setAllowedClockSkewSeconds(10)
-                .parse(token);
-            return true;
-        } catch (JwtException e) {
+            RegistrationAssertionCacheKey cacheKey = new RegistrationAssertionCacheKey(token, tenantId, deviceId);
+            Instant expirationTime = validationCache.get(cacheKey);
+            return isNotExpired(expirationTime);
+        } catch (ExecutionException | UncheckedExecutionException | JwtException e) {
             // token is invalid for some reason
             LOG.debug("failed to validate token", e);
             return false;
         }
+    }
+
+    private boolean isNotExpired(final Instant expirationTime) {
+        Instant now = Instant.now().minus(Duration.ofSeconds(allowedClockSkew));
+
+        if (expirationTime.isBefore(now)) {
+            LOG.debug("token is already expired");
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private void initValidationCache() {
+
+        /*
+         * Using LoadingCache, which works with "if cached, return; otherwise create, cache and return" pattern
+         */
+        validationCache = CacheBuilder.newBuilder()
+            .maximumSize(validationCacheMaxSize)
+            .expireAfterWrite(tokenLifetime.getSeconds(), TimeUnit.SECONDS)
+            .build(new CacheLoader<RegistrationAssertionCacheKey, Instant>() {
+                @Override
+                public Instant load(RegistrationAssertionCacheKey cacheKey) throws Exception {
+
+                    // validate token
+                    Jws<Claims> claimsJws = Jwts.parser()
+                        .setSigningKey(key)
+                        .requireSubject(Objects.requireNonNull(cacheKey.getDeviceId()))
+                        .require("ten", Objects.requireNonNull(cacheKey.getTenantId()))
+                        .setAllowedClockSkewSeconds(allowedClockSkew)
+                        .parseClaimsJws(cacheKey.getToken());
+
+                    // save expiration time
+                    return claimsJws.getBody().getExpiration().toInstant();
+                }
+            });
     }
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImplTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImplTest.java
@@ -12,11 +12,22 @@
 
 package org.eclipse.hono.service.registration;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import java.security.PrivateKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.config.KeyLoader;
 import org.eclipse.hono.config.SignatureSupportingConfigProperties;
 import org.junit.Test;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.vertx.core.Vertx;
 
 
@@ -35,7 +46,7 @@ public class RegistrationAssertionHelperImplTest {
     public void testForSigningRejectsShortSecret() {
 
         String shortSecret = "01234567890123456"; // not 32 bytes long
-        RegistrationAssertionHelperImpl.forSharedSecret(shortSecret, 10);
+        RegistrationAssertionHelperImpl.forSharedSecret(shortSecret, 10, 100_000L);
     }
 
     /**
@@ -53,7 +64,88 @@ public class RegistrationAssertionHelperImplTest {
         assertNotNull(assertion);
         RegistrationAssertionHelper validator = RegistrationAssertionHelperImpl.forValidating(vertx, props);
         assertTrue(validator.isValid(assertion, "tenant", "device"));
+    }
 
+    /**
+     * Verifies that bad tenant, bad token and bad device are detected.
+     */
+    @Test
+    public void testTokenConsistency() {
+        RegistrationAssertionHelper validator = createValidator();
+
+        String token = createToken(1, "tenant", "device");
+        assertNotNull(token);
+        assertFalse(validator.isValid(token, "bad-tenant", "device"));
+        assertFalse(validator.isValid(token, "tenant", "bad-device"));
+
+        String badToken = createToken(1, "another-tenant", "device");
+        assertNotNull(badToken);
+        assertFalse(validator.isValid(badToken, "tenant", "device"));
+    }
+
+    /**
+     * Verifies that expired token is detected
+     */
+    @Test
+    public void testValidatingAlreadyExpiredTokens() {
+        RegistrationAssertionHelper validator = createValidator();
+
+        String tokenStillValid = createToken(1, "tenant", "device");
+        assertTrue(validator.isValid(tokenStillValid, "tenant", "device"));
+
+        String tokenTooOld = createToken(-1, "tenant", "device");
+        assertFalse(validator.isValid(tokenTooOld, "tenant", "device"));
+    }
+
+    /**
+     * Verifies that cache is used
+     */
+    @Test
+    public void testValidationIsUsingCache() {
+        String token = createToken(1, "tenant", "device");
+
+        long firstValidationParsed = getDurationOfValidation(token);
+        long secondValidationCached = getDurationOfValidation(token);
+
+        // ensure that cached validation is at least twice as fast as parsed validation
+        assertTrue((secondValidationCached * 2) < firstValidationParsed);
+    }
+
+    private long getDurationOfValidation(String token) {
+        RegistrationAssertionHelper validator = createValidator();
+        Instant before = Instant.now();
+        assertTrue(validator.isValid(token, "tenant", "device"));
+        Instant after = Instant.now();
+        long result = TimeUnit.NANOSECONDS.toMillis(Duration.between(before, after).getNano());
+        System.out.println("Validation took " + result + " ms");
+        return result;
+    }
+
+    private RegistrationAssertionHelper createValidator() {
+        SignatureSupportingConfigProperties props = new SignatureSupportingConfigProperties();
+        props.setKeyPath("target/certs/hono-messaging-key.pem");
+        props.setCertPath("target/certs/hono-messaging-cert.pem");
+
+        return RegistrationAssertionHelperImpl.forValidating(vertx, props);
+    }
+
+    private String createToken(int validForSeconds, String tenant, String device) {
+
+        PrivateKey key = KeyLoader.fromFiles(vertx, "target/certs/hono-messaging-key.pem", null).getPrivateKey();
+        SignatureAlgorithm algorithm = SignatureAlgorithm.RS256;
+
+        // considering default clock skew
+        int allowedClockSkew = 10;
+        if (validForSeconds <= 0) {
+            validForSeconds -= allowedClockSkew;
+        }
+
+        return Jwts.builder()
+                .signWith(algorithm, key)
+                .setSubject(device)
+                .claim("ten", tenant)
+                .setExpiration(Date.from(Instant.now().plus(Duration.ofSeconds(validForSeconds))))
+                .compact();
     }
 
 }

--- a/services/messaging/src/test/java/org/eclipse/hono/messaging/MessageForwardingEndpointTest.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/messaging/MessageForwardingEndpointTest.java
@@ -11,20 +11,24 @@
  */
 package org.eclipse.hono.messaging;
 
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.config.ServiceConfigProperties;
-import org.eclipse.hono.messaging.DownstreamAdapter;
-import org.eclipse.hono.messaging.ErrorConditions;
-import org.eclipse.hono.messaging.MessageForwardingEndpoint;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.util.MessageHelper;
@@ -238,6 +242,6 @@ public class MessageForwardingEndpointTest {
 
     private String getToken(final String secret, final String tenantId, final String deviceId) {
 
-        return RegistrationAssertionHelperImpl.forSharedSecret(secret, 10).getAssertion(tenantId, deviceId);
+        return RegistrationAssertionHelperImpl.forSharedSecret(secret, 10, 100_000L).getAssertion(tenantId, deviceId);
     }
 }

--- a/services/messaging/src/test/java/org/eclipse/hono/messaging/StandaloneEventApiTest.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/messaging/StandaloneEventApiTest.java
@@ -27,12 +27,12 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.impl.HonoClientImpl;
 import org.eclipse.hono.connection.ConnectionFactoryImpl.ConnectionFactoryBuilder;
-import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.event.impl.EventEndpoint;
 import org.eclipse.hono.service.auth.HonoSaslAuthenticatorFactory;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -80,7 +80,7 @@ public class StandaloneEventApiTest {
     @BeforeClass
     public static void prepareHonoServer(final TestContext ctx) {
 
-        assertionHelper = RegistrationAssertionHelperImpl.forSharedSecret(SECRET, 10);
+        assertionHelper = RegistrationAssertionHelperImpl.forSharedSecret(SECRET, 10, 100_000L);
         downstreamAdapter = new MessageDiscardingDownstreamAdapter(vertx);
         server = new HonoMessaging();
         server.setSaslAuthenticatorFactory(new HonoSaslAuthenticatorFactory(vertx, TestSupport.createAuthenticationService(createUser())));

--- a/services/messaging/src/test/java/org/eclipse/hono/messaging/StandaloneTelemetryApiTest.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/messaging/StandaloneTelemetryApiTest.java
@@ -27,9 +27,9 @@ import org.eclipse.hono.connection.ConnectionFactoryImpl.ConnectionFactoryBuilde
 import org.eclipse.hono.service.auth.HonoSaslAuthenticatorFactory;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
-import org.eclipse.hono.util.TelemetryConstants;
 import org.eclipse.hono.telemetry.impl.TelemetryEndpoint;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -71,7 +71,7 @@ public class StandaloneTelemetryApiTest {
     @BeforeClass
     public static void prepareHonoServer(final TestContext ctx) throws Exception {
 
-        assertionHelper = RegistrationAssertionHelperImpl.forSharedSecret(SECRET, 10);
+        assertionHelper = RegistrationAssertionHelperImpl.forSharedSecret(SECRET, 10, 100_000L);
         telemetryAdapter = new MessageDiscardingDownstreamAdapter(vertx);
         server = new HonoMessaging();
         server.setSaslAuthenticatorFactory(new HonoSaslAuthenticatorFactory(vertx, TestSupport.createAuthenticationService(createUser())));


### PR DESCRIPTION
- implemented cache for token validation
- default max cache size is 100.000 entries (configurable in SignatureSupportingConfigProperties.java)
- using guava loading cache implementation, entries will be auto removed after X after insertion (X = configured token life time)
- cache key consists of parameters of RegistrationAssertionHelper#isValid method (token, tenant, device)
- separate validation of expiration date, because besides auto-remove-feature, token can be stored slightly longer than configured token life time
- added unit tests

Also authored by: Ulrich Overdieck fixed-term.Ulrich.Overdieck@bosch-si.com
Signed-off-by: Oliver Fischer <oliver.fischer@bosch-si.com>