### PR TITLE
[#632] Add metrics for Command and Control to HTTP adapter

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -624,6 +624,10 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                                     endpointName, tenant, deviceId);
                             metrics.incrementProcessedMessages(endpointName, tenant);
                             metrics.incrementProcessedPayload(endpointName, tenant, messagePayloadSize(ctx));
+                            if (command!=null){
+                                metrics.incrementCommandDeliveredToDevice(tenant);
+                                LOG.trace("Command [{}] for device [tenantId: {}, deviceId: {}]", command.getPayload(), tenant, deviceId);
+                            }
                             currentSpan.finish();
                         });
                         ctx.response().exceptionHandler(t -> {
@@ -664,7 +668,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      * <p>
      * This implementation simply counts the bytes of the HTTP payload buffer and ignores all other attributes of the
      * HTTP request.
-     * 
+     *
      * @param ctx The payload to measure. May be {@code null}.
      * @return The number of bytes of the payload or zero if any input is {@code null}.
      */
@@ -698,7 +702,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             if (!ctx.response().closed()) {
                 ctx.response().closeHandler(v -> {
                     cancelCommandReceptionTimer(ctx);
-
+                    metrics.incrementNoCommandReceivedAndTTDExpired(tenantId);
                     LOG.debug("Connection was closed before response could be sent - closing command consumer for device [tenantId: {}, deviceId: {}]", tenantId, deviceId);
 
                     getCommandConnection().closeCommandConsumer(tenantId, deviceId).setHandler(result -> {
@@ -891,6 +895,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             senderTracker.compose(commandResponseSender -> {
                 return commandResponseSender.sendCommandResponse(commandResponse);
             }).map(delivery -> {
+                metrics.incrementCommandResponseDeliveredToApplication(tenant);
                 LOG.trace("command response [command-request-id: {}] accepted by application", commandRequestId);
                 ctx.response().setStatusCode(HttpURLConnection.HTTP_ACCEPTED);
                 ctx.response().end();

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
@@ -23,10 +23,21 @@ import org.springframework.stereotype.Component;
 public class HttpAdapterMetrics extends Metrics {
 
     private static final String SERVICE_PREFIX = "hono.http";
+    private static final String COMMANDS = ".commands";
 
     @Override
     protected String getPrefix() {
         return SERVICE_PREFIX;
     }
+    void incrementCommandDeliveredToDevice(final String tenantId) {
+        counterService.increment(METER_PREFIX + getPrefix() + mergeAsMetric(COMMANDS, tenantId, "device", "delivered"));
+    }
 
+    void incrementNoCommandReceivedAndTTDExpired(final String tenantId) {
+        counterService.increment(METER_PREFIX + getPrefix() + mergeAsMetric(COMMANDS, tenantId, "ttd", "expired"));
+    }
+
+    void incrementCommandResponseDeliveredToApplication(final String tenantId) {
+        counterService.increment(METER_PREFIX + getPrefix() + mergeAsMetric(COMMANDS, tenantId, "response", "delivered"));
+    }
 }

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 public class HttpAdapterMetrics extends Metrics {
 
     private static final String SERVICE_PREFIX = "hono.http";
-    private static final String COMMANDS = ".commands";
 
     @Override
     protected String getPrefix() {

--- a/deploy/src/main/config/grafana/dashboard-definitions/grafana_dashboard.json
+++ b/deploy/src/main/config/grafana/dashboard-definitions/grafana_dashboard.json
@@ -6,7 +6,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 3,
-  "iteration": 1533297853372,
+  "iteration": 1533541889600,
   "links": [
     {
       "icon": "external link",
@@ -776,7 +776,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
@@ -3301,7 +3301,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
@@ -3418,7 +3418,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
@@ -4897,5 +4897,5 @@
   "timezone": "browser",
   "title": "Hono",
   "uid": "a7yIj8Vmz",
-  "version": 3
+  "version": 4
 }

--- a/deploy/src/main/config/grafana/dashboard-definitions/grafana_dashboard.json
+++ b/deploy/src/main/config/grafana/dashboard-definitions/grafana_dashboard.json
@@ -21,7 +21,7 @@
       "content": "<h1 style=\"color:black; background-color:#555555; padding:5px\"><center>Messaging - Telemetry</center></h1>",
       "gridPos": {
         "h": 3,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 0
       },
@@ -36,11 +36,25 @@
       "content": "<h1 style=\"color:black; background-color:#555555; padding:5px\"><center>Messaging - Events</center></h1>",
       "gridPos": {
         "h": 3,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 0
       },
       "id": 25,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "type": "text"
+    },
+    {
+      "content": "<h1 style=\"color:black; background-color:#555555; padding:5px\"><center>Commands</center></h1>",
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 56,
       "links": [],
       "mode": "html",
       "title": "",
@@ -66,7 +80,7 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
+        "w": 2,
         "x": 0,
         "y": 3
       },
@@ -179,8 +193,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 8,
-        "x": 4,
+        "w": 6,
+        "x": 2,
         "y": 3
       },
       "id": 44,
@@ -290,8 +304,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 3
       },
       "id": 46,
@@ -382,6 +396,117 @@
       "valueName": "avg"
     },
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 3
+      },
+      "id": 57,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.device.delivered.m1_rate\" where tenant = '$TENANT'  group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Total Commands Delivered Per Sec (Ø/min)",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -389,8 +514,8 @@
       "datasource": "hono_data",
       "fill": 1,
       "gridPos": {
-        "h": 10,
-        "w": 12,
+        "h": 8,
+        "w": 8,
         "x": 0,
         "y": 6
       },
@@ -507,9 +632,9 @@
       "datasource": "hono_data",
       "fill": 1,
       "gridPos": {
-        "h": 10,
-        "w": 12,
-        "x": 12,
+        "h": 8,
+        "w": 8,
+        "x": 8,
         "y": 6
       },
       "id": 20,
@@ -618,6 +743,123 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "hono_data",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 58,
+      "interval": ">5s",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "policy": "default",
+          "query": "SELECT mean(value) FROM \"meter.hono.commands.device.delivered.m1_rate\" WHERE $timeFilter and  tenant = '$TENANT' GROUP BY host, time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Delivered Commands Per Second (Ø/min)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -637,9 +879,9 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 6,
+        "w": 4,
         "x": 0,
-        "y": 16
+        "y": 14
       },
       "id": 14,
       "interval": null,
@@ -736,9 +978,9 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 6,
-        "x": 6,
-        "y": 16
+        "w": 4,
+        "x": 4,
+        "y": 14
       },
       "id": 15,
       "interval": null,
@@ -831,9 +1073,9 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 6,
-        "x": 12,
-        "y": 16
+        "w": 4,
+        "x": 8,
+        "y": 14
       },
       "id": 19,
       "interval": null,
@@ -930,9 +1172,9 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 6,
-        "x": 18,
-        "y": 16
+        "w": 4,
+        "x": 12,
+        "y": 14
       },
       "id": 17,
       "interval": null,
@@ -1006,12 +1248,198 @@
       "valueName": "avg"
     },
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 14
+      },
+      "id": 59,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.device.delivered.count\" where tenant = '$TENANT' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Commands Delivered",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 14
+      },
+      "id": 60,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.response.delivered.count\" where tenant = '$TENANT' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Command Responses Delivered",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
       "content": "<h1 style=\"color:black; background-color:#555555; padding:5px\"><center>MQTT Adapter</center></h1>",
       "gridPos": {
         "h": 3,
         "w": 12,
         "x": 0,
-        "y": 19
+        "y": 17
       },
       "id": 26,
       "links": [],
@@ -1025,7 +1453,7 @@
         "h": 3,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 17
       },
       "id": 27,
       "links": [],
@@ -1055,7 +1483,7 @@
         "h": 3,
         "w": 4,
         "x": 0,
-        "y": 22
+        "y": 20
       },
       "id": 41,
       "interval": null,
@@ -1166,7 +1594,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 22
+        "y": 20
       },
       "id": 43,
       "interval": null,
@@ -1277,7 +1705,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 22
+        "y": 20
       },
       "id": 47,
       "interval": null,
@@ -1388,7 +1816,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 22
+        "y": 20
       },
       "id": 42,
       "interval": null,
@@ -1499,7 +1927,7 @@
         "h": 3,
         "w": 4,
         "x": 16,
-        "y": 22
+        "y": 20
       },
       "id": 45,
       "interval": null,
@@ -1610,7 +2038,7 @@
         "h": 3,
         "w": 4,
         "x": 20,
-        "y": 22
+        "y": 20
       },
       "id": 48,
       "interval": null,
@@ -1700,6 +2128,673 @@
       "valueName": "avg"
     },
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 23
+      },
+      "id": 52,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.device.delivered.m1_rate\" where tenant = '$TENANT' and protocol='mqtt' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Total Commands Delivered Per Sec (Ø/min)",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 23
+      },
+      "id": 53,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.ttd.expired.m1_rate\" where tenant = '$TENANT' and protocol='mqtt' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Total TTD Expiries  Per Sec (Ø/min)",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 23
+      },
+      "id": 55,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.response.delivered.m1_rate\" where tenant = '$TENANT' and protocol='mqtt' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Total Command Responses Per Sec (Ø/min)",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 23
+      },
+      "id": 49,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.device.delivered.m1_rate\" where tenant = '$TENANT' and protocol='http' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Total Commands Delivered Per Sec (Ø/min)",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "description": "Total number of ttd expiries and no commands were received",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 23
+      },
+      "id": 50,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.ttd.expired.m1_rate\" where tenant = '$TENANT' and protocol='http' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Total TTD Expiries  Per Sec (Ø/min)",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 23
+      },
+      "id": 51,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.response.delivered.m1_rate\" where tenant = '$TENANT' and protocol='http' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Total Command Responses Per Sec (Ø/min)",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -1710,7 +2805,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 25
+        "y": 26
       },
       "id": 28,
       "interval": ">5s",
@@ -1828,7 +2923,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 25
+        "y": 26
       },
       "id": 29,
       "interval": ">5s",
@@ -1947,7 +3042,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 35
       },
       "id": 38,
       "interval": ">5s",
@@ -2065,7 +3160,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 34
+        "y": 35
       },
       "id": 39,
       "interval": ">5s",
@@ -2173,6 +3268,240 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "hono_data",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "id": 67,
+      "interval": ">5s",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "1 Minute",
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "policy": "default",
+          "query": "SELECT mean(value) FROM \"meter.hono.commands.device.delivered.m1_rate\" WHERE $timeFilter and protocol = 'mqtt' and  tenant = '$TENANT' GROUP BY host, time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Delivered MQTT Commands Per Second (Ø/min)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "hono_data",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 66,
+      "interval": ">5s",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "1 Minute",
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "policy": "default",
+          "query": "SELECT mean(value) FROM \"meter.hono.commands.device.delivered.m1_rate\" WHERE $timeFilter and protocol = 'http' and  tenant = '$TENANT' GROUP BY host, time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Delivered HTTP Commands Per Second (Ø/min)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -2194,7 +3523,7 @@
         "h": 3,
         "w": 6,
         "x": 0,
-        "y": 43
+        "y": 53
       },
       "id": 30,
       "interval": null,
@@ -2305,7 +3634,7 @@
         "h": 3,
         "w": 6,
         "x": 6,
-        "y": 43
+        "y": 53
       },
       "id": 31,
       "interval": null,
@@ -2416,7 +3745,7 @@
         "h": 3,
         "w": 6,
         "x": 12,
-        "y": 43
+        "y": 53
       },
       "id": 34,
       "interval": null,
@@ -2527,7 +3856,7 @@
         "h": 3,
         "w": 6,
         "x": 18,
-        "y": 43
+        "y": 53
       },
       "id": 35,
       "interval": null,
@@ -2638,7 +3967,7 @@
         "h": 3,
         "w": 6,
         "x": 0,
-        "y": 46
+        "y": 56
       },
       "id": 32,
       "interval": null,
@@ -2749,7 +4078,7 @@
         "h": 3,
         "w": 6,
         "x": 6,
-        "y": 46
+        "y": 56
       },
       "id": 33,
       "interval": null,
@@ -2860,7 +4189,7 @@
         "h": 3,
         "w": 6,
         "x": 12,
-        "y": 46
+        "y": 56
       },
       "id": 36,
       "interval": null,
@@ -2971,7 +4300,7 @@
         "h": 3,
         "w": 6,
         "x": 18,
-        "y": 46
+        "y": 56
       },
       "id": 37,
       "interval": null,
@@ -3059,6 +4388,450 @@
         }
       ],
       "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 59
+      },
+      "id": 64,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.device.delivered.count\" where tenant = '$TENANT' and protocol = 'mqtt' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "MQTT Commands Delivered",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 6,
+        "y": 59
+      },
+      "id": 62,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.response.delivered.count\" where tenant = '$TENANT' and protocol = 'mqtt' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "MQTT  Command Responses Delivered",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 12,
+        "y": 59
+      },
+      "id": 63,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.device.delivered.count\" where tenant = '$TENANT' and protocol = 'http' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "HTTP Commands Delivered",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "hono_data",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 59
+      },
+      "id": 65,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "policy": "default",
+          "query": "select sum(*) from ( select last(value) from \"meter.hono.commands.response.delivered.count\" where tenant = '$TENANT' and protocol = 'http' group by host ) where $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "HTTP  Command Responses Delivered",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "0",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
     }
   ],
   "refresh": "5s",
@@ -3070,9 +4843,8 @@
       {
         "allValue": null,
         "current": {
-          "isNone": true,
-          "text": "None",
-          "value": ""
+          "text": "DEFAULT_TENANT",
+          "value": "DEFAULT_TENANT"
         },
         "datasource": "hono_data",
         "hide": 0,

--- a/deploy/src/main/deploy/influxdb.conf
+++ b/deploy/src/main/deploy/influxdb.conf
@@ -95,6 +95,7 @@ bind-address = ":8088"
     "*.counter.hono.*.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
     "*.meter.hono.*.messages.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
     "*.meter.hono.*.payload.* host.measurement.measurement.measurement.measurement.type.tenant.measurement*",
+    "*.meter.hono.*.commands.* host.measurement.measurement.protocol.measurement.tenant.measurement*",
     "*.counter.hono.*.connections.* host.measurement.measurement.measurement.measurement.tenant.measurement*",
     # default template
     "host.measurement*"

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -26,7 +26,7 @@ abstract public class Metrics {
 
     /**
      * Special prefixes used by spring boot actuator together with dropwizard metrics.
-     * 
+     *
      * @see <a href=
      *      "https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-dropwizard-metrics">Spring
      *      Boot</a>
@@ -42,6 +42,7 @@ abstract public class Metrics {
     protected static final String UNDELIVERABLE = ".undeliverable";
     protected static final String CONNECTIONS = ".connections.";
     protected static final String UNAUTHENTICATED_CONNECTIONS = ".unauthenticatedConnections.";
+    protected static final String COMMANDS = ".commands";
 
     protected static final String PAYLOAD = ".payload.";
 
@@ -103,7 +104,7 @@ abstract public class Metrics {
 
     /**
      * Merge the given address parts as a full string, separated by '.'.
-     * 
+     *
      * @param parts The address parts
      * @return The full address, separated by points
      */
@@ -113,7 +114,7 @@ abstract public class Metrics {
 
     /**
      * Increment the number of processes messages by one.
-     * 
+     *
      * @param resourceId The ID of the resource to track.
      * @param tenantId The tenant this resource belongs to.
      */
@@ -123,7 +124,7 @@ abstract public class Metrics {
 
     /**
      * Increment the number of undeliverable messages by one.
-     * 
+     *
      * @param resourceId The ID of the resource to track.
      * @param tenantId The tenant this resource belongs to.
      */
@@ -133,7 +134,7 @@ abstract public class Metrics {
 
     /**
      * Increment the counter for the number of processed bytes.
-     * 
+     *
      * @param resourceId The ID of the resource to track.
      * @param tenantId The tenant this resource belongs to.
      * @param payloadSize The size of the payload in bytes.

--- a/site/content/api/Metrics.md
+++ b/site/content/api/Metrics.md
@@ -45,7 +45,7 @@ extracting the following *tags* from metric names transmitted via the Graphite r
 | *host*     | The name of the host that the service reporting the metric is running on. |
 | *type*     | The type of message that the metric is being processed for (either `telemetry` or `event`) |
 | *tenant*   | The name of the tenant that the metric is being reported for. |
-| *protocol* | The protocol of message that the metric is being processed for (example: `http`, `mqtt`) |
+| *protocol* | The protocol of message that the metric is being processed for (example: `http`, `mqtt`). This is used only in Command and Control metrics. |
 
 The following sections describe which of these tags are extracted for which metrics specifically.
  

--- a/site/content/api/Metrics.md
+++ b/site/content/api/Metrics.md
@@ -40,11 +40,12 @@ a way to transmit metrics to InfluxDB resulting in the same database structure.
 The InfluxDB configuration file used for the example deployment contains templates for
 extracting the following *tags* from metric names transmitted via the Graphite reporter.
 
-| Tag      | Description |
-| -------- | ----------- |
-| *host*   | The name of the host that the service reporting the metric is running on. |
-| *type*   | The type of message that the metric is being processed for (either `telemetry` or `event`) |
-| *tenant* | The name of the tenant that the metric is being reported for. |
+| Tag        | Description |
+| ---------- | ----------- |
+| *host*     | The name of the host that the service reporting the metric is running on. |
+| *type*     | The type of message that the metric is being processed for (either `telemetry` or `event`) |
+| *tenant*   | The name of the tenant that the metric is being reported for. |
+| *protocol* | The protocol of message that the metric is being processed for (example: `http`, `mqtt`) |
 
 The following sections describe which of these tags are extracted for which metrics specifically.
  
@@ -70,6 +71,26 @@ The following sections describe which of these tags are extracted for which metr
 | *meter.hono.mqtt.messages.processed.m5_rate*     | *host*, *tenant*, *type* | Messages processed by the MQTT protocol adapter. Five minute, exponentially weighted, moving average. |
 | *meter.hono.mqtt.messages.processed.m15_rate*    | *host*, *tenant*, *type* | Messages processed by the MQTT protocol adapter. Fifteen minute, exponentially weighted, moving average. |
 | *meter.hono.mqtt.messages.processed.mean_rate*   | *host*, *tenant*, *type* | Messages processed by the MQTT protocol adapter. Mean rate of messages since the application start. |
+
+### Command and Control Metrics
+
+| Metric                                             | Tags                             | Description |
+| -------------------------------------------------- | -------------------------------- | ----------- |
+| *meter.hono.commands.device.delivered.count*       | *host*, *tenant*, *protocol*     | Command delivered to device before ttd expires. Total count since application startup. |
+| *meter.hono.commands.response.delivered.count*     | *host*, *tenant*, *protocol*     | Command response delivered from device to application. Total count since application startup. |
+| *meter.hono.commands.ttd.expired.count*            | *host*, *tenant*, *protocol*     | Ttd expired with no command received from application. Total count since application startup. |
+| *meter.hono.commands.device.delivered.m1_rate*     | *host*, *tenant*, *protocol*     | Command delivered to device before ttd expires. One minute, exponentially weighted, moving average. |
+| *meter.hono.commands.response.delivered.m1_rate*   | *host*, *tenant*, *protocol*     | Command response delivered from device to application. One minute, exponentially weighted, moving average. |
+| *meter.hono.commands.ttd.expired.m1_rate*          | *host*, *tenant*, *protocol*     | Ttd expired with no command received from application. One minute, exponentially weighted, moving average. |
+| *meter.hono.commands.device.delivered.m5_rate*     | *host*, *tenant*, *protocol*     | Command delivered to device before ttd expires. Five minute, exponentially weighted, moving average. |
+| *meter.hono.commands.response.delivered.m5_rate*   | *host*, *tenant*, *protocol*     | Command response delivered from device to application. Five minute, exponentially weighted, moving average. |
+| *meter.hono.commands.ttd.expired.m5_rate*          | *host*, *tenant*, *protocol*     | Ttd expired with no command received from application. Five minute, exponentially weighted, moving average. |
+| *meter.hono.commands.device.delivered.m15_rate*    | *host*, *tenant*, *protocol*     | Command delivered to device before ttd expires. Fifteen minute, exponentially weighted, moving average. |
+| *meter.hono.commands.response.delivered.m15_rate*  | *host*, *tenant*, *protocol*     | Command response delivered from device to application. Fifteen minute, exponentially weighted, moving average. |
+| *meter.hono.commands.ttd.expired.m15_rate*         | *host*, *tenant*, *protocol*     | Ttd expired with no command received from application. Fifteen minute, exponentially weighted, moving average. |
+| *meter.hono.commands.device.delivered.mean_rate*   | *host*, *tenant*, *protocol*     | Command delivered to device before ttd expires. Mean rate of messages since the application start. |
+| *meter.hono.commands.response.delivered.mean_rate* | *host*, *tenant*, *protocol*     | Command response delivered from device to application. Mean rate of messages since the application start. |
+| *meter.hono.commands.ttd.expired.mean_rate*        | *host*, *tenant*, *protocol*     | Ttd expired with no command received from application. Mean rate of messages since the application start. |
 
 ## Metrics API
 

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -13,6 +13,7 @@ title = "Release Notes"
 * Hono is now licensed under the [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/). Please refer to the Eclipse Foundation's [FAQ](https://www.eclipse.org/legal/epl-2.0/faq.php) for details regarding any implications this might have.
 * Hono deployment scripts are now available under `deploy` folder. Deployment scripts which were previously available under `example` folder were moved to `deploy`.
 * Hono-cli (Command Line Interface) is now available under folder `cli`. A command line argument `message.type` with value `telemetry`, `event` or `all` (default) tells the client what kind of messages to be received. See [Starting a Consumer]({{< relref "getting-started.md#starting-a-consumer" >}}) for more information.
+* Added metrics to Command and Control for the HTTP protocol adapter. Now Hono-Dashboard also shows the metrics from Command and Control.
 
 ## 0.7-M2
 


### PR DESCRIPTION
Below metrics are added for Command and Control (HTTP).
- Commands delivered (command delivered to device before ttd expires)
- TTD expiries (ttd expired with no command received from applications)
- Commad responses delivered (command response delivered from device to application)

Also the Grafana dashboard has been changed to accommodate the above metrics from command and control for both HTTP and MQTT adapters. For more info refer #632.