### PR TITLE
Add client cert based auth to http adapter

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/X509AuthHandler.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/X509AuthHandler.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.adapter.http;
+
+import java.net.HttpURLConnection;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.service.auth.device.HonoAuthHandler;
+import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.eclipse.hono.util.RequestResponseApiConstants;
+import org.eclipse.hono.util.TenantObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+
+/**
+ * An authentication handler for client certificate based authentication.
+ *
+ */
+public class X509AuthHandler extends HonoAuthHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(X509AuthHandler.class);
+    private static final HttpStatusException UNAUTHORIZED = new HttpStatusException(HttpURLConnection.HTTP_UNAUTHORIZED);
+    private final HonoClient tenantServiceClient;
+
+    /**
+     * Creates a new handler for an authentication provider and a
+     * Tenant service client.
+     * 
+     * @param authProvider The authentication provider to use for verifying
+     *              the device identity.
+     * @param tenantServiceClient The client to use for determining the tenant
+     *              that the device belongs to.
+     */
+    public X509AuthHandler(final HonoClientBasedAuthProvider authProvider, final HonoClient tenantServiceClient) {
+        super(authProvider);
+        this.tenantServiceClient = Objects.requireNonNull(tenantServiceClient);
+    }
+
+    @Override
+    public final void parseCredentials(final RoutingContext context, final Handler<AsyncResult<JsonObject>> handler) {
+
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(handler);
+
+        if (context.request().isSSL()) {
+            try {
+                final Certificate[] clientChain = context.request().sslSession().getPeerCertificates();
+                getX509CertificateChain(clientChain).compose(x509chain -> {
+                    return getTenant(x509chain[0]).compose(tenant -> getCredentials(x509chain, tenant));
+                }).setHandler(handler);
+            } catch (SSLPeerUnverifiedException e) {
+                // client certificate has not been validated
+                handler.handle(Future.failedFuture(UNAUTHORIZED));
+            }
+        } else {
+            handler.handle(Future.failedFuture(UNAUTHORIZED));
+        }
+    }
+
+    private Future<TenantObject> getTenant(final X509Certificate clientCert) {
+
+        return tenantServiceClient.getOrCreateTenantClient().compose(tenantClient ->
+            tenantClient.get(clientCert.getIssuerX500Principal()));
+    }
+
+    private Future<X509Certificate[]> getX509CertificateChain(final Certificate[] clientChain) {
+
+        final List<X509Certificate> chain = new LinkedList<>();
+        for (Certificate cert : clientChain) {
+            if (cert instanceof X509Certificate) {
+                chain.add((X509Certificate) cert);
+            } else {
+                LOG.info("cannot authenticate device using unsupported certificate type [{}]",
+                        cert.getClass().getName());
+                return Future.failedFuture(UNAUTHORIZED);
+            }
+        }
+        return Future.succeededFuture(chain.toArray(new X509Certificate[chain.size()]));
+    }
+
+    /**
+     * Gets the authentication information for a device's client certificate.
+     * <p>
+     * This default implementation returns a JSON object that contains two properties:
+     * <ul>
+     * <li>{@link RequestResponseApiConstants#FIELD_PAYLOAD_SUBJECT_DN} -
+     * the subject DN from the certificate</li>
+     * <li>{@link RequestResponseApiConstants#FIELD_PAYLOAD_TENANT_ID} -
+     * the identifier of the tenant that the device belongs to</li>
+     * </ul>
+     * <p>
+     * Subclasses may override this method in order to extract additional or other
+     * information to be verified by e.g. a custom authentication provider.
+     * 
+     * @param clientCertChain The validated client certificate chain that the device has
+     *                   presented during the TLS handshake. The device's end certificate
+     *                   is contained at index 0.
+     * @param tenant The tenant that the device belongs to.
+     * @return A succeeded future containing the authentication information that will be passed on
+     *         to the {@link HonoClientBasedAuthProvider} for verification. The future will be
+     *         failed if the information cannot be extracted from the certificate chain.
+     */
+    protected Future<JsonObject> getCredentials(final X509Certificate[] clientCertChain, final TenantObject tenant) {
+
+        final String subjectDn = clientCertChain[0].getSubjectX500Principal().getName(X500Principal.RFC2253);
+        LOG.debug("authenticating device of tenant [{}] using X509 certificate [subject DN: {}]",
+                tenant.getTenantId(), subjectDn);
+        return Future.succeededFuture(new JsonObject()
+                .put(CredentialsConstants.FIELD_PAYLOAD_SUBJECT_DN, subjectDn)
+                .put(CredentialsConstants.FIELD_PAYLOAD_TENANT_ID, tenant.getTenantId()));
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
@@ -36,7 +36,17 @@ public final class CredentialsConstants extends RequestResponseApiConstants {
 
     public static final String CREDENTIALS_ENDPOINT              = "credentials";
 
+    /**
+     * The type name that indicates an X.509 client certificate secret.
+     */
+    public static final String SECRETS_TYPE_X509_CERT            = "x509-cert";
+    /**
+     * The type name that indicates a hashed password secret.
+     */
     public static final String SECRETS_TYPE_HASHED_PASSWORD      = "hashed-password";
+    /**
+     * The type name that indicates a pre-shared key secret.
+     */
     public static final String SECRETS_TYPE_PRESHARED_KEY        = "psk";
     public static final String SPECIFIER_WILDCARD                = "*";
 

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
@@ -37,6 +37,12 @@ public abstract class RequestResponseApiConstants {
 
     /* message payload fields */
     public static final String FIELD_PAYLOAD_DEVICE_ID = Constants.JSON_FIELD_DEVICE_ID;
+    /**
+     * The name of the property that contains the <em>subject DN</em> of the CA certificate
+     * that has been configured for a tenant. The subject DN is serialized as defined by
+     * <a href="https://tools.ietf.org/html/rfc2253#section-2">RFC 2253, Section 2</a>.
+     */
+    public static final String FIELD_PAYLOAD_SUBJECT_DN = "subject-dn";
     public static final String FIELD_PAYLOAD_TENANT_ID = Constants.JSON_FIELD_TENANT_ID;
 
     public static final String FIELD_ENABLED   = "enabled";

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -39,11 +39,6 @@ public final class TenantConstants extends RequestResponseApiConstants {
      */
     public static final String FIELD_PAYLOAD_PUBLIC_KEY = "public-key";
     /**
-     * The name of the property that contains the RFC 2253 formatted <em>subject DN</em> of the CA certificate
-     * that has been configured for a tenant.
-     */
-    public static final String FIELD_PAYLOAD_SUBJECT_DN = "subject-dn";
-    /**
      * The name of the property that contains the trusted certificate authority configured for a tenant.
      */
     public static final String FIELD_PAYLOAD_TRUSTED_CA = "trusted-ca";

--- a/core/src/test/java/org/eclipse/hono/util/CredentialsObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/CredentialsObjectTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+
+
+/**
+ * Verifies behavior of {@link CredentialsObject}.
+ *
+ */
+public class CredentialsObjectTest {
+
+    /**
+     * Verifies that credentials that do not contain any secrets are
+     * detected as invalid.
+     */
+    @Test
+    public void testHasValidCredentialsDetectsMissingSecrets() {
+        final CredentialsObject creds = new CredentialsObject("tenant", "device", "x509-cert");
+        assertFalse(creds.hasValidSecrets());
+    }
+
+    /**
+     * Verifies that credentials that contains an empty set of secrets only are
+     * considered valid.
+     */
+    @Test
+    public void testHasValidCredentialsAcceptsEmptySecrets() {
+        final CredentialsObject creds = new CredentialsObject("tenant", "device", "x509-cert");
+        creds.addSecret(new JsonObject());
+        assertTrue(creds.hasValidSecrets());
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -183,7 +183,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @param connectionEventProducer The instance which will handle the production of connection events. Depending on
      *            the setup this could be a simple log message or an event using the Hono Event API.
      */
-    @Autowired
+    @Autowired(required = false)
     public void setConnectionEventProducer(final ConnectionEventProducer connectionEventProducer) {
         this.connectionEventProducer = connectionEventProducer;
     }
@@ -682,11 +682,12 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     }
 
     /**
-     * Trigger the creation of a "connected" event.
+     * Trigger the creation of a <em>connected</em> event.
      * 
      * @param remoteId The remote ID.
      * @param authenticatedDevice The (optional) authenticated device.
-     * 
+     * @return A failed future if an event producer is set but the event
+     *         could not be published. Otherwise, a succeeded event.
      * @see ConnectionEventProducer
      * @see ConnectionEventProducer#connected(String, String, Device, JsonObject)
      */
@@ -699,11 +700,12 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     }
 
     /**
-     * Trigger the creation of a "disconnected" event.
+     * Trigger the creation of a <em>disconnected</em> event.
      * 
      * @param remoteId The remote ID.
      * @param authenticatedDevice The (optional) authenticated device.
-     * 
+     * @return A failed future if an event producer is set but the event
+     *         could not be published. Otherwise, a succeeded event.
      * @see ConnectionEventProducer
      * @see ConnectionEventProducer#disconnected(String, String, Device, JsonObject)
      */

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoChainAuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoChainAuthHandler.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.auth.device;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.AuthHandler;
+import io.vertx.ext.web.handler.ChainAuthHandler;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+
+/**
+ * A Hono specific version of vert.x web's standard {@code ChainAuthHandlerImpl}
+ * that does not swallow the root exception which caused an authentication failure.
+ * <p>
+ * This class is a copy of {@code io.vertx.ext.web.handler.impl.ChainAuthHandlerImpl}.
+ */
+@SuppressWarnings("checkstyle:FinalParameters")
+public class HonoChainAuthHandler extends HonoAuthHandler implements ChainAuthHandler {
+
+    private final List<AuthHandler> handlers = new ArrayList<>();
+
+    /**
+     * Creates a new handler.
+     */
+    public HonoChainAuthHandler() {
+      super(null);
+    }
+
+    @Override
+    public ChainAuthHandler append(AuthHandler other) {
+      handlers.add(other);
+      return this;
+    }
+
+    @Override
+    public boolean remove(AuthHandler other) {
+      return handlers.remove(other);
+    }
+
+    @Override
+    public void clear() {
+      handlers.clear();
+    }
+
+    @Override
+    public AuthHandler addAuthority(String authority) {
+      for (AuthHandler h : handlers) {
+        h.addAuthority(authority);
+      }
+      return this;
+    }
+
+    @Override
+    public AuthHandler addAuthorities(Set<String> authorities) {
+      for (AuthHandler h : handlers) {
+        h.addAuthorities(authorities);
+      }
+      return this;
+    }
+
+    @Override
+    public void parseCredentials(RoutingContext context, Handler<AsyncResult<JsonObject>> handler) {
+      // iterate all possible authN
+      iterate(0, context, null, handler);
+    }
+
+    private void iterate(final int idx, final RoutingContext ctx, HttpStatusException lastException, Handler<AsyncResult<JsonObject>> handler) {
+      // stop condition
+      if (idx >= handlers.size()) {
+        // no more providers, means that we failed to find a provider capable of performing this operation
+        handler.handle(Future.failedFuture(lastException));
+        return;
+      }
+
+      // parse the request in order to extract the credentials object
+      final AuthHandler authHandler = handlers.get(idx);
+
+      authHandler.parseCredentials(ctx, res -> {
+        if (res.failed()) {
+          if (res.cause() instanceof HttpStatusException) {
+            final HttpStatusException exception = (HttpStatusException) res.cause();
+            switch (exception.getStatusCode()) {
+              case 302:
+              case 400:
+              case 401:
+              case 403:
+                // try again with next provider since we know what kind of error it is
+                iterate(idx + 1, ctx, exception, handler);
+                return;
+            }
+          }
+          handler.handle(Future.failedFuture(res.cause()));
+          return;
+        }
+
+        // setup the desired auth provider if we can
+        if (authHandler instanceof HonoAuthHandler) {
+          ctx.put(AUTH_PROVIDER_CONTEXT_KEY, ((HonoAuthHandler) authHandler).authProvider);
+        }
+        handler.handle(Future.succeededFuture(res.result()));
+      });
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/SubjectDnCredentials.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/SubjectDnCredentials.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.auth.device;
+
+import java.util.Objects;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.hono.util.CredentialsConstants;
+
+import io.vertx.core.json.JsonObject;
+
+
+/**
+ * Helper class to generate an authentication ID for an X.509 certificate provided by
+ * a device during authentication.
+ * <p>
+ * The authentication ID is the certificate's <em>subject DN</em> in
+ * RFC 2253 format.
+ *
+ */
+public class SubjectDnCredentials extends AbstractDeviceCredentials {
+
+    private SubjectDnCredentials(final String tenantId, final String authId) {
+        super(tenantId, authId);
+    }
+
+    /**
+     * Creates credentials for a tenant and subject DN.
+     * 
+     * @param tenantId The tenant that the device belongs to.
+     * @param subjectDn The subject DN of the device's client certificate.
+     * @return The credentials.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public static SubjectDnCredentials create(final String tenantId, final String subjectDn) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(subjectDn);
+        return create(tenantId, new X500Principal(subjectDn));
+    }
+
+    /**
+     * Creates credentials for a tenant and subject DN.
+     * 
+     * @param tenantId The tenant that the device belongs to.
+     * @param subjectDn The subject DN of the device's client certificate.
+     * @return The credentials.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public static SubjectDnCredentials create(final String tenantId, final X500Principal subjectDn) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(subjectDn);
+        return new SubjectDnCredentials(tenantId, subjectDn.getName(X500Principal.RFC2253));
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @return Always {@link CredentialsConstants#SECRETS_TYPE_X509_CERT}.
+     */
+    @Override
+    public String getType() {
+        return CredentialsConstants.SECRETS_TYPE_X509_CERT;
+    }
+
+    @Override
+    public boolean matchesCredentials(final JsonObject candidateSecret) {
+        // nothing to check
+        return true;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.auth.device;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.vertx.core.json.JsonObject;
+
+
+/**
+ * An authentication provider that verifies an X.509 certificate using
+ * Hono's <em>Credentials</em> API.
+ *
+ */
+public class X509AuthProvider extends CredentialsApiAuthProvider {
+
+    private final ServiceConfigProperties config;
+
+    /**
+     * Creates a new provider for a given configuration.
+     * 
+     * @param credentialsServiceClient The client.
+     * @param config The configuration.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    @Autowired
+    public X509AuthProvider(final HonoClient credentialsServiceClient, final ServiceConfigProperties config) {
+        super(credentialsServiceClient);
+        this.config = Objects.requireNonNull(config);
+    }
+
+    /**
+     * Creates a {@link SubjectDnCredentials} instance from information provided by a
+     * device in its client (X.509) certificate.
+     * <p>
+     * The JSON object passed in is required to contain a <em>subject-dn</em> property.
+     * If the <em>singleTenant</em> service config property is {@code false}, then the
+     * object is also required to contain a <em>tenant-id</em> property, otherwise
+     * the default tenant is used.
+     * 
+     * @param authInfo The authentication information provided by the device.
+     * @return The credentials or {@code null} if the authentication information
+     *         does not contain a tenant ID and subject DN.
+     * @throws NullPointerException if the authentication info is {@code null}.
+     */
+    @Override
+    protected DeviceCredentials getCredentials(final JsonObject authInfo) {
+
+        Objects.requireNonNull(authInfo);
+        try {
+            final String tenantId = Optional.ofNullable(authInfo.getString(CredentialsConstants.FIELD_PAYLOAD_TENANT_ID))
+                    .orElseGet(() -> {
+                        if (config.isSingleTenant()) {
+                            return Constants.DEFAULT_TENANT;
+                        } else {
+                            return null;
+                        }
+                    });
+            final String subjectDn = authInfo.getString(CredentialsConstants.FIELD_PAYLOAD_SUBJECT_DN);
+            if (tenantId == null || subjectDn == null) {
+                return null;
+            } else {
+                return SubjectDnCredentials.create(tenantId, subjectDn);
+            }
+        } catch (ClassCastException e) {
+            return null;
+        }
+    }
+}

--- a/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
@@ -39,7 +39,6 @@ public class BaseCredentialsServiceTest {
 
     private static BaseCredentialsService<ServiceConfigProperties> service;
 
-    private static final String TEST_FIELD = "test";
     private static final String TEST_TENANT = "dummy";
 
     /**
@@ -242,7 +241,8 @@ public class BaseCredentialsServiceTest {
     }
 
     private static JsonObject createValidCredentialsObject() {
-        return createValidCredentialsObject(new JsonObject().put(TEST_FIELD, "dummyValue"));
+
+        return createValidCredentialsObject(new JsonObject());
     }
 
     private static JsonObject createValidCredentialsObject(final JsonObject secret) {

--- a/site/content/api/Credentials-API.md
+++ b/site/content/api/Credentials-API.md
@@ -266,7 +266,7 @@ The table below provides an overview of the standard members defined for the JSO
 | *device-id*      | *yes*     | *string*   |               | The ID of the device to which the credentials belong. |
 | *type*           | *yes*     | *string*   |               | The credential type name. The value may be arbitrarily chosen by clients but SHOULD reflect the particular type of authentication mechanism the credentials are to be used with. Possible values include (but are not limited to) `psk`, `RawPublicKey`, `hashed-password` etc. |
 | *auth-id*        | *yes*     | *string*   |               | The identity that the device should be authenticated as. |
-| *enabled*        | *no*      | *boolean*  | *true*        | If set to *false* the credentials are not supposed to be used to authenticate devices any longer. This may e.g. be used to disable a particular mechanism for authenticating the device. **NB** It is up to the discretion of the protocol adapter to make use of this information. |
+| *enabled*        | *no*      | *boolean*  | *true*        | If set to *false* the credentials are not supposed to be used to authenticate devices any longer. This may e.g. be used to disable a particular mechanism for authenticating the device. **NB** It is the responsibility of the protocol adapter to make use of this information. |
 | *secrets*        | *yes*     | *array*    |               | A list of secrets scoped to a particular time period. See [Secrets Format]({{< relref "#secrets-format" >}}) for details. **NB** This array must contain at least one element - an empty array is considered an error. |
 
 For each set of credentials the combination of *auth-id* and *type* MUST be unique within a tenant.
@@ -403,3 +403,27 @@ Example:
 | *key*            | *yes*     | *string*   | The Base64 encoded bytes representing the shared (secret) key. |
 
 **NB** The example above does not contain any of the `not-before`, `not-after` and `enabled` properties, thus the credentials can be used at any time according to the rules defined in [Credential Verification]({{< relref "#credential-verification" >}}).
+
+### X.509 Certificate
+
+A credential type for storing the [RFC 2253](https://www.ietf.org/rfc/rfc2253.txt) formatted *subject DN* of a client certificate that is used to authenticate the device as part of a TLS handshake.
+
+Example:
+
+~~~json
+{
+  "device-id": "4711",
+  "type": "x509-cert",
+  "auth-id": "CN=device-1,O=ACME Corporation",
+  "secrets": [{}]
+}
+~~~
+
+| Name             | Mandatory | Type       | Description |
+| :--------------- | :-------: | :--------- | :---------- |
+| *type*           | *yes*     | *string*   | The credential type name, always `x509-cert`. |
+| *auth-id*        | *yes*     | *string*   | The subject DN of the client certificate in the format defined by [RFC 2253](https://www.ietf.org/rfc/rfc2253.txt). |
+| *subject-dn*     | *yes*     | *string*   | MUST be the same as the *auth-id* value. |
+
+**NB** The example above does not contain any of the `not-before`, `not-after` and `enabled` properties. The `not-before` and `not-after` properties should be omitted if the validity period is the same as the period indicated by the client certificate's corresponding properties.
+

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -12,13 +12,13 @@ examples are not both based on EnMasse and follow a similar architecture. The
 newly added *source-to-image*" based approach doesn't require a local
 development setup but does created new images directly in the OpenShift
 instance. It also makes more use of ConfigMaps and service key/cert management.
-
 * Protocol adapters do have the ability to send out connection events. Those
   events are best-effort events, indicating when a connection has been
   established and when it has been lost. There is a pluggable way of
   handling/creating those events, including two default implementations. A
   logger implementation, which simply logs to the logging system. And one
   implementation which sends out events to the *Hono Event API*.
+* The HTTP protocol adapter now supports authentication of devices based on X.509 client certificates. Each tenant can be configured with an individual trust anchor which the HTTP adapter will retrieve using the Tenant API when a device tries to authenticate with a certificate as part of a TLS handshake. The Credentials API now supports a [new credentials type]({{< relref "api/Credentials-API.md#x-509-certificate" >}}) for registering a mapping of the certificate's *subject DN* to the device identifier. Please consult the [HTTP adapter User Guide]({{< relref "user-guide/http-adapter.md#device-authentication" >}}) for details regarding usage.
 
 ### API Changes
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -445,6 +445,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <run>
                     <ports>
                       <port>+http.ip:http.port:8080</port>
+                      <port>https.port:8443</port>
                     </ports>
                     <network>
                       <mode>custom</mode>
@@ -452,8 +453,8 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <alias>hono-adapter-http-vertx.hono</alias>
                     </network>
                     <env>
-                      <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
-                      <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
+                      <LOGGING_CONFIG>file:/etc/hono/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:/etc/hono/</SPRING_CONFIG_LOCATION>
                       <!--<PN_TRACE_FRM>1</PN_TRACE_FRM>-->
                       <SPRING_PROFILES_ACTIVE>prod</SPRING_PROFILES_ACTIVE>
                     </env>
@@ -577,8 +578,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 <deviceregistry.http.port>${deviceregistry.http.port}</deviceregistry.http.port>
                 <http.host>${http.ip}</http.host>
                 <http.port>${http.port}</http.port>
+                <https.port>${https.port}</https.port>
                 <mqtt.host>${mqtt.ip}</mqtt.host>
                 <mqtt.port>${mqtt.port}</mqtt.port>
+                <trust-store.path>${project.build.directory}/certs/trusted-certs.pem</trust-store.path>
+                <!-- javax.net.debug>ssl:handshake</javax.net.debug-->
               </systemProperties>
               <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
               <test>*IT</test>

--- a/tests/src/test/java/org/eclipse/hono/tests/CrudHttpClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/CrudHttpClient.java
@@ -23,8 +23,11 @@ import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -35,42 +38,80 @@ public final class CrudHttpClient {
 
     private static final String CONTENT_TYPE_JSON = "application/json";
 
-    private final Vertx vertx;
-    private final String host;
-    private final int port;
+    private final HttpClient client;
+    private HttpClientOptions options;
 
     /**
      * Creates a new client for a host and port.
      * 
      * @param vertx The vert.x instance to use.
-     * @param host The host to invoke the operations on.
-     * @param port The port that the service is bound to.
+     * @param defaultHost The host to invoke the operations on by default.
+     * @param defaultPort The port to send requests to by default.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    public CrudHttpClient(final Vertx vertx, final String host, final int port) {
-        this.vertx = Objects.requireNonNull(vertx);
-        this.host = Objects.requireNonNull(host);
-        this.port = port;
+    public CrudHttpClient(final Vertx vertx, final String defaultHost, final int defaultPort) {
+        this(vertx, new HttpClientOptions().setDefaultHost(defaultHost).setDefaultPort(defaultPort));
     }
 
     /**
-     * Gets options for a resource using an HTTP OPTIONS.
+     * Creates a new client for a host and port.
+     * 
+     * @param vertx The vert.x instance to use.
+     * @param options The client options to use for connecting to servers.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public CrudHttpClient(final Vertx vertx, final HttpClientOptions options) {
+        this.options = Objects.requireNonNull(options);
+        this.client = vertx.createHttpClient(options);
+    }
+
+    private RequestOptions getRequestOptions() {
+        return new RequestOptions()
+                .setSsl(options.isSsl())
+                .setHost(options.getDefaultHost())
+                .setPort(options.getDefaultPort());
+    }
+
+    /**
+     * Gets options for a resource using an HTTP OPTIONS request.
      * 
      * @param uri The resource URI.
      * @param requestHeaders The headers to include in the request.
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}. In that case the
      *         future will contain the response headers.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<MultiMap> options(
             final String uri,
             final MultiMap requestHeaders,
             final Predicate<Integer> successPredicate) {
 
+        Objects.requireNonNull(uri);
+        return options(getRequestOptions().setURI(uri), requestHeaders, successPredicate);
+    }
+
+    /**
+     * Gets options for a resource using an HTTP OPTIONS request.
+     * 
+     * @param requestOptions The options to use for the request.
+     * @param requestHeaders The headers to include in the request.
+     * @param successPredicate A predicate on the returned HTTP status code for determining success.
+     * @return A future that will succeed if the predicate evaluates to {@code true}. In that case the
+     *         future will contain the response headers.
+     * @throws NullPointerException if options or predicate are {@code null}.
+     */
+    public Future<MultiMap> options(
+            final RequestOptions requestOptions,
+            final MultiMap requestHeaders,
+            final Predicate<Integer> successPredicate) {
+
+        Objects.requireNonNull(requestOptions);
+        Objects.requireNonNull(successPredicate);
+
         final Future<MultiMap> result = Future.future();
 
-        final HttpClientRequest req = vertx.createHttpClient()
-            .options(port, host, uri)
+        final HttpClientRequest req = client.options(requestOptions)
             .handler(response -> {
                 if (successPredicate.test(response.statusCode())) {
                     result.complete(response.headers());
@@ -87,7 +128,7 @@ public final class CrudHttpClient {
     }
 
     /**
-     * Creates a resource using an HTTP POST.
+     * Creates a resource using an HTTP POST request.
      * <p>
      * The content type in the request is set to <em>application/json</em>.
      * 
@@ -95,19 +136,21 @@ public final class CrudHttpClient {
      * @param body The body to post.
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<Void> create(final String uri, final JsonObject body, final Predicate<Integer> successPredicate) {
         return create(uri, body, CONTENT_TYPE_JSON, successPredicate);
     }
 
     /**
-     * Creates a resource using HTTP POST.
+     * Creates a resource using an HTTP POST request.
      * 
      * @param uri The URI to post to.
      * @param body The body to post (may be {@code null}).
      * @param contentType The content type to set in the request (may be {@code null}).
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if URI, content type or predicate are {@code null}.
      */
     public Future<Void> create(final String uri, final JsonObject body, final String contentType, final Predicate<Integer> successPredicate) {
 
@@ -115,13 +158,14 @@ public final class CrudHttpClient {
     }
 
     /**
-     * Creates a resource using HTTP POST.
+     * Creates a resource using an HTTP POST request.
      * 
      * @param uri The URI to post to.
      * @param body The body to post (may be {@code null}).
      * @param contentType The content type to set in the request (may be {@code null}).
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<Void> create(final String uri, final Buffer body, final String contentType, final Predicate<Integer> successPredicate) {
 
@@ -133,13 +177,14 @@ public final class CrudHttpClient {
     }
 
     /**
-     * Creates a resource using HTTP POST.
+     * Creates a resource using an HTTP POST request.
      * 
      * @param uri The URI to post to.
      * @param body The body to post (may be {@code null}).
      * @param requestHeaders The headers to include in the request (may be {@code null}).
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<MultiMap> create(
             final String uri,
@@ -150,10 +195,35 @@ public final class CrudHttpClient {
         Objects.requireNonNull(uri);
         Objects.requireNonNull(successPredicate);
 
+        return create(
+                getRequestOptions().setURI(uri),
+                body,
+                requestHeaders,
+                successPredicate);
+    }
+
+    /**
+     * Creates a resource using an HTTP POST request.
+     * 
+     * @param requestOptions The options to use for the request.
+     * @param body The body to post (may be {@code null}).
+     * @param requestHeaders The headers to include in the request (may be {@code null}).
+     * @param successPredicate A predicate on the returned HTTP status code for determining success.
+     * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if options or predicate are {@code null}.
+     */
+    public Future<MultiMap> create(
+            final RequestOptions requestOptions,
+            final Buffer body,
+            final MultiMap requestHeaders,
+            final Predicate<Integer> successPredicate) {
+
+        Objects.requireNonNull(requestOptions);
+        Objects.requireNonNull(successPredicate);
+
         final Future<MultiMap> result = Future.future();
 
-        final HttpClientRequest req = vertx.createHttpClient()
-            .post(port, host, uri)
+        final HttpClientRequest req = client.post(requestOptions)
             .handler(response -> {
                 if (successPredicate.test(response.statusCode())) {
                     result.complete(response.headers());
@@ -174,7 +244,7 @@ public final class CrudHttpClient {
     }
 
     /**
-     * Updates a resource using HTTP PUT.
+     * Updates a resource using an HTTP PUT request.
      * <p>
      * The content type in the request is set to <em>application/json</em>.
      * 
@@ -182,32 +252,35 @@ public final class CrudHttpClient {
      * @param body The content to update the resource with.
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<Void> update(final String uri, final JsonObject body, final Predicate<Integer> successPredicate) {
         return update(uri, body, CONTENT_TYPE_JSON, successPredicate);
     }
 
     /**
-     * Updates a resource using HTTP PUT.
+     * Updates a resource using an HTTP PUT request.
      * 
      * @param uri The resource to update.
      * @param body The content to update the resource with.
      * @param contentType The content type to set in the request.
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<Void> update(final String uri, final JsonObject body, final String contentType, final Predicate<Integer> successPredicate) {
         return update(uri, Optional.ofNullable(body).map(json -> json.toBuffer()).orElse(null), contentType, successPredicate);
     }
 
     /**
-     * Updates a resource using HTTP PUT.
+     * Updates a resource using an HTTP PUT request.
      * 
      * @param uri The resource to update.
      * @param body The content to update the resource with.
      * @param contentType The content type to set in the request.
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<Void> update(final String uri, final Buffer body, final String contentType, final Predicate<Integer> successPredicate) {
 
@@ -219,20 +292,53 @@ public final class CrudHttpClient {
     }
 
     /**
-     * Updates a resource using HTTP PUT.
+     * Updates a resource using an HTTP PUT request.
      * 
      * @param uri The resource to update.
      * @param body The content to update the resource with.
      * @param requestHeaders The headers to include in the request.
      * @param successPredicate A predicate on the response for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
-    public Future<MultiMap> update(final String uri, final Buffer body, final MultiMap requestHeaders, final Predicate<Integer> successPredicate) {
+    public Future<MultiMap> update(
+            final String uri,
+            final Buffer body,
+            final MultiMap requestHeaders,
+            final Predicate<Integer> successPredicate) {
+
+        Objects.requireNonNull(uri);
+        Objects.requireNonNull(successPredicate);
+
+        return update(
+                getRequestOptions().setURI(uri),
+                body,
+                requestHeaders,
+                successPredicate);
+    }
+
+    /**
+     * Updates a resource using an HTTP PUT request.
+     * 
+     * @param requestOptions The options to use for the request.
+     * @param body The content to update the resource with.
+     * @param requestHeaders The headers to include in the request.
+     * @param successPredicate A predicate on the response for determining success.
+     * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if options or predicate are {@code null}.
+     */
+    public Future<MultiMap> update(
+            final RequestOptions requestOptions,
+            final Buffer body,
+            final MultiMap requestHeaders,
+            final Predicate<Integer> successPredicate) {
+
+        Objects.requireNonNull(requestOptions);
+        Objects.requireNonNull(successPredicate);
 
         final Future<MultiMap> result = Future.future();
 
-        final HttpClientRequest req = vertx.createHttpClient()
-            .put(port, host, uri)
+        final HttpClientRequest req = client.put(requestOptions)
             .handler(response -> {
                 if (successPredicate.test(response.statusCode())) {
                     result.complete(response.headers());
@@ -253,19 +359,38 @@ public final class CrudHttpClient {
     }
 
     /**
-     * Retrieves a resource representation using HTTP GET.
+     * Retrieves a resource representation using an HTTP GET request.
      * 
      * @param uri The resource to retrieve.
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}. In that case the
      *         future will contain the response body.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<Buffer> get(final String uri, final Predicate<Integer> successPredicate) {
 
+        Objects.requireNonNull(uri);
+        Objects.requireNonNull(successPredicate);
+        return get(getRequestOptions().setURI(uri), successPredicate);
+    }
+
+    /**
+     * Retrieves a resource representation using an HTTP GET request.
+     * 
+     * @param requestOptions The options to use for the request.
+     * @param successPredicate A predicate on the returned HTTP status code for determining success.
+     * @return A future that will succeed if the predicate evaluates to {@code true}. In that case the
+     *         future will contain the response body.
+     * @throws NullPointerException if options or predicate are {@code null}.
+     */
+    public Future<Buffer> get(final RequestOptions requestOptions, final Predicate<Integer> successPredicate) {
+
+        Objects.requireNonNull(requestOptions);
+        Objects.requireNonNull(successPredicate);
+
         final Future<Buffer> result = Future.future();
 
-        vertx.createHttpClient()
-            .get(port, host, uri)
+        client.get(requestOptions)
             .handler(response -> {
                 if (successPredicate.test(response.statusCode())) {
                     response.bodyHandler(body -> result.complete(body));
@@ -278,18 +403,37 @@ public final class CrudHttpClient {
     }
 
     /**
-     * Deletes a resource using HTTP DELETE.
+     * Deletes a resource using an HTTP DELETE request.
      * 
      * @param uri The resource to delete.
      * @param successPredicate A predicate on the returned HTTP status code for determining success.
      * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<Void> delete(final String uri, final Predicate<Integer> successPredicate) {
 
+        Objects.requireNonNull(uri);
+        Objects.requireNonNull(successPredicate);
+
+        return delete(getRequestOptions().setURI(uri), successPredicate);
+    }
+
+    /**
+     * Deletes a resource using an HTTP DELETE request.
+     * 
+     * @param requestOptions The options to use for the request.
+     * @param successPredicate A predicate on the returned HTTP status code for determining success.
+     * @return A future that will succeed if the predicate evaluates to {@code true}.
+     * @throws NullPointerException if options or predicate are {@code null}.
+     */
+    public Future<Void> delete(final RequestOptions requestOptions, final Predicate<Integer> successPredicate) {
+
+        Objects.requireNonNull(requestOptions);
+        Objects.requireNonNull(successPredicate);
+
         final Future<Void> result = Future.future();
 
-        vertx.createHttpClient()
-            .delete(port, host, uri)
+        client.delete(requestOptions)
             .handler(response -> {
                 if (successPredicate.test(response.statusCode())) {
                     result.complete();
@@ -299,5 +443,10 @@ public final class CrudHttpClient {
             }).exceptionHandler(result::fail).end();
 
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("CrudHttpClient [%s:%d]", options.getDefaultHost(), options.getDefaultPort());
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -46,6 +46,7 @@ public final class IntegrationTestSupport {
     public static final int    DEFAULT_DEVICEREGISTRY_AMQP_PORT = 25672;
     public static final int    DEFAULT_DEVICEREGISTRY_HTTP_PORT = 28080;
     public static final int    DEFAULT_HTTP_PORT = 8080;
+    public static final int    DEFAULT_HTTPS_PORT = 8443;
     public static final int    DEFAULT_MQTT_PORT = 1883;
 
     public static final String PROPERTY_AUTH_HOST = "auth.host";
@@ -63,6 +64,7 @@ public final class IntegrationTestSupport {
     public static final String PROPERTY_DOWNSTREAM_PASSWORD = "downstream.password";
     public static final String PROPERTY_HTTP_HOST = "http.host";
     public static final String PROPERTY_HTTP_PORT = "http.port";
+    public static final String PROPERTY_HTTPS_PORT = "https.port";
     public static final String PROPERTY_MQTT_HOST = "mqtt.host";
     public static final String PROPERTY_MQTT_PORT = "mqtt.port";
     public static final String PROPERTY_TENANT = "tenant";
@@ -88,11 +90,14 @@ public final class IntegrationTestSupport {
 
     public static final String HTTP_HOST = System.getProperty(PROPERTY_HTTP_HOST, DEFAULT_HOST);
     public static final int    HTTP_PORT = Integer.getInteger(PROPERTY_HTTP_PORT, DEFAULT_HTTP_PORT);
+    public static final int    HTTPS_PORT = Integer.getInteger(PROPERTY_HTTPS_PORT, DEFAULT_HTTPS_PORT);
     public static final String MQTT_HOST = System.getProperty(PROPERTY_MQTT_HOST, DEFAULT_HOST);
     public static final int    MQTT_PORT = Integer.getInteger(PROPERTY_MQTT_PORT, DEFAULT_MQTT_PORT);
 
     public static final String PATH_SEPARATOR = System.getProperty("hono.pathSeparator", "/");
     public static final int    MSG_COUNT = Integer.getInteger("msg.count", 1000);
+
+    public static final String TRUST_STORE_PATH = System.getProperty("trust-store.path");
 
     /**
      * The name of the tenant for which only the MQTT adapter is enabled.

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.hono.tests.http;
 
-import java.net.HttpURLConnection;
 import java.util.function.Consumer;
 
 import org.apache.qpid.proton.message.Message;
@@ -22,9 +21,6 @@ import org.eclipse.hono.util.EventConstants;
 import org.junit.runner.RunWith;
 
 import io.vertx.core.Future;
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 
@@ -35,22 +31,11 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class EventHttpIT extends HttpTestBase {
 
-    @Override
-    protected Future<MultiMap> send(
-            final String origin,
-            final String tenantId,
-            final String deviceId,
-            final String password,
-            final Buffer payload) {
+    private static final String URI = String.format("/%s", EventConstants.EVENT_ENDPOINT);
 
-        return httpClient.create(
-                String.format("/%s", EventConstants.EVENT_ENDPOINT),
-                payload,
-                MultiMap.caseInsensitiveMultiMap()
-                    .add(HttpHeaders.CONTENT_TYPE, "binary/octet-stream")
-                    .add(HttpHeaders.AUTHORIZATION, getBasicAuth(tenantId, deviceId, password))
-                    .add(HttpHeaders.ORIGIN, origin),
-                statusCode -> statusCode == HttpURLConnection.HTTP_ACCEPTED);
+    @Override
+    protected String getEndpointUri() {
+        return URI;
     }
 
     @Override

--- a/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.hono.tests.http;
 
-import java.net.HttpURLConnection;
 import java.util.function.Consumer;
 
 import org.apache.qpid.proton.message.Message;
@@ -22,9 +21,6 @@ import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.runner.RunWith;
 
 import io.vertx.core.Future;
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 
@@ -35,22 +31,11 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class TelemetryHttpIT extends HttpTestBase {
 
-    @Override
-    protected Future<MultiMap> send(
-            final String origin,
-            final String tenantId,
-            final String deviceId,
-            final String password,
-            final Buffer payload) {
+    private static final String URI = String.format("/%s", TelemetryConstants.TELEMETRY_ENDPOINT);
 
-        return httpClient.create(
-                String.format("/%s", TelemetryConstants.TELEMETRY_ENDPOINT),
-                payload,
-                MultiMap.caseInsensitiveMultiMap()
-                    .add(HttpHeaders.CONTENT_TYPE, "binary/octet-stream")
-                    .add(HttpHeaders.AUTHORIZATION, getBasicAuth(tenantId, deviceId, password))
-                    .add(HttpHeaders.ORIGIN, origin),
-                statusCode -> statusCode == HttpURLConnection.HTTP_ACCEPTED);
+    @Override
+    protected String getEndpointUri() {
+        return URI;
     }
 
     @Override

--- a/tests/src/test/resources/http/logback-spring.xml
+++ b/tests/src/test/resources/http/logback-spring.xml
@@ -20,7 +20,7 @@
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
     <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
-    <logger name="org.eclipse.hono.service.auth.device" level="DEBUG"/>
+    <logger name="org.eclipse.hono.service.auth" level="DEBUG"/>
   </springProfile>
 
   <springProfile name="prod">


### PR DESCRIPTION
This PR adds client based authentication to the HTTP adapter as required by #555. The PR includes the implementation of a corresponding vert.x-web AuthHandler, an AuthProvider for verifying the certificate, documentation and integration test cases for uploading telemetry and event messages using HTTP with basic auth as well as with client cert based auth.