### PR TITLE
Improve error handling of HTTP adapter and HTTP based endpoints.

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -30,6 +30,7 @@ import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.auth.device.Device;
 import org.eclipse.hono.service.command.CommandResponseSender;
+import org.eclipse.hono.service.http.DefaultFailureHandler;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
@@ -51,7 +52,6 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
@@ -176,7 +176,9 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                     return Future.failedFuture("no router configured");
                 } else {
                     addRoutes(router);
-                    addTracingHandler(router);
+                    addTracingHandler(router, -5);
+                    // add default handler for failed routes
+                    router.route().order(-1).failureHandler(new DefaultFailureHandler());
                     return CompositeFuture.all(bindSecureHttpServer(router), bindInsecureHttpServer(router));
                 }
             }).compose(s -> {
@@ -193,9 +195,10 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
     /**
      * Adds a handler for adding an OpenTracing Span to the routing context.
      * 
-     * @param router The router.
+     * @param router The router to add the handler to.
+     * @param position The position to add the tracing handler at.
      */
-    private void addTracingHandler(final Router router) {
+    private void addTracingHandler(final Router router, final int position) {
         final Map<String, String> customTags = new HashMap<>();
         customTags.put(Tags.COMPONENT.getKey(), getTypeName());
         addCustomTags(customTags);
@@ -203,7 +206,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
         decorators.add(new ComponentMetaDataDecorator(customTags));
         addCustomSpanDecorators(decorators);
         final TracingHandler tracingHandler = new TracingHandler(tracer, decorators);
-        router.route().order(-1).handler(tracingHandler).failureHandler(tracingHandler);
+        router.route().order(position).handler(tracingHandler).failureHandler(tracingHandler);
     }
 
     /**
@@ -445,7 +448,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
     }
 
     /**
-     * Uploads the body of an HTTP request as a telemetry message to the Hono server.
+     * Uploads the body of an HTTP request as a telemetry message to Hono.
      * <p>
      * This method simply invokes {@link #uploadTelemetryMessage(RoutingContext, String, String, Buffer, String)}
      * with objects retrieved from the routing context.
@@ -466,15 +469,12 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
     }
 
     /**
-     * Uploads a telemetry message to the Hono server.
+     * Uploads a telemetry message to Hono.
      * <p>
-     * Depending on the outcome of the attempt to upload the message to Hono, the HTTP response's code is
-     * set as follows:
-     * <ul>
-     * <li>202 (Accepted) - if the telemetry message has been sent to the Hono server.</li>
-     * <li>400 (Bad Request) - if the message payload is {@code null} or empty or if the content type is {@code null}.</li>
-     * <li>503 (Service Unavailable) - if the message could not be sent to the Hono server, e.g. due to lack of connection or credit.</li>
-     * </ul>
+     * This method always sends a response to the device. The status code will be set
+     * as specified in the
+     * <a href="https://www.eclipse.org/hono/user-guide/http-adapter/#publish-telemetry-data-authenticated-device">
+     * HTTP adapter User Guide</a>.
      *
      * @param ctx The context to retrieve cookies and the HTTP response from.
      * @param tenant The tenant of the device that has produced the data.
@@ -497,7 +497,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
     }
 
     /**
-     * Uploads the body of an HTTP request as an event message to the Hono server.
+     * Uploads the body of an HTTP request as an event message to Hono.
      * <p>
      * This method simply invokes {@link #uploadEventMessage(RoutingContext, String, String, Buffer, String)}
      * with objects retrieved from the routing context.
@@ -518,15 +518,12 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
     }
 
     /**
-     * Uploads an event message to the Hono server.
+     * Uploads an event message to Hono.
      * <p>
-     * Depending on the outcome of the attempt to upload the message to Hono, the HTTP response's code is
-     * set as follows:
-     * <ul>
-     * <li>202 (Accepted) - if the telemetry message has been sent to the Hono server.</li>
-     * <li>400 (Bad Request) - if the message payload is {@code null} or empty or if the content type is {@code null}.</li>
-     * <li>503 (Service Unavailable) - if the message could not be sent to the Hono server, e.g. due to lack of connection or credit.</li>
-     * </ul>
+     * This method always sends a response to the device. The status code will be set
+     * as specified in the
+     * <a href="https://www.eclipse.org/hono/user-guide/http-adapter/#publish-an-event-authenticated-device">
+     * HTTP adapter User Guide</a>.
      *
      * @param ctx The context to retrieve cookies and the HTTP response from.
      * @param tenant The tenant of the device that has produced the data.
@@ -552,13 +549,11 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             final Buffer payload, final String contentType, final Future<MessageSender> senderTracker, final String endpointName) {
 
         if (!isPayloadOfIndicatedType(payload, contentType)) {
-            HttpUtils.badRequest(ctx, String.format("Content-Type %s does not match with the payload", contentType));
+            HttpUtils.badRequest(ctx, String.format("content type [%s] does not match payload", contentType));
         } else {
             final Integer qosHeader = getQoSLevel(ctx.request().getHeader(Constants.HEADER_QOS_LEVEL));
-            if (contentType == null) {
-                HttpUtils.badRequest(ctx, String.format("%s header is missing", HttpHeaders.CONTENT_TYPE));
-            } else if (qosHeader != null && qosHeader == HEADER_QOS_INVALID) {
-                HttpUtils.badRequest(ctx, "Bad QoS Header Value");
+            if (qosHeader != null && qosHeader == HEADER_QOS_INVALID) {
+                HttpUtils.badRequest(ctx, "unsupported QoS-Level header value");
             } else {
 
                 final Device authenticatedDevice = getAuthenticatedDevice(ctx);
@@ -641,10 +636,10 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
 
                     if (ClientErrorException.class.isInstance(t)) {
                         final ClientErrorException e = (ClientErrorException) t;
-                        ctx.fail(e.getErrorCode());
+                        ctx.fail(e);
                     } else {
                         metrics.incrementUndeliverableHttpMessages(endpointName, tenant);
-                        HttpUtils.serviceUnavailable(ctx, 2);
+                        HttpUtils.serviceUnavailable(ctx, 2, "temporarily unavailable");
                     }
                     return Future.failedFuture(t);
                 });
@@ -823,10 +818,10 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                             commandResponseSender.sendCommandResponse(correlationId, contentType, payload, null, statusCode)
                     ).map(delivery -> {
                         if (delivery.remotelySettled()) {
-                            LOG.debug("Command response [command-request-id: {}] acknowledged to sender.", commandRequestId);
+                            LOG.debug("command response [command-request-id: {}] acknowledged to sender.", commandRequestId);
                             ctx.response().setStatusCode(HttpURLConnection.HTTP_ACCEPTED);
                         } else {
-                            LOG.debug("Command response [command-request-id: {}] failed - not remotely settled by sender.", commandRequestId);
+                            LOG.debug("command response [command-request-id: {}] failed - not remotely settled by sender.", commandRequestId);
                             ctx.response().setStatusCode(HttpURLConnection.HTTP_UNAVAILABLE);
                         }
                         responseSender.result().close(v -> {
@@ -834,7 +829,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                         ctx.response().end();
                         return delivery;
                     }).otherwise(t -> {
-                        LOG.debug("Command response [command-request-id: {}] failed", commandRequestId, t);
+                        LOG.debug("command response [command-request-id: {}] failed", commandRequestId, t);
                         Optional.ofNullable(responseSender.result()).map(r -> {
                             r.close(v -> {
                             });
@@ -847,17 +842,14 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
 
                     return commandRequestIdParts;
                 }).orElseGet(() -> {
-                    HttpUtils.badRequest(ctx, String.format("Cannot process command response message - command-request-id %s invalid", commandRequestId));
+                    HttpUtils.badRequest(ctx, String.format("command-request-id [%s] invalid", commandRequestId));
                     return null;
                 })
         ).orElseGet(() -> {
-            HttpUtils.badRequest(ctx, String.format("Cannot process command response message - status code %s invalid", commandRequestStatus));
+            HttpUtils.badRequest(ctx, String.format("status code [%s] invalid", commandRequestStatus));
             return null;
         });
-
     }
-
-
 
     private static Integer getQoSLevel(final String qosValue) {
         try {

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoAuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoAuthHandler.java
@@ -227,10 +227,10 @@ public abstract class HonoAuthHandler implements AuthHandler {
                 ctx.response()
                   .putHeader("WWW-Authenticate", header);
               }
-              ctx.fail(401);
+              ctx.fail(exception);
               return;
             default:
-              ctx.fail(statusCode);
+              ctx.fail(exception);
               return;
           }
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/http/DefaultFailureHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/DefaultFailureHandler.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 1.0 which is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ */
+
+package org.eclipse.hono.service.http;
+
+import java.net.HttpURLConnection;
+
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.impl.HttpStatusException;
+
+
+/**
+ * A generic handler for {@link ServiceInvocationException}s that have caused
+ * an HTTP request to fail.
+ * <p>
+ * This handler can be registered on a {@code io.vertx.ext.web.Route} using its
+ * <em>failureHandler</em> method. The handler inspects the route's <em>failure</em>
+ * property and sets the HTTP response's status code and body based on the exception
+ * type. If the error is a {@code ServiceInvocationException} then the response's
+ * status code and body are set to the exception's <em>errorCode</em> and <em>message</em>
+ * property values respectively. Otherwise the status code is set to 500.
+ */
+public class DefaultFailureHandler implements Handler<RoutingContext> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultFailureHandler.class);
+
+    /**
+     * Handles routing failures.
+     * 
+     * @param ctx The failing routing context.
+     */
+    @Override
+    public void handle(final RoutingContext ctx) {
+
+        if (ctx.failed()) {
+            LOG.debug("handling failed route for request [method: {}, URI: {}]",
+                    ctx.request().method(), ctx.request().absoluteURI());
+            if (ctx.response().ended()) {
+                LOG.debug("cannot handle error, response already ended");
+            } else if (ctx.failure() != null) {
+                if (ctx.failure() instanceof ServiceInvocationException) {
+                    final ServiceInvocationException e = (ServiceInvocationException) ctx.failure();
+                    sendError(ctx.response(), e.getErrorCode(), e.getMessage());
+                } else if (ctx.failure() instanceof HttpStatusException) {
+                    final HttpStatusException e = (HttpStatusException) ctx.failure();
+                    sendError(ctx.response(), e.getStatusCode(), e.getMessage());
+                } else {
+                    sendError(ctx.response(), HttpURLConnection.HTTP_INTERNAL_ERROR, ctx.failure().getMessage());
+                }
+            } else if (ctx.statusCode() != -1) {
+                sendError(ctx.response(), ctx.statusCode(), ctx.response().getStatusMessage());
+            } else {
+                sendError(ctx.response(), HttpURLConnection.HTTP_INTERNAL_ERROR, "Internal Server Error");
+            }
+        } else {
+            LOG.debug("skipping processing of non-failed route");
+            ctx.next();
+        }
+    }
+
+    private void sendError(final HttpServerResponse response, final int errorCode, final String errorMessage) {
+        if (response.ended()) {
+            throw new IllegalStateException("response already ended");
+        } else {
+            response.putHeader(HttpHeaders.CONTENT_TYPE, HttpUtils.CONTENT_TYPE_TEXT_UFT8);
+            response.setStatusCode(errorCode);
+            response.end(errorMessage);
+        }
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -164,8 +164,9 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
 
         final Router router = Router.router(vertx);
         LOG.info("limiting size of inbound request body to {} bytes", getConfig().getMaxPayloadSize());
-        router.route().handler(BodyHandler.create().setBodyLimit(getConfig().getMaxPayloadSize())
-                .setUploadsDirectory(DEFAULT_UPLOADS_DIRECTORY));
+        router.route()
+            .handler(BodyHandler.create().setBodyLimit(getConfig().getMaxPayloadSize()).setUploadsDirectory(DEFAULT_UPLOADS_DIRECTORY))
+            .failureHandler(new DefaultFailureHandler());
 
         return router;
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/device/HonoAuthHandlerImplTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/device/HonoAuthHandlerImplTest.java
@@ -17,10 +17,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,10 +75,10 @@ public class HonoAuthHandlerImplTest {
 
         // GIVEN an auth handler configured with an auth provider that
         // fails with a 503 error code during authentication
-        final int EXPECTED_ERROR_CODE = 503;
+        final ServiceInvocationException error = new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE);
         doAnswer(invocation -> {
             final Handler handler = invocation.getArgument(1);
-            handler.handle(Future.failedFuture(new ServerErrorException(EXPECTED_ERROR_CODE)));
+            handler.handle(Future.failedFuture(error));
             return null;
         }).when(authProvider).authenticate(any(JsonObject.class), any(Handler.class));
 
@@ -96,7 +98,7 @@ public class HonoAuthHandlerImplTest {
         authHandler.handle(ctx);
 
         // THEN the request context is failed with the 503 error code
-        verify(ctx).fail(EXPECTED_ERROR_CODE);
+        verify(ctx).fail(error);
     }
 
 }


### PR DESCRIPTION
A DefaultFailureHandler is now registered on the adapter's Router to
handle ServiceInvocationExceptions that have caused a RoutingContext to
fail. The handler creates an HTTP response corresponding to the
exception's fields.

The HttpUtils methods now fail the routing context with a
ServiceInvocationException instead of just a status code. This way we
can convey additional information to the client, e.g. the detail message
that is contained in the exception.
