### PR TITLE
[#416] Support gateway ID in RegistrationClient.

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -466,7 +466,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             HttpUtils.badRequest(ctx, "missing body");
         } else {
 
-            final Future<JsonObject> tokenTracker = getRegistrationAssertion(tenant, deviceId);
+            final Future<JsonObject> tokenTracker = getRegistrationAssertion(tenant, deviceId, null);
 
             CompositeFuture.all(tokenTracker, senderTracker).compose(ok -> {
 

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -337,7 +337,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
 
         final RegistrationClient regClient = mock(RegistrationClient.class);
         final JsonObject result = new JsonObject().put(RegistrationConstants.FIELD_ASSERTION, "token");
-        when(regClient.assertRegistration(anyString())).thenReturn(Future.succeededFuture(result));
+        when(regClient.assertRegistration(anyString(), anyString())).thenReturn(Future.succeededFuture(result));
 
         when(registrationClient.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(regClient));
 

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -415,7 +415,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
 
     private Future<Void> publishMessage(final MqttEndpoint endpoint, final MqttPublishMessage messageFromDevice, final Message message, final ResourceIdentifier authorizedResource) {
 
-        final Future<JsonObject> assertionTracker = getRegistrationAssertion(authorizedResource.getTenantId(), authorizedResource.getResourceId());
+        final Future<JsonObject> assertionTracker = getRegistrationAssertion(authorizedResource.getTenantId(), authorizedResource.getResourceId(), null);
         final Future<MessageSender> senderTracker = getSenderForEndpoint(authorizedResource.getEndpoint(), authorizedResource.getTenantId());
 
         return CompositeFuture.all(assertionTracker, senderTracker).recover(t -> {

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -492,7 +492,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
         final RegistrationClient regClient = mock(RegistrationClient.class);
         final JsonObject result = new JsonObject().put(RegistrationConstants.FIELD_ASSERTION, "token");
-        when(regClient.assertRegistration(anyString())).thenReturn(Future.succeededFuture(result));
+        when(regClient.assertRegistration(anyString(), anyString())).thenReturn(Future.succeededFuture(result));
 
         when(registrationClient.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(regClient));
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
@@ -263,14 +263,14 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
 
         Objects.requireNonNull(deviceId);
 
-        final TriTuple<String, String, String> key = TriTuple.of("assert", deviceId, null);
+        final TriTuple<String, String, String> key = TriTuple.of("assert", deviceId, gatewayId);
         return getCachedRegistrationAssertion(key).recover(t -> {
             final Future<RegistrationResult> regResult = Future.future();
-            createAndSendRequest(
-                    RegistrationConstants.ACTION_ASSERT,
-                    createDeviceIdProperties(deviceId),
-                    null,
-                    regResult.completer());
+            final Map<String, Object> properties = createDeviceIdProperties(deviceId);
+            if (gatewayId != null) {
+                properties.put(RegistrationConstants.APP_PROPERTY_GATEWAY_ID, gatewayId);
+            }
+            createAndSendRequest(RegistrationConstants.ACTION_ASSERT, properties, null, regResult.completer());
             return regResult.map(response -> {
                 switch(response.getStatus()) {
                 case HttpURLConnection.HTTP_OK:

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.service;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -172,10 +173,10 @@ public class AbstractProtocolAdapterBaseTest {
 
         // GIVEN an adapter connected to a registration service
         final JsonObject assertionResult = newRegistrationAssertionResult("token");
-        when(registrationClient.assertRegistration("device")).thenReturn(Future.succeededFuture(assertionResult));
+        when(registrationClient.assertRegistration(eq("device"), anyString())).thenReturn(Future.succeededFuture(assertionResult));
 
         // WHEN an assertion for the device is retrieved
-        adapter.getRegistrationAssertion("tenant", "device").setHandler(ctx.asyncAssertSuccess(result -> {
+        adapter.getRegistrationAssertion("tenant", "device", null).setHandler(ctx.asyncAssertSuccess(result -> {
             // THEN the result contains the registration assertion
             ctx.assertEquals(assertionResult, result);
         }));
@@ -183,21 +184,21 @@ public class AbstractProtocolAdapterBaseTest {
 
     /**
      * Verifies that the adapter fails a request to get a registration assertion for
-     * a non-existing device with a 403 Forbidden error.
+     * a non-existing device.
      * 
      * @param ctx The vert.x test context.
      */
     @Test
-    public void testGetRegistrationAssertionFailsWith403ForNonExistingDevice(final TestContext ctx) {
+    public void testGetRegistrationAssertionFailsWith404ForNonExistingDevice(final TestContext ctx) {
 
         // GIVEN an adapter connected to a registration service
-        when(registrationClient.assertRegistration("non-existent")).thenReturn(
+        when(registrationClient.assertRegistration(eq("non-existent"), anyString())).thenReturn(
                 Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
 
         // WHEN an assertion for a non-existing device is retrieved
-        adapter.getRegistrationAssertion("tenant", "non-existent").setHandler(ctx.asyncAssertFailure(t -> {
-            // THEN the request fails with a 403
-            ctx.assertEquals(HttpURLConnection.HTTP_FORBIDDEN, ((ServiceInvocationException) t).getErrorCode());
+        adapter.getRegistrationAssertion("tenant", "non-existent", null).setHandler(ctx.asyncAssertFailure(t -> {
+            // THEN the request fails with a 404
+            ctx.assertEquals(HttpURLConnection.HTTP_NOT_FOUND, ((ServiceInvocationException) t).getErrorCode());
         }));
     }
 


### PR DESCRIPTION
This is the 2nd PR for adding support for gateway devices.
It adds an assertRegistration method variant to RegistrationClient accepting a gateway ID in order
to get an assertion for a device that is connected via a gateway.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>