### PR TITLE
[#457] Clearing out connection after loss of connection

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 package org.eclipse.hono.client.impl;
 
@@ -229,12 +230,16 @@ public final class HonoClientImpl implements HonoClient {
         if (connection != null && !connection.isDisconnected()) {
             connection.disconnect();
         }
+
+        final ProtonConnection failedConnection = this.connection;
+        this.connection = null;
+
         activeSenders.clear();
         activeRequestResponseClients.clear();
         failAllCreationRequests();
 
         if (connectionLossHandler != null) {
-            connectionLossHandler.handle(connection);
+            connectionLossHandler.handle(failedConnection);
         } else {
             reconnect(attempt -> {}, failedCon -> onRemoteDisconnect(failedCon, null));
         }

--- a/client/src/test/java/org/eclipse/hono/client/impl/HonoClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/HonoClientImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 
 package org.eclipse.hono.client.impl;
@@ -474,11 +475,11 @@ public class HonoClientImplTest {
             this.closeHandler = closeHandler;
             this.disconnectHandler = disconnectHandler;
             if (expectedFailingConnectionAttempts.getCount() > 0) {
-                expectedFailingConnectionAttempts.countDown();
                 connectionResultHandler.handle(Future.failedFuture("cannot connect"));
+                expectedFailingConnectionAttempts.countDown();
             } else {
-                expectedSucceedingConnectionAttemps.countDown();
                 connectionResultHandler.handle(Future.succeededFuture(connectionToCreate));
+                expectedSucceedingConnectionAttemps.countDown();
             }
         }
 


### PR DESCRIPTION
This change sets the connection to 'null' when it is being handled is
disconnected. This will ensure future checks on the connection won't
consider it usable.

Signed-off-by: Jens Reimann <jreimann@redhat.com>