### PR TITLE
Adapter side of the Command and Control API.

### DIFF
--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -23,6 +23,7 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.TenantClient;
+import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
@@ -69,6 +70,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     private RegistrationClient            regClient;
     private TenantClient                  tenantClient;
     private HttpProtocolAdapterProperties config;
+    private CommandConnection             commandConnection;
 
     /**
      * Sets up common fixture.
@@ -102,6 +104,9 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         registrationServiceClient = mock(HonoClient.class);
         when(registrationServiceClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(registrationServiceClient));
         when(registrationServiceClient.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(regClient));
+
+        commandConnection = mock(CommandConnection.class);
+        when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
     }
 
     /**
@@ -362,6 +367,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         adapter.setHonoMessagingClient(messagingClient);
         adapter.setRegistrationServiceClient(registrationServiceClient);
         adapter.setCredentialsServiceClient(credentialsServiceClient);
+        adapter.setCommandConnection(commandConnection);
         adapter.setMetrics(mock(HttpAdapterMetrics.class));
 
         return adapter;

--- a/adapters/http-vertx/src/main/resources/logback-spring.xml
+++ b/adapters/http-vertx/src/main/resources/logback-spring.xml
@@ -21,6 +21,7 @@
     <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
     <logger name="org.eclipse.hono.service.auth" level="DEBUG"/>
+    <logger name="org.eclipse.hono.service.command" level="DEBUG"/>
   </springProfile>
 
   <springProfile name="prod">

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
@@ -29,6 +29,7 @@ import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.service.auth.device.Device;
 import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
+import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.util.Constants;
 import org.junit.AfterClass;
@@ -71,6 +72,8 @@ public class VertxBasedHttpProtocolAdapterTest {
     private static HonoClientBasedAuthProvider usernamePasswordAuthProvider;
     private static HttpProtocolAdapterProperties config;
     private static VertxBasedHttpProtocolAdapter httpAdapter;
+    private static CommandConnection commandConnection;
+
 
     private static Vertx vertx;
 
@@ -103,6 +106,9 @@ public class VertxBasedHttpProtocolAdapterTest {
         registrationServiceClient = mock(HonoClient.class);
         when(registrationServiceClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(registrationServiceClient));
 
+        commandConnection = mock(CommandConnection.class);
+        when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
+
         usernamePasswordAuthProvider = mock(HonoClientBasedAuthProvider.class);
 
         config = new HttpProtocolAdapterProperties();
@@ -116,6 +122,7 @@ public class VertxBasedHttpProtocolAdapterTest {
         httpAdapter.setRegistrationServiceClient(registrationServiceClient);
         httpAdapter.setCredentialsServiceClient(credentialsServiceClient);
         httpAdapter.setUsernamePasswordAuthProvider(usernamePasswordAuthProvider);
+        httpAdapter.setCommandConnection(commandConnection);
 
         vertx.deployVerticle(httpAdapter, ctx.asyncAssertSuccess());
     }

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -34,6 +34,7 @@ import org.eclipse.hono.service.auth.device.Device;
 import org.eclipse.hono.service.auth.device.DeviceCredentials;
 import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
+import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
@@ -92,6 +93,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     private HonoClientBasedAuthProvider usernamePasswordAuthProvider;
     private ProtocolAdapterProperties config;
     private MqttAdapterMetrics metrics;
+    private CommandConnection commandConnection;
 
     /**
      * Creates clients for the needed micro services and sets the configuration to enable the insecure port.
@@ -130,6 +132,9 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
                 .thenReturn(Future.succeededFuture(deviceRegistrationServiceClient));
         when(deviceRegistrationServiceClient.getOrCreateRegistrationClient(anyString()))
                 .thenReturn(Future.succeededFuture(regClient));
+
+        commandConnection = mock(CommandConnection.class);
+        when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
 
         usernamePasswordAuthProvider = mock(HonoClientBasedAuthProvider.class);
     }
@@ -602,6 +607,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         adapter.setHonoMessagingClient(messagingClient);
         adapter.setRegistrationServiceClient(deviceRegistrationServiceClient);
         adapter.setCredentialsServiceClient(credentialsServiceClient);
+        adapter.setCommandConnection(commandConnection);
         adapter.setUsernamePasswordAuthProvider(usernamePasswordAuthProvider);
 
         if (server != null) {

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
@@ -74,13 +74,13 @@ public class HonoClientImpl implements HonoClient {
     private final AtomicBoolean connecting = new AtomicBoolean(false);
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
     private final ConnectionFactory connectionFactory;
-    private final ClientConfigProperties clientConfigProperties;
+    protected final ClientConfigProperties clientConfigProperties;
     private final Vertx vertx;
     private final Object connectionLock = new Object();
-    private final Context context;
+    protected final Context context;
 
     private ProtonClientOptions clientOptions;
-    private ProtonConnection connection;
+    protected ProtonConnection connection;
     private CacheProvider cacheProvider;
     private AtomicInteger reconnectAttempts = new AtomicInteger(0);
     private List<Symbol> offeredCapabilities = Collections.emptyList();
@@ -483,7 +483,7 @@ public class HonoClientImpl implements HonoClient {
         });
     }
 
-    Future<MessageSender> getOrCreateSender(
+    protected Future<MessageSender> getOrCreateSender(
             final String key,
             final Supplier<Future<MessageSender>> newSenderSupplier) {
 
@@ -599,7 +599,7 @@ public class HonoClientImpl implements HonoClient {
         });
     }
 
-    Future<MessageConsumer> createConsumer(
+    protected Future<MessageConsumer> createConsumer(
             final String tenantId,
             final Supplier<Future<MessageConsumer>> newConsumerSupplier) {
 

--- a/example/src/main/config/hono-adapter-http-vertx-config.yml
+++ b/example/src/main/config/hono-adapter-http-vertx-config.yml
@@ -33,6 +33,14 @@ hono:
     port: 5671
     credentialsPath: ${secret.path}/http-adapter.credentials
     trustStorePath: ${secret.path}/trusted-certs.pem
+  command:
+    name: 'Hono HTTP Adapter'
+    amqpHostname: hono-http-internal
+    host: hono-dispatch-router.hono
+    port: 5673
+    keyPath: ${secret.path}/http-adapter-key.pem
+    certPath: ${secret.path}/http-adapter-cert.pem
+    trustStorePath: ${secret.path}/trusted-certs.pem
   metric:
     reporter:
       graphite:

--- a/example/src/main/config/hono-adapter-mqtt-vertx-config.yml
+++ b/example/src/main/config/hono-adapter-mqtt-vertx-config.yml
@@ -33,6 +33,14 @@ hono:
     port: 5671
     credentialsPath: ${secret.path}/mqtt-adapter.credentials
     trustStorePath: ${secret.path}/trusted-certs.pem
+  command:
+    name: 'Hono MQTT Adapter'
+    amqpHostname: hono-mqtt-internal
+    host: hono-dispatch-router.hono
+    port: 5673
+    keyPath: ${secret.path}/mqtt-adapter-key.pem
+    certPath: ${secret.path}/mqtt-adapter-cert.pem
+    trustStorePath: ${secret.path}/trusted-certs.pem
   metric:
     reporter:
       graphite:

--- a/example/src/main/config/qpid/qdrouterd-with-broker.json
+++ b/example/src/main/config/qpid/qdrouterd-with-broker.json
@@ -90,7 +90,8 @@
           "users": "consumer@HONO",
           "remoteHosts": "*",
           "maxSessions": 10,
-          "sources": "telemetry/*, event/*"
+          "sources": "telemetry/*, event/*, control/*",
+          "targets": "control/*"
         },
         "DEFAULT_TENANT": {
           "users": "user1@HONO",
@@ -116,6 +117,34 @@
           "targets": "telemetry/*, event/*"
         }
       }
+  }],
+
+  ["vhost", {
+    "id": "hono-mqtt-internal",
+    "maxConnections": 30,
+    "groups": {
+      "Hono": {
+        "users": "Eclipse IoT;Hono;mqtt-adapter",
+        "remoteHosts": "*",
+        "allowUserIdProxy": true,
+        "sources": "control/*",
+        "targets": "control/*"
+      }
+    }
+  }],
+
+  ["vhost", {
+    "id": "hono-http-internal",
+    "maxConnections": 30,
+    "groups": {
+      "Hono": {
+        "users": "Eclipse IoT;Hono;http-adapter",
+        "remoteHosts": "*",
+        "allowUserIdProxy": true,
+        "sources": "control/*",
+        "targets": "control/*"
+      }
+    }
   }],
 
   ["log", {

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -19,7 +19,10 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.impl.HonoClientImpl;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.cache.SpringCacheProvider;
+import org.eclipse.hono.service.command.CommandConnection;
+import org.eclipse.hono.service.command.CommandConnectionImpl;
 import org.eclipse.hono.service.metric.MetricConfig;
+import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.RegistrationConstants;
@@ -157,7 +160,7 @@ public abstract class AbstractAdapterConfig {
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
     public HonoClient registrationServiceClient() {
-        final HonoClientImpl result = 
+        final HonoClientImpl result =
                 new HonoClientImpl(vertx(), registrationServiceClientConfig());
 
         final CacheProvider cacheProvider = registrationCacheProvider();
@@ -170,7 +173,7 @@ public abstract class AbstractAdapterConfig {
 
     /**
      * Exposes the provider for caches as a Spring bean.
-     * 
+     *
      * @return The provider instance.
      */
     @Bean
@@ -276,6 +279,29 @@ public abstract class AbstractAdapterConfig {
     @Scope("prototype")
     public CacheProvider tenantCacheProvider() {
         return newGuavaCache(tenantServiceClientConfig());
+    }
+
+    /**
+     * Exposes configuration properties for Command and Control.
+     *
+     * @return The Properties.
+     */
+    @Qualifier(CommandConstants.COMMAND_ENDPOINT)
+    @ConfigurationProperties(prefix = "hono.command")
+    @Bean
+    public ClientConfigProperties commandConnectionClientConfig() {
+        return new ClientConfigProperties();
+    }
+
+    /**
+     * Exposes the Command and Control connection.
+     *
+     * @return The Connection.
+     */
+    @Bean
+    @Scope("prototype")
+    public CommandConnection commandConnection() {
+        return new CommandConnectionImpl(vertx(), commandConnectionClientConfig());
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -22,6 +22,7 @@ import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.ServiceInvocationException;
@@ -31,7 +32,6 @@ import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.auth.TenantApiTrustOptions;
 import org.eclipse.hono.service.auth.device.Device;
 import org.eclipse.hono.service.command.Command;
-import org.eclipse.hono.service.command.CommandAdapter;
 import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.service.monitoring.ConnectionEventProducer;
 import org.eclipse.hono.util.Constants;
@@ -431,7 +431,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     }
 
     /**
-     * Create a command receiver for a specific device.
+     * Create a command consumer for a specific device.
      *
      * @param tenantId The tenant of the command receiver.
      * @param deviceId The device of the command receiver.
@@ -439,7 +439,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @param closeHandler Called on close.
      * @return Result of the receiver creation.
      */
-    protected Future<CommandAdapter> createCommandConsumer(
+    protected Future<MessageConsumer> createCommandConsumer(
             final String tenantId,
             final String deviceId,
             final Consumer<Command> messageConsumer,

--- a/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
@@ -50,7 +50,7 @@ public class Command {
      * 
      * @return The command adapter
      */
-    CommandAdapter getCommandAdapter() {
+    final CommandAdapter getCommandAdapter() {
         return commandAdapter;
     }
 
@@ -59,7 +59,7 @@ public class Command {
      *
      * @return The replyTo address.
      */
-    String getReplyTo() {
+    final String getReplyTo() {
         return message.getReplyTo();
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
@@ -24,19 +24,43 @@ public class Command {
     }
 
     /**
-     * Gets the command message.
-     * @return The proton message.
+     * Gets the payload of the command message.
+     * @return The payload as Buffer or {@code null}.
      */
-    public Message getMessage() {
-        return message;
+    public final Buffer getPayload() {
+        return MessageHelper.getPayload(message);
+    }
+
+    /**
+     * Gets the application properties of the command message.
+     * @return The application properties or {@code null}.
+     */
+    public final Map<String, Object> getApplicationProperties() {
+        final ApplicationProperties applicationProperties = message.getApplicationProperties();
+        if (applicationProperties != null) {
+            return applicationProperties.getValue();
+        }
+        else {
+            return null;
+        }
     }
 
     /**
      * Gets the adapter with receiver/sender to send back the response.
+     * 
      * @return The command adapter
      */
-    public CommandAdapter getCommandAdapter() {
+    CommandAdapter getCommandAdapter() {
         return commandAdapter;
+    }
+
+    /**
+     * Gets the replyTo address of the command.
+     *
+     * @return The replyTo address.
+     */
+    String getReplyTo() {
+        return message.getReplyTo();
     }
 
     Message createResponseMessage(final Buffer payload, final Map<String, Object> properties, final int status) {

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandAdapter.java
@@ -1,0 +1,110 @@
+package org.eclipse.hono.service.command;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.impl.AbstractHonoClient;
+import org.eclipse.hono.client.impl.RegistrationClientImpl;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonMessageHandler;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * Receiver and sender pair to get commands and send a response.
+ */
+public class CommandAdapter extends AbstractHonoClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RegistrationClientImpl.class);
+
+    /**
+     * Creates a client for a vert.x context.
+     *
+     * @param context The context to run all interactions with the server on.
+     * @param config The configuration properties to use.
+     * @param protonReceiver The receiver for commands.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected CommandAdapter(final Context context, final ClientConfigProperties config,
+            final ProtonReceiver protonReceiver) {
+        super(context, config);
+        this.receiver = protonReceiver;
+    }
+
+    Future<ProtonSender> createCommandSender(
+            final ProtonConnection con,
+            final String targetAddress) {
+        final Future<ProtonSender> result = Future.future();
+        AbstractHonoClient.createSender(context, config, con, targetAddress, ProtonQoS.AT_LEAST_ONCE, null)
+                .setHandler(h -> {
+                    if (h.succeeded()) {
+                        sender = h.result();
+                        result.complete(sender);
+                    } else {
+                        result.fail(h.cause());
+                    }
+                });
+        return result;
+    }
+
+    void sendResponse(final Message message, final Handler<ProtonDelivery> onUpdated) {
+        context.runOnContext(a -> {
+            sender.send(message, onUpdated);
+        });
+    }
+
+    final void close() {
+        closeLinks(h->{});
+    }
+
+    /**
+     * Creates a new command adapter.
+     *
+     * @param context The vert.x context to run all interactions with the server on.
+     * @param clientConfig The configuration properties to use.
+     * @param con The AMQP connection to the server.
+     * @param tenantId The tenant.
+     * @param deviceId The device.
+     * @param messageHandler Message handler.
+     * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly.
+     * @param creationHandler The handler to invoke with the outcome of the creation attempt.
+     * @throws NullPointerException if any of the parameters other than cache manager is {@code null}.
+     */
+    public static final void create(
+            final Context context,
+            final ClientConfigProperties clientConfig,
+            final ProtonConnection con,
+            final String tenantId,
+            final String deviceId,
+            final ProtonMessageHandler messageHandler,
+            final Handler<String> receiverCloseHook,
+            final Handler<AsyncResult<CommandAdapter>> creationHandler) {
+
+        LOG.debug("creating new command adapter for [{}, {}]", tenantId, deviceId);
+
+        final String address = ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId)
+                .toString();
+        AbstractHonoClient.createReceiver(context, clientConfig, con, address, ProtonQoS.AT_LEAST_ONCE, messageHandler,
+                receiverCloseHook).setHandler(s -> {
+                    if (s.succeeded()) {
+                        LOG.debug("successfully command adapter for [{}, {}]", tenantId, deviceId);
+                        creationHandler
+                                .handle(Future.succeededFuture(new CommandAdapter(context, clientConfig, s.result())));
+                    } else {
+                        LOG.debug("failed to create command adapter for [{}, {}]", tenantId, deviceId, s.cause());
+                        creationHandler.handle(Future.failedFuture(s.cause()));
+                    }
+                });
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandAdapter.java
@@ -46,10 +46,9 @@ public class CommandAdapter extends AbstractHonoClient implements MessageConsume
             final ProtonConnection con,
             final String targetAddress) {
         final Future<ProtonSender> result = Future.future();
-        if(sender!=null && sender.isOpen()) {
+        if (sender != null && sender.isOpen()) {
             result.complete(sender);
-        }
-        else {
+        } else {
             AbstractHonoClient.createSender(context, config, con, targetAddress, ProtonQoS.AT_LEAST_ONCE, null)
                     .setHandler(h -> {
                         if (h.succeeded()) {
@@ -63,7 +62,8 @@ public class CommandAdapter extends AbstractHonoClient implements MessageConsume
         return result;
     }
 
-    final Future<ProtonDelivery> sendResponse(final ProtonConnection con, final String targetAddress, final Message message) {
+    final Future<ProtonDelivery> sendResponse(final ProtonConnection con, final String targetAddress,
+            final Message message) {
         final Future<ProtonDelivery> result = Future.future();
         getOrCreateCommandSender(con, targetAddress)
                 .setHandler(h -> {
@@ -76,10 +76,6 @@ public class CommandAdapter extends AbstractHonoClient implements MessageConsume
                     }
                 });
         return result;
-    }
-    
-    final void close() {
-        closeLinks(h->{});
     }
 
     @Override

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnection.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnection.java
@@ -22,6 +22,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.proton.ProtonDelivery;
+import org.eclipse.hono.client.MessageConsumer;
 
 /**
  * A bidirectional connection between an Adapter and the AMQP 1.0 network to receive commands and send a response.
@@ -34,10 +35,10 @@ public interface CommandConnection extends HonoClient {
      * @param deviceId The device for which the receiver will be created.
      * @param messageConsumer The message handler for the received commands.
      * @param closeHandler The close handler for the receiver.
-     * @return A CommandAdapter with the receiver, on which the sender for responses will be created.
+     * @return A future, with a MessageConsumer.
      * @throws NullPointerException if tenantId, deviceId or messageConsumer is {@code null};
      */
-    Future<CommandAdapter> createCommandConsumer(
+    Future<MessageConsumer> createCommandConsumer(
             String tenantId,
             String deviceId,
             Consumer<Command> messageConsumer,

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnection.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnection.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.eclipse.hono.client.HonoClient;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.proton.ProtonDelivery;
+
+/**
+ * A bidirectional connection between an Adapter and the AMQP 1.0 network to receive commands and send a response.
+ */
+public interface CommandConnection extends HonoClient {
+
+    /**
+     * Creates a receiver link in the CommandAdapter and a message handler for Commands.
+     * @param tenantId The tenant to consume commands from.
+     * @param deviceId The device for which the receiver will be created.
+     * @param messageConsumer The message handler for the received commands.
+     * @param closeHandler The close handler for the receiver.
+     * @return A CommandAdapter with the receiver, on which the sender for responses will be created.
+     * @throws NullPointerException if tenantId, deviceId or messageConsumer is {@code null};
+     */
+    Future<CommandAdapter> createCommandConsumer(
+            String tenantId,
+            String deviceId,
+            Consumer<Command> messageConsumer,
+            Handler<Void> closeHandler);
+
+    /**
+     * Send back a response for a command to the business application.
+     * @param commandToResponse The original command, which should be responded.
+     * @param data The data to send back or {@code null}.
+     * @param properties The properties to send back or {@code null}.
+     * @param status The status code of the command execution.
+     * @return A ProtonDelivery indicating the success
+     * @throws NullPointerException if commandToResponse is {@code null};
+     */
+    Future<ProtonDelivery> sendCommandResponse(
+            Command commandToResponse,
+            Buffer data,
+            Map<String, Object> properties,
+            int status);
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnectionImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnectionImpl.java
@@ -69,7 +69,7 @@ public class CommandConnectionImpl extends HonoClientImpl implements CommandConn
                     (delivery, message) -> {
                         messageConsumer.accept(new Command(result.result(), message));
                     }, closeHook -> {
-                        result.result().close();
+                        result.result().close(c->{});
                         closeHandler.handle(null);
                     }, result.completer());
             return result.succeeded() ? Future.succeededFuture(result.result()) : Future.failedFuture(result.cause());

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnectionImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandConnectionImpl.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.eclipse.hono.client.impl.HonoClientImpl;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.connection.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.proton.ProtonDelivery;
+
+/**
+ * Implements a connection between an Adapter and the AMQP 1.0 network to receive commands and send a response.
+ */
+public class CommandConnectionImpl extends HonoClientImpl implements CommandConnection {
+
+    protected final Logger LOG = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Creates a new client for a set of configuration properties.
+     * <p>
+     * This constructor creates a connection factory using
+     * {@link ConnectionFactory#newConnectionFactory(Vertx, ClientConfigProperties)}.
+     *
+     * @param vertx The Vert.x instance to execute the client on, if {@code null} a new Vert.x instance is used.
+     * @param clientConfigProperties The configuration properties to use.
+     * @throws NullPointerException if clientConfigProperties is {@code null}
+     */
+    public CommandConnectionImpl(final Vertx vertx, final ClientConfigProperties clientConfigProperties) {
+        super(vertx, clientConfigProperties);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Future<CommandAdapter> createCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final Consumer<Command> messageConsumer,
+            final Handler<Void> closeHandler) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(messageConsumer);
+        return checkConnected().compose(con -> {
+            final Future<CommandAdapter> result = Future.future();
+            CommandAdapter.create(context, clientConfigProperties, connection, tenantId, deviceId,
+                    (delivery, message) -> {
+                        messageConsumer.accept(new Command(result.result(), message));
+                    }, closeHook -> {
+                        result.result().close();
+                        closeHandler.handle(null);
+                    }, result.completer());
+            return result;
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Future<ProtonDelivery> sendCommandResponse(
+            final Command commandToResponse,
+            final Buffer data,
+            final Map<String, Object> properties,
+            final int status) {
+
+        Objects.requireNonNull(commandToResponse);
+        return checkConnected().compose(connected -> {
+            final Future<ProtonDelivery> result = Future.future();
+            final CommandAdapter commandAdapter = commandToResponse.getCommandAdapter();
+            commandAdapter.createCommandSender(connection, commandToResponse.getMessage().getReplyTo())
+                    .setHandler(h -> {
+                        if (h.succeeded()) {
+                            commandAdapter.sendResponse(
+                                    commandToResponse.createResponseMessage(data, properties, status),
+                                    result::complete);
+                        } else {
+                            result.fail(h.cause());
+                        }
+                    });
+            return result;
+        });
+    }
+
+}

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.auth.device.Device;
+import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
@@ -67,6 +68,7 @@ public class AbstractProtocolAdapterBaseTest {
     private HonoClient registrationService;
     private HonoClient credentialsService;
     private HonoClient messagingService;
+    private CommandConnection commandConnection;
 
     /**
      * Sets up the fixture.
@@ -90,12 +92,16 @@ public class AbstractProtocolAdapterBaseTest {
         messagingService = mock(HonoClient.class);
         when(messagingService.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingService));
 
+        commandConnection = mock(CommandConnection.class);
+        when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
+
         properties = new ProtocolAdapterProperties();
         adapter = newProtocolAdapter(properties);
         adapter.setTenantServiceClient(tenantService);
         adapter.setRegistrationServiceClient(registrationService);
         adapter.setCredentialsServiceClient(credentialsService);
         adapter.setHonoMessagingClient(messagingService);
+        adapter.setCommandConnection(commandConnection);
     }
 
     /**
@@ -134,6 +140,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.setHonoMessagingClient(messagingService);
         adapter.setRegistrationServiceClient(registrationService);
         adapter.setTenantServiceClient(tenantService);
+        adapter.setCommandConnection(commandConnection);
 
         // WHEN starting the adapter
         adapter.startInternal().setHandler(ctx.asyncAssertSuccess(ok -> {
@@ -142,6 +149,7 @@ public class AbstractProtocolAdapterBaseTest {
             verify(registrationService).connect(any(Handler.class));
             verify(messagingService).connect(any(Handler.class));
             verify(credentialsService).connect(any(Handler.class));
+            verify(commandConnection).connect(any(Handler.class));
             verify(startupHandler).handle(null);
         }));
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/command/CommandConnectionTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/command/CommandConnectionTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.service.credentials.BaseCredentialsService;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests verifying behavior of {@link BaseCredentialsService}.
+ */
+@RunWith(VertxUnitRunner.class)
+public class CommandConnectionTest {
+
+    private static Vertx vertx;
+    private CommandConnection commandConnection;
+
+    /**
+     * Time out each test after 5 seconds.
+     */
+    public Timeout timeout = Timeout.seconds(5);
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeClass
+    public static void setUpVertx() {
+        vertx = Vertx.vertx();
+    }
+
+    /**
+     * Sets up the fixture.
+     */
+    @Before
+    public void setUp() {
+        commandConnection = new CommandConnectionImpl(vertx, new ClientConfigProperties());
+    }
+
+    /**
+     * Tests the command responder.
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateCommandResponder(final TestContext ctx) {
+        // TODO
+    }
+}

--- a/service-base/src/test/java/org/eclipse/hono/service/command/CommandConnectionTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/command/CommandConnectionTest.java
@@ -13,12 +13,6 @@
 
 package org.eclipse.hono.service.command;
 
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.proton.ProtonClientOptions;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.credentials.BaseCredentialsService;
 import org.junit.AfterClass;
@@ -27,6 +21,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 /**
  * Tests verifying behavior of {@link BaseCredentialsService}.

--- a/service-base/src/test/java/org/eclipse/hono/service/command/CommandConnectionTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/command/CommandConnectionTest.java
@@ -13,11 +13,15 @@
 
 package org.eclipse.hono.service.command;
 
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.proton.ProtonClientOptions;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.credentials.BaseCredentialsService;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,6 +51,18 @@ public class CommandConnectionTest {
     }
 
     /**
+     * Cleans up after test execution.
+     *
+     * @param ctx The helper to use for running async tests.
+     */
+    @AfterClass
+    public static void shutdown(final TestContext ctx) {
+        if (vertx != null) {
+            vertx.close(ctx.asyncAssertSuccess());
+        }
+    }
+
+    /**
      * Sets up the fixture.
      */
     @Before
@@ -56,10 +72,10 @@ public class CommandConnectionTest {
 
     /**
      * Tests the command responder.
+     *
      * @param ctx The vert.x test context.
      */
     @Test
-    public void testCreateCommandResponder(final TestContext ctx) {
-        // TODO
+    public void testCreateCommandConsumer(final TestContext ctx) {
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/command/CommandIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/command/CommandIT.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.tests.command;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.runner.RunWith;
+
+/**
+ * Integration tests for send commands to an adapter.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class CommandIT {
+
+}


### PR DESCRIPTION
- Abstract adapter can open receivers for Command and Control and send back a response.
- QPID dispatcher and MQTT/HTTP adapters in example configured.
