### PR TITLE
[#701] Improve JMeter plugin Receiver UI concerning useSenderTime options

### DIFF
--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
@@ -60,7 +60,7 @@ public class HonoReceiver extends AbstractClient {
     public HonoReceiver(final HonoReceiverSampler sampler) {
 
         super();
-        if (sampler.isUseSenderTime() && sampler.getSenderTimeVariableName() == null) {
+        if (sampler.isUseSenderTime() && sampler.isSenderTimeInPayload() && sampler.getSenderTimeVariableName() == null) {
             throw new IllegalArgumentException("SenderTime VariableName must be set when using SenderTime flag");
         }
         this.sampler = sampler;
@@ -254,7 +254,7 @@ public class HonoReceiver extends AbstractClient {
         final Long senderTime = MessageHelper.getApplicationProperty(message.getApplicationProperties(), TIME_STAMP_VARIABLE,
                 Long.class);
         if (senderTime == null) {
-            LOGGER.warn("could not get sender time from 'timeStamp' message application property");
+            LOGGER.warn("could not get sender time from '" + TIME_STAMP_VARIABLE + "' message application property");
         }
         return senderTime;
     }


### PR DESCRIPTION
This fixes #701:
Adds RadioButtons for the `useSenderTime` options to make clear what the default behaviour is.

Also fixes alignment and padding of the `endpoint` JLabeledChoice.