### PR TITLE
Added provision to get application properties from command.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/command/Command.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.service.command;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -148,7 +149,7 @@ public final class Command {
 
     /**
      * Checks if this command contains all required information.
-     * 
+     *
      * @return {@code true} if this is a valid command.
      */
     public boolean isValid() {
@@ -248,7 +249,7 @@ public final class Command {
 
     /**
      * Gets the type of this command's payload.
-     * 
+     *
      * @return The content type or {@code null} if not set.
      * @throws IllegalStateException if this command is invalid.
      */
@@ -289,8 +290,24 @@ public final class Command {
     }
 
     /**
+     * Gets the application properties of a message if any.
+     *
+     * @return The application properties.
+     * @throws IllegalStateException if this command is invalid.
+     */
+    public Map<String, Object> getApplicationProperties() {
+        if (isValid()) {
+            if (message.getApplicationProperties() == null) {
+                return null;
+            }
+            return message.getApplicationProperties().getValue();
+        } else {
+            throw new IllegalStateException("command is invalid");
+        }
+    }
+    /**
      * Creates a request ID for a command.
-     * 
+     *
      * @param correlationId The identifier to use for correlating the response with the request.
      * @param replyToId An arbitrary identifier to encode into the request ID.
      * @param deviceId The target of the command.

--- a/service-base/src/test/java/org/eclipse/hono/service/command/CommandTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/command/CommandTest.java
@@ -14,17 +14,22 @@
 package org.eclipse.hono.service.command;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.junit.Test;
-
 
 /**
  * Verifies behavior of {@link Command}.
@@ -50,6 +55,58 @@ public class CommandTest {
         assertThat(cmd.getName(), is("doThis"));
         assertThat(cmd.getReplyToId(), is(String.format("4711/%s", replyToId)));
         assertThat(cmd.getCorrelationId(), is(correlationId));
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message with application properties.
+     * Verifies that the application properties is able to be retrieved from message.
+     */
+    @Test
+    public void testFromMessageSucceedsWithApplicationProperties() {
+        final String replyToId = "the-reply-to-id";
+        final String correlationId = "the-correlation-id";
+        final Message message = mock(Message.class);
+        final Map<String, Object> applicationProperties = new HashMap<String, Object>() {
+            {
+                put("deviceId", "4711");
+                put("tenantId", "DEFAULT_TENANT");
+            }
+        };
+        when(message.getApplicationProperties()).thenReturn(new ApplicationProperties(applicationProperties));
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final Command cmd = Command.from(message, Constants.DEFAULT_TENANT, "4711");
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getName(), is("doThis"));
+        assertThat(cmd.getReplyToId(), is(String.format("4711/%s", replyToId)));
+        assertThat(cmd.getCorrelationId(), is(correlationId));
+        assertThat(cmd.getApplicationProperties(), is(notNullValue()));
+        assertThat(cmd.getApplicationProperties(), is(notNullValue()));
+        assertThat(cmd.getApplicationProperties().get("deviceId"), is("4711"));
+        assertThat(cmd.getApplicationProperties().get("tenantId"), is("DEFAULT_TENANT"));
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message with no application properties.
+     */
+    @Test
+    public void testFromMessageSucceedsWithNoApplicationProperties() {
+        final String replyToId = "the-reply-to-id";
+        final String correlationId = "the-correlation-id";
+        final Message message = mock(Message.class);
+        when(message.getApplicationProperties()).thenReturn(null);
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final Command cmd = Command.from(message, Constants.DEFAULT_TENANT, "4711");
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getName(), is("doThis"));
+        assertThat(cmd.getReplyToId(), is(String.format("4711/%s", replyToId)));
+        assertThat(cmd.getCorrelationId(), is(correlationId));
+        assertThat(cmd.getApplicationProperties(), is(nullValue()));
     }
 
     /**


### PR DESCRIPTION
 while sending commands using a command client, there is a provision available in Hono to set application properties to a message. This PR provides a provision to retrieve application properties from a command, if it is set. So that the command consumer can make use of  them.