### PR TITLE
Fix for #601 - Response for delete tenant is broken in BaseTenantService

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseTenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseTenantService.java
@@ -208,9 +208,8 @@ public abstract class BaseTenantService<T> extends EventBusService<T> implements
             final Future<TenantResult<JsonObject>> removeResult = Future.future();
             remove(tenantId, removeResult.completer());
             return removeResult.map(tr -> {
-                return EventBusMessage.forStatusCode(tr.getStatus())
+                return request.getResponse(tr.getStatus())
                         .setJsonPayload(tr.getPayload())
-                        .setTenant(tenantId)
                         .setCacheDirective(tr.getCacheDirective());
             });
         }


### PR DESCRIPTION
Create response for delete tenant out of request in order to include correlation-id.

I am a little bit lost how to test this. I would favour to have an integration test, but as removing tenants is not part of public API you cannot use tenant client. However, I tested it manually and it works. Any suggestions how to test this in a realistic way?

Signed-off-by: Daniel Maier <daniel.maier@bosch-si.com>