### PR TITLE
Prevent a large file based repository from spamming the log

### DIFF
--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 
 package org.eclipse.hono.deviceregistry;
@@ -163,8 +164,9 @@ public final class FileBasedRegistrationService extends BaseRegistrationService<
                     JsonObject device = (JsonObject) deviceObj;
                     String deviceId = device.getString(FIELD_DEVICE_ID);
                     if (deviceId != null) {
-                        log.debug("loading device [{}]", deviceId);
-                        JsonObject data = device.getJsonObject(FIELD_DATA, new JsonObject().put(FIELD_ENABLED, Boolean.TRUE));
+                        log.trace("loading device [{}]", deviceId);
+                        final JsonObject data = device.getJsonObject(FIELD_DATA,
+                                new JsonObject().put(FIELD_ENABLED, Boolean.TRUE));
                         deviceMap.put(deviceId, data);
                         count++;
                     }
@@ -172,6 +174,7 @@ public final class FileBasedRegistrationService extends BaseRegistrationService<
             }
             identities.put(tenantId, deviceMap);
         }
+        log.debug("Loaded {} devices for tenant {}", count, tenantId);
         return count;
     }
 


### PR DESCRIPTION
The device registry does print out one line on "debug" level per loaded
device. This can really spam the log when you have a larger registry
for testing.

This change lowers the output to trace and adds a summary line on
"debug" level after the load is complete.

Signed-off-by: Jens Reimann <jreimann@redhat.com>