### PR TITLE
[#784] AMQP Adapter: Implement Command & Control

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpContext.java
@@ -89,6 +89,15 @@ public class AmqpContext extends MapBasedExecutionContext {
     }
 
     /**
+     * Gets the AMQP 1.0 message sent by the client.
+     * 
+     * @return The AMQP 1.0 message.
+     */
+    Message getMessage() {
+        return message;
+    }
+
+    /**
      * Gets the tenant identifier for this context.
      *
      * @return The tenant identifier.

--- a/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
@@ -48,6 +48,10 @@ public final class Command {
 
         this.valid = valid;
         this.message = message;
+        if (valid) {
+            this.message.setCorrelationId(correlationId);
+            this.message.setReplyTo(replyToId);
+        }
         this.tenantId = tenantId;
         this.deviceId = deviceId;
         this.correlationId = correlationId;
@@ -139,6 +143,15 @@ public final class Command {
                 replyToId);
 
         return result;
+    }
+
+    /**
+     * Gets the AMQP 1.0 message representing this command.
+     * 
+     * @return The command message.
+     */
+    public Message getCommandMessage() {
+        return message;
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponse.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/CommandResponse.java
@@ -83,7 +83,7 @@ public final class CommandResponse {
                 final boolean addDeviceIdToReply = "1".equals(requestId.substring(0, 1));
                 final int lengthStringOne = Integer.parseInt(requestId.substring(1, 3), 16);
                 final String replyId = requestId.substring(3 + lengthStringOne);
-                return new CommandResponse(
+                return from(
                         payload,
                         contentType,
                         status,
@@ -96,7 +96,31 @@ public final class CommandResponse {
     }
 
     /**
-     * Gets the reply-to identifier that has bee extracted from the request ID.
+     * Creates a command response for a reply-to ID, correlation ID and status.
+     * 
+     * @param payload The command response payload.
+     * @param contentType The content-type of the response payload.
+     * @param status The HTTP status code indicating the outcome of executing the command on the device.
+     * @param correlationId The identifier used to correlate this response with the command request.
+     * @param replyTo The reply-to ID of the command response.
+     * 
+     * @return The command response or {@code null} if any of correlationId, replyTo and status is null or if the
+     *         status code is &lt; 200 or &gt;= 600.
+     */
+    public static CommandResponse from(final Buffer payload, final String contentType, final Integer status,
+            final String correlationId, final String replyTo) {
+
+        if (correlationId == null || replyTo == null || status == null) {
+            return null;
+        } else if (INVALID_STATUS_CODE.test(status)) {
+            return null;
+        } else {
+            return new CommandResponse(payload, contentType, status, correlationId, replyTo);
+        }
+    }
+
+    /**
+     * Gets the reply-to identifier that has been extracted from the request ID.
      * 
      * @return The identifier or {@code null} if the request ID could not be parsed.
      */

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -785,7 +785,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <port>+adapter.amqp.ip:adapter.amqp.port:5672</port>
                       <port>+adapter.amqps.ip:adapter.amqps.port:5671</port>
                       <port>+adapter.amqp.ip:adapter.amqp.health.port:8088</port>
-                      <port>8000:8000</port>
                     </ports>
                     <network>
                       <mode>custom</mode>
@@ -799,7 +798,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>prod</SPRING_PROFILES_ACTIVE>
                       <_JAVA_OPTIONS>${default.java.options}</_JAVA_OPTIONS>
-                      <!--<_JAVA_OPTIONS>-Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=y</_JAVA_OPTIONS>  -->
                     </env>
                     <log>
                       <prefix>AMQP</prefix>


### PR DESCRIPTION
@sophokles73 This patch address #784, with two separate commits:
* 6b67f7b: allow clients to subscribe to commands + unit tests
* 86bb838: allow clients to publish command responses + unit tests