### PR TITLE
Tenant API implementation for AMQP endpoint.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
@@ -159,9 +159,34 @@ public class RequestResponseApiConstants {
      *
      * @param operation The operation that shall be processed by the service.
      * @param tenantId The tenant for which the message was processed.
-     * @param deviceId The device that the message relates to.
-     * @return JsonObject The JSON object for the request that is to be sent via the vert.x event bus.
      * @throws NullPointerException if operation or tenant ID are {@code null}.
+     * @return JsonObject The json object for the request that is to be sent via the vert.x event bus.
+     */
+    public static final JsonObject getServiceRequestAsJson(final String operation, final String tenantId) {
+        return getServiceRequestAsJson(operation, tenantId, null, null);
+    }
+
+    /**
+     * Build a Json object as a request for internal communication via the vert.x event bus.
+     * Clients use this object to build their request that is sent to the processing service.
+     *
+     * @param operation The operation that shall be processed by the service.
+     * @param tenantId The tenant for which the message was processed.
+     * @param payload The payload from the request that is passed to the processing service.
+     * @return JsonObject The json object for the request that is to be sent via the vert.x event bus.
+     */
+    public static final JsonObject getServiceRequestAsJson(final String operation, final String tenantId, final JsonObject payload) {
+        return getServiceRequestAsJson(operation, tenantId, null, payload);
+    }
+
+    /**
+     * Build a Json object as a request for internal communication via the vert.x event bus.
+     * Clients use this object to build their request that is sent to the processing service.
+     *
+     * @param operation The operation that shall be processed by the service.
+     * @param tenantId The tenant for which the message was processed.
+     * @param deviceId The device that the message relates to. Maybe null - then no deviceId will be contained.
+     * @return JsonObject The json object for the request that is to be sent via the vert.x event bus.
      */
     public static final JsonObject getServiceRequestAsJson(final String operation, final String tenantId, final String deviceId) {
         return getServiceRequestAsJson(operation, tenantId, deviceId, null);

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.hono.util;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 import io.vertx.core.json.DecodeException;
 import org.apache.qpid.proton.message.Message;
@@ -28,20 +26,42 @@ import io.vertx.core.json.JsonObject;
 public final class TenantConstants extends RequestResponseApiConstants {
 
     /* tenant actions */
-    public static final String ACTION_GET                        = "get";
-    public static final String ACTION_ADD                        = "add";
-    public static final String ACTION_UPDATE                     = "update";
-    public static final String ACTION_REMOVE                     = "remove";
+    public enum Action {
+        ACTION_GET, ACTION_ADD, ACTION_UPDATE, ACTION_REMOVE, ACTION_UNKNOWN;
 
+        /**
+         * Construct an Action from a subject.
+         *
+         * @param subject The subject from which the Action needs to be constructed.
+         * @return Action The Action as enum, or {@link Action#ACTION_UNKNOWN} otherwise.
+         */
+        public static Action from(final String subject) {
+            if (subject != null) {
+                try {
+                    return Action.valueOf(subject);
+                } catch (IllegalArgumentException e) {
+                }
+            }
+            return ACTION_UNKNOWN;
+        }
+
+        /**
+         * Helper method to check if a subject is a valid Tenant API action.
+         *
+         * @param subject The subject to validate.
+         * @return boolean {@link Boolean#TRUE} if the subject denotes a valid action, {@link Boolean#FALSE} otherwise.
+         */
+        public static boolean isValid(final String subject) {
+            return Action.from(subject) != Action.ACTION_UNKNOWN;
+        }
+    }
 
     /* message payload fields */
-    public static final String FIELD_ENABLED                     = "enabled";
     public static final String FIELD_ADAPTERS                    = "adapters";
     public static final String FIELD_ADAPTERS_TYPE               = "type";
     public static final String FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED = "device-authentication-required";
 
-
-    private static final List<String> ACTIONS = Arrays.asList(ACTION_GET, ACTION_ADD, ACTION_UPDATE, ACTION_REMOVE);
+    public static final String FIELD_RESPONSE_STATUS = "status";
 
     /**
      * The name of the Tenant API endpoint.
@@ -72,27 +92,21 @@ public final class TenantConstants extends RequestResponseApiConstants {
     /**
      * Gets a JSON object representing the reply to a Tenant API request via the vert.x event bus.
      *
-     * @param tenantId The tenant for which the message was processed.
-     * @param result The result to return to the sender of the request.
+     * @param tenantId The tenant for which the message was processed. Must not be null.
+     * @param tenantResult The result to return to the sender of the request.
      * @return JsonObject The JSON reply object.
+     * @throws NullPointerException If tenantId or tenantResult is null.
      */
-    public static final JsonObject getServiceReplyAsJson(final String tenantId, final TenantResult result) {
+    public static final JsonObject getServiceReplyAsJson(final String tenantId, final TenantResult tenantResult) {
+        Objects.requireNonNull(tenantId);
         final JsonObject jsonObject = new JsonObject();
         jsonObject.put(RequestResponseApiConstants.FIELD_TENANT_ID, tenantId);
 
-        jsonObject.put("status", result.getStatus());
-        if (result.getPayload() != null) {
-            jsonObject.put(RequestResponseApiConstants.FIELD_PAYLOAD, result.getPayload());
+        jsonObject.put(FIELD_RESPONSE_STATUS, tenantResult.getStatus());
+        if (tenantResult.getPayload() != null) {
+            jsonObject.put(RequestResponseApiConstants.FIELD_PAYLOAD, tenantResult.getPayload());
         }
 
         return jsonObject;
-    }
-
-    public static boolean isValidAction(final String subject) {
-        if (subject == null) {
-            return false;
-        } else {
-            return ACTIONS.contains(subject);
-        }
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -92,13 +92,13 @@ public final class TenantConstants extends RequestResponseApiConstants {
     /**
      * Gets a JSON object representing the reply to a Tenant API request via the vert.x event bus.
      *
-     * @param tenantId The tenant for which the message was processed. Must not be null.
+     * @param tenantId The tenant for which the message was processed. If null, the value for the key
+     *                 {@link RequestResponseApiConstants#FIELD_TENANT_ID} in the reply will be null, too.
      * @param tenantResult The result to return to the sender of the request.
      * @return JsonObject The JSON reply object.
-     * @throws NullPointerException If tenantId or tenantResult is null.
+     * @throws NullPointerException If tenantResult is null.
      */
     public static final JsonObject getServiceReplyAsJson(final String tenantId, final TenantResult tenantResult) {
-        Objects.requireNonNull(tenantId);
         final JsonObject jsonObject = new JsonObject();
         jsonObject.put(RequestResponseApiConstants.FIELD_TENANT_ID, tenantId);
 

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import io.vertx.core.json.DecodeException;
+import org.apache.qpid.proton.message.Message;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Constants &amp; utility methods used throughout the Tenant API.
+ */
+
+public final class TenantConstants extends RequestResponseApiConstants {
+
+    /* tenant actions */
+    public static final String ACTION_GET                        = "get";
+    public static final String ACTION_ADD                        = "add";
+    public static final String ACTION_UPDATE                     = "update";
+    public static final String ACTION_REMOVE                     = "remove";
+
+
+    /* message payload fields */
+    public static final String FIELD_ENABLED                     = "enabled";
+    public static final String FIELD_ADAPTERS                    = "adapters";
+    public static final String FIELD_ADAPTERS_TYPE               = "type";
+    public static final String FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED = "device-authentication-required";
+
+
+    private static final List<String> ACTIONS = Arrays.asList(ACTION_GET, ACTION_ADD, ACTION_UPDATE, ACTION_REMOVE);
+
+    /**
+     * The name of the Tenant API endpoint.
+     */
+    public static final String TENANT_ENDPOINT = "tenant";
+
+    /**
+     * The vert.x event bus address to which inbound registration messages are published.
+     */
+    public static final String EVENT_BUS_ADDRESS_TENANT_IN = "tenant.in";
+
+    /**
+     * Creates a JSON object from a Tenant API request message.
+     *
+     * @param message The AMQP 1.0 tenant request message.
+     * @return The tenant message created from the AMQP message.
+     * @throws NullPointerException if message is {@code null}.
+     * @throws DecodeException if the message contains a body that cannot be parsed into a JSON object.
+     */
+    public static JsonObject getTenantMsg(final Message message) {
+        Objects.requireNonNull(message);
+        final String subject = message.getSubject();
+        final String tenantId = MessageHelper.getTenantIdAnnotation(message);
+        final JsonObject payload = MessageHelper.getJsonPayload(message);
+        return getServiceRequestAsJson(subject, tenantId, payload);
+    }
+
+    /**
+     * Gets a JSON object representing the reply to a Tenant API request via the vert.x event bus.
+     *
+     * @param tenantId The tenant for which the message was processed.
+     * @param result The result to return to the sender of the request.
+     * @return JsonObject The JSON reply object.
+     */
+    public static final JsonObject getServiceReplyAsJson(final String tenantId, final TenantResult result) {
+        final JsonObject jsonObject = new JsonObject();
+        jsonObject.put(RequestResponseApiConstants.FIELD_TENANT_ID, tenantId);
+
+        jsonObject.put("status", result.getStatus());
+        if (result.getPayload() != null) {
+            jsonObject.put(RequestResponseApiConstants.FIELD_PAYLOAD, result.getPayload());
+        }
+
+        return jsonObject;
+    }
+
+    public static boolean isValidAction(final String subject) {
+        if (subject == null) {
+            return false;
+        } else {
+            return ACTIONS.contains(subject);
+        }
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/TenantResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantResult.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.util;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.DecodeException;
 
 /**
  * A container for the result returned by Hono's Tenant API.
@@ -24,6 +25,12 @@ public final class TenantResult extends RequestResponseResult<JsonObject> {
         super(status, payload);
     }
 
+    /**
+     * Creates a new result for a status code.
+     *
+     * @param status The status code indicating the outcome of the request.
+     * @return The result.
+     */
     public static TenantResult from(final int status) {
         return new TenantResult(status, null);
     }
@@ -45,6 +52,7 @@ public final class TenantResult extends RequestResponseResult<JsonObject> {
      * @param status The status code indicating the outcome of the request.
      * @param payloadString The payload to convey to the sender of the request, represented as String.
      * @return The result.
+     * @throws DecodeException if the given payload is not valid JSON.
      */
     public static TenantResult from(final int status, final String payloadString) {
         if (payloadString != null) {

--- a/core/src/main/java/org/eclipse/hono/util/TenantResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantResult.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A container for the result returned by Hono's Tenant API.
+ *
+ */
+public final class TenantResult extends RequestResponseResult<JsonObject> {
+    private TenantResult(final int status, final JsonObject payload) {
+        super(status, payload);
+    }
+
+    public static TenantResult from(final int status) {
+        return new TenantResult(status, null);
+    }
+
+    /**
+     * Creates a new result for a status code and payload.
+     *
+     * @param status The status code indicating the outcome of the request.
+     * @param payload The payload to convey to the sender of the request.
+     * @return The result.
+     */
+    public static TenantResult from(final int status, final JsonObject payload) {
+        return new TenantResult(status, payload);
+    }
+
+    /**
+     * Creates a new result for a status code and payload represented as String.
+     *
+     * @param status The status code indicating the outcome of the request.
+     * @param payloadString The payload to convey to the sender of the request, represented as String.
+     * @return The result.
+     */
+    public static TenantResult from(final int status, final String payloadString) {
+        if (payloadString != null) {
+            return new TenantResult(status, new JsonObject(payloadString));
+        } else {
+            return new TenantResult(status, null);
+        }
+    }
+}

--- a/example/src/main/config/example-tenants.json
+++ b/example/src/main/config/example-tenants.json
@@ -11,15 +11,15 @@
       "enabled": "true"
     },
     "adapters": {
-      "http": {
+      "hono-http": {
         "enabled": true,
         "device-authentication-required": true
       },
-      "mqtt": {
+      "hono-mqtt": {
         "enabled": false,
         "device-authentication-required": true
       },
-      "kura": {
+      "hono-kura": {
         "enabled": false,
         "device-authentication-required": true
       }

--- a/example/src/main/config/example-tenants.json
+++ b/example/src/main/config/example-tenants.json
@@ -1,0 +1,29 @@
+[
+  {
+    "tenant": "DEFAULT_TENANT",
+    "data": {
+      "enabled": "true"
+    }
+  },
+  {
+    "tenant": "HTTP_TENANT",
+    "data": {
+      "enabled": "true"
+    },
+    "adapters": {
+      "http": {
+        "enabled": true,
+        "device-authentication-required": true
+      },
+      "mqtt": {
+        "enabled": false,
+        "device-authentication-required": true
+      },
+      "kura": {
+        "enabled": false,
+        "device-authentication-required": true
+      }
+
+    }
+  }
+]

--- a/example/src/main/config/hono-service-device-registry-config.yml
+++ b/example/src/main/config/hono-service-device-registry-config.yml
@@ -32,4 +32,8 @@ hono:
     svc:
       filename: /var/lib/hono/device-registry/credentials.json
       saveToFile: true
+  tenants:
+    svc:
+      tenantsFilename: /var/lib/hono/device-registry/tenants.json
+      saveToFile: true
 

--- a/example/src/main/deploy/docker/swarm_deploy.sh
+++ b/example/src/main/deploy/docker/swarm_deploy.sh
@@ -103,11 +103,13 @@ then
   echo "Creating and initializing Docker Volume for Device Registry..."
   docker volume create --label project=$NS device-registry
   docker secret create -l project=$NS example-credentials.json $CONFIG/example-credentials.json
+  docker secret create -l project=$NS example-tenants.json $CONFIG/example-tenants.json
   docker service create --detach=true --name init-device-registry-data \
     --secret example-credentials.json \
+    --secret example-tenants.json \
     --mount type=volume,source=device-registry,target=/var/lib/hono/device-registry \
     --restart-condition=none \
-    busybox sh -c 'cp -u /run/secrets/example-credentials.json /var/lib/hono/device-registry/credentials.json'
+    busybox sh -c 'cp -u /run/secrets/example-credentials.json /var/lib/hono/device-registry/credentials.json;cp -u /run/secrets/example-tenants.json /var/lib/hono/device-registry/tenants.json'
 fi
 docker secret create -l project=$NS device-registry-key.pem $CERTS/device-registry-key.pem
 docker secret create -l project=$NS device-registry-cert.pem $CERTS/device-registry-cert.pem

--- a/example/src/main/deploy/kubernetes/kubernetes_deploy.sh
+++ b/example/src/main/deploy/kubernetes/kubernetes_deploy.sh
@@ -85,6 +85,7 @@ kubectl create secret generic hono-service-device-registry-conf \
   --from-file=$CERTS/auth-server-cert.pem \
   --from-file=$CERTS/trusted-certs.pem \
   --from-file=$CONFIG/example-credentials.json \
+  --from-file=$CONFIG/example-tenants.json \
   --from-file=application.yml=$CONFIG/hono-service-device-registry-config.yml \
   --namespace $NS
 kubectl create -f $CONFIG/hono-service-device-registry-jar/META-INF/fabric8/kubernetes.yml --namespace $NS

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseTenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseTenantService.java
@@ -1,0 +1,305 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.tenant;
+
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static org.eclipse.hono.util.TenantConstants.*;
+
+import java.net.HttpURLConnection;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import org.eclipse.hono.util.ConfigurationSupportingVerticle;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RequestResponseApiConstants;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Base class for implementing {@code TenantService}s.
+ * <p>
+ * In particular, this base class provides support for parsing tenant CRUD request messages received via the event bus
+ * and route them to specific methods corresponding to the <em>action</em> indicated in the message.
+ *
+ * @param <T> The type of configuration properties this service requires.
+ */
+public abstract class BaseTenantService<T> extends ConfigurationSupportingVerticle<T> implements TenantService {
+
+    /**
+     * A logger to be shared by subclasses.
+     */
+    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    private MessageConsumer<JsonObject> tenantConsumer;
+
+
+    /**
+     * Starts up this service.
+     * <ol>
+     * <li>Registers an event bus consumer for address {@link TenantConstants#EVENT_BUS_ADDRESS_TENANT_IN} listening for
+     * tenant CRUD requests.</li>
+     * <li>Invokes {@link #doStart(Future)}.</li>
+     * </ol>
+     *
+     * @param startFuture The future to complete on successful startup.
+     */
+    public final void start(final Future<Void> startFuture) {
+        this.tenantConsumer();
+        this.doStart(startFuture);
+    }
+
+    /**
+     * Subclasses should override this method to perform any work required on start-up of this verticle.
+     * <p>
+     * This method is invoked by {@link #start()} as part of the verticle deployment process.
+     * </p>
+     *
+     * @param startFuture future to invoke once start up is complete.
+     */
+    protected void doStart(final Future<Void> startFuture) {
+        // should be overridden by subclasses
+        startFuture.complete();
+    }
+
+    private void tenantConsumer() {
+        this.tenantConsumer = this.vertx.eventBus().consumer(TenantConstants.EVENT_BUS_ADDRESS_TENANT_IN);
+        this.tenantConsumer.handler(this::processTenantMessage);
+        this.log.info("listening on event bus [address: {}] for incoming tenant CRUD messages",
+                TenantConstants.EVENT_BUS_ADDRESS_TENANT_IN);
+    }
+
+    /**
+     * Unregisters the registration message consumer from the Vert.x event bus and then invokes {@link #doStop(Future)}.
+     *
+     * @param stopFuture the future to invoke once shutdown is complete.
+     */
+    public final void stop(final Future<Void> stopFuture) {
+        this.tenantConsumer.unregister();
+        this.log.info("unregistered tenant data consumer from event bus");
+        this.doStop(stopFuture);
+    }
+
+    /**
+     * Subclasses should override this method to perform any work required before shutting down this verticle.
+     * <p>
+     * This method is invoked by {@link #stop()} as part of the verticle deployment process.
+     * </p>
+     *
+     * @param stopFuture the future to invoke once shutdown is complete.
+     */
+    protected void doStop(final Future<Void> stopFuture) {
+        // to be overridden by subclasses
+        stopFuture.complete();
+    }
+
+    /**
+     * Processes a tenant request message received via the Vertx event bus.
+     *
+     * @param tenantMsg The message.
+     */
+    public final void processTenantMessage(final Message<JsonObject> tenantMsg) {
+        try {
+            final JsonObject body = tenantMsg.body();
+            final String tenantId = body.getString(RequestResponseApiConstants.FIELD_TENANT_ID);
+            final String operation = body.getString(MessageHelper.SYS_PROPERTY_SUBJECT);
+
+            if (tenantId == null) {
+                log.debug("tenant request does not contain mandatory property [{}]",
+                        RequestResponseApiConstants.FIELD_TENANT_ID);
+                reply(tenantMsg, TenantResult.from(HttpURLConnection.HTTP_BAD_REQUEST));
+                return;
+            }
+
+            JsonObject payload;
+
+            switch (operation) {
+            case ACTION_GET:
+                log.debug("retrieving tenant [{}]", tenantId);
+                get(tenantId, result -> reply(tenantMsg, result));
+                break;
+            case ACTION_ADD:
+                if (!isValidRequestPayload(body)) {
+                    log.debug("tenant request contains invalid structure");
+                    reply(tenantMsg, TenantResult.from(HttpURLConnection.HTTP_BAD_REQUEST));
+                    break;
+                }
+                payload = getRequestPayload(body);
+                log.debug("creating tenant [{}] with data {}", tenantId, payload != null ? payload.encode() : null);
+                add(tenantId, payload, result -> reply(tenantMsg, result));
+                break;
+            case ACTION_UPDATE:
+                payload = getRequestPayload(body);
+                log.debug("updating tenant [{}] with data {}", tenantId, payload != null ? payload.encode() : null);
+                update(tenantId, payload, result -> reply(tenantMsg, result));
+                break;
+            case ACTION_REMOVE:
+                log.debug("deleting tenant [{}]", tenantId);
+                remove(tenantId, result -> reply(tenantMsg, result));
+                break;
+            default:
+                break;
+            }
+        } catch (final ClassCastException e) {
+            log.debug("malformed request message [{}]", e.getMessage());
+            reply(tenantMsg, TenantResult.from(HTTP_BAD_REQUEST));
+        }
+    }
+
+    private void reply(final Message<JsonObject> request, final AsyncResult<TenantResult> result) {
+        if (result.succeeded()) {
+            this.reply(request, result.result());
+        } else {
+            request.fail(HTTP_INTERNAL_ERROR, "cannot process tenant management request");
+        }
+    }
+
+    /**
+     * Sends a response to a tenant request over the Vertx event bus.
+     *
+     * @param request The message to respond to.
+     * @param result The tenant result that should be conveyed in the response.
+     */
+    protected final void reply(final Message<JsonObject> request, final TenantResult result) {
+        final JsonObject body = request.body();
+        final String tenantId = body.getString(RequestResponseApiConstants.FIELD_TENANT_ID);
+        request.reply(TenantConstants.getServiceReplyAsJson(tenantId, result));
+    }
+
+    private JsonObject getRequestPayload(final JsonObject request) {
+        final JsonObject payload = request.getJsonObject(TenantConstants.FIELD_PAYLOAD, new JsonObject());
+        addNotPresentFieldsWithDefaultValuesForTenant(payload);
+        return payload;
+    }
+
+    private boolean isValidRequestPayload(final JsonObject request) {
+        final JsonObject payload = request.getJsonObject(TenantConstants.FIELD_PAYLOAD, new JsonObject());
+        final JsonArray adapters = payload.getJsonArray(TenantConstants.FIELD_ADAPTERS);
+        if (adapters != null) {
+            if (adapters.size() == 0) {
+                return false;
+            }
+            for (int i = 0; i < adapters.size(); i++) {
+                final JsonObject adapterDetails = adapters.getJsonObject(i);
+                if (adapterDetails == null) {
+                    return false;
+                }
+                // check for mandatory field adapter type
+                if (adapterDetails.getString(FIELD_ADAPTERS_TYPE) == null) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void addNotPresentFieldsWithDefaultValuesForTenant(final JsonObject payload) {
+        if(!payload.containsKey(TenantConstants.FIELD_ENABLED)) {
+            log.debug("adding 'enabled' key to payload");
+            payload.put(TenantConstants.FIELD_ENABLED, Boolean.TRUE);
+        }
+
+        final JsonArray adapters = payload.getJsonArray(TenantConstants.FIELD_ADAPTERS);
+        if (adapters != null) {
+            for (int i = 0; i < adapters.size(); i++) {
+                final JsonObject adapterDetails = adapters.getJsonObject(i);
+                addNotPresentFieldsWithDefaultValuesForAdapter(adapterDetails);
+            }
+        }
+    }
+    
+    private void addNotPresentFieldsWithDefaultValuesForAdapter(final JsonObject adapter) {
+        if(!adapter.containsKey(TenantConstants.FIELD_ENABLED)) {
+            log.debug("adding 'enabled' key to payload");
+            adapter.put(TenantConstants.FIELD_ENABLED, Boolean.TRUE);
+        }
+        
+        if(!adapter.containsKey(TenantConstants.FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED)) {
+            log.debug("adding 'device-authentication-required' key to adapter payload");
+            adapter.put(TenantConstants.FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED, Boolean.TRUE);
+        }
+    }
+
+    /**
+     * Wraps a given tenant ID, it's properties data and it's adapter configuration data into a JSON structure suitable
+     * to be returned to clients as the result of a tenant API operation.
+     *
+     * @param tenantId The tenant ID.
+     * @param data The tenant properties data.
+     * @param adapterConfigurations The adapter configurations data for the tenant as JsonArray.
+     * @return The JSON structure.
+     */
+    protected final static JsonObject getResultPayload(final String tenantId, final JsonObject data,
+                                                       final JsonArray adapterConfigurations) {
+        final JsonObject result = new JsonObject()
+                .put(TenantConstants.FIELD_TENANT_ID, tenantId)
+                .mergeIn(data);
+        if (adapterConfigurations != null) {
+            result.put(TenantConstants.FIELD_ADAPTERS, adapterConfigurations);
+        }
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * This default implementation simply returns an empty result with status code 501 (Not Implemented).
+     * Subclasses should override this method in order to provide a reasonable implementation.
+     */
+    public void get(String tenantId, Handler<AsyncResult<TenantResult>> resultHandler) {
+        handleUnimplementedOperation(resultHandler);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * This default implementation simply returns an empty result with status code 501 (Not Implemented).
+     * Subclasses should override this method in order to provide a reasonable implementation.
+     */
+    public void add(String tenantId, JsonObject tenantObj, Handler<AsyncResult<TenantResult>> resultHandler) {
+        handleUnimplementedOperation(resultHandler);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * This default implementation simply returns an empty result with status code 501 (Not Implemented).
+     * Subclasses should override this method in order to provide a reasonable implementation.
+     */
+    public void update(String tenantId, JsonObject tenantObj, Handler<AsyncResult<TenantResult>> resultHandler) {
+        handleUnimplementedOperation(resultHandler);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * This default implementation simply returns an empty result with status code 501 (Not Implemented).
+     * Subclasses should override this method in order to provide a reasonable implementation.
+     */
+    public void remove(String tenantId, Handler<AsyncResult<TenantResult>> resultHandler) {
+        handleUnimplementedOperation(resultHandler);
+    }
+
+    private void handleUnimplementedOperation(final Handler<AsyncResult<TenantResult>> resultHandler) {
+        resultHandler.handle(Future.succeededFuture(TenantResult.from(HttpURLConnection.HTTP_NOT_IMPLEMENTED)));
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
@@ -32,7 +32,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * An {@code AmqpEndpoint} for managing tenant information.
  * <p>
- * This endpoint implements Hono's <a href="https://www.eclipse.org/hono/api/TODO/">Tenant API</a>. It receives AMQP 1.0
+ * This endpoint implements Hono's <a href="https://www.eclipse.org/hono/api/tenant-api/">Tenant API</a>. It receives AMQP 1.0
  * messages representing requests and sends them to an address on the vertx event bus for processing. The outcome is
  * then returned to the peer in a response message.
  */

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.tenant;
+
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+
+import java.util.Objects;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.auth.HonoUser;
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.service.amqp.RequestResponseEndpoint;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TenantConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * An {@code AmqpEndpoint} for managing tenant information.
+ * <p>
+ * This endpoint implements Hono's <a href="https://www.eclipse.org/hono/api/TODO/">Tenant API</a>. It receives AMQP 1.0
+ * messages representing requests and sends them to an address on the vertx event bus for processing. The outcome is
+ * then returned to the peer in a response message.
+ */
+public final class TenantAmqpEndpoint extends RequestResponseEndpoint<ServiceConfigProperties> {
+
+    /**
+     * Creates a new tenant endpoint for a vertx instance.
+     *
+     * @param vertx The vertx instance to use.
+     */
+    @Autowired
+    public TenantAmqpEndpoint(final Vertx vertx) {
+        super(Objects.requireNonNull(vertx));
+    }
+
+    @Override
+    public String getName() {
+        return TenantConstants.TENANT_ENDPOINT;
+    }
+
+    @Override
+    public void processRequest(final Message msg, final ResourceIdentifier targetAddress,
+            final HonoUser clientPrincipal) {
+
+        final JsonObject tenantMsg = TenantConstants.getTenantMsg(msg);
+        vertx.eventBus().send(TenantConstants.EVENT_BUS_ADDRESS_TENANT_IN, tenantMsg,
+                result -> {
+                    JsonObject response = null;
+                    if (result.succeeded()) {
+                        response = (JsonObject) result.result().body();
+                    } else {
+                        logger.debug("failed to process tenant management request [msg ID: {}] due to {}",
+                                msg.getMessageId(), result.cause());
+                        response = TenantConstants.getServiceReplyAsJson(HTTP_INTERNAL_ERROR,
+                                MessageHelper.getTenantIdAnnotation(msg), null, null);
+                    }
+                    addHeadersToResponse(msg, response);
+                    vertx.eventBus().send(msg.getReplyTo(), response);
+                });
+    }
+
+    @Override
+    protected boolean passesFormalVerification(final ResourceIdentifier linkTarget, final Message msg) {
+        return TenantMessageFilter.verify(linkTarget, msg);
+    }
+
+    @Override
+    protected Message getAmqpReply(final io.vertx.core.eventbus.Message<JsonObject> message) {
+        return TenantConstants.getAmqpReply(TenantConstants.TENANT_ENDPOINT, message.body());
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantMessageFilter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantMessageFilter.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.tenant;
+
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.util.BaseMessageFilter;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TenantConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A filter for verifying the format of <em>Tenant</em> messages.
+ */
+public final class TenantMessageFilter extends BaseMessageFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TenantMessageFilter.class);
+
+    private TenantMessageFilter() {
+        // prevent instantiation
+    }
+
+    /**
+     * Checks whether a given tenant message contains all required properties.
+     * 
+     * @param linkTarget The resource path to check the message's properties against for consistency.
+     * @param msg The AMQP 1.0 message to perform the checks on.
+     * @return {@code true} if the message passes all checks.
+     */
+    public static boolean verify(final ResourceIdentifier linkTarget, final Message msg) {
+
+        if (MessageHelper.getTenantId(msg) == null) {
+            LOG.trace("message [{}] does not contain a tenant-id", msg.getMessageId());
+            return false;
+        } else if (msg.getMessageId() == null && msg.getCorrelationId() == null) {
+            LOG.trace("message has neither a message-id nor correlation-id");
+            return false;
+        } else if (!TenantConstants.isValidAction(msg.getSubject())) {
+            LOG.trace("message [{}] does not contain valid action property", msg.getMessageId());
+            return false;
+        } else if (msg.getReplyTo() == null) {
+            LOG.trace("message [{}] contains no reply-to address", msg.getMessageId());
+            return false;
+        } else if (msg.getBody() != null) {
+            if (!(msg.getBody() instanceof AmqpValue)) {
+                LOG.trace("message [{}] contains non-AmqpValue section payload", msg.getMessageId());
+                return false;
+            } else {
+                annotate(linkTarget, msg);
+                return true;
+            }
+        } else {
+            annotate(linkTarget, msg);
+            return true;
+        }
+    }
+
+    private static void annotate(final ResourceIdentifier linkTarget, final Message msg) {
+        final ResourceIdentifier targetResource = ResourceIdentifier
+                .from(linkTarget.getEndpoint(), linkTarget.getTenantId(), null);
+        MessageHelper.annotate(msg, targetResource);
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantMessageFilter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantMessageFilter.java
@@ -48,7 +48,7 @@ public final class TenantMessageFilter extends BaseMessageFilter {
         } else if (msg.getMessageId() == null && msg.getCorrelationId() == null) {
             LOG.trace("message has neither a message-id nor correlation-id");
             return false;
-        } else if (!TenantConstants.isValidAction(msg.getSubject())) {
+        } else if (!TenantConstants.Action.isValid(msg.getSubject())) {
             LOG.trace("message [{}] does not contain valid action property", msg.getMessageId());
             return false;
         } else if (msg.getReplyTo() == null) {

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantService.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.tenant;
+
+import java.net.HttpURLConnection;
+
+import org.eclipse.hono.util.TenantResult;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Verticle;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A service for keeping record of tenant information.
+ *
+ */
+public interface TenantService extends Verticle {
+
+    /**
+     * Gets tenant data by tenant ID.
+     *
+     * @param tenantId The ID of he tenant for which data is requested.
+     * @param resultHandler The handler to invoke with the result of the operation. If tenant exists, the
+     *            <em>status</em> will be {@link HttpURLConnection#HTTP_OK} and the <em>payload</em> will contain the
+     *            tenant object. Otherwise the status will be {@link HttpURLConnection#HTTP_NOT_FOUND}.
+     */
+    void get(String tenantId, Handler<AsyncResult<TenantResult>> resultHandler);
+
+    /**
+     * Creates a new Tenant.
+     *
+     * @param tenantId The ID of the tenant that shall be created.
+     * @param tenantObj A map containing the properties of the tenant (may be {@code null}).
+     * @param resultHandler The handler to invoke with the result of the operation. If a tenant with the given ID does
+     *            not yet exist, the <em>status</em> will be {@link HttpURLConnection#HTTP_CREATED}.
+     *            Otherwise the status will be {@link HttpURLConnection#HTTP_CONFLICT}.
+     */
+    void add(String tenantId, JsonObject tenantObj, Handler<AsyncResult<TenantResult>> resultHandler);
+
+    /**
+     * Updates tenant data.
+     *
+     * @param tenantId The tenant ID.
+     * @param tenantObj A map containing the properties of the tenant (may be {@code null}).
+     * @param resultHandler The handler to invoke with the result of the operation. If a tenant with the given ID exists
+     *         and was updated, the <em>status</em> will be {@link HttpURLConnection#HTTP_NO_CONTENT}.
+               Otherwise the status will be {@link HttpURLConnection#HTTP_NOT_FOUND}.
+     */
+    void update(String tenantId, JsonObject tenantObj, Handler<AsyncResult<TenantResult>> resultHandler);
+
+    /**
+     * Removes a tenant.
+     *
+     * @param tenantId The tenant ID.
+     * @param resultHandler The handler to invoke with the result of the operation. If the tenant has been removed, the
+     *            <em>status</em> will be {@link HttpURLConnection#HTTP_NO_CONTENT}. Otherwise the status will be
+     *            {@link HttpURLConnection#HTTP_NOT_FOUND}.
+     */
+    void remove(String tenantId, Handler<AsyncResult<TenantResult>> resultHandler);
+}

--- a/services/device-registry/src/main/fabric8/deployment.yml
+++ b/services/device-registry/src/main/fabric8/deployment.yml
@@ -23,6 +23,20 @@ spec:
         - sh
         - -c
         - 'cp -u /tmp/hono/example-credentials.json /var/lib/hono/device-registry/credentials.json'
+      # we use another init container to populate the registry
+      # with some default tenants
+      - name: copy-example-tenants
+        image: busybox
+        volumeMounts:
+        - name: conf
+          mountPath: /tmp/hono/example-tenants.json
+          subPath: example-tenants.json
+        - name: registry
+          mountPath: /var/lib/hono/device-registry
+        command:
+        - sh
+        - -c
+        - 'cp -u /tmp/hono/example-tenants.json /var/lib/hono/device-registry/tenants.json'
       containers:
       - volumeMounts:
         - name: registry

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
@@ -22,6 +22,7 @@ import org.eclipse.hono.service.HealthCheckProvider;
 import org.eclipse.hono.service.auth.AuthenticationService;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.registration.RegistrationService;
+import org.eclipse.hono.service.tenant.TenantService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -45,6 +46,7 @@ public class Application extends AbstractApplication {
     private AuthenticationService authenticationService;
     private CredentialsService credentialsService;
     private RegistrationService registrationService;
+    private TenantService tenantService;
 
     /**
      * Sets the credentials service implementation this server is based on.
@@ -60,7 +62,7 @@ public class Application extends AbstractApplication {
     /**
      * Sets the registration service implementation this server is based on.
      *
-     * @param registrationService the registrationService to set
+     * @param registrationService The registrationService to set.
      * @throws NullPointerException if service is {@code null}.
      */
     @Autowired
@@ -69,9 +71,20 @@ public class Application extends AbstractApplication {
     }
 
     /**
+     * Sets the tenant service implementation this server is based on.
+     *
+     * @param tenantService The tenantService to set.
+     * @throws NullPointerException if service is {@code null}.
+     */
+    @Autowired
+    public final void setTenantService(final TenantService tenantService) {
+        this.tenantService = Objects.requireNonNull(tenantService);
+    }
+
+    /**
      * Sets the authentication service implementation this server is based on.
      *
-     * @param authenticationService the authenticationService to set
+     * @param authenticationService The authenticationService to set.
      * @throws NullPointerException if service is {@code null}.
      */
     @Autowired
@@ -85,6 +98,7 @@ public class Application extends AbstractApplication {
         Future<Void> result = Future.future();
         CompositeFuture.all(
                 deployAuthenticationService(), // we only need 1 authentication service
+                deployTenantService(),
                 deployRegistrationService(),
                 deployCredentialsService()).setHandler(ar -> {
             if (ar.succeeded()) {
@@ -118,6 +132,13 @@ public class Application extends AbstractApplication {
         Future<String> result = Future.future();
         log.info("Starting registration service {}", registrationService);
         getVertx().deployVerticle(registrationService, result.completer());
+        return result;
+    }
+
+    private Future<String> deployTenantService() {
+        Future<String> result = Future.future();
+        log.info("Starting tenant service {}", tenantService);
+        getVertx().deployVerticle(tenantService, result.completer());
         return result;
     }
 

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
@@ -95,7 +95,7 @@ public class Application extends AbstractApplication {
     @Override
     protected final Future<Void> deployRequiredVerticles(int maxInstances) {
 
-        Future<Void> result = Future.future();
+        final Future<Void> result = Future.future();
         CompositeFuture.all(
                 deployAuthenticationService(), // we only need 1 authentication service
                 deployTenantService(),
@@ -111,14 +111,14 @@ public class Application extends AbstractApplication {
     }
 
     private Future<String> deployCredentialsService() {
-        Future<String> result = Future.future();
+        final Future<String> result = Future.future();
         log.info("Starting credentials service {}", credentialsService);
         getVertx().deployVerticle(credentialsService, result.completer());
         return result;
     }
 
     private Future<String> deployAuthenticationService() {
-        Future<String> result = Future.future();
+        final Future<String> result = Future.future();
         if (!Verticle.class.isInstance(authenticationService)) {
             result.fail("authentication service is not a verticle");
         } else {
@@ -129,14 +129,14 @@ public class Application extends AbstractApplication {
     }
 
     private Future<String> deployRegistrationService() {
-        Future<String> result = Future.future();
+        final Future<String> result = Future.future();
         log.info("Starting registration service {}", registrationService);
         getVertx().deployVerticle(registrationService, result.completer());
         return result;
     }
 
     private Future<String> deployTenantService() {
-        Future<String> result = Future.future();
+        final Future<String> result = Future.future();
         log.info("Starting tenant service {}", tenantService);
         getVertx().deployVerticle(tenantService, result.completer());
         return result;

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -23,6 +23,7 @@ import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.service.registration.RegistrationHttpEndpoint;
 import org.eclipse.hono.service.registration.RegistrationAmqpEndpoint;
+import org.eclipse.hono.service.tenant.TenantAmqpEndpoint;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
@@ -103,6 +104,17 @@ public class ApplicationConfig {
     @Scope("prototype")
     public CredentialsAmqpEndpoint credentialsAmqpEndpoint() {
         return new CredentialsAmqpEndpoint(vertx());
+    }
+
+    /**
+     * Creates a new instance of an AMQP 1.0 protocol handler for Hono's <em>Tenant</em> API.
+     *
+     * @return The handler.
+     */
+    @Bean
+    @Scope("prototype")
+    public TenantAmqpEndpoint tenantAmqpEndpoint() {
+        return new TenantAmqpEndpoint(vertx());
     }
 
     /**

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -227,6 +227,18 @@ public class ApplicationConfig {
     }
 
     /**
+     * Gets properties for configuring {@code FileBasedTenantsService} which implements
+     * the <em>Tenants</em> API.
+     *
+     * @return The properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.tenants.svc")
+    public FileBasedTenantsConfigProperties tenantsProperties() {
+        return new FileBasedTenantsConfigProperties();
+    }
+
+    /**
      * Exposes a factory for JWTs asserting a device's registration status as a Spring bean.
      *
      * @return The bean.

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
@@ -350,6 +350,9 @@ public final class FileBasedTenantService extends BaseTenantService<FileBasedTen
                     }
                     // all is checked and prepared, now store it internally
                     tenantsAdapterConfigurations.put(tenantId, adapterConfigurationsMap);
+                } else {
+                    // in case of update: remove a possibly existing previous entry
+                    tenantsAdapterConfigurations.remove(tenantId);
                 }
             } catch (ClassCastException cce) {
                 log.debug("addTenant invoked with wrong type for {}: not a JsonArray!", FIELD_ADAPTERS);

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
@@ -1,0 +1,392 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.deviceregistry;
+
+import static java.net.HttpURLConnection.*;
+import static org.eclipse.hono.util.RequestResponseApiConstants.FIELD_ENABLED;
+import static org.eclipse.hono.util.TenantConstants.FIELD_ADAPTERS;
+import static org.eclipse.hono.util.TenantConstants.FIELD_ADAPTERS_TYPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.eclipse.hono.service.tenant.BaseTenantService;
+import org.eclipse.hono.util.TenantResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A tenant service that keeps all data in memory but is backed by a file.
+ * <p>
+ * On startup this adapter loads all registered tenants from a file. On shutdown all tenants kept in memory are written
+ * to the file.
+ */
+@Repository
+public final class FileBasedTenantService extends BaseTenantService<FileBasedTenantsConfigProperties> {
+
+    /**
+     * The name of the JSON property containing the tenant ID.
+     */
+    public static final String FIELD_TENANT = "tenant";
+    /**
+     * The name of the JSON property containing the tenant data.
+     */
+    public static final String FIELD_DATA = "data";
+
+    // <tenantId, tenantPropertyValueObject>
+    private Map<String, JsonObject> tenants = new HashMap<>();
+    // <tenantId, <adapterType, adapterDataObject>>
+    private Map<String, Map<String, JsonObject>> tenantsAdapterConfigurations = new HashMap<>();
+    private boolean running = false;
+    private boolean dirty = false;
+
+    @Autowired
+    @Override
+    public void setConfig(final FileBasedTenantsConfigProperties configuration) {
+        setSpecificConfig(configuration);
+    }
+
+    @Override
+    protected void doStart(Future<Void> startFuture) {
+
+        if (running) {
+            startFuture.complete();
+        } else {
+
+            if (!getConfig().isModificationEnabled()) {
+                log.info("modification of registered tenants has been disabled");
+            }
+
+            if (getConfig().getFilename() == null) {
+                log.debug("tenant manager filename is not set, no tenant information will be loaded");
+                running = true;
+                startFuture.complete();
+            } else {
+                checkFileExists(getConfig().isSaveToFile()).compose(ok -> {
+                    return loadTenantData();
+                }).compose(s -> {
+                    if (getConfig().isSaveToFile()) {
+                        log.info("saving tenants to file every 3 seconds");
+                        vertx.setPeriodic(3000, tid -> {
+                            saveToFile();
+                        });
+                    } else {
+                        log.info("persistence is disabled, will not save tenants to file");
+                    }
+                    running = true;
+                    startFuture.complete();
+                }, startFuture);
+            }
+        }
+    }
+
+    Future<Void> loadTenantData() {
+
+        if (getConfig().getFilename() == null) {
+            return Future.succeededFuture();
+        } else {
+            Future<Buffer> readResult = Future.future();
+            vertx.fileSystem().readFile(getConfig().getFilename(), readResult.completer());
+            return readResult.compose(buffer -> {
+                return addAll(buffer);
+            }).recover(t -> {
+                log.debug("cannot load tenants from file [{}]: {}", getConfig().getFilename(), t.getMessage());
+                return Future.succeededFuture();
+            });
+        }
+    }
+
+    private Future<Void> checkFileExists(final boolean createIfMissing) {
+
+        Future<Void> result = Future.future();
+        if (getConfig().getFilename() == null) {
+            result.fail("no filename set");
+        } else if (vertx.fileSystem().existsBlocking(getConfig().getFilename())) {
+            result.complete();
+        } else if (createIfMissing) {
+            vertx.fileSystem().createFile(getConfig().getFilename(), result.completer());
+        } else {
+            log.debug("no such file [{}]", getConfig().getFilename());
+            result.complete();
+        }
+        return result;
+    }
+
+    private Future<Void> addAll(final Buffer tenantsBuffer) {
+
+        final Future<Void> result = Future.future();
+        try {
+            int tenantCount = 0;
+            final JsonArray allObjects = tenantsBuffer.toJsonArray();
+            for (Object obj : allObjects) {
+                if (JsonObject.class.isInstance(obj)) {
+                    tenantCount++;
+                    addTenants((JsonObject) obj);
+                }
+            }
+            log.info("successfully loaded {} tenants from file [{}]", tenantCount, getConfig().getFilename());
+            result.complete();
+        } catch (DecodeException e) {
+            log.warn("cannot read malformed JSON from tenants file [{}]", getConfig().getFilename());
+            result.fail(e);
+        }
+        return result;
+    }
+
+    private void addTenants(final JsonObject tenant) {
+        final String tenantId = tenant.getString(FIELD_TENANT);
+        if (tenantId != null) {
+
+            log.debug("loading tenant [{}]", tenantId);
+            final JsonObject tenantData = (JsonObject) tenant.getJsonObject(FIELD_DATA);
+
+            tenants.put(tenantId, tenantData);
+            final JsonObject adaptersData = (JsonObject) tenant.getJsonObject(FIELD_ADAPTERS);
+
+            if (adaptersData != null) {
+                final Map<String, JsonObject> adapterPropertiesMap = new HashMap<>();
+
+                for (final String adapterType : adaptersData.fieldNames()) {
+                    if (adapterType != null) {
+                        final JsonObject adapterConfigObject = adaptersData.getJsonObject(adapterType);
+                        if (JsonObject.class.isInstance(adapterConfigObject)) {
+                            log.debug("loading adapter properties for type [{}]", adapterType);
+                            adapterPropertiesMap.put(adapterType, adapterConfigObject);
+                        }
+                    }
+                }
+                tenantsAdapterConfigurations.put(tenantId, adapterPropertiesMap);
+            }
+        }
+    }
+
+    @Override
+    protected void doStop(final Future<Void> stopFuture) {
+
+        if (running) {
+            saveToFile().compose(s -> {
+                running = false;
+                stopFuture.complete();
+            }, stopFuture);
+        } else {
+            stopFuture.complete();
+        }
+    }
+
+    Future<Void> saveToFile() {
+
+        if (!getConfig().isSaveToFile()) {
+            return Future.succeededFuture();
+        } else if (dirty) {
+            return checkFileExists(true).compose(s -> {
+                final JsonArray tenantsJson = new JsonArray();
+
+                for (final Entry<String, JsonObject> entry : tenants.entrySet()) {
+                    final String tenantId = entry.getKey();
+                    final JsonObject tenantJson = new JsonObject();
+                    tenantJson.put(FIELD_TENANT, entry.getKey());
+                    tenantJson.put(FIELD_DATA, entry.getValue());
+
+                    // now the adapters (if any)
+                    final Map<String, JsonObject> adapters = tenantsAdapterConfigurations.get(tenantId);
+                    if (adapters != null) {
+                        final JsonObject adaptersJson = new JsonObject();
+                        for (final Entry<String, JsonObject> adapterEntry : adapters.entrySet()) {
+                            final String adapterType = adapterEntry.getKey();
+                            adaptersJson.put(adapterType, adapterEntry.getValue());
+                        }
+                        tenantJson.put(FIELD_ADAPTERS, adaptersJson);
+                    }
+
+                    tenantsJson.add(tenantJson);
+                }
+
+                final Future<Void> writeHandler = Future.future();
+                vertx.fileSystem().writeFile(getConfig().getFilename(),
+                        Buffer.factory.buffer(tenantsJson.encodePrettily()), writeHandler.completer());
+                return writeHandler.map(ok -> {
+                    dirty = false;
+                    log.trace("successfully wrote {} tenants to file {}", tenantsJson.size(),
+                            getConfig().getFilename());
+                    return (Void) null;
+                }).otherwise(t -> {
+                    log.warn("could not write tenants to file {}", getConfig().getFilename(), t);
+                    return (Void) null;
+                });
+            });
+        } else {
+            log.trace("tenants registry does not need to be persisted");
+            return Future.succeededFuture();
+        }
+    }
+
+    @Override
+    public void get(final String tenantId, final Handler<AsyncResult<TenantResult>> resultHandler) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(resultHandler);
+        resultHandler.handle(Future.succeededFuture(getTenantResult(tenantId)));
+    }
+
+    TenantResult getTenantResult(final String tenantId) {
+        final JsonObject data = tenants.get(tenantId);
+
+        if (data != null) {
+            final JsonArray adapterConfigurationsJson = getAdapterConfigurationsData(tenantId);
+            return TenantResult.from(HTTP_OK, getResultPayload(tenantId, data, adapterConfigurationsJson));
+        } else {
+            return TenantResult.from(HTTP_NOT_FOUND);
+        }
+    }
+
+    private JsonArray getAdapterConfigurationsData(final String tenantId) {
+        final Map<String, JsonObject> adapterConfigurations = tenantsAdapterConfigurations.get(tenantId);
+        if (adapterConfigurations == null) {
+            return null;
+        }
+        final JsonArray adapterDataArray = new JsonArray();
+        for (Entry<String, JsonObject> configEntry : adapterConfigurations.entrySet()) {
+            final JsonObject data = new JsonObject();
+            data.put(FIELD_ADAPTERS_TYPE, configEntry.getKey()).mergeIn(configEntry.getValue());
+            adapterDataArray.add(data);
+        }
+        return adapterDataArray;
+    }
+
+    @Override
+    public void remove(final String tenantId, final Handler<AsyncResult<TenantResult>> resultHandler) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(resultHandler);
+        resultHandler.handle(Future.succeededFuture(removeTenant(tenantId)));
+    }
+
+    TenantResult removeTenant(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+
+        if (getConfig().isModificationEnabled()) {
+            if (tenants.remove(tenantId) != null) {
+                dirty = true;
+                tenantsAdapterConfigurations.remove(tenantId);
+                return TenantResult.from(HTTP_NO_CONTENT);
+            } else {
+                return TenantResult.from(HTTP_NOT_FOUND);
+            }
+        } else {
+            return TenantResult.from(HTTP_FORBIDDEN);
+        }
+    }
+
+    @Override
+    public void add(final String tenantId, final JsonObject data,
+            final Handler<AsyncResult<TenantResult>> resultHandler) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(data);
+        Objects.requireNonNull(resultHandler);
+
+        resultHandler.handle(Future.succeededFuture(addOrUpdateTenant(tenantId, data, false)));
+    }
+
+    /**
+     * Adds or updates a tenant to this tenant registry.
+     *
+     * @param tenantId The tenant to add.
+     * @param data Additional data to register with the tenant (may be {@code null}).
+     * @param update If true, an existing tenant shall be overwritten (otherwise the outcome of this method will result
+     *               in {@link java.net.HttpURLConnection#HTTP_CONFLICT};
+     * @return The outcome of the operation indicating success or failure.
+     */
+    public TenantResult addOrUpdateTenant(final String tenantId, final JsonObject data, final boolean update) {
+
+        Objects.requireNonNull(tenantId);
+        if (update) {
+            if (!tenants.containsKey(tenantId)) {
+                return TenantResult.from(HTTP_NOT_FOUND);
+            }
+        } else {
+            if (tenants.containsKey(tenantId)) {
+                return TenantResult.from(HTTP_CONFLICT);
+            }
+        }
+
+        JsonObject obj = data != null ? data : new JsonObject().put(FIELD_ENABLED, Boolean.TRUE);
+
+        try {
+            final JsonArray adaptersConfigurationArray = obj.getJsonArray(FIELD_ADAPTERS);
+            if (adaptersConfigurationArray != null) {
+                final Map<String, JsonObject> adapterConfigurationsMap = new HashMap<>();
+                for (int i = 0; i < adaptersConfigurationArray.size(); i++) {
+                    final JsonObject adapterConfiguration = adaptersConfigurationArray.getJsonObject(i);
+                    final String adapterType = (String) adapterConfiguration.remove(FIELD_ADAPTERS_TYPE);
+                    if (adapterType != null) {
+                        adapterConfiguration.remove(FIELD_ADAPTERS_TYPE);
+                        adapterConfigurationsMap.put(adapterType, adapterConfiguration);
+                    } else {
+                        return TenantResult.from(HTTP_BAD_REQUEST);
+                    }
+                }
+                // all is checked and prepared, now store it internally
+                tenantsAdapterConfigurations.put(tenantId, adapterConfigurationsMap);
+            }
+        }
+        catch (ClassCastException cce) {
+            log.warn("addTenant invoked with wrong type for {}: not a JsonArray!", FIELD_ADAPTERS);
+            return TenantResult.from(HTTP_BAD_REQUEST);
+        }
+
+        dirty = true;
+        obj.remove(FIELD_TENANT);
+        obj.remove(FIELD_ADAPTERS);
+        tenants.put(tenantId, obj);
+
+        if (update) {
+            return TenantResult.from(HTTP_NO_CONTENT);
+        } else {
+            return TenantResult.from(HTTP_CREATED);
+        }
+    }
+
+    @Override
+    public void update(final String tenantId, final JsonObject data, final Handler<AsyncResult<TenantResult>> resultHandler) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(data);
+        Objects.requireNonNull(resultHandler);
+
+        resultHandler.handle(Future.succeededFuture(addOrUpdateTenant(tenantId, data, true)));
+    }
+
+    /**
+     * Removes all devices from the tenant registry.
+     */
+    public void clear() {
+        dirty = true;
+        tenants.clear();
+        tenantsAdapterConfigurations.clear();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s[filename=%s]", FileBasedTenantService.class.getSimpleName(),
+                getConfig().getFilename());
+    }
+}

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantsConfigProperties.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantsConfigProperties.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.deviceregistry;
+
+import org.eclipse.hono.service.tenant.TenantService;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+
+
+/**
+ * Configuration properties for the Hono's tenant manager as own server.
+ *
+ */
+public final class FileBasedTenantsConfigProperties {
+
+    private static final String DEFAULT_TENANTS_FILENAME = "/var/lib/hono/device-registry/tenants.json";
+
+    // the name of the file used to persist the tenant content
+    private String filename = DEFAULT_TENANTS_FILENAME;
+    private boolean saveToFile = false;
+    private boolean modificationEnabled = true;
+
+    /**
+     * Gets the path to the file that the content of the tenant manager should be persisted to
+     * periodically.
+     * <p>
+     * Default value is <em>/home/hono/device-registry/tenants.json</em>.
+     * 
+     * @return The file name.
+     */
+    public String getFilename() {
+        return filename;
+    }
+
+    /**
+     * Sets the path to the file that the content of the tenant manager should be persisted to
+     * periodically.
+     * <p>
+     * Default value is <em>/home/hono/device-registry/tenants.json</em>.
+     * 
+     * @param filename The name of the file to persist to (can be a relative or absolute path).
+     */
+    public void setFilename(final String filename) {
+        this.filename = filename;
+    }
+
+    /**
+     * Checks whether the content of the tenant manager should be persisted to the file system
+     * periodically.
+     * <p>
+     * Default value is {@code false}.
+     * 
+     * @return {@code true} if tenant manager content should be persisted.
+     */
+    public boolean isSaveToFile() {
+        return saveToFile;
+    }
+
+    /**
+     * Sets whether the content of the tenant manager should be persisted to the file system
+     * periodically.
+     * <p>
+     * Default value is {@code false}.
+     * 
+     * @param enabled {@code true} if content of the tenant manager should be persisted.
+     * @throws IllegalStateException if this tenant manager is already running.
+     */
+    public void setSaveToFile(final boolean enabled) {
+        this.saveToFile = enabled;
+    }
+
+    /**
+     * Checks whether this tenant manager allows modification and removal of registered tenants.
+     * <p>
+     * If set to {@code false} then the methods {@link TenantService#update(String, JsonObject, Handler)}
+     * and {@link TenantService#remove(String, Handler)} always return a <em>403 Forbidden</em> response.
+     * <p>
+     * The default value of this property is {@code true}.
+     * 
+     * @return The flag.
+     */
+    public boolean isModificationEnabled() {
+        return modificationEnabled;
+    }
+
+    /**
+     * Sets whether this tenant manager allows modification and removal of registered tenants.
+     * <p>
+     * If set to {@code false} then the methods {@link TenantService#update(String, JsonObject, Handler)}
+     * and {@link TenantService#remove(String, Handler)} always return a <em>403 Forbidden</em> response.
+     * <p>
+     * The default value of this property is {@code true}.
+     * 
+     * @param flag The flag.
+     */
+    public void setModificationEnabled(final boolean flag) {
+        modificationEnabled = flag;
+    }
+}

--- a/services/device-registry/src/test/resources/tenants.json
+++ b/services/device-registry/src/test/resources/tenants.json
@@ -11,15 +11,15 @@
       "enabled": "true"
     },
     "adapters": {
-      "http": {
+      "hono-http": {
         "enabled": true,
         "device-authentication-required": true
       },
-      "mqtt": {
+      "hono-mqtt": {
         "enabled": false,
         "device-authentication-required": true
       },
-      "kura": {
+      "hono-kura": {
         "enabled": false,
         "device-authentication-required": true
       }

--- a/services/device-registry/src/test/resources/tenants.json
+++ b/services/device-registry/src/test/resources/tenants.json
@@ -1,0 +1,29 @@
+[
+  {
+    "tenant": "DEFAULT_TENANT",
+    "data": {
+      "enabled": "true"
+    }
+  },
+  {
+    "tenant": "HTTP_TENANT",
+    "data": {
+      "enabled": "true"
+    },
+    "adapters": {
+      "http": {
+        "enabled": true,
+        "device-authentication-required": true
+      },
+      "mqtt": {
+        "enabled": false,
+        "device-authentication-required": true
+      },
+      "kura": {
+        "enabled": false,
+        "device-authentication-required": true
+      }
+
+    }
+  }
+]


### PR DESCRIPTION
This is the first PR for implementing the Tenant API in Hono.
Contained is the AMQP endpoint `/tenant`, the base service for the tenant service, an example file based implementation and the support for Docker Swarm and Kubernetes.
The example file based implementation is part of the Device Registry microservice.

Not in this PR are:
- tests
- RESTful interface for the tenant API
- Hono client for the tenant API
- Usage of the tenant API in protocol adapters, the registration and credentials API (tenant needs to be checked first)
- documentation (except for javadoc)

They will follow in different PRs soon.