### PR TITLE
Making the Registration and Credentials Service API extensible

### DIFF
--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
@@ -73,7 +73,7 @@ public class VertxBasedHttpProtocolAdapterTest {
      */
     @SuppressWarnings("unchecked")
     @BeforeClass
-    public final static void setup(final TestContext context) {
+    public static final void setup(final TestContext context) {
 
         vertx = Vertx.vertx();
         final Async startup = context.async();
@@ -106,7 +106,7 @@ public class VertxBasedHttpProtocolAdapterTest {
      * Shuts down the server.
      */
     @AfterClass
-    public final static void shutDown() {
+    public static final void shutDown() {
         vertx.close();
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
@@ -39,29 +39,29 @@ import io.vertx.proton.ProtonConnection;
  * A Vertx-Proton based client for Hono's Credentials API.
  *
  */
-public final class CredentialsClientImpl extends AbstractRequestResponseClient<CredentialsResult<CredentialsObject>> implements CredentialsClient {
+public class CredentialsClientImpl extends AbstractRequestResponseClient<CredentialsResult<CredentialsObject>> implements CredentialsClient {
 
     private static Logger LOG = LoggerFactory.getLogger(CredentialsClientImpl.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    private CredentialsClientImpl(final Context context, final ClientConfigProperties config, final String tenantId) {
+    protected CredentialsClientImpl(final Context context, final ClientConfigProperties config, final String tenantId) {
         super(context, config, tenantId);
     }
 
     @Override
-    protected String getName() {
+    protected final String getName() {
 
         return CredentialsConstants.CREDENTIALS_ENDPOINT;
     }
 
     @Override
-    protected String createMessageId() {
+    protected final String createMessageId() {
 
         return String.format("cred-client-%s", UUID.randomUUID());
     }
 
     @Override
-    protected CredentialsResult<CredentialsObject> getResult(final int status, final String payload) {
+    protected final CredentialsResult<CredentialsObject> getResult(final int status, final String payload) {
         try {
             if (status == HttpURLConnection.HTTP_OK) {
                 return CredentialsResult.from(status, objectMapper.readValue(payload, CredentialsObject.class));
@@ -80,7 +80,7 @@ public final class CredentialsClientImpl extends AbstractRequestResponseClient<C
      * @return The target address.
      * @throws NullPointerException if tenant is {@code null}.
      */
-    public static String getTargetAddress(final String tenantId) {
+    public static final String getTargetAddress(final String tenantId) {
         return String.format("%s/%s", CredentialsConstants.CREDENTIALS_ENDPOINT, Objects.requireNonNull(tenantId));
     }
 
@@ -96,7 +96,7 @@ public final class CredentialsClientImpl extends AbstractRequestResponseClient<C
      * @param creationHandler The handler to invoke with the outcome of the creation attempt.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    public static void create(
+    public static final void create(
             final Context context,
             final ClientConfigProperties clientConfig,
             final ProtonConnection con,
@@ -124,7 +124,7 @@ public final class CredentialsClientImpl extends AbstractRequestResponseClient<C
      * on the service represented by the <em>sender</em> and <em>receiver</em> links.
      */
     @Override
-    public Future<CredentialsObject> get(final String type, final String authId) {
+    public final Future<CredentialsObject> get(final String type, final String authId) {
 
         Objects.requireNonNull(type);
         Objects.requireNonNull(authId);

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
@@ -46,16 +46,16 @@ import io.vertx.proton.ProtonSender;
  * A Vertx-Proton based client for Hono's Registration API.
  *
  */
-public final class RegistrationClientImpl extends AbstractRequestResponseClient<RegistrationResult> implements RegistrationClient {
+public class RegistrationClientImpl extends AbstractRequestResponseClient<RegistrationResult> implements RegistrationClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(RegistrationClientImpl.class);
 
-    RegistrationClientImpl(final Context context, final ClientConfigProperties config, final String tenantId) {
+    protected RegistrationClientImpl(final Context context, final ClientConfigProperties config, final String tenantId) {
 
         super(context, config, tenantId);
     }
 
-    RegistrationClientImpl(final Context context, final ClientConfigProperties config, final String tenantId,
+    protected RegistrationClientImpl(final Context context, final ClientConfigProperties config, final String tenantId,
             final ProtonSender sender, final ProtonReceiver receiver) {
 
         super(context, config, tenantId, sender, receiver);
@@ -68,24 +68,24 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      * @return The target address.
      * @throws NullPointerException if tenant is {@code null}.
      */
-    public static String getTargetAddress(final String tenantId) {
+    public static final String getTargetAddress(final String tenantId) {
         return String.format("%s/%s", RegistrationConstants.REGISTRATION_ENDPOINT, Objects.requireNonNull(tenantId));
     }
 
     @Override
-    protected String getName() {
+    protected final String getName() {
 
         return RegistrationConstants.REGISTRATION_ENDPOINT;
     }
 
     @Override
-    protected String createMessageId() {
+    protected final String createMessageId() {
 
         return String.format("reg-client-%s", UUID.randomUUID());
     }
 
     @Override
-    protected RegistrationResult getResult(final int status, final String payload) {
+    protected final RegistrationResult getResult(final int status, final String payload) {
 
         return RegistrationResult.from(status, payload);
     }
@@ -104,7 +104,7 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      * @param creationHandler The handler to invoke with the outcome of the creation attempt.
      * @throws NullPointerException if any of the parameters other than cache manager is {@code null}.
      */
-    public static void create(
+    public static final void create(
             final Context context,
             final ClientConfigProperties clientConfig,
             final CacheManager cacheManager,
@@ -143,7 +143,7 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      * on the service represented by the <em>sender</em> and <em>receiver</em> links.
      */
     @Override
-    public Future<Void> register(final String deviceId, final JsonObject data) {
+    public final Future<Void> register(final String deviceId, final JsonObject data) {
 
         Objects.requireNonNull(deviceId);
 
@@ -169,7 +169,7 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      * on the service represented by the <em>sender</em> and <em>receiver</em> links.
      */
     @Override
-    public Future<Void> update(final String deviceId, final JsonObject data) {
+    public final Future<Void> update(final String deviceId, final JsonObject data) {
 
         Objects.requireNonNull(deviceId);
 
@@ -195,7 +195,7 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      * on the service represented by the <em>sender</em> and <em>receiver</em> links.
      */
     @Override
-    public Future<Void> deregister(final String deviceId) {
+    public final Future<Void> deregister(final String deviceId) {
 
         Objects.requireNonNull(deviceId);
 
@@ -221,7 +221,7 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      * on the service represented by the <em>sender</em> and <em>receiver</em> links.
      */
     @Override
-    public Future<JsonObject> get(final String deviceId) {
+    public final Future<JsonObject> get(final String deviceId) {
 
         Objects.requireNonNull(deviceId);
         final Future<RegistrationResult> resultTracker = Future.future();
@@ -249,7 +249,7 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      * as the <em>gatewayId</em>.
      */
     @Override
-    public Future<JsonObject> assertRegistration(final String deviceId) {
+    public final Future<JsonObject> assertRegistration(final String deviceId) {
         return assertRegistration(deviceId, null);
     }
 
@@ -259,7 +259,7 @@ public final class RegistrationClientImpl extends AbstractRequestResponseClient<
      * on the service represented by the <em>sender</em> and <em>receiver</em> links.
      */
     @Override
-    public Future<JsonObject> assertRegistration(final String deviceId, final String gatewayId) {
+    public final Future<JsonObject> assertRegistration(final String deviceId, final String gatewayId) {
 
         Objects.requireNonNull(deviceId);
 


### PR DESCRIPTION
Making the CredentialsService, RegistrationService extensible and also allowing the corresponding client implementation to be extensible. Concrete implementations will be able to extend them as per their need.

Signed-off-by: Bala Azhagappan <balasubramanian.azhagappan@bosch-si.com>