### PR TITLE
Hono JMeter Plugin: Using sender Time for sampling

### DIFF
--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoReceiverSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoReceiverSampler.java
@@ -34,15 +34,19 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
     private static final Logger LOGGER = LoggerFactory.getLogger(HonoReceiverSampler.class);
 
     private static final String USE_SENDER_TIME = "useSenderTime";
+    private static final String SENDER_TIME_IN_PAYLOAD = "senderTimeInPayload";
+    private static final String SENDER_TIME_VARIABLE_NAME = "senderTimeVariableName";
+    private static final String RECONNECT_ATTEMPTS = "reconnectAttempts";
+    private static final String DEFAULT_SENDER_TIME_VARIABLE_NAME = "timeStamp";
     private static final String PREFETCH = "prefetch";
 
     private HonoReceiver honoReceiver;
 
-    public Boolean isUseSenderTime() {
+    public boolean isUseSenderTime() {
         return getPropertyAsBoolean(USE_SENDER_TIME);
     }
 
-    public void setUseSenderTime(final Boolean useSenderTime) {
+    public void setUseSenderTime(final boolean useSenderTime) {
         setProperty(USE_SENDER_TIME, useSenderTime);
     }
 
@@ -54,13 +58,37 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
         setProperty(PREFETCH, prefetch);
     }
 
+    public String getSenderTimeVariableName() {
+        return getPropertyAsString(SENDER_TIME_VARIABLE_NAME, DEFAULT_SENDER_TIME_VARIABLE_NAME);
+    }
+
+    public void setSenderTimeVariableName(final String variableName) {
+        setProperty(SENDER_TIME_VARIABLE_NAME, variableName);
+    }
+
+    public boolean isSenderTimeInPayload() {
+        return getPropertyAsBoolean(SENDER_TIME_IN_PAYLOAD);
+    }
+
+    public void setSenderTimeInPayload(final boolean senderTimeInPayload) {
+        setProperty(SENDER_TIME_IN_PAYLOAD, senderTimeInPayload);
+    }
+
+    public String getReconnectAttempts() {
+        return getPropertyAsString(RECONNECT_ATTEMPTS, "1");
+    }
+
+    public void setReconnectAttempts(final String reconnectAttempts) {
+        setProperty(RECONNECT_ATTEMPTS, reconnectAttempts);
+    }
+
     @Override
     public SampleResult sample(final Entry entry) {
         SampleResult res = new SampleResult();
         res.setResponseOK();
         res.setDataType(SampleResult.TEXT);
         res.setSampleLabel(getName());
-        honoReceiver.sample(res, isUseSenderTime());
+        honoReceiver.sample(res);
         return res;
     }
 

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/AbstractClient.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/AbstractClient.java
@@ -1,0 +1,29 @@
+package org.eclipse.hono.jmeter.client;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.dns.AddressResolverOptions;
+import io.vertx.proton.ProtonClientOptions;
+
+public class AbstractClient {
+
+    static final int    DEFAULT_CONNECT_TIMEOUT_MILLIS            = 2000;
+    static final int    DEFAULT_ADDRESS_RESOLUTION_TIMEOUT_MILLIS = 2000;
+    static final String TIME_STAMP_VARIABLE                       = "timeStamp";
+
+    Vertx vertx() {
+        VertxOptions options = new VertxOptions()
+                .setWarningExceptionTime(1500000000)
+                .setAddressResolverOptions(new AddressResolverOptions()
+                        .setCacheNegativeTimeToLive(0) // discard failed DNS lookup results immediately
+                        .setCacheMaxTimeToLive(0) // support DNS based service resolution
+                        .setRotateServers(true)
+                        .setQueryTimeout(DEFAULT_ADDRESS_RESOLUTION_TIMEOUT_MILLIS));
+        return Vertx.vertx(options);
+    }
+
+    ProtonClientOptions getClientOptions(int reconnectAttempts) {
+        return new ProtonClientOptions().setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS)
+                .setReconnectAttempts(reconnectAttempts);
+    }
+}

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoReceiverSamplerUI.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoReceiverSamplerUI.java
@@ -12,26 +12,38 @@
 
 package org.eclipse.hono.jmeter.ui;
 
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.JCheckBox;
+import javax.swing.JPanel;
 
+import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jorphan.gui.JLabeledTextField;
-import org.eclipse.hono.client.impl.AbstractHonoClient;
 import org.eclipse.hono.jmeter.HonoReceiverSampler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Swing UI for receiver sampler
  */
 public class HonoReceiverSamplerUI extends HonoSamplerUI {
 
-    private final JCheckBox         useSenderTime = new JCheckBox("Use sender time");
-    private final JLabeledTextField prefetch      = new JLabeledTextField("Prefetch");
+    private static final long serialVersionUID = 2577635965483186422L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HonoReceiverSamplerUI.class);
+
+    private final JCheckBox         useSenderTime          = new JCheckBox("Use sender time");
+    private final JCheckBox         senderTimeInPayload    = new JCheckBox("Sender time in Payload");
+    private final JLabeledTextField senderTimeVariableName = new JLabeledTextField("Sender time variable name");
+    private final JLabeledTextField prefetch               = new JLabeledTextField("Prefetch");
+    private final JLabeledTextField reconnectAttempts      = new JLabeledTextField("Max reconnect attempts");
 
     public HonoReceiverSamplerUI() {
         super("Qpid Dispatch Router");
         addDefaultOptions();
         addOption(prefetch);
-        addOption(useSenderTime);
+        addOption(reconnectAttempts);
+        addOption(createTimeStampPanel());
     }
 
     @Override
@@ -51,7 +63,10 @@ public class HonoReceiverSamplerUI extends HonoSamplerUI {
         super.modifyTestElement(testElement);
         HonoReceiverSampler sampler = (HonoReceiverSampler) testElement;
         sampler.setPrefetch(prefetch.getText());
+        sampler.setReconnectAttempts(reconnectAttempts.getText());
         sampler.setUseSenderTime(useSenderTime.isSelected());
+        sampler.setSenderTimeInPayload(senderTimeInPayload.isSelected());
+        sampler.setSenderTimeVariableName(senderTimeVariableName.getText());
     }
 
     @Override
@@ -59,14 +74,42 @@ public class HonoReceiverSamplerUI extends HonoSamplerUI {
         super.configure(element);
         HonoReceiverSampler sampler = (HonoReceiverSampler) element;
         prefetch.setText(sampler.getPrefetch());
+        reconnectAttempts.setText(sampler.getReconnectAttempts());
         useSenderTime.setSelected(sampler.isUseSenderTime());
+        senderTimeInPayload.setSelected(sampler.isSenderTimeInPayload());
+        senderTimeVariableName.setText(sampler.getSenderTimeVariableName());
     }
 
     @Override
     public void clearGui() {
         super.clearGui();
+        LOGGER.debug("clearGui() invoked");
+        reconnectAttempts.setText("0");
         prefetch.setText("50");
         useSenderTime.setSelected(false);
+        senderTimeInPayload.setSelected(false);
+        senderTimeVariableName.setText("timeStamp");
     }
 
+    private JPanel createTimeStampPanel() {
+        LOGGER.debug("createTimeStampPanel() invoked");
+        JPanel timeStampPanel = new VerticalPanel();
+        timeStampPanel.setBorder(
+                BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Timestamp used for sampling"));
+        timeStampPanel.add(useSenderTime);
+        timeStampPanel.add(senderTimeInPayload);
+        timeStampPanel.add(senderTimeVariableName);
+        useSenderTime.addChangeListener(e -> {
+            if (e.getSource() == this.useSenderTime) {
+                if (this.useSenderTime.isSelected()) {
+                    senderTimeInPayload.setVisible(true);
+                    senderTimeVariableName.setVisible(true);
+                } else {
+                    senderTimeInPayload.setVisible(false);
+                    senderTimeVariableName.setVisible(false);
+                }
+            }
+        });
+        return timeStampPanel;
+    }
 }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSamplerUI.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSamplerUI.java
@@ -12,10 +12,11 @@
 
 package org.eclipse.hono.jmeter.ui;
 
-import java.awt.*;
+import java.awt.BorderLayout;
 import java.util.stream.Stream;
 
-import javax.swing.*;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
 
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;


### PR DESCRIPTION
As part of this PR a new feature for JMeter Hono plugin is provided. Hono JMeter plugin could now use the time stamp from the received message (set by the sender) for sampling. This is esspecially useful when a JMeter scenario contains delays between sending messages to Hono and receiving it. The time stamp can either be part of the payload (restricted currently to JSON format) or as Application property.

Signed-off-by: Balasubramanian balasubramanian.azhagappan@bosch-si.com