### PR TITLE
Enable a few Javadoc codestyle checks

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -50,7 +50,7 @@ import io.vertx.ext.web.handler.BodyHandler;
 public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtocolAdapterProperties> extends AbstractProtocolAdapterBase<T> {
 
     /**
-     * Default file uploads directory used by Vert.x Web
+     * Default file uploads directory used by Vert.x Web.
      */
     protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
 
@@ -61,7 +61,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
     private HttpAdapterMetrics metrics;
 
     /**
-     * Sets the metrics for this service
+     * Sets the metrics for this service.
      *
      * @param metrics The metrics
      */

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoAuthHandlerImpl.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoAuthHandlerImpl.java
@@ -84,6 +84,11 @@ public class HonoAuthHandlerImpl implements AuthHandler {
     protected final AuthProvider authProvider;
     protected final Set<String> authorities = new HashSet<>();
 
+    /**
+     * Create a new auth handler instance
+     * @param authProvider The authentication provider to use
+     * @param realm the realm to use
+     */
     public HonoAuthHandlerImpl(AuthProvider authProvider, String realm) {
         this.authProvider = authProvider;
         this.realm = realm;

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoAuthHandlerImpl.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoAuthHandlerImpl.java
@@ -49,6 +49,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class HonoAuthHandlerImpl implements AuthHandler {
 
     // this should match the IANA registry: https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
+    /**
+     * Authentication type.
+     */
     enum Type {
         BASIC("Basic"),
         DIGEST("Digest"),

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoAuthHandlerImpl.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoAuthHandlerImpl.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Combination of the original classes
+ * Combination of the original classes.
  * <ul>
  * <li>io.vertx.ext.web.handler.impl.AuthHandlerImpl</li>
  * <li>io.vertx.ext.web.handler.impl.AuthorizationAuthHandler</li>
@@ -85,7 +85,8 @@ public class HonoAuthHandlerImpl implements AuthHandler {
     protected final Set<String> authorities = new HashSet<>();
 
     /**
-     * Create a new auth handler instance
+     * Create a new auth handler instance.
+     * 
      * @param authProvider The authentication provider to use
      * @param realm the realm to use
      */

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
@@ -16,7 +16,7 @@ import org.eclipse.hono.service.metric.Metrics;
 import org.springframework.stereotype.Component;
 
 /**
- * Metrics for the HTTP based adapters
+ * Metrics for the HTTP based adapters.
  */
 @Component
 public class HttpAdapterMetrics extends Metrics {

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/KuraAdapterMetrics.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/KuraAdapterMetrics.java
@@ -17,7 +17,7 @@ import org.eclipse.hono.adapter.mqtt.MqttAdapterMetrics;
 import org.springframework.stereotype.Component;
 
 /**
- * Metrics for the Kura adapter
+ * Metrics for the Kura adapter.
  */
 @Component
 public class KuraAdapterMetrics extends MqttAdapterMetrics {

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -89,7 +89,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
     }
 
     /**
-     * Sets the metrics for this service
+     * Sets the metrics for this service.
      *
      * @param metrics The metrics
      */

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
@@ -16,7 +16,7 @@ import org.eclipse.hono.service.metric.Metrics;
 import org.springframework.stereotype.Component;
 
 /**
- * Metrics for the MQTT adapter
+ * Metrics for the MQTT adapter.
  */
 @Component
 public class MqttAdapterMetrics extends Metrics {

--- a/core/src/main/java/org/eclipse/hono/config/FileFormat.java
+++ b/core/src/main/java/org/eclipse/hono/config/FileFormat.java
@@ -16,6 +16,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * File formats for using key materials.
+ */
 public enum FileFormat {
     /**
      * PEM encoded PKCS#1 or PKCS#8.

--- a/core/src/main/java/org/eclipse/hono/config/FileFormat.java
+++ b/core/src/main/java/org/eclipse/hono/config/FileFormat.java
@@ -18,15 +18,15 @@ import java.util.Optional;
 
 public enum FileFormat {
     /**
-     * PEM encoded PKCS#1 or PKCS#8
+     * PEM encoded PKCS#1 or PKCS#8.
      */
     PEM,
     /**
-     * Java Key Store
+     * Java Key Store.
      */
     JKS,
     /**
-     * PKCS#12 key store
+     * PKCS#12 key store.
      */
     PKCS12;
 

--- a/core/src/main/java/org/eclipse/hono/config/KeyLoader.java
+++ b/core/src/main/java/org/eclipse/hono/config/KeyLoader.java
@@ -49,6 +49,11 @@ public final class KeyLoader {
 
     private static final Logger LOG = LoggerFactory.getLogger(KeyLoader.class);
 
+    /**
+     * A processor for PEM file content.
+     *  
+     * @param <R> The type of the result.
+     */
     @FunctionalInterface
     private interface PemProcessor<R> {
 

--- a/core/src/main/java/org/eclipse/hono/config/PemReader.java
+++ b/core/src/main/java/org/eclipse/hono/config/PemReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2018 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@ package org.eclipse.hono.config;
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static java.nio.file.Files.newBufferedReader;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.io.LineNumberReader;
@@ -51,23 +52,55 @@ public final class PemReader {
             this.payload = payload;
         }
 
+        /**
+         * Gets the PEM entry payload.
+         * 
+         * @return the payload
+         */
         public byte[] getPayload() {
             return payload;
         }
 
+        /**
+         * Gets the PEM entry type.
+         * 
+         * @return the type
+         */
         public String getType() {
             return type;
         }
 
     }
 
+    /**
+     * Reads a PEM file and return its entries.
+     * 
+     * @param path The file to read.
+     * @return The PEM entries.
+     * 
+     * @throws IOException I case of any error.
+     */
     public static List<Entry> readAll(final Path path) throws IOException {
+        requireNonNull(path);
+
         try (final Reader reader = newBufferedReader(path, StandardCharsets.US_ASCII)) {
             return readAll(reader);
         }
     }
 
+    /**
+     * Reads a PEM file using vertx in blocking mode and return its entries.
+     * 
+     * @param vertx The vertx instance to use.
+     * @param path The file to read.
+     * @return The PEM entries.
+     * 
+     * @throws IOException I case of any error.
+     */
     public static List<Entry> readAllBlocking(final Vertx vertx, final Path path) throws IOException {
+        requireNonNull(vertx);
+        requireNonNull(path);
+
         return readAllFromBuffer(
                 vertx
                         .fileSystem()
@@ -85,7 +118,17 @@ public final class PemReader {
         return readAll(new StringReader(string));
     }
 
+    /**
+     * Asynchronously reads a PEM file using vertx and report its entries.
+     * @param vertx The vertx instance to use.
+     * @param path The file to read.
+     * @param handler The handler to receive the result
+     */
     public static void readAll(final Vertx vertx, final Path path, final Handler<AsyncResult<List<Entry>>> handler) {
+
+        requireNonNull(vertx);
+        requireNonNull(path);
+        requireNonNull(handler);
 
         vertx.fileSystem().readFile(path.toString(), reader -> {
 
@@ -113,6 +156,13 @@ public final class PemReader {
         });
     }
 
+    /**
+     * Reads a PEM file and return its entries.
+     * 
+     * @param reader The source to read from.
+     * @return The list of entries.
+     * @throws IOException In case of any error.
+     */
     public static List<Entry> readAll(final Reader reader) throws IOException {
 
         final LineNumberReader lnr = new LineNumberReader(reader);

--- a/core/src/main/java/org/eclipse/hono/config/PemReader.java
+++ b/core/src/main/java/org/eclipse/hono/config/PemReader.java
@@ -34,6 +34,9 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 
+/**
+ * A reader for PEM files.
+ */
 public final class PemReader {
 
     private static final Pattern BEGIN_PATTERN = Pattern.compile("-+BEGIN (.*?)-+");
@@ -42,6 +45,9 @@ public final class PemReader {
     private PemReader() {
     }
 
+    /**
+     * An entry in a PEM file.
+     */
     public static class Entry {
 
         private String type;

--- a/core/src/main/java/org/eclipse/hono/util/EndpointType.java
+++ b/core/src/main/java/org/eclipse/hono/util/EndpointType.java
@@ -11,21 +11,29 @@
 package org.eclipse.hono.util;
 
 /**
- * Utility used to determine type of the endpoint
+ * Utility used to determine type of the endpoint.
  */
 public enum EndpointType {
     TELEMETRY, EVENT, UNKNOWN;
 
+    /**
+     * Gets the endpoint type from a string value.
+     * 
+     * @param name The name of the endpoint type.
+     * 
+     * @return The enum literal of the endpoint type. Returns {@value #UNKNOWN} if it cannot find the endpoint type.
+     *         Never returns {@code null}.
+     */
     public static EndpointType fromString(String name) {
         switch (name) {
-            case TelemetryConstants.TELEMETRY_ENDPOINT:
-            case TelemetryConstants.TELEMETRY_ENDPOINT_SHORT:
-                return TELEMETRY;
-            case EventConstants.EVENT_ENDPOINT:
-            case EventConstants.EVENT_ENDPOINT_SHORT:
-                return EVENT;
-            default:
-                return UNKNOWN;
+        case TelemetryConstants.TELEMETRY_ENDPOINT:
+        case TelemetryConstants.TELEMETRY_ENDPOINT_SHORT:
+            return TELEMETRY;
+        case EventConstants.EVENT_ENDPOINT:
+        case EventConstants.EVENT_ENDPOINT_SHORT:
+            return EVENT;
+        default:
+            return UNKNOWN;
         }
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/Strings.java
+++ b/core/src/main/java/org/eclipse/hono/util/Strings.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.hono.util;
 
+/**
+ * A helper class for working with {@link String}s.
+ */
 public final class Strings {
 
     private Strings() {

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoReceiverSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoReceiverSampler.java
@@ -48,6 +48,11 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
         return getPropertyAsBoolean(USE_SENDER_TIME);
     }
 
+    /**
+     * Sets whether or not to use the sender time.
+     * 
+     * @param useSenderTime {@code true} in order to use the sender time. 
+     */
     public void setUseSenderTime(final boolean useSenderTime) {
         setProperty(USE_SENDER_TIME, useSenderTime);
     }
@@ -56,6 +61,11 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
         return getPropertyAsString(PREFETCH);
     }
 
+    /**
+     * Sets the number of messages to prefetch.
+     * 
+     * @param prefetch The number of messages to prefetch, encoded as String.
+     */
     public void setPrefetch(final String prefetch) {
         setProperty(PREFETCH, prefetch);
     }
@@ -64,6 +74,11 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
         return getPropertyAsString(SENDER_TIME_VARIABLE_NAME, DEFAULT_SENDER_TIME_VARIABLE_NAME);
     }
 
+    /**
+     * Sets the name of the sender time in the payload.
+     * 
+     * @param variableName The name of the variable the sender time uses in the payload.
+     */
     public void setSenderTimeVariableName(final String variableName) {
         setProperty(SENDER_TIME_VARIABLE_NAME, variableName);
     }
@@ -72,6 +87,11 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
         return getPropertyAsBoolean(SENDER_TIME_IN_PAYLOAD);
     }
 
+    /**
+     * Sets if the payload contains the sender time.
+     * 
+     * @param senderTimeInPayload {@code true} if the payload contains the sender time.
+     */
     public void setSenderTimeInPayload(final boolean senderTimeInPayload) {
         setProperty(SENDER_TIME_IN_PAYLOAD, senderTimeInPayload);
     }
@@ -80,6 +100,11 @@ public class HonoReceiverSampler extends HonoSampler implements TestBean, Thread
         return getPropertyAsString(RECONNECT_ATTEMPTS, "1");
     }
 
+    /**
+     * Sets the number of re-connect attempts.
+     * 
+     * @param reconnectAttempts The number of attempts as string. 
+     */
     public void setReconnectAttempts(final String reconnectAttempts) {
         setProperty(RECONNECT_ATTEMPTS, reconnectAttempts);
     }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSampler.java
@@ -32,6 +32,9 @@ public abstract class HonoSampler extends AbstractSampler {
     private static final long serialVersionUID = 1L;
     private static final Object semaphoreLock = new Object();
 
+    /**
+     * Endpoint type.
+     */
     public enum Endpoint {
         telemetry, event
     }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSampler.java
@@ -50,6 +50,11 @@ public abstract class HonoSampler extends AbstractSampler {
     private static final String TENANT                   = "tenant";
     private static final String ENDPOINT                 = "endpoint";
 
+    /**
+     * Applies the options to the local UI.
+     * 
+     * @param serverOptions The options to apply.
+     */
     public void modifyServerOptions(final ServerOptionsPanel serverOptions) {
         setHost(serverOptions.getHost());
         setPort(serverOptions.getPort());
@@ -58,6 +63,11 @@ public abstract class HonoSampler extends AbstractSampler {
         setTrustStorePath(serverOptions.getTrustStorePath());
     }
 
+    /**
+     * Apply the local UI options to the provided object.
+     * 
+     * @param serverOptions The options to change.
+     */
     public void configureServerOptions(final ServerOptionsPanel serverOptions) {
         serverOptions.setHost(getHost());
         serverOptions.setPort(getPort());
@@ -70,6 +80,11 @@ public abstract class HonoSampler extends AbstractSampler {
         return getPropertyAsString(TRUSTSTORE_PATH);
     }
 
+    /**
+     * Sets the path of the trust store.
+     * 
+     * @param trustStorePath The path to the trust store.
+     */
     public void setTrustStorePath(final String trustStorePath) {
         setProperty(TRUSTSTORE_PATH, trustStorePath);
     }
@@ -78,6 +93,11 @@ public abstract class HonoSampler extends AbstractSampler {
         return getPropertyAsString(HOST);
     }
 
+    /**
+     * Sets the host to use.
+     * 
+     * @param host The hostname to use.
+     */
     public void setHost(final String host) {
         setProperty(HOST, host);
     }
@@ -86,6 +106,11 @@ public abstract class HonoSampler extends AbstractSampler {
         return getPropertyAsString(USER);
     }
 
+    /**
+     * Sets the user to use.
+     * 
+     * @param user The user name to use.
+     */
     public void setUser(final String user) {
         setProperty(USER, user);
     }
@@ -94,10 +119,20 @@ public abstract class HonoSampler extends AbstractSampler {
         return getPropertyAsString(PWD);
     }
 
+    /**
+     * Sets the password to use.
+     * 
+     * @param pwd The password to use.
+     */
     public void setPwd(final String pwd) {
         setProperty(PWD, pwd);
     }
 
+    /**
+     * Returns the port number as int.
+     * 
+     * @return The port number as int.
+     */
     public int getPortAsInt() {
         final String portString = getPort();
         try {
@@ -111,6 +146,11 @@ public abstract class HonoSampler extends AbstractSampler {
         return getPropertyAsString(PORT);
     }
 
+    /**
+     * Sets the port to use.
+     * 
+     * @param port The port to use.
+     */
     public void setPort(final String port) {
         setProperty(PORT, port);
     }
@@ -119,6 +159,11 @@ public abstract class HonoSampler extends AbstractSampler {
         return getPropertyAsString(CONTAINER);
     }
 
+    /**
+     * Sets the AMQP container name to use.
+     * 
+     * @param container The container name to use.
+     */
     public void setContainer(final String container) {
         setProperty(CONTAINER, container);
     }
@@ -127,6 +172,11 @@ public abstract class HonoSampler extends AbstractSampler {
         return getPropertyAsString(TENANT);
     }
 
+    /**
+     * Sets the tenant name to use.
+     * 
+     * @param tenant The tenant name to use.
+     */
     public void setTenant(final String tenant) {
         setProperty(TENANT, tenant);
     }
@@ -135,6 +185,11 @@ public abstract class HonoSampler extends AbstractSampler {
         return getPropertyAsString(ENDPOINT);
     }
 
+    /**
+     * Sets the endpoint type to use.
+     * 
+     * @param endpoint The endpoint type to use.
+     */
     public void setEndpoint(final Endpoint endpoint) {
         setProperty(ENDPOINT, endpoint.toString());
     }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSenderSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSenderSampler.java
@@ -37,23 +37,28 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HonoSenderSampler.class);
 
-    private static final String REGISTRY_HOST              = "registryHost";
-    private static final String REGISTRY_USER              = "registryUser";
-    private static final String REGISTRY_PWD               = "registryPwd";
-    private static final String REGISTRY_PORT              = "registryPort";
-    private static final String REGISTRY_TRUSTSTORE_PATH   = "registryTrustStorePath";
+    private static final String REGISTRY_HOST = "registryHost";
+    private static final String REGISTRY_USER = "registryUser";
+    private static final String REGISTRY_PWD = "registryPwd";
+    private static final String REGISTRY_PORT = "registryPort";
+    private static final String REGISTRY_TRUSTSTORE_PATH = "registryTrustStorePath";
 
-    private static final String DEVICE_ID                  = "deviceId";
-    private static final String SET_SENDER_TIME            = "setSenderTime";
-    private static final String CONTENT_TYPE               = "contentType";
-    private static final String DATA                       = "data";
-    private static final String WAIT_FOR_CREDITS           = "waitForCredits";
-    private static final String WAIT_FOR_RECEIVERS         = "waitForReceivers";
+    private static final String DEVICE_ID = "deviceId";
+    private static final String SET_SENDER_TIME = "setSenderTime";
+    private static final String CONTENT_TYPE = "contentType";
+    private static final String DATA = "data";
+    private static final String WAIT_FOR_CREDITS = "waitForCredits";
+    private static final String WAIT_FOR_RECEIVERS = "waitForReceivers";
     private static final String WAIT_FOR_RECEIVERS_TIMEOUT = "waitForReceiversTimeout";
     private static final String PROPERTY_REGISTRATION_ASSERTION = "PROPERTY_REGISTRATION_ASSERTION";
 
     private HonoSender honoSender;
 
+    /**
+     * Applies the options to the local UI.
+     * 
+     * @param serverOptions The options to apply.
+     */
     public void modifyRegistrationServiceOptions(final ServerOptionsPanel serverOptions) {
         setRegistryHost(serverOptions.getHost());
         setRegistryPort(serverOptions.getPort());
@@ -62,6 +67,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         setRegistryTrustStorePath(serverOptions.getTrustStorePath());
     }
 
+    /**
+     * Apply the local UI options to the provided object.
+     * 
+     * @param serverOptions The options to change.
+     */
     public void configureRegistrationServiceOptions(final ServerOptionsPanel serverOptions) {
         serverOptions.setHost(getRegistryHost());
         serverOptions.setPort(getRegistryPort());
@@ -74,6 +84,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(REGISTRY_TRUSTSTORE_PATH);
     }
 
+    /**
+     * Sets the path to the trust store of the registry.
+     * 
+     * @param trustStorePath The path to the registry trust store.
+     */
     public void setRegistryTrustStorePath(final String trustStorePath) {
         setProperty(REGISTRY_TRUSTSTORE_PATH, trustStorePath);
     }
@@ -82,6 +97,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(REGISTRY_HOST);
     }
 
+    /**
+     * Sets the host of the registry.
+     * 
+     * @param host The hostname of the registry.
+     */
     public void setRegistryHost(final String host) {
         setProperty(REGISTRY_HOST, host);
     }
@@ -90,6 +110,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(REGISTRY_USER);
     }
 
+    /**
+     * Get the user to use for the registry.
+     * 
+     * @param user The username to use.
+     */
     public void setRegistryUser(final String user) {
         setProperty(REGISTRY_USER, user);
     }
@@ -98,10 +123,20 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(REGISTRY_PWD);
     }
 
+    /**
+     * Get the password to use for the registry.
+     * 
+     * @param pwd The password to use.
+     */
     public void setRegistryPwd(final String pwd) {
         setProperty(REGISTRY_PWD, pwd);
     }
 
+    /**
+     * Gets the port of the registry as integer.
+     * 
+     * @return The registry port as integer, {@code 0} if the value cannot be parsed as an integer.
+     */
     public int getRegistryPortAsInt() {
         final String portString = getRegistryPort();
         try {
@@ -115,10 +150,21 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(REGISTRY_PORT);
     }
 
+    /**
+     * Sets the port of the registry.
+     * 
+     * @param port The port of the registry.
+     */
     public void setRegistryPort(final String port) {
         setProperty(REGISTRY_PORT, port);
     }
 
+    /**
+     * Gets the number of receivers as integer.
+     * 
+     * @return The number of receivers to wait for as integer or {@code 0}
+     * if the value cannot be parsed as integer.
+     */
     public int getWaitForReceiversAsInt() {
         final String value = getPropertyAsString(WAIT_FOR_RECEIVERS);
         try {
@@ -132,10 +178,21 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(WAIT_FOR_RECEIVERS);
     }
 
+    /**
+     * Sets the number of receivers to wait for.
+     * 
+     * @param waitForReceivers Number of receivers to wait for (e.g. from other threads).
+     */
     public void setWaitForReceivers(final String waitForReceivers) {
         setProperty(WAIT_FOR_RECEIVERS, waitForReceivers);
     }
 
+    /**
+     * Gets the timeout to wait for receivers as integer.
+     * 
+     * @return The timeout to wait for receivers in milliseconds or {@code 0}
+     * if the value cannot be parsed as integer.
+     */
     public int getWaitForReceiversTimeoutAsInt() {
         final String value = getPropertyAsString(WAIT_FOR_RECEIVERS_TIMEOUT);
         try {
@@ -149,6 +206,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(WAIT_FOR_RECEIVERS_TIMEOUT);
     }
 
+    /**
+     * Sets the timeout to wait for receivers in milliseconds.
+     * 
+     * @param waitForReceiversTimeout The timeout in milliseconds encoded as string.
+     */
     public void setWaitForReceiversTimeout(final String waitForReceiversTimeout) {
         setProperty(WAIT_FOR_RECEIVERS_TIMEOUT, waitForReceiversTimeout);
     }
@@ -157,6 +219,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(DEVICE_ID);
     }
 
+    /**
+     * Sets the device id.
+     * 
+     * @param deviceId The device ID to use.
+     */
     public void setDeviceId(final String deviceId) {
         setProperty(DEVICE_ID, deviceId);
     }
@@ -165,6 +232,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsBoolean(SET_SENDER_TIME);
     }
 
+    /**
+     * Sets whether or not to add the current timestamp in the payload.
+     * 
+     * @param isSetSenderTime {@code true} to add the current timestamp at the point of sending.
+     */
     public void setSetSenderTime(final boolean isSetSenderTime) {
         setProperty(SET_SENDER_TIME, isSetSenderTime);
     }
@@ -173,6 +245,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsBoolean(WAIT_FOR_CREDITS);
     }
 
+    /**
+     * Sets whether to wait for credits.
+     * 
+     * @param isWaitForCredits {@code true} in order to wait for credits.
+     */
     public void setWaitForCredits(final boolean isWaitForCredits) {
         setProperty(WAIT_FOR_CREDITS, isWaitForCredits);
     }
@@ -181,6 +258,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(CONTENT_TYPE);
     }
 
+    /**
+     * Sets the content type.
+     * 
+     * @param contentType The MIME type of the payload.
+     */
     public void setContentType(final String contentType) {
         setProperty(CONTENT_TYPE, contentType);
     }
@@ -189,6 +271,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(DATA);
     }
 
+    /**
+     * Sets the payload data to send.
+     * 
+     * @param data The payload data.
+     */
     public void setData(final String data) {
         setProperty(DATA, data);
     }
@@ -197,6 +284,11 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         return getPropertyAsString(PROPERTY_REGISTRATION_ASSERTION);
     }
 
+    /**
+     * Sets the registration assertion to use.
+     * 
+     * @param assertion The registration assertion.
+     */
     public void setRegistrationAssertion(final String assertion) {
         setProperty(PROPERTY_REGISTRATION_ASSERTION, assertion);
     }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
@@ -35,7 +35,7 @@ import io.vertx.core.json.JsonObject;
 
 /**
  * Receiver, which connects to the AMQP network; asynchronous API needs to be used synchronous for JMeters threading
- * model
+ * model.
  */
 public class HonoReceiver extends AbstractClient {
 

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/ServerOptionsPanel.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/ServerOptionsPanel.java
@@ -49,6 +49,11 @@ public class ServerOptionsPanel extends VerticalPanel {
         return host.getText();
     }
 
+    /**
+     * Sets the host to use.
+     * 
+     * @param hostname The hostname to use.
+     */
     public void setHost(final String hostname) {
         this.host.setText(hostname);
     }
@@ -57,6 +62,11 @@ public class ServerOptionsPanel extends VerticalPanel {
         return port.getText();
     }
 
+    /**
+     * Sets the port to use.
+     * 
+     * @param port The port to use.
+     */
     public void setPort(final String port) {
         this.port.setText(port);
     }
@@ -65,6 +75,11 @@ public class ServerOptionsPanel extends VerticalPanel {
         return user.getText();
     }
 
+    /**
+     * Sets the user to use.
+     * 
+     * @param username The user name to use.
+     */
     public void setUser(final String username) {
         this.user.setText(username);
     }
@@ -73,6 +88,11 @@ public class ServerOptionsPanel extends VerticalPanel {
         return pwd.getText();
     }
 
+    /**
+     * Sets the password to use.
+     * 
+     * @param pwd The password to use.
+     */
     public void setPwd(final String pwd) {
         this.pwd.setText(pwd);
     }
@@ -81,10 +101,18 @@ public class ServerOptionsPanel extends VerticalPanel {
         return trustStorePath.getText();
     }
 
+    /**
+     * Sets the path of the trust store.
+     * 
+     * @param path The path to the trust store.
+     */
     public void setTrustStorePath(final String path) {
         this.trustStorePath.setText(path);
     }
 
+    /**
+     * Clears all UI fields.
+     */
     public void clearGui() {
         host.setText("");
         port.setText("");

--- a/legal/src/main/resources/checkstyle/default.xml
+++ b/legal/src/main/resources/checkstyle/default.xml
@@ -46,6 +46,13 @@
       <property name="message" value="Empty lines must not contain whitespaces" />
     </module>
 
+    <!-- javadoc validation -->
+    <module name="JavadocMethod">
+      <property name="scope" value="public"/>
+      <property name="ignoreMethodNamesRegex" value="^main$"/>
+      <property name="allowMissingPropertyJavadoc" value="true"/>
+    </module>
+
   </module>
 
   <!-- only spaces, no tabs -->

--- a/legal/src/main/resources/checkstyle/default.xml
+++ b/legal/src/main/resources/checkstyle/default.xml
@@ -47,6 +47,7 @@
     </module>
 
     <!-- javadoc validation -->
+
     <module name="JavadocMethod">
       <property name="scope" value="public"/>
       <property name="ignoreMethodNamesRegex" value="^main$"/>
@@ -54,6 +55,7 @@
     </module>
     <module name="JavadocStyle"/>
     <module name="JavadocType"/>
+    <module name="NonEmptyAtclauseDescription"/>
 
   </module>
 

--- a/legal/src/main/resources/checkstyle/default.xml
+++ b/legal/src/main/resources/checkstyle/default.xml
@@ -53,6 +53,7 @@
       <property name="allowMissingPropertyJavadoc" value="true"/>
     </module>
     <module name="JavadocStyle"/>
+    <module name="JavadocType"/>
 
   </module>
 

--- a/legal/src/main/resources/checkstyle/default.xml
+++ b/legal/src/main/resources/checkstyle/default.xml
@@ -52,6 +52,7 @@
       <property name="ignoreMethodNamesRegex" value="^main$"/>
       <property name="allowMissingPropertyJavadoc" value="true"/>
     </module>
+    <module name="JavadocStyle"/>
 
   </module>
 

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -45,7 +45,7 @@ public abstract class AbstractAdapterConfig {
     private MetricsOptions metricsOptions;
 
     /**
-     * Vert.x metrics options, if configured
+     * Vert.x metrics options, if configured.
      *
      * @param metricsOptions Vert.x metrics options
      * @see MetricConfig

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -41,7 +41,7 @@ import io.vertx.ext.web.handler.BodyHandler;
 public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends AbstractServiceBase<T> {
 
     /**
-     * Default file uploads directory used by Vert.x Web
+     * Default file uploads directory used by Vert.x Web.
      */
     protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
 

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MetricConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MetricConfig.java
@@ -61,7 +61,7 @@ public class MetricConfig {
     }
 
     /**
-     * Set the prefix to scope values of each service
+     * Set the prefix to scope values of each service.
      *
      * @param prefix The prefix
      */

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MetricConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MetricConfig.java
@@ -51,6 +51,11 @@ public class MetricConfig {
 
     private final MetricRegistry metricRegistry;
 
+    /**
+     * Create a new metric configuration.
+     * 
+     * @param metricRegistry The metric registry to use.
+     */
     public MetricConfig(final MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
     }
@@ -64,6 +69,11 @@ public class MetricConfig {
         this.prefix = prefix;
     }
 
+    /**
+     * Gets a gauge instance for the JVM memory.
+     * 
+     * @return A gauge instance for the JVM memory.
+     */
     @Bean
     @ConditionalOnProperty(prefix = "hono.metric.jvm", name = "memory", havingValue = "true")
     public MemoryUsageGaugeSet jvmMetricsMemory() {
@@ -71,6 +81,11 @@ public class MetricConfig {
         return metricRegistry.register(prefix + ".jvm.memory", new MemoryUsageGaugeSet());
     }
 
+    /**
+     * Gets a gauge instance for the JVM thread states.
+     * 
+     * @return A gauge instance for the JVM thread states.
+     */
     @Bean
     @ConditionalOnProperty(prefix = "hono.metric.jvm", name = "thread", havingValue = "true")
     public ThreadStatesGaugeSet jvmMetricsThreads() {
@@ -78,6 +93,11 @@ public class MetricConfig {
         return metricRegistry.register(prefix + ".jvm.thread", new ThreadStatesGaugeSet());
     }
 
+    /**
+     * Gets the vertx metrics options bean.
+     * 
+     * @return A new metrics options instance for vertx.
+     */
     @Bean
     @ConditionalOnProperty(prefix = "hono.metric", name = "vertx", havingValue = "true")
     public MetricsOptions vertxMetricsOptions() {
@@ -88,6 +108,12 @@ public class MetricConfig {
                 .setBaseName(prefix + ".vertx").setJmxEnabled(true);
     }
 
+    /**
+     * Gets a new instance for a console reporter.
+     * 
+     * @param period The period to update the state on console in milliseconds.
+     * @return The new console reporter instance.
+     */
     @Bean
     @ConditionalOnProperty(prefix = "hono.metric.reporter.console", name = "active", havingValue = "true")
     public ConsoleReporter consoleMetricReporter(
@@ -102,6 +128,16 @@ public class MetricConfig {
         return consoleReporter;
     }
 
+    /**
+     * Gets a new instance for a graphite reporter.
+     * 
+     * @param period The period to publish the state in milliseconds.
+     * @param host The host to report to.
+     * @param port The port to report to.
+     * @param prefix The prefix used when reporting.
+     * 
+     * @return The new graphite reporter instance.
+     */
     @Bean
     @ConditionalOnProperty(prefix = "hono.metric.reporter.graphite", name = "active", havingValue = "true")
     public GraphiteReporter graphiteReporter(

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -19,6 +19,9 @@ import org.springframework.stereotype.Component;
 
 import java.util.Objects;
 
+/**
+ * Base metrics collector.
+ */
 @Component
 abstract public class Metrics {
 

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 abstract public class Metrics {
 
     /**
-     * special prefixes used by spring boot actuator together with dropwizard metrics
+     * Special prefixes used by spring boot actuator together with dropwizard metrics.
      * @see <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-dropwizard-metrics">Spring Boot</a>
      */
     protected static final String METER_PREFIX     = "meter.";
@@ -41,7 +41,7 @@ abstract public class Metrics {
     protected CounterService counterService = NullCounterService.getInstance();
 
     /**
-     * It is needed to set the specific service prefix; if no config is given it is not needed and will never be used
+     * It is needed to set the specific service prefix; if no config is given it is not needed and will never be used.
      *
      * @param metricConfig The metrics config
      */
@@ -51,7 +51,7 @@ abstract public class Metrics {
     }
 
     /**
-     * Deriving classes need to provide a prefix to scope the metrics of the service
+     * Deriving classes need to provide a prefix to scope the metrics of the service.
      *
      * @return The Prefix
      */
@@ -93,7 +93,7 @@ abstract public class Metrics {
     }
 
     /**
-     * Merge the given address parts as a full string, seperated by '.'
+     * Merge the given address parts as a full string, separated by '.'.
      * @param parts The address parts
      * @return The full address, separated by points
      */

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NullCounterService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NullCounterService.java
@@ -9,6 +9,9 @@ public final class NullCounterService implements CounterService {
 
     private NullCounterService() {}
 
+    /**
+     * A no-op metrics counter service.
+     */
     private static class NullCounterServiceSingleton {
         private static final NullCounterService INSTANCE = new NullCounterService();
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NullGaugeService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NullGaugeService.java
@@ -9,6 +9,9 @@ public final class NullGaugeService implements GaugeService {
 
     private NullGaugeService() {}
 
+    /**
+     * A no-op gauge metrics service.
+     */
     private static class NullGaugeServiceSingleton {
         private static final NullGaugeService INSTANCE = new NullGaugeService();
     }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
@@ -288,9 +288,17 @@ public final class FileBasedTenantService extends BaseTenantService<FileBasedTen
         }
     }
 
+    /**
+     * Updates the tenant information.
+     * 
+     * @param tenantId The tenant to update
+     * @param tenantSpec The new tenant information
+     * @param resultHandler The handler receiving the result of the operation.
+     * 
+     * @throws NullPointerException if either of the input parameters is {@code null}.
+     */
     @Override
     public void update(final String tenantId, final JsonObject tenantSpec, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
-
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(tenantSpec);
         Objects.requireNonNull(resultHandler);

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/ForwardingDownstreamAdapter.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/ForwardingDownstreamAdapter.java
@@ -113,7 +113,7 @@ public abstract class ForwardingDownstreamAdapter implements DownstreamAdapter {
     }
 
     /**
-     * Sets the metrics for this service
+     * Sets the metrics for this service.
      *
      * @param metrics The metrics
      */

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplicationConfig.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplicationConfig.java
@@ -43,7 +43,7 @@ public class HonoMessagingApplicationConfig {
     private MetricsOptions metricsOptions;
 
     /**
-     * Vert.x metrics options, if configured
+     * Vert.x metrics options, if configured.
      *
      * @param metricsOptions Vert.x metrics options
      * @see MetricConfig

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/MessageDiscardingDownstreamAdapter.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/MessageDiscardingDownstreamAdapter.java
@@ -143,6 +143,9 @@ public final class MessageDiscardingDownstreamAdapter implements DownstreamAdapt
         status.onMsgReceived();
     }
 
+    /**
+     * Information about the link status.
+     */
     private class LinkStatus {
 
         private long msgCount;

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/MessageForwardingEndpoint.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/MessageForwardingEndpoint.java
@@ -77,7 +77,7 @@ public abstract class MessageForwardingEndpoint<T extends HonoMessagingConfigPro
     }
 
     /**
-     * Sets the metric for this service
+     * Sets the metric for this service.
      *
      * @param metrics The metric
      */

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/MessagingMetrics.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/MessagingMetrics.java
@@ -16,7 +16,7 @@ import org.eclipse.hono.service.metric.Metrics;
 import org.springframework.stereotype.Component;
 
 /**
- * Metrics for Hono Messaging
+ * Metrics for Hono Messaging.
  */
 @Component
 public class MessagingMetrics extends Metrics {


### PR DESCRIPTION
This PR aims fixing #542 by adding a few codestyle checks and fixing the remaining violations detected. 

The checks enabled are:
* Require javadoc for public types and methods
* Require valid HTML, end of first sentence punctuation
* Check for empty javadocs and at-clauses

I did not enable the check to validate public (global) variables as too many javadocs would have been missing, so I think this might need further discussion. Although I would recommend to document publicly accessible fields. You can check the outcome by adding the following snipped to `default.xml` checkstyle file:

~~~xml
<module name="JavadocVariable">
  <property name="scope" value="public"/>
</module>
~~~