### PR TITLE
Introduction of a detach handler at links in Hono Client.

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoClient.java
@@ -117,8 +117,24 @@ public interface HonoClient {
      * @param tenantId The tenant to consume data for.
      * @param telemetryConsumer The handler to invoke with every message received.
      * @param creationHandler The handler to invoke with the outcome of the operation.
+     * @param detachHandler The handler invoked on detached (not closed) link.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
+    void createTelemetryConsumer(
+            String tenantId,
+            Consumer<Message> telemetryConsumer,
+            Handler<AsyncResult<MessageConsumer>> creationHandler,
+            Handler<AsyncResult<Void>> detachHandler);
+
+    /**
+     * Creates a new consumer of telemetry data for a tenant.
+     *
+     * @param tenantId The tenant to consume data for.
+     * @param telemetryConsumer The handler to invoke with every message received.
+     * @param creationHandler The handler to invoke with the outcome of the operation.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    @Deprecated
     void createTelemetryConsumer(
             String tenantId,
             Consumer<Message> telemetryConsumer,
@@ -134,8 +150,28 @@ public interface HonoClient {
      * @param tenantId The tenant to consume events for.
      * @param eventConsumer The handler to invoke with every event received.
      * @param creationHandler The handler to invoke with the outcome of the operation.
+     * @param detachHandler The handler invoked on detached (not closed) link.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
+    void createEventConsumer(
+            String tenantId,
+            Consumer<Message> eventConsumer,
+            Handler<AsyncResult<MessageConsumer>> creationHandler,
+            Handler<AsyncResult<Void>> detachHandler);
+
+    /**
+     * Creates a new consumer of events for a tenant.
+     * <p>
+     * The events passed in to the registered eventConsumer will be settled
+     * automatically if the consumer does not throw an exception and does not
+     * manually handle the message disposition using the passed in delivery.
+     *
+     * @param tenantId The tenant to consume events for.
+     * @param eventConsumer The handler to invoke with every event received.
+     * @param creationHandler The handler to invoke with the outcome of the operation.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    @Deprecated
     void createEventConsumer(
             String tenantId,
             Consumer<Message> eventConsumer,
@@ -151,8 +187,28 @@ public interface HonoClient {
      * @param tenantId The tenant to consume events for.
      * @param eventConsumer The handler to invoke with every event received.
      * @param creationHandler The handler to invoke with the outcome of the operation.
+     * @param detachHandler The handler invoked on detached (not closed) link.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
+    void createEventConsumer(
+            String tenantId,
+            BiConsumer<ProtonDelivery, Message> eventConsumer,
+            Handler<AsyncResult<MessageConsumer>> creationHandler,
+            Handler<AsyncResult<Void>> detachHandler);
+
+    /**
+     * Creates a new consumer of events for a tenant.
+     * <p>
+     * The events passed in to the registered eventConsumer will be settled
+     * automatically if the consumer does not throw an exception and does not
+     * manually handle the message disposition using the passed in delivery.
+     *
+     * @param tenantId The tenant to consume events for.
+     * @param eventConsumer The handler to invoke with every event received.
+     * @param creationHandler The handler to invoke with the outcome of the operation.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    @Deprecated
     void createEventConsumer(
             String tenantId,
             BiConsumer<ProtonDelivery, Message> eventConsumer,

--- a/client/src/main/java/org/eclipse/hono/client/HonoClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoClient.java
@@ -117,14 +117,14 @@ public interface HonoClient {
      * @param tenantId The tenant to consume data for.
      * @param telemetryConsumer The handler to invoke with every message received.
      * @param creationHandler The handler to invoke with the outcome of the operation.
-     * @param detachHandler The handler invoked on detached (not closed) link.
+     * @param closeHandler The handler invoked on detached link (detach with close=true and close=false).
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     void createTelemetryConsumer(
             String tenantId,
             Consumer<Message> telemetryConsumer,
             Handler<AsyncResult<MessageConsumer>> creationHandler,
-            Handler<AsyncResult<Void>> detachHandler);
+            Handler<AsyncResult<Void>> closeHandler);
 
     /**
      * Creates a new consumer of telemetry data for a tenant.
@@ -150,14 +150,14 @@ public interface HonoClient {
      * @param tenantId The tenant to consume events for.
      * @param eventConsumer The handler to invoke with every event received.
      * @param creationHandler The handler to invoke with the outcome of the operation.
-     * @param detachHandler The handler invoked on detached (not closed) link.
+     * @param closeHandler The handler invoked on detached link (detach with close=true and close=false).
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     void createEventConsumer(
             String tenantId,
             Consumer<Message> eventConsumer,
             Handler<AsyncResult<MessageConsumer>> creationHandler,
-            Handler<AsyncResult<Void>> detachHandler);
+            Handler<AsyncResult<Void>> closeHandler);
 
     /**
      * Creates a new consumer of events for a tenant.
@@ -187,14 +187,14 @@ public interface HonoClient {
      * @param tenantId The tenant to consume events for.
      * @param eventConsumer The handler to invoke with every event received.
      * @param creationHandler The handler to invoke with the outcome of the operation.
-     * @param detachHandler The handler invoked on detached (not closed) link.
+     * @param closeHandler The handler invoked on detached link (detach with close=true and close=false).
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     void createEventConsumer(
             String tenantId,
             BiConsumer<ProtonDelivery, Message> eventConsumer,
             Handler<AsyncResult<MessageConsumer>> creationHandler,
-            Handler<AsyncResult<Void>> detachHandler);
+            Handler<AsyncResult<Void>> closeHandler);
 
     /**
      * Creates a new consumer of events for a tenant.

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -213,7 +213,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
 
     private Future<ProtonReceiver> createReceiver(final ProtonConnection con, final String sourceAddress, final Handler<String> closeHook) {
 
-        return AbstractHonoClient.createReceiver(context, config, con, sourceAddress, ProtonQoS.AT_LEAST_ONCE, this::handleResponse, closeHook, detach -> {});
+        return AbstractHonoClient.createReceiver(context, config, con, sourceAddress, ProtonQoS.AT_LEAST_ONCE, this::handleResponse, closeHook);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -76,7 +76,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
     /**
      * Creates a request-response client.
      * <p>
-     * The client will be ready to use after invoking {@link #createLinks(ProtonConnection, int, long)} only.
+     * The client will be ready to use after invoking {@link #createLinks(ProtonConnection)} only.
      * 
      * @param context The vert.x context to run message exchanges with the peer on.
      * @param config The configuration properties to use.
@@ -213,7 +213,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
 
     private Future<ProtonReceiver> createReceiver(final ProtonConnection con, final String sourceAddress, final Handler<String> closeHook) {
 
-        return AbstractHonoClient.createReceiver(context, config, con, sourceAddress, ProtonQoS.AT_LEAST_ONCE, this::handleResponse, closeHook);
+        return AbstractHonoClient.createReceiver(context, config, con, sourceAddress, ProtonQoS.AT_LEAST_ONCE, this::handleResponse, closeHook, detach -> {});
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/EventConsumerImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/EventConsumerImpl.java
@@ -13,6 +13,15 @@
 
 package org.eclipse.hono.client.impl;
 
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -21,14 +30,6 @@ import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.ProtonDelivery;
 import io.vertx.proton.ProtonQoS;
 import io.vertx.proton.ProtonReceiver;
-import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.MessageConsumer;
-import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.EventConstants;
-
-import java.util.Objects;
-import java.util.function.BiConsumer;
 
 /**
  * A Vertx-Proton based client for consuming event messages from a Hono server.
@@ -50,7 +51,7 @@ public class EventConsumerImpl extends AbstractConsumer implements MessageConsum
      * @param tenantId The tenant to consumer events for.
      * @param eventConsumer The consumer to invoke with each event received.
      * @param creationHandler The handler to invoke with the outcome of the creation attempt.
-     * @param detachHandler The handler invoked on detached (not closed) link.
+     * @param closeHook The handler to invoke when the link is closed by the peer (may be {@code null}).
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public static void create(
@@ -60,9 +61,9 @@ public class EventConsumerImpl extends AbstractConsumer implements MessageConsum
             final String tenantId,
             final BiConsumer<ProtonDelivery, Message> eventConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler,
-            final Handler<AsyncResult<Void>> detachHandler) {
+            final Handler<String> closeHook) {
 
-        create(context, clientConfig, con, tenantId, Constants.DEFAULT_PATH_SEPARATOR, eventConsumer, creationHandler, detachHandler);
+        create(context, clientConfig, con, tenantId, Constants.DEFAULT_PATH_SEPARATOR, eventConsumer, creationHandler, closeHook);
     }
 
     /**
@@ -75,7 +76,7 @@ public class EventConsumerImpl extends AbstractConsumer implements MessageConsum
      * @param pathSeparator The address path separator character used by the server.
      * @param eventConsumer The consumer to invoke with each event received.
      * @param creationHandler The handler to invoke with the outcome of the creation attempt.
-     * @param detachHandler The handler invoked on detached (not closed) link.
+     * @param closeHook The handler to invoke when the link is closed by the peer (may be {@code null}).
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public static void create(
@@ -86,7 +87,7 @@ public class EventConsumerImpl extends AbstractConsumer implements MessageConsum
             final String pathSeparator,
             final BiConsumer<ProtonDelivery, Message> eventConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler,
-            final Handler<AsyncResult<Void>> detachHandler) {
+            final Handler<String> closeHook) {
 
         Objects.requireNonNull(context);
         Objects.requireNonNull(clientConfig);
@@ -95,10 +96,9 @@ public class EventConsumerImpl extends AbstractConsumer implements MessageConsum
         Objects.requireNonNull(pathSeparator);
         Objects.requireNonNull(eventConsumer);
         Objects.requireNonNull(creationHandler);
-        Objects.requireNonNull(detachHandler);
 
         createReceiver(context, clientConfig, con, String.format(EVENT_ADDRESS_TEMPLATE, pathSeparator, tenantId),
-                ProtonQoS.AT_LEAST_ONCE, eventConsumer::accept, null, detachHandler).setHandler(created -> {
+                ProtonQoS.AT_LEAST_ONCE, eventConsumer::accept, closeHook).setHandler(created -> {
             if (created.succeeded()) {
                 creationHandler.handle(Future.succeededFuture(
                         new EventConsumerImpl(context, clientConfig, created.result())));

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
@@ -352,7 +352,7 @@ public final class HonoClientImpl implements HonoClient {
             final String tenantId,
             final Consumer<Message> telemetryConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler) {
-        createTelemetryConsumer(tenantId, telemetryConsumer, creationHandler, detachHandler -> {});
+        createTelemetryConsumer(tenantId, telemetryConsumer, creationHandler, closeHandler -> {});
     }
 
     @Override
@@ -360,7 +360,7 @@ public final class HonoClientImpl implements HonoClient {
             final String tenantId,
             final Consumer<Message> telemetryConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler,
-            final Handler<AsyncResult<Void>> detachHandler) {
+            final Handler<AsyncResult<Void>> closeHandler) {
 
         // register a handler to be notified if the underlying connection to the server fails
         // so that we can fail the result handler passed in
@@ -377,7 +377,7 @@ public final class HonoClientImpl implements HonoClient {
         });
         checkConnection().compose(
                 connected -> TelemetryConsumerImpl.create(context, clientConfigProperties, connection, tenantId,
-                        connectionFactory.getPathSeparator(), telemetryConsumer, consumerTracker.completer(), detachHandler),
+                        connectionFactory.getPathSeparator(), telemetryConsumer, consumerTracker.completer(), closeHook -> closeHandler.handle(Future.succeededFuture())),
                 consumerTracker);
     }
 
@@ -388,16 +388,16 @@ public final class HonoClientImpl implements HonoClient {
             final Consumer<Message> eventConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler) {
 
-        createEventConsumer(tenantId, (delivery, message) -> eventConsumer.accept(message), creationHandler, detachHandler->{});
+        createEventConsumer(tenantId, (delivery, message) -> eventConsumer.accept(message), creationHandler, closeHandler->{});
     }
     @Override
     public void createEventConsumer(
             final String tenantId,
             final Consumer<Message> eventConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler,
-            final Handler<AsyncResult<Void>> detachHandler) {
+            final Handler<AsyncResult<Void>> closeHandler) {
 
-        createEventConsumer(tenantId, (delivery, message) -> eventConsumer.accept(message), creationHandler, detachHandler);
+        createEventConsumer(tenantId, (delivery, message) -> eventConsumer.accept(message), creationHandler, closeHandler);
     }
 
     @Override
@@ -406,14 +406,14 @@ public final class HonoClientImpl implements HonoClient {
             final String tenantId,
             final BiConsumer<ProtonDelivery, Message> eventConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler) {
-        createEventConsumer(tenantId, eventConsumer, creationHandler, detachHandler -> { });
+        createEventConsumer(tenantId, eventConsumer, creationHandler, closeHandler -> { });
     }
     @Override
     public void createEventConsumer(
             final String tenantId,
             final BiConsumer<ProtonDelivery, Message> eventConsumer,
             final Handler<AsyncResult<MessageConsumer>> creationHandler,
-            final Handler<AsyncResult<Void>> detachHandler) {
+            final Handler<AsyncResult<Void>> closeHandler) {
 
         // register a handler to be notified if the underlying connection to the server fails
         // so that we can fail the result handler passed in
@@ -430,7 +430,7 @@ public final class HonoClientImpl implements HonoClient {
         });
         checkConnection().compose(
                 connected -> EventConsumerImpl.create(context, clientConfigProperties, connection, tenantId,
-                        connectionFactory.getPathSeparator(), eventConsumer, consumerTracker.completer(), detachHandler),
+                        connectionFactory.getPathSeparator(), eventConsumer, consumerTracker.completer(), closeHook -> closeHandler.handle(Future.succeededFuture())),
                 consumerTracker);
     }
 

--- a/client/src/test/java/org/eclipse/hono/client/impl/EventConsumerImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/EventConsumerImplTest.java
@@ -93,7 +93,7 @@ public class EventConsumerImplTest {
         Async consumerCreation = ctx.async();
         EventConsumerImpl.create(vertx.getOrCreateContext(), new ClientConfigProperties(), con, "tenant", eventConsumer, ctx.asyncAssertSuccess(s -> {
             consumerCreation.complete();
-        }));
+        }), detachHandler -> {});
         consumerCreation.await(500);
 
         // WHEN an event is received

--- a/example/src/main/resources/logback.xml
+++ b/example/src/main/resources/logback.xml
@@ -15,6 +15,7 @@
     <appender-ref ref="STDOUT" />
   </root>
 
-  <logger name="org.eclipse.hono.client" level="DEBUG"/>
+  <logger name="org.eclipse.hono.client" level="TRACE"/>
+  <logger name="org.eclipse.hono.client.impl" level="TRACE"/>
 
 </configuration>

--- a/example/src/main/resources/logback.xml
+++ b/example/src/main/resources/logback.xml
@@ -15,7 +15,7 @@
     <appender-ref ref="STDOUT" />
   </root>
 
-  <logger name="org.eclipse.hono.client" level="TRACE"/>
-  <logger name="org.eclipse.hono.client.impl" level="TRACE"/>
+  <logger name="org.eclipse.hono.client" level="DEBUG"/>
+  <logger name="org.eclipse.hono.client.impl" level="DEBUG"/>
 
 </configuration>

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/SenderFactoryImpl.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/SenderFactoryImpl.java
@@ -122,14 +122,6 @@ public class SenderFactoryImpl implements SenderFactory {
                 LOG.debug("sender [{}] for container [{}] closed", address, connection.getRemoteContainer());
             }
         });
-        sender.detachHandler(remoteDetached -> {
-            if (remoteDetached.succeeded()) {
-                LOG.debug("sender [{}] detached (with closed=false) by peer [{}]", sender.getRemoteSource(), connection.getRemoteContainer());
-            } else {
-                LOG.debug("sender [{}] detached (with closed=false) by peer [{}]: {}", sender.getRemoteSource(), connection.getRemoteContainer(), remoteDetached.cause().getMessage());
-            }
-            sender.close();
-        });
         sender.open();
         return result;
     }

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/SenderFactoryImpl.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/SenderFactoryImpl.java
@@ -122,6 +122,14 @@ public class SenderFactoryImpl implements SenderFactory {
                 LOG.debug("sender [{}] for container [{}] closed", address, connection.getRemoteContainer());
             }
         });
+        sender.detachHandler(remoteDetached -> {
+            if (remoteDetached.succeeded()) {
+                LOG.debug("sender [{}] detached (with closed=false) by peer [{}]", sender.getRemoteSource(), connection.getRemoteContainer());
+            } else {
+                LOG.debug("sender [{}] detached (with closed=false) by peer [{}]: {}", sender.getRemoteSource(), connection.getRemoteContainer(), remoteDetached.cause().getMessage());
+            }
+            sender.close();
+        });
         sender.open();
         return result;
     }


### PR DESCRIPTION
The client application can react on a detach(close=false) and reopen the link later (retry).
In future this should be handled inside the Hono client as well as the connection retry.
