### PR TITLE
Allow to re-use the ApplicationConfig with other config types

### DIFF
--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -221,9 +221,8 @@ public class ApplicationConfig {
      */
     @Bean
     @Qualifier("signing")
-    public RegistrationAssertionHelper registrationAssertionFactory() {
+    public RegistrationAssertionHelper registrationAssertionFactory(final SignatureSupporting serviceProps) {
         ServiceConfigProperties amqpProps = amqpProperties();
-        FileBasedRegistrationConfigProperties serviceProps = serviceProperties();
         if (!serviceProps.getSigning().isAppropriateForCreating() && amqpProps.getKeyPath() != null) {
             // fall back to TLS configuration
             serviceProps.getSigning().setKeyPath(amqpProps.getKeyPath());

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationConfigProperties.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationConfigProperties.java
@@ -23,7 +23,7 @@ import io.vertx.core.json.JsonObject;
  * Configuration properties for the Hono's device registry as own server.
  *
  */
-public final class FileBasedRegistrationConfigProperties {
+public final class FileBasedRegistrationConfigProperties implements SignatureSupporting {
 
     /**
      * The default number of devices that can be registered for each tenant.
@@ -146,6 +146,7 @@ public final class FileBasedRegistrationConfigProperties {
      *
      * @return The properties.
      */
+    @Override
     public SignatureSupportingConfigProperties getSigning() {
         return registrationAssertionProperties;
     }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/SignatureSupporting.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/SignatureSupporting.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2017 Red Hat Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Red Hat Inc - initial creation
+ */
+
+package org.eclipse.hono.deviceregistry;
+
+import org.eclipse.hono.config.SignatureSupportingConfigProperties;
+
+public interface SignatureSupporting {
+
+    public SignatureSupportingConfigProperties getSigning();
+
+}

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/SignatureSupporting.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/SignatureSupporting.java
@@ -14,8 +14,19 @@ package org.eclipse.hono.deviceregistry;
 
 import org.eclipse.hono.config.SignatureSupportingConfigProperties;
 
+/**
+ * An interface for providing {@link SignatureSupportingConfigProperties}
+ * <p>
+ * This interface is intended for implementors of configurations which support
+ * {@link SignatureSupportingConfigProperties}.
+ */
 public interface SignatureSupporting {
 
+    /**
+     * Gets the properties for determining key material for creating registration assertion tokens.
+     *
+     * @return The properties.
+     */
     public SignatureSupportingConfigProperties getSigning();
 
 }


### PR DESCRIPTION
I would like to propose a change to the device-registry module in order to allow swapping the file based implementations more easily with different implementations. Please let me know what you think.

I personally think that the `SignatureSupporting` name is not optimal, my natural choice would have been `SignatureSupportingConfigProperties`, but this is already taken by the signing information itself. So `SignatureSupporting` seems like a good compromise.

---

This change does refactor the device registry module in order to allow re-using the same ApplicationConfig class with different device registry implementations. Right now the method 'registrationAssertionFactory' limits this so "File*" implementations.

With the change applied the configuration is no longer actively looked up by the method, but injected by the IoC framework and thus can be swapped. Also is only the "signature" part required and so the interface `SignatureSupporting` was added.

Signed-off-by: Jens Reimann <jreimann@redhat.com>