### PR TITLE
[#319] Include downstream messages in tracing.

### DIFF
--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -379,7 +380,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     private void givenAnEventSenderForOutcome(final Future<ProtonDelivery> outcome) {
 
         final MessageSender sender = mock(MessageSender.class);
-        when(sender.send(any(Message.class))).thenReturn(outcome);
+        when(sender.send(any(Message.class), (SpanContext) any())).thenReturn(outcome);
 
         when(messagingClient.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
     }
@@ -387,7 +388,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     private void givenATelemetrySenderForOutcome(final Future<ProtonDelivery> outcome) {
 
         final MessageSender sender = mock(MessageSender.class);
-        when(sender.send(any(Message.class))).thenReturn(outcome);
+        when(sender.send(any(Message.class), (SpanContext) any())).thenReturn(outcome);
 
         when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
     }

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
@@ -54,6 +54,7 @@ import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -212,13 +213,14 @@ public class VertxBasedHttpProtocolAdapterTest {
                 thenReturn(Future.succeededFuture(commandConsumer));
 
         telemetrySender = mock(MessageSender.class);
-        when(telemetrySender.send(any(Message.class))).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
-        when(telemetrySender.sendAndWaitForOutcome(any(Message.class))).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
+        when(telemetrySender.send(any(Message.class), (SpanContext) any())).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
+        when(telemetrySender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(
+                Future.succeededFuture(mock(ProtonDelivery.class)));
         when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(telemetrySender));
         when(messagingClient.getOrCreateTelemetrySender(anyString(), anyString())).thenReturn(Future.succeededFuture(telemetrySender));
 
         eventSender = mock(MessageSender.class);
-        when(eventSender.send(any(Message.class))).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
+        when(eventSender.send(any(Message.class), (SpanContext) any())).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
         when(messagingClient.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(eventSender));
         when(messagingClient.getOrCreateEventSender(anyString(), anyString())).thenReturn(Future.succeededFuture(eventSender));
 
@@ -425,7 +427,7 @@ public class VertxBasedHttpProtocolAdapterTest {
                 .putHeader(HttpHeaders.ORIGIN, "hono.eclipse.org")
                 .handler(response -> {
                     ctx.assertEquals(HttpURLConnection.HTTP_ACCEPTED, response.statusCode());
-                    verify(telemetrySender).send(any(Message.class));
+                    verify(telemetrySender).send(any(Message.class), any(SpanContext.class));
                     async.complete();
                 }).exceptionHandler(ctx::fail).end(new JsonObject().encode());
     }
@@ -449,7 +451,7 @@ public class VertxBasedHttpProtocolAdapterTest {
                 .putHeader(HttpHeaders.ORIGIN, "hono.eclipse.org")
                 .handler(response -> {
                     ctx.assertEquals(HttpURLConnection.HTTP_ACCEPTED, response.statusCode());
-                    verify(eventSender).send(any(Message.class));
+                    verify(eventSender).send(any(Message.class), any(SpanContext.class));
                     async.complete();
                 }).exceptionHandler(ctx::fail).end(new JsonObject().encode());
     }

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -59,6 +59,7 @@ import org.mockito.ArgumentCaptor;
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -159,7 +160,9 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
     private static MqttContext newMqttContext(final MqttPublishMessage message, final MqttEndpoint endpoint) {
         final MqttContext result = new MqttContext(message, endpoint);
-        result.put(AbstractVertxBasedMqttProtocolAdapter.KEY_CURRENT_SPAN, mock(Span.class));
+        final Span currentSpan = mock(Span.class);
+        when(currentSpan.context()).thenReturn(mock(SpanContext.class));
+        result.put(AbstractVertxBasedMqttProtocolAdapter.KEY_CURRENT_SPAN, currentSpan);
         return result;
     }
 
@@ -639,8 +642,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
         final MessageSender sender = mock(MessageSender.class);
         when(sender.getEndpoint()).thenReturn(EventConstants.EVENT_ENDPOINT);
-        when(sender.send(any(Message.class))).thenReturn(outcome);
-        when(sender.sendAndWaitForOutcome(any(Message.class))).thenReturn(outcome);
+        when(sender.send(any(Message.class), (SpanContext) any())).thenReturn(outcome);
+        when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(outcome);
 
         when(messagingClient.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
     }
@@ -649,8 +652,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
         final MessageSender sender = mock(MessageSender.class);
         when(sender.getEndpoint()).thenReturn(TelemetryConstants.TELEMETRY_ENDPOINT);
-        when(sender.send(any(Message.class))).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
-        when(sender.sendAndWaitForOutcome(any(Message.class))).thenThrow(new UnsupportedOperationException());
+        when(sender.send(any(Message.class), (SpanContext) any())).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
+        when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenThrow(new UnsupportedOperationException());
 
         when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
     }
@@ -659,8 +662,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
         final MessageSender sender = mock(MessageSender.class);
         when(sender.getEndpoint()).thenReturn(TelemetryConstants.TELEMETRY_ENDPOINT);
-        when(sender.send(any(Message.class))).thenThrow(new UnsupportedOperationException());
-        when(sender.sendAndWaitForOutcome(any(Message.class))).thenReturn(outcome);
+        when(sender.send(any(Message.class), (SpanContext) any())).thenThrow(new UnsupportedOperationException());
+        when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(outcome);
 
         when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
     }


### PR DESCRIPTION
The protocol adapters include the sending of downstream telemetry and
event messages in the overall OpenTracing span for processing a request.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>