### PR TITLE
Hono HTTP adapter Command and Control.

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -616,7 +616,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
 
             if (commandSubject.isPresent() && commandRequestId.isPresent()) {
 
-                ctx.response().putHeader(Constants.HEADER_COMMAND, commandSubject.get().toString());
+                ctx.response().putHeader(Constants.HEADER_COMMAND, commandSubject.get());
                 ctx.response().putHeader(Constants.HEADER_COMMAND_REQUEST_ID, commandRequestId.get());
 
                 HttpUtils.setResponseBody(ctx.response(), MessageHelper.getPayload(commandMessage));
@@ -640,7 +640,8 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      *                              was sent already.
      * @param messageConsumerRef An AtomicReference to the {@link MessageConsumer} that is set for further usage
      *                           by the caller of this method.
-     * @return Optional An optional timerId if there was a
+     * @return Optional An optional timerId if there was a timer started to automatically close the receiver link after
+     * the time to disconnect expired.
      */
     private Future<Optional<Long>> openCommandReceiverLink(final RoutingContext ctx, final String tenant,
             final String deviceId, final AtomicBoolean downstreamMessageSent, final AtomicReference<MessageConsumer> messageConsumerRef) {
@@ -684,7 +685,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                                         ctx.response().end();
                                     }
                                 }));
-                        // responseTimerId.set(timerId.longValue());
                         resultWithTimerId.complete(Optional.of(timerId.longValue()));
 
                         // let only one command reach the adapter (may change in the future)

--- a/core/src/main/java/org/eclipse/hono/util/Constants.java
+++ b/core/src/main/java/org/eclipse/hono/util/Constants.java
@@ -201,6 +201,11 @@ public final class Constants {
      */
     static final char STRING_COMBINATION_SEPARATION_CHAR = '#';
 
+    /**
+     * The header name defined for setting the <em>subject</em> of a command that is sent to the device.
+     */
+    public static final String HEADER_COMMAND_SUBJECT = "hono-command-subject";
+
     private Constants() {
     }
 

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
@@ -161,10 +161,7 @@ public class HonoConsumerBase {
         final String deviceId = notification.getDeviceId();
 
         honoClient.getOrCreateCommandClient(tenantId, deviceId).map(commandClient -> {
-            // generate a correlationId for the application in the payload
-            final UUID correlationIdForPayload = UUID.randomUUID();
-            final JsonObject jsonCmd = new JsonObject().put("brightness", (int)(Math.random() * 100)).
-                    put("correlationId", correlationIdForPayload.toString());
+            final JsonObject jsonCmd = new JsonObject().put("brightness", (int)(Math.random() * 100));
             final Buffer commandBuffer = Buffer.buffer(jsonCmd.encodePrettily());
 
             // send the command upstream to the device

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.vertx.example.base;
 
-import java.util.UUID;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
@@ -163,10 +163,12 @@ public class HonoConsumerBase {
         honoClient.getOrCreateCommandClient(tenantId, deviceId).map(commandClient -> {
             final JsonObject jsonCmd = new JsonObject().put("brightness", (int)(Math.random() * 100));
             final Buffer commandBuffer = Buffer.buffer(jsonCmd.encodePrettily());
+            commandClient.setRequestTimeout(60*1000);
 
             // send the command upstream to the device
             commandClient.sendCommand("setBrightness", commandBuffer).map(result -> {
-                System.out.println("Successfully sent command and received response");
+                System.out.println(String.format("Successfully sent command and received response: %s",
+                        Optional.ofNullable(result).orElse(Buffer.buffer()).toString()));
                 return result;
             }).otherwise(t -> {
                 System.out.println(String.format("Could not send command or did not receive a response : %s", t.getMessage()));

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -464,7 +464,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         Objects.requireNonNull(commandMessage);
 
         // example of commandReplyId: control/DEFAULT_TENANT/4711/33fe70fd-5a2e-4095-83db-00101bf74a07
-        final String commandReplyId = commandMessage.getProperties().getReplyTo();
+        final String commandReplyId = commandMessage.getReplyTo();
         if (commandReplyId == null) {
             return Optional.empty();
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
@@ -43,6 +43,11 @@ public final class HttpUtils {
      */
     public static final String CONTENT_TYPE_JSON_UFT8 = "application/json; charset=utf-8";
 
+    /**
+     * The <em>application/json; charset=utf-8</em> content type.
+     */
+    public static final String CONTENT_TYPE_OCTET_STREAM = "application/octet-stream";
+
     private HttpUtils() {
         // prevent instantiation
     }
@@ -204,4 +209,23 @@ public final class HttpUtils {
                     .write(buffer);
         }
     }
+
+    /**
+     * Writes a Buffer to an HTTP response body.
+     * <p>
+     * This method also sets the <em>content-type</em> and <em>content-length</em>
+     * headers of the HTTP response accordingly but does not end the response.
+     *
+     * @param response The HTTP response.
+     * @param buffer The Buffer to set as the response body (may be {@code null}).
+     * @throws NullPointerException if response is {@code null}.
+     */
+    public static void setResponseBody(final HttpServerResponse response, final Buffer buffer) {
+        Objects.requireNonNull(response);
+        if (buffer != null) {
+            response.putHeader(HttpHeaders.CONTENT_LENGTH, String.valueOf(buffer.length()))
+                    .write(buffer);
+        }
+    }
+
 }


### PR DESCRIPTION
This PR contains the fully working version of "void" commands for the HTTP adapter.
Included also is the extended example consumer, which now reacts to a notification callback (having been empty before) by trying to send a command upstream.
The result can be watched e.g. by using `curl`, like the following:

```
$ curl -X POST -i -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' --data-binary '{"temp": 5}' http://localhost:8080/telemetry?hono-ttd=10
```

resulting in

```
HTTP/1.1 202 Accepted
hono-command: setBrightness
hono-cmd-req-id: 47#cmd-client-f577a018-32ba-4b14-bc1f-902acc77da12/28c2b33a-a5f7-4962-8dcf-316725583cb9
Content-Length: 82

{
  "brightness" : 6,
  "correlationId" : "0315ad62-32a1-497e-80d6-950dbf6d8f02"
}
```