### PR TITLE
Enable device registry file persistence

### DIFF
--- a/services/device-registry/src/main/fabric8/deployment.yml
+++ b/services/device-registry/src/main/fabric8/deployment.yml
@@ -21,3 +21,8 @@ spec:
           value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
+        - name: HONO_REGISTRY_SVC_SAVE_TO_FILE
+          value: true
+        - name: HONO_CREDENTIALS_SVC_SAVE_TO_FILE
+          value: true
+


### PR DESCRIPTION
This change enabled the device registry file persistence support as the
OpenShift deployment already has a PV assigned.

Signed-off-by: Jens Reimann <jreimann@redhat.com>