### PR TITLE
Fix for #577 - ConnectionFactoryImpl does not handle corner case when…

### DIFF
--- a/core/src/main/java/org/eclipse/hono/connection/ConnectionFactoryImpl.java
+++ b/core/src/main/java/org/eclipse/hono/connection/ConnectionFactoryImpl.java
@@ -176,6 +176,13 @@ public final class ConnectionFactoryImpl implements ConnectionFactory {
                             }
                             connectionResultHandler.handle(Future.failedFuture(openCon.cause()));
                         }
+                    }).disconnectHandler(disconnectedCon -> {
+                        logger.warn("can't open connection to container [{}] at [{}://{}:{}]: {}",
+                                downstreamConnection.getRemoteContainer(),
+                                clientOptions.isSsl() ? "amqps" : "amqp", config.getHost(), config.getPort(),
+                                "underlying connection was disconnected while opening AMQP connection");
+                        connectionResultHandler.handle(Future
+                                .failedFuture("underlying connection was disconnected while opening AMQP connection"));
                     }).open();
         }
     }


### PR DESCRIPTION
… underlying connection gets closed before client received open frame

Added disconnect handler to downstreamConnection to be aware when underlying AMQP connection gets closed after SASL handshake and sending AMQP open frame. If connection gets closed call connectionResultHandler.

If you do not like the test case, e.g. because it starts a real AMQP server and can last some time (500 msec on my machine), I can replace it with a test that mocks ProtonClient. But this test would actually only test if disconnect handler was set on connection.

Signed-off-by: Daniel Maier <daniel.maier@bosch-si.com>