### PR TITLE
[#331] Make connection timeout params configurable

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/AbstractClient.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/AbstractClient.java
@@ -40,10 +40,11 @@ abstract class AbstractClient {
     protected String tenantId;
     @Value(value = "${message.type}")
     protected String messageType;
+    @Value(value = "${connection.timeout}")
+    protected int connectionTimeOut;
     protected Vertx vertx;
     protected HonoClient client;
     protected List<String> activeProfiles;
-
 
     /**
      * Empty default constructor.

--- a/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
@@ -32,28 +32,34 @@ import io.vertx.core.dns.AddressResolverOptions;
 @Configuration
 public class AppConfiguration {
 
-    private final int DEFAULT_ADDRESS_RESOLUTION_TIMEOUT = 2000;
-
     /**
      * Exposes a Vert.x instance as a Spring bean.
-     * 
+     *
      * @return The Vert.x instance.
      */
     @Bean
     public Vertx vertx() {
         final VertxOptions options = new VertxOptions()
                 .setWarningExceptionTime(1500000000)
-                .setAddressResolverOptions(new AddressResolverOptions()
-                        .setCacheNegativeTimeToLive(0) // discard failed DNS lookup results immediately
-                        .setCacheMaxTimeToLive(0) // support DNS based service resolution
-                        .setRotateServers(true)
-                        .setQueryTimeout(DEFAULT_ADDRESS_RESOLUTION_TIMEOUT));
+                .setAddressResolverOptions(addressResolverOptions());
         return Vertx.vertx(options);
     }
 
     /**
+     * Exposes address resolver option properties as a Spring bean.
+     *
+     * @return The properties.
+     */
+    @ConfigurationProperties(prefix = "address.resolver")
+    @Bean
+    public AddressResolverOptions addressResolverOptions() {
+        final AddressResolverOptions addressResolverOptions = new AddressResolverOptions();
+        return addressResolverOptions;
+    }
+
+    /**
      * Exposes client configuration properties as a Spring bean.
-     * 
+     *
      * @return The properties.
      */
     @ConfigurationProperties(prefix = "hono.client")
@@ -65,7 +71,7 @@ public class AppConfiguration {
 
     /**
      * Exposes a factory for connections to the Hono as a Spring bean.
-     * 
+     *
      * @return The connection factory.
      */
     @Bean
@@ -73,10 +79,9 @@ public class AppConfiguration {
         return new ConnectionFactoryImpl(vertx(), honoClientConfig());
     }
 
-
     /**
      * Exposes a {@code HonoClient} as a Spring bean.
-     * 
+     *
      * @return The Hono client.
      */
     @Bean

--- a/cli/src/main/java/org/eclipse/hono/cli/Receiver.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/Receiver.java
@@ -44,7 +44,6 @@ import java.util.List;
 @Profile("receiver")
 public class Receiver extends AbstractClient {
 
-    private final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 1000;
     private static final String TYPE_TELEMETRY = "telemetry";
     private static final String TYPE_EVENT = "event";
     private static final String TYPE_ALL = "all";
@@ -65,7 +64,7 @@ public class Receiver extends AbstractClient {
     private CompositeFuture createConsumer(final HonoClient connectedClient) {
         final Handler<Void> closeHandler = closeHook -> {
             LOG.info("close handler of consumer is called");
-            vertx.setTimer(DEFAULT_CONNECT_TIMEOUT_MILLIS, reconnect -> {
+            vertx.setTimer(connectionTimeOut, reconnect -> {
                 LOG.info("attempting to re-open the consumer link ...");
                 createConsumer(connectedClient);
             });
@@ -90,7 +89,7 @@ public class Receiver extends AbstractClient {
 
     private void onDisconnect(final ProtonConnection con) {
         // give Vert.x some time to clean up NetClient
-        vertx.setTimer(DEFAULT_CONNECT_TIMEOUT_MILLIS, reconnect -> {
+        vertx.setTimer(connectionTimeOut, reconnect -> {
             LOG.info("attempting to re-connect to Hono ...");
             client.connect(this::onDisconnect)
                     .compose(this::createConsumer);

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -18,9 +18,21 @@ device:
 
 spring:
   profiles: receiver
+
 hono:
   client:
     port: 15671
+
+address:
+  resolver:
+    cacheNegativeTimeToLive: 0 #discard failed DNS lookup results immediately
+    cacheMaxTimeToLive: 0 #support DNS based service resolution
+    rotateServers: true
+    queryTimeout: 2000
+
+connection:
+  timeout: 1000
+
 message:
   type: all
 


### PR DESCRIPTION
With reference to #331, now connection timeout parameter and QueryResolverOptions are configurable.

Example:mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,**--address.resolver.queryTimeout=5000**,**--connection.timeout=3000**
