### PR TITLE
Add caching of registration responses in HonoClient.

### DIFF
--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/Config.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/Config.java
@@ -13,6 +13,7 @@
 package org.eclipse.hono.adapter.http.vertx;
 
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
@@ -44,21 +45,21 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeMessagingClientConfigProperties(final ClientConfigProperties props) {
+    protected void customizeMessagingClientConfig(final ClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
         }
     }
 
     @Override
-    protected void customizeRegistrationServiceClientConfigProperties(final ClientConfigProperties props) {
+    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
         }
     }
 
     @Override
-    protected void customizeCredentialsServiceClientConfigProperties(final ClientConfigProperties props) {
+    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
         }

--- a/adapters/http-vertx/src/main/resources/logback-spring.xml
+++ b/adapters/http-vertx/src/main/resources/logback-spring.xml
@@ -18,6 +18,7 @@
   <springProfile name="dev">
     <logger name="org.eclipse.hono.adapter" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="TRACE"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
     <logger name="org.eclipse.hono.service.auth.device" level="DEBUG"/>
   </springProfile>

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/Config.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/Config.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.adapter.kura;
 
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
@@ -44,21 +45,21 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeMessagingClientConfigProperties(final ClientConfigProperties props) {
+    protected void customizeMessagingClientConfig(final ClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_KURA_ADAPTER);
         }
     }
 
     @Override
-    protected void customizeRegistrationServiceClientConfigProperties(final ClientConfigProperties props) {
+    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_KURA_ADAPTER);
         }
     }
 
     @Override
-    protected void customizeCredentialsServiceClientConfigProperties(final ClientConfigProperties props) {
+    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_KURA_ADAPTER);
         }

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 Red Hat and others.
+ * Copyright (c) 2016, 2018 Red Hat and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.adapter.mqtt.impl;
 
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
@@ -45,21 +46,21 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeMessagingClientConfigProperties(final ClientConfigProperties props) {
+    protected void customizeMessagingClientConfig(final ClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
         }
     }
 
     @Override
-    protected void customizeRegistrationServiceClientConfigProperties(final ClientConfigProperties props) {
+    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
         }
     }
 
     @Override
-    protected void customizeCredentialsServiceClientConfigProperties(final ClientConfigProperties props) {
+    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
         }

--- a/adapters/mqtt-vertx/src/main/resources/logback-spring.xml
+++ b/adapters/mqtt-vertx/src/main/resources/logback-spring.xml
@@ -18,6 +18,7 @@
   <springProfile name="dev">
     <logger name="org.eclipse.hono.adapter" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="TRACE"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
     <logger name="org.eclipse.hono.service.auth.device" level="DEBUG"/>
   </springProfile>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016 Bosch Software Innovations GmbH.
+    Copyright (c) 2016, 2018 Bosch Software Innovations GmbH.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -34,6 +34,7 @@
     <dispatch-router.image.name>enmasseproject/qdrouterd-base:0.8.0-1</dispatch-router.image.name>
     <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
     <grafana.version>4.2.0</grafana.version>
+    <guava.version>19.0</guava.version>
     <influxdb.version>1.2.4-alpine</influxdb.version>
     <jackson.version>2.9.0</jackson.version>
     <java-base-image.name>openjdk:8-jre-alpine</java-base-image.name>
@@ -296,6 +297,11 @@
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-dispatch-router</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/client/src/main/java/org/eclipse/hono/client/RequestResponseClientConfigProperties.java
+++ b/client/src/main/java/org/eclipse/hono/client/RequestResponseClientConfigProperties.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.client;
+
+import org.eclipse.hono.config.ClientConfigProperties;
+
+
+/**
+ * Configuration properties for clients invoking request/response operations
+ * on Hono's service APIs.
+ *
+ */
+public class RequestResponseClientConfigProperties extends ClientConfigProperties {
+
+    /**
+     * The default minimum size of response caches.
+     */
+    public static final int DEFAULT_RESPONSE_CACHE_MIN_SIZE = 100;
+    /**
+     * The default maximum size of response caches.
+     */
+    public static final long DEFAULT_RESPONSE_CACHE_MAX_SIZE = 1000L;
+
+    private int responseCacheMinSize = DEFAULT_RESPONSE_CACHE_MIN_SIZE;
+    private long responseCacheMaxSize = DEFAULT_RESPONSE_CACHE_MAX_SIZE;
+
+    /**
+     * Gets the minimum size of the response cache.
+     * <p>
+     * The cache will be initialized with this size upon creation.
+     * <p>
+     * The default value is {@link #DEFAULT_RESPONSE_CACHE_MIN_SIZE}.
+     * 
+     * @return The maximum number of results to keep in the cache.
+     */
+    public final int getResponseCacheMinSize() {
+        return responseCacheMinSize;
+    }
+
+    /**
+     * Sets the minimum size of the response cache.
+     * <p>
+     * The cache will be initialized with this size upon creation.
+     * <p>
+     * The default value is {@link #DEFAULT_RESPONSE_CACHE_MIN_SIZE}.
+     * 
+     * @param size The maximum number of results to keep in the cache.
+     */
+    public final void setResponseCacheMinSize(int size) {
+        this.responseCacheMinSize = size;
+    }
+
+    /**
+     * Gets the maximum size of the response cache.
+     * <p>
+     * Once the maximum number of entries is reached, the cache applies
+     * an implementation specific policy for handling new entries that
+     * are be put to the cache.
+     * <p>
+     * The default value is {@link #DEFAULT_RESPONSE_CACHE_MAX_SIZE}.
+     * 
+     * @return The maximum number of results to keep in the cache.
+     */
+    public final long getResponseCacheMaxSize() {
+        return responseCacheMaxSize;
+    }
+
+    /**
+     * Sets the maximum size of the response cache.
+     * <p>
+     * Once the maximum number of entries is reached, the cache applies
+     * an implementation specific policy for handling new entries that
+     * are be put to the cache.
+     * <p>
+     * The default value is {@link #DEFAULT_RESPONSE_CACHE_MAX_SIZE}.
+     * 
+     * @param size The maximum number of results to keep in the cache.
+     */
+    public final void setResponseCacheMaxSize(long size) {
+        this.responseCacheMaxSize = size;
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/RequestResponseClientConfigProperties.java
+++ b/client/src/main/java/org/eclipse/hono/client/RequestResponseClientConfigProperties.java
@@ -66,7 +66,7 @@ public class RequestResponseClientConfigProperties extends ClientConfigPropertie
      * <p>
      * Once the maximum number of entries is reached, the cache applies
      * an implementation specific policy for handling new entries that
-     * are be put to the cache.
+     * are put to the cache.
      * <p>
      * The default value is {@link #DEFAULT_RESPONSE_CACHE_MAX_SIZE}.
      * 
@@ -81,7 +81,7 @@ public class RequestResponseClientConfigProperties extends ClientConfigPropertie
      * <p>
      * Once the maximum number of entries is reached, the cache applies
      * an implementation specific policy for handling new entries that
-     * are be put to the cache.
+     * are put to the cache.
      * <p>
      * The default value is {@link #DEFAULT_RESPONSE_CACHE_MAX_SIZE}.
      * 

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -12,6 +12,7 @@
 package org.eclipse.hono.client.impl;
 
 import java.net.HttpURLConnection;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -23,6 +24,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.RequestResponseClient;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.util.ExpiringValueCache;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RequestResponseApiConstants;
 import org.eclipse.hono.util.RequestResponseResult;
@@ -60,6 +62,11 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
     private final String replyToAddress;
     private final String targetAddress;
 
+    /**
+     * A cache to use for responses received from the service.
+     */
+    private ExpiringValueCache responseCache;
+
     private long requestTimeoutMillis = DEFAULT_TIMEOUT_MILLIS;
 
     /**
@@ -93,6 +100,15 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
         this(context, config, tenantId);
         this.sender = Objects.requireNonNull(sender);
         this.receiver = Objects.requireNonNull(receiver);
+    }
+
+    /**
+     * Sets a cache for results received from the service.
+     * 
+     * @param cache The cache or {@code null} if no results should be cached.
+     */
+    public final void setResultCache(final ExpiringValueCache cache) {
+        this.responseCache = cache;
     }
 
     /**
@@ -150,6 +166,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
      * @param con The AMQP 1.0 connection to the peer.
      * @return A future indicating the outcome. The future will succeed if the links
      *         have been created.
+     * @throws NullPointerException if con is {@code null}.
      */
     protected final Future<Void> createLinks(final ProtonConnection con) {
         return createLinks(con, null, null);
@@ -164,6 +181,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
      * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly.
      * @return A future indicating the outcome. The future will succeed if the links
      *         have been created.
+     * @throws NullPointerException if con is {@code null}.
      */
     protected final Future<Void> createLinks(final ProtonConnection con, final Handler<String> senderCloseHook, final Handler<String> receiverCloseHook) {
         Future<Void> result = Future.future();
@@ -389,4 +407,46 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
         closeLinks(closeHandler);
     }
 
+    /**
+     * Checks if this client supports caching of results.
+     * 
+     * @return {@code true} if caching is supported.
+     */
+    protected final boolean isCachingEnabled() {
+        return responseCache != null;
+    }
+
+    /**
+     * Gets a response from the cache.
+     * 
+     * @param key The key to get the response for.
+     * @return The value or {@code null} if no response exists for the key
+     *         or the response is expired.
+     */
+    protected final R getResponseFromCache(final String key) {
+
+        if (responseCache == null) {
+            return null;
+        } else {
+            return responseCache.get(key);
+        }
+    }
+
+    /**
+     * Adds a response to the cache.
+     * 
+     * @param key The key to store the value under.
+     * @param response The response to cache. Any existing response for the key will be replaced.
+     * @param expirationTime The time after which the response should be considered invalid.
+     * @throws IllegalArgumentException if the current time is not before the expiration time.
+     * @throws IllegalStateException if no cache has been configured.
+     */
+    protected final void putResponseToCache(final String key, final R response, final Instant expirationTime) {
+
+        if (responseCache == null) {
+            throw new IllegalStateException("no cache configured");
+        } else {
+            responseCache.put(key, response, expirationTime);
+        }
+    }
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,12 +8,14 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Bosch Software Innovations GmbH - add caching of results
  */
 
 package org.eclipse.hono.client.impl;
 
 import static org.eclipse.hono.util.RegistrationConstants.*;
 
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -21,11 +23,15 @@ import java.util.UUID;
 
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.util.JwtHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.RegistrationResult;
+import org.eclipse.hono.util.SpringBasedExpiringValueCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -33,6 +39,8 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
 
 /**
  * A Vertx-Proton based client for Hono's Registration API.
@@ -42,9 +50,15 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
 
     private static final Logger LOG = LoggerFactory.getLogger(RegistrationClientImpl.class);
 
-    private RegistrationClientImpl(final Context context, final ClientConfigProperties config, final String tenantId) {
+    RegistrationClientImpl(final Context context, final ClientConfigProperties config, final String tenantId) {
 
         super(context, config, tenantId);
+    }
+
+    RegistrationClientImpl(final Context context, final ClientConfigProperties config, final String tenantId,
+            final ProtonSender sender, final ProtonReceiver receiver) {
+
+        super(context, config, tenantId, sender, receiver);
     }
 
     /**
@@ -81,16 +95,19 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      * 
      * @param context The vert.x context to run all interactions with the server on.
      * @param clientConfig The configuration properties to use.
+     * @param cacheManager A factory for cache instances for registration results. If {@code null}
+     *                     the client will not cache any results from the Device Registration service.
      * @param con The AMQP connection to the server.
      * @param tenantId The tenant to consumer events for.
      * @param senderCloseHook A handler to invoke if the peer closes the sender link unexpectedly.
      * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly.
      * @param creationHandler The handler to invoke with the outcome of the creation attempt.
-     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws NullPointerException if any of the parameters other than cache manager is {@code null}.
      */
     public static void create(
             final Context context,
             final ClientConfigProperties clientConfig,
+            final CacheManager cacheManager,
             final ProtonConnection con,
             final String tenantId,
             final Handler<String> senderCloseHook,
@@ -99,6 +116,10 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
 
         LOG.debug("creating new registration client for [{}]", tenantId);
         final RegistrationClientImpl client = new RegistrationClientImpl(context, clientConfig, tenantId);
+        if (cacheManager != null) {
+            final Cache cache = cacheManager.getCache(RegistrationClientImpl.getTargetAddress(tenantId));
+            client.setResultCache(new SpringBasedExpiringValueCache(cache));
+        }
         client.createLinks(con, senderCloseHook, receiverCloseHook).setHandler(s -> {
             if (s.succeeded()) {
                 LOG.debug("successfully created registration client for [{}]", tenantId);
@@ -171,8 +192,36 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      */
     @Override
     public void assertRegistration(final String deviceId, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(resultHandler);
-        createAndSendRequest(ACTION_ASSERT, createDeviceIdProperties(deviceId), null, resultHandler);
+
+        final String key = "assert-" + deviceId;
+        getCachedRegistrationAssertion(key).recover(t -> {
+            final Future<RegistrationResult> regResult = Future.future();
+            createAndSendRequest(ACTION_ASSERT, createDeviceIdProperties(deviceId), null, regResult.completer());
+            return regResult.map(response -> {
+                switch(response.getStatus()) {
+                case HttpURLConnection.HTTP_OK:
+                    if (isCachingEnabled()) {
+                        final String token = response.getPayload().getString(RegistrationConstants.FIELD_ASSERTION);
+                        putResponseToCache(key, response, JwtHelper.getExpiration(token).toInstant());
+                    }
+                default:
+                    return response;
+                }
+            });
+        }).setHandler(resultHandler);
+
+    }
+
+    private Future<RegistrationResult> getCachedRegistrationAssertion(final String key) {
+
+        final RegistrationResult result = getResponseFromCache(key);
+        if (result == null) {
+            return Future.failedFuture("cache miss");
+        } else {
+            return Future.succeededFuture(result);
+        }
     }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,9 +12,11 @@
 
 package org.eclipse.hono.client.impl;
 
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.util.Collections;

--- a/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientImplTest.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.client.impl;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.net.HttpURLConnection;
+import java.sql.Date;
+import java.time.Instant;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.util.ExpiringValueCache;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.eclipse.hono.util.RegistrationResult;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+
+/**
+ * Tests verifying behavior of {@link RegistrationClientImpl}.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class RegistrationClientImplTest {
+
+    /**
+     * Time out test cases after 5 seconds.
+     */
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(5);
+
+    private RegistrationClientImpl client;
+    private ExpiringValueCache cache;
+    private ProtonSender sender;
+    private ProtonReceiver receiver;
+
+    /**
+     * Sets up the fixture.
+     */
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() {
+
+        final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
+        final Vertx vertx = mock(Vertx.class);
+
+        final Context context = mock(Context.class);
+        when(context.owner()).thenReturn(vertx);
+        doAnswer(invocation -> {
+            Handler<Void> handler = invocation.getArgumentAt(0, Handler.class);
+            handler.handle(null);
+            return null;
+        }).when(context).runOnContext(any(Handler.class));
+
+        sender = mock(ProtonSender.class);
+        receiver = mock(ProtonReceiver.class);
+
+        cache = mock(ExpiringValueCache.class);
+        client = new RegistrationClientImpl(context, config, "tenant", sender, receiver);
+    }
+
+    /**
+     * Verifies that on a cache miss the adapter retrieves registration information
+     * from the Device Registration service and puts it to the cache.
+     * 
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testAssertRegistrationAddsInfoOnCacheMiss(final TestContext ctx) {
+
+        // GIVEN an adapter with an empty cache
+        client.setResultCache(cache);
+        final JsonObject registrationAssertion = newRegistrationAssertionResult();
+        final Message response = ProtonHelper.message(registrationAssertion.encode());
+        MessageHelper.addProperty(response, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        when(sender.isOpen()).thenReturn(Boolean.TRUE);
+        when(sender.send(any(Message.class))).thenReturn(mock(ProtonDelivery.class));
+        when(receiver.isOpen()).thenReturn(Boolean.TRUE);
+
+        // WHEN getting registration information
+        client.assertRegistration("device", ctx.asyncAssertSuccess(result -> {
+            // THEN the registration information has been added to the cache
+            verify(cache).put(eq("assert-device"), any(RegistrationResult.class), any(Instant.class));
+            ctx.assertEquals(registrationAssertion, result.getPayload());
+        }));
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(sender).send(messageCaptor.capture());
+        response.setCorrelationId(messageCaptor.getValue().getMessageId());
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        client.handleResponse(delivery, response);
+    }
+
+    /**
+     * Verifies that the client retrieves registration information from the
+     * Device Registration service if no cache is configured.
+     * 
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testAssertRegistrationInvokesServiceOnIfNoCacheConfigured(final TestContext ctx) {
+
+        // GIVEN an adapter with no cache configured
+        final JsonObject registrationAssertion = newRegistrationAssertionResult();
+        final Message response = ProtonHelper.message(registrationAssertion.encode());
+        MessageHelper.addProperty(response, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        when(sender.isOpen()).thenReturn(Boolean.TRUE);
+        when(sender.send(any(Message.class))).thenReturn(mock(ProtonDelivery.class));
+        when(receiver.isOpen()).thenReturn(Boolean.TRUE);
+
+        // WHEN getting registration information
+        client.assertRegistration("device", ctx.asyncAssertSuccess(result -> {
+            // THEN the registration information has been retrieved from the service
+            verify(cache, never()).put(anyString(), any(RegistrationResult.class), any(Instant.class));
+            ctx.assertEquals(registrationAssertion, result.getPayload());
+        }));
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(sender).send(messageCaptor.capture());
+        response.setCorrelationId(messageCaptor.getValue().getMessageId());
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        client.handleResponse(delivery, response);
+    }
+
+    /**
+     * Verifies that registration information is taken from cache.
+     * 
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testGetRegistrationInfoReturnsValueFromCache(final TestContext ctx) {
+
+        // GIVEN an adapter with a cache containing a registration assertion
+        // response for "device"
+        client.setResultCache(cache);
+        final JsonObject registrationAssertion = newRegistrationAssertionResult();
+        final RegistrationResult regResult = RegistrationResult.from(HttpURLConnection.HTTP_OK, registrationAssertion);
+        when(cache.get("assert-device")).thenReturn(regResult);
+
+        // WHEN getting registration information
+        client.assertRegistration("device", ctx.asyncAssertSuccess(result -> {
+            // THEN the registration information is read from the cache
+            ctx.assertEquals(regResult, result);
+            verify(sender, never()).send(any(Message.class));
+        }));
+
+    }
+
+    private static JsonObject newRegistrationAssertionResult() {
+        return newRegistrationAssertionResult(null);
+    }
+
+    private static JsonObject newRegistrationAssertionResult(final String defaultContentType) {
+
+        final String token = Jwts.builder()
+            .signWith(SignatureAlgorithm.HS256, "asecretkeywithatleastthirtytwobytes")
+            .setExpiration(Date.from(Instant.now().plusSeconds(10)))
+            .setIssuer("test")
+            .compact();
+        final JsonObject result = new JsonObject().put(RegistrationConstants.FIELD_ASSERTION, token);
+        if (defaultContentType != null) {
+            result.put(RegistrationConstants.FIELD_DEFAULTS, new JsonObject()
+                    .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, defaultContentType));
+        }
+        return result;
+    }
+
+}

--- a/core/src/main/java/org/eclipse/hono/util/BasicExpiringValue.java
+++ b/core/src/main/java/org/eclipse/hono/util/BasicExpiringValue.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A base class for implementing an expiring value.
+ *
+ * @param <T> The value type.
+ */
+public class BasicExpiringValue<T> implements ExpiringValue<T> {
+
+    private T value;
+    private Instant expirationTime;
+
+    /**
+     * Creates a new instance for a value and an expiration time.
+     * 
+     * @param value The value.
+     * @param expirationTime The instant after which the value will be considered expired.
+     */
+    public BasicExpiringValue(final T value, final Instant expirationTime) {
+        this.value = Objects.requireNonNull(value);
+        this.expirationTime = Objects.requireNonNull(expirationTime);
+    }
+
+    @Override
+    public final T getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean isExpired() {
+        return isExpired(Instant.now());
+    }
+
+    @Override
+    public boolean isExpired(final Instant now) {
+        Objects.requireNonNull(now);
+        return now.isAfter(expirationTime);
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/ExpiringValue.java
+++ b/core/src/main/java/org/eclipse/hono/util/ExpiringValue.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import java.time.Instant;
+
+/**
+ * A generic <em>value</em> with a limited validity period.
+ *
+ * @param <T> The type of value.
+ */
+public interface ExpiringValue<T> {
+
+    /**
+     * Gets the value.
+     * 
+     * @return The value.
+     */
+    T getValue();
+
+    /**
+     * Checks if the value has already expired.
+     * 
+     * @return {@code true} if the value has expired based on the current system time,
+     *         {@code false} otherwise.
+     */
+    boolean isExpired();
+
+    /**
+     * Checks if the value has already expired.
+     * 
+     * @param now The reference point in time to check expiration against.
+     * @return {@code true} if the value has expired based on the given instant,
+     *         {@code false} otherwise.
+     * @throws NullPointerException if the instant is {@code null}.
+     */
+    boolean isExpired(Instant now);
+}

--- a/core/src/main/java/org/eclipse/hono/util/ExpiringValue.java
+++ b/core/src/main/java/org/eclipse/hono/util/ExpiringValue.java
@@ -40,10 +40,10 @@ public interface ExpiringValue<T> {
     /**
      * Checks if the value has already expired.
      * 
-     * @param now The reference point in time to check expiration against.
+     * @param refInstant The reference point in time to check expiration against.
      * @return {@code true} if the value has expired based on the given instant,
      *         {@code false} otherwise.
      * @throws NullPointerException if the instant is {@code null}.
      */
-    boolean isExpired(Instant now);
+    boolean isExpired(Instant refInstant);
 }

--- a/core/src/main/java/org/eclipse/hono/util/ExpiringValueCache.java
+++ b/core/src/main/java/org/eclipse/hono/util/ExpiringValueCache.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import java.time.Instant;
+
+/**
+ * A cache for values that have a limited validity period.
+ * 
+ */
+public interface ExpiringValueCache {
+
+    /**
+     * Puts a value to the cache.
+     * <p>
+     * Any previous value for the key will be replaced with the new one.
+     * 
+     * @param key The key under which the value is stored.
+     * @param value The value to store.
+     * @param expirationTime The point in time after which the value should be
+     *                       considered invalid.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws IllegalArgumentException if the expiration time is not in the future.
+     */
+    <T> void put(String key, T value, Instant expirationTime);
+
+    /**
+     * Gets a value from the cache.
+     * 
+     * @param key The key to get the value for.
+     * @return The value or {@code null} if no value exists for the key or
+     *         if the value is expired.
+     */
+    <T> T get(String key);
+}

--- a/core/src/main/java/org/eclipse/hono/util/SpringBasedExpiringValueCache.java
+++ b/core/src/main/java/org/eclipse/hono/util/SpringBasedExpiringValueCache.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+
+
+/**
+ * A cache for expiring values based on Spring's Cache abstraction.
+ *
+ */
+public class SpringBasedExpiringValueCache implements ExpiringValueCache {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpringBasedExpiringValueCache.class);
+
+    private final Cache cache;
+
+    /**
+     * Creates a new cache.
+     * 
+     * @param cache The Spring cache instance to use for storing values.
+     */
+    public SpringBasedExpiringValueCache(final Cache cache) {
+        this.cache = Objects.requireNonNull(cache);
+    }
+
+    @Override
+    public <T> void put(final String key, final T value, final Instant expirationTime) {
+
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        Objects.requireNonNull(expirationTime);
+
+        if (Instant.now().isBefore(expirationTime)) {
+            final ExpiringValue<T> expiringValue = new BasicExpiringValue<>(value, expirationTime);
+            cache.put(key, expiringValue);
+        } else {
+            throw new IllegalArgumentException("value is already expired");
+        }
+    }
+
+    @Override
+    public <T> T get(final String key) {
+
+        if (key == null) {
+            return null;
+        } else {
+            @SuppressWarnings("unchecked")
+            ExpiringValue<T> value = cache.get(key, ExpiringValue.class);
+            if (value == null) {
+                LOG.trace("cache miss [key: {}]", key);
+                return null;
+            } else if (value.isExpired()) {
+                LOG.trace("cache hit expired [key: {}]", key);
+                cache.evict(key);
+                return null;
+            } else {
+                LOG.trace("cache hit [key: {}]", key);
+                return value.getValue();
+            }
+        }
+    }
+
+}

--- a/core/src/test/java/org/eclipse/hono/util/SpringBasedExpiringValueCacheTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/SpringBasedExpiringValueCacheTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cache.Cache;
+
+
+/**
+ * Tests verifying behavior of {@link SpringBasedExpiringValueCache}.
+ *
+ */
+public class SpringBasedExpiringValueCacheTest {
+
+    private Cache springCache;
+    private SpringBasedExpiringValueCache cache;
+
+    /**
+     * Sets up the fixture.
+     */
+    @Before
+    public void setUp() {
+        springCache = mock(Cache.class);
+        cache = new SpringBasedExpiringValueCache(springCache);
+    }
+
+    /**
+     * Verifies that the cache returns non-expired values.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGetResponseFromCache() {
+
+        // GIVEN a cache that contains a non-expired response
+        final ExpiringValue<String> value = mock(ExpiringValue.class);
+        when(value.isExpired()).thenReturn(Boolean.FALSE);
+        when(value.getValue()).thenReturn("hello");
+        when(springCache.get("key", ExpiringValue.class)).thenReturn(value);
+
+        // WHEN trying to get a cached response for the key
+        final String result = cache.get("key");
+
+        // THEN the result is not null
+        assertThat(result, is("hello"));
+        // and the value has not been evicted from the cache
+        verify(springCache, never()).evict("key");
+    }
+
+    /**
+     * Verifies that the cache evicts expired values.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGetResponseFromCacheEvictsExpiredValue() {
+
+        // GIVEN a cache that contains an expired value
+        final ExpiringValue<String> value = mock(ExpiringValue.class);
+        when(value.isExpired()).thenReturn(Boolean.TRUE);
+        when(springCache.get("key", ExpiringValue.class)).thenReturn(value);
+
+        // WHEN trying to get a cached response for the key
+        final String result = cache.get("key");
+
+        // THEN the result is null
+        assertNull(result);
+        // and the expired value has been evicted from the cache
+        verify(springCache).evict("key");
+    }
+
+}

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -94,6 +94,15 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context-support</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -14,8 +14,11 @@
 package org.eclipse.hono.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoClient;


### PR DESCRIPTION
This PR adds support to Hono's request/response based clients for caching responses received from the services.
In particular, it adds support to `RegistrationClientImpl` for caching registration assertion responses so that e.g. the HTTP protocol adapter does not need to retrieve a fresh registration assertion for every message being POSTed. So far we have cached the assertions in the MQTT adapter only where we have kept the assertion in the context of the `MQTTEndpoint`. This PR replaces this MQTT adapter specific caching with a generic approach so that any protocol adapter can take advantage of the caching.