### PR TITLE
Print out a warning when the connection could not be established

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/CredentialsApiAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/CredentialsApiAuthProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 
 package org.eclipse.hono.service.auth.device;
@@ -114,7 +115,13 @@ public abstract class CredentialsApiAuthProvider implements HonoClientBasedAuthP
         } else {
             credentialsClient.connect(
                     createClientOptions(),
-                    connectAttempt -> log.info("connected to Credentials service"),
+                    connectAttempt -> {
+                        if (connectAttempt.failed()) {
+                            log.warn("connection to Credentials service failed", connectAttempt.cause());
+                        } else {
+                            log.info("connected to Credentials service");
+                        }
+                    },
                     this::onDisconnectCredentialsService);
         }
     }


### PR DESCRIPTION
When the handler gets called it is not clear if the connection was indeed successful.
This change actually checks the result and does print out a warning if it wasn't.