### PR TITLE
[#703] JMeter plugin: Sender timeout configurable

### DIFF
--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSenderSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSenderSampler.java
@@ -37,6 +37,8 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HonoSenderSampler.class);
 
+    public static final int DEFAULT_SEND_TIMEOUT = 1000; // milliseconds
+
     private static final String REGISTRY_HOST = "registryHost";
     private static final String REGISTRY_USER = "registryUser";
     private static final String REGISTRY_PWD = "registryPwd";
@@ -50,6 +52,7 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
     private static final String WAIT_FOR_CREDITS = "waitForCredits";
     private static final String WAIT_FOR_RECEIVERS = "waitForReceivers";
     private static final String WAIT_FOR_RECEIVERS_TIMEOUT = "waitForReceiversTimeout";
+    private static final String SEND_TIMEOUT = "sendTimeout";
     private static final String PROPERTY_REGISTRATION_ASSERTION = "PROPERTY_REGISTRATION_ASSERTION";
 
     private HonoSender honoSender;
@@ -215,6 +218,44 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
         setProperty(WAIT_FOR_RECEIVERS_TIMEOUT, waitForReceiversTimeout);
     }
 
+    /**
+     * Gets the timeout for sending a message in milliseconds as integer.
+     *
+     * @return The timeout for sending a message in milliseconds or the default timeout
+     * if the value is empty or cannot be parsed as integer.
+     */
+    public int getSendTimeoutOrDefaultAsInt() {
+        final String value = getPropertyAsString(SEND_TIMEOUT);
+        if (value == null || value.isEmpty()) {
+            return DEFAULT_SEND_TIMEOUT;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
+            return DEFAULT_SEND_TIMEOUT;
+        }
+    }
+
+    /**
+     * Gets the timeout for sending a message in milliseconds.
+     * 
+     * @return The timeout for sending a message in milliseconds or the default timeout
+     * if the value is empty.
+     */
+    public String getSendTimeoutOrDefault() {
+        final String value = getPropertyAsString(SEND_TIMEOUT);
+        return value == null || value.isEmpty() ? Integer.toString(DEFAULT_SEND_TIMEOUT) : value;
+    }
+
+    /**
+     * Sets the timeout for sending a message.
+     * 
+     * @param sendTimeout The timeout in milliseconds encoded as string.
+     */
+    public void setSendTimeout(final String sendTimeout) {
+        setProperty(SEND_TIMEOUT, sendTimeout);
+    }
+
     public String getDeviceId() {
         return getPropertyAsString(DEVICE_ID);
     }
@@ -321,6 +362,7 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
                     Thread.sleep(100);
                 } catch (final InterruptedException e) {
                     LOGGER.error("wait on receiver", e);
+                    Thread.currentThread().interrupt();
                 }
                 activeReceivers = getSemaphores();
                 LOGGER.info("wait on receivers ({}/{}) for address: {} ({})", activeReceivers, waitOn, getAddress(),

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
@@ -51,7 +51,6 @@ public class HonoSender extends AbstractClient {
 
     private static final int MAX_RECONNECT_ATTEMPTS = 3;
     private static final Logger LOGGER = LoggerFactory.getLogger(HonoSender.class);
-    private static final int SAMPLE_SEND_TIMEOUT = 1; // seconds
 
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final HonoSenderSampler sampler;
@@ -268,7 +267,7 @@ public class HonoSender extends AbstractClient {
         });
 
         try {
-            tracker.get(SAMPLE_SEND_TIMEOUT, TimeUnit.SECONDS);
+            tracker.get(sampler.getSendTimeoutOrDefaultAsInt(), TimeUnit.MILLISECONDS);
             LOGGER.debug("{}: sent message for device [{}]", sampler.getThreadName(), deviceId);
         } catch (InterruptedException | CancellationException | ExecutionException | TimeoutException e) {
             sampleResult.setSuccessful(false);

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSenderSamplerUI.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSenderSamplerUI.java
@@ -38,6 +38,7 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
     private final JLabeledTextField  assertion;
     private final JLabeledTextField  waitForReceivers;
     private final JLabeledTextField  waitForReceiversTimeout;
+    private final JLabeledTextField  sampleSendTimeout;
     private final ServerOptionsPanel registrationServiceOptions;
     private final JLabeledTextField  tenant;
     private final JLabeledTextField  container;
@@ -76,6 +77,7 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
                 "Number of receivers to wait for (e.g. from other threads)");
         waitForReceiversTimeout = new JLabeledTextField(
                 "Max time (millis) to wait for receivers");
+        sampleSendTimeout = new JLabeledTextField("Max time (millis) for sending a message");
 
         addOption(honoServerOptions);
         addOption(tenant);
@@ -90,6 +92,7 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
         addOption(setSenderTime);
         addOption(waitForReceivers);
         addOption(waitForReceiversTimeout);
+        addOption(sampleSendTimeout);
     }
 
     @Override
@@ -118,6 +121,7 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
         sampler.setWaitForCredits(waitForCredits.isSelected());
         sampler.setWaitForReceivers(waitForReceivers.getText());
         sampler.setWaitForReceiversTimeout(waitForReceiversTimeout.getText());
+        sampler.setSendTimeout(sampleSendTimeout.getText());
         sampler.setContentType(contentType.getText());
         sampler.setData(data.getText());
         sampler.setRegistrationAssertion(assertion.getText());
@@ -136,6 +140,7 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
         deviceId.setText(sampler.getDeviceId());
         waitForReceivers.setText(sampler.getWaitForReceivers());
         waitForReceiversTimeout.setText(sampler.getWaitForReceiversTimeout());
+        sampleSendTimeout.setText(sampler.getSendTimeoutOrDefault());
         setSenderTime.setSelected(sampler.isSetSenderTime());
         waitForCredits.setSelected(sampler.isWaitForCredits());
         contentType.setText(sampler.getContentType());
@@ -160,6 +165,7 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
         waitForCredits.setSelected(true);
         waitForReceivers.setText("0");
         waitForReceiversTimeout.setText("5000");
+        sampleSendTimeout.setText(Integer.toString(HonoSenderSampler.DEFAULT_SEND_TIMEOUT));
         // device registration service
         registrationServiceOptions.clearGui();
     }


### PR DESCRIPTION
This fixes #703:
Make the timeout for sending a message configurable.