### PR TITLE
[#475]: Enable support for OSGi

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016 Bosch Software Innovations GmbH.
+    Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -10,6 +10,7 @@
 
     Contributors:
        Bosch Software Innovations GmbH - initial API and implementation and initial documentation
+       Red Hat Inc
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -24,6 +25,7 @@
   </parent>
 
   <artifactId>hono-client</artifactId>
+  <packaging>bundle</packaging>
 
   <name>Hono Client</name>
   <description>A library providing a Vert.x based client for accessing Hono's APIs.</description>
@@ -48,8 +50,8 @@
       <artifactId>hono-core</artifactId>
     </dependency>
     <dependency>
-    	<groupId>org.eclipse.hono</groupId>
-    	<artifactId>hono-legal</artifactId>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-legal</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -80,6 +82,11 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,3 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+       Bosch Software Innovations GmbH - initial API and implementation and initial documentation
+       Red Hat Inc
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -7,7 +22,10 @@
     <version>0.6-M2-SNAPSHOT</version>
     <relativePath>../bom</relativePath>
   </parent>
+
   <artifactId>hono-core</artifactId>
+  <packaging>bundle</packaging>
+
   <name>Hono Core</name>
   <description>Basic classes used by all other modules.</description>
   <inceptionYear>2016</inceptionYear>
@@ -65,6 +83,11 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,11 @@
           <artifactId>maven-assembly-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
This change adds the maven-bundle-plugin in order to generate OSGi
metadata during the build. Currently only for core and client.

---

This PR is intended to let people see the changes introduced by adding OSGi support.