### PR TITLE
Adapter side of the Command and Control API.

### DIFF
--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -23,6 +23,7 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.TenantClient;
+import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
@@ -69,6 +70,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     private RegistrationClient            regClient;
     private TenantClient                  tenantClient;
     private HttpProtocolAdapterProperties config;
+    private CommandConnection             commandConnection;
 
     /**
      * Sets up common fixture.
@@ -102,6 +104,9 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         registrationServiceClient = mock(HonoClient.class);
         when(registrationServiceClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(registrationServiceClient));
         when(registrationServiceClient.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(regClient));
+
+        commandConnection = mock(CommandConnection.class);
+        when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
     }
 
     /**
@@ -362,6 +367,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         adapter.setHonoMessagingClient(messagingClient);
         adapter.setRegistrationServiceClient(registrationServiceClient);
         adapter.setCredentialsServiceClient(credentialsServiceClient);
+        adapter.setCommandConnection(commandConnection);
         adapter.setMetrics(mock(HttpAdapterMetrics.class));
 
         return adapter;

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
@@ -29,6 +29,7 @@ import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.service.auth.device.Device;
 import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
+import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.util.Constants;
 import org.junit.AfterClass;
@@ -71,6 +72,8 @@ public class VertxBasedHttpProtocolAdapterTest {
     private static HonoClientBasedAuthProvider usernamePasswordAuthProvider;
     private static HttpProtocolAdapterProperties config;
     private static VertxBasedHttpProtocolAdapter httpAdapter;
+    private static CommandConnection commandConnection;
+
 
     private static Vertx vertx;
 
@@ -103,6 +106,9 @@ public class VertxBasedHttpProtocolAdapterTest {
         registrationServiceClient = mock(HonoClient.class);
         when(registrationServiceClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(registrationServiceClient));
 
+        commandConnection = mock(CommandConnection.class);
+        when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
+
         usernamePasswordAuthProvider = mock(HonoClientBasedAuthProvider.class);
 
         config = new HttpProtocolAdapterProperties();
@@ -116,6 +122,7 @@ public class VertxBasedHttpProtocolAdapterTest {
         httpAdapter.setRegistrationServiceClient(registrationServiceClient);
         httpAdapter.setCredentialsServiceClient(credentialsServiceClient);
         httpAdapter.setUsernamePasswordAuthProvider(usernamePasswordAuthProvider);
+        httpAdapter.setCommandConnection(commandConnection);
 
         vertx.deployVerticle(httpAdapter, ctx.asyncAssertSuccess());
     }

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -34,6 +34,7 @@ import org.eclipse.hono.service.auth.device.Device;
 import org.eclipse.hono.service.auth.device.DeviceCredentials;
 import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
+import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
@@ -92,6 +93,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     private HonoClientBasedAuthProvider usernamePasswordAuthProvider;
     private ProtocolAdapterProperties config;
     private MqttAdapterMetrics metrics;
+    private CommandConnection commandConnection;
 
     /**
      * Creates clients for the needed micro services and sets the configuration to enable the insecure port.
@@ -130,6 +132,9 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
                 .thenReturn(Future.succeededFuture(deviceRegistrationServiceClient));
         when(deviceRegistrationServiceClient.getOrCreateRegistrationClient(anyString()))
                 .thenReturn(Future.succeededFuture(regClient));
+
+        commandConnection = mock(CommandConnection.class);
+        when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
 
         usernamePasswordAuthProvider = mock(HonoClientBasedAuthProvider.class);
     }
@@ -602,6 +607,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         adapter.setHonoMessagingClient(messagingClient);
         adapter.setRegistrationServiceClient(deviceRegistrationServiceClient);
         adapter.setCredentialsServiceClient(credentialsServiceClient);
+        adapter.setCommandConnection(commandConnection);
         adapter.setUsernamePasswordAuthProvider(usernamePasswordAuthProvider);
 
         if (server != null) {

--- a/example/src/main/config/hono-adapter-http-vertx-config.yml
+++ b/example/src/main/config/hono-adapter-http-vertx-config.yml
@@ -33,6 +33,14 @@ hono:
     port: 5671
     credentialsPath: ${secret.path}/http-adapter.credentials
     trustStorePath: ${secret.path}/trusted-certs.pem
+  command:
+    name: 'Hono HTTP Adapter'
+    amqpHostname: hono-http-internal
+    host: hono-dispatch-router.hono
+    port: 5673
+    keyPath: ${secret.path}/http-adapter-key.pem
+    certPath: ${secret.path}/http-adapter-cert.pem
+    trustStorePath: ${secret.path}/trusted-certs.pem
   metric:
     reporter:
       graphite:

--- a/example/src/main/config/hono-adapter-mqtt-vertx-config.yml
+++ b/example/src/main/config/hono-adapter-mqtt-vertx-config.yml
@@ -33,6 +33,14 @@ hono:
     port: 5671
     credentialsPath: ${secret.path}/mqtt-adapter.credentials
     trustStorePath: ${secret.path}/trusted-certs.pem
+  command:
+    name: 'Hono MQTT Adapter'
+    amqpHostname: hono-mqtt-internal
+    host: hono-dispatch-router.hono
+    port: 5673
+    keyPath: ${secret.path}/mqtt-adapter-key.pem
+    certPath: ${secret.path}/mqtt-adapter-cert.pem
+    trustStorePath: ${secret.path}/trusted-certs.pem
   metric:
     reporter:
       graphite:

--- a/example/src/main/config/qpid/qdrouterd-with-broker.json
+++ b/example/src/main/config/qpid/qdrouterd-with-broker.json
@@ -90,7 +90,8 @@
           "users": "consumer@HONO",
           "remoteHosts": "*",
           "maxSessions": 10,
-          "sources": "telemetry/*, event/*"
+          "sources": "telemetry/*, event/*, control/*",
+          "targets": "control/*"
         },
         "DEFAULT_TENANT": {
           "users": "user1@HONO",
@@ -116,6 +117,34 @@
           "targets": "telemetry/*, event/*"
         }
       }
+  }],
+
+  ["vhost", {
+    "id": "hono-mqtt-internal",
+    "maxConnections": 30,
+    "groups": {
+      "Hono": {
+        "users": "Eclipse IoT;Hono;mqtt-adapter",
+        "remoteHosts": "*",
+        "allowUserIdProxy": true,
+        "sources": "control/*",
+        "targets": "control/*"
+      }
+    }
+  }],
+
+  ["vhost", {
+    "id": "hono-http-internal",
+    "maxConnections": 30,
+    "groups": {
+      "Hono": {
+        "users": "Eclipse IoT;Hono;http-adapter",
+        "remoteHosts": "*",
+        "allowUserIdProxy": true,
+        "sources": "control/*",
+        "targets": "control/*"
+      }
+    }
   }],
 
   ["log", {

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -19,7 +19,10 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.impl.HonoClientImpl;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.cache.SpringCacheProvider;
+import org.eclipse.hono.service.command.CommandConnection;
+import org.eclipse.hono.service.command.CommandConnectionImpl;
 import org.eclipse.hono.service.metric.MetricConfig;
+import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.RegistrationConstants;
@@ -157,7 +160,7 @@ public abstract class AbstractAdapterConfig {
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
     public HonoClient registrationServiceClient() {
-        final HonoClientImpl result = 
+        final HonoClientImpl result =
                 new HonoClientImpl(vertx(), registrationServiceClientConfig());
 
         final CacheProvider cacheProvider = registrationCacheProvider();
@@ -170,7 +173,7 @@ public abstract class AbstractAdapterConfig {
 
     /**
      * Exposes the provider for caches as a Spring bean.
-     * 
+     *
      * @return The provider instance.
      */
     @Bean
@@ -276,6 +279,29 @@ public abstract class AbstractAdapterConfig {
     @Scope("prototype")
     public CacheProvider tenantCacheProvider() {
         return newGuavaCache(tenantServiceClientConfig());
+    }
+
+    /**
+     * Exposes configuration properties for Command and Control.
+     *
+     * @return The Properties.
+     */
+    @Qualifier(CommandConstants.COMMAND_ENDPOINT)
+    @ConfigurationProperties(prefix = "hono.command")
+    @Bean
+    public ClientConfigProperties commandConnectionClientConfig() {
+        return new ClientConfigProperties();
+    }
+
+    /**
+     * Exposes the Command and Control connection.
+     *
+     * @return The Connection.
+     */
+    @Bean
+    @Scope("prototype")
+    public CommandConnection commandConnection() {
+        return new CommandConnectionImpl(vertx(), commandConnectionClientConfig());
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -29,12 +29,16 @@ import org.eclipse.hono.config.AbstractConfig;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.auth.TenantApiTrustOptions;
 import org.eclipse.hono.service.auth.device.Device;
+import org.eclipse.hono.service.command.Command;
+import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.service.monitoring.ConnectionEventProducer;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
+import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.Strings;
+import org.eclipse.hono.util.TenantObject;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,6 +73,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     private HonoClient registrationClient;
     private HonoClient tenantClient;
     private HonoClient credentialsServiceClient;
+    private CommandConnection commandConnection;
 
     private ConnectionEventProducer connectionEventProducer;
 
@@ -179,7 +184,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
     /**
      * Sets the producer for connections events.
-     * 
+     *
      * @param connectionEventProducer The instance which will handle the production of connection events. Depending on
      *            the setup this could be a simple log message or an event using the Hono Event API.
      */
@@ -190,7 +195,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
     /**
      * Gets the producer of connection events.
-     * 
+     *
      * @return The implementation for producing connection events. Maybe {@code null}.
      */
     public ConnectionEventProducer getConnectionEventProducer() {
@@ -214,6 +219,17 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     protected abstract String getTypeName();
 
+    /**
+     * Sets the client to use for connecting to the AMQP 1.0 network to receive commands.
+     *
+     * @param commandConnection The command connection.
+     * @throws NullPointerException if the client is {@code null}.
+     */
+    @Autowired
+    public final void setCommandConnection(final CommandConnection commandConnection) {
+        this.commandConnection = commandConnection;
+    }
+
     @Override
     protected final Future<Void> startInternal() {
 
@@ -229,11 +245,14 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             result.fail(new IllegalStateException("Device Registration service client must be set"));
         } else if (credentialsServiceClient == null) {
             result.fail(new IllegalStateException("Credentials service client must be set"));
+        } else if (commandConnection == null) {
+            result.fail(new IllegalStateException("Command and Control service client must be set"));
         } else {
             connectToService(tenantClient, "Tenant service");
             connectToService(messagingClient, "Messaging");
             connectToService(registrationClient, "Device Registration service");
             connectToService(credentialsServiceClient, "Credentials service");
+            connectToService(commandConnection, "Command and Control service");
             doStart(result);
         }
         return result;
@@ -409,6 +428,19 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         return CompositeFuture.all(tenantCheck, messagingCheck, registrationCheck, credentialsCheck).compose(ok -> {
             return Future.succeededFuture();
         });
+    }
+
+    /**
+     * Create a command receiver for a specific device.
+     *
+     * @param tenantId The tenant of the command receiver.
+     * @param deviceId The device of the command receiver.
+     * @param commandHandler Handler will be called for each command to the device.
+     * @return Result of the receiver creation.
+     */
+    protected Future<Void> createCommandReceiver(final String tenantId, final String deviceId,
+                                                           final Handler<Command> commandHandler) {
+        return commandConnection.createCommandResponder(tenantId, deviceId, commandHandler);
     }
 
     /**
@@ -683,7 +715,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
     /**
      * Trigger the creation of a <em>connected</em> event.
-     * 
+     *
      * @param remoteId The remote ID.
      * @param authenticatedDevice The (optional) authenticated device.
      * @return A failed future if an event producer is set but the event
@@ -701,7 +733,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
     /**
      * Trigger the creation of a <em>disconnected</em> event.
-     * 
+     *
      * @param remoteId The remote ID.
      * @param authenticatedDevice The (optional) authenticated device.
      * @return A failed future if an event producer is set but the event

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -39,8 +39,6 @@ import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TenantObject;
-import org.eclipse.hono.util.TenantConstants;
-import org.eclipse.hono.util.TenantObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -223,7 +221,6 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * Sets the client to use for connecting to the AMQP 1.0 network to receive commands.
      *
      * @param commandConnection The command connection.
-     * @throws NullPointerException if the client is {@code null}.
      */
     @Autowired
     public final void setCommandConnection(final CommandConnection commandConnection) {

--- a/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
@@ -47,26 +47,25 @@ public class Command {
         this.replyAddress = message.getReplyTo();
         this.messageData = MessageHelper.getPayload(message);
         this.contentType = message.getContentType();
-        ApplicationProperties applicationProperties = message.getApplicationProperties();
+        final ApplicationProperties applicationProperties = message.getApplicationProperties();
         if (applicationProperties != null) {
             this.applicationProperties = applicationProperties.getValue();
         }
     }
 
     void sendResponse(final Buffer data, final Map<String, Object> properties, final Handler<ProtonDelivery> update) {
-        Message message = ProtonHelper.message();
+        final Message message = ProtonHelper.message();
         message.setCorrelationId(correlationId);
-        if(data!=null) {
+        if (data != null) {
             message.setBody(new Data(new Binary(data.getBytes())));
         }
         if (properties != null) {
             message.setApplicationProperties(new ApplicationProperties(properties));
         }
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
-        if(update!=null) {
+        if (update != null) {
             responder.getSender().send(message, update);
-        }
-        else {
+        } else {
             responder.getSender().send(message);
         }
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import java.net.HttpURLConnection;
+import java.util.Map;
+
+import io.vertx.core.buffer.Buffer;
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.util.MessageHelper;
+
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+
+/**
+ * Represents a Command and Control API command on the receiver side (adapter).
+ * <p>
+ * Received command includes the message data and all application properties.
+ */
+public class Command {
+
+    private Object correlationId;
+    private String replyAddress;
+    private String contentType;
+    private Buffer messageData;
+    private Map<String, Object> applicationProperties;
+    private CommandResponder responder;
+
+    Command(final CommandResponder responder, final Message message) {
+        this.responder = responder;
+        this.correlationId = message.getMessageId();
+        this.replyAddress = message.getReplyTo();
+        this.messageData = MessageHelper.getPayload(message);
+        this.contentType = message.getContentType();
+        ApplicationProperties applicationProperties = message.getApplicationProperties();
+        if (applicationProperties != null) {
+            this.applicationProperties = applicationProperties.getValue();
+        }
+    }
+
+    void sendResponse(final Buffer data, final Map<String, Object> properties, final Handler<ProtonDelivery> update) {
+        Message message = ProtonHelper.message();
+        message.setCorrelationId(correlationId);
+        if(data!=null) {
+            message.setBody(new Data(new Binary(data.getBytes())));
+        }
+        if (properties != null) {
+            message.setApplicationProperties(new ApplicationProperties(properties));
+        }
+        MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        if(update!=null) {
+            responder.getSender().send(message, update);
+        }
+        else {
+            responder.getSender().send(message);
+        }
+    }
+
+    CommandResponder getResponder() {
+        return responder;
+    }
+
+    /**
+     * Gets the reply address of the sender link.
+     *
+     * @return The reply address.
+     */
+    public String getReplyAddress() {
+        return replyAddress;
+    }
+
+    /**
+     * Gets the data of the commands request.
+     *
+     * @return The raw request data.
+     */
+    public Buffer getRequestData() {
+        return messageData;
+    }
+
+    /**
+     * Gets the AMQP application properties of the request.
+     *
+     * @return The application properties or {@code null}.
+     */
+    public Map<String, Object> getRequestProperties() {
+        return applicationProperties;
+    }
+
+    /**
+     * Gets the AMQP content type property of the request.
+     *
+     * @return The content type of the data or {@code null}.
+     */
+    public String getContentType() {
+        return contentType;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnection.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnection.java
@@ -22,7 +22,7 @@ import org.eclipse.hono.client.HonoClient;
 import java.util.Map;
 
 /**
- * A connection between an Adapter and the AMQP 1.0 network to receive commands and send a response.
+ * A bidirectional connection between an Adapter and the AMQP 1.0 network to receive commands and send a response.
  */
 public interface CommandConnection extends HonoClient {
 
@@ -36,7 +36,7 @@ public interface CommandConnection extends HonoClient {
      * @throws NullPointerException if tenantId, deviceId or commandHandler is {@code null};
      */
     Future<Void> createCommandResponder(String tenantId, String deviceId,
-                                               Handler<Command> commandHandler);
+            Handler<Command> commandHandler);
 
     /**
      * Sends a result back to the sender, based on a received command message.
@@ -49,5 +49,5 @@ public interface CommandConnection extends HonoClient {
      * @throws NullPointerException if command is {@code null};
      */
     Future<Void> sendCommandResponse(Command command, Buffer data, Map<String, Object> properties,
-                                     Handler<ProtonDelivery> update);
+            Handler<ProtonDelivery> update);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnection.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnection.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.proton.ProtonDelivery;
+import org.eclipse.hono.client.HonoClient;
+
+import java.util.Map;
+
+/**
+ * A connection between an Adapter and the AMQP 1.0 network to receive commands and send a response.
+ */
+public interface CommandConnection extends HonoClient {
+
+    /**
+     * Creates a receiver link and a command handler for Command and Control API messages.
+     *
+     * @param tenantId The tenant to consume commands from.
+     * @param deviceId The device for which this receiver will be created.
+     * @param commandHandler The message handler for the received commands.
+     * @return A future indicating the outcome. The future will succeed if the receiver link has been created.
+     * @throws NullPointerException if tenantId, deviceId or commandHandler is {@code null};
+     */
+    Future<Void> createCommandResponder(String tenantId, String deviceId,
+                                               Handler<Command> commandHandler);
+
+    /**
+     * Sends a result back to the sender, based on a received command message.
+     *
+     * @param command The received Command.
+     * @param data The data so send back to the command sender or {@code null}.
+     * @param properties Any application properties or {@code null}.
+     * @param update The proton delivery handler or {@code null}.
+     * @return A future indicating the outcome. The future will succeed if the sender link has been created.
+     * @throws NullPointerException if command is {@code null};
+     */
+    Future<Void> sendCommandResponse(Command command, Buffer data, Map<String, Object> properties,
+                                     Handler<ProtonDelivery> update);
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnectionImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnectionImpl.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import java.util.Map;
+import java.util.Objects;
+
+import io.vertx.core.buffer.Buffer;
+import org.eclipse.hono.client.impl.HonoClientImpl;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.connection.ConnectionFactory;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * Implements a connection between an Adapter and the AMQP 1.0 network to receive commands and send a response.
+ */
+public class CommandConnectionImpl extends HonoClientImpl implements CommandConnection {
+
+    protected final Logger LOG = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Creates a new client for a set of configuration properties.
+     * <p>
+     * This constructor creates a connection factory using
+     * {@link ConnectionFactory#newConnectionFactory(Vertx, ClientConfigProperties)}.
+     *
+     * @param vertx The Vert.x instance to execute the client on, if {@code null} a new Vert.x instance is used.
+     * @param clientConfigProperties The configuration properties to use.
+     * @throws NullPointerException if clientConfigProperties is {@code null}
+     */
+    public CommandConnectionImpl(final Vertx vertx, final ClientConfigProperties clientConfigProperties) {
+        super(vertx, clientConfigProperties);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Future<Void> createCommandResponder(final String tenantId, final String deviceId,
+                                                           final Handler<Command> commandHandler) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(commandHandler);
+
+        LOG.debug("create a command receiver for [tenant: {}, device-id: {}]", tenantId, deviceId);
+        Future<Void> result = Future.future();
+        connect().setHandler(h -> {
+            if(h.succeeded()) {
+                getConnection().createReceiver(ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId).toString()) // TODO
+                        .openHandler(oh -> {
+                            if (oh.succeeded()) {
+                                LOG.debug("command receiver successfully opened for [tenant: {}, device-id: {}]", tenantId, deviceId);
+                                ProtonReceiver protonReceiver = oh.result();
+                                CommandResponder responder = new CommandResponder(protonReceiver);
+                                protonReceiver.handler((delivery, message) -> {
+                                    LOG.debug("command message received on [address: {}]", message.getAddress());
+                                    commandHandler.handle(new Command(responder, message));
+                                });
+                                result.complete();
+                            } else {
+                                LOG.debug("command receiver failed opening for [tenant: {}, device-id: {}] : {}", tenantId, deviceId, oh.cause().getMessage());
+                                result.fail(oh.cause());
+                            }
+                        }).open();
+            }
+            else {
+                result.fail(h.cause());
+            }
+        });
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Future<Void> sendCommandResponse(final Command command, final Buffer data, final Map<String, Object> properties,
+                                            final Handler<ProtonDelivery> update) {
+        Objects.requireNonNull(command);
+        LOG.debug("create a command responder (sender link) for [replyAddress: {}]", command.getReplyAddress());
+        Future<Void> result = Future.future();
+        synchronized (command) {
+            ProtonSender sender = command.getResponder().getSender();
+            if (sender == null || !sender.isOpen()) {
+                connect().setHandler(h -> {
+                    getConnection().createSender(command.getReplyAddress())
+                            .openHandler(oh -> {
+                                if (oh.succeeded()) {
+                                    LOG.debug("command reply sender opened successful for [replyAddress: {}]", command.getReplyAddress());
+                                    command.getResponder().setSender(oh.result());
+                                    command.sendResponse(data, properties, update);
+                                    result.complete();
+                                } else {
+                                    LOG.debug("command reply failed opening for [replyAddress: {}] : {}", command.getReplyAddress(), oh.cause());
+                                }
+                            }).open();
+                });
+            } else {
+                LOG.debug("reuse open command reply sender for [replyAddress: {}]", command.getReplyAddress());
+                command.sendResponse(data, properties, update);
+                result.complete();
+            }
+        }
+        return result;
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnectionImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnectionImpl.java
@@ -57,7 +57,7 @@ public class CommandConnectionImpl extends HonoClientImpl implements CommandConn
      * {@inheritDoc}
      */
     public Future<Void> createCommandResponder(final String tenantId, final String deviceId,
-                                                           final Handler<Command> commandHandler) {
+            final Handler<Command> commandHandler) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(commandHandler);
@@ -65,11 +65,14 @@ public class CommandConnectionImpl extends HonoClientImpl implements CommandConn
         LOG.debug("create a command receiver for [tenant: {}, device-id: {}]", tenantId, deviceId);
         Future<Void> result = Future.future();
         connect().setHandler(h -> {
-            if(h.succeeded()) {
-                getConnection().createReceiver(ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId).toString()) // TODO
+            if (h.succeeded()) {
+                getConnection()
+                        .createReceiver(ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId)
+                                .toString()) // TODO
                         .openHandler(oh -> {
                             if (oh.succeeded()) {
-                                LOG.debug("command receiver successfully opened for [tenant: {}, device-id: {}]", tenantId, deviceId);
+                                LOG.debug("command receiver successfully opened for [tenant: {}, device-id: {}]",
+                                        tenantId, deviceId);
                                 ProtonReceiver protonReceiver = oh.result();
                                 CommandResponder responder = new CommandResponder(protonReceiver);
                                 protonReceiver.handler((delivery, message) -> {
@@ -78,12 +81,12 @@ public class CommandConnectionImpl extends HonoClientImpl implements CommandConn
                                 });
                                 result.complete();
                             } else {
-                                LOG.debug("command receiver failed opening for [tenant: {}, device-id: {}] : {}", tenantId, deviceId, oh.cause().getMessage());
+                                LOG.debug("command receiver failed opening for [tenant: {}, device-id: {}] : {}",
+                                        tenantId, deviceId, oh.cause().getMessage());
                                 result.fail(oh.cause());
                             }
                         }).open();
-            }
-            else {
+            } else {
                 result.fail(h.cause());
             }
         });
@@ -93,8 +96,9 @@ public class CommandConnectionImpl extends HonoClientImpl implements CommandConn
     /**
      * {@inheritDoc}
      */
-    public Future<Void> sendCommandResponse(final Command command, final Buffer data, final Map<String, Object> properties,
-                                            final Handler<ProtonDelivery> update) {
+    public Future<Void> sendCommandResponse(final Command command, final Buffer data,
+            final Map<String, Object> properties,
+            final Handler<ProtonDelivery> update) {
         Objects.requireNonNull(command);
         LOG.debug("create a command responder (sender link) for [replyAddress: {}]", command.getReplyAddress());
         Future<Void> result = Future.future();
@@ -105,12 +109,14 @@ public class CommandConnectionImpl extends HonoClientImpl implements CommandConn
                     getConnection().createSender(command.getReplyAddress())
                             .openHandler(oh -> {
                                 if (oh.succeeded()) {
-                                    LOG.debug("command reply sender opened successful for [replyAddress: {}]", command.getReplyAddress());
+                                    LOG.debug("command reply sender opened successful for [replyAddress: {}]",
+                                            command.getReplyAddress());
                                     command.getResponder().setSender(oh.result());
                                     command.sendResponse(data, properties, update);
                                     result.complete();
                                 } else {
-                                    LOG.debug("command reply failed opening for [replyAddress: {}] : {}", command.getReplyAddress(), oh.cause());
+                                    LOG.debug("command reply failed opening for [replyAddress: {}] : {}",
+                                            command.getReplyAddress(), oh.cause());
                                 }
                             }).open();
                 });

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponder.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponder.java
@@ -44,7 +44,7 @@ class CommandResponder {
     }
 
     void close() {
-        if(protonReceiver.isOpen()) {
+        if (protonReceiver.isOpen()) {
             protonReceiver.close();
         }
         if (protonSender != null && protonSender.isOpen()) {

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponder.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponder.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * A command responder with a receiver/sender pair.
+ */
+class CommandResponder {
+
+    private ProtonReceiver protonReceiver;
+    private ProtonSender protonSender;
+
+    CommandResponder(final ProtonReceiver receiver) {
+        this.protonReceiver = receiver;
+        this.protonReceiver.closeHandler(onClose -> {
+            close();
+        });
+    }
+
+    ProtonSender getSender() {
+        return protonSender;
+    }
+
+    void setSender(final ProtonSender protonSender) {
+        this.protonSender = protonSender;
+    }
+
+    boolean isOpen() {
+        return protonReceiver.isOpen();
+    }
+
+    void close() {
+        if(protonReceiver.isOpen()) {
+            protonReceiver.close();
+        }
+        if (protonSender != null && protonSender.isOpen()) {
+            protonSender.close();
+        }
+    }
+
+}

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.auth.device.Device;
+import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.junit.Before;
@@ -65,6 +66,7 @@ public class AbstractProtocolAdapterBaseTest {
     private HonoClient registrationService;
     private HonoClient credentialsService;
     private HonoClient messagingService;
+    private CommandConnection commandConnection;
 
     /**
      * Sets up the fixture.
@@ -88,12 +90,16 @@ public class AbstractProtocolAdapterBaseTest {
         messagingService = mock(HonoClient.class);
         when(messagingService.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingService));
 
+        commandConnection = mock(CommandConnection.class);
+        when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
+
         properties = new ProtocolAdapterProperties();
         adapter = newProtocolAdapter(properties);
         adapter.setTenantServiceClient(tenantService);
         adapter.setRegistrationServiceClient(registrationService);
         adapter.setCredentialsServiceClient(credentialsService);
         adapter.setHonoMessagingClient(messagingService);
+        adapter.setCommandConnection(commandConnection);
     }
 
     /**
@@ -132,6 +138,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.setHonoMessagingClient(messagingService);
         adapter.setRegistrationServiceClient(registrationService);
         adapter.setTenantServiceClient(tenantService);
+        adapter.setCommandConnection(commandConnection);
 
         // WHEN starting the adapter
         adapter.startInternal().setHandler(ctx.asyncAssertSuccess(ok -> {
@@ -140,6 +147,7 @@ public class AbstractProtocolAdapterBaseTest {
             verify(registrationService).connect(any(Handler.class));
             verify(messagingService).connect(any(Handler.class));
             verify(credentialsService).connect(any(Handler.class));
+            verify(commandConnection).connect(any(Handler.class));
             verify(startupHandler).handle(null);
         }));
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/command/CommandConnectionTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/command/CommandConnectionTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.service.credentials.BaseCredentialsService;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests verifying behavior of {@link BaseCredentialsService}.
+ */
+@RunWith(VertxUnitRunner.class)
+public class CommandConnectionTest {
+
+    private static Vertx vertx;
+    private CommandConnection commandConnection;
+
+    /**
+     * Time out each test after 5 seconds.
+     */
+    public Timeout timeout = Timeout.seconds(5);
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeClass
+    public static void setUpVertx() {
+        vertx = Vertx.vertx();
+    }
+
+    /**
+     * Sets up the fixture.
+     */
+    @Before
+    public void setUp() {
+        commandConnection = new CommandConnectionImpl(vertx, new ClientConfigProperties());
+    }
+
+    /**
+     * Tests the command responder.
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateCommandResponder(final TestContext ctx) {
+        // TODO
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/command/CommandIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/command/CommandIT.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.tests.command;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.runner.RunWith;
+
+/**
+ * Integration tests for send commands to an adapter.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class CommandIT {
+
+}


### PR DESCRIPTION
- Abstract adapter can open receivers for Command and Control and send back a response.
- QPID dispatcher and MQTT/HTTP adapters in example configured.
