### PR TITLE
Enable JDK 10 build on Travis in addition to JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 dist: trusty
 sudo: required
 language: java
+
 jdk:
   - openjdk8
+  - oraclejdk10
+
 script:
   - mvn install verify -B -Dtest.env=true -DcreateJavadoc=true -Ddocker.host=unix:///var/run/docker.sock -Pbuild-docker-image,run-tests -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 before_install:
+
 env:
   global:
   - COMMIT=${TRAVIS_COMMIT::8}

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -37,6 +37,8 @@
     <influxdb.version>1.5.4-alpine</influxdb.version>
     <jackson.version>2.9.5</jackson.version>
     <java-base-image.name>openjdk:8u171-jre-slim</java-base-image.name>
+    <jaxb.api.version>2.2.12</jaxb.api.version>
+    <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
     <jjwt.version>0.7.0</jjwt.version>
     <jmeter.version>3.3</jmeter.version>
     <junit.version>4.12</junit.version>
@@ -242,6 +244,12 @@
         <version>${jjwt.version}</version>
       </dependency>
       <dependency>
+        <!-- required as a (missing) transient dependency for JJWT -->
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${jaxb.api.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.jmeter</groupId>
         <artifactId>ApacheJMeter_core</artifactId>
         <version>${jmeter.version}</version>
@@ -271,6 +279,11 @@
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-dispatch-router</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+          <version>${javax.annotation.api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>hono-demo-certs</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${spring-boot.version}</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,6 +60,11 @@
       <artifactId>jjwt</artifactId>
     </dependency>
     <dependency>
+      <!-- required as a (missing) transient dependency for JJWT -->
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -132,6 +132,10 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-tracerresolver</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This change also contains the necessary upgrades and fixes for
successfully running the unit tests on Travis.

---

Please see this a a preview PR, which we can use for discussions.
