### PR TITLE
Allow to customize vertx options and set option to prefer native sockets

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/VertxProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/VertxProperties.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.config;
+
+import io.vertx.core.VertxOptions;
+
+/**
+ * Vertx properties.
+ */
+public class VertxProperties {
+
+    private boolean preferNative = VertxOptions.DEFAULT_PREFER_NATIVE_TRANSPORT;
+
+    /**
+     * Prefer to use native networking or not.
+     * <p>
+     * Also see {@link VertxOptions#setPreferNativeTransport(boolean)}.
+     * </p>
+     * 
+     * @param preferNative {@code true} to prefer native networking, {@code false} otherwise.
+     */
+    public void setPreferNative(final boolean preferNative) {
+        this.preferNative = preferNative;
+    }
+
+    /**
+     * Configure the Vertx options according to our settings.
+     * 
+     * @param options The options to configure.
+     */
+    public void configureVertx(final VertxOptions options) {
+
+        options.setPreferNativeTransport(this.preferNative);
+
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -20,6 +20,7 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.impl.HonoClientImpl;
 import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.config.VertxProperties;
 import org.eclipse.hono.service.cache.SpringCacheProvider;
 import org.eclipse.hono.service.command.CommandConnection;
 import org.eclipse.hono.service.command.CommandConnectionImpl;
@@ -93,9 +94,13 @@ public abstract class AbstractAdapterConfig {
                         .setCacheNegativeTimeToLive(0) // discard failed DNS lookup results immediately
                         .setCacheMaxTimeToLive(0) // support DNS based service resolution
                         .setQueryTimeout(1000));
+
         if (metricsOptions != null) {
             options.setMetricsOptions(metricsOptions);
         }
+
+        vertxProperties().configureVertx(options);
+
         return Vertx.vertx(options);
     }
 
@@ -323,6 +328,17 @@ public abstract class AbstractAdapterConfig {
     @Scope("prototype")
     public CommandConnection commandConnection() {
         return new CommandConnectionImpl(vertx(), commandConnectionClientConfig());
+    }
+
+    /**
+     * Exposes configuration options for vertx.
+     * 
+     * @return The Properties.
+     */
+    @ConfigurationProperties("hono.vertx")
+    @Bean
+    public VertxProperties vertxProperties() {
+        return new VertxProperties();
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
@@ -224,6 +224,10 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
      */
     protected final Future<Void> checkPortConfiguration() {
 
+        if (vertx != null) {
+            LOG.info("Vertx native support: {}", vertx.isNativeTransportEnabled());
+        }
+
         final Future<Void> result = Future.future();
 
         if (getConfig().getKeyCertOptions() == null) {
@@ -399,7 +403,7 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
             final boolean isOpenSslAvailable = OpenSsl.isAvailable();
             final boolean supportsKeyManagerFactory =  OpenSsl.supportsKeyManagerFactory();
             final boolean useOpenSsl =
-                    getConfig().isNativeTlsRequired() || (isOpenSslAvailable && supportsKeyManagerFactory);
+                    getConfig().isNativeTlsRequired() || isOpenSslAvailable && supportsKeyManagerFactory;
 
             LOG.debug("OpenSSL [available: {}, supports KeyManagerFactory: {}]",
                     isOpenSslAvailable, supportsKeyManagerFactory);

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -18,6 +18,7 @@ import io.vertx.core.dns.AddressResolverOptions;
 
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.config.VertxProperties;
 import org.eclipse.hono.service.credentials.CredentialsAmqpEndpoint;
 import org.eclipse.hono.service.credentials.CredentialsHttpEndpoint;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
@@ -59,6 +60,9 @@ public class ApplicationConfig {
                         .setCacheNegativeTimeToLive(0) // discard failed DNS lookup results immediately
                         .setCacheMaxTimeToLive(0) // support DNS based service resolution
                         .setQueryTimeout(1000));
+
+        vertxProperties().configureVertx(options);
+
         return Vertx.vertx(options);
     }
 
@@ -267,4 +271,16 @@ public class ApplicationConfig {
         }
         return RegistrationAssertionHelperImpl.forSigning(vertx(), serviceProps.getSigning());
     }
+
+    /**
+     * Exposes configuration options for vertx.
+     * 
+     * @return The Properties.
+     */
+    @ConfigurationProperties("hono.vertx")
+    @Bean
+    public VertxProperties vertxProperties() {
+        return new VertxProperties();
+    }
+
 }


### PR DESCRIPTION
This PR introduces a common way to configure vertx specific options. As a first option is allows to set whether to prefer native TCP sockets or not.

Using native sockets still requires e.g. the netty epoll or kqueue implementation. However simply adding this dependency doesn't enable it unless the flag in the vertx option is set.

This is independent of the native TLS implementation!