### PR TITLE
Add code check validation with checkstyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **/.classpath
 **/.project
 **/.settings/
+.checkstyle

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpProtocolAdapterProperties.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpProtocolAdapterProperties.java
@@ -42,7 +42,6 @@ public class HttpProtocolAdapterProperties extends ProtocolAdapterProperties {
         return regAssertionEnabled;
     }
 
-    
     /**
      * Sets whether the adapter should return a token to devices asserting the device's
      * registration status.
@@ -55,7 +54,6 @@ public class HttpProtocolAdapterProperties extends ProtocolAdapterProperties {
         this.regAssertionEnabled = regAssertionEnabled;
     }
 
-    
     /**
      * Gets the name of the realm that unauthenticated devices are prompted to provide credentials for.
      * <p>
@@ -70,8 +68,6 @@ public class HttpProtocolAdapterProperties extends ProtocolAdapterProperties {
         return realm;
     }
 
-
-    
     /**
      * Sets the name of the realm that unauthenticated devices are prompted to provide credentials for.
      * <p>

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/KuraAdapterProperties.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/KuraAdapterProperties.java
@@ -51,7 +51,6 @@ public class KuraAdapterProperties extends ProtocolAdapterProperties {
         return controlPrefix;
     }
 
-    
     /**
      * Sets the <em>topic.control-prefix</em> to use for determining if a message published
      * by a Kura gateway is a <em>control</em> message.

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -323,7 +323,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
                         onAuthenticationSuccess(endpoint, authenticatedDevice);
                     }
                 });
-                
+
             }
         }
     }

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -82,6 +82,10 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -71,6 +71,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
         <!-- 
           Copy legal documents from "legal" module to "target/classes" folder
           so that we make sure to include legal docs in all modules.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -70,6 +70,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
         <!-- 
           Copy legal documents from "legal" module to "target/classes" folder
           so that we make sure to include legal docs in all modules.

--- a/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
@@ -66,7 +66,6 @@ public class ProtocolAdapterProperties extends ServiceConfigProperties {
         return jmsVendorPropsEnabled;
     }
 
-    
     /**
      * Sets if the adapter should include <em>Vendor Properties</em> as defined by <a
      * href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">

--- a/core/src/main/java/org/eclipse/hono/util/AmqpErrorException.java
+++ b/core/src/main/java/org/eclipse/hono/util/AmqpErrorException.java
@@ -51,7 +51,6 @@ public final class AmqpErrorException extends RuntimeException {
         this.error = Symbol.getSymbol(Objects.requireNonNull(error));
     }
 
-    
     /**
      * Gets the AMQP error conveyed in this exception.
      * 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -146,6 +146,10 @@ Also contains scripts for deploying a Hono instance to a Docker Swarm, a Kuberne
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
         <!-- 
           Copy legal documents from "legal" module to "target/classes" folder
           so that we make sure to include legal docs in all modules.

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoSenderBase.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoSenderBase.java
@@ -1,16 +1,13 @@
 package org.eclipse.hono.vertx.example.base;
 
-import io.vertx.core.*;
-import io.vertx.proton.ProtonClientOptions;
-import io.vertx.proton.ProtonDelivery;
-import org.apache.qpid.proton.amqp.messaging.Accepted;
-import org.eclipse.hono.client.HonoClient;
-import org.eclipse.hono.client.RegistrationClient;
-import org.eclipse.hono.client.impl.HonoClientImpl;
-import org.eclipse.hono.client.MessageSender;
-import org.eclipse.hono.connection.ConnectionFactoryImpl;
-import org.eclipse.hono.util.RegistrationConstants;
-import org.eclipse.hono.util.RegistrationResult;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.eclipse.hono.vertx.example.base.HonoExampleConstants.DEVICE_ID;
+import static org.eclipse.hono.vertx.example.base.HonoExampleConstants.HONO_MESSAGING_HOST;
+import static org.eclipse.hono.vertx.example.base.HonoExampleConstants.HONO_MESSAGING_PORT;
+import static org.eclipse.hono.vertx.example.base.HonoExampleConstants.HONO_REGISTRY_HOST;
+import static org.eclipse.hono.vertx.example.base.HonoExampleConstants.HONO_REGISTRY_PORT;
+import static org.eclipse.hono.vertx.example.base.HonoExampleConstants.TENANT_ID;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,9 +17,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.stream.IntStream;
 
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
-import static java.net.HttpURLConnection.HTTP_OK;
-import static org.eclipse.hono.vertx.example.base.HonoExampleConstants.*;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.MessageSender;
+import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.impl.HonoClientImpl;
+import org.eclipse.hono.connection.ConnectionFactoryImpl;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.eclipse.hono.util.RegistrationResult;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonClientOptions;
+import io.vertx.proton.ProtonDelivery;
 
 /**
  * Example base class for sending data to Hono.

--- a/jmeter/pom.xml
+++ b/jmeter/pom.xml
@@ -48,6 +48,10 @@
           </descriptorRefs>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSenderSamplerUI.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSenderSamplerUI.java
@@ -12,7 +12,7 @@
 
 package org.eclipse.hono.jmeter.ui;
 
-import javax.swing.*;
+import javax.swing.JCheckBox;
 
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jorphan.gui.JLabeledTextArea;

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoServerOptionsPanel.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoServerOptionsPanel.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.hono.jmeter.ui;
 
-import javax.swing.*;
+import javax.swing.BorderFactory;
 
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jorphan.gui.JLabeledTextField;

--- a/legal/pom.xml
+++ b/legal/pom.xml
@@ -16,6 +16,9 @@
         <directory>legal</directory>
         <filtering>true</filtering>
       </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
     </resources>
   </build>
   <properties>

--- a/legal/src/main/resources/checkstyle/default.xml
+++ b/legal/src/main/resources/checkstyle/default.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+    Copyright (c) 2018 Red Hat Inc and others.
+
+    All rights reserved. This program and the accompanying materials 
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Red Hat Inc - initial API and implementation and initial documentation
+-->
+
+<module name="Checker">
+
+  <!-- suppression file -->
+
+  <module name="SuppressionFilter">
+    <property name="file" value="${checkstyle.suppressions.file}" />
+    <property name="optional" value="false" />
+  </module>
+
+  <module name="TreeWalker">
+
+    <!-- imports -->
+
+    <module name="AvoidStarImport">
+      <property name="allowStaticMemberImports" value="true"/>
+    </module>
+
+    <module name="UnusedImports" />
+
+    <!-- possible issues -->
+
+    <module name="OneStatementPerLine" />
+    <module name="StringLiteralEquality" />
+
+    <!-- whitespaces, linebreaks -->
+
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="^\s+$" />
+      <property name="message" value="Empty lines must not contain whitespaces" />
+    </module>
+
+  </module>
+
+  <!-- only spaces, no tabs -->
+
+  <module name="FileTabCharacter" />
+
+</module>

--- a/legal/src/main/resources/checkstyle/suppressions.xml
+++ b/legal/src/main/resources/checkstyle/suppressions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<!--
+    Copyright (c) 2018 Red Hat Inc and others.
+
+    All rights reserved. This program and the accompanying materials 
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+    
+    Contributors:
+        Red Hat Inc - initial API and implementation and initial documentation
+-->
+
+<suppressions>
+  <suppress checks="FileTabCharacter" files=".*\.sasldb" />
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
               <configuration>
                 <includeArtifactIds>hono-legal</includeArtifactIds>
                 <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
-                <excludes>META-INF/**</excludes>
+                <excludes>META-INF/**,checkstyle/**</excludes>
               </configuration>
             </execution>
           </executions>
@@ -363,6 +363,39 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <!--
+            we need to stick to 2.17 as long as m2eclipse checkstyle is
+            not updated to support 3.0.0
+            -->
+          <version>2.17</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.eclipse.hono</groupId>
+              <artifactId>hono-legal</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>7.6.1</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <id>checkstyle-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <configLocation>checkstyle/default.xml</configLocation>
+            <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -449,6 +482,7 @@
           <autoReleaseAfterClose>false</autoReleaseAfterClose>
         </configuration>
       </plugin>
+
     </plugins>
   </build>
 

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractApplication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractApplication.java
@@ -34,7 +34,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 
-import io.vertx.core.*;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 
 /**
  * A base class for implementing Spring Boot applications.

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/BaseAuthorizationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/BaseAuthorizationService.java
@@ -64,7 +64,6 @@ public abstract class BaseAuthorizationService extends AbstractVerticle implemen
         this.config = Objects.requireNonNull(props);
     }
 
-    
     /**
      * Gets the service configuration properties.
      * 

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
@@ -368,7 +368,7 @@ public abstract class BaseCredentialsService<T> extends ConfigurationSupportingV
         Objects.requireNonNull(payload);
         Objects.requireNonNull(field);
         Objects.requireNonNull(type);
-        
+
         final Object value = payload.getValue(field);
         if (type.isInstance(value)) {
             return (T) value;

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
@@ -222,7 +222,6 @@ public final class FileBasedRegistrationService extends BaseRegistrationService<
                     return (Void) null;
                 });
             });
-            
         } else {
             log.trace("registry does not need to be persisted");
             return Future.succeededFuture();

--- a/services/messaging/src/test/resources/logging.properties
+++ b/services/messaging/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 ############################################################
-#  	Default Logging Configuration File
+#  Default Logging Configuration File
 #
 # You can use a different file by specifying a filename
 # with the java.util.logging.config.file system property.  
@@ -7,7 +7,7 @@
 ############################################################
 
 ############################################################
-#  	Global properties
+#  Global properties
 ############################################################
 
 # "handlers" specifies a comma separated list of log Handler 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -79,6 +79,10 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -81,6 +81,15 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>run-tests</id>


### PR DESCRIPTION
This PR works on automatic code style validation with checkstyle.

The initial changes add a global checkstyle validation on all hono projects by adding the checkstyle plugin in a multi-module setup. Failing the build when violations are found.

This change only introduces a very limited check set in order to focus on the integration of checkstyle and not on fixing code issues. Fixing code issues would be the next step.

The setup is compatible with Eclipse Checkstyle and the M2Eclipse integration. Saving a file in Eclipse automatically triggers the validation and shows error markers right away.

The validation consists of two major elements. A new module containing the checks (`hono-code-style`) and the execution of the `checkstyle-maven-plugin`. The latter part is currently added to the `hono-bom` module, which is technically fine, but not optimal. As the execution of `maven-checkstyle-plugin` creates a dependency on the `hono-code-style` module it is not possible to simply add the plugin configuration to the `hono-parent` module. This would create a circular dependency.

It would be possible to create a derived module of `hono-bom` and change all hono modules to inherit from this module instead. Reverting `hono-bom` to providing only the "bill of material".