### PR TITLE
[#557] Pipeline script for Hono-CI jenkins build job

### DIFF
--- a/jenkins/Hono-CI-Pipeline.groovy
+++ b/jenkins/Hono-CI-Pipeline.groovy
@@ -27,6 +27,7 @@ node {
         utils.checkOutHonoRepoMaster()
         utils.build()
         utils.aggregateJunitResults()
+        utils.captureCodeCoverageReport()
         currentBuild.result = 'SUCCESS'
     } catch (err) {
         currentBuild.result = 'FAILURE'

--- a/jenkins/Hono-CI-Pipeline.groovy
+++ b/jenkins/Hono-CI-Pipeline.groovy
@@ -1,0 +1,39 @@
+#!/usr/bin/env groovy
+
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/**
+ * Jenkins pipeline script for Continuous integration build of Hono master.
+ * Checks GitHub repository every minute for changes.
+ *
+ */
+
+node {
+    def utils = evaluate readTrusted("jenkins/Hono-PipelineUtils.groovy")
+    properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '5', daysToKeepStr: '', numToKeepStr: '')),
+                pipelineTriggers([pollSCM('* * * * *')])])
+    try {
+        utils.checkOutHonoRepoMaster()
+        utils.build()
+        utils.aggregateJunitResults()
+        currentBuild.result = 'SUCCESS'
+    } catch (err) {
+        currentBuild.result = 'FAILURE'
+        echo "Error: ${err}"
+    }
+    finally {
+        echo "Build status: ${currentBuild.result}"
+        utils.notifyBuildStatus()
+    }
+}

--- a/jenkins/Hono-PipelineUtils.groovy
+++ b/jenkins/Hono-PipelineUtils.groovy
@@ -70,9 +70,24 @@ void notifyBuildStatus() {
               notifyEveryUnstableBuild: true,
               recipients              : 'hono-dev@eclipse.org',
               sendToIndividuals       : false])
-    } catch (err) {
-        echo "Error sending mail"
-        echo err.getMessage()
+    } catch (error) {
+        echo "Error notifying build status via Email"
+        echo error.getMessage()
+        throw error
+    }
+}
+
+/**
+ * Capture code coverage reports using Jacoco jenkins plugin.
+ *
+ */
+void captureCodeCoverageReport() {
+    stage('Capture Code Coverage Report') {
+        step([$class       : 'JacocoPublisher',
+              execPattern  : '**/**.exec',
+              classPattern : '**/classes',
+              sourcePattern: '**/src/main/java'
+        ])
     }
 }
 

--- a/jenkins/Hono-PipelineUtils.groovy
+++ b/jenkins/Hono-PipelineUtils.groovy
@@ -44,7 +44,7 @@ void checkOutHonoRepoMaster() {
  */
 void build() {
     stage('Build') {
-        withMaven(maven: 'apache-maven-latest', jdk: 'jdk1.8.0-latest') {
+        withMaven(maven: 'apache-maven-latest', jdk: 'jdk1.8.0-latest', options: [jacocoPublisher(disabled: true)]) {
             sh 'mvn -B clean install'
         }
     }

--- a/jenkins/Hono-PipelineUtils.groovy
+++ b/jenkins/Hono-PipelineUtils.groovy
@@ -1,0 +1,79 @@
+#!/usr/bin/env groovy
+
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0checkOutGitRepoMaster
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+/**
+ * A collection of utility methods to build pipelines
+ *
+ */
+
+/**
+ * Checks out the specified branch from hono github repo
+ *
+ * @param branch Branch to be checked out
+ */
+void checkOutHonoRepo(String branch) {
+    stage('Checkout') {
+        echo "Check out branch: $branch"
+        git branch: "$branch", url: "https://github.com/eclipse/hono.git"
+    }
+}
+
+/**
+ * Checks out the master branch from hono github repo
+ *
+ */
+void checkOutHonoRepoMaster() {
+    checkOutHonoRepo("master")
+}
+
+/**
+ * Build with maven (with jdk1.8.0-latest and apache-maven-latest as configured in 'Global Tool Configuration' in Jenkins).
+ *
+ */
+void build() {
+    stage('Build') {
+        withMaven(maven: 'apache-maven-latest', jdk: 'jdk1.8.0-latest') {
+            sh 'mvn -B clean install'
+        }
+    }
+}
+
+/**
+ * Aggregate junit test results.
+ *
+ */
+void aggregateJunitResults() {
+    stage('Aggregate Junit Test Results') {
+        junit '**/surefire-reports/*.xml'
+    }
+}
+
+/**
+ * Notify build status via email to 'hono-dev@eclipse.org'.
+ *
+ */
+void notifyBuildStatus() {
+    try {
+        step([$class                  : 'Mailer',
+              notifyEveryUnstableBuild: true,
+              recipients              : 'hono-dev@eclipse.org',
+              sendToIndividuals       : false])
+    } catch (err) {
+        echo "Error sending mail"
+        echo err.getMessage()
+    }
+}
+
+return this


### PR DESCRIPTION
With reference to #557,  all the jenkins build jobs are to be implemented as pipelines. To start with, jenkins [Hono-CI](https://ci.eclipse.org/hono/job/Hono-CI/) build job is to be implemented as a pipeline. This PR contains respective pipeline scripts.


Below screen shot is from a local jenkins after deploying above scripts:
![image](https://user-images.githubusercontent.com/18659982/45626121-f0085380-ba8e-11e8-959c-7a793896b761.png)
