### PR TITLE
Hono device notifications impl

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/EventDemultiplexer.java
+++ b/core/src/main/java/org/eclipse/hono/util/EventDemultiplexer.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Section;
+import org.apache.qpid.proton.message.Message;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * A helper for handling different types of events with explicit callbacks.
+ * Currently it demultiplexes callbacks for generic events and notifications (being well defined events).
+ */
+public final class EventDemultiplexer {
+    /**
+     * Prevent construction.
+     */
+    private EventDemultiplexer() {
+    }
+
+
+    /**
+     * Construct a event consumer that delegates different kinds of events to specific handlers.
+     * @param eventConsumer Consumer that handles generic events.
+     * @param notificationConsumer Consumer that handles events that were detected to be a notification. Maybe {@code null}.
+     * @return The event consumer that invokes the specific handlers depending on the event type.
+     */
+    public static final Consumer<Message> createEventHandler(final Consumer<Message> eventConsumer,
+                                                             final Consumer<Message> notificationConsumer
+                                                             ) {
+        return (msg -> {
+            final Section body = msg.getBody();
+            if (!(body instanceof Data)) {
+                return;
+            }
+
+            Optional.ofNullable(notificationConsumer).map(consumer -> {
+                if (NotificationConstants.isNotification(msg)) {
+                    notificationConsumer.accept(msg);
+                } else {
+                    eventConsumer.accept(msg);
+                }
+                return consumer;
+            }).orElse(consumer -> eventConsumer.accept(msg));
+        });
+    }
+
+}

--- a/core/src/main/java/org/eclipse/hono/util/NotificationConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/NotificationConstants.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import org.apache.qpid.proton.message.Message;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Constants used for notification events.
+ */
+public abstract class NotificationConstants {
+
+    /**
+     * The content type that is defined for device command readiness notification events.
+     */
+    public static final String CONTENT_TYPE_DEVICE_COMMAND_READINESS_NOTIFICATION = "application/vnd.eclipse-hono-dcr-notification+json";
+
+    /**
+     * The content type that is defined for device connection notification events.
+     */
+    public static final String CONTENT_TYPE_DEVICE_CONNECTION_NOTIFICATION = "application/vnd.eclipse-hono-dc-notification+json";
+
+    /**
+     * Enum that defines all valid notifications by their content-type.
+     */
+    public enum NotificationContentType {
+        DEVICE_COMMAND_READINESS_NOTIFICATION(CONTENT_TYPE_DEVICE_COMMAND_READINESS_NOTIFICATION),
+        DEVICE_CONNECTION_NOTIFICATION(CONTENT_TYPE_DEVICE_CONNECTION_NOTIFICATION);
+
+        private final String contentType;
+
+        NotificationContentType(final String contentType) {
+            this.contentType = contentType;
+        }
+
+        /**
+         * Helper method to check if a subject is a valid content type.
+         *
+         * @param subject The subject to validate.
+         * @return boolean {@code true} if the subject denotes a valid action, {@code false} otherwise.
+         */
+        public static boolean isValid(final String subject) {
+            return Arrays.stream(NotificationContentType.values()).filter(type -> type.contentType.equals(subject)).findFirst().isPresent();
+        }
+    }
+
+    /**
+     * JSON field name for specifying the source of the event.
+     */
+    public static final String FIELD_SOURCE = "src";
+    /**
+     * Value for the JSON field name {@link #FIELD_SOURCE} that must be used if a device sends a device notification event itself.
+     */
+    public static final String VALUE_SOURCE_DEVICE = "dev";
+    /**
+     * JSON field name for specifying the cause of the event.
+     */
+    public static final String FIELD_CAUSE = "cause";
+    /**
+     * JSON field name for additional data that can contain a JSON object for arbitrary purpose.
+     * Any content using this key is not evaluated by Hono anywhere.
+     */
+    public static final String FIELD_ADDITIONAL_DATA = "data";
+
+    /**
+     * Validates if the passed event message is of one the defined content types for notifications.
+     *
+     * @param eventMessage The message to investigate for being a notification.
+     * @return boolean {@code true} if the message is a notification, {@code false} otherwise.
+     */
+    public static final boolean isNotification(final Message eventMessage) {
+        Objects.requireNonNull(eventMessage);
+
+        return NotificationContentType.isValid(eventMessage.getContentType());
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/NotificationDeviceCommandReadyConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/NotificationDeviceCommandReadyConstants.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.DecodeException;
+
+/**
+ * Constants used for command readiness notifications of a device.
+ */
+public final class NotificationDeviceCommandReadyConstants extends NotificationConstants {
+    /**
+     * Prevent construction.
+     */
+    private NotificationDeviceCommandReadyConstants() {
+    }
+
+    /**
+     * JSON field name for specifying the time that a device tries to be ready for receiving messages (e.g. a command).
+     */
+    public static final String FIELD_AVAILABLE = "avail";
+
+    /**
+     * Value for the JSON field name {@link #FIELD_CAUSE} that must be used if a device wants to signal that it is ready to
+     * receive a command.
+     */
+    public static final String VALUE_CAUSE_READY_FOR_COMMAND = "cr";
+
+    /**
+     * Create a command-ready event for a device.
+     *
+     * @param timeToBeReady Time in milliseconds that the device will be ready for receiving a command.
+     * @return JsonObject A JsonObject that contains the necessary key-value pairs defined for such an event.
+     */
+    public static final JsonObject createDeviceCommandReadinessNotification(
+            final long timeToBeReady) {
+        final JsonObject notificationObject = new JsonObject()
+                .put(NotificationConstants.FIELD_SOURCE, NotificationConstants.VALUE_SOURCE_DEVICE)
+                .put(NotificationConstants.FIELD_CAUSE, NotificationDeviceCommandReadyConstants.VALUE_CAUSE_READY_FOR_COMMAND)
+                .put(NotificationDeviceCommandReadyConstants.FIELD_AVAILABLE, timeToBeReady);
+        return notificationObject;
+    }
+
+    /**
+     * Verify if a deviceNotification event (as a JSON object that is defined in the Event API) is signalling that the
+     * device for which it was received should be ready to receive a command.
+     * This is evaluated at the point in time this method is invoked.
+     *
+     * @param deviceNotification JsonObject that is evaluated.
+     * @param creationTime The creation time in milliseconds as epoche time.
+     * @return Boolean {@code true} if the event signals that the device now should be ready to receive a command, {@code false}
+     * otherwise.
+     * @throws NullPointerException If deviceNotification is {@code null} or if the body of deviceNotification is null.
+     * @throws ClassCastException If deviceNotification has a member of wrong type for {@link NotificationDeviceCommandReadyConstants#FIELD_AVAILABLE}.
+     * @throws DecodeException If deviceNotification has a body that does not encode a valid JSON object.
+     */
+    public static final Boolean isDeviceCurrentlyReadyForCommands(final JsonObject deviceNotification, final long creationTime) {
+        final Optional<Long> avail = Optional.ofNullable(deviceNotification.getLong(NotificationDeviceCommandReadyConstants.FIELD_AVAILABLE));
+
+        if (avail.isPresent()) {
+            final Instant deviceCommandReadyUntil = Instant.ofEpochMilli(creationTime).plusMillis(avail.get());
+            return deviceCommandReadyUntil.isAfter(Instant.now());
+        } else {
+            // if no time to be ready is set, the device should be ready to always receive commands
+            return true;
+        }
+    }
+
+}

--- a/core/src/main/java/org/eclipse/hono/util/NotificationDeviceConnectionConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/NotificationDeviceConnectionConstants.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Constants used for command readiness notifications of a device.
+ */
+public final class NotificationDeviceConnectionConstants extends NotificationConstants {
+    /**
+     * Prevent construction.
+     */
+    private NotificationDeviceConnectionConstants() {
+    }
+
+    /**
+     * Value for the JSON field name {@link #FIELD_CAUSE} to notify that a device connected to Hono.
+     */
+    public static final String VALUE_CAUSE_DEVICE_CONNECTED = "connected";
+
+    /**
+     * Value for the JSON field name {@link #FIELD_CAUSE} to notify that a device disconnected from Hono.
+     */
+    public static final String VALUE_CAUSE_DEVICE_DISCONNECTED = "disconnected";
+
+    /**
+     * Create a command-ready event for a device.
+     *
+     * @param source The source of this notification (e.g. the type of protocol adapter).
+     * @param cause The cause of sending this notification.
+     * @return JsonObject A JsonObject that contains the necessary key-value pairs defined for such an event.
+     */
+    public static final JsonObject createDeviceConnectionNotification(
+            final String source, final String cause) {
+        final JsonObject notificationObject = new JsonObject()
+                .put(NotificationConstants.FIELD_SOURCE, source)
+                .put(NotificationConstants.FIELD_CAUSE, cause);
+        return notificationObject;
+    }
+
+}

--- a/example/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
+++ b/example/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.devices;
+
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+
+import io.vertx.core.json.JsonObject;
+import org.eclipse.hono.client.ServiceInvocationException;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpHeaders;
+import org.eclipse.hono.util.NotificationConstants;
+import org.eclipse.hono.util.NotificationDeviceCommandReadyConstants;
+
+/**
+ * Example base class for sending messages to Hono and signal the readiness for commands for a certain time interval.
+ * <p>
+ * This class implements all necessary code to simulate an http device. It sends event messages 20 times
+ * in sequence and shows the necessary programming patterns for that. For this period, the device signals its readiness
+ * to receive commands by using the specifically defined event for that purpose.
+ * <p>
+ */
+public class HonoHttpDevice {
+
+    /**
+     * The number of messages to send.
+     */
+    public static final int COUNT = 10;
+    /**
+     Define the host where Hono's HTTP adapter can be reached.
+     */
+    public static final String HONO_HTTP_ADAPTER_HOST = "localhost";
+
+    /**
+     * Port of Hono's http adapter microservice.
+     */
+    public static final int HONO_HTTP_ADAPTER_PORT = 8080;
+
+    /**
+     * The CORS <em>origin</em> address to use for sending messages.
+     */
+    protected static final String ORIGIN_URI = "http://hono.eclipse.org";
+
+    /**
+     * The tenant ID to use for these examples.
+     */
+    public static final String TENANT_ID = "DEFAULT_TENANT";
+
+    /**
+     * The authId of the device that is used inside this class.
+     * NB: you need to register credentials for this authId before data can be sent.
+     * Please refer to Hono's "Getting started" guide for details.
+     */
+    public static final String DEVICE_AUTH_ID = "sensor1";
+
+    /**
+     * The password to use for accessing the HTTP adapter.
+     */
+    public static final String DEVICE_PASSWORD = "hono-secret";
+
+    private final Vertx vertx = Vertx.vertx();
+
+    public static void main(final String[] args) {
+        HonoHttpDevice httpDevice = new HonoHttpDevice();
+        httpDevice.sendData();
+    }
+
+    /**
+     * Send an event to Hono HTTP adapter. Delay the successful response by 1000 milliseconds.
+     *
+     * @param payload JSON object that will be sent as UTF-8 encoded String.
+     * @param contentType The content-type that will be set for the event.
+     * @return CompletableFuture&lt;MultiMap&gt; A completable future that contains the HTTP response in a MultiMap.
+     */
+    private CompletableFuture<MultiMap> sendEvent(final JsonObject payload, final String contentType) {
+        final CompletableFuture<MultiMap> result = new CompletableFuture<>();
+
+        final Predicate<Integer> successfulStatus = statusCode -> statusCode == HttpURLConnection.HTTP_ACCEPTED;
+        final HttpClientRequest req = vertx.createHttpClient()
+                .post(HONO_HTTP_ADAPTER_PORT, HONO_HTTP_ADAPTER_HOST, "/event")
+                .handler(response -> {
+                    if (successfulStatus.test(response.statusCode())) {
+                        vertx.setTimer(1000, l -> result.complete(response.headers()));
+                    } else {
+                        result.completeExceptionally(new ServiceInvocationException(response.statusCode()));
+                    }
+                }).exceptionHandler(t -> result.completeExceptionally(t));
+
+        req.headers().addAll(MultiMap.caseInsensitiveMultiMap()
+                .add(HttpHeaders.CONTENT_TYPE, contentType)
+                .add(HttpHeaders.AUTHORIZATION, getBasicAuth(TENANT_ID, DEVICE_AUTH_ID, DEVICE_PASSWORD))
+                .add(HttpHeaders.ORIGIN, ORIGIN_URI));
+
+
+        if (payload == null) {
+            req.end();
+        } else {
+            req.end(payload.encode());
+        }
+        return result;
+    }
+
+
+    /**
+     * Send events to Hono HTTP adapter {@link HonoHttpDevice#COUNT} times in a sequence.
+     * <p>
+     * Alternate the event every second time to be a device notification.
+     */
+    protected void sendData() {
+            // then send single messages sequentially in a loop
+            for (int messagesSent = 0; messagesSent < COUNT; messagesSent++) {
+                // send message and wait until it was delivered
+                String contentType;
+                JsonObject eventJson;
+                if (messagesSent %2 == 0) {
+                    contentType = NotificationConstants.CONTENT_TYPE_DEVICE_COMMAND_READINESS_NOTIFICATION;
+                    final long timeToBeReady = (messagesSent % 4 == 0) ? 1 : 60000;
+                    eventJson = NotificationDeviceCommandReadyConstants.createDeviceCommandReadinessNotification(timeToBeReady);
+                } else {
+                    contentType = "application/json";
+                    eventJson = new JsonObject().put("aKey", "aValue");
+                }
+
+                final CompletableFuture<MultiMap> eventResponseFuture = sendEvent(eventJson, contentType);
+
+                try {
+                    final MultiMap resultMap = eventResponseFuture.get();
+                    System.out.println("Got #" + resultMap.size());
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                } catch (ExecutionException e) {
+                    e.printStackTrace();
+                }
+            }
+        // print a summary of the message deliveries.
+        System.out.println("Total number of events: " + COUNT);
+
+        // give some time for flushing asynchronous message buffers before shutdown
+        vertx.setTimer(2000, timerId -> {
+            vertx.close();
+        });
+    }
+
+    /**
+     * Creates an HTTP Basic auth header value for a device.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceId The device identifier.
+     * @param password The device's password.
+     * @return The header value.
+     */
+    private static String getBasicAuth(final String tenant, final String deviceId, final String password) {
+
+        final StringBuilder result = new StringBuilder("Basic ");
+        final String username = getUsername(deviceId, tenant);
+        result.append(Base64.getEncoder().encodeToString(new StringBuilder(username).append(":").append(password)
+                .toString().getBytes(StandardCharsets.UTF_8)));
+        return result.toString();
+    }
+
+    /**
+     * Creates an authentication identifier from a device and tenant ID.
+     * <p>
+     * The returned identifier can be used as the <em>username</em> with
+     * Hono's protocol adapters that support username/password authentication.
+     *
+     * @param deviceId The device identifier.
+     * @param tenant The tenant that the device belongs to.
+     * @return The authentication identifier.
+     */
+    private static String getUsername(final String deviceId, final String tenant) {
+        return String.format("%s@%s", deviceId, tenant);
+    }
+
+}


### PR DESCRIPTION
This PR implements device notifications for signalling the readiness to receive a message, as intended to be sent by devices themselves. It thus implements part of [#536].

The notification is sent via the Event API with a specific content-type, and has an own object that is mapped by jackson.
The northbound applications are supported by a multiplexer class that invokes the provided specialized callbacks in the application, so that the application itself is freed from parsing event messages itself to try to find this type of event.
The sending of such a notification is shown in an example device class that sends it via the HTTP adapter, the application example is extended to show the usage of the multiplexer.
