### PR TITLE
Use OpenJDK 11 instead of OracleJDK 10 on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: java
 
 jdk:
   - openjdk8
-  - oraclejdk10
+  - openjdk11
 
 script:
   - mvn install verify -B -Dtest.env=true -DcreateJavadoc=true -Ddocker.host=unix:///var/run/docker.sock -Pbuild-docker-image,run-tests -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn


### PR DESCRIPTION
This PR simply replaces the currently used OracleJDK 11 with OpenJDK 11 because OpenJDK is what we also use in our Docker images.