### PR TITLE
[#349] Extend Tenant API with operation to get tenant by CA.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -29,10 +29,24 @@ public final class TenantConstants extends RequestResponseApiConstants {
     public static final String FIELD_ADAPTERS_TYPE               = "type";
     public static final String FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED = "device-authentication-required";
     /**
-     * The name of the property that contains the <em>subject DN</em> of the CA certificate
+     * The name of the property that contains the Base64 encoded (binary) DER encoding of
+     * the trusted certificate configured for a tenant.
+     */
+    public static final String FIELD_PAYLOAD_CERT = "cert";
+    /**
+     * The name of the property that contains the Base64 encoded DER encoding of the public key of the
+     * trusted certificate authority configured for a tenant.
+     */
+    public static final String FIELD_PAYLOAD_PUBLIC_KEY = "public-key";
+    /**
+     * The name of the property that contains the RFC 2253 formatted <em>subject DN</em> of the CA certificate
      * that has been configured for a tenant.
      */
-    public static final String FIELD_SUBJECT_DN = "subject-dn";
+    public static final String FIELD_PAYLOAD_SUBJECT_DN = "subject-dn";
+    /**
+     * The name of the property that contains the trusted certificate authority configured for a tenant.
+     */
+    public static final String FIELD_PAYLOAD_TRUSTED_CA = "trusted-ca";
     /**
      * The name of the Tenant API endpoint.
      */
@@ -47,13 +61,36 @@ public final class TenantConstants extends RequestResponseApiConstants {
      * Request actions that belong to the Tenant API.
      */
     public enum TenantAction {
-        get, add, update, remove, unknown;
+        /**
+         * The <em>add Tenant</em> operation.
+         */
+        add,
+        /**
+         * The <em>get Tenant</em> operation.
+         */
+        get,
+        /**
+         * The <em>get Tenant by Certificate Authority</em> operation.
+         */
+        getByCa,
+        /**
+         * The <em>update Tenant</em> operation.
+         */
+        update,
+        /**
+         * The <em>remove Tenant</em> operation.
+         */
+        remove,
+        /**
+         * The <em>custom</em> operation.
+         */
+        custom;
 
         /**
          * Construct a TenantAction from a subject.
          *
          * @param subject The subject from which the TenantAction needs to be constructed.
-         * @return TenantAction The TenantAction as enum, or {@link TenantAction#unknown} otherwise.
+         * @return TenantAction The TenantAction as enum, or {@link TenantAction#custom} otherwise.
          */
         public static TenantAction from(final String subject) {
             if (subject != null) {
@@ -62,17 +99,7 @@ public final class TenantConstants extends RequestResponseApiConstants {
                 } catch (final IllegalArgumentException e) {
                 }
             }
-            return unknown;
-        }
-
-        /**
-         * Helper method to check if a subject is a valid Tenant API action.
-         *
-         * @param subject The subject to validate.
-         * @return boolean {@link Boolean#TRUE} if the subject denotes a valid action, {@link Boolean#FALSE} otherwise.
-         */
-        public static boolean isValid(final String subject) {
-            return TenantAction.from(subject) != TenantAction.unknown;
+            return custom;
         }
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
@@ -96,11 +96,11 @@ public class TenantAmqpEndpoint extends RequestResponseEndpoint<ServiceConfigPro
      * client is authorized to retrieve.
      * <p>
      * If the response does not contain a tenant ID nor a payload, then the
-     * response is returned as-is.
+     * returned future will succeed with the response <em>as-is</em>.
      * Otherwise the tenant ID is used together with the endpoint and operation
-     * name to check the client's authority to retrieve the data. If the check
-     * succeeds, the response will be returned as-is, otherwise the returned
-     * future will be failed with a {@link ClientErrorException} containing a
+     * name to check the client's authority to retrieve the data. If the client
+     * is authorized, the returned future will succeed with the response as-is,
+     * otherwise the future will fail with a {@link ClientErrorException} containing a
      * <em>403 Forbidden</em> status.
      */
     @Override

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantMessageFilter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantMessageFilter.java
@@ -16,14 +16,12 @@ package org.eclipse.hono.service.tenant;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.BaseMessageFilter;
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
-import org.eclipse.hono.util.TenantConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A filter for verifying the format of <em>Tenant</em> messages.
+ * A filter for verifying the format of <em>Tenant API</em> request messages.
  */
 public final class TenantMessageFilter extends BaseMessageFilter {
 
@@ -42,14 +40,11 @@ public final class TenantMessageFilter extends BaseMessageFilter {
      */
     public static boolean verify(final ResourceIdentifier linkTarget, final Message msg) {
 
-        if (MessageHelper.getTenantId(msg) == null) {
-            LOG.trace("message [{}] does not contain a tenant-id", msg.getMessageId());
-            return false;
-        } else if (msg.getMessageId() == null && msg.getCorrelationId() == null) {
+        if (msg.getMessageId() == null && msg.getCorrelationId() == null) {
             LOG.trace("message has neither a message-id nor correlation-id");
             return false;
-        } else if (!TenantConstants.TenantAction.isValid(msg.getSubject())) {
-            LOG.trace("message [{}] does not contain valid action property", msg.getMessageId());
+        } else if (msg.getSubject() == null) {
+            LOG.trace("message [{}] does not contain subject", msg.getMessageId());
             return false;
         } else if (msg.getReplyTo() == null) {
             LOG.trace("message [{}] contains no reply-to address", msg.getMessageId());

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantService.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.service.tenant;
 
+import javax.security.auth.x500.X500Principal;
+
 import org.eclipse.hono.util.TenantResult;
 
 import io.vertx.core.AsyncResult;
@@ -45,7 +47,7 @@ public interface TenantService extends Verticle {
     void add(String tenantId, JsonObject tenantObj, Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler);
 
     /**
-     * Gets configuration information for a tenant.
+     * Gets tenant configuration information for a tenant identifier.
      *
      * @param tenantId The identifier of the tenant.
      * @param resultHandler The handler to invoke with the result of the operation.
@@ -60,6 +62,29 @@ public interface TenantService extends Verticle {
      *      Tenant API - Get Tenant Information</a>
      */
     void get(String tenantId, Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler);
+
+    /**
+     * Gets tenant configuration information for a <em>subject DN</em>
+     * of a trusted certificate authority.
+     * <p>
+     * This method can e.g. be used when trying to authenticate a device based on
+     * an X.509 client certificate. Using this method, the <em>issuer DN</em> from the
+     * client's certificate can be used to determine the tenant that the device belongs to.
+     * 
+     * @param subjectDn The <em>subject DN</em> of the trusted CA certificate
+     *                  that has been configured for the tenant.
+     * @param resultHandler The handler to invoke with the result of the operation.
+     *             The <em>status</em> will be
+     *             <ul>
+     *             <li><em>200 OK</em> if a tenant with a matching trusted certificate authority exists.
+     *             The <em>payload</em> will contain the tenant's configuration information.</li>
+     *             <li><em>404 Not Found</em> if no matching tenant exists.</li>
+     *             </ul>
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @see <a href="https://www.eclipse.org/hono/api/tenant-api/#get-tenant-information">
+     *      Tenant API - Get Tenant Information</a>
+     */
+    void getByCertificateAuthority(X500Principal subjectDn, Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler);
 
     /**
      * Updates configuration information of a tenant.

--- a/service-base/src/test/java/org/eclipse/hono/service/tenant/TenantMessageFilterTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/tenant/TenantMessageFilterTest.java
@@ -33,13 +33,15 @@ public class TenantMessageFilterTest {
     private static final String DEFAULT_TENANT = "DEFAULT_TENANT";
 
     /**
-     * Verifies that {@link TenantMessageFilter#verify(ResourceIdentifier, Message)} detects if the mandatory tenantId
-     * property is missing.
+     * Verifies that the filter detects a missing subject.
      */
     @Test
-    public void testVerifyDetectsMissingTenantProperty() {
-        // GIVEN a valid tenant GET message without an AMQP value
-        final Message msg = givenAMessageHavingProperties(TenantConstants.TenantAction.get);
+    public void testVerifyDetectsMissingSubject() {
+
+        // GIVEN a request message without a subject
+        final Message msg = ProtonHelper.message();
+        msg.setMessageId("msg");
+        msg.setReplyTo("reply");
         // WHEN receiving the message via a link with any tenant
         final ResourceIdentifier linkTarget = getResourceIdentifier(DEFAULT_TENANT);
 

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.security.auth.x500.X500Principal;
+
 import org.eclipse.hono.service.tenant.BaseTenantService;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.TenantObject;
@@ -223,6 +225,31 @@ public final class FileBasedTenantService extends BaseTenantService<FileBasedTen
     }
 
     @Override
+    public void getByCertificateAuthority(final X500Principal subjectDn,
+            final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
+
+        Objects.requireNonNull(subjectDn);
+        Objects.requireNonNull(resultHandler);
+
+        resultHandler.handle(Future.succeededFuture(getForCertificateAuthority(subjectDn)));
+    }
+
+    private TenantResult<JsonObject> getForCertificateAuthority(final X500Principal subjectDn) {
+
+        if (subjectDn == null) {
+            return TenantResult.from(HttpURLConnection.HTTP_BAD_REQUEST);
+        } else {
+            final TenantObject tenant = getByCa(subjectDn);
+
+            if (tenant == null) {
+                return TenantResult.from(HttpURLConnection.HTTP_NOT_FOUND);
+            } else {
+                return TenantResult.from(HttpURLConnection.HTTP_OK, JsonObject.mapFrom(tenant), CacheDirective.maxAgeDirective(MAX_AGE_GET_TENANT));
+            }
+        }
+    }
+
+    @Override
     public void remove(final String tenantId, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
 
         Objects.requireNonNull(tenantId);
@@ -275,9 +302,15 @@ public final class FileBasedTenantService extends BaseTenantService<FileBasedTen
             try {
                 final TenantObject tenant = tenantSpec.mapTo(TenantObject.class);
                 tenant.setTenantId(tenantId);
-                tenants.put(tenantId, tenant);
-                dirty = true;
-                return TenantResult.from(HttpURLConnection.HTTP_CREATED);
+                final TenantObject conflictingTenant = getByCa(tenant.getTrustedCaSubjectDn());
+                if (conflictingTenant != null) {
+                    // we are trying to use the same CA as an already existing tenant
+                    return TenantResult.from(HttpURLConnection.HTTP_CONFLICT);
+                } else {
+                    tenants.put(tenantId, tenant);
+                    dirty = true;
+                    return TenantResult.from(HttpURLConnection.HTTP_CREATED);
+                }
             } catch (IllegalArgumentException e) {
                 return TenantResult.from(HttpURLConnection.HTTP_BAD_REQUEST);
             }
@@ -320,9 +353,15 @@ public final class FileBasedTenantService extends BaseTenantService<FileBasedTen
                 try {
                     final TenantObject tenant = tenantSpec.mapTo(TenantObject.class);
                     tenant.setTenantId(tenantId);
-                    tenants.put(tenantId, tenant);
-                    dirty = true;
-                    return TenantResult.from(HttpURLConnection.HTTP_NO_CONTENT);
+                    final TenantObject conflictingTenant = getByCa(tenant.getTrustedCaSubjectDn());
+                    if (conflictingTenant != null && !tenantId.equals(conflictingTenant.getTenantId())) {
+                        // we are trying to use the same CA as another tenant
+                        return TenantResult.from(HttpURLConnection.HTTP_CONFLICT);
+                    } else {
+                        tenants.put(tenantId, tenant);
+                        dirty = true;
+                        return TenantResult.from(HttpURLConnection.HTTP_NO_CONTENT);
+                    }
                 } catch (IllegalArgumentException e) {
                     return TenantResult.from(HttpURLConnection.HTTP_BAD_REQUEST);
                 }
@@ -331,6 +370,17 @@ public final class FileBasedTenantService extends BaseTenantService<FileBasedTen
             }
         } else {
             return TenantResult.from(HttpURLConnection.HTTP_FORBIDDEN);
+        }
+    }
+
+    private TenantObject getByCa(final X500Principal subjectDn) {
+
+        if (subjectDn == null) {
+            return null;
+        } else {
+            return tenants.values().stream()
+                    .filter(t -> subjectDn.equals(t.getTrustedCaSubjectDn()))
+                    .findFirst().orElse(null);
         }
     }
 

--- a/site/content/api/Tenant-API.md
+++ b/site/content/api/Tenant-API.md
@@ -59,10 +59,10 @@ The following table provides an overview of the properties a client needs to set
 | Name        | Mandatory | Location                 | Type     | Description |
 | :---------- | :-------: | :----------------------- | :------- | :---------- |
 | *subject*   | yes       | *properties*             | *string* | MUST be set to `add`. |
+| *tenant_id* | yes       | *application-properties* | *string* | MUST contain the ID of the tenant to add. |
 
 The request message MUST contain a tenant payload as defined in the [Request Payload]({{< relref "#request-payload" >}}) section below.
 
- 
 **Response Message Format**
 
 A response to an *add tenant* request contains the [Standard Response Properties]({{< relref "#standard-response-properties" >}}).
@@ -73,7 +73,7 @@ The response message's *status* property may contain the following codes:
 | :---- | :---------- |
 | *201* | Created, the tenant has been successfully created. |
 | *400* | Bad Request, the tenant has NOT been created due to invalid data in the request. |
-| *409* | Conflict, there already exists a tenant for the given *tenant_id*. |
+| *409* | Conflict, there already exists a tenant with the same *tenant_id* or using a trusted certificate authority with the same subject DN. |
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
@@ -96,6 +96,7 @@ The following table provides an overview of the properties a client needs to set
 | Name        | Mandatory | Location                 | Type     | Description |
 | :---------- | :-------: | :----------------------- | :------- | :---------- |
 | *subject*   | yes       | *properties*             | *string* | MUST be set to `get`. |
+| *tenant_id* | yes       | *application-properties* | *string* | MUST contain the ID of the tenant to get. |
 
 The body of the message SHOULD be empty and will be ignored if it is not.
 
@@ -111,6 +112,55 @@ The response message's *status* property may contain the following codes:
 | :--- | :---------- |
 | *200* | OK, the payload contains the tenant information for the requested tenant. |
 | *404* | Not Found, there is no tenant identified with the given *tenant_id*. |
+
+For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
+
+## Get Tenant Information by Trusted Certificate Authority
+
+Clients use this command to *retrieve* information about a tenant by the *subject DN* of the trusted certificate authority configured for the tenant.
+
+This operation is *mandatory* to implement.
+
+**Message Flow**
+
+The following sequence diagram illustrates the flow of messages involved in a *Client* retrieving tenant information.
+
+![Get Tenant Information by CA message flow](../tenant_GetTenantByCaSuccess.png)
+
+**Request Message Format**
+
+The following table provides an overview of the properties a client needs to set on a message to get tenant information in addition to the [Standard Request Properties]({{< relref "#standard-request-properties" >}}).
+
+| Name        | Mandatory | Location                 | Type     | Description |
+| :---------- | :-------: | :----------------------- | :------- | :---------- |
+| *subject*   | yes       | *properties*             | *string* | MUST be set to `getByCa`. |
+
+The body of the request MUST consist of a single *AMQP Value* section containing a UTF-8 encoded string representation of a single JSON object having the following members:
+
+| Name             | Mandatory | Type       | Description |
+| :--------------- | :-------: | :--------- | :---------- |
+| *subject-dn*     | *yes*     | *string*   | The subject DN of the trusted certificate authority's public key in the format defined by [RFC 2253](https://www.ietf.org/rfc/rfc2253.txt). |
+
+The following request payload may be used to look up the tenant for which a trusted certificate authority with subject DN `O=ACME Corporation, CN=devices` has been configured:
+
+~~~json
+{
+  "subject-dn": "CN=devices,O=ACME Corporation"
+}
+~~~
+
+**Response Message Format**
+
+A response to a *get tenant information by CA* request contains the [Standard Response Properties]({{< relref "#standard-response-properties" >}}).
+
+The response message includes payload as defined in the [Response Payload]({{< relref "#response-payload" >}}) section below.
+
+The response message's *status* property may contain the following codes:
+
+| Code | Description |
+| :--- | :---------- |
+| *200* | OK, the payload contains the tenant information for the tenant configured with a trusted certificate authority that matches the given subject DN. |
+| *404* | Not Found, there is no tenant identified with the given subject DN. |
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
@@ -143,6 +193,7 @@ The following table provides an overview of the properties a client needs to set
 | Name        | Mandatory | Location                 | Type     | Description |
 | :---------- | :-------: | :----------------------- | :------- | :---------- |
 | *subject*   | yes       | *properties*             | *string* | MUST be set to `update`. |
+| *tenant_id* | yes       | *application-properties* | *string* | MUST contain the ID of the tenant to update. |
 
 The request message MUST include payload as defined in the [Request Payload]({{< relref "#request-payload" >}}) section below.
  
@@ -157,6 +208,7 @@ The response message's *status* property may contain the following codes:
 | *204* | No Content, the tenant has been updated successfully. |
 | *400* | Bad Request, the tenant has NOT been updated due to invalid data in the request. |
 | *404* | Not Found, there is no tenant identified with the given *tenant_id*. |
+| *409* | Conflict, there already exists another tenant that uses a trusted certificate authority with the same subject DN. |
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
@@ -190,6 +242,7 @@ The following table provides an overview of the properties a client needs to set
 | Name        | Mandatory | Location                 | Type     | Description |
 | :---------- | :-------: | :----------------------- | :------- | :---------- |
 | *subject*   | yes       | *properties*             | *string* | MUST be set to `remove`. |
+| *tenant_id* | yes       | *application-properties* | *string* | MUST contain the ID of the tenant to remove. |
 
 The body of the message SHOULD be empty and will be ignored if it is not.
 
@@ -221,7 +274,6 @@ The following table provides an overview of the properties shared by all request
 | *correlation-id* | no        | *properties*             | *message-id* | MAY contain an ID used to correlate a response message to the original request. If set, it is used as the *correlation-id* property in the response, otherwise the value of the *message-id* property is used. |
 | *message-id*     | yes       | *properties*             | *string*     | MUST contain an identifier that uniquely identifies the message at the sender side. |
 | *reply-to*       | yes       | *properties*             | *string*     | MUST contain the source address that the client wants to received response messages from. This address MUST be the same as the source address used for establishing the client's receive link (see [Preconditions]({{< relref "#preconditions" >}})). |
-| *tenant_id*      | yes       | *application-properties* | *string*     | MUST contain the ID of the tenant that is subject to the operation. |
 
 ## Standard Response Properties
 
@@ -252,19 +304,22 @@ messages as part of a single *AMQP Value* section.
 The tenant data is carried in the payload as a UTF-8 encoded string representation of a single JSON object. It is an error to include payload that is not of this type.
 
 ## Request Payload
+
 The table below provides an overview of the standard members defined for the JSON request object:
 
-| Name                     | Mandatory | Type       | Default Value | Description |
-| :------------------------| :-------: | :--------- | :------------ | :---------- |
-| *enabled*                | *no*      | *boolean*  | `true`        | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices.
-| *adapters*               | *no*      | *array*    |               | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration.
+| Name                     | Mandatory | Type          | Default Value | Description |
+| :------------------------| :-------: | :------------ | :------------ | :---------- |
+| *enabled*                | *no*      | *boolean*     | `true`       | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
+| *trusted-ca*             | *no*      | *JSON object* |               | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
+| *adapters*               | *no*      | *array*       |               | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration. |
 
-If any of the mandatory members is either missing or present with invalid data in the payload object operations MUST return status code *`400` - Bad Request*.
+If any of the mandatory members is either missing or contains invalid data, implementations MUST NOT accept the payload and return *400 Bad Request* status code.
 
-Additionally to the specified properties the JSON object MAY contain an arbitrary number of members with arbitrary names which can be of a scalar or a complex type. 
+The JSON object MAY contain an arbitrary number of additional members with arbitrary names of either scalar or complex type.
 This allows for future *well-known* additions and also allows *clients* to add further information which might be relevant to a *custom* adapter only.
 
 ### Examples
+
 Below is an example for a request payload defining an *enabled* tenant.
 Devices belonging to the tenant can connect to Hono via the rest-adapter only and are required to authenticate with the adapter on connection.
 
@@ -277,31 +332,61 @@ Devices belonging to the tenant can connect to Hono via the rest-adapter only an
     {
       "type": "hono-http",
       "enabled": true,
-      "device-authentication-required": true
+      "device-authentication-required": true,
+      "deployment": {
+        "maxInstances": 4
+      }
     }
   ]
 }
 ~~~
 
-In the following example the tenant is allowed to use **all** adapters, as the `adapters` property is omitted in the tenant configuration:
+In the following example the tenant is allowed to use **all** adapters, as the `adapters` property is omitted in the tenant configuration (note that the payload also contains a custom property *plan* which might be used to indicate the customer's service level):
 
 ~~~json
 {
   "enabled": true
+  "plan": "gold",
+}
+~~~
+
+The following example contains information for a tenant including the public key of the trusted root certificate authority (note that the example does not contain the complete Base64 encoding of the public key for reasons of brevity):
+
+~~~json
+{
+  "enabled": true,
+  "trusted-ca": {
+    "subject-dn": "CN=devices,O=ACME Corporation",
+    "public-key": "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEApK5L6yUknQnj4FREQqs/ ..."
+  }
 }
 ~~~
 
 ## Response Payload
+
 The table below provides an overview of the standard members defined for the JSON response object:
 
 | Name                     | Mandatory | Type       | Description |
 | :------------------------| :-------: | :--------- | :---------- |
 | *tenant-id*              | *yes*     | *string*   | The ID of the tenant. |
-| *enabled*                | *yes*     | *boolean*  | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices.
-| *adapters*               | *no*      | *array*    | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration.
+| *enabled*                | *yes*     | *boolean*  | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
+| *trusted-ca*             | *no*      | *JSON object* |               | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
+| *adapters*               | *no*      | *array*    | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration. |
 
 Additionally to the specified properties the JSON object MAY contain an arbitrary number of members with arbitrary names which can be of a scalar or a complex type. 
 This allows for future *well-known* additions and also allows *clients* to add further information which might be relevant to a *custom* adapter only.
+
+## Trusted CA Format
+
+The table below provides an overview of the members defined for the *trusted-ca* JSON object:
+
+| Name                     | Mandatory | Type          | Default Value | Description |
+| :------------------------| :-------: | :------------ | :------------ | :---------- |
+| *subject-dn*             | *yes*      | *string*      |               | The subject DN of the trusted root certificate in the format defined by [RFC 2253](https://www.ietf.org/rfc/rfc2253.txt). |
+| *public-key*             | *yes*      | *string*      |               | The Base64 encoded binary DER encoding of the trusted root certificate's public key. |
+
+The *subject-dn* MUST be unique among all registered tenants. Implementations MUST reject requests to add or update a tenant with payload that contains a subject DN that is already configured for another tenant and return a status code of *409 Conflict*.
+
 
 ## Adapter Configuration Format
 
@@ -315,16 +400,17 @@ The table below contains the properties which are used to configure a *Hono prot
 
 Protocol Adapters SHOULD use the configuration properties set for a tenant when interacting with devices of that tenant, e.g. in order to make authorization decisions or to limit message rates per tenant etc.
 
-Additionally to the specified properties the JSON object MAY contain an arbitrary number of members with arbitrary names which can be of a scalar or a complex type. 
+The JSON object MAY contain an arbitrary number of additional members with arbitrary names of either scalar or complex type.
 
 ### Examples
 
-Below is an example for a payload of the response to a *get* request for tenant `TEST_TENANT`.
+Below is an example for a payload of the response to a *get* request for tenant `TEST_TENANT`. Note that the payload contains some *custom* properties at both the tenant as well as the adapter configuration level.
 
 ~~~json
 {
   "tenant-id" : "TEST_TENANT",
   "enabled" : true,
+  "plan": "gold",
   "adapters" : [ {
     "type" : "hono-mqtt",
     "enabled" : true,
@@ -332,7 +418,10 @@ Below is an example for a payload of the response to a *get* request for tenant 
   }, {
     "type" : "hono-http",
     "enabled" : true,
-    "device-authentication-required" : true
+    "device-authentication-required" : true,
+    "deployment": {
+      "maxInstances": 4
+    }
   } ]
 }
 ~~~

--- a/site/content/api/Tenant-API.md
+++ b/site/content/api/Tenant-API.md
@@ -310,8 +310,8 @@ The table below provides an overview of the standard members defined for the JSO
 | Name                     | Mandatory | Type          | Default Value | Description |
 | :------------------------| :-------: | :------------ | :------------ | :---------- |
 | *enabled*                | *no*      | *boolean*     | `true`       | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
-| *trusted-ca*             | *no*      | *JSON object* |               | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
-| *adapters*               | *no*      | *array*       |               | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration. |
+| *trusted-ca*             | *no*      | *JSON object* | `-`          | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
+| *adapters*               | *no*      | *array*       | `-`          | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration. |
 
 If any of the mandatory members is either missing or contains invalid data, implementations MUST NOT accept the payload and return *400 Bad Request* status code.
 
@@ -323,7 +323,7 @@ This allows for future *well-known* additions and also allows *clients* to add f
 Below is an example for a request payload defining an *enabled* tenant.
 Devices belonging to the tenant can connect to Hono via the rest-adapter only and are required to authenticate with the adapter on connection.
 
-**NB** The id of the tenant is not part of the json as it is defined in the application properties of the amqp message.
+**NB** The id of the tenant is not part of the JSON as it is defined in the application properties of the AMQP 1.0 message.
 
 ~~~json
 {
@@ -341,7 +341,7 @@ Devices belonging to the tenant can connect to Hono via the rest-adapter only an
 }
 ~~~
 
-In the following example the tenant is allowed to use **all** adapters, as the `adapters` property is omitted in the tenant configuration (note that the payload also contains a custom property *plan* which might be used to indicate the customer's service level):
+In the following example the tenant is allowed to use **all** adapters, as the *adapters* property is omitted in the tenant configuration. Note that the payload also contains a custom property *plan* which might be used to indicate the customer's service level:
 
 ~~~json
 {
@@ -350,7 +350,7 @@ In the following example the tenant is allowed to use **all** adapters, as the `
 }
 ~~~
 
-The following example contains information for a tenant including the public key of the trusted root certificate authority (note that the example does not contain the complete Base64 encoding of the public key for reasons of brevity):
+The following example contains information for a tenant including the public key of the trusted root certificate authority. Note that the example does not contain the complete Base64 encoding of the public key for reasons of brevity:
 
 ~~~json
 {
@@ -366,12 +366,12 @@ The following example contains information for a tenant including the public key
 
 The table below provides an overview of the standard members defined for the JSON response object:
 
-| Name                     | Mandatory | Type       | Description |
-| :------------------------| :-------: | :--------- | :---------- |
-| *tenant-id*              | *yes*     | *string*   | The ID of the tenant. |
-| *enabled*                | *yes*     | *boolean*  | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
-| *trusted-ca*             | *no*      | *JSON object* |               | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
-| *adapters*               | *no*      | *array*    | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration. |
+| Name                     | Mandatory | Type          | Description |
+| :------------------------| :-------: | :------------ | :---------- |
+| *tenant-id*              | *yes*     | *string*      | The ID of the tenant. |
+| *enabled*                | *yes*     | *boolean*     | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
+| *trusted-ca*             | *no*      | *JSON object* | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
+| *adapters*               | *no*      | *JSON array*  | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration. |
 
 Additionally to the specified properties the JSON object MAY contain an arbitrary number of members with arbitrary names which can be of a scalar or a complex type. 
 This allows for future *well-known* additions and also allows *clients* to add further information which might be relevant to a *custom* adapter only.
@@ -394,17 +394,17 @@ The table below contains the properties which are used to configure a *Hono prot
 
 | Name                               | Mandatory | Type       | Default Value | Description |
 | :--------------------------------- | :-------: | :--------- | :------------ | :---------- |
-| *type*                       | *yes*     | *string*   |         | The type of the adapter which this configuration belongs to.|
-| *enabled*                          | *no*      | *boolean*   | `false`       | If set to false the tenant is not allowed to receive / send data utilizing the given adapter. |
-| *device-authentication-required*   | *no*      | *boolean*   | `true`        | If set to false, devices are not required to authenticate with the adapter before sending / receiving data. |
+| *type*                             | *yes*     | *string*   | `-`          | The type of the adapter which this configuration belongs to.|
+| *enabled*                          | *no*      | *boolean*  | `false`      | If set to false the tenant is not allowed to receive / send data utilizing the given adapter. |
+| *device-authentication-required*   | *no*      | *boolean*  | `true`       | If set to false, devices are not required to authenticate with the adapter before sending / receiving data. |
 
-Protocol Adapters SHOULD use the configuration properties set for a tenant when interacting with devices of that tenant, e.g. in order to make authorization decisions or to limit message rates per tenant etc.
+Protocol adapters SHOULD use the configuration properties set for a tenant when interacting with devices of that tenant, e.g. in order to make authorization decisions or to limit message rates per tenant etc.
 
 The JSON object MAY contain an arbitrary number of additional members with arbitrary names of either scalar or complex type.
 
 ### Examples
 
-Below is an example for a payload of the response to a *get* request for tenant `TEST_TENANT`. Note that the payload contains some *custom* properties at both the tenant as well as the adapter configuration level.
+Below is an example for a payload of the response to a *get* request for tenant `TEST_TENANT`. Note that the payload contains some custom properties at both the tenant (*plan*) as well as the adapter configuration level (*deployment*).
 
 ~~~json
 {


### PR DESCRIPTION
This is the first step for supporting authentication of devices using client certificates.

The PR defines a new operation in the Tenant API (*Get Tenant Information by Trusted Certificate Authority*) which is used to determine the tenant that the device belongs to when it presents its client cert during the TLS handshake.

We should discuss
* whether we want to have a separate operation for this purpose (as implemented in this PR) or whether we would rather modify the existing *get* operation which currently only supports retrieving the tenant by ID. I can also imagine to require the *get* operation to have a request payload specifying either a tenant ID or a subject DN.
* whether the *trusted-ca* configuration property serves its purpose as defined by this PR or needs modification.