### PR TITLE
Protocol adapter liveness check to detect blocked vert.x event loop.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
@@ -22,6 +22,7 @@ public class ProtocolAdapterProperties extends ServiceConfigProperties {
     private boolean authenticationRequired = true;
     private boolean jmsVendorPropsEnabled = false;
     private boolean defaultsEnabled = true;
+    private long eventLoopBlockedCheckTimeout = 5000L;
 
     /**
      * Checks whether the protocol adapter always authenticates devices using their provided credentials as defined
@@ -129,5 +130,28 @@ public class ProtocolAdapterProperties extends ServiceConfigProperties {
      */
     public void setDefaultsEnabled(final boolean flag) {
         this.defaultsEnabled = flag;
+    }
+
+    /**
+     * Gets the timeout value used by protocol adapter liveness check,
+     * which determines if protocol adapter vert.x event loop is blocked.
+     * <p>
+     * Default value of the timeout is 5000 milliseconds.
+     *
+     * @return The timeout value in milliseconds.
+     */
+    public final long getEventLoopBlockedCheckTimeout() {
+        return eventLoopBlockedCheckTimeout;
+    }
+
+    /**
+     * Sets the timeout value used by protocol adapter liveness check,
+     * which determines if protocol adapter vert.x event loop is blocked.
+     * <p>
+     *
+     * @param eventLoopBlockedCheckTimeout Liveness check timeout value in milliseconds.
+     */
+    public final void setEventLoopBlockedCheckTimeout(final long eventLoopBlockedCheckTimeout) {
+        this.eventLoopBlockedCheckTimeout = eventLoopBlockedCheckTimeout;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -50,8 +50,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 
 import io.opentracing.SpanContext;
 import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
@@ -852,10 +854,14 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     }
 
     /**
-     * Does not register any checks.
+     * Register a liveness check procedure which succeeds if
+     * the vert.x event loop of this protocol adapter is not blocked.
+     *
+     * @param handler The health check handler to register the checks with.
      */
     @Override
     public void registerLivenessChecks(final HealthCheckHandler handler) {
+        registerEventLoopBlockedCheck(handler);
     }
 
     /**
@@ -998,5 +1004,27 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                                         ) {
         LOG.debug("Command consumer was closed for [tenantId: {}, deviceId: {}] - no command will be received for this request anymore.",
                 tenant, deviceId);
+    }
+
+    /**
+     * Registers a health check procedure which tries to run an action on the protocol adapter context.
+     * If the protocol adapter vert.x event loop is blocked, the health check procedure will not complete
+     * with OK status within the defined timeout.
+     *
+     * @param handler The health check handler to register the checks with.
+     */
+    protected void registerEventLoopBlockedCheck(final HealthCheckHandler handler) {
+        handler.register("event-loop-blocked-check", getConfig().getEventLoopBlockedCheckTimeout(), procedure -> {
+            final Context currentContext = Vertx.currentContext();
+
+            if (currentContext != context) {
+                context.runOnContext(action -> {
+                    procedure.complete(Status.OK());
+                });
+            } else {
+                LOG.info("Protocol Adapter - HealthCheck Server context match. Assume protocol adapter is alive.");
+                procedure.complete(Status.OK());
+            }
+        });
     }
 }


### PR DESCRIPTION
Signed-off-by: Marko Pascan <marko.pascan@bosch-si.com>

Currently no liveness checks are registered for protocol adapters. In our use case, where Hono services are running as part of Kubernetes cluster, this could lead to problems if a adapter runs into a deadlock (see https://github.com/eclipse/hono/issues/696). The expectation here is that a liveness check would detect a blocked/deadlocked protocol adapter and restart the Kubernetes POD.

The implemented liveness check procedure tries to execute an action on the protocol adapter context an in this way detect whether the vert.x event loop is blocked. If the event loop is blocked, the procedure will not complete within the defined timeout, thus causing failure of the liveness check.