### PR TITLE
Allow devices to indicate readiness-to-receive-messages (impl).

### DIFF
--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/Config.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/Config.java
@@ -39,7 +39,7 @@ public class Config extends AbstractAdapterConfig {
      */
     @Bean(name = BEAN_NAME_VERTX_BASED_HTTP_PROTOCOL_ADAPTER)
     @Scope("prototype")
-    public VertxBasedHttpProtocolAdapter vertxBasedHttpProtocolAdapter(){
+    public VertxBasedHttpProtocolAdapter vertxBasedHttpProtocolAdapter() {
         return new VertxBasedHttpProtocolAdapter();
     }
 
@@ -71,7 +71,7 @@ public class Config extends AbstractAdapterConfig {
      */
     @Bean
     @ConfigurationProperties(prefix = "hono.app")
-    public ApplicationConfigProperties applicationConfigProperties(){
+    public ApplicationConfigProperties applicationConfigProperties() {
         return new ApplicationConfigProperties();
     }
 

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -538,9 +538,9 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
     private Future<Void> uploadMessage(final MqttContext ctx, final String tenant, final String deviceId,
             final Buffer payload, final Future<MessageSender> senderTracker, final String endpointName) {
 
-        if (payload.length() == 0) {
-            return Future.failedFuture(
-                    new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "payload must not be empty"));
+        if (!isPayloadOfIndicatedType(payload, ctx.contentType())) {
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
+                    String.format("Content-Type %s does not match with the payload", ctx.contentType())));
         } else {
 
             final Future<JsonObject> tokenTracker = getRegistrationAssertion(tenant, deviceId,
@@ -558,8 +558,8 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
                             ctx.message().topicName(),
                             ctx.contentType(),
                             payload,
-                            tokenTracker.result());
-
+                            tokenTracker.result(),
+                            null);
                     customizeDownstreamMessage(downstreamMessage, ctx);
 
                     if (ctx.message().qosLevel() == MqttQoS.AT_LEAST_ONCE) {

--- a/core/src/main/java/org/eclipse/hono/util/Constants.java
+++ b/core/src/main/java/org/eclipse/hono/util/Constants.java
@@ -178,6 +178,11 @@ public final class Constants {
         }
     };
 
+    /**
+     * The header name defined for setting the <em>time to deliver</em> for device command readiness notification events.
+     */
+    public static final String HEADER_TIME_TIL_DISCONNECT = "hono-ttd";
+
     private Constants() {
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/EventConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/EventConstants.java
@@ -35,4 +35,10 @@ public final class EventConstants {
 
     private EventConstants() {
     }
+
+    /**
+     * The content type that is defined for empty events without any payload.
+     */
+    public static final String CONTENT_TYPE_EMPTY_NOTIFICATION = "application/vnd.eclipse-hono-empty-notification";
+
 }

--- a/core/src/main/java/org/eclipse/hono/util/MessageTap.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageTap.java
@@ -40,7 +40,7 @@ public final class MessageTap implements Consumer<Message> {
                     if (!(body instanceof Data)) {
                         return;
                     }
-                    MessageHelper.fromMessage(msg).ifPresent(
+                    TimeUntilDisconnectNotification.fromMessage(msg).ifPresent(
                             notificationObject -> notificationReadyToDeliverConsumer.accept(notificationObject));
 
                     messageConsumer.accept(msg);

--- a/core/src/main/java/org/eclipse/hono/util/MessageTap.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageTap.java
@@ -1,0 +1,57 @@
+package org.eclipse.hono.util;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Section;
+import org.apache.qpid.proton.message.Message;
+
+/**
+ * A consumer that inspects a received message to detect if it indicates that a device should be currently ready to
+ * receive an upstream message. Depending on the outcome the passed callbacks are invoked (effectively implementing a <em>tap</em>).
+ */
+public final class MessageTap implements Consumer<Message> {
+
+    private Consumer<Message> tapConsumer;
+
+    private MessageTap(final Consumer<Message> tapConsumer) {
+        this.tapConsumer = tapConsumer;
+    }
+
+    /**
+     * Construct a message consumer that detects an indication that a device is ready to receive an upstream
+     * message and delegates to the passed callback handlers.
+     *
+     * @param messageConsumer Message consumer that handles generic messages.
+     * @param notificationReadyToDeliverConsumer Consumer&lt;TimeUntilDisconnectNotification&gt; that is called when the message indicates the current readiness
+     *                                           to receive an upstream message.
+     * @return The message consumer that invokes the specific handlers depending on the event type.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public static Consumer<Message> getConsumer(final Consumer<Message> messageConsumer,
+                                                final Consumer<TimeUntilDisconnectNotification> notificationReadyToDeliverConsumer) {
+        Objects.requireNonNull(messageConsumer);
+        Objects.requireNonNull(notificationReadyToDeliverConsumer);
+
+        return new MessageTap(
+                msg -> {
+                    final Section body = msg.getBody();
+                    if (!(body instanceof Data)) {
+                        return;
+                    }
+                    MessageHelper.fromMessage(msg).ifPresent(
+                            notificationObject -> notificationReadyToDeliverConsumer.accept(notificationObject));
+
+                    messageConsumer.accept(msg);
+                });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void accept(final Message msg) {
+        this.tapConsumer.accept(msg);
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/TimeUntilDisconnectNotification.java
+++ b/core/src/main/java/org/eclipse/hono/util/TimeUntilDisconnectNotification.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import java.time.Instant;
+
+/**
+ * Contains all information about a device that is indicating being ready to receive an upstream message.
+ */
+public final class TimeUntilDisconnectNotification {
+
+    private String tenantId;
+
+    private String deviceId;
+
+    private Instant readyUntil;
+
+    /**
+     * Build a notification object to indicate that a device is ready to receive an upstream message.
+     *
+     * @param tenantId The identifier of the tenant of the device the notification is constructed for.
+     * @param deviceId The id of the device the notification is constructed for.
+     * @param readyUntil The Instant that determines until when this notification is valid.
+     */
+    public TimeUntilDisconnectNotification(final String tenantId, final String deviceId, final Instant readyUntil) {
+        this.tenantId = tenantId;
+        this.deviceId = deviceId;
+        this.readyUntil = readyUntil;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public Instant getReadyUntil() {
+        return readyUntil;
+    }
+
+    @Override
+    public String toString() {
+        return "TimeUntilDisconnectNotification{" +
+                "tenantId='" + tenantId + '\'' +
+                ", deviceId='" + deviceId + '\'' +
+                ", readyUntil=" + readyUntil +
+                '}';
+    }
+}

--- a/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
@@ -78,4 +78,5 @@ public class MessageHelperTest {
         MessageHelper.addJmsVendorProperties(msg);
         assertNull(msg.getApplicationProperties());
     }
+
 }

--- a/core/src/test/java/org/eclipse/hono/util/MessageTapTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/MessageTapTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+
+package org.eclipse.hono.util;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Section;
+import org.apache.qpid.proton.message.Message;
+import org.junit.Test;
+
+import io.vertx.proton.ProtonHelper;
+
+/**
+ * Tests MessageTap.
+ */
+public class MessageTapTest {
+
+    /**
+     * Verifies that the message tap calls message consumer.
+     */
+    @Test
+    public void testTapCallsMessageConsumer() {
+
+        final Message msg = createTestMessage("", "bum/lux");
+
+        MessageHelper.addTimeUntilDisconnect(msg, 60);
+
+        final AtomicBoolean consumerCalled = new AtomicBoolean(false);
+
+        Consumer<Message> messageConsumer = MessageTap.getConsumer(
+                message -> consumerCalled.set(true),
+                n -> {});
+        messageConsumer.accept(msg);
+        assertTrue(consumerCalled.get());
+    }
+
+    /**
+     * Verifies that the message tap calls the message AND the notification consumer
+     * if the message indicates command readiness.
+     */
+    @Test
+    public void testTapCallsNotificationDeviceReadyToDeliverConsumer() {
+
+        final Message msg = createTestMessage("", "bum/lux");
+
+        MessageHelper.addTimeUntilDisconnect(msg, 6000);
+
+        final AtomicBoolean messageConsumerCalled = new AtomicBoolean(false);
+        final AtomicBoolean notificationConsumerCalled = new AtomicBoolean(false);
+
+        Consumer<Message> messageConsumer = MessageTap.getConsumer(
+                m -> messageConsumerCalled.set(true),
+                message -> notificationConsumerCalled.set(true)
+        );
+        messageConsumer.accept(msg);
+
+        assertTrue(notificationConsumerCalled.get());
+        assertTrue(messageConsumerCalled.get());
+    }
+
+    private Message createTestMessage(final String contentEncoding, final String payload) {
+        final Message msg = ProtonHelper.message();
+        msg.setBody(new Section() {});
+        MessageHelper.setCreationTime(msg);
+        MessageHelper.addDeviceId(msg, "4711");
+        MessageHelper.addAnnotation(msg, MessageHelper.APP_PROPERTY_TENANT_ID, Constants.DEFAULT_TENANT);
+        msg.setContentEncoding(contentEncoding);
+        msg.setBody(new Data(new Binary(payload.getBytes())));
+        return msg;
+    }
+
+}

--- a/example/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
+++ b/example/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.devices;
+
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+
+import io.vertx.core.json.JsonObject;
+import org.eclipse.hono.client.ServiceInvocationException;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpHeaders;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
+
+/**
+ * Example base class for sending messages to Hono and signal the readiness for commands for a certain time interval.
+ * <p>
+ * This class simulates an http device. It sends different kind of messages (defined per enum in an array) and sends them sequentially
+ * with 1 second delay. Some messages signal the command readiness while others do not - see the enum description for details.
+ */
+public class HonoHttpDevice {
+
+    /**
+     Define the host where Hono's HTTP adapter can be reached.
+     */
+    public static final String HONO_HTTP_ADAPTER_HOST = "localhost";
+
+    /**
+     * Port of Hono's http adapter microservice.
+     */
+    public static final int HONO_HTTP_ADAPTER_PORT = 8080;
+
+    /**
+     * The CORS <em>origin</em> address to use for sending messages.
+     */
+    protected static final String ORIGIN_URI = "http://hono.eclipse.org";
+
+    /**
+     * The tenant ID to use for these examples.
+     */
+    public static final String TENANT_ID = "DEFAULT_TENANT";
+
+    /**
+     * The authId of the device that is used inside this class.
+     * NB: you need to register credentials for this authId before data can be sent.
+     * Please refer to Hono's "Getting started" guide for details.
+     */
+    public static final String DEVICE_AUTH_ID = "sensor1";
+
+    /**
+     * The password to use for accessing the HTTP adapter.
+     */
+    public static final String DEVICE_PASSWORD = "hono-secret";
+
+    /**
+     * Different type of messages this application may sent, defined as enum.
+     */
+    private enum MessageTypes {
+        EmptyEventWithTtd(null, EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION, 60, true),
+        EmptyEventAlreadyInvalid(null, EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION, 0, true),
+        JsonEventWithoutTtd(new JsonObject().put("anEventKey", "aValue"), "application/json", null, true),
+        JsonEventWithTtd(new JsonObject().put("anEventKey", "aValue"), "application/json", 120, true),
+        TelemetryWithoutTtd(new JsonObject().put("aTeleKey", "aValue"), "application/json", null, false),
+        TelemetryWithTtd(new JsonObject().put("aTeleKey", "aValue"), "application/json", 60, false);
+
+        /**
+         * The payload of the message, defined as JsonObject. Maybe {@code null}.
+         */
+        private JsonObject payload;
+        /**
+         * The Content-Type that is set for the message.
+         */
+        private String contentType;
+        /**
+         * The <em>time-to-deliver</em> of the message, which is defined as application property of the AMQP 1.0 message.
+         */
+        private Integer ttd;
+        /**
+         * Property to define if the message shall be sent as event or as telemetry message.
+         */
+        private Boolean isEvent;
+
+        MessageTypes(final JsonObject payload, final String contentType, final Integer ttd, final Boolean isEvent) {
+            this.payload = payload;
+            this.contentType = contentType;
+            this.ttd = ttd;
+            this.isEvent = isEvent;
+        }
+
+        @Override
+        public String toString() {
+            return "MessageTypes{" +
+                    "payload=" + payload +
+                    ", contentType='" + contentType + '\'' +
+                    ", ttd=" + ttd +
+                    ", isEvent=" + isEvent +
+                    '}';
+        }
+    }
+
+    final List<MessageTypes> messages = Arrays.asList(
+            MessageTypes.EmptyEventWithTtd,
+            MessageTypes.EmptyEventWithTtd,
+            MessageTypes.EmptyEventWithTtd,
+            MessageTypes.TelemetryWithoutTtd,
+            MessageTypes.EmptyEventWithTtd,
+            MessageTypes.TelemetryWithoutTtd,
+            MessageTypes.JsonEventWithTtd,
+            MessageTypes.TelemetryWithoutTtd,
+            MessageTypes.JsonEventWithoutTtd,
+            MessageTypes.EmptyEventAlreadyInvalid,
+            MessageTypes.TelemetryWithTtd,
+            MessageTypes.TelemetryWithoutTtd
+    );
+
+    private final Vertx vertx = Vertx.vertx();
+
+    public static void main(final String[] args) {
+        HonoHttpDevice httpDevice = new HonoHttpDevice();
+        httpDevice.sendData();
+    }
+
+    /**
+     * Send a message to Hono HTTP adapter. Delay any successful response by 1000 milliseconds.
+     *
+     * @param payload JSON object that will be sent as UTF-8 encoded String.
+     * @param headersToAdd A map that contains all headers to add to the http request.
+     * @param asEvent If {@code true}, an event message is sent, otherwise a telemetry message.
+     * @return CompletableFuture&lt;MultiMap&gt; A completable future that contains the HTTP response in a MultiMap.
+     */
+    private CompletableFuture<MultiMap> sendMessage(final JsonObject payload, final MultiMap headersToAdd, final boolean asEvent) {
+        final CompletableFuture<MultiMap> result = new CompletableFuture<>();
+
+        final Predicate<Integer> successfulStatus = statusCode -> statusCode == HttpURLConnection.HTTP_ACCEPTED;
+        final HttpClientRequest req = vertx.createHttpClient()
+                .post(HONO_HTTP_ADAPTER_PORT, HONO_HTTP_ADAPTER_HOST, asEvent ? "/event" : "/telemetry")
+                .handler(response -> {
+                    if (successfulStatus.test(response.statusCode())) {
+                        vertx.setTimer(1000, l -> result.complete(response.headers()));
+                    } else {
+                        result.completeExceptionally(new ServiceInvocationException(response.statusCode()));
+                    }
+                }).exceptionHandler(t -> result.completeExceptionally(t));
+
+        req.headers().addAll(headersToAdd);
+        req.headers().addAll(MultiMap.caseInsensitiveMultiMap()
+                .add(HttpHeaders.AUTHORIZATION, getBasicAuth(TENANT_ID, DEVICE_AUTH_ID, DEVICE_PASSWORD))
+                .add(HttpHeaders.ORIGIN, ORIGIN_URI));
+
+
+        if (payload == null) {
+            req.end();
+        } else {
+            req.end(payload.encode());
+        }
+        return result;
+    }
+
+
+    /**
+     * Send messages to Hono HTTP adapter in a sequence.
+     * <p>
+     * Alternate the event every 4th time to be an event.
+     */
+    protected void sendData() {
+        // Send single messages sequentially in a loop and print a summary of the message deliveries.
+        System.out.println(String.format("Total number of messages: %s", messages.size()));
+
+
+        messages.stream().forEachOrdered(messageType -> {
+            final MultiMap headerMap = MultiMap.caseInsensitiveMultiMap();
+            headerMap.add(HttpHeaders.CONTENT_TYPE, messageType.contentType);
+            Optional.ofNullable(messageType.ttd).ifPresent(
+                    timeToDeliver -> headerMap.add(Constants.HEADER_TIME_TIL_DISCONNECT, timeToDeliver.toString())
+            );
+
+            System.out.println(String.format("Sending message type %s", messageType.toString()));
+
+            CompletableFuture<MultiMap> responseFuture = sendMessage(messageType.payload, headerMap, messageType.isEvent);
+            try {
+                final MultiMap resultMap = responseFuture.get();
+                System.out.println(String.format("Got %d response keys.", resultMap.size()));
+                resultMap.entries().stream().forEach(entry -> {
+                    System.out.println(String.format("  %s:%s", entry.getKey(), entry.getValue()));
+                });
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } catch (ExecutionException e) {
+                e.printStackTrace();
+            }
+        });
+
+        // give some time for flushing asynchronous message buffers before shutdown
+        vertx.setTimer(2000, timerId -> {
+            vertx.close();
+        });
+    }
+
+    /**
+     * Creates an HTTP Basic auth header value for a device.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceId The device identifier.
+     * @param password The device's password.
+     * @return The header value.
+     */
+    private static String getBasicAuth(final String tenant, final String deviceId, final String password) {
+
+        final StringBuilder result = new StringBuilder("Basic ");
+        final String username = getUsername(deviceId, tenant);
+        result.append(Base64.getEncoder().encodeToString(new StringBuilder(username).append(":").append(password)
+                .toString().getBytes(StandardCharsets.UTF_8)));
+        return result.toString();
+    }
+
+    /**
+     * Creates an authentication identifier from a device and tenant ID.
+     * <p>
+     * The returned identifier can be used as the <em>username</em> with
+     * Hono's protocol adapters that support username/password authentication.
+     *
+     * @param deviceId The device identifier.
+     * @param tenant The tenant that the device belongs to.
+     * @return The authentication identifier.
+     */
+    private static String getUsername(final String deviceId, final String tenant) {
+        return String.format("%s@%s", deviceId, tenant);
+    }
+
+}

--- a/example/src/main/java/org/eclipse/hono/vertx/example/HonoEventConsumer.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/HonoEventConsumer.java
@@ -25,10 +25,10 @@ public class HonoEventConsumer extends HonoConsumerBase {
 
     public static void main(final String[] args) throws Exception {
 
-        System.out.println("Starting downstream consumer...");
+        System.out.println("Starting event consumer...");
         HonoEventConsumer honoDownstreamEventConsumer = new HonoEventConsumer();
-        honoDownstreamEventConsumer.setEventMode(true);
+        honoDownstreamEventConsumer.setMode(MODE.EVENT);
         honoDownstreamEventConsumer.consumeData();
-        System.out.println("Finishing downstream consumer.");
+        System.out.println("Finishing event consumer.");
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -679,7 +679,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             msg.setBody(new Data(new Binary(payload.getBytes())));
         }
         if (timeUntilDisconnect != null) {
-            MessageHelper.addTimeUntilDisconnect(msg, timeUntilDisconnect);
+            MessageHelper.addTimeUntilDisconnect(msg, timeUntilDisconnect.intValue());
         }
 
         MessageHelper.setCreationTime(msg);

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
@@ -18,12 +18,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import org.eclipse.hono.util.Constants;
 
 /**
  * A collection of utility methods for processing HTTP requests.
@@ -149,6 +151,37 @@ public final class HttpUtils {
     public static String getContentType(final RoutingContext ctx) {
 
         return Objects.requireNonNull(ctx).parsedHeaders().contentType().value();
+    }
+
+    /**
+     * Gets the value of the {@link org.eclipse.hono.util.Constants#HEADER_TIME_TIL_DISCONNECT} HTTP header for a request.
+     * If no such header can be found, the query is searched for containing a query parameter with the same key.
+     *
+     * @param ctx The routing context containing the HTTP request.
+     * @return The time til disconnect or {@code null} if
+     * <ul>
+     *     <li>the request doesn't contain a {@link org.eclipse.hono.util.Constants#HEADER_TIME_TIL_DISCONNECT} header or query parameter.</li>
+     *     <li>the contained value cannot be parsed as an Integer</li>
+     * </ul>
+     * @throws NullPointerException if context is {@code null}.
+     */
+    public static Integer getTimeTilDisconnect(final RoutingContext ctx) {
+        Objects.requireNonNull(ctx);
+
+        try {
+            Optional<String> timeTilDisconnectHeader = Optional.ofNullable(ctx.request().getHeader(Constants.HEADER_TIME_TIL_DISCONNECT));
+
+            if (!timeTilDisconnectHeader.isPresent()) {
+                timeTilDisconnectHeader = Optional.ofNullable(ctx.request().getParam(Constants.HEADER_TIME_TIL_DISCONNECT));
+            }
+
+            if (timeTilDisconnectHeader.isPresent()) {
+                return Integer.parseInt(timeTilDisconnectHeader.get());
+            }
+        } catch (NumberFormatException e) {
+        }
+
+        return null;
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.auth.device.Device;
+import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.junit.Before;
@@ -37,6 +38,7 @@ import org.junit.runner.RunWith;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -337,4 +339,92 @@ public class AbstractProtocolAdapterBaseTest {
         }
         return result;
     }
+
+    /**
+     * Verifies that the helper approves empty notification without payload.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testEmptyNotificationWithoutPayload(final TestContext ctx) {
+        // GIVEN an adapter
+        adapter = newProtocolAdapter(properties, null);
+
+        // WHEN an empty event with an empty payload is approved, no error message must be returned
+        final Buffer payload = null;
+        final String contentType = EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION;
+
+        ctx.assertTrue(adapter.isPayloadOfIndicatedType(payload, contentType));
+    }
+
+    /**
+     * Verifies that any empty notification with a payload is an error.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testEmptyNotificationWithPayload(final TestContext ctx) {
+        // GIVEN an adapter
+        adapter = newProtocolAdapter(properties, null);
+
+        // WHEN an empty event with a non empty payload is approved, an error message must be returned
+        final Buffer payload = Buffer.buffer("test");
+        final String contentType = EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION;
+
+        ctx.assertFalse(adapter.isPayloadOfIndicatedType(payload, contentType));
+    }
+
+    /**
+     * Verifies that any general message with a payload is approved.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testNonEmptyGeneralMessage(final TestContext ctx) {
+        // GIVEN an adapter
+        adapter = newProtocolAdapter(properties, null);
+
+        // WHEN an non empty event with a non empty payload is approved, no error message must be returned
+        final Buffer payload = Buffer.buffer("test");
+        final String arbitraryContentType = "bum/lux";
+
+        // arbitrary content-type needs non empty payload
+        ctx.assertTrue(adapter.isPayloadOfIndicatedType(payload, arbitraryContentType));
+    }
+
+    /**
+     * Verifies that any non empty message without a content type is approved.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testNonEmptyMessageWithoutContentType(final TestContext ctx) {
+        // GIVEN an adapter
+        adapter = newProtocolAdapter(properties, null);
+
+        // WHEN an event without content type and a non empty payload is approved, no error message must be returned
+        final Buffer payload = Buffer.buffer("test");
+
+        // arbitrary content-type needs non empty payload
+        ctx.assertTrue(adapter.isPayloadOfIndicatedType(payload, null));
+    }
+
+    /**
+     * Verifies that any empty general message is an error.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testEmptyGeneralMessage(final TestContext ctx) {
+        // GIVEN an adapter
+        adapter = newProtocolAdapter(properties, null);
+
+        // WHEN an event with content type and an empty payload is approved, an error message must be returned
+        final Buffer payload = null;
+        final String arbitraryContentType = "bum/lux";
+
+        // arbitrary content-type needs non empty payload
+        ctx.assertFalse(adapter.isPayloadOfIndicatedType(payload, arbitraryContentType));
+    }
+
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/http/HttpUtilsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/http/HttpUtilsTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.hono.util.Constants;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Test verifying functionality of the {@link HttpUtils} class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HttpUtilsTest {
+
+    @Mock
+    private RoutingContext routingContext;
+    @Mock
+    private HttpServerRequest httpServerRequest;
+
+    /**
+     * Sets up the fixture.
+     */
+    @Before
+    public void setUp() {
+
+        when(routingContext.request()).thenReturn(httpServerRequest);
+
+    }
+
+    /**
+     * Verifies that the {@link Constants#HEADER_TIME_TIL_DISCONNECT} header is used by
+     * the {@link HttpUtils#getTimeTilDisconnect(RoutingContext)} method.
+     */
+    @Test
+    public void testGetTimeTilDisonnectUsesHeader() {
+
+        // GIVEN a time til disconnect
+        final Integer timeTilDisconnect = 60;
+        // WHEN evaluating a routingContext that has this value set as header
+        when(httpServerRequest.getHeader(Constants.HEADER_TIME_TIL_DISCONNECT)).thenReturn(timeTilDisconnect.toString());
+
+        // THEN the get method returns this value
+        assertEquals(HttpUtils.getTimeTilDisconnect(routingContext), timeTilDisconnect);
+    }
+
+    /**
+     * Verifies that the {@link Constants#HEADER_TIME_TIL_DISCONNECT} query parameter is used by
+     * the {@link HttpUtils#getTimeTilDisconnect(RoutingContext)} method.
+     */
+    @Test
+    public void testGetTimeTilDisonnectUsesQueryParam() {
+
+        // GIVEN a time til disconnect
+        final Integer timeTilDisconnect = 60;
+        // WHEN evaluating a routingContext that has this value set as query param
+        when(httpServerRequest.getParam(Constants.HEADER_TIME_TIL_DISCONNECT)).thenReturn(timeTilDisconnect.toString());
+
+        // THEN the get method returns this value
+        assertEquals(HttpUtils.getTimeTilDisconnect(routingContext), timeTilDisconnect);
+    }
+
+    /**
+     * Verifies that
+     * the {@link HttpUtils#getTimeTilDisconnect(RoutingContext)} method returns {@code null} if
+     * {@link Constants#HEADER_TIME_TIL_DISCONNECT} is neither provided as query parameter nor as requests header.
+     */
+    @Test
+    public void testGetTimeTilDisonnectReturnsNullIfNotSpecified() {
+
+        assertNull(HttpUtils.getTimeTilDisconnect(routingContext));
+    }
+
+}


### PR DESCRIPTION
Http clients of the HTTP protocol adapter can set the `ttd` AMQP property
for any command by using the `hono-ttd` HTTP header (scaled in seconds).
Northbound applications can register a specific callback that is invoked
if at the current time the device indicated it will still be connected.

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>