### PR TITLE
Hono JMeter Plugin: using the time stamp from the message received for sampling

### DIFF
--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoReceiverSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoReceiverSampler.java
@@ -34,15 +34,19 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
     private static final Logger LOGGER = LoggerFactory.getLogger(HonoReceiverSampler.class);
 
     private static final String USE_SENDER_TIME = "useSenderTime";
+    private static final String SENDER_TIME_IN_PAYLOAD = "senderTimeInPayload";
+    private static final String SENDER_TIME_VARIABLE_NAME = "senderTimeVariableName";
+    private static final String RECONNECT_ATTEMPTS = "reconnectAttempts";
+    private static final String DEFAULT_SENDER_TIME_VARIABLE_NAME = "timeStamp";
     private static final String PREFETCH = "prefetch";
 
     private HonoReceiver honoReceiver;
 
-    public Boolean isUseSenderTime() {
+    public boolean isUseSenderTime() {
         return getPropertyAsBoolean(USE_SENDER_TIME);
     }
 
-    public void setUseSenderTime(final Boolean useSenderTime) {
+    public void setUseSenderTime(final boolean useSenderTime) {
         setProperty(USE_SENDER_TIME, useSenderTime);
     }
 
@@ -54,13 +58,37 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
         setProperty(PREFETCH, prefetch);
     }
 
+    public String getSenderTimeVariableName() {
+        return getPropertyAsString(SENDER_TIME_VARIABLE_NAME, DEFAULT_SENDER_TIME_VARIABLE_NAME);
+    }
+
+    public void setSenderTimeVariableName(final String variableName) {
+        setProperty(SENDER_TIME_VARIABLE_NAME, variableName);
+    }
+
+    public boolean isSenderTimeInPayload() {
+        return getPropertyAsBoolean(SENDER_TIME_IN_PAYLOAD);
+    }
+
+    public void setSenderTimeInPayload(final boolean senderTimeInPayload) {
+        setProperty(SENDER_TIME_IN_PAYLOAD, senderTimeInPayload);
+    }
+
+    public String getReconnectAttempts() {
+        return getPropertyAsString(RECONNECT_ATTEMPTS, "1");
+    }
+
+    public void setReconnectAttempts(final String reconnectAttempts) {
+        setProperty(RECONNECT_ATTEMPTS, reconnectAttempts);
+    }
+
     @Override
     public SampleResult sample(final Entry entry) {
         SampleResult res = new SampleResult();
         res.setResponseOK();
         res.setDataType(SampleResult.TEXT);
         res.setSampleLabel(getName());
-        honoReceiver.sample(res, isUseSenderTime());
+        honoReceiver.sample(res);
         return res;
     }
 

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/AbstractClient.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/AbstractClient.java
@@ -1,0 +1,29 @@
+package org.eclipse.hono.jmeter.client;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.dns.AddressResolverOptions;
+import io.vertx.proton.ProtonClientOptions;
+
+public class AbstractClient {
+
+    static final int    DEFAULT_CONNECT_TIMEOUT_MILLIS            = 2000;
+    static final int    DEFAULT_ADDRESS_RESOLUTION_TIMEOUT_MILLIS = 2000;
+    static final String TIME_STAMP_VARIABLE                       = "timeStamp";
+
+    Vertx vertx() {
+        VertxOptions options = new VertxOptions()
+                .setWarningExceptionTime(1500000000)
+                .setAddressResolverOptions(new AddressResolverOptions()
+                        .setCacheNegativeTimeToLive(0) // discard failed DNS lookup results immediately
+                        .setCacheMaxTimeToLive(0) // support DNS based service resolution
+                        .setRotateServers(true)
+                        .setQueryTimeout(DEFAULT_ADDRESS_RESOLUTION_TIMEOUT_MILLIS));
+        return Vertx.vertx(options);
+    }
+
+    ProtonClientOptions getClientOptions(int reconnectAttempts) {
+        return new ProtonClientOptions().setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS)
+                .setReconnectAttempts(reconnectAttempts);
+    }
+}

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
@@ -12,8 +12,12 @@
 
 package org.eclipse.hono.jmeter.client;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.jmeter.samplers.SampleResult;
@@ -29,35 +33,36 @@ import org.eclipse.hono.jmeter.HonoReceiverSampler;
 import org.eclipse.hono.jmeter.HonoSampler;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
-import io.vertx.core.dns.AddressResolverOptions;
-import io.vertx.proton.ProtonClientOptions;
 
 /**
  * Receiver, which connects to the AMQP network; asynchronous API needs to be used synchronous for JMeters threading
  * model
  */
-public class HonoReceiver {
+public class HonoReceiver extends AbstractClient {
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(HonoReceiver.class);
 
-    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 2000;
-    private static final int DEFAULT_ADDRESS_RESOLUTION_TIMEOUT_MILLIS = 2000;
+    private ConnectionFactory amqpNetworkConnectionFactory;
+    private HonoClient amqpNetworkClient;
 
-    private ConnectionFactory   amqpNetworkConnectionFactory;
-    private HonoClient          amqpNetworkClient;
-    private Vertx               vertx = vertx();
-
-    private long                sampleStart;
-    private int                 messageCount;
-    private long                messageSize;
+    private long sampleStart;
+    private long sampleEnd;
+    private int messageCount;
+    private long messageSize;
     private HonoReceiverSampler sampler;
+    private Vertx vertx = vertx();
 
     private final transient Object lock = new Object();
 
     public HonoReceiver(final HonoReceiverSampler sampler) throws InterruptedException {
         this.sampler = sampler;
+
+        if (sampler.isUseSenderTime() && sampler.getSenderTimeVariableName() == null) {
+            throw new IllegalArgumentException("SenderTime VariableName must be set when using SenderTime flag");
+        }
 
         // amqp network config
         amqpNetworkConnectionFactory = ConnectionFactoryImpl.ConnectionFactoryBuilder.newBuilder()
@@ -81,12 +86,13 @@ public class HonoReceiver {
     private void connect() throws InterruptedException {
         final CountDownLatch receiverConnectLatch = new CountDownLatch(1);
         amqpNetworkClient = new HonoClientImpl(vertx, amqpNetworkConnectionFactory);
-        amqpNetworkClient.connect(getClientOptions(), connectionHandler -> {
-            if (connectionHandler.failed()) {
-                LOGGER.error("HonoClient.connect() failed", connectionHandler.cause());
-            }
-            receiverConnectLatch.countDown();
-        });
+        amqpNetworkClient.connect(getClientOptions(Integer.parseInt(sampler.getReconnectAttempts())),
+                connectionHandler -> {
+                    if (connectionHandler.failed()) {
+                        LOGGER.error("HonoClient.connect() failed", connectionHandler.cause());
+                    }
+                    receiverConnectLatch.countDown();
+                });
         receiverConnectLatch.await();
     }
 
@@ -113,24 +119,70 @@ public class HonoReceiver {
         receiverLatch.await();
     }
 
-    public void sample(final SampleResult result, final boolean isUseSenderTime) {
+    public void sample(final SampleResult result) {
         synchronized (lock) {
-            long elapsed = System.currentTimeMillis() - sampleStart;
+            long elapsed = 0;
             result.setResponseCodeOK();
             result.setSuccessful(true);
             result.setSampleCount(messageCount);
-            result.setResponseMessage(MessageFormat.format("count: {0}, bytes received: {1}, period: {2}", messageCount, messageSize, elapsed));
             result.setBytes(messageSize);
-            if (messageCount > 0) {
+            result.setResponseMessage(
+                    MessageFormat.format("count: {0}, bytes received: {1}, period: {2}", messageCount,
+                            messageSize, elapsed));
+            if (sampler.isUseSenderTime()) {
+                if (messageCount > 1) {
+                    LOGGER.warn(
+                            "More than one message per receiver was not expected. It could result in wrong sampling time");
+                } else if (messageCount == 1) {
+                    elapsed = sampleEnd - sampleStart;
+                    result.setStampAndTime(sampleStart, elapsed);
+                } else {
+                    noMessagesReceived(result);
+                }
+            } else if (messageCount > 0 && sampleStart != 0) {
+                elapsed = System.currentTimeMillis() - sampleStart;
                 result.setStampAndTime(sampleStart, elapsed);
+                result.setIdleTime(elapsed);
             } else {
-                result.setStampAndTime(sampleStart, 0);
+                noMessagesReceived(result);
             }
-            LOGGER.info("{}: received batch of {} messages in {} milliseconds", sampler.getThreadName(), messageCount, elapsed);
+            LOGGER.info("{}: received batch of {} messages in {} milliseconds", sampler.getThreadName(), messageCount,
+                    elapsed);
             messageSize = 0;
             messageCount = 0;
-            sampleStart = System.currentTimeMillis();
+            sampleStart = 0;
         }
+    }
+
+    private void noMessagesReceived(final SampleResult result) {
+        LOGGER.warn("No messages were received");
+        result.setIdleTime(0);
+    }
+
+    private void verifySenderTimeAndSetSamplingTime(final Long time, boolean senderTimeInPayload) {
+        if (time != null) {
+            sampleStart = time;
+            LOGGER.debug("Message sent time : {}", sampleStart);
+        } else {
+            throw new IllegalArgumentException("No Timestamp variable found in message");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getJSONValue(final Section message) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> result;
+        try {
+            result = objectMapper.readValue(getValue(message),
+                    HashMap.class);
+            if (result == null) {
+                result = Collections.emptyMap();
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Could not parse the received message", e);
+            result = Collections.emptyMap();
+        }
+        return result;
     }
 
     private byte[] getValue(final Section body) {
@@ -144,22 +196,28 @@ public class HonoReceiver {
     }
 
     private void messageReceived(final Message message) {
-        try {
-            synchronized (lock) {
-                final int bodyLength = getValue(message.getBody()).length;
-                if (sampleStart == 0) {
-                    final Long time = (Long) message.getApplicationProperties().getValue().get("millis");
-                    if (time != null) {
-                        sampleStart = time;
-                    } else {
-                        sampleStart = System.currentTimeMillis();
-                    }
+        synchronized (lock) {
+            messageCount++;
+            LOGGER.trace("Received message. count : {}", messageCount);
+            byte[] messageBody = getValue(message.getBody());
+            messageSize += messageBody.length;
+
+            if (sampler.isUseSenderTime()) {
+                sampleEnd = System.currentTimeMillis();
+                LOGGER.debug("Message received time : {}", sampleEnd);
+                if (sampler.isSenderTimeInPayload()) {
+                    final Long time = (Long) getJSONValue(message.getBody())
+                            .get(sampler.getSenderTimeVariableName());
+                    verifySenderTimeAndSetSamplingTime(time, sampler.isSenderTimeInPayload());
+                } else {
+                    final Long time = (Long) message.getApplicationProperties().getValue().get("timeStamp");
+                    verifySenderTimeAndSetSamplingTime(time, sampler.isSenderTimeInPayload());
                 }
-                messageSize += bodyLength;
-                messageCount++;
+            } else {
+                if (sampleStart == 0) {
+                    sampleStart = System.currentTimeMillis();
+                }
             }
-        } catch (final Throwable t) {
-            LOGGER.error("unknown exception in messageReceived()", t);
         }
     }
 
@@ -170,20 +228,5 @@ public class HonoReceiver {
         } catch (final Throwable t) {
             LOGGER.error("unknown exception in closing of receiver", t);
         }
-    }
-
-    private Vertx vertx() {
-        VertxOptions options = new VertxOptions()
-                .setWarningExceptionTime(1500000000)
-                .setAddressResolverOptions(new AddressResolverOptions()
-                        .setCacheNegativeTimeToLive(0) // discard failed DNS lookup results immediately
-                        .setCacheMaxTimeToLive(0) // support DNS based service resolution
-                        .setRotateServers(true)
-                        .setQueryTimeout(DEFAULT_ADDRESS_RESOLUTION_TIMEOUT_MILLIS));
-        return Vertx.vertx(options);
-    }
-
-    private ProtonClientOptions getClientOptions() {
-        return new ProtonClientOptions().setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS).setReconnectAttempts(1);
     }
 }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
@@ -37,14 +37,14 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.proton.ProtonClientOptions;
 
 /**
  * A wrapper around a {@code HonoClient} mapping the client's asynchronous API to the blocking
  * threading model used by JMeter.
  */
-public class HonoSender {
+public class HonoSender extends AbstractClient {
 
+    private static final int MAX_RECONNECT_ATTEMPTS      = 0;
     private static final Logger LOGGER = LoggerFactory.getLogger(HonoSender.class);
     private static final int MAX_MESSAGES_PER_BATCH_SEND = 300;
 
@@ -59,7 +59,7 @@ public class HonoSender {
 
     private String             token;
     private MessageSender      messageSender;
-    private Vertx              vertx = Vertx.vertx();
+    private Vertx              vertx = vertx();
     private HonoSenderSampler  sampler;
 
     public HonoSender(final HonoSenderSampler sampler) throws InterruptedException {
@@ -105,7 +105,7 @@ public class HonoSender {
     private void connect() throws InterruptedException {
         final CountDownLatch connectLatch = new CountDownLatch(1);
         honoClient = new HonoClientImpl(vertx, honoConnectionFactory);
-        honoClient.connect(new ProtonClientOptions(), connectionHandler -> {
+        honoClient.connect(getClientOptions(MAX_RECONNECT_ATTEMPTS), connectionHandler -> {
             if (connectionHandler.failed()) {
                 LOGGER.error("HonoClient.connect() failed", connectionHandler.cause());
             }
@@ -117,7 +117,7 @@ public class HonoSender {
     private void connectRegistry() throws InterruptedException {
         final CountDownLatch connectLatch = new CountDownLatch(1);
         registrationHonoClient = new HonoClientImpl(vertx, registrationConnectionFactory);
-        registrationHonoClient.connect(new ProtonClientOptions(), connectionHandler -> {
+        registrationHonoClient.connect(getClientOptions(MAX_RECONNECT_ATTEMPTS), connectionHandler -> {
             if (connectionHandler.failed()) {
                 LOGGER.error("HonoClient.connect() failed", connectionHandler.cause());
             }
@@ -195,7 +195,9 @@ public class HonoSender {
                         LOGGER.info("starting batch send with {} credits available", messageSender.getCredit());
                         while (!messageSender.sendQueueFull() && messagesSent.get() < MAX_MESSAGES_PER_BATCH_SEND) {
                             Map<String, Object> properties = new HashMap<>();
-                            properties.put("millis", System.currentTimeMillis());
+                            if (sampler.isSetSenderTime()) {
+                                properties.put(TIME_STAMP_VARIABLE, System.currentTimeMillis());
+                            }
                             messageSender.send(deviceId, properties, sampler.getData(), sampler.getContentType(), token, (Handler<Void>) null);
                             bytesSent.addAndGet(messageLength);
                             messagesSent.incrementAndGet();
@@ -224,7 +226,7 @@ public class HonoSender {
 
                     Map<String, Long> properties = new HashMap<>();
                     if (sampler.isSetSenderTime()) {
-                        properties.put("millis", System.currentTimeMillis());
+                        properties.put(TIME_STAMP_VARIABLE, System.currentTimeMillis());
                     }
 
                     // mark send as error when we have no credits

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoReceiverSamplerUI.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoReceiverSamplerUI.java
@@ -12,26 +12,38 @@
 
 package org.eclipse.hono.jmeter.ui;
 
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.JCheckBox;
+import javax.swing.JPanel;
 
+import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jorphan.gui.JLabeledTextField;
-import org.eclipse.hono.client.impl.AbstractHonoClient;
 import org.eclipse.hono.jmeter.HonoReceiverSampler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Swing UI for receiver sampler
  */
 public class HonoReceiverSamplerUI extends HonoSamplerUI {
 
-    private final JCheckBox         useSenderTime = new JCheckBox("Use sender time");
-    private final JLabeledTextField prefetch      = new JLabeledTextField("Prefetch");
+    private static final long serialVersionUID = 2577635965483186422L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HonoReceiverSamplerUI.class);
+
+    private final JCheckBox         useSenderTime          = new JCheckBox("Use sender time");
+    private final JCheckBox         senderTimeInPayload    = new JCheckBox("Sender time in Payload");
+    private final JLabeledTextField senderTimeVariableName = new JLabeledTextField("Sender time variable name");
+    private final JLabeledTextField prefetch               = new JLabeledTextField("Prefetch");
+    private final JLabeledTextField reconnectAttempts      = new JLabeledTextField("Max reconnect attempts");
 
     public HonoReceiverSamplerUI() {
         super("Qpid Dispatch Router");
         addDefaultOptions();
         addOption(prefetch);
-        addOption(useSenderTime);
+        addOption(reconnectAttempts);
+        addOption(createTimeStampPanel());
     }
 
     @Override
@@ -51,7 +63,10 @@ public class HonoReceiverSamplerUI extends HonoSamplerUI {
         super.modifyTestElement(testElement);
         HonoReceiverSampler sampler = (HonoReceiverSampler) testElement;
         sampler.setPrefetch(prefetch.getText());
+        sampler.setReconnectAttempts(reconnectAttempts.getText());
         sampler.setUseSenderTime(useSenderTime.isSelected());
+        sampler.setSenderTimeInPayload(senderTimeInPayload.isSelected());
+        sampler.setSenderTimeVariableName(senderTimeVariableName.getText());
     }
 
     @Override
@@ -59,14 +74,42 @@ public class HonoReceiverSamplerUI extends HonoSamplerUI {
         super.configure(element);
         HonoReceiverSampler sampler = (HonoReceiverSampler) element;
         prefetch.setText(sampler.getPrefetch());
+        reconnectAttempts.setText(sampler.getReconnectAttempts());
         useSenderTime.setSelected(sampler.isUseSenderTime());
+        senderTimeInPayload.setSelected(sampler.isSenderTimeInPayload());
+        senderTimeVariableName.setText(sampler.getSenderTimeVariableName());
     }
 
     @Override
     public void clearGui() {
         super.clearGui();
+        LOGGER.debug("clearGui() invoked");
+        reconnectAttempts.setText("0");
         prefetch.setText("50");
         useSenderTime.setSelected(false);
+        senderTimeInPayload.setSelected(false);
+        senderTimeVariableName.setText("timeStamp");
     }
 
+    private JPanel createTimeStampPanel() {
+        LOGGER.debug("createTimeStampPanel() invoked");
+        JPanel timeStampPanel = new VerticalPanel();
+        timeStampPanel.setBorder(
+                BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Timestamp used for sampling"));
+        timeStampPanel.add(useSenderTime);
+        timeStampPanel.add(senderTimeInPayload);
+        timeStampPanel.add(senderTimeVariableName);
+        useSenderTime.addChangeListener(e -> {
+            if (e.getSource() == this.useSenderTime) {
+                if (this.useSenderTime.isSelected()) {
+                    senderTimeInPayload.setVisible(true);
+                    senderTimeVariableName.setVisible(true);
+                } else {
+                    senderTimeInPayload.setVisible(false);
+                    senderTimeVariableName.setVisible(false);
+                }
+            }
+        });
+        return timeStampPanel;
+    }
 }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSamplerUI.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSamplerUI.java
@@ -12,10 +12,11 @@
 
 package org.eclipse.hono.jmeter.ui;
 
-import java.awt.*;
+import java.awt.BorderLayout;
 import java.util.stream.Stream;
 
-import javax.swing.*;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
 
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;


### PR DESCRIPTION
As part of this PR a new feature for JMeter Hono plugin is provided. Hono JMeter plugin could now use the time stamp from the received message for sampling. This is esspecially useful when a JMeter scenario contains delays between sending messages to Hono and receiving it. The time stamp can either be part of the payload (restricted currently to JSON format) or as Application property.

Signed-off-by: Balasubramanian <balasubramanian.azhagappan@bosch-si.com>