### PR TITLE
[#319] Support tracing of TenantClient requests.

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Bosch Software Innovations GmbH - add Open Tracing support
  */
 
 package org.eclipse.hono.adapter.http;
@@ -564,7 +565,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                 }).orElse(null);
 
                 final Future<JsonObject> tokenTracker = getRegistrationAssertion(tenant, deviceId, authenticatedDevice);
-                final Future<TenantObject> tenantConfigTracker = getTenantConfiguration(tenant);
+                final Future<TenantObject> tenantConfigTracker = getTenantConfiguration(tenant, currentSpan);
                 final Future<MessageConsumer> commandConsumerTracker = createCommandConsumer(tenant, deviceId, ctx, responseReady);
 
                 CompositeFuture.all(tokenTracker, tenantConfigTracker, senderTracker, commandConsumerTracker).compose(ok -> {

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -92,7 +92,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         when(regClient.assertRegistration(anyString(), any())).thenReturn(Future.succeededFuture(result));
 
         tenantClient = mock(TenantClient.class);
-        when(tenantClient.get(anyString())).thenAnswer(invocation -> {
+        when(tenantClient.get(anyString(), (SpanContext) any())).thenAnswer(invocation -> {
             return Future.succeededFuture(TenantObject.from(invocation.getArgument(0), true));
         });
 
@@ -209,7 +209,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         myTenantConfig.addAdapterConfiguration(new JsonObject()
                 .put(TenantConstants.FIELD_ADAPTERS_TYPE, ADAPTER_TYPE)
                 .put(TenantConstants.FIELD_ENABLED, false));
-        when(tenantClient.get("my-tenant")).thenReturn(Future.succeededFuture(myTenantConfig));
+        when(tenantClient.get(eq("my-tenant"), any())).thenReturn(Future.succeededFuture(myTenantConfig));
         final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
 
         // WHEN a device that belongs to "my-tenant" publishes a telemetry message

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapterTest.java
@@ -206,7 +206,7 @@ public class VertxBasedHttpProtocolAdapterTest {
         final TenantClient tenantClient = mock(TenantClient.class);
         doAnswer(invocation -> {
             return Future.succeededFuture(TenantObject.from(invocation.getArgument(0), true));
-        }).when(tenantClient).get(anyString());
+        }).when(tenantClient).get(anyString(), (SpanContext) any());
         when(tenantServiceClient.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
 
         final MessageConsumer commandConsumer = mock(MessageConsumer.class);

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -129,7 +129,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(regClient.assertRegistration(anyString(), any())).thenReturn(Future.succeededFuture(result));
 
         tenantClient = mock(TenantClient.class);
-        when(tenantClient.get(anyString())).thenAnswer(invocation -> {
+        when(tenantClient.get(anyString(), (SpanContext) any())).thenAnswer(invocation -> {
             return Future.succeededFuture(TenantObject.from(invocation.getArgument(0), true));
         });
 
@@ -255,7 +255,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         myTenantConfig.addAdapterConfiguration(new JsonObject()
                 .put(TenantConstants.FIELD_ADAPTERS_TYPE, ADAPTER_TYPE)
                 .put(TenantConstants.FIELD_ENABLED, false));
-        when(tenantClient.get("my-tenant")).thenReturn(Future.succeededFuture(myTenantConfig));
+        when(tenantClient.get(eq("my-tenant"), (SpanContext) any())).thenReturn(Future.succeededFuture(myTenantConfig));
         final AbstractVertxBasedMqttProtocolAdapter<ProtocolAdapterProperties> adapter = getAdapter(server);
         forceClientMocksToConnected();
 
@@ -417,7 +417,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         myTenantConfig.addAdapterConfiguration(new JsonObject()
                 .put(TenantConstants.FIELD_ADAPTERS_TYPE, ADAPTER_TYPE)
                 .put(TenantConstants.FIELD_ENABLED, false));
-        when(tenantClient.get("my-tenant")).thenReturn(Future.succeededFuture(myTenantConfig));
+        when(tenantClient.get(eq("my-tenant"), (SpanContext) any())).thenReturn(Future.succeededFuture(myTenantConfig));
         final AbstractVertxBasedMqttProtocolAdapter<ProtocolAdapterProperties> adapter = getAdapter(server);
         forceClientMocksToConnected();
         final MessageSender sender = mock(MessageSender.class);

--- a/client/src/main/java/org/eclipse/hono/client/TenantClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/TenantClient.java
@@ -13,11 +13,12 @@
 
 package org.eclipse.hono.client;
 
-import io.vertx.core.Future;
-
 import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
 
 /**
  * A client for accessing Hono's Tenant API.
@@ -41,8 +42,34 @@ public interface TenantClient extends RequestResponseClient {
      *         <li>Otherwise, the future will fail with a {@link ServiceInvocationException} containing
      *         the (error) status code returned by the service.</li>
      *         </ul>
+     * @throws NullPointerException if tenant ID is {@code null}.
      */
     Future<TenantObject> get(String tenantId);
+
+    /**
+     * Gets configuration information for a tenant.
+     * <p>
+     * This default implementation simply returns the result of
+     * {@link #get(String)}.
+     * 
+     * @param tenantId The id of the tenant to retrieve details for.
+     * @param context The currently active OpenTracing span. An implementation
+     *         should use this as the parent for any span it creates for tracing
+     *         the execution of this operation.
+     * @return A future indicating the result of the operation.
+     *         <ul>
+     *         <li>The future will succeed if a response with status 200 has been received from the
+     *         tenant service. The JSON object will then contain values as defined in
+     *         <a href="https://www.eclipse.org/hono/api/tenant-api/#get-tenant-information">
+     *         Get Tenant Information</a>.</li>
+     *         <li>Otherwise, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code returned by the service.</li>
+     *         </ul>
+     * @throws NullPointerException if tenant ID is {@code null}.
+     */
+    default Future<TenantObject> get(final String tenantId, final SpanContext context) {
+        return get(tenantId);
+    }
 
     /**
      * Gets tenant configuration information for the <em>subject DN</em>
@@ -63,6 +90,38 @@ public interface TenantClient extends RequestResponseClient {
      *         <li>Otherwise, the future will fail with a {@link ServiceInvocationException} containing
      *         the (error) status code returned by the service.</li>
      *         </ul>
+     * @throws NullPointerException if subject DN is {@code null}.
      */
     Future<TenantObject> get(X500Principal subjectDn);
+
+    /**
+     * Gets tenant configuration information for the <em>subject DN</em>
+     * of a trusted certificate authority.
+     * <p>
+     * This method can e.g. be used when trying to authenticate a device based on
+     * an X.509 client certificate. Using this method, the <em>issuer DN</em> from the
+     * client's certificate can be used to determine the tenant that the device belongs to.
+     * <p>
+     * This default implementation simply returns the result of
+     * {@link #get(X500Principal)}.
+     * 
+     * @param subjectDn The <em>subject DN</em> of the trusted CA certificate
+     *                  that has been configured for the tenant.
+     * @param context The currently active OpenTracing span. An implementation
+     *         should use this as the parent for any span it creates for tracing
+     *         the execution of this operation.
+     * @return A future indicating the result of the operation.
+     *         <ul>
+     *         <li>The future will succeed if a response with status 200 has been received from the
+     *         tenant service. The JSON object will then contain values as defined in
+     *         <a href="https://www.eclipse.org/hono/api/tenant-api/#get-tenant-information">
+     *         Get Tenant Information</a>.</li>
+     *         <li>Otherwise, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code returned by the service.</li>
+     *         </ul>
+     * @throws NullPointerException if subject DN is {@code null}.
+     */
+    default Future<TenantObject> get(final X500Principal subjectDn, final SpanContext context) {
+        return get(subjectDn);
+    }
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
@@ -857,6 +857,7 @@ public class HonoClientImpl implements HonoClient {
                     context,
                     clientConfigProperties,
                     cacheProvider,
+                    tracer,
                     connection,
                     this::removeTenantClient,
                     this::removeTenantClient,

--- a/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
@@ -37,6 +37,22 @@ public final class TracingHelper {
      */
     public static final BooleanTag TAG_AUTHENTICATED = new BooleanTag("authenticated");
     /**
+     * An OpenTracing tag that is used to indicate if the result of an operation
+     * has been taken from a local cache.
+     */
+    public static final BooleanTag TAG_CACHE_HIT = new BooleanTag("cache_hit");
+    /**
+     * An OpenTracing tag that contains the (transport protocol specific) identifier of a
+     * client connecting to a server. This could be the MQTT <em>client identifier</em> or the
+     * AMQP 1.0 <em>container name</em>.
+     */
+    public static final StringTag TAG_CLIENT_ID = new StringTag("client_id");
+    /**
+     * An OpenTracing tag that contains the identifier used to correlate a response
+     * with a request message.
+     */
+    public static final StringTag TAG_CORRELATION_ID = new StringTag("message_bus.correlation_id");
+    /**
      * An OpenTracing tag that contains the number of available credits for a sender link.
      */
     public static final IntTag TAG_CREDIT = new IntTag("message_bus.credit");

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -9,6 +9,7 @@
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
  *    Red Hat Inc
+ *    Bosch Software Innovations GmbH - add Open Tracing support
  */
 package org.eclipse.hono.service;
 
@@ -50,6 +51,7 @@ import org.eclipse.hono.util.TenantObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -642,10 +644,31 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @throws NullPointerException if tenant ID is {@code null}.
      */
     protected final Future<TenantObject> getTenantConfiguration(final String tenantId) {
+        Objects.requireNonNull(tenantId);
+        return getTenantClient().compose(client -> client.get(tenantId));
+    }
+
+    /**
+     * Gets configuration information for a tenant.
+     * <p>
+     * The returned JSON object contains information as defined by Hono's
+     * <a href="https://www.eclipse.org/hono/api/tenant-api/#response-payload">Tenant API</a>.
+     * 
+     * @param tenantId The tenant to retrieve information for.
+     * @param context The currently active OpenTracing span that is used to
+     *                trace the retrieval of the tenant configuration.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will fail if the information cannot be retrieved. The cause will be a
+     *         {@link ServiceInvocationException} containing a corresponding error code.
+     *         <p>
+     *         Otherwise the future will contain the configuration information.
+     * @throws NullPointerException if tenant ID is {@code null}.
+     */
+    protected final Future<TenantObject> getTenantConfiguration(final String tenantId, final SpanContext context) {
 
         Objects.requireNonNull(tenantId);
-
-        return getTenantClient().compose(client -> client.get(tenantId));
+        return getTenantClient().compose(client -> client.get(tenantId, context));
     }
 
     /**


### PR DESCRIPTION
The TenanClientImpl methods have been instrumented with OpenTracing API calls.
The protocol adapters invoke the variants of the TenantClient's methods that accept a SpanContext.