### PR TITLE
Support JMS vendor properties in REST adapter.

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -36,6 +36,7 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
 import io.netty.handler.codec.mqtt.MqttQoS;
@@ -507,12 +508,15 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
 
     private void addProperties(final MqttPublishMessage messageFromDevice, final Message message, final String registrationAssertion) {
 
-        if (message.getContentType() == null) {
+        if (StringUtils.isEmpty(message.getContentType())) {
             message.setContentType(CONTENT_TYPE_OCTET_STREAM);
         }
         message.setBody(new Data(new Binary(messageFromDevice.payload().getBytes())));
         MessageHelper.addRegistrationAssertion(message, registrationAssertion);
         MessageHelper.addProperty(message, PROPERTY_HONO_ORIG_ADDRESS, messageFromDevice.topicName());
+        if (getConfig().isJmsVendorPropsEnabled()) {
+            MessageHelper.addJmsVendorProperties(message);
+        }
     }
 
     private Future<String> getRegistrationAssertion(final MqttEndpoint endpoint, final String tenantId, final String deviceId) {

--- a/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
@@ -19,10 +19,11 @@ package org.eclipse.hono.config;
 public class ProtocolAdapterProperties extends ServiceConfigProperties {
 
     private boolean authenticationRequired = true;
+    private boolean jmsVendorPropsEnabled = false;
 
     /**
      * Checks whether the protocol adapter always authenticates devices using their provided credentials as defined
-     * in the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * in the <a href="https://www.eclipse.org/hono/api/credentials-api/">Credentials API</a>.
      * <p>
      * If this property is {@code false} then devices are always allowed to publish data without providing
      * credentials. This should only be set to false in test setups.
@@ -37,7 +38,7 @@ public class ProtocolAdapterProperties extends ServiceConfigProperties {
 
     /**
      * Sets whether the protocol adapter always authenticates devices using their provided credentials as defined
-     * in the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
+     * in the <a href="https://www.eclipse.org/hono/api/credentials-api/">Credentials API</a>.
      * <p>
      * If this property is set to {@code false} then devices are always allowed to publish data without providing
      * credentials. This should only be set to false in test setups.
@@ -48,5 +49,48 @@ public class ProtocolAdapterProperties extends ServiceConfigProperties {
      */
     public final void setAuthenticationRequired(final boolean authenticationRequired) {
         this.authenticationRequired = authenticationRequired;
+    }
+
+    /**
+     * Checks if adapter should include <em>Vendor Properties</em> as defined by <a
+     * href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
+     * Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a>
+     * in downstream messages.
+     * <p>
+     * The default value of this property is {@code false}.
+     * 
+     * @return {@code true} if the properties should be included.
+     */
+    public final boolean isJmsVendorPropsEnabled() {
+        return jmsVendorPropsEnabled;
+    }
+
+    
+    /**
+     * Sets if the adapter should include <em>Vendor Properties</em> as defined by <a
+     * href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
+     * Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a>
+     * in downstream messages.
+     * <p>
+     * Setting this property to {@code true} can be helpful if downstream consumers
+     * receive messages from Hono using a JMS provider which doesn't support the vendor
+     * properties but provides access to all application properties of received
+     * messages.
+     * <p>
+     * If set to {@code} the adapter will add the following vendor properties to a message's
+     * application properties:
+     * <ul>
+     * <li>{@code JMS_AMQP_CONTENT_TYPE} - with the value of the standard AMQP 1.0
+     * <em>content-type</em> property (if set)</li>
+     * <li>{@code JMS_AMQP_CONTENT_ENCODING} - with the value of the standard AMQP 1.0
+     * <em>content-encoding</em> property (if set)</li>
+     * </ul>
+     * <p>
+     * The default value of this property is {@code false}.
+     * 
+     * @param flag {@code true} if the properties should be included.
+     */
+    public final void setJmsVendorPropsEnabled(final boolean flag) {
+        this.jmsVendorPropsEnabled = flag;
     }
 }

--- a/example/src/main/sandbox/hono-adapter-mqtt-vertx-config.yml
+++ b/example/src/main/sandbox/hono-adapter-mqtt-vertx-config.yml
@@ -9,6 +9,7 @@ hono:
     insecurePortEnabled: true
     keyPath: /run/secrets/mqtt-adapter-key.pem
     certPath: /run/secrets/mqtt-adapter-cert.pem
+    jmsVendorPropsEnabled: true
     maxPayloadSize: 8096
   messaging:
     name: 'Hono MQTT Adapter'

--- a/example/src/main/sandbox/hono-adapter-rest-vertx-config.yml
+++ b/example/src/main/sandbox/hono-adapter-rest-vertx-config.yml
@@ -9,6 +9,7 @@ hono:
     insecurePortEnabled: true
     keyPath: /run/secrets/rest-adapter-key.pem
     certPath: /run/secrets/rest-adapter-cert.pem
+    jmsVendorPropsEnabled: true
     maxPayloadSize: 8096
   messaging:
     name: 'Hono REST Adapter'


### PR DESCRIPTION
This is a proposal to allow Hono's protocol adapters to include JMS vendor properties to downstream messages as described in #420 
