### PR TITLE
Support content type in command messages

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -725,7 +725,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             response.putHeader(Constants.HEADER_COMMAND, command.getName());
             response.putHeader(Constants.HEADER_COMMAND_REQUEST_ID, command.getRequestId());
 
-            HttpUtils.setResponseBody(response, command.getPayload());
+            HttpUtils.setResponseBody(response, command.getPayload(), command.getContentType());
         }
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/CommandClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandClient.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.client;
 
+import org.eclipse.hono.util.BufferResult;
+
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 
@@ -42,7 +44,7 @@ public interface CommandClient extends RequestResponseClient {
      * @throws NullPointerException if command is {@code null}.
      * @see RequestResponseClient#setRequestTimeout(long)
      */
-    Future<Buffer> sendCommand(String command, Buffer data);
+    Future<BufferResult> sendCommand(String command, Buffer data);
 
     /**
      * Sends a command to a device and expects a response.
@@ -62,5 +64,5 @@ public interface CommandClient extends RequestResponseClient {
      * @throws NullPointerException if command is {@code null}.
      * @see RequestResponseClient#setRequestTimeout(long)
      */
-    Future<Buffer> sendCommand(String command, String contentType, Buffer data);
+    Future<BufferResult> sendCommand(String command, String contentType, Buffer data);
 }

--- a/client/src/main/java/org/eclipse/hono/client/CommandClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandClient.java
@@ -34,7 +34,8 @@ public interface CommandClient extends RequestResponseClient {
      * @param data The command data to send to the device or {@code null} if the command has no input data.
      * @return A future indicating the result of the operation.
      *         <p>
-     *         The future will succeed if a response with status 2xx has been received from the device. If the response has no payload, the future will complete with {@code null}.
+     *         The future will succeed if a response with status 2xx has been received from the device.
+     *         If the response has no payload, the future will complete with {@code null}.
      *         <p>
      *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
      *         the (error) status code. Status codes are defined at <a href="https://www.eclipse.org/hono/api/command-and-control-api">Command and Control API</a>.
@@ -43,4 +44,23 @@ public interface CommandClient extends RequestResponseClient {
      */
     Future<Buffer> sendCommand(String command, Buffer data);
 
+    /**
+     * Sends a command to a device and expects a response.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected for a successful delivery.
+     *
+     * @param command The command name.
+     * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed if a response with status 2xx has been received from the device. If the response has no payload, the future will complete with {@code null}.
+     *         <p>
+     *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code. Status codes are defined at <a href="https://www.eclipse.org/hono/api/command-and-control-api">Command and Control API</a>.
+     * @throws NullPointerException if command is {@code null}.
+     * @see RequestResponseClient#setRequestTimeout(long)
+     */
+    Future<Buffer> sendCommand(String command, String contentType, Buffer data);
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -340,11 +340,12 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
      * Creates a result object from the status and payload of a response received from the endpoint.
      *
      * @param status The status of the response.
+     * @param contentType A media type describing the payload or {@code null} if unknown.
      * @param payload The representation of the payload (may be {@code null}).
      * @param cacheDirective Restrictions regarding the caching of the payload (may be {@code null}).
      * @return The result object.
      */
-    protected abstract R getResult(int status, Buffer payload, CacheDirective cacheDirective);
+    protected abstract R getResult(int status, String contentType, Buffer payload, CacheDirective cacheDirective);
 
     /**
      * Creates the sender and receiver links to the peer for sending requests
@@ -486,7 +487,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
             return null;
         } else {
             final CacheDirective cacheDirective = CacheDirective.from(MessageHelper.getCacheDirective(message));
-            return getResult(status, MessageHelper.getPayload(message), cacheDirective);
+            return getResult(status, message.getContentType(), MessageHelper.getPayload(message), cacheDirective);
         }
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
@@ -114,8 +114,8 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
     }
 
     @Override
-    protected BufferResult getResult(final int status, final Buffer payload, final CacheDirective cacheDirective) {
-        return BufferResult.from(status, payload);
+    protected BufferResult getResult(final int status, final String contentType, final Buffer payload, final CacheDirective cacheDirective) {
+        return BufferResult.from(status, contentType, payload);
     }
 
     /**
@@ -125,7 +125,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
      * {@code null} as the *content-type*.
      */
     @Override
-    public Future<Buffer> sendCommand(final String command, final Buffer data) {
+    public Future<BufferResult> sendCommand(final String command, final Buffer data) {
         return sendCommand(command, null, data);
     }
 
@@ -136,7 +136,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
      * from a device with the request.
      */
     @Override
-    public Future<Buffer> sendCommand(final String command, final String contentType, final Buffer data) {
+    public Future<BufferResult> sendCommand(final String command, final String contentType, final Buffer data) {
 
         Objects.requireNonNull(command);
 
@@ -145,7 +145,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
 
         return responseTracker.map(response -> {
             if (response.isOk()) {
-                return response.getPayload();
+                return response;
             } else {
                 throw StatusCodeMapper.from(response);
             }

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
@@ -73,13 +73,20 @@ public class CredentialsClientImpl extends AbstractRequestResponseClient<Credent
     }
 
     @Override
-    protected final CredentialsResult<CredentialsObject> getResult(final int status, final Buffer payload, final CacheDirective cacheDirective) {
+    protected final CredentialsResult<CredentialsObject> getResult(
+            final int status,
+            final String contentType,
+            final Buffer payload,
+            final CacheDirective cacheDirective) {
 
         if (payload == null) {
             return CredentialsResult.from(status);
         } else {
             try {
-                return CredentialsResult.from(status, OBJECT_MAPPER.readValue(payload.getBytes(), CredentialsObject.class), cacheDirective);
+                return CredentialsResult.from(
+                        status,
+                        OBJECT_MAPPER.readValue(payload.getBytes(), CredentialsObject.class),
+                        cacheDirective);
             } catch (final IOException e) {
                 LOG.warn("received malformed payload from Credentials service", e);
                 return CredentialsResult.from(HttpURLConnection.HTTP_INTERNAL_ERROR);

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
@@ -953,10 +953,11 @@ public class HonoClientImpl implements HonoClient {
             final String replyId) {
         return checkConnected().compose(connected -> {
             final Future<CommandClient> result = Future.future();
-            CommandClientImpl.create(tenantId, deviceId, replyId,
+            CommandClientImpl.create(
                     context,
                     clientConfigProperties,
                     connection,
+                    tenantId, deviceId, replyId,
                     this::removeActiveRequestResponseClient,
                     this::removeActiveRequestResponseClient,
                     result.completer());

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
@@ -111,7 +111,11 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
     }
 
     @Override
-    protected final RegistrationResult getResult(final int status, final Buffer payload, final CacheDirective cacheDirective) {
+    protected final RegistrationResult getResult(
+            final int status,
+            final String contentType,
+            final Buffer payload,
+            final CacheDirective cacheDirective) {
 
         if (payload == null) {
             return RegistrationResult.from(status);

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
@@ -135,13 +135,20 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
     }
 
     @Override
-    protected final TenantResult<TenantObject> getResult(final int status, final Buffer payload, final CacheDirective cacheDirective) {
+    protected final TenantResult<TenantObject> getResult(
+            final int status,
+            final String contentType,
+            final Buffer payload,
+            final CacheDirective cacheDirective) {
 
         if (payload == null) {
             return TenantResult.from(status, (TenantObject) null, cacheDirective);
         } else {
             try {
-                return TenantResult.from(status, OBJECT_MAPPER.readValue(payload.getBytes(), TenantObject.class), cacheDirective);
+                return TenantResult.from(
+                        status,
+                        OBJECT_MAPPER.readValue(payload.getBytes(), TenantObject.class),
+                        cacheDirective);
             } catch (final IOException e) {
                 LOG.warn("received malformed payload from Tenant service", e);
                 return TenantResult.from(HttpURLConnection.HTTP_INTERNAL_ERROR);

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
@@ -431,7 +431,11 @@ public class AbstractRequestResponseClientTest  {
             }
 
             @Override
-            protected SimpleRequestResponseResult getResult(final int status, final Buffer payload, final CacheDirective cacheDirective) {
+            protected SimpleRequestResponseResult getResult(
+                    final int status,
+                    final String contentType,
+                    final Buffer payload,
+                    final CacheDirective cacheDirective) {
                 return SimpleRequestResponseResult.from(status, payload, cacheDirective);
             }
         };

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.util.Constants;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+
+/**
+ * Tests verifying behavior of {@link CommandClientImpl}.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class CommandClientImplTest {
+
+    private static final String DEVICE_ID = "device";
+    private static final String REPLY_ID = "very-unique";
+    /**
+     * Time out test cases after 3 seconds.
+     */
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(3);
+
+    private Vertx vertx;
+    private Context context;
+    private ProtonSender sender;
+    private ProtonReceiver receiver;
+    private CommandClientImpl client;
+
+    /**
+     * Sets up the fixture.
+     */
+    @Before
+    public void setUp() {
+
+        vertx = mock(Vertx.class);
+        context = HonoClientUnitTestHelper.mockContext(vertx);
+        receiver = HonoClientUnitTestHelper.mockProtonReceiver();
+        sender = HonoClientUnitTestHelper.mockProtonSender();
+
+        final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
+        client = new CommandClientImpl(
+                context,
+                config,
+                Constants.DEFAULT_TENANT,
+                DEVICE_ID,
+                REPLY_ID,
+                sender,
+                receiver);
+    }
+
+    /**
+     * Verifies that a command sent has its properties set correctly.
+     *
+     * <ul>
+     * <li>subject set to given command</li>
+     * <li>message-id not null</li>
+     * <li>content-type set to given type</li>
+     * <li>reply-to address set to default address created from device and UUID</li>
+     * </ul>
+     * 
+     * @param ctx The vert.x test context.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSendCommandSetsProperties(final TestContext ctx) {
+
+        client.sendCommand("doSomething", "text/plain", Buffer.buffer("payload"));
+        final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(sender).send(messageCaptor.capture(), any(Handler.class));
+        assertThat(messageCaptor.getValue().getSubject(), is("doSomething"));
+        assertNotNull(messageCaptor.getValue().getMessageId());
+        assertThat(messageCaptor.getValue().getContentType(), is("text/plain"));
+        assertThat(messageCaptor.getValue().getReplyTo(),
+                is(String.format("%s/%s/%s/%s", client.getName(), Constants.DEFAULT_TENANT, DEVICE_ID, REPLY_ID)));
+    }
+}

--- a/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
@@ -177,7 +177,8 @@ public class TenantClientImplTest {
         client.setResponseCache(cache);
 
         final JsonObject tenantJsonObject = newTenantResult("tenant");
-        final TenantResult<TenantObject> tenantResult = client.getResult(HttpURLConnection.HTTP_OK, tenantJsonObject.toBuffer(), null);
+        final TenantResult<TenantObject> tenantResult = client.getResult(
+                HttpURLConnection.HTTP_OK, "application/json", tenantJsonObject.toBuffer(), null);
 
         when(cache.get(any(TriTuple.class))).thenReturn(tenantResult);
 

--- a/core/src/main/java/org/eclipse/hono/util/BufferResult.java
+++ b/core/src/main/java/org/eclipse/hono/util/BufferResult.java
@@ -16,13 +16,16 @@ package org.eclipse.hono.util;
 import io.vertx.core.buffer.Buffer;
 
 /**
- * A container for a RequestResponseResult with an opaque value.
+ * A container for the opaque result of a request-response service invocation.
  *
  */
 public final class BufferResult extends RequestResponseResult<Buffer> {
 
-    private BufferResult(final int status, final Buffer payload) {
+    private final String contentType;
+
+    private BufferResult(final int status, final String contentType, final Buffer payload) {
         super(status, payload, CacheDirective.noCacheDirective());
+        this.contentType = contentType;
     }
 
     /**
@@ -32,7 +35,7 @@ public final class BufferResult extends RequestResponseResult<Buffer> {
      * @return The result.
      */
     public static BufferResult from(final int status) {
-        return new BufferResult(status, null);
+        return new BufferResult(status, null, null);
     }
 
     /**
@@ -43,6 +46,27 @@ public final class BufferResult extends RequestResponseResult<Buffer> {
      * @return The result.
      */
     public static BufferResult from(final int status, final Buffer payload) {
-        return new BufferResult(status, payload);
+        return new BufferResult(status, null, payload);
+    }
+
+    /**
+     * Creates a new result for a status code and payload.
+     * 
+     * @param status The status code.
+     * @param contentType A media type describing the payload or {@code null} if unknown.
+     * @param payload The payload to include in the result.
+     * @return The result.
+     */
+    public static BufferResult from(final int status, final String contentType, final Buffer payload) {
+        return new BufferResult(status, contentType, payload);
+    }
+
+    /**
+     * Gets the type of the payload.
+     * 
+     * @return The media type describing the payload or {@code null} if unknown.
+     */
+    public String getContentType() {
+        return contentType;
     }
 }

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
@@ -19,10 +19,6 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
-import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
-import io.vertx.proton.ProtonConnection;
 import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.CommandClient;
@@ -30,12 +26,16 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.impl.HonoClientImpl;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.util.MessageTap;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessageTap;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.proton.ProtonConnection;
 
 
 /**
@@ -246,7 +246,7 @@ public class HonoConsumerBase {
                                       final TimeUntilDisconnectNotification notification) {
         commandClient.sendCommand("setBrightness", commandBuffer).map(result -> {
             System.out.println(String.format("Successfully sent command [%s] and received response: [%s]",
-                    commandBuffer.toString(), Optional.ofNullable(result).orElse(Buffer.buffer()).toString()));
+                    commandBuffer.toString(), Optional.ofNullable(result.getPayload()).orElse(Buffer.buffer()).toString()));
             if (notification.getTtd() != -1) {
                 // do not close the command client if device stays connected
                 commandClient.close(v -> {
@@ -261,7 +261,7 @@ public class HonoConsumerBase {
                 commandClient.close(v -> {
                 });
             }
-            return (Buffer) null;
+            return null;
         });
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
@@ -274,6 +274,20 @@ public final class Command {
     }
 
     /**
+     * Gets the type of this command's payload.
+     * 
+     * @return The content type or {@code null} if not set.
+     * @throws IllegalStateException if this command is invalid.
+     */
+    public String getContentType() {
+        if (isValid()) {
+            return message.getContentType();
+        } else {
+            throw new IllegalStateException("command is invalid");
+        }
+    }
+
+    /**
      * Gets this command's reply-to-id.
      *
      * @return The identifier.

--- a/site/content/api/Command-And-Control-API.md
+++ b/site/content/api/Command-And-Control-API.md
@@ -40,10 +40,11 @@ The following sequence diagram shows the whole message exchange including the re
 
 The following table provides an overview of the properties the *Business Application* needs to set on a command message.
 
-| Name | Mandatory | Location | Type      | Description |
-| :--- | :-------: | :------- | :-------- | :---------- |
+| Name             | Mandatory | Location                 | Type         | Description |
+| :--------------- | :-------: | :----------------------- | :----------- | :---------- |
 | *subject*        | yes       | *properties*             | *string*     | MUST contain the command name to be executed by a device. |
-| *correlation-id* | no        | *properties*             | *message-id* | MAY contain an ID used to correlate a response message to the original request. If set, it is used as the *correlation-id* property in the response, otherwise the value of the *message-id* property is used. |
+| *content-type*   | no        | *properties*             | *string*     | If present, MUST contain a *Media Type* as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046) which describes the semantics and format of the command's input data contained in the message payload. However, not all protocol adapters will support this property as not all transport protocols provide means to convey this information, e.g. MQTT 3.1.1 has no notion of message headers. |
+| *correlation-id* | no        | *properties*             | *message-id* | If present, MUST contain an ID used to correlate a response message to the original request. If set, it is used as the *correlation-id* property in the response, otherwise the value of the *message-id* property is used. |
 | *message-id*     | yes       | *properties*             | *string*     | MUST contain an identifier that uniquely identifies the message at the sender side. |
 | *reply-to*       | yes       | *properties*             | *string*     | MUST contain the source address that the client wants to receive response messages from. This address MUST be the same as the source address used for establishing the client's receive link (see [Preconditions]({{< relref "#preconditions" >}})). |
 
@@ -57,10 +58,11 @@ After execution of a command on a device, the device MUST send a response messag
 
 The following table provides an overview of the properties set on a Command's response message.
 
-| Name | Mandatory | Location | Type | Description |
-| :--- | :-------: | :------- | :-------- | :---------- |
-| *correlation-id* | yes | *properties* | *message-id* | MUST contain the correlation ID used to match the command message with the response message containing the result of execution on the device. |
-| *status* | yes | *application-properties* | *integer* | MUST indicate the status of the execution. See table below for possible values. |
+| Name             | Mandatory | Location                 | Type         | Description |
+| :--------------- | :-------: | :----------------------- | :----------- | :---------- |
+| *content-type*   | no        | *properties*             | *string*     | If present, MUST contain a *Media Type* as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046) which describes the semantics and format of the command's input data contained in the message payload. However, not all protocol adapters will support this property as not all transport protocols provide means to convey this information, e.g. MQTT 3.1.1 has no notion of message headers. |
+| *correlation-id* | yes       | *properties*             | *message-id* | MUST contain the correlation ID used to match the command message with the response message containing the result of execution on the device. |
+| *status*         | yes       | *application-properties* | *integer*    | MUST indicate the status of the execution. See table below for possible values. |
 
 The status property must contain a valid HTTP status code: <a name="status"></a>
 

--- a/site/content/user-guide/http-adapter.md
+++ b/site/content/user-guide/http-adapter.md
@@ -32,12 +32,13 @@ NB: There is a subtle difference between the *device identifier* (*device-id*) a
 * Method: `POST`
 * Request Headers:
   * (optional) `Authorization`: The device's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the device to present a client certificate as part of the TLS handshake during connection establishment.
-  * (required) `Content-Type`: The type of payload contained in the body.
+  * (required) `Content-Type`: The type of payload contained in the request body.
   * (optional) `hono-ttd`: The number of seconds the device will wait for the response. (since 0.6)
   * (optional) `QoS-Level`: The QoS level for publishing telemetry messages. Only QoS 1 is supported by the adapter. (since 0.6)
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
+  * (optional) `Content-Type`: A media type describing the semantics and format of payload contained in the response body. This header will only be present if the response contains a command to be executed by the device which requires input data. (since 0.7)
   * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
   * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
 * Response Body:
@@ -101,6 +102,7 @@ Publish some JSON data for device `4711`, indicating that the device will wait f
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
+  * (optional) `Content-Type`: A media type describing the semantics and format of payload contained in the response body. This header will only be present if the response contains a command to be executed by the device which requires input data. (since 0.7)
   * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
   * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
 * Response Body:
@@ -166,6 +168,7 @@ Publish some JSON data for device `4711`, indicating that the device will wait f
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
+  * (optional) `Content-Type`: A media type describing the semantics and format of payload contained in the response body. This header will only be present if the response contains a command to be executed by the device which requires input data. (since 0.7)
   * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
   * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
 * Response Body:
@@ -235,6 +238,7 @@ Publish some JSON data for device `4712`, indicating that the gateway will wait 
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
+  * (optional) `Content-Type`: A media type describing the semantics and format of payload contained in the response body. This header will only be present if the response contains a command to be executed by the device which requires input data. (since 0.7)
   * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
   * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
 * Response Body:
@@ -274,6 +278,7 @@ Publish some JSON data for device `4711`:
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
+  * (optional) `Content-Type`: A media type describing the semantics and format of payload contained in the response body. This header will only be present if the response contains a command to be executed by the device which requires input data. (since 0.7)
   * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
   * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
 * Response Body:
@@ -314,6 +319,7 @@ Publish some JSON data for device `4711`:
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
+  * (optional) `Content-Type`: A media type describing the semantics and format of payload contained in the response body. This header will only be present if the response contains a command to be executed by the device which requires input data. (since 0.7)
   * (optional) `hono-command`: The name of the command to execute. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
   * (optional) `hono-cmd-req-id`: An identifier that the device must include in its response to a command. This header will only be present if the response contains a command to be executed by the device. (since 0.6)
 * Response Body:
@@ -391,11 +397,11 @@ Example:
 * Method: `POST`
 * Request Headers:
   * (optional) `Authorization`: The device's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the device to present a client certificate as part of the TLS handshake during connection establishment.
+  * (optional) `Content-Type`: A media type describing the semantics and format of the payload contained in the request body. This header may be set if the result of processing the command on the device is non-empty. In this case the result data is contained in the request body. (since 0.7)
   * (optional) `hono-cmd-status`: The status of the command execution. If not set, the adapter expects that the URI contains it
     as request parameter at the end.
 * Request Body:
-  * (optional) Arbitrary payload. The type of the payload should be determined by the command that was sent to the device previously
-    and is unknown to Hono.
+  * (optional) Arbitrary data representing the result of processing the command on the device.
 * Status Codes:
   * 202 (Accepted): The response has been accepted and was successfully delivered to the application.
   * 400 (Bad Request): The request cannot be processed because the command status is missing.
@@ -426,11 +432,11 @@ Send a response to a previously received command with the command-request-id `re
 * URI: `/control/res/${tenantId}/${deviceId}/${commandRequestId}` or `/control/res/${tenantId}/${deviceId}/${commandRequestId}?hono-cmd-status=${status}`
 * Method: `PUT`
 * Request Headers:
+  * (optional) `Content-Type`: A media type describing the semantics and format of the payload contained in the request body (the outcome of processing the command). (since 0.7)
   * (optional) `hono-cmd-status`: The status of the command execution. If not set, the adapter expects that the URI contains it
     as request parameter at the end.
 * Request Body:
-  * (optional) Arbitrary payload. The type of the payload should be determined by the command that was sent to the device previously
-    and is unknown to Hono.
+  * (optional) Arbitrary data representing the result of processing the command on the device.
 * Status Codes:
   * 200 (OK): The event has been accepted and put to a persistent store for delivery to consumers. The response contains a command for the device to execute.
   * 202 (Accepted): The event has been accepted and put to a persistent store for delivery to consumers.
@@ -464,11 +470,11 @@ Send a response to a previously received command with the command-request-id `re
 * Method: `PUT`
 * Request Headers:
   * (optional) `Authorization`: The gateway's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the gateway to present a client certificate as part of the TLS handshake during connection establishment.
+  * (optional) `Content-Type`: A media type describing the semantics and format of the payload contained in the request body (the outcome of processing the command). (since 0.7)
   * (optional) `hono-cmd-status`: The status of the command execution. If not set, the adapter expects that the URI contains it
     as request parameter at the end.
 * Request Body:
-  * (optional) Arbitrary payload. The type of the payload should be determined by the command that was sent to the device previously
-    and is unknown to Hono.
+  * (optional) Arbitrary data representing the result of processing the command on the device.
 * Status Codes:
   * 202 (Accepted): The event has been accepted and put to a persistent store for delivery to consumers.
   * 400 (Bad Request): The request cannot be processed because the command status is missing.

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 import org.slf4j.Logger;
@@ -247,12 +248,24 @@ public final class IntegrationTestSupport {
      * 
      * @param notification The empty notification indicating the device's readiness to receive a command.
      * @param command The name of the command to send.
+     * @param contentType The type of the command's input data.
      * @param payload The command's input data to send to the device.
      * @return A future that is either succeeded with the response payload from the device or
      *         failed with a {@link ServiceInvocationException}.
      */
-    public Future<Buffer> sendCommand(final TimeUntilDisconnectNotification notification, final String command, final Buffer payload) {
-        return sendCommand(notification.getTenantId(), notification.getDeviceId(), command, payload, notification.getMillisecondsUntilExpiry());
+    public Future<BufferResult> sendCommand(
+            final TimeUntilDisconnectNotification notification,
+            final String command,
+            final String contentType,
+            final Buffer payload) {
+
+        return sendCommand(
+                notification.getTenantId(),
+                notification.getDeviceId(),
+                command,
+                contentType,
+                payload,
+                notification.getMillisecondsUntilExpiry());
     }
 
     /**
@@ -261,15 +274,17 @@ public final class IntegrationTestSupport {
      * @param tenantId The tenant that the device belongs to.
      * @param deviceId The identifier of the device.
      * @param command The name of the command to send.
+     * @param contentType The type of the command's input data.
      * @param payload The command's input data to send to the device.
      * @param requestTimeout The number of milliseconds to wait for a response from the device.
      * @return A future that is either succeeded with the response payload from the device or
      *         failed with a {@link ServiceInvocationException}.
      */
-    public Future<Buffer> sendCommand(
+    public Future<BufferResult> sendCommand(
             final String tenantId,
             final String deviceId,
             final String command,
+            final String contentType,
             final Buffer payload,
             final long requestTimeout) {
 
@@ -278,8 +293,8 @@ public final class IntegrationTestSupport {
             commandClient.setRequestTimeout(requestTimeout);
 
             // send the command upstream to the device
-            LOGGER.trace("sending command [name: {}, payload: {}]", command, payload);
-            return commandClient.sendCommand(command, payload).map(responsePayload -> {
+            LOGGER.trace("sending command [name: {}, contentType: {}, payload: {}]", command, contentType, payload);
+            return commandClient.sendCommand(command, contentType, payload).map(responsePayload -> {
                 LOGGER.debug("successfully sent command [name: {}, payload: {}] and received response [payload: {}]",
                         command, payload, responsePayload);
                 commandClient.close(v -> {});

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -513,7 +513,11 @@ public abstract class HttpTestBase {
                     ctx.assertEquals(deviceId, notification.getDeviceId());
                     // now ready to send a command
                     final JsonObject inputData = new JsonObject().put(COMMAND_JSON_KEY, (int) (Math.random() * 100));
-                    helper.sendCommand(notification, COMMAND_TO_SEND, inputData.toBuffer());
+                    helper
+                        .sendCommand(notification, COMMAND_TO_SEND, "application/json", inputData.toBuffer())
+                        .setHandler(ctx.asyncAssertSuccess(response -> {
+                            ctx.assertEquals("text/plain", response.getContentType());
+                        }));
                 },
                 count -> {
                     return httpClient.create(
@@ -524,6 +528,7 @@ public abstract class HttpTestBase {
 
                                 // assert that the response contains a command
                                 ctx.assertEquals(COMMAND_TO_SEND, responseHeaders.get(Constants.HEADER_COMMAND));
+                                ctx.assertEquals("application/json", responseHeaders.get(HttpHeaders.CONTENT_TYPE));
                                 final String requestId = responseHeaders.get(Constants.HEADER_COMMAND_REQUEST_ID);
                                 ctx.assertNotNull(requestId);
                                 ctx.assertNotEquals(responseHeaders.get(HttpHeaders.CONTENT_LENGTH), "0");

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -145,7 +145,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
             final Async commandSent = ctx.async();
             context.runOnContext(go -> {
                 final Buffer msg = Buffer.buffer("value: " + commandsSent.getAndIncrement());
-                helper.sendCommand(tenantId, deviceId, "setValue", msg, 200).setHandler(sendAttempt -> {
+                helper.sendCommand(tenantId, deviceId, "setValue", "text/plain", msg, 200).setHandler(sendAttempt -> {
                     if (sendAttempt.failed()) {
                         LOGGER.debug("error sending command {}", commandsSent.get(), sendAttempt.cause());
                     } else {


### PR DESCRIPTION
So far, the C&C API doesn't explicitly support the usage of Content-Type. IMHO it is worth doing so, even if not all protocol adapters will be able to forward the type information hence and forth due to limitations of the transport protocols.