### PR TITLE
Add failing unittest for getRequestPayload

### DIFF
--- a/service-base/src/test/java/org/eclipse/hono/service/EventBusServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/EventBusServiceTest.java
@@ -1,0 +1,37 @@
+package org.eclipse.hono.service;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import org.eclipse.hono.util.EventBusMessage;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EventBusServiceTest {
+
+    @Test
+    public void getRequestPayloadHandlesInvalidClass() {
+        JsonObject device = new JsonObject().put("device-id", "someValue").put("enabled", "notABoolean");
+
+        EventBusService e = new EventBusService<Object>(){
+
+            @Override
+            public void setConfig(Object configuration) {
+
+            }
+
+            @Override
+            protected String getEventBusAddress() {
+                return null;
+            }
+
+            @Override
+            protected Future<EventBusMessage> processRequest(EventBusMessage request) {
+                return null;
+            }
+        };
+
+        JsonObject result = e.getRequestPayload(device);
+        assertEquals(result.getBoolean("enabled"), true);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sebastian Poehn <sebastian.poehn@bosch-si.com>

I have some trouble with my Java JDK. For me the function `getTypesafeValueForField` does not work as I should in my opinion.

Scenario: Someone expects a Boolean but the passed JSON field is actually a String.

Expected: function returns null
Actual: function returns String, caller will suffer from a ClassCastException