### PR TITLE
[#406] and [#312], InfluxDB templates and metrics for device connections

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
@@ -29,11 +29,11 @@ public class HttpAdapterMetrics extends Metrics {
     }
 
     void incrementProcessedHttpMessages(final String resourceId, final String tenantId) {
-        counterService.increment(METER_PREFIX + SERVICE_PREFIX + MESSAGES + mergeAsMetric(resourceId,tenantId) + PROCESSED);
+        counterService.increment(METER_PREFIX + getPrefix() + MESSAGES + mergeAsMetric(resourceId,tenantId) + PROCESSED);
     }
 
     void incrementUndeliverableHttpMessages(final String resourceId, final String tenantId) {
-        counterService.increment(SERVICE_PREFIX + MESSAGES + mergeAsMetric(resourceId,tenantId) + UNDELIVERABLE);
+        counterService.increment(getPrefix() + MESSAGES + mergeAsMetric(resourceId,tenantId) + UNDELIVERABLE);
     }
 
 }

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/KuraAdapterMetrics.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/KuraAdapterMetrics.java
@@ -13,14 +13,14 @@
 
 package org.eclipse.hono.adapter.kura;
 
-import org.eclipse.hono.service.metric.Metrics;
+import org.eclipse.hono.adapter.mqtt.MqttAdapterMetrics;
 import org.springframework.stereotype.Component;
 
 /**
  * Metrics for the Kura adapter
  */
 @Component
-public class KuraAdapterMetrics extends Metrics {
+public class KuraAdapterMetrics extends MqttAdapterMetrics {
 
     private static final String SERVICE_PREFIX = "hono.kura";
 
@@ -28,13 +28,4 @@ public class KuraAdapterMetrics extends Metrics {
     protected String getPrefix() {
         return SERVICE_PREFIX;
     }
-
-    void incrementProcessedMqttMessages(final String resourceId, final String tenantId) {
-        counterService.increment(METER_PREFIX + SERVICE_PREFIX + MESSAGES + mergeAsMetric(resourceId,tenantId) + PROCESSED);
-    }
-
-    void incrementUndeliverableMqttMessages(final String resourceId, final String tenantId) {
-        counterService.increment(SERVICE_PREFIX + MESSAGES + mergeAsMetric(resourceId,tenantId) + UNDELIVERABLE);
-    }
-
 }

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
@@ -10,7 +10,7 @@
  *    Bosch Software Innovations GmbH - initial creation
  */
 
-package org.eclipse.hono.adapter.mqtt.impl;
+package org.eclipse.hono.adapter.mqtt;
 
 import org.eclipse.hono.service.metric.Metrics;
 import org.springframework.stereotype.Component;
@@ -29,11 +29,18 @@ public class MqttAdapterMetrics extends Metrics {
     }
 
     void incrementProcessedMqttMessages(final String resourceId, final String tenantId) {
-        counterService.increment(METER_PREFIX + SERVICE_PREFIX + MESSAGES + mergeAsMetric(resourceId,tenantId) + PROCESSED);
+        counterService.increment(METER_PREFIX + getPrefix() + MESSAGES + mergeAsMetric(resourceId,tenantId) + PROCESSED);
     }
 
     void incrementUndeliverableMqttMessages(final String resourceId, final String tenantId) {
-        counterService.increment(SERVICE_PREFIX + MESSAGES + mergeAsMetric(resourceId,tenantId) + UNDELIVERABLE);
+        counterService.increment(getPrefix() + MESSAGES + mergeAsMetric(resourceId,tenantId) + UNDELIVERABLE);
     }
 
+    void incrementMqttConnections(final String tenantId) {
+        counterService.increment(getPrefix() + CONNECTIONS + tenantId);
+    }
+
+    void decrementMqttConnections(final String tenantId) {
+        counterService.increment(getPrefix() + CONNECTIONS + tenantId);
+    }
 }

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -363,6 +363,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
             }
         };
         adapter.setConfig(config);
+        adapter.setMetrics(new MqttAdapterMetrics());
         adapter.setHonoMessagingClient(messagingClient);
         adapter.setRegistrationServiceClient(registrationClient);
         adapter.setCredentialsAuthProvider(credentialsAuthProvider);

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
@@ -29,28 +29,6 @@ import io.vertx.mqtt.messages.MqttPublishMessage;
  */
 public final class VertxBasedMqttProtocolAdapter extends AbstractVertxBasedMqttProtocolAdapter<ProtocolAdapterProperties> {
 
-    private MqttAdapterMetrics metrics;
-
-    /**
-     * Sets the metrics for this service
-     *
-     * @param metrics The metrics
-     */
-    @Autowired
-    public final void setMetrics(final MqttAdapterMetrics metrics) {
-        this.metrics = metrics;
-    }
-
-    @Override
-    protected void onMessageSent(final ResourceIdentifier downstreamAddress) {
-        metrics.incrementProcessedMqttMessages(downstreamAddress.getEndpoint(), downstreamAddress.getTenantId());
-    }
-
-    @Override
-    protected void onMessageUndeliverable(final ResourceIdentifier downstreamAddress) {
-        metrics.incrementUndeliverableMqttMessages(downstreamAddress.getEndpoint(), downstreamAddress.getTenantId());
-    }
-
     @Override
     protected Future<Message> getDownstreamMessage(final MqttPublishMessage messageFromDevice) {
 

--- a/example/src/main/config/influxdb.conf
+++ b/example/src/main/config/influxdb.conf
@@ -91,15 +91,10 @@ bind-address = ":8088"
     "*.gauge.hono.messaging.link.downstream.credits.* host.measurement.measurement.measurement.measurement.measurement.measurement.type.tenant",
     "*.counter.hono.messaging.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
     "*.meter.hono.messaging.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
-    # hono http adapter
-    "*.counter.hono.http.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
-    "*.meter.hono.http.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
-    # hono mqtt adapter
-    "*.counter.hono.mqtt.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
-    "*.meter.hono.mqtt.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
-    # hono Kura adapter
-    "*.counter.hono.kura.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
-    "*.meter.hono.kura.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
+    # hono adapters
+    "*.counter.hono.*.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
+    "*.meter.hono.*.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
+    "*.counter.hono.*.connections.* host.measurement.measurement.measurement.measurement.tenant.measurement*",
     # default template
     "host.measurement*"
   ]

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MetricConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MetricConfig.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -66,7 +67,7 @@ public class MetricConfig {
 
     @Bean
     @ConditionalOnProperty(prefix = "hono.metric.jvm", name = "memory", havingValue = "true")
-    public MemoryUsageGaugeSet jvmMetricsMemory(final MetricRegistry metricRegistry) {
+    public MemoryUsageGaugeSet jvmMetricsMemory() {
         LOG.info("metrics - jvm/memory activated");
         return metricRegistry.register(prefix + ".jvm.memory", new MemoryUsageGaugeSet());
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -35,6 +35,7 @@ abstract public class Metrics {
     protected static final String PROCESSED     = ".processed";
     protected static final String DISCARDED     = ".discarded";
     protected static final String UNDELIVERABLE = ".undeliverable";
+    protected static final String CONNECTIONS   = ".connections.";
 
     protected GaugeService   gaugeService   = NullGaugeService.getInstance();
     protected CounterService counterService = NullCounterService.getInstance();
@@ -76,11 +77,22 @@ abstract public class Metrics {
         this.counterService = counterService;
     }
 
+    /**
+     * Replaces '/' with '.' to transform e.g. <code>telemetry/DEFAULT_TENANT</code> to <code>telemetry.DEFAULT_TENANT</code>
+     *
+     * @param address The address with slashes to transform in an address with points
+     * @return The address with points
+     */
     protected String normalizeAddress(final String address) {
         Objects.requireNonNull(address);
         return address.replace('/', '.');
     }
 
+    /**
+     * Merge the given address parts as a full string, seperated by '.'
+     * @param parts The address parts
+     * @return The full address, separated by points
+     */
     protected String mergeAsMetric(final String... parts ) {
         return String.join(".",parts);
     }


### PR DESCRIPTION
- Use common template for tagging protocol adapter metrics in influxDB
- Add number of connected devices metric to MQTT adapter
