### PR TITLE
Coap adapter 0.7

### DIFF
--- a/adapters/coap-vertx-base/pom.xml
+++ b/adapters/coap-vertx-base/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-adapters</artifactId>
+    <version>0.7-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-adapter-coap-vertx-base</artifactId>
+  <name>Hono COAP Adapter base</name>
+  <url>https://www.eclipse.org/hono</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.californium</groupId>
+      <artifactId>californium-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.californium</groupId>
+      <artifactId>element-connector</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.californium</groupId>
+      <artifactId>scandium</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -1,0 +1,429 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.adapter.coap;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.util.Objects;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.MessageSender;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.service.AbstractProtocolAdapterBase;
+import org.eclipse.hono.service.auth.device.Device;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TelemetryConstants;
+import org.eclipse.hono.util.TenantObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Base class for a Vert.x based Hono protocol adapter that uses CoAP. It provides access to the Telemetry and Event
+ * API.
+ * 
+ * @param <T> The type of configuration properties used by this service.
+ */
+public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterProperties>
+        extends AbstractProtocolAdapterBase<T> {
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    /**
+     * COAP server. Created from blocking execution, therefore use volatile.
+     */
+    private CoapServer server;
+    private volatile Endpoint insecureEndpoint;
+    private CoapAdapterMetrics metrics;
+
+    /**
+     * Sets the metrics for this service.
+     *
+     * @param metrics The metrics
+     */
+    @Autowired
+    public final void setMetrics(final CoapAdapterMetrics metrics) {
+        this.metrics = metrics;
+    }
+
+    /**
+     * @return {@link CoAP#DEFAULT_COAP_SECURE_PORT}
+     */
+    @Override
+    public final int getPortDefaultValue() {
+        return CoAP.DEFAULT_COAP_SECURE_PORT;
+    }
+
+    /**
+     * @return {@link CoAP#DEFAULT_COAP_PORT}
+     */
+    @Override
+    public final int getInsecurePortDefaultValue() {
+        return CoAP.DEFAULT_COAP_PORT;
+    }
+
+    @Override
+    protected final int getActualPort() {
+        return Constants.PORT_UNCONFIGURED;
+    }
+
+    @Override
+    protected final int getActualInsecurePort() {
+        int port = Constants.PORT_UNCONFIGURED;
+        final Endpoint endpoint = insecureEndpoint;
+        if (endpoint != null) {
+            port = endpoint.getAddress().getPort();
+        }
+        return port;
+    }
+
+    /**
+     * Called during {@link #doStart(Future)}.
+     * 
+     * Note: The call is in the scope of "executeBlocking" and therefore special care accessing this instance must be
+     * obeyed.
+     * 
+     * @param adapterContext context of this adapter. Intended for schedule calls back into this vertical.
+     * @param server coap server to add resources.
+     */
+    protected abstract void addResources(Context adapterContext, CoapServer server);
+
+    /**
+     * Sets the coap server instance configured to serve requests.
+     * <p>
+     * If no server is set using this method, then a server instance is created during startup of this adapter based on
+     * the <em>config</em> properties.
+     * 
+     * @param server The coap server.
+     * @throws NullPointerException if server is {@code null}.
+     */
+    @Autowired(required = false)
+    public final void setCoapServer(final CoapServer server) {
+        Objects.requireNonNull(server);
+        this.server = server;
+    }
+
+    @Override
+    public final void doStart(final Future<Void> startFuture) {
+        checkPortConfiguration().compose(s -> preStartup()).compose(s -> {
+            final Future<Void> deployFuture = Future.future();
+            // access environment using the context of this vertx and
+            // load it into finals to access them within the executeBlocking
+            final CoapAdapterProperties config = getConfig();
+            final NetworkConfig insecureNetworkConfig = getInsecureNetworkConfig();
+            final Context adapterContext = this.context;
+            final CoapServer server = this.server;
+
+            // delegate for blocking execution
+            getVertx().executeBlocking(future -> {
+                // Call some potential blocking API
+                final CoapServer startingServer = server == null ? new CoapServer(insecureNetworkConfig) : server;
+                addResources(adapterContext, startingServer);
+                Endpoint insecureEndpoint = null;
+                if (config.isInsecurePortEnabled()) {
+                    if (config.isAuthenticationRequired()) {
+                        LOG.warn("ambig configuration! authenticationRequired is not supported for insecure endpoint!");
+                    } else {
+                        final CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+                        builder.setNetworkConfig(insecureNetworkConfig);
+                        builder.setInetSocketAddress(new InetSocketAddress(config.getInsecurePortBindAddress(),
+                                config.getInsecurePort(getInsecurePortDefaultValue())));
+                        insecureEndpoint = builder.build();
+                        startingServer.addEndpoint(insecureEndpoint);
+                    }
+                }
+                startingServer.start();
+                this.insecureEndpoint = insecureEndpoint;
+                future.complete(startingServer);
+            }, res -> {
+                if (res.succeeded()) {
+                    this.server = (CoapServer) res.result();
+                    deployFuture.complete();
+                } else {
+                    deployFuture.fail(res.cause());
+                }
+            });
+            return deployFuture;
+        }).compose(s -> {
+            try {
+                onStartupSuccess();
+                startFuture.complete();
+            } catch (Exception e) {
+                LOG.error("error in onStartupSuccess", e);
+                startFuture.fail(e);
+            }
+        }, startFuture);
+    }
+
+    /**
+     * Invoked before the coap server is started.
+     * <p>
+     * May be overridden by sub-classes to provide additional startup handling.
+     * 
+     * @return A future indicating the outcome of the operation. The start up process fails if the returned future
+     *         fails.
+     */
+    protected Future<Void> preStartup() {
+
+        return Future.succeededFuture();
+    }
+
+    /**
+     * Invoked after this adapter has started up successfully.
+     * <p>
+     * May be overridden by sub-classes.
+     */
+    protected void onStartupSuccess() {
+        // empty
+    }
+
+    /**
+     * Get the coap network configuration for the insecure endpoint.
+     * 
+     * Creates a coap network configuration setup with defaults. If the {@link CoapAdapterProperties} provides a
+     * filename in "networkConfig", load that available values from that file overwriting existing values. If the
+     * {@link CoapAdapterProperties} provides a filename in "insecureNetworkConfig", load that available values from
+     * that file also overwriting existing values.
+     * 
+     * @return coap network configuration for the insecure endpoint.
+     */
+    protected NetworkConfig getInsecureNetworkConfig() {
+        final CoapAdapterProperties config = getConfig();
+        final NetworkConfig networkConfig = new NetworkConfig();
+        networkConfig.setInt(NetworkConfig.Keys.PROTOCOL_STAGE_THREAD_COUNT, config.getCoapThreads());
+        networkConfig.setInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT, config.getConnectorThreads());
+        networkConfig.setInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT, config.getConnectorThreads());
+        loadNetworkConfig(config.getNetworkConfig(), networkConfig);
+        loadNetworkConfig(config.getInsecureNetworkConfig(), networkConfig);
+        return networkConfig;
+    }
+
+    protected void loadNetworkConfig(final String fileName, final NetworkConfig networkConfig) {
+        if (fileName != null && !fileName.isEmpty()) {
+            final File file = new File(fileName);
+            String cause = null;
+            if (!file.exists()) {
+                cause = "File doesn't exists!";
+            } else if (!file.isFile()) {
+                cause = "Isn't a file!";
+            } else if (!file.canRead()) {
+                cause = "Can't read file!";
+            } else {
+                networkConfig.load(file);
+            }
+            if (cause != null) {
+                LOG.warn("Can't read NetworkConfig from {}! {}", fileName, cause);
+            }
+        }
+    }
+
+    /**
+     * Invoked before the message is sent to the downstream peer.
+     * <p>
+     * Subclasses may override this method in order to customize the message before it is sent, e.g. adding custom
+     * properties.
+     * 
+     * @param downstreamMessage The message that will be sent downstream.
+     * @param exchange coap message exchange.
+     */
+    protected void customizeDownstreamMessage(final Message downstreamMessage, final CoapExchange exchange) {
+        // this default implementation does nothing
+    }
+
+    @Override
+    public final void doStop(final Future<Void> stopFuture) {
+
+        try {
+            preShutdown();
+        } catch (Exception e) {
+            LOG.error("error in preShutdown", e);
+        }
+
+        final Future<Void> serverStopTracker = Future.future();
+        if (server != null) {
+            getVertx().executeBlocking(future -> {
+                // Call some blocking API
+                server.stop();
+                future.complete();
+            }, serverStopTracker);
+        } else {
+            serverStopTracker.complete();
+        }
+
+        serverStopTracker.compose(v -> postShutdown()).compose(s -> stopFuture.complete(), stopFuture);
+    }
+
+    /**
+     * Invoked before the coap server is shut down. May be overridden by sub-classes.
+     */
+    protected void preShutdown() {
+        // empty
+    }
+
+    /**
+     * Invoked after the Adapter has been shutdown successfully. May be overridden by sub-classes to provide further
+     * shutdown handling.
+     * 
+     * @return A future that has to be completed when this operation is finished.
+     */
+    protected Future<Void> postShutdown() {
+        return Future.succeededFuture();
+    }
+
+    /**
+     * Uploads the body of an COAP request as a telemetry message to the Hono server.
+     * <p>
+     * This method simply invokes
+     * {@link #doUploadMessage(CoapExchange, Device, Device, boolean, Buffer, String, Future, String)} with objects
+     * retrieved from the coap message exchange.
+     * 
+     * @param exchange coap message exchange
+     * @param authenticatedDevice authenticated device
+     * @param originDevice message's origin device
+     * @param waitForOutcome {@code true} to send the message waiting for the outcome, {@code false}, to wait just for
+     *            the sent.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public final void uploadTelemetryMessage(final CoapExchange exchange, final Device authenticatedDevice,
+            final Device originDevice, final boolean waitForOutcome) {
+        doUploadMessage(Objects.requireNonNull(exchange), Objects.requireNonNull(authenticatedDevice),
+                Objects.requireNonNull(originDevice), waitForOutcome,
+                Buffer.buffer(exchange.getRequestPayload()),
+                MediaTypeRegistry.toString(exchange.getRequestOptions().getContentFormat()),
+                getTelemetrySender(authenticatedDevice.getTenantId()),
+                TelemetryConstants.TELEMETRY_ENDPOINT);
+    }
+
+    /**
+     * Uploads the body of an COAP request as a event message to the Hono server.
+     * <p>
+     * This method simply invokes
+     * {@link #doUploadMessage(CoapExchange, Device, Device, boolean, Buffer, String, Future, String)} with objects
+     * retrieved from the coap message exchange.
+     * 
+     * @param exchange coap message exchange
+     * @param authenticatedDevice authenticated device
+     * @param originDevice message's origin device
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public final void uploadEventMessage(final CoapExchange exchange, final Device authenticatedDevice,
+            final Device originDevice) {
+        doUploadMessage(Objects.requireNonNull(exchange), Objects.requireNonNull(authenticatedDevice),
+                Objects.requireNonNull(originDevice), true,
+                Buffer.buffer(exchange.getRequestPayload()),
+                MediaTypeRegistry.toString(exchange.getRequestOptions().getContentFormat()),
+                getEventSender(authenticatedDevice.getTenantId()), EventConstants.EVENT_ENDPOINT);
+    }
+
+    /**
+     * Uploads a telemetry or event message to the Hono server.
+     * <p>
+     * Depending on the outcome of the attempt to upload the message to Hono, the COAP response's code is set as
+     * follows:
+     * <ul>
+     * <li>2.04 (Changed) - if the message has been sent to the Hono server.</li>
+     * <li>4.01 (Unauthorized) - if the device could not be authorized.</li>
+     * <li>4.03 (Forbidden) - if the tenant/device is not authorized to send messages.</li>
+     * <li>4.06 (Not Acceptable) - if the message is misformed.</li>
+     * <li>5.00 (Internal Server Error) - if the message could not be sent caused by an unspecific processing
+     * error.</li>
+     * <li>5.03 (Service Unavailable) - if the message could not be sent to the Hono server, e.g. due to lack of
+     * connection or credit.</li>
+     * <li>?.?? (Generic mapped HTPP error) - if the message could not be sent caused by an specific processing error.
+     * See {@link CoapErrorResponse}.</li>
+     * </ul>
+     * 
+     * @param exchange coap message exchange
+     * @param authenticatedDevice authenticated device
+     * @param device message's origin device
+     * @param waitForOutcome {@code true} to send the message waiting for the outcome, {@code false}, to wait just for
+     *            the sent.
+     * @param payload message payload
+     * @param contentType content type of message payload
+     * @param senderTracker hono message sender tracker
+     * @param endpointName message destination endpoint name
+     */
+    private void doUploadMessage(final CoapExchange exchange, final Device authenticatedDevice, final Device device,
+            final boolean waitForOutcome, final Buffer payload, final String contentType,
+            final Future<MessageSender> senderTracker,
+            final String endpointName) {
+
+        if (contentType == null) {
+            exchange.respond(ResponseCode.NOT_ACCEPTABLE);
+        } else if (payload == null || payload.length() == 0) {
+            exchange.respond(ResponseCode.NOT_ACCEPTABLE);
+        } else {
+
+            final Future<JsonObject> tokenTracker = getRegistrationAssertion(device.getTenantId(), device.getDeviceId(),
+                    authenticatedDevice);
+            final Future<TenantObject> tenantConfigTracker = getTenantConfiguration(device.getTenantId());
+
+            CompositeFuture.all(tokenTracker, senderTracker, tenantConfigTracker).compose(ok -> {
+
+                if (tenantConfigTracker.result().isAdapterEnabled(getTypeName())) {
+                    final MessageSender sender = senderTracker.result();
+                    final Message downstreamMessage = newMessage(
+                            ResourceIdentifier.from(endpointName, device.getTenantId(), device.getDeviceId()),
+                            sender.isRegistrationAssertionRequired(),
+                            "/" + exchange.getRequestOptions().getUriPathString(),
+                            contentType,
+                            payload,
+                            tokenTracker.result(),
+                            null);
+                    customizeDownstreamMessage(downstreamMessage, exchange);
+                    if (waitForOutcome) {
+                        // wait for outcome, ensure message order, if CoAP NSTART-1 is used.
+                        return sender.sendAndWaitForOutcome(downstreamMessage);
+                    } else {
+                        return sender.send(downstreamMessage);
+                    }
+                } else {
+                    // this adapter is not enabled for the tenant
+                    return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN));
+                }
+            }).compose(delivery -> {
+                LOG.trace("successfully processed message for device [tenantId: {}, deviceId: {}, endpoint: {}]",
+                        device.getTenantId(), device.getDeviceId(), endpointName);
+                metrics.incrementProcessedCoapMessages(endpointName, device.getTenantId());
+                exchange.respond(ResponseCode.CHANGED);
+                return Future.succeededFuture();
+            }).recover(t -> {
+                LOG.debug("cannot process message for device [tenantId: {}, deviceId: {}, endpoint: {}]: {}",
+                        device.getTenantId(), device.getDeviceId(), endpointName, t.getMessage());
+                if (ServerErrorException.class.isInstance(t)) {
+                    metrics.incrementUndeliverableCoapMessages(endpointName, device.getTenantId());
+                }
+                CoapErrorResponse.respond(exchange, t);
+                return Future.failedFuture(t);
+            });
+        }
+    }
+}

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterMetrics.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterMetrics.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.coap;
+
+import org.eclipse.hono.service.metric.Metrics;
+import org.springframework.stereotype.Component;
+
+/**
+ * Metrics for the COAP based adapters.
+ */
+@Component
+public class CoapAdapterMetrics extends Metrics {
+
+    private static final String SERVICE_PREFIX = "hono.coap";
+
+    @Override
+    protected String getPrefix() {
+        return SERVICE_PREFIX;
+    }
+
+    void incrementProcessedCoapMessages(final String resourceId, final String tenantId) {
+        counterService
+                .increment(METER_PREFIX + getPrefix() + MESSAGES + mergeAsMetric(resourceId, tenantId) + PROCESSED);
+    }
+
+    void incrementUndeliverableCoapMessages(final String resourceId, final String tenantId) {
+        counterService.increment(getPrefix() + MESSAGES + mergeAsMetric(resourceId, tenantId) + UNDELIVERABLE);
+    }
+
+}

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterProperties.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterProperties.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.coap;
+
+import java.util.Objects;
+
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+
+/**
+ * Properties for configuring an COAP adapter.
+ */
+public class CoapAdapterProperties extends ProtocolAdapterProperties {
+
+    private String networkConfig = null;
+    private String insecureNetworkConfig = null;
+    private int connectorThreads = 1;
+    private int coapThreads = 2;
+
+
+    public final String getNetworkConfig() {
+        return networkConfig;
+    }
+
+    public final void setNetworkConfig(final String networkConfig) {
+        this.networkConfig = Objects.requireNonNull(networkConfig);
+    }
+
+    public final String getInsecureNetworkConfig() {
+        return insecureNetworkConfig;
+    }
+
+    public final void setInsecureNetworkConfig(final String insecureNetworkConfig) {
+        this.insecureNetworkConfig = Objects.requireNonNull(insecureNetworkConfig);
+    }
+
+    /**
+     * Gets the number of connector threads.
+     * 
+     * The connector will start sender and receiver threads, so the resulting number will be doubled!
+     * 
+     * @return The number of threads per connector.
+     */
+    public final int getConnectorThreads() {
+        return connectorThreads;
+    }
+
+    /**
+     * Sets the number of connector threads.
+     * 
+     * @param threads The number of sender and receiver threads per connector.
+     * @throws IllegalArgumentException if threads is &lt; 1.
+     */
+    public final void setConnectorThreads(final int threads) {
+        if (threads < 1) {
+            throw new IllegalArgumentException("connector threads must not be less than one");
+        }
+        this.connectorThreads = threads;
+    }
+
+    /**
+     * Gets the number of coap threads.
+     * 
+     * @return The number of threads for coap stack.
+     */
+    public final int getCoapThreads() {
+        return coapThreads;
+    }
+
+    /**
+     * Sets the number of coap protocol threads.
+     * 
+     * @param threads The number of threads for the coap protocol stack.
+     * @throws IllegalArgumentException if threads is &lt; 1.
+     */
+    public final void setCoapThreads(final int threads) {
+        if (threads < 1) {
+            throw new IllegalArgumentException("protocol threads must not be less than one");
+        }
+        this.coapThreads = threads;
+    }
+
+}

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapErrorResponse.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapErrorResponse.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.coap;
+
+import java.net.HttpURLConnection;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MessageFormatException;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.hono.client.ServiceInvocationException;
+
+/**
+ * Utility send response with an error.
+ */
+public class CoapErrorResponse {
+
+    private CoapErrorResponse() {
+
+    }
+
+    /**
+     * Check, if reported error cause indicates a temporary error.
+     * 
+     * @param cause reported error cause
+     * @return {@code true}, if error is temporary and the client may retry its action, {@code false}, otherwise, when
+     *         the client should not repeat this action.
+     */
+    public static boolean isTemporaryError(final Throwable cause) {
+        if (ServiceInvocationException.class.isInstance(cause)) {
+            return ((ServiceInvocationException) cause).getErrorCode() == HttpURLConnection.HTTP_UNAVAILABLE;
+        }
+        return false;
+    }
+
+    /**
+     * Respond the coap exchange with the provide error cause.
+     * 
+     * @param exchange coap exchange to be responded
+     * @param cause error cause
+     */
+    public static void respond(final CoapExchange exchange, final Throwable cause) {
+        respond(exchange, cause, ResponseCode.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Respond the coap exchange with the provide error cause.
+     * 
+     * Convert http-code into coap-code, if available. Add cause message as payload for response.
+     * 
+     * @param exchange coap exchange to be responded
+     * @param cause error cause
+     * @param defaultCode default response code, if a more specific response code is not available.
+     */
+    public static void respond(final CoapExchange exchange, final Throwable cause, final ResponseCode defaultCode) {
+        final ResponseCode code;
+        if (ServiceInvocationException.class.isInstance(cause)) {
+            final int error = ((ServiceInvocationException) cause).getErrorCode();
+            code = toCoapCode(error, defaultCode);
+            switch (error) {
+            case HttpURLConnection.HTTP_UNAVAILABLE:
+                // delay retry by 2 seconds, see http adapter, HttpUtils.serviceUnavailable(ctx, 2)
+                exchange.setMaxAge(2);
+                break;
+            default:
+                break;
+            }
+        } else {
+            code = defaultCode;
+        }
+        final Response response = new Response(code);
+        response.setPayload(cause.getMessage());
+        exchange.respond(response);
+    }
+
+    /**
+     * Convert http-code into coap-code.
+     * 
+     * @param httpCode http-code
+     * @param defaultCode default response code, if http-code could not be mapped.
+     * @return coap-code
+     */
+    public static ResponseCode toCoapCode(final int httpCode, final ResponseCode defaultCode) {
+        final int codeClass = httpCode / 100;
+        final int codeDetail = httpCode % 100;
+        if (0 < codeClass && codeClass < 8 && 0 <= codeDetail && codeDetail < 64) {
+            try {
+                return ResponseCode.valueOf(codeClass << 5 | codeDetail);
+            } catch (MessageFormatException e) {
+            }
+        }
+        return defaultCode;
+    }
+}

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -1,0 +1,460 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.coap;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.net.HttpURLConnection;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.MessageSender;
+import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.TenantClient;
+import org.eclipse.hono.service.auth.device.Device;
+import org.eclipse.hono.service.command.CommandConnection;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.proton.ProtonDelivery;
+
+/**
+ * Verifies behavior of {@link AbstractVertxBasedCoapAdapter}.
+ */
+@RunWith(VertxUnitRunner.class)
+public class AbstractVertxBasedCoapAdapterTest {
+
+    private static final String ADAPTER_TYPE = "coap";
+
+    private static final Vertx vertx = Vertx.vertx();
+
+    /**
+     * Global timeout for all test cases.
+     */
+    @Rule
+    public final Timeout globalTimeout = Timeout.seconds(5);
+
+    private HonoClient credentialsServiceClient;
+    private HonoClient tenantServiceClient;
+    private HonoClient messagingClient;
+    private HonoClient registrationServiceClient;
+    private RegistrationClient regClient;
+    private TenantClient tenantClient;
+    private CoapAdapterProperties config;
+    private CommandConnection commandConnection;
+
+    /**
+     * Sets up common fixture.
+     */
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setup() {
+
+        config = new CoapAdapterProperties();
+        config.setInsecurePortEnabled(true);
+        config.setAuthenticationRequired(false);
+
+        regClient = mock(RegistrationClient.class);
+        final JsonObject result = new JsonObject().put(RegistrationConstants.FIELD_ASSERTION, "token");
+        when(regClient.assertRegistration(anyString(), any())).thenReturn(Future.succeededFuture(result));
+
+        tenantClient = mock(TenantClient.class);
+        when(tenantClient.get(anyString())).thenAnswer(invocation -> {
+            return Future.succeededFuture(TenantObject.from(invocation.getArgument(0), true));
+        });
+
+        tenantServiceClient = mock(HonoClient.class);
+        when(tenantServiceClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(tenantServiceClient));
+        when(tenantServiceClient.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
+
+        credentialsServiceClient = mock(HonoClient.class);
+        when(credentialsServiceClient.connect(any(Handler.class)))
+                .thenReturn(Future.succeededFuture(credentialsServiceClient));
+
+        messagingClient = mock(HonoClient.class);
+        when(messagingClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingClient));
+
+        registrationServiceClient = mock(HonoClient.class);
+        when(registrationServiceClient.connect(any(Handler.class)))
+                .thenReturn(Future.succeededFuture(registrationServiceClient));
+        when(registrationServiceClient.getOrCreateRegistrationClient(anyString()))
+                .thenReturn(Future.succeededFuture(regClient));
+
+        commandConnection = mock(CommandConnection.class);
+        when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
+    }
+
+    /**
+     * Cleans up fixture.
+     */
+    @AfterClass
+    public static void shutDown() {
+        vertx.close();
+    }
+
+    /**
+     * Verifies that the <em>onStartupSuccess</em> method is invoked if the coap server has been started successfully.
+     * 
+     * @param ctx The helper to use for running async tests on vertx.
+     */
+    @Test
+    public void testStartInvokesOnStartupSuccess(final TestContext ctx) {
+
+        // GIVEN an adapter
+        final CoapServer server = getCoapServer(false);
+        final Async onStartupSuccess = ctx.async();
+
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true,
+                s -> onStartupSuccess.complete());
+        adapter.setMetrics(mock(CoapAdapterMetrics.class));
+
+        // WHEN starting the adapter
+        final Async startup = ctx.async();
+        final Future<Void> startupTracker = Future.future();
+        startupTracker.setHandler(ctx.asyncAssertSuccess(s -> {
+            startup.complete();
+        }));
+        adapter.start(startupTracker);
+
+        // THEN the onStartupSuccess method has been invoked
+        startup.await();
+        onStartupSuccess.await();
+    }
+
+    /**
+     * Verifies that the <em>onStartupSuccess</em> method is not invoked if no credentials authentication provider is
+     * set.
+     *
+     * @param ctx The helper to use for running async tests on vertx.
+     */
+    @Test
+    public void testStartUpFailsIfCredentialsAuthProviderIsNotSet(final TestContext ctx) {
+
+        // GIVEN an adapter
+        final CoapServer server = getCoapServer(false);
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, false,
+                s -> ctx.fail("should not have invoked onStartupSuccess"));
+
+        // WHEN starting the adapter
+        final Async startup = ctx.async();
+        final Future<Void> startupTracker = Future.future();
+        startupTracker.setHandler(ctx.asyncAssertFailure(s -> {
+            startup.complete();
+        }));
+        adapter.start(startupTracker);
+
+        // THEN the onStartupSuccess method has been invoked, see ctx.fail
+        startup.await();
+    }
+
+    /**
+     * Verifies that the <em>onStartupSuccess</em> method is not invoked if a client provided coap server fails to
+     * start.
+     * 
+     * @param ctx The helper to use for running async tests on vertx.
+     */
+    @Test
+    public void testStartDoesNotInvokeOnStartupSuccessIfStartupFails(final TestContext ctx) {
+
+        // GIVEN an adapter with a client provided http server that fails to bind to a socket when started
+        final CoapServer server = getCoapServer(true);
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true,
+                s -> ctx.fail("should not have invoked onStartupSuccess"));
+
+        // WHEN starting the adapter
+        final Async startup = ctx.async();
+        final Future<Void> startupTracker = Future.future();
+        startupTracker.setHandler(ctx.asyncAssertFailure(s -> {
+            startup.complete();
+        }));
+        adapter.start(startupTracker);
+
+        // THEN the onStartupSuccess method has been invoked, see ctx.fail
+        startup.await();
+    }
+
+    /**
+     * Verifies that the adapter fails the upload of an event with a 4.03 result if the device belongs to a tenant for
+     * which the adapter is disabled.
+     */
+    @Test
+    public void testUploadTelemetryFailsForDisabledTenant() {
+
+        // GIVEN an adapter
+        final MessageSender sender = mock(MessageSender.class);
+        when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+        // which is disabled for tenant "my-tenant"
+        final TenantObject myTenantConfig = TenantObject.from("my-tenant", true);
+        myTenantConfig.addAdapterConfiguration(new JsonObject()
+                .put(TenantConstants.FIELD_ADAPTERS_TYPE, ADAPTER_TYPE)
+                .put(TenantConstants.FIELD_ENABLED, false));
+        when(tenantClient.get("my-tenant")).thenReturn(Future.succeededFuture(myTenantConfig));
+        final CoapServer server = getCoapServer(false);
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true, null);
+
+        // WHEN a device that belongs to "my-tenant" publishes a telemetry message
+        final Buffer payload = Buffer.buffer("some payload");
+        final CoapExchange coapExchange = newCoapExchange(payload);
+        final Device authenticatedDevice = new Device("my-tenant", "the-device");
+
+        adapter.uploadTelemetryMessage(coapExchange, authenticatedDevice, authenticatedDevice, false);
+
+        // THEN the device gets a 4.03
+
+        final ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(coapExchange).respond(captor.capture());
+        assertThat("response with forbidden", captor.getValue().getCode(), is(ResponseCode.FORBIDDEN));
+
+        // and the message has not been forwarded downstream
+        verify(sender, never()).send(any(Message.class));
+    }
+
+    /**
+     * Verifies that the adapter waits for an event being send with wait for outcome before responding with a 2.04
+     * status to the device.
+     */
+    @Test
+    public void testUploadEventWaitsForAcceptedOutcome() {
+
+        // GIVEN an adapter with a downstream event consumer attached
+        final Future<ProtonDelivery> outcome = Future.future();
+        givenAnEventSenderForOutcome(outcome);
+        final CoapServer server = getCoapServer(false);
+
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true, null);
+
+        // WHEN a device publishes an event
+        final Buffer payload = Buffer.buffer("some payload");
+        final CoapExchange coapExchange = newCoapExchange(payload);
+        final Device authenticatedDevice = new Device("tenant", "device");
+
+        adapter.uploadEventMessage(coapExchange, authenticatedDevice, authenticatedDevice);
+
+        // THEN the device does not get a response
+        verify(coapExchange, never()).respond(ResponseCode.CHANGED);
+
+        // until the event has been accepted
+        outcome.complete(mock(ProtonDelivery.class));
+        verify(coapExchange).respond(ResponseCode.CHANGED);
+    }
+
+    /**
+     * Verifies that the adapter fails the upload of an event with a 4.00 result if it is rejected by the downstream
+     * peer.
+     */
+    @Test
+    public void testUploadEventFailsForRejectedOutcome() {
+
+        // GIVEN an adapter with a downstream event consumer attached
+        final Future<ProtonDelivery> outcome = Future.future();
+        givenAnEventSenderForOutcome(outcome);
+        final CoapServer server = getCoapServer(false);
+
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true, null);
+
+        // WHEN a device publishes an event that is not accepted by the peer
+        final Buffer payload = Buffer.buffer("some payload");
+        final CoapExchange coapExchange = newCoapExchange(payload);
+        final Device authenticatedDevice = new Device("tenant", "device");
+
+        adapter.uploadEventMessage(coapExchange, authenticatedDevice, authenticatedDevice);
+        outcome.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "malformed message"));
+
+        // THEN the device gets a 4.00
+        final ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(coapExchange).respond(captor.capture());
+        assertThat("response with bad request", captor.getValue().getCode(),
+                is(ResponseCode.BAD_REQUEST));
+    }
+
+    /**
+     * Verifies that the adapter waits for an telemetry message being send (without wait for outcome) before responding
+     * with a 2.04 status to the device.
+     */
+    @Test
+    public void testUploadTelemetry() {
+
+        // GIVEN an adapter with a downstream telemetry consumer attached
+        final Future<ProtonDelivery> outcome = Future.future();
+        givenATelemetrySender(outcome);
+        final CoapServer server = getCoapServer(false);
+
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true, null);
+
+        // WHEN a device publishes an telemetry message
+        final Buffer payload = Buffer.buffer("some payload");
+        final CoapExchange coapExchange = newCoapExchange(payload);
+        final Device authenticatedDevice = new Device("tenant", "device");
+
+        adapter.uploadTelemetryMessage(coapExchange, authenticatedDevice, authenticatedDevice, false);
+
+        // THEN the device does not get a response
+        verify(coapExchange, never()).respond(ResponseCode.CHANGED);
+
+        // until the telemetry message has been accepted
+        outcome.complete(mock(ProtonDelivery.class));
+        verify(coapExchange).respond(ResponseCode.CHANGED);
+    }
+
+    /**
+     * Verifies that the adapter waits for an telemetry message being send with wait for outcome before responding with
+     * a 2.04 status to the device.
+     */
+    @Test
+    public void testUploadTelemetryWaitsForAcceptedOutcome() {
+
+        // GIVEN an adapter with a downstream telemetry consumer attached
+        final Future<ProtonDelivery> outcome = Future.future();
+        givenATelemetrySenderForOutcome(outcome);
+        final CoapServer server = getCoapServer(false);
+
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true, null);
+
+        // WHEN a device publishes an telemetry message
+        final Buffer payload = Buffer.buffer("some payload");
+        final CoapExchange coapExchange = newCoapExchange(payload);
+        final Device authenticatedDevice = new Device("tenant", "device");
+
+        adapter.uploadTelemetryMessage(coapExchange, authenticatedDevice, authenticatedDevice, true);
+
+        // THEN the device does not get a response
+        verify(coapExchange, never()).respond(ResponseCode.CHANGED);
+
+        // until the telemetry message has been accepted
+        outcome.complete(mock(ProtonDelivery.class));
+        verify(coapExchange).respond(ResponseCode.CHANGED);
+    }
+
+    private static CoapExchange newCoapExchange(final Buffer payload) {
+
+        final OptionSet options = new OptionSet().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+        final CoapExchange coapExchange = mock(CoapExchange.class);
+        when(coapExchange.getRequestPayload()).thenReturn(payload.getBytes());
+        when(coapExchange.getRequestOptions()).thenReturn(options);
+        return coapExchange;
+    }
+
+    private CoapServer getCoapServer(final boolean startupShouldFail) {
+
+        final CoapServer server = mock(CoapServer.class);
+        if (startupShouldFail) {
+            doThrow(new IllegalStateException("Coap Server start with intented failure!")).when(server).start();
+        } else {
+            doNothing().when(server).start();
+        }
+        return server;
+    }
+
+    /**
+     * Creates a protocol adapter for a given HTTP server.
+     * 
+     * @param server The coap server.
+     * @param complete {@code true}, if that adapter should be created with all hono clients set, {@code false}, if the
+     *            adapter should be created, and all hono clients set, but the credentials client is not set.
+     * @param onStartupSuccess The handler to invoke on successful startup.
+     * 
+     * @return The adapter.
+     */
+    private AbstractVertxBasedCoapAdapter<CoapAdapterProperties> getAdapter(
+            final CoapServer server,
+            final boolean complete,
+            final Handler<Void> onStartupSuccess) {
+
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = new AbstractVertxBasedCoapAdapter<CoapAdapterProperties>() {
+
+            @Override
+            protected String getTypeName() {
+                return ADAPTER_TYPE;
+            }
+
+            @Override
+            protected void onStartupSuccess() {
+                if (onStartupSuccess != null) {
+                    onStartupSuccess.handle(null);
+                }
+            }
+
+            @Override
+            protected void addResources(final Context adapterContext, final CoapServer server) {
+
+            }
+        };
+
+        adapter.setConfig(config);
+        adapter.setCoapServer(server);
+        adapter.setTenantServiceClient(tenantServiceClient);
+        adapter.setHonoMessagingClient(messagingClient);
+        adapter.setRegistrationServiceClient(registrationServiceClient);
+        if (complete) {
+            adapter.setCredentialsServiceClient(credentialsServiceClient);
+        }
+        adapter.setCommandConnection(commandConnection);
+        adapter.setMetrics(mock(CoapAdapterMetrics.class));
+        adapter.init(vertx, mock(Context.class));
+
+        return adapter;
+    }
+
+    private void givenAnEventSenderForOutcome(final Future<ProtonDelivery> outcome) {
+
+        final MessageSender sender = mock(MessageSender.class);
+        when(sender.sendAndWaitForOutcome(any(Message.class))).thenReturn(outcome);
+
+        when(messagingClient.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
+    }
+
+    private void givenATelemetrySenderForOutcome(final Future<ProtonDelivery> outcome) {
+
+        final MessageSender sender = mock(MessageSender.class);
+        when(sender.sendAndWaitForOutcome(any(Message.class))).thenReturn(outcome);
+
+        when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+    }
+
+    private void givenATelemetrySender(final Future<ProtonDelivery> outcome) {
+
+        final MessageSender sender = mock(MessageSender.class);
+        when(sender.send(any(Message.class))).thenReturn(outcome);
+
+        when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+    }
+
+}

--- a/adapters/coap-vertx-base/src/test/resources/logback-test.xml
+++ b/adapters/coap-vertx-base/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.eclipse.hono.adapter" level="INFO"/>
+  <logger name="org.eclipse.hono.auth" level="INFO"/>
+  <logger name="org.eclipse.hono.config" level="INFO"/>
+  <logger name="org.eclipse.hono.connection" level="INFO"/>
+  <logger name="org.eclipse.hono.util" level="INFO"/>
+
+</configuration>

--- a/adapters/coap-vertx/pom.xml
+++ b/adapters/coap-vertx/pom.xml
@@ -1,0 +1,97 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-adapters</artifactId>
+    <version>0.7-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-adapter-coap-vertx</artifactId>
+  <name>Hono COAP Adapter</name>
+
+  <description>A protocol adapter exposing Hono's Telemetry &amp; Event APIs via COAP.</description>
+  <url>https://www.eclipse.org/hono</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-adapter-coap-vertx-base</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>build-docker-image</id>
+      <activation>
+        <property>
+          <name>docker.host</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <build>
+                    <from>${java-base-image.name}</from>
+                    <ports>
+                      <port>5683/udp</port>
+                      <port>5684/udp</port>
+                      <port>${vertx.health.port}</port>
+                    </ports>
+                    <cmd>
+                      <exec>
+                        <arg>java</arg>
+                        <arg>-XX:+UnlockExperimentalVMOptions</arg>
+                        <arg>-XX:+UseCGroupMemoryLimitForHeap</arg>
+                        <arg>-Dvertx.cacheDirBase=/tmp</arg>
+                        <arg>-jar</arg>
+                        <arg>/opt/hono/${project.artifactId}-${project.version}-${classifier.spring.boot.artifact}.jar</arg>
+                      </exec>
+                    </cmd>
+                    <assembly>
+                      <mode>dir</mode>
+                      <basedir>/</basedir>
+                      <inline>
+                        <fileSets>
+                          <fileSet>
+                            <directory>${project.build.directory}</directory>
+                            <outputDirectory>opt/hono</outputDirectory>
+                            <includes>
+                              <include>${project.artifactId}-${project.version}-${classifier.spring.boot.artifact}.jar</include>
+                            </includes>
+                          </fileSet>
+                        </fileSets>
+                      </inline>
+                    </assembly>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/Application.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/Application.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.adapter.coap.vertx;
+
+import org.eclipse.hono.service.AbstractApplication;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * The Hono COAP adapter main application class.
+ */
+@ComponentScan(basePackages = { "org.eclipse.hono.adapter.coap", "org.eclipse.hono.service.metric" })
+@Configuration
+@EnableAutoConfiguration
+public class Application extends AbstractApplication {
+
+    /**
+     * Starts the COAP Adapter application.
+     * 
+     * @param args Command line args passed to the application.
+     */
+    public static void main(final String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/CoapRequestHandler.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/CoapRequestHandler.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.coap.vertx;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+
+/**
+ * COAP request handler to pass COAP request to vertx.
+ */
+public interface CoapRequestHandler {
+
+    /**
+     * Handle COAP PUT request.
+     * 
+     * Called, when a COAP PUT request is forwarded to vertx.
+     * 
+     * @param exchange coap exchange of request
+     * @see CoapResource#handlePUT(CoapExchange)
+     */
+    void handlePUT(CoapExchange exchange);
+}

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/Config.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/Config.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.coap.vertx;
+
+import org.eclipse.hono.adapter.coap.CoapAdapterProperties;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.config.ApplicationConfigProperties;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.service.AbstractAdapterConfig;
+import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+/**
+ * Spring Boot configuration for the COAP adapter.
+ */
+@Configuration
+public class Config extends AbstractAdapterConfig {
+
+    private static final String CONTAINER_ID_HONO_COAP_ADAPTER = "Hono COAP Adapter";
+    private static final String BEAN_NAME_VERTX_BASED_COAP_ADAPTER = "vertxBasedCoapAdapter";
+
+    /**
+     * Creates a new COAP adapter instance.
+     * 
+     * @return The new instance.
+     */
+    @Bean(name = BEAN_NAME_VERTX_BASED_COAP_ADAPTER)
+    @Scope("prototype")
+    public VertxBasedCoapAdapter vertxBasedCoapAdapter() {
+        return new VertxBasedCoapAdapter();
+    }
+
+    @Override
+    protected void customizeMessagingClientConfig(final ClientConfigProperties props) {
+        if (props.getName() == null) {
+            props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
+        }
+    }
+
+    @Override
+    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties props) {
+        if (props.getName() == null) {
+            props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
+        }
+    }
+
+    @Override
+    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties props) {
+        if (props.getName() == null) {
+            props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
+        }
+    }
+
+    /**
+     * Exposes properties for configuring the application properties as a Spring bean.
+     *
+     * @return The application configuration properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.app")
+    public ApplicationConfigProperties applicationConfigProperties() {
+        return new ApplicationConfigProperties();
+    }
+
+    /**
+     * Exposes the COAP adapter's configuration properties as a Spring bean.
+     *
+     * @return The configuration properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.coap")
+    public CoapAdapterProperties adapterProperties() {
+        return new CoapAdapterProperties();
+    }
+
+    /**
+     * Exposes a factory for creating COAP adapter instances.
+     *
+     * @return The factory bean.
+     */
+    @Bean
+    public ObjectFactoryCreatingFactoryBean serviceFactory() {
+        final ObjectFactoryCreatingFactoryBean factory = new ObjectFactoryCreatingFactoryBean();
+        factory.setTargetBeanName(BEAN_NAME_VERTX_BASED_COAP_ADAPTER);
+        return factory;
+    }
+}

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/ExtendedDevice.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/ExtendedDevice.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.adapter.coap.vertx;
+
+import org.eclipse.hono.service.auth.device.Device;
+
+/**
+ * Extended hono device.
+ * 
+ * Tuple of hono devices, providing an authenticated device and optionally different device. For the gateway based
+ * communication the authenticated device would be the gateway and the device will contain the hono device, which is the
+ * origin of the associated message data. For direct communication both devices of the tuple are the same and used as
+ * origin of the associated message data.
+ */
+public class ExtendedDevice {
+
+    /**
+     * Authenticated device.
+     */
+    public final Device authenticatedDevice;
+    /**
+     * Message data origin device.
+     */
+    public final Device originDevice;
+
+    /**
+     * Create extended device.
+     * 
+     * @param authenticatedDevice authenticated device. Maybe a gateway.
+     * @param originDevice origin device. Maybe different or the same as the authenticatedDevice.
+     */
+    public ExtendedDevice(final Device authenticatedDevice, final Device originDevice) {
+        this.authenticatedDevice = authenticatedDevice;
+        this.originDevice = originDevice;
+    }
+
+    @Override
+    public String toString() {
+        if (authenticatedDevice == null || originDevice == null) {
+            return "unauthenticated";
+        }
+        if (authenticatedDevice == originDevice) {
+            return authenticatedDevice.toString();
+        }
+        return originDevice.toString() + " via " + authenticatedDevice.toString();
+    }
+}

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/VertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/VertxBasedCoapAdapter.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.coap.vertx;
+
+import java.util.List;
+
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.hono.adapter.coap.AbstractVertxBasedCoapAdapter;
+import org.eclipse.hono.adapter.coap.CoapAdapterProperties;
+import org.eclipse.hono.adapter.coap.CoapErrorResponse;
+import org.eclipse.hono.service.auth.device.Device;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TelemetryConstants;
+
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+
+/**
+ * A Vert.x based Hono protocol adapter for accessing Hono's Telemetry &amp; Event API using COAP.
+ */
+public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<CoapAdapterProperties> {
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @return {@link Constants#PROTOCOL_ADAPTER_TYPE_COAP}
+     */
+    @Override
+    protected String getTypeName() {
+        return Constants.PROTOCOL_ADAPTER_TYPE_COAP;
+    }
+
+    /**
+     * Get extended device.
+     * 
+     * @param exchange coap exchange with URI.
+     * @param handler handler for determined extended device
+     */
+    public void getExtendedDevice(final CoapExchange exchange, final Handler<ExtendedDevice> handler) {
+        try {
+            final List<String> pathList = exchange.getRequestOptions().getUriPath();
+            final String[] path = pathList.toArray(new String[pathList.size()]);
+            final ResourceIdentifier identifier = ResourceIdentifier.fromPath(path);
+            final Device device = new Device(identifier.getTenantId(), identifier.getResourceId());
+            final ExtendedDevice extendedDevice = new ExtendedDevice(device, device);
+            log.debug("use {}", extendedDevice);
+            handler.handle(extendedDevice);
+        } catch (Throwable cause) {
+            CoapErrorResponse.respond(exchange, cause, ResponseCode.BAD_REQUEST);
+        }
+    }
+
+    private boolean useWaitForOutcome(final CoapExchange exchange) {
+        return exchange.advanced().getRequest().isConfirmable();
+    }
+
+    protected void addResources(final Context adapterContext, final CoapServer server) {
+        final CoapRequestHandler telemetry = new CoapRequestHandler() {
+
+            @Override
+            public void handlePUT(final CoapExchange exchange) {
+                getExtendedDevice(exchange,
+                        (device) -> {
+                            final boolean waitForOutcome = useWaitForOutcome(exchange);
+                            uploadTelemetryMessage(exchange, device.authenticatedDevice, device.originDevice,
+                                    waitForOutcome);
+                        });
+            }
+        };
+
+        final CoapRequestHandler event = new CoapRequestHandler() {
+
+            @Override
+            public void handlePUT(final CoapExchange exchange) {
+                getExtendedDevice(exchange,
+                        (device) -> uploadEventMessage(exchange, device.authenticatedDevice, device.originDevice));
+            }
+        };
+
+        server.add(new VertxCoapResource(TelemetryConstants.TELEMETRY_ENDPOINT, adapterContext, telemetry));
+        server.add(new VertxCoapResource(EventConstants.EVENT_ENDPOINT, adapterContext, event));
+    }
+}

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/VertxCoapResource.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/VertxCoapResource.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.coap.vertx;
+
+import static org.eclipse.californium.core.coap.MediaTypeRegistry.APPLICATION_JSON;
+import static org.eclipse.californium.core.coap.MediaTypeRegistry.TEXT_PLAIN;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.core.server.resources.Resource;
+
+import io.vertx.core.Context;
+
+/**
+ * COAP resource delegating request to a vertx based implementation.
+ */
+public class VertxCoapResource extends CoapResource {
+
+    /**
+     * Vertx context to forward requests.
+     */
+    private final Context adapterContext;
+    /**
+     * Request handler called in scope of vertx.
+     */
+    private final CoapRequestHandler handler;
+
+    /**
+     * Create COAP resource.
+     * 
+     * @param name COAP name of resource
+     * @param adapterContext vertx context to call the handler
+     * @param handler request handler called within scope of vertx.
+     */
+    public VertxCoapResource(final String name, final Context adapterContext, final CoapRequestHandler handler) {
+        super(name);
+        this.handler = handler;
+        this.adapterContext = adapterContext;
+        getAttributes().setTitle("Resource for hono " + name);
+        getAttributes().addContentType(TEXT_PLAIN);
+        getAttributes().addContentType(APPLICATION_JSON);
+    }
+
+    /*
+     * Override the default behavior so that requests to sub resources are also handled by this instance
+     */
+    @Override
+    public Resource getChild(final String name) {
+        return this;
+    }
+
+    @Override
+    public void handlePUT(final CoapExchange exchange) {
+        adapterContext.runOnContext((v) -> {
+            handler.handlePUT(exchange);
+        });
+    }
+
+}

--- a/adapters/coap-vertx/src/main/resources/banner.txt
+++ b/adapters/coap-vertx/src/main/resources/banner.txt
@@ -1,0 +1,15 @@
+
+  ______     _ _                  _    _                   
+ |  ____|   | (_)                | |  | |                  
+ | |__   ___| |_ _ __  ___  ___  | |__| | ___  _ __   ___  
+ |  __| / __| | | '_ \/ __|/ _ \ |  __  |/ _ \| '_ \ / _ \ 
+ | |___| (__| | | |_) \__ \  __/ | |  | | (_) | | | | (_) |
+ |______\___|_|_| .__/|___/\___| |_|  |_|\___/|_| |_|\___/ 
+                | |                                        
+                |_|                                        
+
+Eclipse Hono COAP Adapter ${application.formatted-version}
+using Spring Boot ${spring-boot.formatted-version}
+
+Go to https://www.eclipse.org/hono for more information.
+

--- a/adapters/coap-vertx/src/main/resources/logback-spring.xml
+++ b/adapters/coap-vertx/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <springProfile name="trace">
+    <logger name="org.eclipse.hono.adapter" level="TRACE"/>
+    <logger name="org.eclipse.hono.client" level="TRACE"/>
+    <logger name="org.eclipse.hono.connection" level="TRACE"/>
+    <logger name="org.eclipse.hono.service" level="TRACE"/>
+  </springProfile>
+
+  <springProfile name="dev">
+    <logger name="org.eclipse.hono.adapter" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
+    <logger name="org.eclipse.hono.connection" level="DEBUG"/>
+    <logger name="org.eclipse.hono.service" level="DEBUG"/>
+  </springProfile>
+
+  <springProfile name="prod">
+    <logger name="org.eclipse.hono" level="INFO"/>
+  </springProfile>
+
+  <logger name="io.netty.handler.logging.LoggingHandler" level="INFO"/>
+
+  <logger name="io.vertx.proton.impl" level="INFO"/>
+  <logger name="io.vertx.core.net.impl" level="INFO"/>
+
+</configuration>

--- a/adapters/coap-vertx/src/test/resources/logback-test.xml
+++ b/adapters/coap-vertx/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.eclipse.hono.adapter" level="INFO"/>
+  <logger name="org.eclipse.hono.auth" level="INFO"/>
+  <logger name="org.eclipse.hono.config" level="INFO"/>
+  <logger name="org.eclipse.hono.connection" level="INFO"/>
+  <logger name="org.eclipse.hono.util" level="INFO"/>
+
+</configuration>

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -28,11 +28,13 @@
 
   <modules>
     <module>amqp-vertx</module>
-    <module>http-vertx-base</module>
+    <module>coap-vertx</module>
+    <module>coap-vertx-base</module>
     <module>http-vertx</module>
+    <module>http-vertx-base</module>
+    <module>kura</module>
     <module>mqtt-vertx</module>
     <module>mqtt-vertx-base</module>
-    <module>kura</module>
   </modules>
 
   <name>Hono Protocol Adapters</name>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <artemis.image.name>enmasseproject/activemq-artemis:2.2.0-4</artemis.image.name>
     <assertj-core.version>3.2.0</assertj-core.version>
+    <californium.version>2.0.0-M11</californium.version>
     <dispatch-router.image.name>enmasseproject/qdrouterd-base:1.1.0</dispatch-router.image.name>
     <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
     <grafana.version>5.1.4</grafana.version>
@@ -64,6 +65,21 @@
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>
         <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.californium</groupId>
+        <artifactId>californium-core</artifactId>
+        <version>${californium.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.californium</groupId>
+        <artifactId>element-connector</artifactId>
+        <version>${californium.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.californium</groupId>
+        <artifactId>scandium</artifactId>
+        <version>${californium.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>

--- a/core/src/main/java/org/eclipse/hono/util/Constants.java
+++ b/core/src/main/java/org/eclipse/hono/util/Constants.java
@@ -66,6 +66,11 @@ public final class Constants {
     public static final String PROTOCOL_ADAPTER_TYPE_AMQP= "hono-amqp";
 
     /**
+     * The type of the Eclipse coap adapter.
+     */
+    public static final String PROTOCOL_ADAPTER_TYPE_COAP= "hono-coap";
+
+    /**
      * The "QoS-Level" request header indicating the quality of service level supported by the HTTP Adapter.
      * The HTTP adapter supports QoS level AT_LEAST_ONCE when uploading telemetry messages.
      */


### PR DESCRIPTION
coap adapter update to work with hono 0.7-SNAPSHOT after hono 07-M2.
Supports x.509 client authentication.
Obsoletes my old PR #599 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
