### PR TITLE
BugFix: Fix wrong variable names in C&C ITs for the MQTT adapter

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -225,16 +225,16 @@ public class CommandAndControlMqttIT extends MqttTestBase {
 
         // send a message without message and correlation ID
         final Message messageWithoutId = ProtonHelper.message("input data");
-        messageWithoutSubject.setSubject("setValue");
-        messageWithoutSubject.setReplyTo("reply/to/address");
+        messageWithoutId.setSubject("setValue");
+        messageWithoutId.setReplyTo("reply/to/address");
         sender.get().sendAndWaitForOutcome(messageWithoutId).setHandler(ctx.asyncAssertFailure(t -> {
             ctx.assertTrue(t instanceof ClientErrorException);
         }));
 
         // send a message without reply-to address
         final Message messageWithoutReplyTo = ProtonHelper.message("input data");
-        messageWithoutSubject.setSubject("setValue");
-        messageWithoutSubject.setMessageId("message-id");
+        messageWithoutReplyTo.setSubject("setValue");
+        messageWithoutReplyTo.setMessageId("message-id");
         sender.get().sendAndWaitForOutcome(messageWithoutReplyTo).setHandler(ctx.asyncAssertFailure(t -> {
             ctx.assertTrue(t instanceof ClientErrorException);
         }));


### PR DESCRIPTION
@sophokles73: In the MQTT C&C integration test, the wrong variable names were used in the `testSendCommandFailsForMalformedMessage` test. this trivial patch fixes that.

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>