### PR TITLE
Fix MQTT message count metrics

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -288,11 +288,13 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
         endpoint.closeHandler(v -> {
             close(endpoint);
             LOG.debug("connection to unauthenticated device [clientId: {}] closed", endpoint.clientIdentifier());
+            metrics.decrementUnauthenticatedMqttConnections();
         });
         endpoint.publishHandler(message -> onPublishedMessage(new MqttContext(message, endpoint)));
 
         LOG.debug("unauthenticated device [clientId: {}] connected", endpoint.clientIdentifier());
         endpoint.accept(false);
+        metrics.incrementUnauthenticatedMqttConnections();
     }
 
     private void handleEndpointConnectionWithAuthentication(final MqttEndpoint endpoint) {

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 
 package org.eclipse.hono.adapter.mqtt;
@@ -29,11 +30,11 @@ public class MqttAdapterMetrics extends Metrics {
     }
 
     void incrementProcessedMqttMessages(final String resourceId, final String tenantId) {
-        counterService.increment(METER_PREFIX + getPrefix() + MESSAGES + mergeAsMetric(resourceId,tenantId) + PROCESSED);
+        counterService.increment(METER_PREFIX + getPrefix() + MESSAGES + mergeAsMetric(resourceId, tenantId) + PROCESSED);
     }
 
     void incrementUndeliverableMqttMessages(final String resourceId, final String tenantId) {
-        counterService.increment(getPrefix() + MESSAGES + mergeAsMetric(resourceId,tenantId) + UNDELIVERABLE);
+        counterService.increment(getPrefix() + MESSAGES + mergeAsMetric(resourceId, tenantId) + UNDELIVERABLE);
     }
 
     void incrementMqttConnections(final String tenantId) {
@@ -41,6 +42,14 @@ public class MqttAdapterMetrics extends Metrics {
     }
 
     void decrementMqttConnections(final String tenantId) {
-        counterService.increment(getPrefix() + CONNECTIONS + tenantId);
+        counterService.decrement(getPrefix() + CONNECTIONS + tenantId);
+    }
+
+    void incrementUnauthenticatedMqttConnections() {
+        counterService.increment(getPrefix() + UNAUTHENTICATED_CONNECTIONS);
+    }
+
+    void decrementUnauthenticatedMqttConnections() {
+        counterService.decrement(getPrefix() + UNAUTHENTICATED_CONNECTIONS);
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Red Hat Inc
  */
 
 package org.eclipse.hono.service.metric;
@@ -39,6 +40,7 @@ abstract public class Metrics {
     protected static final String DISCARDED     = ".discarded";
     protected static final String UNDELIVERABLE = ".undeliverable";
     protected static final String CONNECTIONS   = ".connections.";
+    protected static final String UNAUTHENTICATED_CONNECTIONS   = ".unauthenticatedConnections.";
 
     protected GaugeService   gaugeService   = NullGaugeService.getInstance();
     protected CounterService counterService = NullCounterService.getInstance();


### PR DESCRIPTION
This change does fix two issues with the MQTT connection count metrics.
The first issue is a simple mistake of calling increment instead of
decrement. The second issue ignores unauthenticated MQTT connections in
the metrics.