### PR TITLE
Enable code coverage for integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,8 @@
       The organization name to use for our Docker image names.
      -->
      <docker.image.org-name>eclipse</docker.image.org-name>
+
+     <jacoco.version>0.8.2</jacoco.version>
   </properties>
 
   <modules>
@@ -222,6 +224,11 @@
               </image>
             </images>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.8</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -446,7 +453,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
+        <version>${jacoco.version}</version>
         <executions>
           <execution>
             <!-- enable test execution with jacoco -->
@@ -460,7 +467,7 @@
       <plugin>
         <groupId>de.dentrassi.maven</groupId>
         <artifactId>jacoco-extras</artifactId>
-        <version>0.1.2</version>
+        <version>0.1.4</version>
         <executions>
           <execution>
             <!--

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -88,6 +88,26 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <version>${netty.tcnative.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hono-adapter-amqp-vertx</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hono-adapter-http-vertx</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hono-adapter-mqtt-vertx</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -132,6 +152,26 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <excludeTransitive>true</excludeTransitive>
                 </configuration>
               </execution>
+              <execution>
+                <id>copy_jacoco_agent</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.jacoco</groupId>
+                      <artifactId>org.jacoco.agent</artifactId>
+                      <version>${jacoco.version}</version>
+                      <classifier>runtime</classifier>
+                    </artifactItem>
+                  </artifactItems>
+                  <outputDirectory>${project.build.directory}/agent</outputDirectory>
+                  <stripVersion>true</stripVersion>
+                  <stripClassifier>true</stripClassifier>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>
@@ -150,27 +190,36 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <from>${docker.image.org-name}/hono-service-auth:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
-                      <basedir>/etc/hono</basedir>
+                      <basedir>/</basedir>
                       <inline>
                         <id>config</id>
                         <fileSets>
                           <fileSet>
                             <directory>${project.basedir}/src/test/resources/auth</directory>
-                            <outputDirectory>.</outputDirectory>
+                            <outputDirectory>etc/hono</outputDirectory>
                             <includes>
                               <include>*</include>
                             </includes>
                           </fileSet>
                           <fileSet>
                             <directory>${project.build.directory}/certs</directory>
-                            <outputDirectory>certs</outputDirectory>
+                            <outputDirectory>etc/hono/certs</outputDirectory>
                             <includes>
                               <include>auth-server-*.pem</include>
                             </includes>
                           </fileSet>
+                          <fileSet>
+                            <directory>${project.build.directory}/agent</directory>
+                            <outputDirectory>opt/hono/agent</outputDirectory>
+                          </fileSet>
                         </fileSets>
                       </inline>
                     </assembly>
+                    <runCmds>
+                      <runCmd>install -m 0777 -d /opt/hono/jacoco.result</runCmd>
+                      <runCmd>touch /opt/hono/jacoco.result/jacoco.part</runCmd>
+                      <runCmd>chmod 0666 /opt/hono/jacoco.result/jacoco.part</runCmd>
+                    </runCmds>
                   </build>
                   <run>
                     <ports>
@@ -185,11 +234,17 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>authentication-impl,prod</SPRING_PROFILES_ACTIVE>
+                      <_JAVA_OPTIONS>-javaagent:/opt/hono/agent/org.jacoco.agent.jar=destfile=/opt/hono/jacoco.result/jacoco.part</_JAVA_OPTIONS>
                     </env>
                     <log>
                       <prefix>AUTH</prefix>
                       <color>cyan</color>
                     </log>
+                    <volumes>
+                      <bind>
+                        <volume>${project.build.directory}/jacoco.result/auth:/opt/hono/jacoco.result:z</volume>
+                      </bind>
+                    </volumes>
                     <wait>
                       <time>${service.startup.timeout}</time>
                       <tcp>
@@ -207,29 +262,38 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <from>${docker.image.org-name}/hono-service-device-registry:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
-                      <basedir>/etc/hono</basedir>
+                      <basedir>/</basedir>
                       <inline>
                         <id>config</id>
                         <fileSets>
                           <fileSet>
                             <directory>${project.basedir}/src/test/resources/deviceregistry</directory>
-                            <outputDirectory>.</outputDirectory>
+                            <outputDirectory>etc/hono</outputDirectory>
                             <includes>
                               <include>*</include>
                             </includes>
                           </fileSet>
                           <fileSet>
                             <directory>${project.build.directory}/certs</directory>
-                            <outputDirectory>certs</outputDirectory>
+                            <outputDirectory>etc/hono/certs</outputDirectory>
                             <includes>
                               <include>device-registry-*.pem</include>
                               <include>auth-server-cert.pem</include>
                               <include>trusted-certs.pem</include>
                             </includes>
                           </fileSet>
+                          <fileSet>
+                            <directory>${project.build.directory}/agent</directory>
+                            <outputDirectory>opt/hono/agent</outputDirectory>
+                          </fileSet>
                         </fileSets>
                       </inline>
                     </assembly>
+                    <runCmds>
+                      <runCmd>install -m 0777 -d /opt/hono/jacoco.result</runCmd>
+                      <runCmd>touch /opt/hono/jacoco.result/jacoco.part</runCmd>
+                      <runCmd>chmod 0666 /opt/hono/jacoco.result/jacoco.part</runCmd>
+                    </runCmds>
                   </build>
                   <run>
                     <ports>
@@ -246,11 +310,17 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>prod</SPRING_PROFILES_ACTIVE>
+                      <_JAVA_OPTIONS>-javaagent:/opt/hono/agent/org.jacoco.agent.jar=destfile=/opt/hono/jacoco.result/jacoco.part</_JAVA_OPTIONS>
                     </env>
                     <log>
                       <prefix>REGISTRY</prefix>
                       <color>yellow</color>
                     </log>
+                    <volumes>
+                      <bind>
+                        <volume>${project.build.directory}/jacoco.result/registry:/opt/hono/jacoco.result:z</volume>
+                      </bind>
+                    </volumes>
                     <wait>
                       <time>${service.startup.timeout}</time>
                       <http>
@@ -406,29 +476,38 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <from>${docker.image.org-name}/hono-service-messaging:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
-                      <basedir>/etc/hono</basedir>
+                      <basedir>/</basedir>
                       <inline>
                         <id>config</id>
                         <fileSets>
                           <fileSet>
                             <directory>${project.basedir}/src/test/resources/messaging</directory>
-                            <outputDirectory>.</outputDirectory>
+                            <outputDirectory>etc/hono</outputDirectory>
                             <includes>
                               <include>*</include>
                             </includes>
                           </fileSet>
                           <fileSet>
                             <directory>${project.build.directory}/certs</directory>
-                            <outputDirectory>certs</outputDirectory>
+                            <outputDirectory>etc/hono/certs</outputDirectory>
                             <includes>
                               <include>hono-messaging-*.pem</include>
                               <include>auth-server-cert.pem</include>
                               <include>trusted-certs.pem</include>
                             </includes>
                           </fileSet>
+                          <fileSet>
+                            <directory>${project.build.directory}/agent</directory>
+                            <outputDirectory>opt/hono/agent</outputDirectory>
+                          </fileSet>
                         </fileSets>
                       </inline>
                     </assembly>
+                    <runCmds>
+                      <runCmd>install -m 0777 -d /opt/hono/jacoco.result</runCmd>
+                      <runCmd>touch /opt/hono/jacoco.result/jacoco.part</runCmd>
+                      <runCmd>chmod 0666 /opt/hono/jacoco.result/jacoco.part</runCmd>
+                    </runCmds>
                   </build>
                   <run>
                     <ports>
@@ -445,11 +524,17 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
                       <!--<PN_TRACE_FRM>1</PN_TRACE_FRM>-->
                       <SPRING_PROFILES_ACTIVE>qpid,prod</SPRING_PROFILES_ACTIVE>
+                      <_JAVA_OPTIONS>-javaagent:/opt/hono/agent/org.jacoco.agent.jar=destfile=/opt/hono/jacoco.result/jacoco.part</_JAVA_OPTIONS>
                     </env>
                     <log>
                       <prefix>MESSAGING</prefix>
                       <color>green</color>
                     </log>
+                    <volumes>
+                      <bind>
+                        <volume>${project.build.directory}/jacoco.result/messaging:/opt/hono/jacoco.result:z</volume>
+                      </bind>
+                    </volumes>
                     <wait>
                       <time>${service.startup.timeout}</time>
                       <http>
@@ -495,9 +580,18 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                               <include>trusted-certs.pem</include>
                             </includes>
                           </fileSet>
+                          <fileSet>
+                            <directory>${project.build.directory}/agent</directory>
+                            <outputDirectory>opt/hono/agent</outputDirectory>
+                          </fileSet>
                         </fileSets>
                       </inline>
                     </assembly>
+                    <runCmds>
+                      <runCmd>install -m 0777 -d /opt/hono/jacoco.result</runCmd>
+                      <runCmd>touch /opt/hono/jacoco.result/jacoco.part</runCmd>
+                      <runCmd>chmod 0666 /opt/hono/jacoco.result/jacoco.part</runCmd>
+                    </runCmds>
                   </build>
                   <run>
                     <ports>
@@ -516,10 +610,16 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <!--<PN_TRACE_FRM>1</PN_TRACE_FRM>-->
                       <SPRING_PROFILES_ACTIVE>prod</SPRING_PROFILES_ACTIVE>
                       <HONO_HTTP_NATIVE_TLS_REQUIRED>true</HONO_HTTP_NATIVE_TLS_REQUIRED>
+                      <_JAVA_OPTIONS>-javaagent:/opt/hono/agent/org.jacoco.agent.jar=destfile=/opt/hono/jacoco.result/jacoco.part</_JAVA_OPTIONS>
                     </env>
                     <log>
                       <prefix>HTTP</prefix>
                     </log>
+                    <volumes>
+                      <bind>
+                        <volume>${project.build.directory}/jacoco.result/http:/opt/hono/jacoco.result:z</volume>
+                      </bind>
+                    </volumes>
                     <wait>
                       <time>${service.startup.timeout}</time>
                       <http>
@@ -565,9 +665,18 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                               <include>trusted-certs.pem</include>
                             </includes>
                           </fileSet>
+                          <fileSet>
+                            <directory>${project.build.directory}/agent</directory>
+                            <outputDirectory>opt/hono/agent</outputDirectory>
+                          </fileSet>
                         </fileSets>
                       </inline>
                     </assembly>
+                    <runCmds>
+                      <runCmd>install -m 0777 -d /opt/hono/jacoco.result</runCmd>
+                      <runCmd>touch /opt/hono/jacoco.result/jacoco.part</runCmd>
+                      <runCmd>chmod 0666 /opt/hono/jacoco.result/jacoco.part</runCmd>
+                    </runCmds>
                   </build>
                   <run>
                     <ports>
@@ -585,10 +694,16 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <!--<PN_TRACE_FRM>1</PN_TRACE_FRM>-->
                       <SPRING_PROFILES_ACTIVE>prod</SPRING_PROFILES_ACTIVE>
                       <HONO_MQTT_NATIVE_TLS_REQUIRED>true</HONO_MQTT_NATIVE_TLS_REQUIRED>
+                      <_JAVA_OPTIONS>-javaagent:/opt/hono/agent/org.jacoco.agent.jar=destfile=/opt/hono/jacoco.result/jacoco.part</_JAVA_OPTIONS>
                     </env>
                     <log>
                       <prefix>MQTT</prefix>
                     </log>
+                    <volumes>
+                      <bind>
+                        <volume>${project.build.directory}/jacoco.result/mqtt:/opt/hono/jacoco.result:z</volume>
+                      </bind>
+                    </volumes>
                     <wait>
                       <time>${service.startup.timeout}</time>
                       <http>
@@ -607,28 +722,37 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <from>${docker.image.org-name}/hono-adapter-amqp-vertx:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
-                      <basedir>/etc/hono</basedir>
+                      <basedir>/</basedir>
                       <inline>
                         <id>config</id>
                         <fileSets>
                           <fileSet>
                             <directory>${project.basedir}/src/test/resources/amqp</directory>
-                            <outputDirectory>.</outputDirectory>
+                            <outputDirectory>etc/hono</outputDirectory>
                             <includes>
                               <include>*</include>
                             </includes>
                           </fileSet>
                           <fileSet>
                             <directory>${project.build.directory}/certs</directory>
-                            <outputDirectory>certs</outputDirectory>
+                            <outputDirectory>etc/hono/certs</outputDirectory>
                             <includes>
                               <include>amqp-adapter-*.pem</include>
                               <include>trusted-certs.pem</include>
                             </includes>
                           </fileSet>
+                          <fileSet>
+                            <directory>${project.build.directory}/agent</directory>
+                            <outputDirectory>opt/hono/agent</outputDirectory>
+                          </fileSet>
                         </fileSets>
                       </inline>
                     </assembly>
+                    <runCmds>
+                      <runCmd>install -m 0777 -d /opt/hono/jacoco.result</runCmd>
+                      <runCmd>touch /opt/hono/jacoco.result/jacoco.part</runCmd>
+                      <runCmd>chmod 0666 /opt/hono/jacoco.result/jacoco.part</runCmd>
+                    </runCmds>
                   </build>
                   <run>
                     <ports>
@@ -646,12 +770,18 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>prod</SPRING_PROFILES_ACTIVE>
+                      <_JAVA_OPTIONS>-javaagent:/opt/hono/agent/org.jacoco.agent.jar=destfile=/opt/hono/jacoco.result/jacoco.part</_JAVA_OPTIONS>
                       <!--<_JAVA_OPTIONS>-Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=y</_JAVA_OPTIONS>  -->
                     </env>
                     <log>
                       <prefix>AMQP</prefix>
                       <color>RED</color>
                     </log>
+                    <volumes>
+                      <bind>
+                        <volume>${project.build.directory}/jacoco.result/amqp:/opt/hono/jacoco.result:z</volume>
+                      </bind>
+                    </volumes>
                     <wait>
                       <time>${service.startup.timeout}</time>
                       <http>
@@ -687,6 +817,50 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 </goals>
                 <configuration>
                   <removeAll>true</removeAll>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <!--
+              - The Maven Antrun plugin has to be defined after the fabric8
+              - plugin so that this plugin's 'post-integration-test' runs
+              - after the containers are stopped. But before the 'verify'
+              - phase of the jacoco extras plugin.
+              -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>create_dirs</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <mkdir dir="${project.build.directory}/jacoco.result" />
+                    <mkdir dir="${project.build.directory}/jacoco.result/auth" />
+                    <mkdir dir="${project.build.directory}/jacoco.result/registry" />
+                    <mkdir dir="${project.build.directory}/jacoco.result/messaging" />
+                    <mkdir dir="${project.build.directory}/jacoco.result/amqp" />
+                    <mkdir dir="${project.build.directory}/jacoco.result/http" />
+                    <mkdir dir="${project.build.directory}/jacoco.result/mqtt" />
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>concat-jacoco-exec</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <concat destfile="${project.build.directory}/jacoco.exec" append="yes" binary="yes">
+                      <fileset dir="${project.build.directory}/jacoco.result" includes="**/jacoco.part"/>
+                    </concat>
+                  </target>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
This change does enable the code coverage agent for containers when
running the integration tests in hono-tests.