### PR TITLE
De-duplicate code in JwtHelper derived classes

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/JwtHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/JwtHelper.java
@@ -28,7 +28,12 @@ import org.eclipse.hono.config.SignatureSupportingConfigProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SigningKeyResolverAdapter;
 import io.vertx.core.Vertx;
 
 /**
@@ -39,7 +44,8 @@ public abstract class JwtHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(JwtHelper.class);
 
-    private static final Key DUMMY_KEY = new SecretKeySpec(new byte[]{ 0x00,  0x01 }, SignatureAlgorithm.HS256.getJcaName());
+    private static final Key DUMMY_KEY = new SecretKeySpec(new byte[] { 0x00, 0x01 },
+            SignatureAlgorithm.HS256.getJcaName());
     private final Vertx vertx;
 
     /**
@@ -75,8 +81,7 @@ public abstract class JwtHelper {
     }
 
     /**
-     * Sets the secret to use for signing tokens asserting the
-     * registration status of devices.
+     * Sets the secret to use for signing tokens asserting the registration status of devices.
      * 
      * @param secret The secret to use.
      * @throws NullPointerException if secret is {@code null}.
@@ -91,8 +96,8 @@ public abstract class JwtHelper {
     }
 
     /**
-     * Sets the path to a PKCS8 PEM file containing the RSA private key to use for signing tokens
-     * asserting the registration status of devices.
+     * Sets the path to a PKCS8 PEM file containing the RSA private key to use for signing tokens asserting the
+     * registration status of devices.
      * 
      * @param keyPath The absolute path to the file.
      * @throws NullPointerException if the path is {@code null}.
@@ -108,8 +113,8 @@ public abstract class JwtHelper {
     }
 
     /**
-     * Sets the path to a PEM file containing a certificate holding a public key to use for validating the
-     * signature of tokens asserting the registration status of devices.
+     * Sets the path to a PEM file containing a certificate holding a public key to use for validating the signature of
+     * tokens asserting the registration status of devices.
      * 
      * @param keyPath The absolute path to the file.
      * @throws NullPointerException if the path is {@code null}.
@@ -125,12 +130,10 @@ public abstract class JwtHelper {
     }
 
     /**
-     * Gets the duration being used for calculating the <em>exp</em> claim of tokens
-     * created by this class.
+     * Gets the duration being used for calculating the <em>exp</em> claim of tokens created by this class.
      * <p>
-     * Clients should always check if a token is expired before using any information
-     * contained in the token.
-     *  
+     * Clients should always check if a token is expired before using any information contained in the token.
+     * 
      * @return The duration.
      */
     public final Duration getTokenLifetime() {
@@ -185,7 +188,8 @@ public abstract class JwtHelper {
         final AtomicReference<Date> result = new AtomicReference<>();
 
         try {
-            Jwts.parser().setSigningKeyResolver(new SigningKeyResolverAdapter(){
+            Jwts.parser().setSigningKeyResolver(new SigningKeyResolverAdapter() {
+
                 @SuppressWarnings("rawtypes")
                 @Override
                 public Key resolveSigningKey(JwsHeader header, Claims claims) {
@@ -219,7 +223,8 @@ public abstract class JwtHelper {
         return result;
     }
 
-    protected static <T extends JwtHelper> T forSigning(final SignatureSupportingConfigProperties config, final Supplier<T> instanceSupplier) {
+    protected static <T extends JwtHelper> T forSigning(final SignatureSupportingConfigProperties config,
+            final Supplier<T> instanceSupplier) {
 
         Objects.requireNonNull(config);
         Objects.requireNonNull(instanceSupplier);
@@ -241,7 +246,8 @@ public abstract class JwtHelper {
         }
     }
 
-    protected static <T extends JwtHelper> T forValidating(final SignatureSupportingConfigProperties config, final Supplier<T> instanceSupplier) {
+    protected static <T extends JwtHelper> T forValidating(final SignatureSupportingConfigProperties config,
+            final Supplier<T> instanceSupplier) {
 
         Objects.requireNonNull(config);
         Objects.requireNonNull(instanceSupplier);

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/AuthTokenHelperImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/AuthTokenHelperImpl.java
@@ -27,7 +27,6 @@ import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.vertx.core.Vertx;
 
-
 /**
  * A helper for creating and validating JSON Web Tokens containing user claims.
  *

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/AuthTokenHelperImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/AuthTokenHelperImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,11 +8,11 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 
 package org.eclipse.hono.service.auth;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Objects;
@@ -20,8 +20,6 @@ import java.util.Objects;
 import org.eclipse.hono.auth.Authorities;
 import org.eclipse.hono.config.SignatureSupportingConfigProperties;
 import org.eclipse.hono.util.JwtHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -35,8 +33,6 @@ import io.vertx.core.Vertx;
  *
  */
 public class AuthTokenHelperImpl extends JwtHelper implements AuthTokenHelper {
-
-    private static final Logger LOG = LoggerFactory.getLogger(AuthTokenHelperImpl.class);
 
     private AuthTokenHelperImpl() {
         this(null);
@@ -56,22 +52,9 @@ public class AuthTokenHelperImpl extends JwtHelper implements AuthTokenHelper {
      * @throws IllegalArgumentException if the key material cannot be determined from config.
      */
     public static AuthTokenHelper forSigning(final Vertx vertx, final SignatureSupportingConfigProperties config) {
-        Objects.requireNonNull(config);
-        if (!config.isAppropriateForCreating()) {
-            throw new IllegalArgumentException("configuration does not specify any signing key material");
-        } else {
-            AuthTokenHelperImpl result = new AuthTokenHelperImpl(vertx);
-            result.tokenLifetime = Duration.ofSeconds(config.getTokenExpiration());
-            if (config.getSharedSecret() != null) {
-                byte[] secret = getBytes(config.getSharedSecret());
-                result.setSharedSecret(secret);
-                LOG.info("using shared secret [{} bytes] for signing JWTs", secret.length);
-            } else if (config.getKeyPath() != null) {
-                result.setPrivateKey(config.getKeyPath());
-                LOG.info("using private key [{}] for signing JWTs", config.getKeyPath());
-            }
-            return result;
-        }
+
+        return JwtHelper.forSigning(config, () -> new AuthTokenHelperImpl(vertx));
+
     }
 
     /**
@@ -84,21 +67,9 @@ public class AuthTokenHelperImpl extends JwtHelper implements AuthTokenHelper {
      * @throws IllegalArgumentException if the key material cannot be determined from config.
      */
     public static AuthTokenHelper forValidating(final Vertx vertx, final SignatureSupportingConfigProperties config) {
-        Objects.requireNonNull(config);
-        if (!config.isAppropriateForValidating()) {
-            throw new IllegalArgumentException("configuration does not specify any key material for validating signatures");
-        } else {
-            AuthTokenHelperImpl result = new AuthTokenHelperImpl(vertx);
-            if (config.getSharedSecret() != null) {
-                byte[] secret = getBytes(config.getSharedSecret());
-                result.setSharedSecret(secret);
-                LOG.info("using shared secret [{} bytes] for validating JWT signatures", secret.length);
-            } else if (config.getCertPath() != null) {
-                result.setPublicKey(config.getCertPath());
-                LOG.info("using public key from certificate [{}] for validating JWT signatures", config.getCertPath());
-            }
-            return result;
-        }
+
+        return JwtHelper.forValidating(config, () -> new AuthTokenHelperImpl(vertx));
+
     }
 
     /**
@@ -110,11 +81,9 @@ public class AuthTokenHelperImpl extends JwtHelper implements AuthTokenHelper {
      * @throws NullPointerException if sharedSecret is {@code null}.
      */
     public static AuthTokenHelper forSharedSecret(final String sharedSecret, final long tokenExpirationSeconds) {
-        Objects.requireNonNull(sharedSecret);
-        AuthTokenHelperImpl result = new AuthTokenHelperImpl();
-        result.setSharedSecret(getBytes(sharedSecret));
-        result.tokenLifetime = Duration.ofSeconds(tokenExpirationSeconds);
-        return result;
+
+        return JwtHelper.forSharedSecret(sharedSecret, tokenExpirationSeconds, AuthTokenHelperImpl::new);
+
     }
 
     @Override

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImpl.java
@@ -106,11 +106,11 @@ public final class RegistrationAssertionHelperImpl extends JwtHelper implements 
 
         try {
             Jwts.parser()
-                .setSigningKey(key)
-                .requireSubject(Objects.requireNonNull(deviceId))
-                .require("ten", Objects.requireNonNull(tenantId))
-                .setAllowedClockSkewSeconds(10)
-                .parse(token);
+                    .setSigningKey(key)
+                    .requireSubject(Objects.requireNonNull(deviceId))
+                    .require("ten", Objects.requireNonNull(tenantId))
+                    .setAllowedClockSkewSeconds(10)
+                    .parse(token);
             return true;
         } catch (JwtException e) {
             // token is invalid for some reason


### PR DESCRIPTION
This change does pull up common code from JwtHelper derived classes back into JwtHelper.