### PR TITLE
[#643] Bug Fix: Use device-id of authenticated device

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -499,7 +499,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                 result.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "address of authenticated message must not contain tenant ID only"));
             } else if (address.getTenantId() == null && address.getResourceId() == null) {
                 final ResourceIdentifier resource = ResourceIdentifier.from(address.getEndpoint(),
-                        authenticatedDevice.getTenantId(), authenticatedDevice.getTenantId());
+                        authenticatedDevice.getTenantId(), authenticatedDevice.getDeviceId());
                 result.complete(resource);
             } else {
                 result.complete(address);


### PR DESCRIPTION
@sophokles73: While working on the integration tests, I detected that the tenant-id is used in place of the device-id during address validation. I don't want to mix this change with the ITs and is the reason for creating a separate PR.

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>