### PR TITLE
Switch to auto-settle instead of manually settling

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 
 package org.eclipse.hono.client.impl;
@@ -176,6 +177,7 @@ public abstract class AbstractHonoClient {
         ctx.runOnContext(create -> {
             final ProtonSender sender = con.createSender(targetAddress);
             sender.setQoS(qos);
+            sender.setAutoSettle(true);
             sender.openHandler(senderOpen -> {
                 if (senderOpen.succeeded()) {
                     LOG.debug("sender open [target: {}, sendQueueFull: {}]", targetAddress, sender.sendQueueFull());

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -1,13 +1,14 @@
 /**
- * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH.
- * <p>
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * <p>
+ *
  * Contributors:
- * Bosch Software Innovations GmbH - initial creation
+ *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 package org.eclipse.hono.client.impl;
 
@@ -371,10 +372,6 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
                 final Object correlationId = Optional.ofNullable(request.getCorrelationId()).orElse(request.getMessageId());
                 replyMap.put(correlationId, resultHandler);
                 sender.send(request, deliveryUpdated -> {
-
-                    // settle locally
-                    deliveryUpdated.settle();
-
                     if (Rejected.class.isInstance(deliveryUpdated.getRemoteState())) {
                         final Rejected rejected = (Rejected) deliveryUpdated.getRemoteState();
                         if (rejected.getError() != null) {

--- a/client/src/main/java/org/eclipse/hono/client/impl/EventSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/EventSenderImpl.java
@@ -129,9 +129,6 @@ public final class EventSenderImpl extends AbstractSender {
         final String messageId = String.format("%s-%d", getClass().getSimpleName(), MESSAGE_COUNTER.getAndIncrement());
         message.setMessageId(messageId);
         sender.send(message, deliveryUpdated -> {
-
-            deliveryUpdated.settle();
-
             if (deliveryUpdated.remotelySettled()) {
                 if (Accepted.class.isInstance(deliveryUpdated.getRemoteState())) {
                     LOG.trace("event [message ID: {}] accepted by peer", messageId);

--- a/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
@@ -117,9 +117,6 @@ public final class TelemetrySenderImpl extends AbstractSender {
         final String messageId = String.format("%s-%d", getClass().getSimpleName(), MESSAGE_COUNTER.getAndIncrement());
         message.setMessageId(messageId);
         final ProtonDelivery result = sender.send(message, deliveryUpdated -> {
-
-            deliveryUpdated.settle();
-
             if (deliveryUpdated.remotelySettled()) {
                 if (Accepted.class.isInstance(deliveryUpdated.getRemoteState())) {
                     LOG.trace("message [message ID: {}] accepted by peer", messageId);

--- a/services/messaging/src/main/java/org/eclipse/hono/event/impl/ForwardingEventDownstreamAdapter.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/event/impl/ForwardingEventDownstreamAdapter.java
@@ -48,16 +48,7 @@ public final class ForwardingEventDownstreamAdapter extends ForwardingDownstream
     }
 
     protected void forwardMessage(final ProtonSender sender, final Message msg, final ProtonDelivery delivery) {
-        sender.send(msg, updatedDelivery -> {
-
-            // settle downstream message locally
-
-            updatedDelivery.settle();
-
-            // forward downstream state to upstream message
-
-            delivery.disposition(updatedDelivery.getRemoteState(), updatedDelivery.remotelySettled());
-        });
+        sender.send(msg, updatedDelivery -> delivery.disposition(updatedDelivery.getRemoteState(), updatedDelivery.remotelySettled()));
     }
 
     @Override

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/SenderFactoryImpl.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/SenderFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 
 package org.eclipse.hono.messaging;
@@ -100,6 +101,7 @@ public class SenderFactoryImpl implements SenderFactory {
         Future<ProtonSender> result = Future.future();
         ProtonSender sender = session.createSender(getTenantOnlyTargetAddress(address));
         sender.setQoS(qos);
+        sender.setAutoSettle(true);
         sender.sendQueueDrainHandler(sendQueueDrainHandler);
         sender.openHandler(openAttempt -> {
             if (openAttempt.succeeded()) {


### PR DESCRIPTION
This change removes the manual calls to settle() and enable autoSettle
on all senders.

Signed-off-by: Jens Reimann <jreimann@redhat.com>