### PR TITLE
http-adapter: Implement OPTIONS method and add CORS handler

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpProtocolAdapterProperties.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpProtocolAdapterProperties.java
@@ -29,6 +29,7 @@ public class HttpProtocolAdapterProperties extends ProtocolAdapterProperties {
      */
     public static final String DEFAULT_REALM = "Hono";
     private String realm = DEFAULT_REALM;
+    private String corsAllowedOrigin = "*";
 
     /**
      * Gets the name of the realm that unauthenticated devices are prompted to provide credentials for.
@@ -57,6 +58,36 @@ public class HttpProtocolAdapterProperties extends ProtocolAdapterProperties {
      */
     public final void setRealm(final String realm) {
         this.realm = Objects.requireNonNull(realm);
+    }
+
+
+    /**
+     * Gets the allowed origin pattern for CORS handler.
+     * <p>
+     * The allowed origin pattern for CORS is returned to clients via the <em>Access-Control-Allow-Origin</em> header.
+     * It can be used by Web Applications to make sure that requests go only to trusted backend entities.
+     * <p>
+     * The default value is '*'.
+     *
+     * @return The allowed origin pattern for CORS handler.
+     */
+    public final String getCorsAllowedOrigin() {
+        return corsAllowedOrigin;
+    }
+
+    /**
+     * Sets the allowed origin pattern for CORS handler.
+     * <p>
+     * The allowed origin pattern for CORS is returned to clients via the <em>Access-Control-Allow-Origin</em> header.
+     * It can be used by Web Applications to make sure that requests go only to trusted backend entities.
+     * <p>
+     * The default value is '*'.
+     *
+     * @param corsAllowedOrigin The allowed origin pattern for CORS handler.
+     * @throws NullPointerException if the allowed origin pattern is {@code null}.
+     */
+    public final void setCorsAllowedOrigin(final String corsAllowedOrigin) {
+        this.corsAllowedOrigin = Objects.requireNonNull(corsAllowedOrigin);
     }
 
 }

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
@@ -14,7 +14,7 @@ package org.eclipse.hono.adapter.http.vertx;
 
 import java.net.HttpURLConnection;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.handler.CorsHandler;
 import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
 import org.eclipse.hono.adapter.http.HonoAuthHandlerImpl;
@@ -66,9 +66,10 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
     private void setupCorsHandler(final Router router) {
         router.route()
-                .handler(CorsHandler.create(getConfig().getCorsAllowedOrigin()).allowedMethod(HttpMethod.PUT)
-                        .allowedMethod(HttpMethod.POST).allowedMethod(HttpMethod.OPTIONS)
-                        .allowedHeader("Authorization").allowedHeader("Content-Type"));
+                .handler(CorsHandler.create(getConfig().getCorsAllowedOrigin())
+                        .allowedMethod(HttpMethod.PUT)
+                        .allowedMethod(HttpMethod.POST)
+                        .allowedHeader(HttpHeaders.AUTHORIZATION.toString()).allowedHeader(HttpHeaders.CONTENT_TYPE.toString()));
     }
 
     private void setupBasicAuth(final Router router) {

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
@@ -51,17 +51,17 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
     @Override
     protected final void addRoutes(final Router router) {
+        setupCorsHandler(router);
+
         if (!getConfig().isAuthenticationRequired()) {
             LOG.warn("device authentication has been disabled");
             LOG.warn("any device may publish data on behalf of all other devices");
         } else {
             setupBasicAuth(router);
         }
+
         addTelemetryApiRoutes(router);
         addEventApiRoutes(router);
-        setupCorsHandler(router);
-
-        router.options().handler(request -> request.response().setStatusCode(HttpResponseStatus.OK.code()).end());
     }
 
     private void setupCorsHandler(final Router router) {
@@ -72,7 +72,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
     }
 
     private void setupBasicAuth(final Router router) {
-        router.route().method(HttpMethod.GET).method(HttpMethod.POST).method(HttpMethod.PUT).handler(new HonoAuthHandlerImpl(getCredentialsAuthProvider(), getConfig().getRealm()) {
+        router.route().handler(new HonoAuthHandlerImpl(getCredentialsAuthProvider(), getConfig().getRealm()) {
             @Override
             protected void processException(RoutingContext ctx, Throwable exception) {
                 if (exception instanceof ServiceInvocationException) {

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
@@ -66,7 +66,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
     private void setupCorsHandler(final Router router) {
         router.route()
-                .handler(CorsHandler.create("*").allowedMethod(HttpMethod.PUT)
+                .handler(CorsHandler.create(getConfig().getCorsAllowedOrigin()).allowedMethod(HttpMethod.PUT)
                         .allowedMethod(HttpMethod.POST).allowedMethod(HttpMethod.OPTIONS)
                         .allowedHeader("Authorization").allowedHeader("Content-Type"));
     }

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
@@ -12,7 +12,6 @@
 
 package org.eclipse.hono.adapter.http.vertx;
 
-import static io.vertx.core.http.HttpHeaders.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -20,6 +19,7 @@ import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
+import io.vertx.core.http.HttpHeaders;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoClient;
@@ -57,7 +57,6 @@ public class VertxBasedHttpProtocolAdapterTest {
     public Timeout timeout = Timeout.seconds(5);
 
     private static final String HOST = "localhost";
-    private static final String AUTHORIZATION_HEADER = "Authorization";
 
     private static HonoClient tenantClient;
     private static HonoClient messagingClient;
@@ -120,7 +119,7 @@ public class VertxBasedHttpProtocolAdapterTest {
         final Async async = context.async();
 
         vertx.createHttpClient().get(httpAdapter.getInsecurePort(), HOST, "/some-non-existing-route")
-                .putHeader("content-type", HttpUtils.CONTENT_TYPE_JSON).handler(response -> {
+                .putHeader(HttpHeaders.CONTENT_TYPE, HttpUtils.CONTENT_TYPE_JSON).handler(response -> {
             context.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, response.statusCode());
             response.bodyHandler(totalBuffer -> {
                 async.complete();
@@ -142,8 +141,8 @@ public class VertxBasedHttpProtocolAdapterTest {
         }).when(credentialsAuthProvider).authenticate(any(JsonObject.class), any(Handler.class));
 
         vertx.createHttpClient().put(httpAdapter.getInsecurePort(), HOST, "/somenonexistingroute")
-                .putHeader("content-type", HttpUtils.CONTENT_TYPE_JSON)
-                .putHeader(AUTHORIZATION_HEADER, "Basic " + encodedUserPass).handler(response -> {
+                .putHeader(HttpHeaders.CONTENT_TYPE, HttpUtils.CONTENT_TYPE_JSON)
+                .putHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedUserPass).handler(response -> {
             context.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, response.statusCode());
             response.bodyHandler(totalBuffer -> {
                 async.complete();
@@ -165,12 +164,12 @@ public class VertxBasedHttpProtocolAdapterTest {
         }).when(credentialsAuthProvider).authenticate(any(JsonObject.class), any(Handler.class));
 
         vertx.createHttpClient().get(httpAdapter.getInsecurePort(), HOST, "/somenonexistingroute")
-                .putHeader("content-type", HttpUtils.CONTENT_TYPE_JSON)
-                .putHeader(AUTHORIZATION_HEADER, "Basic " + encodedUserPass)
-                .putHeader(ORIGIN, "hono.org")
+                .putHeader(HttpHeaders.CONTENT_TYPE, HttpUtils.CONTENT_TYPE_JSON)
+                .putHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedUserPass)
+                .putHeader(HttpHeaders.ORIGIN, "hono.org")
                 .handler(response -> {
             context.assertEquals(HttpURLConnection.HTTP_NOT_FOUND, response.statusCode());
-            context.assertEquals("*", response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN));
+            context.assertEquals("*", response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
             response.bodyHandler(totalBuffer -> {
                 async.complete();
             });
@@ -183,12 +182,12 @@ public class VertxBasedHttpProtocolAdapterTest {
         final Async async = context.async();
 
         vertx.createHttpClient().options(httpAdapter.getInsecurePort(), HOST, "/telemetry")
-                .putHeader(ORIGIN, "hono.org")
-                .putHeader(ACCESS_CONTROL_REQUEST_METHOD, "POST")
+                .putHeader(HttpHeaders.ORIGIN, "hono.org")
+                .putHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST")
                 .handler(response -> {
             context.assertEquals(HttpURLConnection.HTTP_NO_CONTENT, response.statusCode());
-            context.assertTrue(response.getHeader(ACCESS_CONTROL_ALLOW_METHODS).contains("POST"));
-            context.assertEquals("*", response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN));
+            context.assertTrue(response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).contains("POST"));
+            context.assertEquals("*", response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
             response.bodyHandler(totalBuffer -> {
                 async.complete();
             });


### PR DESCRIPTION
This makes the API consumable by web applications (swagger-ui in my case).
The OPTIONS method is used by browsers to do a pre-flight validation,
and must be accessible without authentication. The web application will
then check for the precense and correctness of CORS related headers.

Signed-off-by: Sebastian Poehn <sebastian.poehn@bosch-si.com>