### PR TITLE
[#624] Jmeter client for Command and Control to enable load tests

### DIFF
--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoCommanderSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoCommanderSampler.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.jmeter;
+
+import static java.lang.String.format;
+import static org.eclipse.hono.jmeter.HonoSamplerUtils.getIntValueOrDefault;
+
+import java.util.concurrent.CompletionException;
+
+import org.apache.jmeter.samplers.Entry;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.testelement.ThreadListener;
+import org.eclipse.hono.jmeter.client.HonoCommander;
+import org.eclipse.hono.jmeter.sampleresult.HonoCommanderSampleResult;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JMeter creates an instance of a sampler class for every occurrence of the element in every thread. [some additional
+ * copies may be created before the test run starts]
+ *
+ * Thus each sampler is guaranteed to be called by a single thread - there is no need to synchronize access to instance
+ * variables.
+ *
+ * However, access to class fields must be synchronized.
+ */
+public class HonoCommanderSampler extends HonoSampler implements ThreadListener {
+
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(HonoCommanderSampler.class);
+    private static final String RECONNECT_ATTEMPTS = "reconnectAttempts";
+    private static final String COMMAND = "command";
+    private static final String COMMAND_PAYLOAD = "commandPayload";
+    private static final String COMMAND_TIMEOUT = "commandTimeOut";
+    private static final String TRIGGER_TYPE = "triggerType";
+    private static final int DEFAULT_COMMAND_REQUEST_TIMEOUT = 1000;
+    private HonoCommander honoCommander;
+
+    @Override
+    public SampleResult sample(final Entry entry) {
+        final HonoCommanderSampleResult sampleResult = new HonoCommanderSampleResult();
+        sampleResult.setDataType(SampleResult.TEXT);
+        sampleResult.setSampleLabel(getName());
+        honoCommander.sample(sampleResult);
+        return sampleResult;
+    }
+
+    @Override
+    public void threadStarted() {
+        LOG.info("Sampler thread started");
+        try {
+            honoCommander = new HonoCommander(this);
+            honoCommander.start().join();
+        } catch (final CompletionException e) {
+            throw new RuntimeException(format("Error starting commander sampler for tenant %s", getTenant()),
+                    e.getCause());
+        }
+    }
+
+    @Override
+    public void threadFinished() {
+        LOG.info("Sampler thread finished");
+        if (honoCommander != null) {
+            try {
+                honoCommander.close().join();
+            } catch (final CompletionException e) {
+                LOG.error("error during shut down of command application", e);
+            }
+        }
+
+    }
+
+    public int getReconnectAttemptsAsInt() {
+        return getIntValueOrDefault(getPropertyAsString(RECONNECT_ATTEMPTS), 0);
+    }
+
+    public String getReconnectAttempts() {
+        return getPropertyAsString(RECONNECT_ATTEMPTS);
+    }
+
+    /**
+     * Sets the number of re-connect attempts.
+     *
+     * @param reconnectAttempts The number of attempts as string.
+     */
+    public void setReconnectAttempts(final String reconnectAttempts) {
+        setProperty(RECONNECT_ATTEMPTS, reconnectAttempts);
+    }
+
+    public String getCommand() {
+        return getPropertyAsString(COMMAND, "ArbitraryCommand");
+    }
+
+    /**
+     * Sets the command to send to device.
+     *
+     * @param command Command to send to device
+     */
+    public void setCommand(final String command) {
+        setProperty(COMMAND, command);
+    }
+
+    public String getCommandPayload() {
+        return getPropertyAsString(COMMAND_PAYLOAD, "{\"set\": \"arbitrary value\"}");
+    }
+
+    /**
+     * Sets the command payload to send to device.
+     *
+     * @param commandPayload Command payload to send to device or the default timeout if the value is empty or cannot be
+     *            parsed as integer.
+     */
+    public void setCommandPayload(final String commandPayload) {
+        setProperty(COMMAND_PAYLOAD, commandPayload);
+    }
+
+    public int getCommandTimeoutAsInt() {
+        return getIntValueOrDefault(getPropertyAsString(COMMAND_TIMEOUT), DEFAULT_COMMAND_REQUEST_TIMEOUT);
+    }
+
+    public String getCommandTimeout() {
+        return getPropertyAsString(COMMAND_TIMEOUT);
+    }
+
+    /**
+     * Sets the timeout for waiting for a command response by the application.
+     *
+     * @param commandTimeout The timeout in milliseconds encoded as string.
+     */
+    public void setCommandTimeout(final String commandTimeout) {
+        setProperty(COMMAND_TIMEOUT, commandTimeout);
+    }
+
+    public String getTriggerType() {
+        return getPropertyAsString(TRIGGER_TYPE);
+    }
+
+    /**
+     * Sets the type of trigger for the command sampler.
+     * 
+     * @param triggerType The trigger type (device or sampler)
+     */
+    public void setTriggerType(final String triggerType) {
+        setProperty(TRIGGER_TYPE, triggerType);
+    }
+}

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSamplerUtils.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSamplerUtils.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.jmeter;
+
+/**
+ * A collection of utility methods for Jmeter tests.
+ *
+ */
+public final class HonoSamplerUtils {
+
+    private HonoSamplerUtils() {
+        // prevent instantiation
+    }
+
+    /**
+     * Parses string value and returns an integer value. If input string value is null, then provided default integer
+     * value is returned.
+     * 
+     * @param stringValue The string value that need to be converted as an integer.
+     * @param defaultValue The default value to be used, in case the stringValue is null
+     * @return The converted integer value
+     */
+    static int getIntValueOrDefault(final String stringValue, final int defaultValue) {
+        if (stringValue == null || stringValue.isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(stringValue);
+        } catch (final NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSenderSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSenderSampler.java
@@ -23,6 +23,8 @@ import org.eclipse.hono.jmeter.ui.ServerOptionsPanel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.eclipse.hono.jmeter.HonoSamplerUtils.getIntValueOrDefault;
+
 /**
  * JMeter creates an instance of a sampler class for every occurrence of the element in every thread. [some additional
  * copies may be created before the test run starts]
@@ -307,7 +309,7 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
     /**
      * Gets the number of messages to send per sample run as an integer.
      * <p>
-     * If the property value is smaller than 1 or not a number, 1 is returned. 
+     * If the property value is smaller than 1 or not a number, 1 is returned.
      *
      * @return number of messages as integer.
      */
@@ -324,17 +326,6 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
     public void setMessageCountPerSamplerRun(final String messageCountPerSamplerRun) {
         final int parsedMessageCount = getIntValueOrDefault(messageCountPerSamplerRun, 1);
         setProperty(MESSAGE_COUNT_PER_SAMPLER_RUN, parsedMessageCount > 0 ? Integer.toString(parsedMessageCount) : "1");
-    }
-
-    private static int getIntValueOrDefault(final String stringValue, final int defaultValue) {
-        if (stringValue == null || stringValue.isEmpty()) {
-            return defaultValue;
-        }
-        try {
-            return Integer.parseInt(stringValue);
-        } catch (final NumberFormatException e) {
-            return defaultValue;
-        }
     }
 
     public String getContentType() {

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoCommander.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoCommander.java
@@ -1,0 +1,258 @@
+/*
+ * ******************************************************************************
+ *  * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *  *
+ *  * See the NOTICE file(s) distributed with this work for additional
+ *  * information regarding copyright ownership.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Eclipse Public License 2.0 which is available at
+ *  * http://www.eclipse.org/legal/epl-2.0
+ *  *
+ *  * SPDX-License-Identifier: EPL-2.0
+ *  ******************************************************************************
+ *
+ */
+
+package org.eclipse.hono.jmeter.client;
+
+import static org.eclipse.hono.util.MessageTap.getConsumer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.CommandClient;
+import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.client.impl.HonoClientImpl;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.jmeter.HonoCommanderSampler;
+import org.eclipse.hono.jmeter.sampleresult.HonoCommanderSampleResult;
+import org.eclipse.hono.util.TimeUntilDisconnectNotification;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * Hono commander, which creates command client, send commands to devices and receive responses from devices;
+ * asynchronous API needs to be used synchronous for JMeters threading model.
+ */
+public class HonoCommander extends AbstractClient {
+
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(HonoCommander.class);
+    private final HonoClient client;
+    private final HonoCommanderSampler sampler;
+    private final List<String> devicesReadyToReceiveCommands = new CopyOnWriteArrayList<>();
+    private final AtomicInteger successCount = new AtomicInteger(0);
+    private final AtomicInteger errorCount = new AtomicInteger(0);
+    private final AtomicLong bytesSent = new AtomicLong(0);
+    private final AtomicLong bytesReceived = new AtomicLong(0);
+    private final AtomicLong sampleStart = new AtomicLong(0);
+
+    private final transient Object lock = new Object();
+
+    /**
+     * Creates a new sampler to send commands to devices and receive command responses.
+     *
+     * @param sampler The sampler configuration.
+     */
+    public HonoCommander(final HonoCommanderSampler sampler) {
+        super();
+        this.sampler = sampler;
+        final ClientConfigProperties clientConfig = new ClientConfigProperties();
+        clientConfig.setHostnameVerificationRequired(false);
+        clientConfig.setHost(sampler.getHost());
+        clientConfig.setPort(sampler.getPortAsInt());
+        clientConfig.setName(sampler.getContainer());
+        clientConfig.setUsername(sampler.getUser());
+        clientConfig.setPassword(sampler.getPwd());
+        clientConfig.setTrustStorePath(sampler.getTrustStorePath());
+        clientConfig.setReconnectAttempts(sampler.getReconnectAttemptsAsInt());
+        client = new HonoClientImpl(vertx, clientConfig);
+    }
+
+    /**
+     * Starts this Commander.
+     *
+     * @return A future indicating the outcome of the startup process.
+     */
+    public CompletableFuture<Void> start() {
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+        connect()
+                .compose(x -> createMessageConsumers())
+                .setHandler(connectionStatus -> {
+                    if (connectionStatus.succeeded()) {
+                        result.complete(null);
+                    } else {
+                        LOG.error("Error connecting to Hono. {}", connectionStatus.cause().getMessage());
+                        vertx.close();
+                        result.completeExceptionally(connectionStatus.cause());
+                    }
+                });
+        return result;
+    }
+
+    /**
+     *
+     * @param result The result object representing the combined outcome of the samples.
+     */
+    public void sample(final HonoCommanderSampleResult result) {
+        synchronized (lock) {
+            LOG.debug("Chosen trigger type: {}", sampler.getTriggerType());
+            if ("device".equals(sampler.getTriggerType())) {
+                setSampleStartAndEndTime(result);
+            } else {
+                result.sampleStart();
+                devicesReadyToReceiveCommands
+                        .parallelStream()
+                        .forEach(device -> sendCommandAndReceiveResponse(sampler.getTenant(), device));
+                result.sampleEnd();
+            }
+            final int noOfErrors = errorCount.getAndSet(0);
+            final int noOfSuccess = successCount.getAndSet(0);
+            final int noOfSamples = noOfSuccess + noOfErrors;
+            final long noOfBytesSent = bytesSent.getAndSet(0);
+            final long noOfBytesReceived = bytesReceived.getAndSet(0);
+            result.setSampleCount(noOfSamples);
+            result.setErrorCount(noOfErrors);
+            result.setSentBytes(noOfBytesSent);
+            result.setBytes(noOfBytesReceived);
+            result.setResponseOK();
+            result.setResponseCodeOK();
+            LOG.debug("Commands sent: {}, Response received: {}, Error: {}", noOfSamples,
+                    noOfSuccess, noOfErrors);
+        }
+
+    }
+
+    /**
+     * Closes the connections to the Device Registration Service and Hono Messaging.
+     *
+     * @return A future that successfully completes once the connections are closed.
+     */
+    public CompletableFuture<Void> close() {
+        final CompletableFuture<Void> shutdownTracker = new CompletableFuture<>();
+        final Future<Void> clientTracker = Future.future();
+        LOG.debug("Clean resources...");
+        client.shutdown(clientTracker.completer());
+        clientTracker
+                .compose(ok -> closeVertx())
+                .recover(error -> closeVertx())
+                .setHandler(result -> shutdownTracker.complete(null));
+        return shutdownTracker;
+    }
+
+    private Future<HonoClient> connect() {
+        return client
+                .connect()
+                .map(client -> {
+                    LOG.info("connected to Hono [{}:{}]", sampler.getHost(), sampler.getPort());
+                    return client;
+                });
+    }
+
+    private Future<MessageConsumer> createMessageConsumers() {
+        return client
+                .createEventConsumer(sampler.getTenant(),
+                        getConsumer(message -> handleMessage("Event", message),
+                                this::handleCommandReadinessNotification),
+                        closeHook -> LOG.error("remotely detached consumer link"))
+                .compose(consumer -> client.createTelemetryConsumer(sampler.getTenant(),
+                        getConsumer(message -> handleMessage("Telemetry", message),
+                                this::handleCommandReadinessNotification),
+                        closeHook -> LOG.error("remotely detached consumer link")))
+                .map(consumer -> {
+                    LOG.info("Ready to receive command readiness notifications for tenant [{}]",
+                            sampler.getTenant());
+                    return consumer;
+                })
+                .recover(Future::failedFuture);
+    }
+
+    private void handleMessage(final String msgType, final Message msg) {
+        final Data body = (Data) msg.getBody();
+        LOG.debug("Type: [{}] and Message: [{}]", msgType, body != null ? body.getValue().toString() : "");
+    }
+
+    private void handleCommandReadinessNotification(final TimeUntilDisconnectNotification notification) {
+        if (notification.getMillisecondsUntilExpiry() == 0) {
+            LOG.trace("Device [{}:{}] not ready to receive commands.", notification.getTenantId(),
+                    notification.getDeviceId());
+            if ("sampler".equals(sampler.getTriggerType())) {
+                devicesReadyToReceiveCommands.remove(notification.getDeviceId());
+            }
+        } else {
+            if ("device".equals(sampler.getTriggerType())) {
+                LOG.debug("Sending command to device [{}:{}]", notification.getTenantId(), notification.getDeviceId());
+                setSampleStartIfNotSetYet(System.currentTimeMillis());
+                sendCommandAndReceiveResponse(notification.getTenantId(), notification.getDeviceId());
+            } else {
+                LOG.debug("A device [{}] got registered with trigger type [{}]", notification.getDeviceId(),
+                        sampler.getTriggerType());
+                devicesReadyToReceiveCommands.add(notification.getDeviceId());
+            }
+        }
+    }
+
+    private void sendCommandAndReceiveResponse(final String tenantId, final String deviceId) {
+        client.getOrCreateCommandClient(tenantId, deviceId)
+                .map(this::setCommandTimeOut)
+                .compose(commandClient -> commandClient
+                        .sendCommand(sampler.getCommand(), Buffer.buffer(sampler.getCommandPayload()))
+                        .map(commandResponse -> {
+                            final String commandResponseText = Optional.ofNullable(commandResponse.getPayload())
+                                    .orElse(Buffer.buffer()).toString();
+                            LOG.debug("Command response from device [{}:{}] received [{}]", tenantId,
+                                    deviceId, commandResponseText);
+                            synchronized (lock) {
+                                successCount.incrementAndGet();
+                                bytesReceived.addAndGet(sampler.getCommandPayload().getBytes().length);
+                                bytesSent.addAndGet(commandResponseText.getBytes().length);
+                            }
+                            return commandResponse;
+                        })
+                        .map(x -> closeCommandClient(commandClient, tenantId, deviceId))
+                        .recover(error -> {
+                            if (sampler.getTriggerType().equals("device")
+                                    || devicesReadyToReceiveCommands.contains(deviceId)) {
+                                errorCount.incrementAndGet();
+                            }
+                            LOG.error("Error processing command: {}", error.getMessage());
+                            closeCommandClient(commandClient, tenantId, deviceId);
+                            return Future.failedFuture(error);
+                        }));
+    }
+
+    private CommandClient setCommandTimeOut(final CommandClient commandClient) {
+        commandClient.setRequestTimeout(sampler.getCommandTimeoutAsInt());
+        return commandClient;
+    }
+
+    private Void closeCommandClient(final CommandClient commandClient, final String tenantId, final String deviceId) {
+        commandClient
+                .close(closeHandler -> LOG.debug("CommandClient to device [{}:{}] is closed.", tenantId, deviceId));
+        return null;
+    }
+
+    private void setSampleStartAndEndTime(final SampleResult result) {
+        if (sampleStart.get() == 0) {
+            LOG.debug("SampleStart hasn't been set or no messages received");
+            result.setStampAndTime(System.currentTimeMillis(), 0);
+        } else {
+            final long startTime = sampleStart.getAndSet(0);
+            result.setStampAndTime(startTime, System.currentTimeMillis() - startTime);
+        }
+    }
+
+    private void setSampleStartIfNotSetYet(final long timestamp) {
+        sampleStart.compareAndSet(0, timestamp);
+    }
+}

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/sampleresult/HonoCommanderSampleResult.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/sampleresult/HonoCommanderSampleResult.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.jmeter.sampleresult;
+
+import org.apache.jmeter.samplers.SampleResult;
+
+/**
+ * This is extended SampleResult class for the HonoCommanderSampler. Method setErrorCount is ignored in the SampleResult
+ * class from Jmeter. Here this method is overridden so that the error count set during sampling is available in the
+ * summary report.
+ *
+ */
+public class HonoCommanderSampleResult extends SampleResult {
+
+    private int errorCount = 0;
+
+    public int getErrorCount() {
+        return errorCount;
+    }
+
+    public void setErrorCount(final int errorCount) {
+        this.errorCount = errorCount;
+    }
+
+}

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoCommanderSamplerUI.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoCommanderSamplerUI.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.jmeter.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Insets;
+import java.util.Objects;
+
+import javax.swing.BorderFactory;
+import javax.swing.JComboBox;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+
+import org.apache.jmeter.gui.util.VerticalPanel;
+import org.apache.jmeter.testelement.TestElement;
+import org.apache.jorphan.gui.JLabeledTextArea;
+import org.apache.jorphan.gui.JLabeledTextField;
+import org.eclipse.hono.jmeter.HonoCommanderSampler;
+
+/**
+ * Swing UI for Commander sampler.
+ */
+public class HonoCommanderSamplerUI extends HonoSamplerUI {
+
+    private final ServerOptionsPanel honoServerOptions;
+    private final JLabeledTextField tenant;
+    private final JLabeledTextField reconnectAttempts;
+    private final JLabeledTextField commandTimeOut;
+    private final JLabeledTextArea commandPayload;
+    private final JLabeledTextArea command;
+    private final JComboBox triggerType;
+    private final JTextArea triggerTypeDescription;
+
+    /**
+     * Creates a new UI that provides means to configure the Command &amp; Control endpoint to connect to for sending
+     * commands and receiving command responses.
+     */
+    public HonoCommanderSamplerUI() {
+        honoServerOptions = new ServerOptionsPanel("Hono connection options");
+        reconnectAttempts = new JLabeledTextField("Max reconnect attempts");
+        tenant = new JLabeledTextField("Tenant");
+        command = new JLabeledTextArea("Command");
+        commandPayload = new JLabeledTextArea("Command payload");
+        commandTimeOut = new JLabeledTextField("Command Timeout In Milliseconds");
+        triggerType = new JComboBox(new String[] { "device", "sampler" });
+        triggerTypeDescription = new JTextArea();
+        addOption(honoServerOptions);
+        addOption(reconnectAttempts);
+        addOption(tenant);
+        addOption(command);
+        addOption(commandPayload);
+        addOption(commandTimeOut);
+        addOption(getTriggerTypePanel());
+    }
+
+    @Override
+    public String getStaticLabel() {
+        return "Hono Commander Sampler";
+    }
+
+    @Override
+    public TestElement createTestElement() {
+        final HonoCommanderSampler sampler = new HonoCommanderSampler();
+        modifyTestElement(sampler);
+        return sampler;
+    }
+
+    @Override
+    public void modifyTestElement(final TestElement testElement) {
+        super.configureTestElement(testElement);
+        final HonoCommanderSampler sampler = (HonoCommanderSampler) testElement;
+        sampler.modifyServerOptions(honoServerOptions);
+        sampler.setReconnectAttempts(reconnectAttempts.getText());
+        sampler.setTenant(tenant.getText());
+        sampler.setCommandTimeout(commandTimeOut.getText());
+        sampler.setCommand(command.getText());
+        sampler.setCommandPayload(commandPayload.getText());
+        sampler.setTriggerType(((String) triggerType.getSelectedItem()));
+    }
+
+    @Override
+    public void configure(final TestElement testElement) {
+        super.configure(testElement);
+        final HonoCommanderSampler sampler = (HonoCommanderSampler) testElement;
+        sampler.configureServerOptions(honoServerOptions);
+        reconnectAttempts.setText(sampler.getReconnectAttempts());
+        tenant.setText(sampler.getTenant());
+        commandTimeOut.setText(sampler.getCommandTimeout());
+        command.setText(sampler.getCommand());
+        commandPayload.setText(sampler.getCommandPayload());
+        triggerType.setSelectedItem(sampler.getTriggerType());
+        triggerTypeDescription.setText(getDescriptionTextForSelectedTrigger());
+    }
+
+    @Override
+    public void clearGui() {
+        super.clearGui();
+        honoServerOptions.clearGui();
+        reconnectAttempts.setText("");
+        tenant.setText("");
+        commandTimeOut.setText("");
+        command.setText("");
+        commandPayload.setText("");
+        triggerType.setSelectedIndex(0);
+        triggerTypeDescription.setText(getDescriptionTextForSelectedTrigger());
+    }
+
+    private JPanel getTriggerTypePanel() {
+        final JPanel triggerOuterPanel = new VerticalPanel(50, 0.0F);
+        triggerOuterPanel.setBorder(
+                BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Commands triggered by"));
+        final JPanel triggerPanel = new JPanel(new BorderLayout(10, 50));
+        setDescriptionTextAreaDesign(triggerTypeDescription, triggerPanel);
+        triggerPanel.add(triggerType, BorderLayout.LINE_START);
+        triggerPanel.add(triggerTypeDescription, BorderLayout.CENTER);
+        triggerType.addActionListener(e -> triggerTypeDescription.setText(getDescriptionTextForSelectedTrigger()));
+        triggerOuterPanel.add(triggerPanel);
+        return triggerOuterPanel;
+    }
+
+    private void setDescriptionTextAreaDesign(final JTextArea jTextArea, final JPanel parentPanel) {
+        jTextArea.setLineWrap(true);
+        jTextArea.setWrapStyleWord(true);
+        jTextArea.setEditable(false);
+        jTextArea.setMargin(new Insets(15, 15, 15, 15));
+        jTextArea.setBackground(parentPanel.getBackground());
+        jTextArea.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY, 1));
+    }
+
+    private String getDescriptionTextForSelectedTrigger() {
+        if (Objects.requireNonNull(triggerType.getSelectedItem()).equals("device")) {
+            return "Devices notify hono that they are ready to receive commands. Immediately after receiving this notification, the sampler sends a command (one command per notification). During each sampling interval, no. of commands sent, errors etc are captured by the sampler. \n\nExample Scenario(s): \n1. To send commands using HTTP, the devices always initiate by sending messages with hono-ttd value. \n2. Devices connected for a short duration using mqtt. After subscription, devices expect commands from application if any, then unsubscribe.";
+        } else {
+            return "It is assumed that the devices are ready to receive commands throughout the test time. One Command per sampling interval is sent by the sampler to all subscribed devices. \n\nExample scenario:\nUsing Mqtt, devices subscribe for commands and stay connected for a long time. An Application can send any number of commands and receive responses during this time.\n";
+        }
+    }
+}


### PR DESCRIPTION
This PR contains HonoCommanderSampler, using which settings required to perform load test for feature Command and Control can be configured. Users can choose the type of protocol being used (http or mqtt) for communication between devices and hono. This sampler establishes connection to hono, get devices that are ready to receive commands under a particular tenant, send commands and receive command responses.This sampler can be combined with standard Jmeter samplers (for example HTTP Request Sampler) to create a test plan for C&C. 