### PR TITLE
[#633] Command and Control for MQTT.

### DIFF
--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/KuraProtocolAdapter.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/KuraProtocolAdapter.java
@@ -53,7 +53,7 @@ public final class KuraProtocolAdapter extends AbstractVertxBasedMqttProtocolAda
                 .recover(t -> {
                     LOG.debug("discarding message [topic: {}] from device: {}", ctx.message().topicName(), t.getMessage());
                     return Future.failedFuture(t);
-                }).compose(address -> uploadMessage(ctx, address, ctx.message().payload()));
+                }).compose(address -> uploadMessage(ctx, address, ctx.message()));
     }
 
     Future<ResourceIdentifier> mapTopic(final MqttContext ctx) {

--- a/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
@@ -27,4 +27,42 @@ public class CommandConstants {
      */
     public static final String COMMAND_ENDPOINT = "control";
 
+    /**
+     * The short name of the control endpoint.
+     */
+    public static final String COMMAND_ENDPOINT_SHORT = "c";
+
+    /**
+     * The part of the address for a command response between a device and an adapter, which identifies the request.
+     */
+    public static final String COMMAND_RESPONSE_REQUEST_PART = "req";
+
+
+    /**
+     * Short version of COMMAND_RESPONSE_REQUEST_PART.
+     */
+    public static final String COMMAND_RESPONSE_REQUEST_PART_SHORT = "q";
+
+    /**
+     * Position of the status code in the MQTT command response topic.
+     * {@code control/[tenant]/[device-id]/res/<req-id>/<status>}
+     */
+    public static final int TOPIC_POSITION_RESPONSE_STATUS = 5;
+
+    /**
+     * Position of the request id in the MQTT command response topic.
+     * {@code control/[tenant]/[device-id]/res/<req-id>/<status>}
+     */
+    public static final int TOPIC_POSITION_RESPONSE_REQ_ID = 4;
+
+    /**
+     * Returns true if the passed endpoint denotes a command endpoint (full or short version).
+     *
+     * @param endpoint The endpoint as a string.
+     * @return {@code true} if the endpoint is a command endpoint.
+     */
+    public static final boolean isCommandEndpoint(final String endpoint) {
+        return COMMAND_ENDPOINT.equals(endpoint) || COMMAND_ENDPOINT_SHORT.equals(endpoint);
+    }
+
 }

--- a/core/src/main/java/org/eclipse/hono/util/EndpointType.java
+++ b/core/src/main/java/org/eclipse/hono/util/EndpointType.java
@@ -16,7 +16,7 @@ package org.eclipse.hono.util;
  * Utility used to determine type of the endpoint.
  */
 public enum EndpointType {
-    TELEMETRY, EVENT, UNKNOWN;
+    TELEMETRY, EVENT, CONTROL, UNKNOWN;
 
     /**
      * Gets the endpoint type from a string value.
@@ -34,6 +34,9 @@ public enum EndpointType {
         case EventConstants.EVENT_ENDPOINT:
         case EventConstants.EVENT_ENDPOINT_SHORT:
             return EVENT;
+        case CommandConstants.COMMAND_ENDPOINT:
+        case CommandConstants.COMMAND_ENDPOINT_SHORT:
+            return CONTROL;
         default:
             return UNKNOWN;
         }

--- a/core/src/main/java/org/eclipse/hono/util/MessageTap.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageTap.java
@@ -49,7 +49,7 @@ public final class MessageTap implements Consumer<Message> {
         return new MessageTap(
                 msg -> {
                     final Section body = msg.getBody();
-                    if (!(body instanceof Data)) {
+                    if (body!=null && !(body instanceof Data)) {
                         return;
                     }
                     TimeUntilDisconnectNotification.fromMessage(msg).ifPresent(

--- a/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
@@ -30,6 +30,20 @@ import java.util.Objects;
  * <li>the <em>tenant ID</em></li>
  * <li>an (optional) <em>device ID</em></li>
  * </ol>
+ * <p>
+ * The basic scheme is {@code <endpoint>/[tenant]/[device-id]}
+ * <p>
+ * Examples:
+ * <ol>
+ * <li>telemetry/DEFAULT_TENANT/4711</li>
+ * <li>telemetry</li>
+ * <li>telemetry/</li>
+ * <li>telemetry//</li>
+ * <li>telemetry//4711</li>
+ * <li>telemetry/DEFAULT_TENANT</li>
+ * <li>telemetry/DEFAULT_TENANT/</li>
+ * </ol>
+ *
  */
 public final class ResourceIdentifier {
 
@@ -53,6 +67,17 @@ public final class ResourceIdentifier {
         setResourcePath(new String[]{endpoint, tenantId, resourceId});
     }
 
+    private ResourceIdentifier(final ResourceIdentifier resourceIdentifier, final String tenantId, final String resourceId) {
+        String[] path = resourceIdentifier.getResourcePath();
+        if (path.length < 3) {
+            path = new String[3];
+            path[IDX_ENDPOINT] = resourceIdentifier.getEndpoint();
+        }
+        path[IDX_TENANT_ID] = tenantId;
+        path[IDX_RESOURCE_ID] = resourceId;
+        setResourcePath(path);
+    }
+
     private ResourceIdentifier(final String[] path) {
         setResourcePath(path);
     }
@@ -70,6 +95,12 @@ public final class ResourceIdentifier {
             }
         }
         this.resourcePath = pathSegments.toArray(new String[pathSegments.size()]);
+        if (resourcePath.length > IDX_TENANT_ID && resourcePath[IDX_TENANT_ID].length() == 0) {
+            resourcePath[IDX_TENANT_ID] = null;
+        }
+        if (resourcePath.length > IDX_RESOURCE_ID && resourcePath[IDX_RESOURCE_ID].length() == 0) {
+            resourcePath[IDX_RESOURCE_ID] = null;
+        }
         createStringRepresentation();
     }
 
@@ -152,6 +183,21 @@ public final class ResourceIdentifier {
     public static ResourceIdentifier from(final String endpoint, final String tenantId, final String resourceId) {
         Objects.requireNonNull(endpoint);
         return new ResourceIdentifier(endpoint, tenantId, resourceId);
+    }
+
+    /**
+     * Creates a resource identifier for an endpoint from an other resource identifier. It uses all data from
+     * the original resource identifier but sets the new tenantId and resourceId.
+     *
+     * @param resourceIdentifier original resource identifier to copy values from.
+     * @param tenantId the tenant identifier (may be {@code null}).
+     * @param resourceId the resource identifier (may be {@code null}).
+     * @return the resource identifier.
+     * @throws NullPointerException if endpoint is {@code null}.
+     */
+    public static ResourceIdentifier from(final ResourceIdentifier resourceIdentifier, final String tenantId, final String resourceId) {
+        Objects.requireNonNull(resourceIdentifier);
+        return new ResourceIdentifier(resourceIdentifier, tenantId, resourceId);
     }
 
     /**

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
@@ -161,7 +161,8 @@ public class HonoConsumerBase {
     }
 
     private void printMessage(final String tenantId, final Message msg, final String messageType) {
-        final String content = ((Data) msg.getBody()).getValue().toString();
+        final Data body = (Data) msg.getBody();
+        final String content = body != null ? body.getValue().toString() : "";
         final String deviceId = MessageHelper.getDeviceId(msg);
 
         final StringBuilder sb = new StringBuilder("received ").

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -999,18 +999,4 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         LOG.debug("Command consumer was closed for [tenantId: {}, deviceId: {}] - no command will be received for this request anymore.",
                 tenant, deviceId);
     }
-
-    /**
-     * This method will be called for arriving commands for a device.
-     *
-     * @param tenantId The ID of the tenant to send the command responses for.
-     * @param deviceId The ID of the device to send the command responses for.
-     * @param delivery The delivery state.
-     * @param message The command message.
-     */
-    protected void onCommandReceived(final String tenantId, final String deviceId, final ProtonDelivery delivery,
-                                     final Message message) {
-        LOG.debug("command received [tenantId: {}, deviceId: {}, command: {}", tenantId, deviceId,
-                message.getSubject());
-    }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandSubscription.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandSubscription.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import org.eclipse.hono.service.auth.device.Device;
+import org.eclipse.hono.util.CommandConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/**
+ * The MQTT subscription of devices, to get commands.
+ *
+ * <p>
+ * Format of subscription need to be: {@code control|c/+|TENANT/+|DEVICE_ID/req|q/#} - e.g.:
+ * </p>
+ * <ol>
+ * <li>{@code control/+/+/req/#} - authenticated device and verbose format</li>
+ * <li>{@code c/+/+/q/#} - authenticated device with short format</li>
+ * <li>{@code control/DEFAULT_TENANT/4711/req/#} unauthenticated device with verbose format</li>
+ * </ol>
+ */
+public class CommandSubscription {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CommandSubscription.class);
+
+    private String endpoint;
+    private String req;
+    private String tenant;
+    private String deviceId;
+    private boolean isAuthenticated;
+
+    private CommandSubscription(final String topic) {
+        Objects.requireNonNull(topic);
+        final String[] parts = topic.split("\\/");
+        if (parts.length != 5 || !"#".equals(parts[4])) {
+            throw new IllegalArgumentException("the subscription does not fulfill the 'control|c/+/+/req|q/#' pattern");
+        }
+        endpoint = parts[0];
+        if (!CommandConstants.isCommandEndpoint(endpoint)) {
+            throw new IllegalArgumentException(
+                    "the endpoint needs to be '" + CommandConstants.COMMAND_ENDPOINT + "' or '"
+                            + CommandConstants.COMMAND_ENDPOINT_SHORT + "'");
+        }
+        req = parts[3];
+        if (!CommandConstants.COMMAND_RESPONSE_REQUEST_PART.equals(req)
+                && !CommandConstants.COMMAND_RESPONSE_REQUEST_PART_SHORT.equals(req)) {
+            throw new IllegalArgumentException(
+                    "the request part needs to be '" + CommandConstants.COMMAND_RESPONSE_REQUEST_PART + "' or '"
+                            + CommandConstants.COMMAND_RESPONSE_REQUEST_PART_SHORT + "'");
+        }
+        if (!"+".equals(parts[1])) {
+            tenant = parts[1];
+        }
+        if (!"+".equals(parts[2])) {
+            deviceId = parts[2];
+        }
+    }
+
+    private CommandSubscription(final String topic, final Device authenticatedDevice) {
+        this(topic);
+        if (authenticatedDevice == null) {
+            isAuthenticated = false;
+            if (tenant == null || tenant.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "for unauthenticated devices the tenant needs to be given in the subscription");
+            }
+            if (deviceId == null || deviceId.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "for unauthenticated devices the device-id needs to be given in the subscription");
+            }
+        } else {
+            isAuthenticated = true;
+            if ((tenant != null && !authenticatedDevice.getTenantId().equals(tenant)) ||
+                    (deviceId != null && !authenticatedDevice.getDeviceId().equals(deviceId))) {
+                throw new IllegalArgumentException(
+                        "for authenticated devices the given device-id and tenant need to match the authentication or be undefined ('+')");
+            } else {
+                tenant = authenticatedDevice.getTenantId();
+                deviceId = authenticatedDevice.getDeviceId();
+            }
+        }
+    }
+
+    /**
+     * Gets the tenant from topic or authentication .
+     *
+     * @return The tenant.
+     */
+    public String getTenant() {
+        return tenant;
+    }
+
+    /**
+     * Gets the device id from topic or authentication.
+     *
+     * @return The device id.
+     */
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    /**
+     * Gets the endpoint of the subscription.
+     *
+     * @return The endpoint.
+     */
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    /**
+     * Gets the request part of the subscription.
+     *
+     * @return The request part.
+     */
+    public String getRequestPart() {
+        return req;
+    }
+
+    /**
+     * Gets the authentication status, which indicates the need to publish on tenant/device-id for unauthenticated
+     * devices.
+     *
+     * @return {@code true} if created with an authenticated device.
+     */
+    public boolean isAuthenticated() {
+        return isAuthenticated;
+    }
+
+    /**
+     * Creates a command subscription object for the given topic. When the authenticated device is given it is used to
+     * ether check given tenant and device-id from topic or fill this fields if not given.
+     *
+     * @param topic The topic to subscribe for commands.
+     * @param authenticatedDevice The authenticated device or {@code null}.
+     * @return The CommandSubscription object or {@code null} if the topic does not match the rules.
+     * @throws NullPointerException if topic is {@node null}.
+     */
+    public static CommandSubscription fromTopic(final String topic, final Device authenticatedDevice) {
+        try {
+            return new CommandSubscription(topic, authenticatedDevice);
+        } catch (final IllegalArgumentException e) {
+            LOG.error(e.getMessage());
+            return null;
+        }
+    }
+
+}

--- a/service-base/src/test/java/org/eclipse/hono/service/command/CommandSubscriptionTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/command/CommandSubscriptionTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.service.command;
+
+import org.eclipse.hono.service.auth.device.Device;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies behavior of {@link CommandSubscription}.
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CommandSubscriptionTest {
+
+    private Device device = new Device("tenant", "device");
+
+    /**
+     * Verifies subscription pattern without authenticated device and correct pattern.
+     */
+    @Test
+    public void testSubscriptionUnauth() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("control/tenant/device/req/#", null);
+        assertNotNull(subscription);
+        assertThat(subscription.getDeviceId(), is("device"));
+        assertThat(subscription.getTenant(), is("tenant"));
+        assertThat(subscription.getEndpoint(), is("control"));
+        assertThat(subscription.getRequestPart(), is("req"));
+    }
+
+    /**
+     * Verifies subscription pattern without authenticated device and correct short pattern.
+     */
+    @Test
+    public void testSubscriptionUnauthShort() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("c/tenant/device/q/#", null);
+        assertNotNull(subscription);
+        assertThat(subscription.getDeviceId(), is("device"));
+        assertThat(subscription.getTenant(), is("tenant"));
+        assertThat(subscription.getEndpoint(), is("c"));
+        assertThat(subscription.getRequestPart(), is("q"));
+    }
+
+    /**
+     * Verifies subscription pattern with authenticated device and correct pattern.
+     */
+    @Test
+    public void testSubscriptionAuth() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("control/tenant/device/req/#", device);
+        assertNotNull(subscription);
+    }
+
+    /**
+     * Verifies subscription pattern with authenticated device and correct short pattern.
+     */
+    @Test
+    public void testSubscriptionAuthShort() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("c/tenant/device/q/#", device);
+        assertNotNull(subscription);
+    }
+
+    /**
+     * Verifies subscription pattern with authenticated device and correct pattern with different tenant/device as in
+     * authentication is not allowed.
+     */
+    @Test
+    public void testSubscriptionAuthDeviceDifferent() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("control/tenantA/deviceB/req/#", device);
+        assertNull(subscription);
+    }
+
+    /**
+     * Verifies subscription pattern with authenticated device and correct pattern without given tenant/device.
+     */
+    @Test
+    public void testSubscriptionAuthWithPattern() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("control/+/+/req/#", device);
+        assertNotNull(subscription);
+        assertThat(subscription.getDeviceId(), is("device"));
+        assertThat(subscription.getTenant(), is("tenant"));
+    }
+
+    /**
+     * Verifies subscription pattern without authenticated device and not given tenant/device is not allowed.
+     */
+    @Test
+    public void testSubscriptionUnauthWithPattern() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("control/+/+/req/#", null);
+        assertNull(subscription);
+    }
+
+    /**
+     * Verifies subscription pattern with other endpoint as c and control is not allowed.
+     */
+    @Test
+    public void testSubscriptionEndpoint() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("cx/tenant/device/q/#", null);
+        assertNull(subscription);
+    }
+
+    /**
+     * Verifies subscription pattern with other req part as q and req is not allowed.
+     */
+    @Test
+    public void testSubscriptionReq() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("c/tenant/device/qx/#", null);
+        assertNull(subscription);
+    }
+
+    /**
+     * Verifies subscription pattern with other ending part as # is not allowed.
+     */
+    @Test
+    public void testSubscriptionEnd() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("c/tenant/device/q/a", null);
+        assertNull(subscription);
+    }
+
+    /**
+     * Verifies subscription pattern with other then 5 parts is not allowed.
+     */
+    @Test
+    public void testSubscriptionParts() {
+        final CommandSubscription subscription = CommandSubscription.fromTopic("c/tenant/device/q/#/x", null);
+        assertNull(subscription);
+        final CommandSubscription subscription2 = CommandSubscription.fromTopic("c/tenant/device/q", null);
+        assertNull(subscription2);
+    }
+
+}

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingMessageFilter.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingMessageFilter.java
@@ -58,7 +58,7 @@ public final class HonoMessagingMessageFilter extends BaseMessageFilter {
          if (msg.getContentType() == null) {
              LOG.trace("message [{}] has no content type", msg.getMessageId());
              return false;
-         } else if (msg.getBody() == null || !(msg.getBody() instanceof Data)) {
+         } else if (msg.getBody() != null && !(msg.getBody() instanceof Data)) {
              LOG.trace("message [{}] has no body of type AMQP Data", msg.getMessageId());
              return false;
          } else {

--- a/site/content/concepts/command-and-control.md
+++ b/site/content/concepts/command-and-control.md
@@ -51,8 +51,6 @@ replied with `400 Bad request`.
 
 ## Command & Control over MQTT Adapter
 
-IMPORTANT: **Not implemented and just a DRAFT**
-
 When the device is connected to the MQTT Adapter it receives commands on the topic:
 
 * `control/[tenant]/[device-id]/req/<req-id>/<command>`

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -4,6 +4,10 @@ title = "Release Notes"
 
 ## 0.7 (not released yet)
 
+### New Features
+
+* The MQTT protocol adapter now supports Command and Control. Please refer to [MQTT adapter User Guide]({{< relref "user-guide/mqtt-adapter.md" >}}) for details.
+
 ### Fixes & Enhancements
 
 * Hono is now licensed under the [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/). Please refer to the Eclipse Foundation's [FAQ](https://www.eclipse.org/legal/epl-2.0/faq.php) for details regarding any implications this might have.

--- a/site/content/user-guide/mqtt-adapter.md
+++ b/site/content/user-guide/mqtt-adapter.md
@@ -156,3 +156,52 @@ The following properties are (currently) supported:
 | Name               | Type       | Default Value | Description                                                     |
 | :----------------- | :--------- | :------------ | :-------------------------------------------------------------- |
 | *enabled*          | *boolean*  | `true`       | If set to `false` the adapter will reject all data from devices belonging to the tenant. |
+
+# Command and Control
+
+All topics allow for a short version, as shown below:
+
+* `c` for `control` 
+* `q` for `req`
+* `s` for `res`
+
+Following variable fields will be used:
+
+`${command}` is a string, that indicates the command like e.g. `setBrightness` and is given on the application side. 
+`${req-id}` denotes the unique identifier of the command request and is provided to the device with the command. It has to be used again when sending a response to the command (and is internally used to correlate the command and the received response).
+
+The `property-bag` at the end is an optional bag of properties, that starts with a `?`. It is only allowed at the very end of the topic and is followed by pairs of URL encoded property names and values, that are separated by `&`:
+  `<url-encoded-name>=<url-encoded-value>`
+  
+ Property bags are not used right now but allow future additions.
+  
+`${status}` is the status of the command processing by the device, which is given with the response. 
+
+## Receive Commands 
+
+An **authenticated** device subscribes to: 
+
+* `control/+/+/req/#`
+
+Then the device gets commands on:
+
+* `control///req/${req-id}/${command}[/*][/property-bag]`
+
+An **unauthenticated** device subscribes to:
+* `control/${tenant-id}/${device-id}/req/#`
+
+Then it gets commands on:
+
+* `control/${tenant-id}/${device-id}/req/${req-id}/${command}[/*][/property-bag]`
+
+As soon as a device subscribes to the topic, the adapter sends an event with `ttd=-1` and the specific content-type ([Event API]({{< relref "api/Event-API.md" >}})). At unsubscribe it will send an event with the same content-type and `ttd=0`. 
+
+## Send Command Response
+
+An **authenticated** device sends the response to a previously received command to:
+
+* `control///res/${req-id}/${status}`
+
+An **unauthenticated** device sends the response to a previously received command to:
+
+* `control/${tenant-id}/${device-id}/res/${req-id}/${status}`


### PR DESCRIPTION
- subscription for commands (long and short version).
- send ttl events on subscription and unsubscribe.
- get commands for a device and publish it to subscription.
- command response endpoint to send the result of a received command.
- allow empty event bodies (for the ttl events).
