### PR TITLE
amqp adapter - Improve device authentication

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpContext.java
@@ -106,6 +106,16 @@ public class AmqpContext {
     Device getAuthenticatedDevice() {
         return authenticatedDevice;
     }
+
+    /**
+     * Determines if the AMQP 1.0 device is authenticated to the adapter.
+     * 
+     * @return True if the device is authenticated or false otherwise.
+     */
+    boolean isDeviceAuthenticated() {
+        return authenticatedDevice != null;
+    }
+
     /**
      * Sets an AMQP 1.0 message delivery state to either RELEASED in the case of a <em>ServerErrorException</em> or REJECTED in the
      * case of a <em>ClientErrorException</em>. In the REJECTED case, the supplied exception will provide

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/Config.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/Config.java
@@ -81,7 +81,6 @@ public class Config extends AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.amqp")
     public ProtocolAdapterProperties adapterProperties() {
         final ProtocolAdapterProperties config = new ProtocolAdapterProperties();
-        config.setAuthenticationRequired(false);
         return config;
     }
 


### PR DESCRIPTION
This patch improves the AMQP adapter code base to allow it to properly authenticate client devices using SASL PLAIN.

@sophokles73: These changes were included in the ITs patch. This split contains only changes made to the adapter code base.

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>