### PR TITLE
Fix m2eclipse error "Artifact has not been packaged yet..."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016 Bosch Software Innovations GmbH.
+    Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
 
     All rights reserved. This program and the accompanying materials 
     are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,8 @@
     http://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
-    Bosch Software Innovations GmbH - initial API and implementation and initial documentation
+      Bosch Software Innovations GmbH - initial API and implementation and initial documentation
+      Red Hat Inc
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -292,6 +293,23 @@
                       <runOnConfiguration>true</runOnConfiguration>
                       <runOnIncremental>true</runOnIncremental>
                     </execute>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <!--
+                   Disable unpack-dependecies goal in order to prevent the m2eclipse
+                   error "Artifact has not been packaged yet..."
+                   -->
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <versionRange>[3,)</versionRange>
+                    <goals>
+                      <goal>unpack-dependencies</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
                   </action>
                 </pluginExecution>
               </pluginExecutions>


### PR DESCRIPTION
This change fixes the annoying error:

> Artifact has not been packaged yet. When used on reactor artifact,
unpack should be executed after packaging: see MDEP-98.

It does work around this issue by simply disabling the plugin execution
in the m2eclipse plugin. This means that the IDE builder will no longer
execute the step of packaging the legal files. However running maven
itself, even from within the IDE, will still perform this step.

Signed-off-by: Jens Reimann <jreimann@redhat.com>