### PR TITLE
[#326] Use 'device-id' in device registration REST request params

### DIFF
--- a/adapters/rest-vertx/postman/Hono REST Adapter.postman_collection.json
+++ b/adapters/rest-vertx/postman/Hono REST Adapter.postman_collection.json
@@ -23,7 +23,7 @@
 					"mode": "urlencoded",
 					"urlencoded": [
 						{
-							"key": "device_id",
+							"key": "device-id",
 							"value": "4711",
 							"type": "text",
 							"enabled": true
@@ -50,13 +50,13 @@
 					"mode": "urlencoded",
 					"urlencoded": [
 						{
-							"key": "device_id",
+							"key": "device-id",
 							"value": "4711",
 							"type": "text",
 							"enabled": true
 						},
 						{
-							"key": "aditional_parameter",
+							"key": "additional_parameter",
 							"value": "true",
 							"type": "text",
 							"enabled": true

--- a/site/content/component/device-registry.md
+++ b/site/content/component/device-registry.md
@@ -210,7 +210,7 @@ The following sections describe the resources representing the operations of the
 * Headers:
   * (required) `Content-Type`: either `application/x-www-url-encoded` or `application/json`
 * Parameters (encoded as payload according to the content type):
-  * (required) `device_id`: The ID of the device to register.
+  * (required) `device-id`: The ID of the device to register.
   * (optional) Arbitrary key/value pairs containing additional data to be registered with the device.
 * Status Codes:
   * 201 (Created): Device has been registered successfully under resource indicated by `Location` header.
@@ -221,11 +221,11 @@ The following sections describe the resources representing the operations of the
 
 The following command registers a device with ID `4711`
 
-    $ curl -i -X POST -d device_id=4711 -d ep=IMEI4711 http://127.0.0.1:8080/registration/DEFAULT_TENANT
+    $ curl -i -X POST -d device-id=4711 -d ep=IMEI4711 http://127.0.0.1:8080/registration/DEFAULT_TENANT
 
 or equivalently using JSON
 
-    $ curl -i -X POST -d '{"device_id":"4711","ep":"IMEI4711"}' -H 'Content-Type: application/json' http://localhost:8080/registration/DEFAULT_TENANT
+    $ curl -i -X POST -d '{"device-id":"4711","ep":"IMEI4711"}' -H 'Content-Type: application/json' http://localhost:8080/registration/DEFAULT_TENANT
 
 The response will contain a `Location` header containing the resource path created for the device. In this example it will look
 like this:

--- a/site/content/deployment/kubernetes.md
+++ b/site/content/deployment/kubernetes.md
@@ -108,7 +108,7 @@ In order to upload telemetry data to Hono, the device needs to be registered wit
 *Device Registry* by running the following command (i.e. for a device with ID `4711`):
 
 ~~~sh
-$ curl -X POST -i -d 'device_id=4711' http://<IP_ADDRESS>:31080/registration/DEFAULT_TENANT
+$ curl -X POST -i -d 'device-id=4711' http://<IP_ADDRESS>:31080/registration/DEFAULT_TENANT
 ~~~
 
 After having the device registered, uploading telemetry is just a simple HTTP PUT command to the *REST Adapter*:

--- a/site/content/deployment/openshift.md
+++ b/site/content/deployment/openshift.md
@@ -141,7 +141,7 @@ In order to upload telemetry data to Hono, the device needs to be registered wit
 *Device Registry* by running the following command (i.e. for a device with ID `4711`):
 
 ~~~sh
-$ curl -X POST -i -d 'device_id=4711' http://<IP_ADDRESS>:31080/registration/DEFAULT_TENANT
+$ curl -X POST -i -d 'device-id=4711' http://<IP_ADDRESS>:31080/registration/DEFAULT_TENANT
 ~~~
 
 After having the device registered, uploading telemetry is just a simple HTTP PUT command to the *REST Adapter*:

--- a/site/content/getting-started.md
+++ b/site/content/getting-started.md
@@ -114,13 +114,13 @@ The first thing to do is registering a device identity with Hono. Hono uses this
 The following command registers a device with ID `4711` with the Device Registry.
 
 ~~~sh
-$ curl -X POST -i -d 'device_id=4711' http://localhost:28080/registration/DEFAULT_TENANT
+$ curl -X POST -i -d 'device-id=4711' http://localhost:28080/registration/DEFAULT_TENANT
 ~~~
 
 or (using HTTPie):
 
 ~~~sh
-$ http POST http://localhost:28080/registration/DEFAULT_TENANT device_id=4711
+$ http POST http://localhost:28080/registration/DEFAULT_TENANT device-id=4711
 ~~~
 
 The result will contain a `Location` header containing the resource path created for the device. In this example it will look like this:


### PR DESCRIPTION
To have consistent field names in request and response JSON structures, "device-id" instead of "device_id" is now used in the REST API requests.

Fix for #326.