### PR TITLE
Use Set and EnumSet instead of iterating over array

### DIFF
--- a/services/messaging/src/main/java/org/eclipse/hono/event/impl/EventEndpoint.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/event/impl/EventEndpoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,12 +8,16 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  *
  */
 
 package org.eclipse.hono.event.impl;
 
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.EventConstants;
@@ -39,7 +43,8 @@ import io.vertx.proton.ProtonQoS;
 @Qualifier("event")
 public final class EventEndpoint extends MessageForwardingEndpoint<HonoMessagingConfigProperties> {
 
-    private static final ProtonQoS[] SUPPORTED_DELIVERY_MODES = new ProtonQoS[]{ ProtonQoS.AT_LEAST_ONCE };
+    private static final Set<ProtonQoS> SUPPORTED_DELIVERY_MODES = Collections
+            .unmodifiableSet(EnumSet.of(ProtonQoS.AT_LEAST_ONCE));
 
     /**
      * Creates a new endpoint.
@@ -79,7 +84,7 @@ public final class EventEndpoint extends MessageForwardingEndpoint<HonoMessaging
      * @return <em>AT_LEAST_ONCE</em> delivery mode.
      */
     @Override
-    protected ProtonQoS[] getEndpointQos() {
+    protected Set<ProtonQoS> getEndpointQos() {
         return SUPPORTED_DELIVERY_MODES;
     }
 }

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/MessageForwardingEndpoint.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/MessageForwardingEndpoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,14 +8,15 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 package org.eclipse.hono.messaging;
 
 import static io.vertx.proton.ProtonHelper.condition;
 import static org.eclipse.hono.util.MessageHelper.getAnnotation;
 
-import java.util.Arrays;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import org.apache.qpid.proton.amqp.transport.AmqpError;
@@ -130,7 +131,7 @@ public abstract class MessageForwardingEndpoint<T extends ServiceConfigPropertie
     @Override
     public final void onLinkAttach(final ProtonConnection con, final ProtonReceiver receiver, final ResourceIdentifier targetAddress) {
 
-        if (!Arrays.stream(getEndpointQos()).anyMatch(qos -> qos.equals(receiver.getRemoteQoS()))) {
+        if (!getEndpointQos().contains(receiver.getRemoteQoS())) {
             logger.debug("client [{}] wants to use unsupported delivery mode {} for endpoint [name: {}, QoS: {}], closing link", 
                     con.getRemoteContainer(), receiver.getRemoteQoS(), getName(), getEndpointQos());
             receiver.setCondition(ErrorConditions.ERROR_UNSUPPORTED_DELIVERY_MODE);
@@ -222,10 +223,13 @@ public abstract class MessageForwardingEndpoint<T extends ServiceConfigPropertie
      * <p>
      * The {@link #onLinkAttach(ProtonConnection, ProtonReceiver, ResourceIdentifier)} method will reject a client's
      * attempt to establish a link that does not match at least one of the delivery modes returned by this method.
+     * <p>
+     * Changes to the returned collection must not have any impact on the original data set. Returning an
+     * unmodifiable collection is recommended.
      * 
      * @return The delivery modes this endpoint supports.
      */
-    protected abstract ProtonQoS[] getEndpointQos();
+    protected abstract Set<ProtonQoS> getEndpointQos();
 
     /**
      * Registers a check that succeeds if this endpoint has a usable connection to its

--- a/services/messaging/src/main/java/org/eclipse/hono/telemetry/impl/TelemetryEndpoint.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/telemetry/impl/TelemetryEndpoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,10 +8,14 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 package org.eclipse.hono.telemetry.impl;
 
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.messaging.DownstreamAdapter;
@@ -37,7 +41,8 @@ import io.vertx.proton.ProtonQoS;
 @Qualifier("telemetry")
 public final class TelemetryEndpoint extends MessageForwardingEndpoint<HonoMessagingConfigProperties> {
 
-    private static final ProtonQoS[] SUPPORTED_DELIVERY_MODES = new ProtonQoS[]{ ProtonQoS.AT_LEAST_ONCE, ProtonQoS.AT_MOST_ONCE };
+    private static final Set<ProtonQoS> SUPPORTED_DELIVERY_MODES = Collections
+            .unmodifiableSet(EnumSet.of(ProtonQoS.AT_LEAST_ONCE, ProtonQoS.AT_MOST_ONCE));
 
     /**
      * Creates a new endpoint.
@@ -78,7 +83,7 @@ public final class TelemetryEndpoint extends MessageForwardingEndpoint<HonoMessa
      * @return <em>AT_MOST_ONCE</em> and <em>AT_LEAST_ONCE</em>.
      */
     @Override
-    protected ProtonQoS[] getEndpointQos() {
+    protected Set<ProtonQoS> getEndpointQos() {
         return SUPPORTED_DELIVERY_MODES;
     }
 }

--- a/services/messaging/src/test/java/org/eclipse/hono/messaging/MessageForwardingEndpointTest.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/messaging/MessageForwardingEndpointTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 package org.eclipse.hono.messaging;
 
@@ -16,6 +17,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
+
+import java.util.EnumSet;
+import java.util.Set;
 
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
@@ -228,8 +232,8 @@ public class MessageForwardingEndpointTest {
             }
 
             @Override
-            protected ProtonQoS[] getEndpointQos() {
-                return new ProtonQoS[]{ ProtonQoS.AT_MOST_ONCE };
+            protected Set<ProtonQoS> getEndpointQos() {
+                return EnumSet.of(ProtonQoS.AT_MOST_ONCE);
             }
         };
         endpoint.setMetrics(mock(MessagingMetrics.class));


### PR DESCRIPTION
This change uses optimized EnumSets instead of manually iterating
over the array.

Signed-off-by: Jens Reimann <jreimann@redhat.com>