### PR TITLE
Hono Site: Added support for build on MS Windows

### DIFF
--- a/site/build-site.bat
+++ b/site/build-site.bat
@@ -1,0 +1,27 @@
+@ECHO off
+ECHO Going to build documentation...
+hugo version
+IF ERRORLEVEL 1 (
+  ECHO Please install "hugo" to be able to build the hono documentation. See readme.md for further details.
+  EXIT 1
+) ELSE (
+  ECHO Hugo installation detected...
+)
+
+IF NOT EXIST themes\hugo-material-docs (
+  ECHO Going to download material theme for hugo...
+  git clone https://github.com/digitalcraftsman/hugo-material-docs.git themes/hugo-material-docs
+  cd themes\hugo-material-docs
+  git checkout 194c497216c8389e02e9719381168a668a0ffb05
+  cd ..\..
+) ELSE (
+  ECHO Hugo material theme detected...
+)
+
+IF NOT "%~1"==""  (
+  ECHO Going to build docs in directory: %1
+  hugo --theme hugo-material-docs -d %1
+) ELSE (
+  ECHO Going to build docs in default directory...
+  hugo --theme hugo-material-docs
+)

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -63,5 +63,40 @@
                 </plugins>
             </build>
         </profile>
+        
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>compile</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>cmd.exe</executable>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <arguments>
+                                <argument>/c</argument>
+                                <argument>build-site.bat</argument>
+                                <argument>${project.build.directory}</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Hi Hono Devs,

I just tried to build the project site and found out that there's just a build script for *nix based operating systems.  

As I'm developing under windows I ported the script to a windows batch file.

Maybe you're interested in it.

Cheers
Chris