### PR TITLE
Fix for #598 - HTTP protocol adapter does not allow to PUT events to …

### DIFF
--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
@@ -147,6 +147,9 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
             // route for posting events using tenant and device ID determined as part of
             // device authentication
             router.route(HttpMethod.POST, "/event").handler(this::handlePostEvent);
+
+            // require Basic auth for PUTing event
+            router.route(HttpMethod.PUT, "/event/*").handler(basicAuthHandler);
             // route for asserting that authenticated device's tenant matches tenant from path variables
             router.route(HttpMethod.PUT, String.format("/event/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
                 .handler(this::assertTenant);


### PR DESCRIPTION
…path /event/${tenantId}/${deviceId} for authenticated devices any longer

Added basic auth handler to route PUT event/*

Signed-off-by: Daniel Maier <daniel.maier@bosch-si.com>