### PR TITLE
[#643] Add support for client certificate based authentication

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpContext.java
@@ -49,10 +49,11 @@ public class AmqpContext {
      * @param delivery The delivery of the message.
      * @param message The AMQP 1.0 message. The message must contain a valid address.
      * @param authenticatedDevice The device that authenticates to the adapter or {@code null} if the device is unauthenticated.
+     * @throws NullPointerException if the delivery or message is null.
      */
     AmqpContext(final ProtonDelivery delivery, final Message message, final Device authenticatedDevice) {
-        this.delivery = delivery;
-        this.message = message;
+        this.delivery = Objects.requireNonNull(delivery);
+        this.message = Objects.requireNonNull(message);
         this.authenticatedDevice = authenticatedDevice;
         this.resource = ResourceIdentifier.fromString(message.getAddress());
     }

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -23,8 +23,6 @@ import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.auth.device.Device;
-import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
-import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EndpointType;
 import org.eclipse.hono.util.HonoProtonHelper;
@@ -102,8 +100,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
         checkPortConfiguration()
                 .compose(success -> {
                     if (authenticatorFactory == null && getConfig().isAuthenticationRequired()) {
-                        final HonoClientBasedAuthProvider usernamePasswordAuthProvider = new UsernamePasswordAuthProvider(getCredentialsServiceClient(), getConfig());
-                        authenticatorFactory = new AmqpAdapterSaslAuthenticatorFactory(usernamePasswordAuthProvider, getConfig());
+                        authenticatorFactory = new AmqpAdapterSaslAuthenticatorFactory(getTenantServiceClient(), getCredentialsServiceClient(), getConfig());
                     }
                     return Future.succeededFuture();
                 }).compose(succcess -> {

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
@@ -22,13 +22,11 @@ import org.eclipse.hono.adapter.http.HonoBasicAuthHandler;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.http.X509AuthHandler;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.config.AbstractConfig;
-import org.eclipse.hono.service.auth.ValidityBasedTrustOptions;
 import org.eclipse.hono.service.auth.device.Device;
 import org.eclipse.hono.service.auth.device.HonoChainAuthHandler;
 import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
-import org.eclipse.hono.service.auth.device.X509AuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
+import org.eclipse.hono.service.auth.device.X509AuthProvider;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.util.Constants;
 import org.slf4j.Logger;
@@ -37,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.net.TrustOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.ChainAuthHandler;
@@ -83,29 +80,6 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
      */
     public void setClientCertAuthProvider(final HonoClientBasedAuthProvider provider) {
         this.clientCertAuthProvider = Objects.requireNonNull(provider);
-    }
-
-    /**
-     * Gets the options for configuring the server side trust anchor.
-     * <p>
-     * This implementation returns the options returned by
-     * {@link AbstractConfig#getTrustOptions()} if not {@code null}.
-     * Otherwise, it returns trust options for verifying a client
-     * certificate's validity period.
-     * 
-     * @return The trust options.
-     */
-    @Override
-    protected TrustOptions getServerTrustOptions() {
-
-        return Optional.ofNullable(getConfig().getTrustOptions())
-                .orElseGet(() -> {
-                    if (getConfig().isAuthenticationRequired()) {
-                        return new ValidityBasedTrustOptions();
-                    } else {
-                        return null;
-                    }
-                });
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -27,7 +27,9 @@ import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.TenantClient;
+import org.eclipse.hono.config.AbstractConfig;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.service.auth.ValidityBasedTrustOptions;
 import org.eclipse.hono.service.auth.device.Device;
 import org.eclipse.hono.service.command.Command;
 import org.eclipse.hono.service.command.CommandConnection;
@@ -54,6 +56,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.TrustOptions;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.healthchecks.Status;
 import io.vertx.proton.ProtonConnection;
@@ -1093,4 +1096,26 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             }
         });
     }
+
+    /**
+     * Gets the options for configuring the server side trust anchor.
+     * <p>
+     * This implementation returns the options returned by {@link AbstractConfig#getTrustOptions()} if not {@code null}.
+     * Otherwise, it returns trust options for verifying a client certificate's validity period.
+     * 
+     * @return The trust options.
+     */
+    @Override
+    protected TrustOptions getServerTrustOptions() {
+
+        return Optional.ofNullable(getConfig().getTrustOptions())
+                .orElseGet(() -> {
+                    if (getConfig().isAuthenticationRequired()) {
+                        return new ValidityBasedTrustOptions();
+                    } else {
+                        return null;
+                    }
+                });
+    }
+
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -621,6 +621,10 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                           <fileSet>
                             <directory>${project.build.directory}/certs</directory>
                             <outputDirectory>certs</outputDirectory>
+                            <includes>
+                              <include>amqp-adapter-*.pem</include>
+                              <include>trusted-certs.pem</include>
+                            </includes>
                           </fileSet>
                         </fileSets>
                       </inline>
@@ -629,6 +633,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <run>
                     <ports>
                       <port>+adapter.amqp.ip:adapter.amqp.port:4040</port>
+                      <port>+adapter.amqps.ip:adapter.amqps.port:4041</port>
                       <port>+adapter.amqp.ip:adapter.amqp.health.port:8088</port>
                       <port>8000:8000</port>
                     </ports>
@@ -718,6 +723,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 <mqtt.port>${mqtt.port}</mqtt.port>
                 <adapter.amqp.host>${adapter.amqp.ip}</adapter.amqp.host>
                 <adapter.amqp.port>${adapter.amqp.port}</adapter.amqp.port>
+                <adapter.amqps.port>${adapter.amqps.port}</adapter.amqps.port>
                 <trust-store.path>${project.build.directory}/certs/trusted-certs.pem</trust-store.path>
                 <test.env>${test.env}</test.env>
                 <!-- javax.net.debug>ssl:handshake</javax.net.debug-->

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -13,12 +13,8 @@
 
 package org.eclipse.hono.tests.http;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
@@ -152,25 +148,6 @@ public abstract class HttpTestBase {
            .setTrustOptions(new PemTrustOptions().addCertPath(IntegrationTestSupport.TRUST_STORE_PATH))
            .setVerifyHost(false)
            .setSsl(true);
-    }
-
-    private static Future<Buffer> loadFile(final String path) {
-
-        final Future<Buffer> result = Future.future();
-        VERTX.fileSystem().readFile(path, result.completer());
-        return result;
-    }
-
-    private static Future<X509Certificate> getCertificate(final String path) {
-
-        return loadFile(path).map(buffer -> {
-            try (InputStream is = new ByteArrayInputStream(buffer.getBytes())) {
-                final CertificateFactory factory = CertificateFactory.getInstance("X.509");
-                return (X509Certificate) factory.generateCertificate(is);
-            } catch (final Exception e) {
-                throw new IllegalArgumentException("file cannot be parsed into X.509 certificate");
-            }
-        });
     }
 
     /**
@@ -320,7 +297,7 @@ public abstract class HttpTestBase {
                 .add(HttpHeaders.CONTENT_TYPE, "text/plain")
                 .add(HttpHeaders.ORIGIN, ORIGIN_URI);
 
-        getCertificate(deviceCert.certificatePath()).compose(cert -> {
+        helper.getCertificate(deviceCert.certificatePath()).compose(cert -> {
             final TenantObject tenant = TenantObject.from(tenantId, true);
             tenant.setTrustAnchor(cert.getPublicKey(), cert.getSubjectX500Principal());
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -8,13 +8,15 @@ hono:
     bindAddress: 0.0.0.0
     insecurePortBindAddress: 0.0.0.0
     insecurePortEnabled: true
+    keyPath: /etc/hono/certs/amqp-adapter-key.pem
+    certPath: /etc/hono/certs/amqp-adapter-cert.pem
   messaging:
     name: 'Hono AMQP Adapter'
     host: hono-dispatch-router.hono
     port: 5673
     amqpHostname: hono-internal
-    keyPath: /etc/hono/certs/mqtt-adapter-key.pem
-    certPath: /etc/hono/certs/mqtt-adapter-cert.pem
+    keyPath: /etc/hono/certs/amqp-adapter-key.pem
+    certPath: /etc/hono/certs/amqp-adapter-cert.pem
     trustStorePath: /etc/hono/certs/trusted-certs.pem
   registration:
     name: 'Hono MQTT Adapter'
@@ -39,8 +41,8 @@ hono:
     host: hono-dispatch-router.hono
     port: 5673
     amqpHostname: hono-internal
-    keyPath: /etc/hono/certs/mqtt-adapter-key.pem
-    certPath: /etc/hono/certs/mqtt-adapter-cert.pem
+    keyPath: /etc/hono/certs/amqp-adapter-key.pem
+    certPath: /etc/hono/certs/amqp-adapter-cert.pem
     trustStorePath: /etc/hono/certs/trusted-certs.pem
   metric:
     reporter:

--- a/tests/src/test/resources/qpid/qdrouterd-with-broker.json
+++ b/tests/src/test/resources/qpid/qdrouterd-with-broker.json
@@ -105,7 +105,7 @@
       "maxConnections": 20,
       "groups": {
         "Hono": {
-          "users": "Eclipse IoT;Hono;hono-messaging,Eclipse IoT;Hono;http-adapter,Eclipse IoT;Hono;mqtt-adapter",
+          "users": "Eclipse IoT;Hono;hono-messaging,Eclipse IoT;Hono;http-adapter,Eclipse IoT;Hono;mqtt-adapter,Eclipse IoT;Hono;amqp-adapter",
           "remoteHosts": "*",
           "maxSessions": 2,
           "maxMessageSize": 131072,


### PR DESCRIPTION
@sophokles73: this patch adds support for client certificate authentication. now the auth providers are known only to the SaslAuthenticator class. i plan to test feature in the ITs. 

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>