### PR TITLE
Allow usage of native tls implementation in protocol adapters

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
@@ -104,10 +104,12 @@ public class ServiceConfigProperties extends AbstractConfig {
     /**
      * Checks if this server requires the usage of a native TLS implementation.
      * Native TLS implementations offer in general a better performance but may not be available on all platforms.
-     * If true, the server will require the usage of a native TLS implementation.
+     * If {@code true}, the server will require the usage of a native TLS implementation.
      * Server will not start if native implementation is not available on the current system.
-     * If false, the adapter will try to use a native TLS implementation. If no native implementation is available the
+     * If {@code false}, the adapter will try to use a native TLS implementation. If no native implementation is available the
      * default Java platform independent TLS implementation will be used.
+     * <p>
+     * The default value of this property is {@code false}.
      *
      * @return {@code true} if the server requires native TLS implementation.
      */
@@ -118,10 +120,12 @@ public class ServiceConfigProperties extends AbstractConfig {
     /**
      * Sets if this server should require the usage of a native TLS implementation.
      * Native TLS implementations offer in general a better performance but may not be available on all platforms.
-     * If true, the server will require the usage of a native TLS implementation.
+     * If {@code true}, the server will require the usage of a native TLS implementation.
      * Server will not start if native implementation is not available on the current system.
-     * If false, the adapter will try to use a native TLS implementation. If no native implementation is available the
+     * If {@code false}, the adapter will try to use a native TLS implementation. If no native implementation is available the
      * default Java platform independent TLS implementation will be used.
+     * <p>
+     * The default value of this property is {@code false}.
      *
      * @param nativeTlsRequired {@code true} if the server requires the usage of a native TLS implementation.
      */
@@ -131,8 +135,8 @@ public class ServiceConfigProperties extends AbstractConfig {
 
     /**
      * Checks if this server is configured to listen on an insecure port (i.e. without TLS) at all.
-     * If false, it is guaranteed by the server that no opened port is insecure.
-     * If true, it enables the definition of an insecure port (as the only port <u>or</u> additionally to the secure port).
+     * If {@code false}, it is guaranteed by the server that no opened port is insecure.
+     * If {@code true}, it enables the definition of an insecure port (as the only port <u>or</u> additionally to the secure port).
      *
      * @return {@code true} if the server guarantees that no opened port is insecure.
      */
@@ -142,8 +146,8 @@ public class ServiceConfigProperties extends AbstractConfig {
 
     /**
      * Sets if this server should support insecure AMQP 1.0 ports (i.e. without TLS) at all.
-     * If false, it is guaranteed by the server that no opened port is insecure.
-     * If true, it enables the definition of an insecure port (as the only port <u>or</u> additionally to the secure port).
+     * If {@code false}, it is guaranteed by the server that no opened port is insecure.
+     * If {@code true}, it enables the definition of an insecure port (as the only port <u>or</u> additionally to the secure port).
      *
      * @param insecurePortEnabled {@code true} if the server shall guarantee that no opened port is insecure.
      */

--- a/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
@@ -33,6 +33,7 @@ public class ServiceConfigProperties extends AbstractConfig {
     private boolean waitForDownstreamConnection = false;
     private String bindAddress = LOOPBACK_DEVICE_ADDRESS;
     private int port = Constants.PORT_UNCONFIGURED;
+    private boolean nativeTlsRequired = false;
     private boolean insecurePortEnabled = false;
     private String insecurePortBindAddress = LOOPBACK_DEVICE_ADDRESS;
     private int insecurePort = Constants.PORT_UNCONFIGURED;
@@ -98,6 +99,34 @@ public class ServiceConfigProperties extends AbstractConfig {
         } else {
             throw new IllegalArgumentException("invalid port number");
         }
+    }
+
+    /**
+     * Checks if this server requires the usage of a native TLS implementation.
+     * Native TLS implementations offer in general a better performance but may not be available on all platforms.
+     * If true, the server will require the usage of a native TLS implementation.
+     * Server will not start if native implementation is not available on the current system.
+     * If false, the adapter will try to use a native TLS implementation. If no native implementation is available the
+     * default Java platform independent TLS implementation will be used.
+     *
+     * @return {@code true} if the server requires native TLS implementation.
+     */
+    public final boolean isNativeTlsRequired() {
+        return nativeTlsRequired;
+    }
+
+    /**
+     * Sets if this server should require the usage of a native TLS implementation.
+     * Native TLS implementations offer in general a better performance but may not be available on all platforms.
+     * If true, the server will require the usage of a native TLS implementation.
+     * Server will not start if native implementation is not available on the current system.
+     * If false, the adapter will try to use a native TLS implementation. If no native implementation is available the
+     * default Java platform independent TLS implementation will be used.
+     *
+     * @param nativeTlsRequired {@code true} if the server requires the usage of a native TLS implementation.
+     */
+    public final void setNativeTlsRequired(final boolean nativeTlsRequired) {
+        this.nativeTlsRequired = nativeTlsRequired;
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
@@ -371,7 +371,7 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
      * <p>
      * Finally, if a working instance of Netty's <em>tcnative</em> library is found, then
      * it is used instead of the JDK's default SSL engine.
-     * 
+     *
      * @param serverOptions The options to add configuration to.
      */
     protected final void addTlsKeyCertOptions(final NetServerOptions serverOptions) {
@@ -386,7 +386,8 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
 
             final boolean isOpenSslAvailable = OpenSsl.isAvailable();
             final boolean supportsKeyManagerFactory =  OpenSsl.supportsKeyManagerFactory();
-            final boolean useOpenSsl = isOpenSslAvailable && supportsKeyManagerFactory;
+            final boolean useOpenSsl =
+                    getConfig().isNativeTlsRequired() || (isOpenSslAvailable && supportsKeyManagerFactory);
 
             LOG.debug("OpenSSL [available: {}, supports KeyManagerFactory: {}]",
                     isOpenSslAvailable, supportsKeyManagerFactory);


### PR DESCRIPTION
With this PR it is possible to enable the usage of native TLS implementations in protocol adapters.
It does however not yet contain any dependency to a specific implementation.

To use native TLS a user still  has to add a concrete dependency to a specific `netty-tcnative` in the adapters maven dependencies.