### PR TITLE
On all close calls to ProtonLink instances resources are freed.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/AbstractAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/AbstractAmqpEndpoint.java
@@ -18,6 +18,7 @@ import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.service.AbstractEndpoint;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.LinkHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -108,6 +109,7 @@ public abstract class AbstractAmqpEndpoint<T> extends AbstractEndpoint implement
         logger.info("Endpoint [{}] does not support data upload, closing link.", getName());
         receiver.setCondition(ProtonHelper.condition(AmqpError.NOT_IMPLEMENTED, "resource cannot be written to"));
         receiver.close();
+        LinkHelper.freeLinkResources(receiver);
     }
 
     @Override
@@ -115,6 +117,7 @@ public abstract class AbstractAmqpEndpoint<T> extends AbstractEndpoint implement
         logger.info("Endpoint [{}] does not support data retrieval, closing link.", getName());
         sender.setCondition(ProtonHelper.condition(AmqpError.NOT_IMPLEMENTED, "resource cannot be read from"));
         sender.close();
+        LinkHelper.freeLinkResources(sender);
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
@@ -32,6 +32,7 @@ import org.eclipse.hono.service.AbstractServiceBase;
 import org.eclipse.hono.service.auth.AuthorizationService;
 import org.eclipse.hono.service.auth.ClaimsBasedAuthorizationService;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.LinkHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -501,6 +502,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
                     con.getRemoteContainer());
             receiver.setCondition(ProtonHelper.condition(AmqpError.NOT_ALLOWED, "anonymous relay not supported"));
             receiver.close();
+            LinkHelper.freeLinkResources(receiver);
         } else {
             LOG.debug("client [container: {}] wants to open a link [address: {}] for sending messages",
                     con.getRemoteContainer(), receiver.getRemoteTarget());
@@ -520,6 +522,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
                             LOG.debug("subject [{}] is not authorized to WRITE to [{}]", user.getName(), targetResource);
                             receiver.setCondition(ProtonHelper.condition(AmqpError.UNAUTHORIZED_ACCESS.toString(), "unauthorized"));
                             receiver.close();
+                            LinkHelper.freeLinkResources(receiver);
                         }
                     });
                 }
@@ -527,6 +530,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
                 LOG.debug("client has provided invalid resource identifier as target address", e);
                 receiver.setCondition(ProtonHelper.condition(AmqpError.NOT_FOUND, "no such address"));
                 receiver.close();
+                LinkHelper.freeLinkResources(receiver);
             }
         }
     }
@@ -557,6 +561,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
                         LOG.debug("subject [{}] is not authorized to READ from [{}]", user.getName(), targetResource);
                         sender.setCondition(ProtonHelper.condition(AmqpError.UNAUTHORIZED_ACCESS.toString(), "unauthorized"));
                         sender.close();
+                        LinkHelper.freeLinkResources(sender);
                     }
                 });
             }
@@ -564,6 +569,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
             LOG.debug("client has provided invalid resource identifier as target address", e);
             sender.setCondition(ProtonHelper.condition(AmqpError.NOT_FOUND, "no such address"));
             sender.close();
+            LinkHelper.freeLinkResources(sender);
         }
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/RequestResponseEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/RequestResponseEndpoint.java
@@ -25,6 +25,7 @@ import org.eclipse.hono.service.auth.ClaimsBasedAuthorizationService;
 import org.eclipse.hono.util.AmqpErrorException;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventBusMessage;
+import org.eclipse.hono.util.LinkHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -121,6 +122,7 @@ public abstract class RequestResponseEndpoint<T extends ServiceConfigProperties>
             logger.debug("client wants to use unsupported AT MOST ONCE delivery mode for endpoint [{}], closing link ...", getName());
             receiver.setCondition(ProtonHelper.condition(AmqpError.PRECONDITION_FAILED.toString(), "endpoint requires AT_LEAST_ONCE QoS"));
             receiver.close();
+            LinkHelper.freeLinkResources(receiver);
         } else {
 
             logger.debug("establishing link for receiving messages from client [{}]", receiver.getName());
@@ -284,6 +286,7 @@ public abstract class RequestResponseEndpoint<T extends ServiceConfigProperties>
                 if (senderClosed.succeeded()) {
                     senderClosed.result().close();
                 }
+                LinkHelper.freeLinkResources(sender);
             });
             sender.open();
         } else {
@@ -291,6 +294,7 @@ public abstract class RequestResponseEndpoint<T extends ServiceConfigProperties>
             sender.setCondition(ProtonHelper.condition(AmqpError.INVALID_FIELD,
                     String.format("reply-to address must have the following format %s/<tenant>/<reply-address>", getName())));
             sender.close();
+            LinkHelper.freeLinkResources(sender);
         }
     }
 

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/AuthenticationEndpoint.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/AuthenticationEndpoint.java
@@ -18,6 +18,7 @@ import org.eclipse.hono.auth.HonoUser;
 import org.eclipse.hono.service.amqp.AbstractAmqpEndpoint;
 import org.eclipse.hono.util.AuthenticationConstants;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.LinkHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,6 +72,7 @@ public class AuthenticationEndpoint extends AbstractAmqpEndpoint<AuthenticationS
                     logger.debug("failed to transfer auth token to client");
                 }
                 sender.close();
+                LinkHelper.freeLinkResources(sender);
             });
         } else {
             onLinkDetach(sender, ProtonHelper.condition(AmqpError.INVALID_FIELD, "supports AT_LEAST_ONCE delivery mode only"));

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
@@ -28,6 +28,7 @@ import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.amqp.AmqpEndpoint;
 import org.eclipse.hono.service.amqp.AmqpServiceBase;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.LinkHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -153,6 +154,7 @@ public final class SimpleAuthenticationServer extends AmqpServiceBase<ServiceCon
     @Override
     protected void handleReceiverOpen(final ProtonConnection con, final ProtonReceiver receiver) {
         receiver.setCondition(ProtonHelper.condition(AmqpError.NOT_ALLOWED, "cannot write to node")).close();
+        LinkHelper.freeLinkResources(receiver);
     }
 
     /**

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/MessageForwardingEndpoint.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/MessageForwardingEndpoint.java
@@ -26,6 +26,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.service.amqp.AbstractAmqpEndpoint;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.LinkHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -145,6 +146,7 @@ public abstract class MessageForwardingEndpoint<T extends HonoMessagingConfigPro
                     con.getRemoteContainer(), receiver.getRemoteQoS(), getName(), getEndpointQos());
             receiver.setCondition(ErrorConditions.ERROR_UNSUPPORTED_DELIVERY_MODE);
             receiver.close();
+            LinkHelper.freeLinkResources(receiver);
         } else {
             receiver.setQoS(receiver.getRemoteQoS());
             receiver.setTarget(receiver.getRemoteTarget());
@@ -160,6 +162,7 @@ public abstract class MessageForwardingEndpoint<T extends HonoMessagingConfigPro
                         // client has closed link -> inform TelemetryAdapter about client detach
                         onLinkDetach(link);
                         downstreamAdapter.onClientDetach(link);
+                        LinkHelper.freeLinkResources(receiver);
                         metrics.decrementUpstreamLinks(targetAddress.toString());
                     });
                     receiver.handler((delivery, message) -> {

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/SenderFactoryImpl.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/SenderFactoryImpl.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.messaging;
 import java.util.Objects;
 
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.LinkHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,6 +134,7 @@ public class SenderFactoryImpl implements SenderFactory {
                         connection.getRemoteContainer(), closed.cause().getMessage());
             }
             sender.close();
+            LinkHelper.freeLinkResources(sender);
             if (closeHook != null) {
                 closeHook.handle(address.getResourceId());
             }

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/UpstreamReceiverImpl.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/UpstreamReceiverImpl.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.LinkHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +80,7 @@ public class UpstreamReceiverImpl implements UpstreamReceiver {
             link.setCondition(error);
         }
         link.close();
+        LinkHelper.freeLinkResources(link);
     }
 
     @Override


### PR DESCRIPTION
All calls to close that are not controlled by HonoClient additionally
call the helper method to free resources. This is true for error cases
and for closeHandlers (where defined). Resources are NOT freed in
onDetach methods (with closed=false).

Signed-off-by: Karsten Frank <Karsten.Frank@bosch-si.com>