### PR TITLE
Provide the name of the missing file in the exception message

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/KeyLoader.java
+++ b/core/src/main/java/org/eclipse/hono/config/KeyLoader.java
@@ -139,7 +139,7 @@ public final class KeyLoader {
     private void loadPublicKeyFromFile(final String certPath) {
 
         if (!vertx.fileSystem().existsBlocking(Objects.requireNonNull(certPath))) {
-            throw new IllegalArgumentException("certificate file does not exist");
+            throw new IllegalArgumentException("certificate file does not exist: " + certPath);
         } else if (AbstractConfig.hasPemFileSuffix(certPath)) {
             try {
 


### PR DESCRIPTION
Providing the missing name in the exception helps. Especially when the value can be configured and may be even looked up using the Eclipse variable system.

Signed-off-by: Jens Reimann <jreimann@redhat.com>