### PR TITLE
[#319] Add high level tracing to HTTP and MQTT adapters.

### DIFF
--- a/adapters/http-vertx-base/pom.xml
+++ b/adapters/http-vertx-base/pom.xml
@@ -15,6 +15,10 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-vertx-web</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/ComponentMetaDataDecorator.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/ComponentMetaDataDecorator.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.adapter.http;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.hono.tracing.TracingHelper;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.vertx.ext.web.WebSpanDecorator;
+import io.opentracing.tag.Tags;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+
+
+/**
+ * A decorator which adds Hono component specific
+ * tags to an OpenTracing span covering the processing of a request.
+ *
+ */
+public class ComponentMetaDataDecorator extends WebSpanDecorator.StandardTags {
+
+    private final Map<String, String> tags;
+
+    /**
+     * Creates a new decorator for default tags.
+     */
+    public ComponentMetaDataDecorator() {
+        this(new HashMap<>(0));
+    }
+
+    /**
+     * Creates a new decorator for default and custom tags.
+     * 
+     * @param customTags The tags that should be set on spans for incoming requests.
+     * @throws NullPointerException if tags is {@code null}.
+     */
+    public ComponentMetaDataDecorator(final Map<String, String> customTags) {
+        super();
+        this.tags = Collections.unmodifiableMap(Objects.requireNonNull(customTags));
+    }
+
+    @Override
+    public void onRequest(final HttpServerRequest request, final Span span) {
+        Tags.HTTP_METHOD.set(span, request.method().toString());
+        Tags.HTTP_URL.set(span, request.absoluteURI());
+        tags.forEach((key, value) -> {
+            span.setTag(key, value);
+        });
+    }
+
+    @Override
+    public void onReroute(final HttpServerRequest request, final Span span) {
+        final Map<String, String> logs = new HashMap<>(3);
+        logs.put(TracingHelper.LOG_FIELD_EVENT, "reroute");
+        logs.put(Tags.HTTP_URL.getKey(), request.absoluteURI());
+        logs.put(Tags.HTTP_METHOD.getKey(), request.method().toString());
+        span.log(logs);
+    }
+
+    @Override
+    public void onResponse(final HttpServerRequest request, final Span span) {
+        Tags.HTTP_STATUS.set(span, request.response().getStatusCode());
+    }
+
+    @Override
+    public void onFailure(final Throwable throwable, final HttpServerResponse response, final Span span) {
+        TracingHelper.logError(span, throwable);
+    }
+}

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.adapter.mqtt;
 import java.util.Objects;
 
 import org.eclipse.hono.service.auth.device.Device;
+import org.eclipse.hono.util.ExecutionContext;
 
 import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.messages.MqttPublishMessage;
@@ -25,7 +26,7 @@ import io.vertx.mqtt.messages.MqttPublishMessage;
  * processing of an MQTT message published by a device.
  *
  */
-public final class MqttContext {
+public final class MqttContext extends ExecutionContext {
 
     private final MqttPublishMessage message;
     private final MqttEndpoint deviceEndpoint;

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -92,6 +92,14 @@
       <artifactId>vertx-codegen</artifactId>
       <classifier>processor</classifier>
     </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -45,6 +45,9 @@
     <mockito.version>2.10.0</mockito.version>
     <netty.version>4.1.19.Final</netty.version>
     <objenesis.version>2.6</objenesis.version>
+    <opentracing.version>0.31.0</opentracing.version>
+    <opentracing-resolver.version>0.1.4</opentracing-resolver.version>
+    <opentracing-vertx-web.version>0.1.0</opentracing-vertx-web.version>
     <proton.version>0.25.0</proton.version>
     <qpid-jms.version>0.29.0</qpid-jms.version>
     <slf4j.version>1.7.24</slf4j.version>
@@ -316,6 +319,26 @@
             <artifactId>jackson-databind</artifactId>
           </exclusion>
         </exclusions-->
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-api</artifactId>
+        <version>${opentracing.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-noop</artifactId>
+        <version>${opentracing.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-vertx-web</artifactId>
+        <version>${opentracing-vertx-web.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-tracerresolver</artifactId>
+        <version>${opentracing-resolver.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -67,6 +67,10 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+     <groupId>io.opentracing</groupId>
+     <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-demo-certs</artifactId>
       <scope>test</scope>
@@ -120,6 +124,17 @@
             <Include-Resource>
               META-INF=${project.build.outputDirectory}/META-INF
             </Include-Resource>
+            <!--
+              The OpenTracing API artifact is not a bundle, so we inline
+              and export its packages.
+            -->
+            <Export-Package>
+              io.opentracing*;version=${opentracing.version},
+              {local-packages}
+            </Export-Package>
+            <Embed-Dependency>
+              opentracing-api;inline=true
+            </Embed-Dependency>
           </instructions>
         </configuration>
       </plugin>

--- a/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.tracing;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import io.opentracing.Span;
+import io.opentracing.tag.BooleanTag;
+import io.opentracing.tag.StringTag;
+import io.opentracing.tag.Tags;
+
+/**
+ * A helper class providing utility methods for interacting with the
+ * OpenTracing API.
+ *
+ */
+public final class TracingHelper {
+
+    /**
+     * The name of the field to use for adding an exception to an OpenTracing span's log.
+     */
+    public static final String LOG_FIELD_ERROR_OBJECT = "error.object";
+    /**
+     * The name of the field to use for adding an event to an OpenTracing span's log.
+     */
+    public static final String LOG_FIELD_EVENT = "event";
+    /**
+     * The name of the field to use for adding an explanatory message to an OpenTracing span's log.
+     */
+    public static final String LOG_FIELD_MESSAGE = "message";
+
+    /**
+     * An OpenTracing tag indicating if a client (device) has been authenticated.
+     */
+    public static final BooleanTag TAG_AUTHENTICATED = new BooleanTag("authenticated");
+    /**
+     * An OpenTracing tag that contains the QoS that a device has used for publishing
+     * a message.
+     */
+    public static final StringTag TAG_QOS = new StringTag("qos");
+    /**
+     * An OpenTracing tag indicating if a client's connection is secured using TLS.
+     */
+    public static final BooleanTag TAG_TLS = new BooleanTag("tls");
+
+    private TracingHelper() {
+        // prevent instantiation
+    }
+
+    /**
+     * Marks an <em>OpenTracing</em> span as erroneous and logs an exception.
+     * <p>
+     * This method does <em>not</em> finish the span.
+     * 
+     * @param span The span to mark.
+     * @param error The exception that has occurred.
+     * @throws NullPointerException if error is {@code null}.
+     */
+    public static void logError(final Span span, final Throwable error) {
+        if (span != null) {
+            logError(span, getErrorLogItems(error));
+        }
+    }
+
+    /**
+     * Creates a set of items to log for an error.
+     * 
+     * @param error The error.
+     * @return The items to log.
+     */
+    public static Map<String, Object> getErrorLogItems(final Throwable error) {
+        final Map<String, Object> log = new HashMap<>(2);
+        log.put(LOG_FIELD_EVENT, Tags.ERROR.getKey());
+        if (error != null) {
+            log.put(LOG_FIELD_ERROR_OBJECT, error);
+        }
+        return log;
+    }
+
+    /**
+     * Marks an <em>OpenTracing</em> span as erroneous and logs a message.
+     * <p>
+     * This method does <em>not</em> finish the span.
+     * 
+     * @param span The span to mark.
+     * @param message The message to log on the span.
+     * @throws NullPointerException if message is {@code null}.
+     */
+    public static void logError(final Span span, final String message) {
+        if (span != null) {
+            Objects.requireNonNull(message);
+            logError(span, Collections.singletonMap(LOG_FIELD_MESSAGE, message));
+        }
+    }
+
+    /**
+     * Marks an <em>OpenTracing</em> span as erroneous and logs several items.
+     * <p>
+     * This method does <em>not</em> finish the span.
+     * 
+     * @param span The span to finish.
+     * @param items The items to log on the span. Note that this method will
+     *               also log an item using {@code event} as key and {@code error}
+     *               as the value.
+     */
+    public static void logError(final Span span, final Map<String, ?> items) {
+        if (span != null) {
+            Tags.ERROR.set(span, Boolean.TRUE);
+            if (items != null) {
+                span.log(items);
+                span.log(Tags.ERROR.getKey());
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A context that can be used to pass around arbitrary key/value pairs.
+ *
+ */
+public class ExecutionContext {
+
+    private Map<String, Object> data;
+
+    /**
+     * Creates an empty execution context.
+     * 
+     * @return The new context.
+     */
+    public static ExecutionContext empty() {
+        return new ExecutionContext();
+    }
+
+    /**
+     * Creates an execution context for given set of properties.
+     * 
+     * @param props The properties to add to the new context.
+     * @return The new context.
+     */
+    public static ExecutionContext of(final Map<String, Object> props) {
+        final ExecutionContext result = new ExecutionContext();
+        result.data = new HashMap<>(props);
+        return result;
+    }
+
+    /**
+     * Gets the value for a key.
+     * 
+     * @param <T> The type of the value.
+     * @param key The key to get the value for.
+     * @return The value or {@code null} if the key is unknown.
+     */
+    public final <T> T get(final String key) {
+        return get(key, null);
+    }
+
+    /**
+     * Gets the value for a key.
+     * 
+     * @param <T> The type of the value.
+     * @param key The key to get the value for.
+     * @param defaultValue The value to return if the key is unknown.
+     * @return The value.
+     */
+    @SuppressWarnings("unchecked")
+    public final <T> T get(final String key, final T defaultValue) {
+        return Optional.ofNullable(getData().get(key)).map(value -> {
+            return (T) value;
+        }).orElse(defaultValue);
+    }
+
+    /**
+     * Sets a value for a key.
+     * 
+     * @param key The key.
+     * @param value The value.
+     */
+    public final void put(final String key, final Object value) {
+        getData().put(key, value);
+    }
+
+    /**
+     * Gets the properties stored in this context.
+     * 
+     * @return An unmodifiable view on this context's properties.
+     */
+    public final Map<String, Object> asMap() {
+        return Collections.unmodifiableMap(getData());
+    }
+
+    private Map<String, Object> getData() {
+        return Optional.ofNullable(data).orElseGet(() -> {
+            data = new HashMap<>();
+            return data;
+        });
+    }
+}

--- a/legal/legal/NOTICE.md
+++ b/legal/legal/NOTICE.md
@@ -132,6 +132,36 @@ is also available at http://www.apache.org/licenses/LICENSE-2.0.html.
 
 The source code is available from [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.netty%22%20AND%20v%3A%22${netty.version}%22).
 
+### OpenTracing API for Java ${opentracing.version}
+
+This product includes software developed by the [OpenTracing project](http://opentracing.io/).
+
+Your use of *OpenTracing API for Java* is subject to the terms and conditions of the Apache Software License 2.0.
+A copy of the license is contained in the file [LICENSE-2.0.txt](LICENSE-2.0.txt) and is also available at
+http://www.apache.org/licenses/LICENSE-2.0.html.
+
+The source code is available from [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.opentracing%22%20AND%20v%3A%22${opentracing.version}%22).
+
+### OpenTracing Java Tracer Resolver ${opentracing-resolver.version}
+
+This product includes software developed by the [OpenTracing Java Tracer Resolver project](https://github.com/opentracing-contrib/java-tracerresolver).
+
+Your use of *OpenTracing Java Tracer Resolver* is subject to the terms and conditions of the Apache Software License 2.0.
+A copy of the Apache Software License 2.0 is contained in the file [LICENSE-2.0.txt](LICENSE-2.0.txt) and
+is also available at http://www.apache.org/licenses/LICENSE-2.0.html.
+
+The source code is available from [Maven Central](http://search.maven.org/remotecontent?filepath=io/opentracing/contrib/opentracing-tracerresolver/${opentracing-resolver.version}/opentracing-tracerresolver-${opentracing-resolver.version}-sources.jar).
+
+### OpenTracing Vert.x Web Instrumentation ${opentracing-vertx-web.version}
+
+This product includes software developed by the [OpenTracing Vert.x Web Instrumentation project](https://github.com/opentracing-contrib/java-vertx-web).
+
+Your use of *OpenTracing Vert.x Web Instrumentation* is subject to the terms and conditions of the Apache Software License 2.0.
+A copy of the Apache Software License 2.0 is contained in the file [LICENSE-2.0.txt](LICENSE-2.0.txt) and
+is also available at http://www.apache.org/licenses/LICENSE-2.0.html.
+
+The source code is available from [Maven Central](http://search.maven.org/remotecontent?filepath=io/opentracing/contrib/opentracing-vertx-web/${opentracing-vertx-web.version}/opentracing-vertx-web-${opentracing-vertx-web.version}-sources.jar).
+
 ### Proton-j ${proton.version}
 
 This product includes software developed by the [Apache Software Foundation](http://www.apache.org/).

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -108,6 +108,18 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context-support</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-tracerresolver</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.service;
 
+import java.util.Optional;
+
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
@@ -37,6 +39,9 @@ import org.springframework.context.annotation.Scope;
 
 import com.google.common.cache.CacheBuilder;
 
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.dns.AddressResolverOptions;
@@ -48,6 +53,22 @@ import io.vertx.core.metrics.MetricsOptions;
 public abstract class AbstractAdapterConfig {
 
     private MetricsOptions metricsOptions;
+
+    /**
+     * Exposes an OpenTracing {@code Tracer} as a Spring Bean.
+     * <p>
+     * The Tracer will be resolved by means of a Java service lookup.
+     * If no tracer can be resolved this way, the {@code NoopTracer} is
+     * returned.
+     * 
+     * @return The tracer.
+     */
+    @Bean
+    public Tracer getTracer() {
+
+        return Optional.ofNullable(TracerResolver.resolveTracer())
+                .orElse(NoopTracerFactory.create());
+    }
 
     /**
      * Vert.x metrics options, if configured.

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -17,7 +17,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
-import io.vertx.proton.ProtonDelivery;
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
@@ -42,8 +41,8 @@ import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
-import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.Strings;
+import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -57,6 +56,7 @@ import io.vertx.core.net.TrustOptions;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.healthchecks.Status;
 import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonDelivery;
 import io.vertx.proton.ProtonHelper;
 
 /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
@@ -1,13 +1,18 @@
 package org.eclipse.hono.service;
 
+import java.util.Objects;
+
 import org.eclipse.hono.config.AbstractConfig;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.util.ConfigurationSupportingVerticle;
 import org.eclipse.hono.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import io.netty.handler.ssl.OpenSsl;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Future;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.net.KeyCertOptions;
@@ -27,6 +32,26 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
      * A logger to be shared with subclasses.
      */
     protected final Logger LOG = LoggerFactory.getLogger(getClass());
+
+    /**
+     * The OpenTracing {@code Tracer} for tracking processing of requests.
+     */
+    protected Tracer tracer = NoopTracerFactory.create();
+
+    /**
+     * Sets the OpenTracing {@code Tracer} to use for tracking the processing
+     * of messages published by devices across Hono's components.
+     * <p>
+     * If not set explicitly, the {@code NoopTracer} from Opentracing will
+     * be used.
+     * 
+     * @param opentracingTracer The tracer.
+     */
+    @Autowired(required = false)
+    public final void setTracer(final Tracer opentracingTracer) {
+        LOG.info("using OpenTracing Tracer implementation [{}]", opentracingTracer.getClass().getName());
+        this.tracer = Objects.requireNonNull(opentracingTracer);
+    }
 
     /**
      * Starts up this component.


### PR DESCRIPTION
All standard adapters are instrumented using OpenTracing in order to be
able to track the processing of messages that have been uploaded by
devices.

In this first step, only the handlers for incoming HTTP requests and
published MQTT messages are instrumented, i.e. we only trace the
incoming request and the outcome of processing the request at a very
high level.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>