### PR TITLE
Provide a default message in case none was provided

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/client/src/main/java/org/eclipse/hono/client/ServerErrorException.java
+++ b/client/src/main/java/org/eclipse/hono/client/ServerErrorException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,7 +12,6 @@
  */
 
 package org.eclipse.hono.client;
-
 
 /**
  * Indicates a server error that occurred during a service invocation.
@@ -63,10 +62,26 @@ public class ServerErrorException extends ServiceInvocationException {
      * @throws IllegalArgumentException if the code is not &ge; 500 and &lt; 600.
      */
     public ServerErrorException(final int errorCode, final String msg, final Throwable cause) {
-        super(errorCode, msg, cause);
+        super(errorCode, providedOrDefaultMessage(errorCode, msg), cause);
         if (errorCode < 500 || errorCode >= 600) {
             throw new IllegalArgumentException("client error code must be >= 500 and < 600");
         }
+    }
+
+    /**
+     * Provide a default message if none is provided.
+     * 
+     * @param errorCode The error code
+     * @param msg The detail message. May be {@code null}.
+     * @return The provided message or the default message derived from the error code if {@code null} was provided as a
+     *         message.
+     */
+    private static String providedOrDefaultMessage(final int errorCode, final String msg) {
+        if (msg != null) {
+            return msg;
+        }
+
+        return "Error Code: " + errorCode;
     }
 
 }

--- a/client/src/test/java/org/eclipse/hono/client/ServerErrorExceptionTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/ServerErrorExceptionTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2018 Red Hat Inc and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Red Hat Inc - initial creation
+ */
+
+package org.eclipse.hono.client;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class ServerErrorExceptionTest {
+
+    @Test
+    public void testCodeAndMessage() {
+        ServerErrorException t = new ServerErrorException(500, "Foo Bar");
+
+        Assertions.assertThat(t)
+                .hasMessage("Foo Bar");
+
+        Assertions.assertThat(t.getErrorCode())
+                .isEqualTo(500);
+    }
+
+    @Test
+    public void testCodeAndNoMessage() {
+        ServerErrorException t = new ServerErrorException(500);
+
+        Assertions.assertThat(t)
+                .hasMessage("Error Code: 500");
+
+        Assertions.assertThat(t.getErrorCode())
+                .isEqualTo(500);
+    }
+
+    @Test
+    public void testCodeCauseAndNoMessage() {
+        ServerErrorException t = new ServerErrorException(500, new RuntimeException("Bar Foo"));
+
+        Assertions.assertThat(t)
+                .hasMessage("Error Code: 500")
+                .hasCauseInstanceOf(RuntimeException.class);
+
+        Assertions.assertThat(t.getErrorCode())
+                .isEqualTo(500);
+    }
+
+    @Test
+    public void testCodeCauseAndMessage() {
+        ServerErrorException t = new ServerErrorException(500, "Foo Bar", new RuntimeException("Bar Foo"));
+
+        Assertions.assertThat(t)
+                .hasMessage("Foo Bar")
+                .hasCauseInstanceOf(RuntimeException.class);
+
+        Assertions.assertThat(t.getErrorCode())
+                .isEqualTo(500);
+    }
+}


### PR DESCRIPTION
This improves the ServerErrorException in way that it will
always provide an error message and never simply "null" as message.

If no message was provided a default one (derived from the error code)
will be generated.

Signed-off-by: Jens Reimann <jreimann@redhat.com>