### PR TITLE
Example for Hono sender and consumer with minimal dependencies.

### DIFF
--- a/example/src/main/java/org/eclipse/hono/vertx/example/HonoEventConsumer.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/HonoEventConsumer.java
@@ -1,0 +1,19 @@
+package org.eclipse.hono.vertx.example;
+
+import org.eclipse.hono.vertx.example.base.AbstractHonoConsumer;
+
+/**
+ * Example class with minimal dependencies for consuming event data from Hono.
+ *
+ * Please refer to {@link org.eclipse.hono.vertx.example.base.HonoExampleConstants} to configure where Hono's
+ * microservices are reachable.
+ */
+public class HonoEventConsumer extends AbstractHonoConsumer {
+    public static void main(final String[] args) throws Exception {
+        System.out.println("Starting downstream consumer...");
+        HonoEventConsumer honoDownstreamEventConsumer = new HonoEventConsumer();
+        honoDownstreamEventConsumer.setEventMode(true);
+        honoDownstreamEventConsumer.consumeData();
+        System.out.println("Finishing downstream consumer.");
+    }
+}

--- a/example/src/main/java/org/eclipse/hono/vertx/example/HonoEventSender.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/HonoEventSender.java
@@ -1,0 +1,19 @@
+package org.eclipse.hono.vertx.example;
+
+import org.eclipse.hono.vertx.example.base.AbstractHonoSender;
+
+/**
+ * Example class with minimal dependencies for sending event data to Hono.
+ *
+ * Please refer to {@link org.eclipse.hono.vertx.example.base.HonoExampleConstants} to configure where Hono's
+ * microservices are reachable.
+ */
+public class HonoEventSender extends AbstractHonoSender {
+    public static void main(final String[] args) throws Exception {
+        System.out.println("Starting downstream event sender...");
+        HonoEventSender honoDownstreamSender = new HonoEventSender();
+        honoDownstreamSender.setEventMode(true);
+        honoDownstreamSender.sendData();
+        System.out.println("Finishing downstream event sender.");
+    }
+}

--- a/example/src/main/java/org/eclipse/hono/vertx/example/HonoTelemetryConsumer.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/HonoTelemetryConsumer.java
@@ -1,0 +1,19 @@
+package org.eclipse.hono.vertx.example;
+
+import org.eclipse.hono.vertx.example.base.AbstractHonoConsumer;
+
+/**
+ * Example class with minimal dependencies for consuming telemetry data from Hono.
+ *
+ * Please refer to {@link org.eclipse.hono.vertx.example.base.HonoExampleConstants} to configure where Hono's
+ * microservices are reachable.
+ */
+public class HonoTelemetryConsumer extends AbstractHonoConsumer {
+    public static void main(final String[] args) throws Exception {
+        System.out.println("Starting telemetry consumer...");
+        HonoTelemetryConsumer honoDownstreamEventConsumer = new HonoTelemetryConsumer();
+        honoDownstreamEventConsumer.consumeData();
+        System.out.println("Finishing telemetry consumer.");
+    }
+
+}

--- a/example/src/main/java/org/eclipse/hono/vertx/example/HonoTelemetrySender.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/HonoTelemetrySender.java
@@ -1,0 +1,18 @@
+package org.eclipse.hono.vertx.example;
+
+import org.eclipse.hono.vertx.example.base.AbstractHonoSender;
+
+/**
+ * Example class with minimal dependencies for sending telemetry data to Hono.
+ *
+ * Please refer to {@link org.eclipse.hono.vertx.example.base.HonoExampleConstants} to configure where Hono's
+ * microservices are reachable.
+ */
+public class HonoTelemetrySender extends AbstractHonoSender {
+    public static void main(final String[] args) throws Exception {
+        System.out.println("Starting downstream telemetry sender...");
+        HonoTelemetrySender honoDownstreamSender = new HonoTelemetrySender();
+        honoDownstreamSender.sendData();
+        System.out.println("Finishing downstream telemetry sender.");
+    }
+}

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/AbstractHonoConsumer.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/AbstractHonoConsumer.java
@@ -1,0 +1,103 @@
+package org.eclipse.hono.vertx.example.base;
+
+import java.util.concurrent.CountDownLatch;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Section;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.client.impl.HonoClientImpl;
+import org.eclipse.hono.connection.ConnectionFactoryImpl;
+import org.eclipse.hono.util.MessageHelper;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonClientOptions;
+
+import static org.eclipse.hono.vertx.example.base.HonoExampleConstants.*;
+
+/**
+ * Abstract example base class for consuming data from Hono.
+ */
+public abstract class AbstractHonoConsumer {
+    public static final String HONO_CLIENT_USER = "consumer@HONO";
+    public static final String HONO_CLIENT_PASSWORD = "verysecret";
+
+    private final Vertx vertx = Vertx.vertx();
+    private final HonoClient honoClient;
+
+    private boolean eventMode = false;
+
+    public AbstractHonoConsumer() {
+        honoClient = new HonoClientImpl(vertx,
+                ConnectionFactoryImpl.ConnectionFactoryBuilder.newBuilder()
+                        .vertx(vertx)
+                        .host(HONO_AMQP_CONSUMER_HOST)
+                        .port(HONO_AMQP_CONSUMER_PORT)
+                        .user(HONO_CLIENT_USER)
+                        .password(HONO_CLIENT_PASSWORD)
+                        .trustStorePath("target/config/hono-demo-certs-jar/trusted-certs.pem")
+                        .disableHostnameVerification()
+                        .build());
+    }
+
+    protected void consumeData() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Future<MessageConsumer> consumerFuture = Future.future();
+
+        consumerFuture.setHandler(result -> {
+            if (!result.succeeded()) {
+                System.err.println("honoClient could not create telemetry consumer : " + result.cause());
+            }
+            latch.countDown();
+        });
+
+        final Future<HonoClient> connectionTracker = Future.future();
+
+        honoClient.connect(new ProtonClientOptions(), connectionTracker.completer());
+
+        connectionTracker.compose(honoClient -> {
+            if (eventMode) {
+                honoClient.createEventConsumer(TENANT_ID,
+                        msg -> handleMessage(msg), consumerFuture.completer());
+            } else {
+                honoClient.createTelemetryConsumer(TENANT_ID,
+                        msg -> handleMessage(msg), consumerFuture.completer());
+            }
+        },
+                consumerFuture);
+
+        latch.await();
+
+        if (consumerFuture.succeeded())
+            System.in.read();
+        vertx.close();
+    }
+
+    private void handleMessage(final Message msg) {
+        final Section body = msg.getBody();
+        if (!(body instanceof Data))
+            return;
+
+        final String content = ((Data) msg.getBody()).getValue().toString();
+
+        final String deviceId = MessageHelper.getDeviceId(msg);
+
+        final StringBuilder sb = new StringBuilder("received message [device: ").
+                append(deviceId).append(", content-type: ").append(msg.getContentType()).append(" ]: ").append(content);
+
+        if (msg.getApplicationProperties() != null) {
+            sb.append(" with application properties: ").append(msg.getApplicationProperties().getValue());
+        }
+
+        System.out.println(sb.toString());
+    }
+
+    public boolean isEventMode() {
+        return eventMode;
+    }
+
+    public void setEventMode(boolean eventMode) {
+        this.eventMode = eventMode;
+    }
+}

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/AbstractHonoConsumer.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/AbstractHonoConsumer.java
@@ -69,15 +69,17 @@ public abstract class AbstractHonoConsumer {
 
         latch.await();
 
-        if (consumerFuture.succeeded())
+        if (consumerFuture.succeeded()) {
             System.in.read();
+        }
         vertx.close();
     }
 
     private void handleMessage(final Message msg) {
         final Section body = msg.getBody();
-        if (!(body instanceof Data))
+        if (!(body instanceof Data)) {
             return;
+        }
 
         final String content = ((Data) msg.getBody()).getValue().toString();
 

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/AbstractHonoSender.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/AbstractHonoSender.java
@@ -1,0 +1,204 @@
+package org.eclipse.hono.vertx.example.base;
+
+import io.vertx.core.*;
+import io.vertx.proton.ProtonClientOptions;
+import io.vertx.proton.ProtonDelivery;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.impl.HonoClientImpl;
+import org.eclipse.hono.client.MessageSender;
+import org.eclipse.hono.connection.ConnectionFactoryImpl;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.eclipse.hono.util.RegistrationResult;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.stream.IntStream;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.eclipse.hono.vertx.example.base.HonoExampleConstants.*;
+
+/**
+ * Abstract example base class for sending data to Hono.
+ */
+public abstract class AbstractHonoSender {
+    public static final int COUNT = 50;
+    public static final String HONO_CLIENT_USER = "hono-client@HONO";
+    public static final String HONO_CLIENT_PASSWORD = "secret";
+
+    private final Vertx vertx = Vertx.vertx();
+    private final HonoClient honoRegistryClient;
+    private final HonoClient honoMessagingClient;
+
+    private RegistrationClient registrationClient;
+    private MessageSender messageSender;
+
+    private AtomicInteger dispositionHandlerCalled = new AtomicInteger(0);
+
+    private boolean eventMode = false;
+
+    public AbstractHonoSender() {
+        honoMessagingClient = new HonoClientImpl(vertx,
+                ConnectionFactoryImpl.ConnectionFactoryBuilder.newBuilder()
+                        .vertx(vertx)
+                        .host(HONO_MESSAGING_HOST)
+                        .port(HONO_MESSAGING_PORT)
+                        .user(HONO_CLIENT_USER)
+                        .password(HONO_CLIENT_PASSWORD)
+                        .trustStorePath("target/config/hono-demo-certs-jar/trusted-certs.pem")
+                        .disableHostnameVerification()
+                        .build());
+        honoRegistryClient = new HonoClientImpl(vertx,
+                ConnectionFactoryImpl.ConnectionFactoryBuilder.newBuilder()
+                        .vertx(vertx)
+                        .host(HONO_REGISTRY_HOST)
+                        .port(HONO_REGISTRY_PORT)
+                        .user(HONO_CLIENT_USER)
+                        .password(HONO_CLIENT_PASSWORD)
+                        .trustStorePath("target/config/hono-demo-certs-jar/trusted-certs.pem")
+                        .disableHostnameVerification()
+                        .build());
+    }
+
+    protected void sendData() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final AtomicBoolean clientsCreated = getHonoClients(latch);
+
+        latch.await();
+
+        if (clientsCreated.get()) {
+            IntStream.range(0, COUNT).forEach(value -> {
+                handleSingleMessage(value);
+            });
+        }
+
+        vertx.close();
+    }
+
+    private boolean sendMessageToHono(final int value, final String token) {
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("my_prop_string", "I'm a string");
+        properties.put("my_prop_int", value);
+
+        if (eventMode) {
+            final BiConsumer<Object, ProtonDelivery> myDispositionHandler = (messageId, delivery) -> {
+                dispositionHandlerCalled.incrementAndGet();
+                if (! (delivery.getRemoteState() instanceof Accepted)) {
+                    System.err.println("delivery failed for [message ID: " + messageId + ", new remote state: " + delivery.getRemoteState());
+                } else {
+                    System.out.println("delivery accepted for [message ID: " + messageId);
+                }
+            };
+            return (messageSender.send(DEVICE_ID, properties, "myMessage" + value, "text/plain", token, myDispositionHandler));
+        } else {
+            return (messageSender.send(DEVICE_ID, properties, "myMessage" + value, "text/plain", token));
+        }
+    }
+
+    private AtomicBoolean getHonoClients(final CountDownLatch countDownLatch) {
+        // we need two clients to get it working, define futures for them
+        final Future<RegistrationClient> registrationClientTracker = getRegistrationClient();
+        final Future<MessageSender> messageSenderTracker = getMessageSender();
+
+        final AtomicBoolean clientsCreated = new AtomicBoolean(false);
+
+        CompositeFuture.all(registrationClientTracker, messageSenderTracker).setHandler(result -> {
+            if (!result.succeeded()) {
+                System.err.println(
+                        "hono clients could not be created : " + result.cause().getMessage());
+            } else {
+                clientsCreated.set(true);
+                registrationClient = registrationClientTracker.result();
+                messageSender = messageSenderTracker.result();
+            }
+            countDownLatch.countDown();
+        });
+
+        return clientsCreated;
+    }
+
+    private Future<RegistrationClient> getRegistrationClient() {
+        final Future<RegistrationClient> registrationClientTracker = Future.future();
+
+        final Future<HonoClient> registryConnectionTracker = Future.future();
+        honoRegistryClient.connect(new ProtonClientOptions(), registryConnectionTracker.completer());
+        registryConnectionTracker.compose(registryClient -> {
+            honoRegistryClient.getOrCreateRegistrationClient(TENANT_ID, registrationClientTracker.completer());
+        }, registrationClientTracker);
+
+        return registrationClientTracker;
+    }
+
+    private Future<MessageSender> getMessageSender() {
+        final Future<MessageSender> messageSenderTracker = Future.future();
+
+        final Future<HonoClient> messagingConnectionTracker = Future.future();
+        honoMessagingClient.connect(new ProtonClientOptions(), messagingConnectionTracker.completer());
+        messagingConnectionTracker.compose(messagingClient -> {
+            if (eventMode) {
+                messagingClient.getOrCreateEventSender(TENANT_ID, messageSenderTracker.completer());
+            } else {
+                messagingClient.getOrCreateTelemetrySender(TENANT_ID, messageSenderTracker.completer());
+            }
+        }, messageSenderTracker);
+
+        return messageSenderTracker;
+    }
+
+    private void handleSingleMessage(final int value) {
+        final CountDownLatch messageSenderLatch = new CountDownLatch(1);
+
+        final Future<Void> senderTracker = Future.future();
+        senderTracker.setHandler(v -> {
+            if (senderTracker.failed()) {
+                System.err.println("Failed: Sending message... #" + value + " - " + senderTracker.toString());
+            } else {
+                System.out.println("Sending message... #" + value);
+            }
+            messageSenderLatch.countDown();
+        });
+        getRegistrationAssertion().compose(token -> {
+            if (sendMessageToHono(value, token)) {
+                senderTracker.complete();
+            } else {
+                senderTracker.fail("Sender might have no credits, is a consumer attached?");
+            }
+        }, senderTracker);
+        try {
+            messageSenderLatch.await();
+        } catch (InterruptedException e) {
+        }
+    }
+
+    private Future<String> getRegistrationAssertion() {
+        final Future<String> result = Future.future();
+        final Future<RegistrationResult> tokenTracker = Future.future();
+        registrationClient.assertRegistration(DEVICE_ID, tokenTracker.completer());
+
+        tokenTracker.compose(regResult -> {
+            if (regResult.getStatus() == HTTP_OK) {
+                result.complete(regResult.getPayload().getString(RegistrationConstants.FIELD_ASSERTION));
+            } else if (regResult.getStatus() == HTTP_NOT_FOUND) {
+                result.fail("cannot assert registration status (device needs to be registered)");
+            } else {
+                result.fail("cannot assert registration status : " + regResult.getStatus());
+            }
+        }, result);
+        return result;
+    }
+
+    public boolean isEventMode() {
+        return eventMode;
+    }
+
+    public void setEventMode(boolean eventMode) {
+        this.eventMode = eventMode;
+    }
+}

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleConstants.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleConstants.java
@@ -1,0 +1,46 @@
+package org.eclipse.hono.vertx.example.base;
+
+/**
+ * Class defines where to reach Hono's microservices that need to be accessed for sending and consuming data.
+ * This is intentionally done as pure Java constants to provide an example with minimal dependencies (no Spring is
+ * used e.g.).
+ *
+ * Please adopt the values to your needs - the defaults serve for a typical docker swarm setup.
+ * TODO: check and (possibly) change to kubernetes values.
+ */
+public class HonoExampleConstants {
+    /**
+     Define the host where Hono's microservices can be reached.
+     */
+    public static final String HONO_CONTAINER_HOST = "192.168.99.100";
+
+    public static final String HONO_AMQP_CONSUMER_HOST = HONO_CONTAINER_HOST;
+    /**
+     * Port of the AMQP network where consumers can receive data (in the standard setup this is the port of the qdrouter).
+     */
+    public static final int HONO_AMQP_CONSUMER_PORT = 15671;
+
+    public static final String HONO_REGISTRY_HOST = HONO_CONTAINER_HOST;
+    /**
+     * Port of Hono's device registry microservice (used to register and enable devices).
+     */
+    public static final int HONO_REGISTRY_PORT = 25671;
+
+    public static final String HONO_MESSAGING_HOST = HONO_CONTAINER_HOST;
+    /**
+     * Port of Hono's messaging microservice (used for sending data).
+     */
+    public static final int HONO_MESSAGING_PORT = 5671;
+
+    public static final String TENANT_ID = "DEFAULT_TENANT";
+
+    /**
+     * Id of the device that is used inside these examples.
+     * NB: you need to register the device before data can be sent.
+     * E.g. like
+     *    {@code http POST http://192.168.99.100:28080/registration/DEFAULT_TENANT device-id=4711}.
+     * Please refer to Hono's "Getting started" guide for details.
+     */
+    public static final String DEVICE_ID = "4711"; // needs to be registered first
+
+}

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleConstants.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleConstants.java
@@ -12,7 +12,7 @@ public class HonoExampleConstants {
     /**
      Define the host where Hono's microservices can be reached.
      */
-    public static final String HONO_CONTAINER_HOST = "192.168.99.100";
+    public static final String HONO_CONTAINER_HOST = "127.0.0.1";
 
     public static final String HONO_AMQP_CONSUMER_HOST = HONO_CONTAINER_HOST;
     /**


### PR DESCRIPTION
Contained is what was mainly available in documentation only so far:
- java standalone programs that can either send or consume telemetry or event data
- intentionally they are as reduced as possible, i.e.:
-- no Spring dependency (instead hard defined constants for host, port, users in a class)
-- no cmd-line args
-- no automatic registration of the device used (instead only a hint in javadoc how this could be done).
-- no gathering of console input that is then sent, but provide a simple fixed loop in the sender

Why is this version of example justified in parallel to the Example(Sender|Receiver)?
IMHO the examples are not what I would like to find as a very first example how Hono 
- can be accessed
- integrated with existing source code
- or just for understanding the programming model behind.

Looking at the source code of Example(Sender|Receiver) I personally think it looks like "Hono seems to be not so simple to access", which is not the truth IMHO.

This set of programs can be started by

`mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoTelemetryConsumer`

`mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoTelemetrySender`

`mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoEventConsumer`

`mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoEventSender`


So, take this PR as a discussion proposal how to provide the current documentation version of these programs inside the source code.

I have several concerns myself so far which I give as input here for further discussion:
- the example maven module is having 2 independent tasks currently: example code AND deployment (generation of scripts, collecting certs, etc.). This should be separated from the example, but should NOT be part of this PR IMHO (a task to do later).
- derived from that, the pom.xml of this module looks way too complicated for a newbie, since it needs be figured out what is _really_ necessary for integrating a simple Hono client into own source code.
  - one option that I favoured is to provide an own maven module with the minimal pom.xml to clarify this. 
  - This could be done by freeing the example maven module from it's deployment parts though as well (which probably melts down the pom.xml to mainly hono-client as dependency).
- package name `vertx.example.*`. Can you think of a better name? I couldn't think of a better one.

Remark: I did not update the documentation yet, I will do that after we have clarity on this PR.

@sophokles73 @ppatierno @pellmann : can you please provide your thoughts on this? Thx.