### PR TITLE
extending hono example receiver with proxy options

### DIFF
--- a/core/src/test/java/org/eclipse/hono/config/ClientConfigPropertiesTest.java
+++ b/core/src/test/java/org/eclipse/hono/config/ClientConfigPropertiesTest.java
@@ -1,0 +1,42 @@
+package org.eclipse.hono.config;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.vertx.core.net.ProxyType;
+
+public class ClientConfigPropertiesTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetInvalidProxyPort() {
+        ClientConfigProperties config = new ClientConfigProperties();
+        config.setProxyPort(0);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetEmptyProxyHost() {
+        ClientConfigProperties config = new ClientConfigProperties();
+        config.setProxyHost(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidProxyType() {
+        ClientConfigProperties config = new ClientConfigProperties();
+        config.setProxyType("Unknown");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testEmptyProxyType() {
+        ClientConfigProperties config = new ClientConfigProperties();
+        config.setProxyType(null);
+    }
+
+    @Test
+    public void testProxyOptions() {
+        ClientConfigProperties config = new ClientConfigProperties();
+        assertEquals(ProxyType.SOCKS5, config.getProxyType());
+        config.setProxyType("SOCKS4");
+        assertEquals(ProxyType.SOCKS4, config.getProxyType());
+    }
+}

--- a/example/src/main/java/org/eclipse/hono/example/AbstractExampleClient.java
+++ b/example/src/main/java/org/eclipse/hono/example/AbstractExampleClient.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.config.ClientConfigProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +42,7 @@ abstract class AbstractExampleClient {
     protected String tenantId;
     protected Vertx vertx;
     protected HonoClient client;
+    protected ClientConfigProperties clientConfigProperties;
     protected List<String> activeProfiles;
 
     /**
@@ -57,7 +59,7 @@ abstract class AbstractExampleClient {
     @Autowired
     public final void setVertx(final Vertx vertx) {
         this.vertx = vertx;
-        this.ctx = vertx.getOrCreateContext();
+        ctx = vertx.getOrCreateContext();
     }
 
     @Autowired
@@ -65,7 +67,14 @@ abstract class AbstractExampleClient {
         this.client = Objects.requireNonNull(client);
     }
 
+    @Autowired
+    public final void setClientConfigProperties(final ClientConfigProperties config) {
+        this.clientConfigProperties = Objects.requireNonNull(config);
+    }
+
     protected final ProtonClientOptions getClientOptions() {
-        return new ProtonClientOptions().setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS).setReconnectAttempts(2);
+        return new ProtonClientOptions()
+                .setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS).setReconnectAttempts(2)
+                .setProxyOptions(clientConfigProperties.getProxyOptions());
     }
 }

--- a/site/content/getting-started.md
+++ b/site/content/getting-started.md
@@ -96,6 +96,14 @@ mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.u
 Replace *localhost* with the name or IP address of the host that Docker is running on.
 {{% /warning %}}
 
+If the command line client is behind a proxy, you can use the proxy options to connect. The default proxy type is SOCKS5. Run the client from the `example` folder as follows:
+                                                                                                                
+~~~sh
+mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,--hono.client.proxyHost=proxy.company.com,--hono.client.proxyPort=15671,--hono.client.proxyUsername=my-company-id,--hono.client.proxyPassword=verysecret,--hono.client.proxyType=SOCKS5
+~~~
+
+If either *hono.client.proxyHost* or *hono.client.proxyPort* is not set, then no proxy options will be configured for the client.
+
 ## Publishing Data
 
 Now that the Hono instance is up and running you can use Hono's protocol adapters to upload some telemetry data and watch it being forwarded to the downstream consumer.


### PR DESCRIPTION
Added the following arguments that can be used to connect the example receiver from behind a proxy

```
hono.client.proxyHost
hono.client.proxyPort
hono.client.proxyUsername
hono.client.proxyPassword
```

Signed-off-by: Bala Azhagappan <balasubramanian.azhagappan@bosch-si.com>