### PR TITLE
[#607]: Use 'Data' type for AMQP body section

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpContext.java
@@ -40,6 +40,7 @@ public class AmqpContext extends MapBasedExecutionContext {
     private final Message message;
     private final ResourceIdentifier resource;
     private final Device authenticatedDevice;
+    private final Buffer payload;
 
     /**
      * Creates an AmqpContext instance using the specified delivery, message and authenticated device.
@@ -57,6 +58,7 @@ public class AmqpContext extends MapBasedExecutionContext {
         this.message = Objects.requireNonNull(message);
         this.authenticatedDevice = authenticatedDevice;
         this.resource = ResourceIdentifier.fromString(message.getAddress());
+        this.payload = MessageHelper.getPayload(message);
     }
 
     /**
@@ -65,7 +67,7 @@ public class AmqpContext extends MapBasedExecutionContext {
      * @return The body of the AMQP 1.0 message as a buffer object.
      */
     Buffer getMessagePayload() {
-        return MessageHelper.getPayload(message);
+        return payload;
     }
 
     /**

--- a/cli/src/main/java/org/eclipse/hono/cli/Receiver.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/Receiver.java
@@ -17,9 +17,8 @@ import javax.annotation.PostConstruct;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Handler;
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
-import org.apache.qpid.proton.amqp.messaging.Data;
-import org.apache.qpid.proton.amqp.messaging.Section;
+import io.vertx.core.buffer.Buffer;
+
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.util.MessageHelper;
@@ -101,16 +100,11 @@ public class Receiver extends AbstractClient {
 
     private void handleMessage(final String endpoint, final Message msg) {
         final String deviceId = MessageHelper.getDeviceId(msg);
-        final Section body = msg.getBody();
-        String content = null;
-        if (body instanceof Data) {
-            content = ((Data) msg.getBody()).getValue().toString();
-        } else if (body instanceof AmqpValue) {
-            content = ((AmqpValue) msg.getBody()).getValue().toString();
-        }
+
+        final Buffer payload = MessageHelper.getPayload(msg);
 
         LOG.info("received {} message [device: {}, content-type: {}]: {}", endpoint, deviceId, msg.getContentType(),
-                content);
+                payload);
 
         if (msg.getApplicationProperties() != null) {
             LOG.info("... with application properties: {}", msg.getApplicationProperties().getValue());

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -519,11 +519,11 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
     /**
      * Creates a request message for a payload and sends it to the peer.
      * <p>
-     * This method simply invokes {@link #createAndSendRequest(String, Map, Buffer, Handler)}
-     * with {@code null} for the properties parameter.
+     * This method simply invokes {@link #createAndSendRequest(String, Map, Buffer, Handler)} with {@code null} for the
+     * properties parameter.
      * 
      * @param action The operation that the request is supposed to trigger/invoke.
-     * @param payload The payload to include in the request message as a an AMQP Value section.
+     * @param payload The payload to include in the request message as an AMQP Value section.
      * @param resultHandler The handler to notify about the outcome of the request.
      * @throws NullPointerException if any of action or result handler is {@code null}.
      */
@@ -538,11 +538,11 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
     /**
      * Creates a request message for a payload and sends it to the peer.
      * <p>
-     * This method simply invokes {@link #createAndSendRequest(String, Map, Buffer, String, Handler, Object, Span)}
-     * with {@code null} for the properties, content type and cache key parameters.
+     * This method simply invokes {@link #createAndSendRequest(String, Map, Buffer, String, Handler, Object, Span)} with
+     * {@code null} for the properties, content type and cache key parameters.
      * 
      * @param action The operation that the request is supposed to trigger/invoke.
-     * @param payload The payload to include in the request message as a an AMQP Value section.
+     * @param payload The payload to include in the request message as an AMQP Value section.
      * @param resultHandler The handler to notify about the outcome of the request.
      * @param currentSpan The <em>Opentracing</em> span used to trace the request execution.
      * @throws NullPointerException if any of action, result handler or current span is {@code null}.

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.qpid.proton.amqp.messaging.Accepted;
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.message.Message;
@@ -699,12 +698,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
 
         if (isOpen()) {
             final Message request = createMessage(action, properties);
-            if (payload != null) {
-                if (contentType != null) {
-                    request.setContentType(contentType);
-                }
-                request.setBody(new AmqpValue(payload.getBytes()));
-            }
+            MessageHelper.setPayload(request, contentType, payload);
             sendRequest(request, resultHandler, cacheKey, currentSpan);
         } else {
             TracingHelper.logError(currentSpan, "sender and/or receiver link is not open");

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
@@ -26,9 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
-import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.message.Message;
@@ -266,9 +264,9 @@ abstract public class AbstractSender extends AbstractHonoClient implements Messa
 
         final Message msg = ProtonHelper.message();
         msg.setAddress(getTo(deviceId));
-        msg.setBody(new Data(new Binary(payload)));
+        MessageHelper.setPayload(msg, contentType, payload);
         setApplicationProperties(msg, properties);
-        addProperties(msg, deviceId, contentType, registrationAssertion);
+        addProperties(msg, deviceId, registrationAssertion);
         return send(msg);
     }
 
@@ -295,9 +293,9 @@ abstract public class AbstractSender extends AbstractHonoClient implements Messa
 
         final Message msg = ProtonHelper.message();
         msg.setAddress(getTo(deviceId));
-        msg.setBody(new Data(new Binary(payload)));
+        MessageHelper.setPayload(msg, contentType, payload);
         setApplicationProperties(msg, properties);
-        addProperties(msg, deviceId, contentType, registrationAssertion);
+        addProperties(msg, deviceId, registrationAssertion);
         return send(msg, capacityAvailableHandler);
     }
 
@@ -356,8 +354,7 @@ abstract public class AbstractSender extends AbstractHonoClient implements Messa
      */
     protected abstract String getTo(String deviceId);
 
-    private void addProperties(final Message msg, final String deviceId, final String contentType, final String registrationAssertion) {
-        msg.setContentType(contentType);
+    private void addProperties(final Message msg, final String deviceId, final String registrationAssertion) {
         MessageHelper.addDeviceId(msg, deviceId);
         if (isRegistrationAssertionRequired()) {
             MessageHelper.addRegistrationAssertion(msg, registrationAssertion);
@@ -399,7 +396,6 @@ abstract public class AbstractSender extends AbstractHonoClient implements Messa
     protected Future<ProtonDelivery> sendMessageAndWaitForOutcome(final Message message, final Span currentSpan) {
 
         Objects.requireNonNull(message);
-
 
         final Future<ProtonDelivery> result = Future.future();
         final String messageId = String.format("%s-%d", getClass().getSimpleName(), MESSAGE_COUNTER.getAndIncrement());

--- a/client/src/main/java/org/eclipse/hono/client/impl/AuthenticationServerClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AuthenticationServerClient.java
@@ -15,8 +15,6 @@ package org.eclipse.hono.client.impl;
 
 import java.util.Objects;
 
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
-import org.apache.qpid.proton.amqp.messaging.Section;
 import org.eclipse.hono.auth.HonoUser;
 import org.eclipse.hono.auth.HonoUserAdapter;
 import org.eclipse.hono.connection.ConnectionFactory;
@@ -131,18 +129,17 @@ public final class AuthenticationServerClient {
                     String.class);
 
             if (AuthenticationConstants.TYPE_AMQP_JWT.equals(type)) {
-                final Section body = message.getBody();
-                if (body instanceof AmqpValue) {
-                    final String token = ((AmqpValue) body).getValue().toString();
+
+                final String payload = MessageHelper.getPayloadAsString(message);
+                if (payload != null) {
                     final HonoUser user = new HonoUserAdapter() {
                         @Override
                         public String getToken() {
-                            return token;
+                            return payload;
                         }
                     };
                     LOG.debug("successfully retrieved token from Authentication service");
                     authResult.complete(user);
-
                 } else {
                     authResult.fail("message from Authentication service contains no body");
                 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
@@ -228,7 +228,7 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
         span.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
         return get(
                 key,
-                () -> new JsonObject().put(TenantConstants.FIELD_PAYLOAD_TENANT_ID, tenantId).toBuffer(),
+                () -> new JsonObject().put(TenantConstants.FIELD_PAYLOAD_TENANT_ID, tenantId),
                 span).map(tenant -> {
                     span.finish();
                     return tenant;
@@ -262,7 +262,7 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
         TAG_SUBJECT_DN.set(span, subjectDnRfc2253);
         return get(
                 key,
-                () -> new JsonObject().put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, subjectDnRfc2253).toBuffer(),
+                () -> new JsonObject().put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, subjectDnRfc2253),
                 span).map(tenant -> {
                     span.finish();
                     return tenant;
@@ -275,7 +275,7 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
 
     private <T> Future<TenantObject> get(
             final TriTuple<TenantAction, T, Object> key,
-            final Supplier<Buffer> payloadSupplier,
+            final Supplier<JsonObject> payloadSupplier,
             final Span currentSpan) {
 
         TracingHelper.TAG_CACHE_HIT.set(currentSpan, true);
@@ -286,7 +286,7 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
             createAndSendRequest(
                     TenantConstants.TenantAction.get.toString(),
                     customizeRequestApplicationProperties(),
-                    payloadSupplier.get(),
+                    payloadSupplier.get().toBuffer(),
                     RegistrationConstants.CONTENT_TYPE_APPLICATION_JSON,
                     tenantResult.completer(),
                     key,

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import io.vertx.core.buffer.Buffer;
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.Target;
 import org.apache.qpid.proton.message.Message;
@@ -151,9 +151,9 @@ public class AbstractRequestResponseClientTest  {
         verify(sender).send(messageCaptor.capture(), any(Handler.class));
         assertThat(messageCaptor.getValue(), is(notNullValue()));
         assertThat(messageCaptor.getValue().getBody(), is(notNullValue()));
-        assertThat(messageCaptor.getValue().getBody(), instanceOf(AmqpValue.class));
-        final AmqpValue body = (AmqpValue) messageCaptor.getValue().getBody();
-        assertThat(body.getValue(), is(payload.toBuffer().getBytes()));
+        assertThat(messageCaptor.getValue().getBody(), instanceOf(Data.class));
+        final Buffer body = MessageHelper.getPayload(messageCaptor.getValue());
+        assertThat(body.getBytes(), is(payload.toBuffer().getBytes()));
         assertThat(messageCaptor.getValue().getApplicationProperties(), is(notNullValue()));
         assertThat(messageCaptor.getValue().getApplicationProperties().getValue().get("test-key"), is("test-value"));
         // and a timer has been set to time out the request after 200 ms

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -173,6 +173,11 @@ public final class MessageHelper {
      */
     public static final String JMS_VENDOR_PROPERTY_CONTENT_TYPE = "JMS_AMQP_CONTENT_TYPE";
 
+    /**
+     * The MIME type representing the String representation of a JSON Object.
+     */
+    public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
+
     private static final Logger LOG = LoggerFactory.getLogger(MessageHelper.class);
 
     private MessageHelper() {
@@ -682,39 +687,41 @@ public final class MessageHelper {
     }
 
     /**
-     * Set the payload of the message.
+     * Set the JSON payload of the message.
      * <p>
      * If the payload is {@code null}, then neither the payload, nor content type will be set.
      * </p>
      * 
      * @param message The message to update.
-     * @param contentType An optional content type.
      * @param payload The optional message payload.
      * 
      * @throws NullPointerException If the parameter {@code message} was {@code null}.
      */
-    public static void setPayload(final Message message, final String contentType, final JsonObject payload) {
+    public static void setJsonPayload(final Message message, final JsonObject payload) {
         Objects.requireNonNull(message);
 
-        setPayload(message, contentType, payload != null ? payload.toBuffer() : null);
+        setPayload(message, CONTENT_TYPE_APPLICATION_JSON, payload != null ? payload.toBuffer() : null);
     }
 
     /**
-     * Set the payload of the message.
+     * Set the JSON payload of the message.
      * <p>
      * If the payload is {@code null}, then neither the payload, nor content type will be set.
      * </p>
+     * <p>
+     * <b>Note:</b> No formal check is done if the payload actually is a JSON string.
+     * </p>
      * 
      * @param message The message to update.
-     * @param contentType An optional content type.
      * @param payload The optional message payload.
      * 
      * @throws NullPointerException If the parameter {@code message} was {@code null}.
      */
-    public static void setPayload(final Message message, final String contentType, final String payload) {
+    public static void setJsonPayload(final Message message, final String payload) {
         Objects.requireNonNull(message);
 
-        setPayload(message, contentType, payload != null ? payload.getBytes(StandardCharsets.UTF_8) : null);
+        setPayload(message, CONTENT_TYPE_APPLICATION_JSON,
+                payload != null ? payload.getBytes(StandardCharsets.UTF_8) : null);
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -356,7 +356,7 @@ public final class MessageHelper {
     }
 
     /**
-     * Gets a message's body as Buffer object as {@link String}.
+     * Gets a message's body as String.
      *
      * @param message The AMQP 1.0 message to parse the body of.
      * @return The message body as a {@link String} or {@code null} if the message does not have a <em>Data</em> nor an
@@ -646,7 +646,7 @@ public final class MessageHelper {
     }
 
     /**
-     * Set the payload of the message.
+     * Set the payload of the message using a {@link Data} section.
      * <p>
      * If the payload is {@code null}, then neither the payload, nor content type will be set.
      * </p>
@@ -660,16 +660,16 @@ public final class MessageHelper {
     public static void setPayload(final Message message, final String contentType, final byte[] payload) {
         Objects.requireNonNull(message);
 
+        if (contentType != null) {
+            message.setContentType(contentType);
+        }
         if (payload != null) {
-            if (contentType != null) {
-                message.setContentType(contentType);
-            }
             message.setBody(new Data(new Binary(payload)));
         }
     }
 
     /**
-     * Set the payload of the message.
+     * Set the payload of the message using a {@link Data} section.
      * <p>
      * If the payload is {@code null}, then neither the payload, nor content type will be set.
      * </p>
@@ -687,7 +687,7 @@ public final class MessageHelper {
     }
 
     /**
-     * Set the JSON payload of the message.
+     * Set the JSON payload of the message using a {@link Data} section.
      * <p>
      * If the payload is {@code null}, then neither the payload, nor content type will be set.
      * </p>
@@ -704,7 +704,7 @@ public final class MessageHelper {
     }
 
     /**
-     * Set the JSON payload of the message.
+     * Set the JSON payload of the message using a {@link Data} section.
      * <p>
      * If the payload is {@code null}, then neither the payload, nor content type will be set.
      * </p>
@@ -725,7 +725,7 @@ public final class MessageHelper {
     }
 
     /**
-     * Test is the message has a data section set as the body.
+     * Test if the message has a {@link Data} section set as the body.
      * 
      * @param message The message to test.
      * @param allowAmqpValue Whether or now to allow AmqpValue of type {@code String} or {@code byte[]} to pass as well.

--- a/core/src/main/java/org/eclipse/hono/util/MessageTap.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageTap.java
@@ -15,8 +15,6 @@ package org.eclipse.hono.util;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-import org.apache.qpid.proton.amqp.messaging.Data;
-import org.apache.qpid.proton.amqp.messaging.Section;
 import org.apache.qpid.proton.message.Message;
 
 /**
@@ -25,7 +23,7 @@ import org.apache.qpid.proton.message.Message;
  */
 public final class MessageTap implements Consumer<Message> {
 
-    private Consumer<Message> tapConsumer;
+    private final Consumer<Message> tapConsumer;
 
     private MessageTap(final Consumer<Message> tapConsumer) {
         this.tapConsumer = tapConsumer;
@@ -48,8 +46,7 @@ public final class MessageTap implements Consumer<Message> {
 
         return new MessageTap(
                 msg -> {
-                    final Section body = msg.getBody();
-                    if (body!=null && !(body instanceof Data)) {
+                    if (!MessageHelper.hasDataBody(msg, false)) {
                         return;
                     }
                     TimeUntilDisconnectNotification.fromMessage(msg).ifPresent(

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
@@ -33,7 +33,7 @@ public abstract class RequestResponseApiConstants {
     /**
      * The MIME type representing the String representation of a JSON Object.
      */
-    public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
+    public static final String CONTENT_TYPE_APPLICATION_JSON = MessageHelper.CONTENT_TYPE_APPLICATION_JSON;
 
     /* message payload fields */
     public static final String FIELD_PAYLOAD_DEVICE_ID = Constants.JSON_FIELD_DEVICE_ID;
@@ -103,7 +103,7 @@ public abstract class RequestResponseApiConstants {
                 message.setMessageAnnotations(new MessageAnnotations(annotations));
             }
 
-            MessageHelper.setPayload(message, CONTENT_TYPE_APPLICATION_JSON, payload);
+            MessageHelper.setJsonPayload(message, payload);
 
             return message;
         }

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.qpid.proton.amqp.Symbol;
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
 import org.apache.qpid.proton.message.Message;
@@ -104,10 +103,8 @@ public abstract class RequestResponseApiConstants {
                 message.setMessageAnnotations(new MessageAnnotations(annotations));
             }
 
-            if (payload != null) {
-                message.setContentType(CONTENT_TYPE_APPLICATION_JSON);
-                message.setBody(new AmqpValue(payload.encode()));
-            }
+            MessageHelper.setPayload(message, CONTENT_TYPE_APPLICATION_JSON, payload);
+
             return message;
         }
     }

--- a/core/src/test/java/org/eclipse/hono/util/MessageTapTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/MessageTapTest.java
@@ -79,7 +79,7 @@ public class MessageTapTest {
         MessageHelper.setCreationTime(msg);
         MessageHelper.addDeviceId(msg, "4711");
         MessageHelper.addAnnotation(msg, MessageHelper.APP_PROPERTY_TENANT_ID, Constants.DEFAULT_TENANT);
-        MessageHelper.setPayload(msg, null, payload);
+        MessageHelper.setJsonPayload(msg, payload);
         msg.setContentEncoding(contentEncoding);
         return msg;
     }

--- a/core/src/test/java/org/eclipse/hono/util/MessageTapTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/MessageTapTest.java
@@ -19,8 +19,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
-import org.apache.qpid.proton.amqp.Binary;
-import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.amqp.messaging.Section;
 import org.apache.qpid.proton.message.Message;
 import org.junit.Test;
@@ -81,8 +79,8 @@ public class MessageTapTest {
         MessageHelper.setCreationTime(msg);
         MessageHelper.addDeviceId(msg, "4711");
         MessageHelper.addAnnotation(msg, MessageHelper.APP_PROPERTY_TENANT_ID, Constants.DEFAULT_TENANT);
+        MessageHelper.setPayload(msg, null, payload);
         msg.setContentEncoding(contentEncoding);
-        msg.setBody(new Data(new Binary(payload.getBytes())));
         return msg;
     }
 

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoConsumerBase.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
-import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.CommandClient;
 import org.eclipse.hono.client.HonoClient;
@@ -172,8 +171,7 @@ public class HonoConsumerBase {
 
     private void printMessage(final String tenantId, final Message msg, final String messageType) {
         if (LOG.isDebugEnabled()) {
-            final Data body = (Data) msg.getBody();
-            final String content = body != null ? body.getValue().toString() : "";
+            final String content = MessageHelper.getPayloadAsString(msg);
             final String deviceId = MessageHelper.getDeviceId(msg);
 
             final StringBuilder sb = new StringBuilder("received ").

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
@@ -18,7 +18,6 @@ import java.util.concurrent.CompletableFuture;
 import javax.jms.IllegalStateException;
 
 import org.apache.jmeter.samplers.SampleResult;
-import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageConsumer;
@@ -199,14 +198,15 @@ public class HonoReceiver extends AbstractClient {
             final long sampleReceivedTime = System.currentTimeMillis();
             messageCount++;
 
-            if (!(message.getBody() instanceof Data)) {
+            if (!MessageHelper.hasDataBody(message, false)) {
                 errorCount++;
                 setSampleStartIfNotSetYet(sampleReceivedTime);
                 LOGGER.warn("got message with non-Data body section; increasing errorCount in batch to {}; current batch size: {}",
                         errorCount, messageCount);
                 return;
             }
-            final byte[] messageBody = ((Data) message.getBody()).getValue().getArray();
+            final Buffer payload = MessageHelper.getPayload(message);
+            final byte[] messageBody = payload.getBytes();
             bytesReceived += messageBody.length;
             final Long senderTime = getSenderTime(message, messageBody);
             if (sampler.isUseSenderTime() && senderTime == null) {

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -17,8 +17,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
-import org.apache.qpid.proton.amqp.Binary;
-import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoClient;
@@ -948,12 +946,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         if (publishAddress != null) {
             MessageHelper.addProperty(msg, MessageHelper.APP_PROPERTY_ORIG_ADDRESS, publishAddress);
         }
-        if (contentType != null) {
-            msg.setContentType(contentType);
-        }
-        if (payload != null) {
-            msg.setBody(new Data(new Binary(payload.getBytes())));
-        }
+        MessageHelper.setPayload(msg, contentType, payload);
+        msg.setContentType(contentType);
         if (timeUntilDisconnect != null) {
             MessageHelper.addTimeUntilDisconnect(msg, timeUntilDisconnect);
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponseSenderImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponseSenderImpl.java
@@ -15,15 +15,12 @@ package org.eclipse.hono.service.command;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
-import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.impl.AbstractSender;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
-
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -94,6 +91,7 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
     /**
      * {@inheritDoc}
      */
+    @Override
     public Future<ProtonDelivery> sendCommandResponse(
             final String correlationId,
             final String contentType,
@@ -111,6 +109,7 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
     /**
      * {@inheritDoc}
      */
+    @Override
     public Future<ProtonDelivery> sendCommandResponse(final CommandResponse commandResponse, final SpanContext context) {
 
         Objects.requireNonNull(commandResponse);
@@ -144,9 +143,7 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
         if (contentType != null) {
             msg.setContentType(contentType);
         }
-        if (payload != null) {
-            msg.setBody(new Data(new Binary(payload.getBytes())));
-        }
+        MessageHelper.setPayload(msg, contentType, payload);
         if (properties != null) {
             msg.setApplicationProperties(new ApplicationProperties(properties));
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponseSenderImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponseSenderImpl.java
@@ -42,11 +42,10 @@ import io.vertx.proton.ProtonSender;
 public class CommandResponseSenderImpl extends AbstractSender implements CommandResponseSender {
 
     /**
-     * The default amount of time to wait for credits after link creation. This
-     * is higher as in the client defaults, because for the command response the link
-     * is created on demand and the response should not fail.
+     * The default amount of time to wait for credits after link creation. This is higher as in the client defaults,
+     * because for the command response the link is created on demand and the response should not fail.
      */
-    public static final long DEFAULT_COMMAND_FLOW_LATENCY = 200L; //ms
+    public static final long DEFAULT_COMMAND_FLOW_LATENCY = 200L; // ms
 
     CommandResponseSenderImpl(
             final ClientConfigProperties config,
@@ -110,7 +109,8 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
      * {@inheritDoc}
      */
     @Override
-    public Future<ProtonDelivery> sendCommandResponse(final CommandResponse commandResponse, final SpanContext context) {
+    public Future<ProtonDelivery> sendCommandResponse(final CommandResponse commandResponse,
+            final SpanContext context) {
 
         Objects.requireNonNull(commandResponse);
         return sendAndWaitForOutcome(createResponseMessage(commandResponse), context);
@@ -140,9 +140,6 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
         final Message msg = ProtonHelper.message();
         msg.setCorrelationId(correlationId);
         msg.setAddress(targetAddress);
-        if (contentType != null) {
-            msg.setContentType(contentType);
-        }
         MessageHelper.setPayload(msg, contentType, payload);
         if (properties != null) {
             msg.setApplicationProperties(new ApplicationProperties(properties));
@@ -157,8 +154,8 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
      * <p>
      * The underlying sender link will be created with the following properties:
      * <ul>
-     * <li><em>flow latency</em> will be set to @{@link #DEFAULT_COMMAND_FLOW_LATENCY} if
-     * the configured value is smaller than the default</li>
+     * <li><em>flow latency</em> will be set to @{@link #DEFAULT_COMMAND_FLOW_LATENCY} if the configured value is
+     * smaller than the default</li>
      * </ul>
      *
      * @param context The vert.x context to run all interactions with the server on.
@@ -168,9 +165,10 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
      * @param replyId The reply id as the unique postfix of the replyTo address.
      * @param closeHook A handler to invoke if the peer closes the link unexpectedly.
      * @param creationHandler The handler to invoke with the result of the creation attempt.
-     * @param tracer The tracer to use for tracking the processing of received
-     *               messages. If {@code null}, OpenTracing's {@code NoopTracer} will be used.
-     * @throws NullPointerException if any of context, clientConfig, con, tenantId, deviceId or replyId  are {@code null}.
+     * @param tracer The tracer to use for tracking the processing of received messages. If {@code null}, OpenTracing's
+     *            {@code NoopTracer} will be used.
+     * @throws NullPointerException if any of context, clientConfig, con, tenantId, deviceId or replyId are
+     *             {@code null}.
      */
     public static void create(
             final Context context,
@@ -195,8 +193,9 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
         }
 
         createSender(context, props, con, targetAddress, ProtonQoS.AT_LEAST_ONCE, closeHook)
-            .map(sender -> (CommandResponseSender) new CommandResponseSenderImpl(clientConfig, sender, tenantId, targetAddress, context, tracer))
-            .setHandler(creationHandler);
+                .map(sender -> (CommandResponseSender) new CommandResponseSenderImpl(clientConfig, sender, tenantId,
+                        targetAddress, context, tracer))
+                .setHandler(creationHandler);
     }
 
     @Override

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsMessageFilter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsMessageFilter.java
@@ -13,9 +13,9 @@
 
 package org.eclipse.hono.service.credentials;
 
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.CredentialsConstants;
+import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,8 +49,8 @@ public final class CredentialsMessageFilter {
         } else if (msg.getReplyTo() == null) {
             LOG.trace("message [{}] has no reply-to address set", msg.getMessageId());
             return false;
-        } else if (!(msg.getBody() instanceof AmqpValue)) {
-            LOG.trace("message [{}] contains non-AmqpValue section payload", msg.getMessageId());
+        } else if (!MessageHelper.hasDataBody(msg, true)) {
+            LOG.trace("message [{}] contains no AmqpValue or Data section payload", msg.getMessageId());
             return false;
         } else {
             return true;

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationMessageFilter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationMessageFilter.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.hono.service.registration;
 
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.BaseMessageFilter;
+import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.slf4j.Logger;
@@ -50,13 +50,9 @@ public final class RegistrationMessageFilter extends BaseMessageFilter {
          } else if (msg.getReplyTo() == null) {
              LOG.trace("message [{}] contains no reply-to address", msg.getMessageId());
              return false;
-         } else if (msg.getBody() != null) {
-             if (!(msg.getBody() instanceof AmqpValue)) {
-                 LOG.trace("message [{}] contains non-AmqpValue section payload", msg.getMessageId());
-                 return false;
-             } else {
-                 return true;
-             }
+        } else if (msg.getBody() != null && !MessageHelper.hasDataBody(msg, true)) {
+            LOG.trace("message [{}] contains no AmqpValue or Data section payload", msg.getMessageId());
+            return false;
          } else {
              return true;
          }

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantMessageFilter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantMessageFilter.java
@@ -13,9 +13,9 @@
 
 package org.eclipse.hono.service.tenant;
 
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.BaseMessageFilter;
+import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,13 +49,9 @@ public final class TenantMessageFilter extends BaseMessageFilter {
         } else if (msg.getReplyTo() == null) {
             LOG.trace("message [{}] contains no reply-to address", msg.getMessageId());
             return false;
-        } else if (msg.getBody() != null) {
-            if (!(msg.getBody() instanceof AmqpValue)) {
-                LOG.trace("message [{}] contains non-AmqpValue section payload", msg.getMessageId());
-                return false;
-            } else {
-                return true;
-            }
+        } else if (msg.getBody() != null && !MessageHelper.hasDataBody(msg, true)) {
+            LOG.trace("message [{}] contains no AmqpValue or Data section payload", msg.getMessageId());
+            return false;
         } else {
             return true;
         }

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingMessageFilter.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingMessageFilter.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.hono.messaging;
 
-import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.BaseMessageFilter;
 import org.eclipse.hono.util.MessageHelper;
@@ -58,7 +57,7 @@ public final class HonoMessagingMessageFilter extends BaseMessageFilter {
          if (msg.getContentType() == null) {
              LOG.trace("message [{}] has no content type", msg.getMessageId());
              return false;
-         } else if (msg.getBody() != null && !(msg.getBody() instanceof Data)) {
+        } else if (!MessageHelper.hasDataBody(msg, false)) {
              LOG.trace("message [{}] has no body of type AMQP Data", msg.getMessageId());
              return false;
          } else {

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingMessageFilter.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingMessageFilter.java
@@ -57,7 +57,7 @@ public final class HonoMessagingMessageFilter extends BaseMessageFilter {
          if (msg.getContentType() == null) {
              LOG.trace("message [{}] has no content type", msg.getMessageId());
              return false;
-        } else if (!MessageHelper.hasDataBody(msg, false)) {
+        } else if (msg.getBody() != null && !MessageHelper.hasDataBody(msg, false)) {
              LOG.trace("message [{}] has no body of type AMQP Data", msg.getMessageId());
              return false;
          } else {

--- a/services/messaging/src/test/java/org/eclipse/hono/TestSupport.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/TestSupport.java
@@ -92,7 +92,7 @@ public final class TestSupport {
         final Message message = ProtonHelper.message();
         message.setMessageId(messageId);
         MessageHelper.addDeviceId(message, deviceId);
-        MessageHelper.setPayload(message, "application/json", String.format("{\"temp\" : %d}", temperature));
+        MessageHelper.setJsonPayload(message, String.format("{\"temp\" : %d}", temperature));
         return message;
     }
 

--- a/services/messaging/src/test/java/org/eclipse/hono/TestSupport.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/TestSupport.java
@@ -17,8 +17,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.apache.qpid.proton.amqp.Binary;
-import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.amqp.messaging.Target;
 import org.apache.qpid.proton.engine.Record;
 import org.apache.qpid.proton.message.Message;
@@ -93,9 +91,8 @@ public final class TestSupport {
     public static Message newTelemetryData(final String messageId, final String deviceId, final int temperature) {
         final Message message = ProtonHelper.message();
         message.setMessageId(messageId);
-        message.setContentType("application/json");
         MessageHelper.addDeviceId(message, deviceId);
-        message.setBody(new Data(new Binary(String.format("{\"temp\" : %d}", temperature).getBytes())));
+        MessageHelper.setPayload(message, "application/json", String.format("{\"temp\" : %d}", temperature));
         return message;
     }
 

--- a/site/content/api/Credentials-API.md
+++ b/site/content/api/Credentials-API.md
@@ -92,7 +92,7 @@ The following table provides an overview of the properties a client needs to set
 | :--------------- | :-------: | :----------------------- | :-------- | :---------------------------- |
 | *subject*        | yes       | *properties*             | *string*  | MUST contain the value `get`. |
 
-The body of the request MUST consist of a single *AMQP Value* section containing a UTF-8 encoded string representation of a single JSON object having the following members:
+The body of the request MUST consist of a single *Data* section containing a UTF-8 encoded string representation of a single JSON object having the following members:
 
 | Name             | Mandatory | Type       | Description |
 | :--------------- | :-------: | :--------- | :---------- |
@@ -183,7 +183,7 @@ The following table provides an overview of the properties a client needs to set
 | :--------------- | :-------: | :----------------------- | :------- | :---------- |
 | *subject*        | yes       | *properties*             | *string* | MUST contain the value `remove`. |
 
-The body of the message MUST consist of a single *AMQP Value* section containing a UTF-8 encoded string representation of a single JSON object having the following properties:
+The body of the message MUST consist of a single *Data* section containing a UTF-8 encoded string representation of a single JSON object having the following properties:
 
 | Name             | Mandatory | Type       | Description |
 | :--------------- | :-------: | :--------- | :---------- |
@@ -229,6 +229,7 @@ The following table provides an overview of the properties shared by all request
 | *correlation-id* | no        | *properties*             | *message-id | MAY contain an ID used to correlate a response message to the original request. If set, it is used as the *correlation-id* property in the response, otherwise the value of the *message-id* property is used. |
 | *message-id*     | yes       | *properties*             | *string*    | MUST contain an identifier that uniquely identifies the message at the sender side. |
 | *reply-to*       | yes       | *properties*             | *string*    | MUST contain the source address that the client wants to received response messages from. This address MUST be the same as the source address used for establishing the client's receive link (see [Preconditions]({{< relref "#Preconditions" >}})). |
+| *content-type*   | yes       | *properties*             | *string*     | MUST be set to `application/json`. |
 
 ### Standard Response Properties
 
@@ -237,6 +238,7 @@ The following table provides an overview of the properties shared by all respons
 | Name             | Mandatory | Location                 | Type         | Description |
 | :--------------- | :-------: | :----------------------- | :----------- | :---------- |
 | *correlation-id* | yes       | *properties*             | *message-id* | Contains the *message-id* (or the *correlation-id*, if specified) of the request message that this message is the response to. |
+| *content-type*   | yes       | *properties*             | *string*     | MUST be set to `application/json`. |
 | *device_id*      | yes       | *application-properties* | *string*     | Contains the ID of the device. |
 | *tenant_id*      | yes       | *application-properties* | *string*     | Contains the ID of the tenant to which the device belongs. |
 | *status*         | yes       | *application-properties* | *int*        | Contains the status code indicating the outcome of the operation. Concrete values and their semantics are defined for each particular operation. |
@@ -255,7 +257,7 @@ Hono uses the following AMQP message delivery states when receiving request mess
 
 Most of the operations of the Credentials API allow or require the inclusion of credential data in the payload of the
 request or response messages of the operation. Such payload is carried in the body of the corresponding AMQP 
-messages as part of a single *AMQP Value* section.
+messages as part of a single *Data* section. The content type must be set to `application/json`. 
 
 The credential data is carried in the payload as a UTF-8 encoded string representation of a single JSON object. It is an error to include payload that is not of this type.
 

--- a/site/content/api/Device-Registration-API.md
+++ b/site/content/api/Device-Registration-API.md
@@ -136,7 +136,7 @@ The body of the message SHOULD be empty and will be ignored if it is not.
 
 A response to an *assertion* request contains the [Standard Response Properties]({{< relref "#standard-response-properties" >}}).
 
-The body of the response message consists of a single *AMQP Value* section containing a UTF-8 encoded string representation of a single JSON object having the following properties:
+The body of the response message consists of a single *Data* section containing a UTF-8 encoded string representation of a single JSON object having the following properties:
 
 | Name             | Mandatory | Type          | Description |
 | :--------------- | :-------: | :------------ | :---------- |
@@ -252,6 +252,7 @@ The following table provides an overview of the properties shared by all request
 | *correlation-id* | no        | *properties*             | *message-id* | MAY contain an ID used to correlate a response message to the original request. If set, it is used as the *correlation-id* property in the response, otherwise the value of the *message-id* property is used. |
 | *message-id*     | yes       | *properties*             | *string*     | MUST contain an identifier that uniquely identifies the message at the sender side. |
 | *reply-to*       | yes       | *properties*             | *string*     | MUST contain the source address that the client wants to received response messages from. This address MUST be the same as the source address used for establishing the client's receive link (see [Preconditions]({{< relref "#preconditions" >}})). |
+| *content-type*   | yes       | *properties*             | *string*     | MUST be set to `application/json`. |
 | *device_id*      | yes       | *application-properties* | *string*     | MUST contain the ID of the device that is subject to the operation. |
 
 ## Standard Response Properties
@@ -261,6 +262,7 @@ The following table provides an overview of the properties shared by all respons
 | Name             | Mandatory | Location                 | Type         | Description |
 | :--------------- | :-------: | :----------------------- | :----------- | :---------- |
 | *correlation-id* | yes       | *properties*             | *message-id* | Contains the *message-id* (or the *correlation-id*, if specified) of the request message that this message is the response to. |
+| *content-type*   | yes       | *properties*             | *string*     | MUST be set to `application/json`. |
 | *device_id*      | yes       | *application-properties* | *string*     | Contains the ID of the device. |
 | *tenant_id*      | yes       | *application-properties* | *string*     | Contains the ID of the tenant to which the device belongs. |
 | *status*         | yes       | *application-properties* | *int*        | Contains the status code indicating the outcome of the operation. Concrete values and their semantics are defined for each particular operation. |
@@ -279,7 +281,7 @@ Hono uses the following AMQP message delivery states when receiving request mess
 
 Most of the operations of the Device Registration API allow or require the inclusion of registration data in the payload of the
 request or response messages of the operation. Such payload is carried in the body of the corresponding AMQP 
-messages as part of a single *AMQP Value* section.
+messages as part of a single *Data* section. The content type must be set to `application/json`.
 
 The registration data is carried in the payload as a UTF-8 encoded string representation of a single JSON object. It is an error to include payload that is not of this type.
 

--- a/site/content/api/Tenant-API.md
+++ b/site/content/api/Tenant-API.md
@@ -92,11 +92,11 @@ The following sequence diagram illustrates the flow of messages involved in a *C
 
 The following table provides an overview of the properties a client needs to set on a message to get tenant information in addition to the [Standard Request Properties]({{< relref "#standard-request-properties" >}}).
 
-| Name        | Mandatory | Location                 | Type     | Description |
-| :---------- | :-------: | :----------------------- | :------- | :---------- |
-| *subject*   | yes       | *properties*             | *string* | MUST be set to `get`. |
+| Name           | Mandatory | Location                 | Type     | Description |
+| :------------- | :-------: | :----------------------- | :------- | :---------- |
+| *subject*      | yes       | *properties*             | *string* | MUST be set to `get`. |
 
-The body of the request MUST consist of a single *AMQP Value* section containing a UTF-8 encoded string representation of a single JSON object containing *exactly one* of the following search criteria properties:
+The body of the request MUST consist of a single *Data* section containing a UTF-8 encoded string representation of a single JSON object containing *exactly one* of the following search criteria properties:
 
 | Name             | Mandatory | Type       | Description |
 | :--------------- | :-------: | :--------- | :---------- |
@@ -244,6 +244,7 @@ The following table provides an overview of the properties shared by all request
 | *correlation-id* | no        | *properties*             | *message-id* | MAY contain an ID used to correlate a response message to the original request. If set, it is used as the *correlation-id* property in the response, otherwise the value of the *message-id* property is used. |
 | *message-id*     | yes       | *properties*             | *string*     | MUST contain an identifier that uniquely identifies the message at the sender side. |
 | *reply-to*       | yes       | *properties*             | *string*     | MUST contain the source address that the client wants to received response messages from. This address MUST be the same as the source address used for establishing the client's receive link (see [Preconditions]({{< relref "#preconditions" >}})). |
+| *content-type*   | yes       | *properties*             | *string*     | MUST be set to `application/json`. |
 
 ## Standard Response Properties
 
@@ -252,6 +253,7 @@ The following table provides an overview of the properties shared by all respons
 | Name             | Mandatory | Location                 | Type         | Description |
 | :--------------- | :-------: | :----------------------- | :----------- | :---------- |
 | *correlation-id* | yes       | *properties*             | *message-id* | Contains the *message-id* (or the *correlation-id*, if specified) of the request message that this message is the response to. |
+| *content-type*   | yes       | *properties*             | *string*     | MUST be set to `application/json`. |
 | *tenant_id*      | yes       | *application-properties* | *string*     | Contains the ID of the tenant that is subject of the outcome of the operation. |
 | *status*         | yes       | *application-properties* | *int*        | Contains the status code indicating the outcome of the operation. Concrete values and their semantics are defined for each particular operation. |
 | *cache_control*  | no        | *application-properties* | *string*     | Contains an [RFC 2616](https://tools.ietf.org/html/rfc2616#section-14.9) compliant <em>cache directive</em>. The directive contained in the property MUST be obeyed by clients that are caching responses. |
@@ -269,7 +271,7 @@ Hono uses the following AMQP message delivery states when receiving request mess
 
 Most of the operations of the Tenant API allow or require the inclusion of tenant data in the payload of the
 request or response messages of the operation. Such payload is carried in the body of the corresponding AMQP 
-messages as part of a single *AMQP Value* section.
+messages as part of a single *Data* section. The content type must be set to `application/json`.
 
 The tenant data is carried in the payload as a UTF-8 encoded string representation of a single JSON object. It is an error to include payload that is not of this type.
 

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -14,6 +14,11 @@ title = "Release Notes"
 * The `org.eclipse.hono.service.registration.RegistrationService` interface now describes only the mandatory operations of the API. The complete API is offered in `org.eclipse.hono.service.registration.CompleteRegistrationService`. These interfaces are implemented in `org.eclipse.hono.service.registration.BaseRegistrationService` and `org.eclipse.hono.service.registration.CompleteBaseRegistrationService` respectfully. Device Registries implementations can offer the mandatory only or the full API by extending the according base class.
 * The `org.eclipse.hono.service.tenant.TenantService` interface now describes only the mandatory operations of the API. The complete API is offered in `org.eclipse.hono.service.tenant.CompleteTenantService`. These interfaces are implemented in `org.eclipse.hono.service.tenant.BaseTenantService` and `org.eclipse.hono.service.tenant.CompleteBaseTenantService` respectfully. Tenant services implementations can offer the mandatory only or the full API by extending the according base class.
 * The `org.eclipse.hono.service.credentials.CredentialsService` interface now describes only the mandatory operations of the API. The complete API is offered in `org.eclipse.hono.service.credentials.CompleteCredentialsService`. These interfaces are implemented in `org.eclipse.hono.service.credentials.BaseCredentialsService` and `org.eclipse.hono.service.credentials.CompleteBaseCredentialsService` respectfully. Credentials services implementations can offer the mandatory only or the full API by extending the according base class.
+* All messages containing JSON objects as payload are now encoded using *Data*
+  sections and are required to have the content type `application/json`.
+  This affects the Tenant, Credentials and Registry API. When evaluating Hono
+  still accepts *AMQP Values* of type String or byte[]. But this behavior is
+  deprecated and my be dropped in releases after 0.8.
 
 ## 0.7
 

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/DeviceRegistrationIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/DeviceRegistrationIT.java
@@ -17,6 +17,7 @@ import static java.net.HttpURLConnection.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -33,6 +34,8 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
 
 /**
  * Register some devices, send some messages.
@@ -109,9 +112,38 @@ public class DeviceRegistrationIT {
     @Test
     public void testRegisterDeviceSucceeds() throws Exception {
         final String deviceId = getRandomDeviceId();
-        registration.register(deviceId, HTTP_CREATED).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
+        registration.register(deviceId, Optional.empty(), HTTP_CREATED).get(DEFAULT_TEST_TIMEOUT,
+                TimeUnit.MILLISECONDS);
         registration.retrieve(deviceId, HTTP_OK).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
         assertThat("Did not receive responses to all requests", registration.getCorrelationHelperSize(), is(0));
+    }
+
+    /**
+     * Verifies that a device can be retrieved by ID once it has been registered with payload.
+     * 
+     * @throws Exception if the test fails.
+     */
+    @Test
+    public void testRegisterWithPayloadDeviceSucceeds() throws Exception {
+        final String deviceId = getRandomDeviceId();
+
+        final JsonObject data = new JsonObject();
+        data.put("foo", "bar");
+        data.put("answer", 42);
+
+        registration.register(deviceId, Optional.of(data), HTTP_CREATED).get(DEFAULT_TEST_TIMEOUT,
+                TimeUnit.MILLISECONDS);
+
+        final RegistrationResult result = registration.retrieve(deviceId, HTTP_OK).get(DEFAULT_TEST_TIMEOUT,
+                TimeUnit.MILLISECONDS);
+
+        assertThat("Did not receive responses to all requests", registration.getCorrelationHelperSize(), is(0));
+        assertNotNull(result.getPayload());
+        final JsonObject responseData = result.getPayload().getJsonObject("data");
+        assertNotNull(responseData);
+
+        assertEquals(data.getString("foo"), responseData.getString("foo"));
+        assertEquals(data.getInteger("answer"), responseData.getInteger("answer"));
     }
 
     /**
@@ -122,8 +154,10 @@ public class DeviceRegistrationIT {
     @Test
     public void testDuplicateRegistrationFailsWithConflict() throws Exception {
         final String deviceId = getRandomDeviceId();
-        registration.register(deviceId, HTTP_CREATED).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
-        registration.register(deviceId, HTTP_CONFLICT).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
+        registration.register(deviceId, Optional.empty(), HTTP_CREATED).get(DEFAULT_TEST_TIMEOUT,
+                TimeUnit.MILLISECONDS);
+        registration.register(deviceId, Optional.empty(), HTTP_CONFLICT).get(DEFAULT_TEST_TIMEOUT,
+                TimeUnit.MILLISECONDS);
         assertThat("Did not receive responses to all requests", registration.getCorrelationHelperSize(), is(0));
     }
 
@@ -135,7 +169,8 @@ public class DeviceRegistrationIT {
     @Test
     public void testAssertRegistrationSucceeds() throws Exception {
         final String deviceId = getRandomDeviceId();
-        registration.register(deviceId, HTTP_CREATED).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
+        registration.register(deviceId, Optional.empty(), HTTP_CREATED).get(DEFAULT_TEST_TIMEOUT,
+                TimeUnit.MILLISECONDS);
         final RegistrationResult result = registration.assertRegistration(deviceId, HTTP_OK).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
         assertTrue(result.getPayload().containsKey(RegistrationConstants.FIELD_ASSERTION));
         assertThat("Did not receive responses to all requests", registration.getCorrelationHelperSize(), is(0));
@@ -150,7 +185,8 @@ public class DeviceRegistrationIT {
     public void testDeregisterDeviceSucceeds() throws Exception {
 
         final String deviceId = getRandomDeviceId();
-        registration.register(deviceId, HTTP_CREATED).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
+        registration.register(deviceId, Optional.empty(), HTTP_CREATED).get(DEFAULT_TEST_TIMEOUT,
+                TimeUnit.MILLISECONDS);
         registration.retrieve(deviceId, HTTP_OK).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
         registration.deregister(deviceId, HTTP_NO_CONTENT).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
         registration.retrieve(deviceId, HTTP_NOT_FOUND).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
@@ -165,7 +201,8 @@ public class DeviceRegistrationIT {
     @Test
     public void testDeregisterNonExistingDeviceFailsWithNotFound() throws Exception {
 
-        registration.deregister(NON_EXISTING_DEVICE_ID, HTTP_NOT_FOUND).get(DEFAULT_TEST_TIMEOUT, TimeUnit.MILLISECONDS);
+        registration.deregister(NON_EXISTING_DEVICE_ID, HTTP_NOT_FOUND).get(DEFAULT_TEST_TIMEOUT,
+                TimeUnit.MILLISECONDS);
         assertThat("Did not receive responses to all requests", registration.getCorrelationHelperSize(), is(0));
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/SendReceiveIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/SendReceiveIT.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.time.Duration;
 import java.util.LongSummaryStatistics;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
@@ -124,7 +125,7 @@ public class SendReceiveIT {
 
         givenAReceiver();
         givenASender();
-        getRegistrationClient().register(DEVICE_ID, Duration.ofMillis(DEFAULT_TEST_TIMEOUT));
+        getRegistrationClient().register(DEVICE_ID, Optional.empty(), Duration.ofMillis(DEFAULT_TEST_TIMEOUT));
         final CountDownLatch latch = new CountDownLatch(IntegrationTestSupport.MSG_COUNT);
         final LongSummaryStatistics stats = new LongSummaryStatistics();
 
@@ -178,7 +179,7 @@ public class SendReceiveIT {
 
         givenAReceiver();
         givenASender();
-        getRegistrationClient().register(SPECIAL_DEVICE, Duration.ofMillis(DEFAULT_TEST_TIMEOUT));
+        getRegistrationClient().register(SPECIAL_DEVICE, Optional.empty(), Duration.ofMillis(DEFAULT_TEST_TIMEOUT));
         final CountDownLatch latch = new CountDownLatch(1);
 
         // get registration assertion


### PR DESCRIPTION
This PR switches to always use the the 'Data' type for AMQP body sections. As of now, it still can receive AmqpValue body sections of type byte[] or String in addition. However I am not sure if we should keep this.