### PR TITLE
[#319] Allow auto wiring of OpenTracing Tracer into HonoClientImpl.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -79,6 +79,12 @@
       <classifier>processor</classifier>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-noop</artifactId>
     </dependency>

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
@@ -51,6 +51,7 @@ import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
@@ -170,6 +171,7 @@ public class HonoClientImpl implements HonoClient {
      * 
      * @param opentracingTracer The tracer.
      */
+    @Autowired(required = false)
     public final void setTracer(final Tracer opentracingTracer) {
         LOG.info("using OpenTracing implementation [{}]", opentracingTracer.getClass().getName());
         this.tracer = Objects.requireNonNull(opentracingTracer);


### PR DESCRIPTION
The corresponding Spring library dependencies are declared *provided* in
the POM so the client artifact should be usable without Spring on the
classpath as well (e.g. in an OSGi environment).

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>