### PR TITLE
Check that constructors of utility-only classes are hidden

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/BaseMessageFilter.java
+++ b/core/src/main/java/org/eclipse/hono/util/BaseMessageFilter.java
@@ -23,6 +23,9 @@ public class BaseMessageFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseMessageFilter.class);
 
+    protected BaseMessageFilter () {
+    }
+
     /**
      * Checks whether an AMQP message contains required standard properties.
      * <p>

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
@@ -43,6 +43,9 @@ public class RequestResponseApiConstants {
     public static final String FIELD_ERROR     = "error";
     public static final String FIELD_PAYLOAD   = "payload";
 
+    protected RequestResponseApiConstants () {
+    }
+
     /**
      * Creates an AMQP message from a JSON message containing the response to an
      * invocation of a service operation.

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -75,4 +75,7 @@ public final class TenantConstants extends RequestResponseApiConstants {
             return TenantAction.from(subject) != TenantAction.unknown;
         }
     }
+
+    private TenantConstants () {
+    }
 }

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleConstants.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleConstants.java
@@ -56,4 +56,6 @@ public class HonoExampleConstants {
      */
     public static final String DEVICE_ID = "4711"; // needs to be registered first
 
+    private HonoExampleConstants () {
+    }
 }

--- a/legal/src/main/resources/checkstyle/default.xml
+++ b/legal/src/main/resources/checkstyle/default.xml
@@ -35,6 +35,7 @@
 
     <!-- possible issues -->
 
+    <module name="HideUtilityClassConstructor"/>
     <module name="OneStatementPerLine" />
     <module name="StringLiteralEquality" />
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/AuthorizationConstants.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/AuthorizationConstants.java
@@ -44,6 +44,9 @@ public final class AuthorizationConstants {
      */
     public static final String DENIED = "denied";
 
+    private AuthorizationConstants () {
+    }
+
     /**
      * Creates a message for checking a subject's authority on a given resource.
      * 


### PR DESCRIPTION
This change makes use of the checkstyle module "HideUtilityClassConstructor" in order to find utility-only classes which have an accessible constructor. If the class is a utility-only class creating a new instance from it is an error.

With a few exceptions Hono already follows this approach. So aside from adding the check only a few classes had to be fixed.