### PR TITLE
Checkout git repo without credentials for nightly build pipeline

### DIFF
--- a/jenkins/Hono-Nightly-Pipeline.groovy
+++ b/jenkins/Hono-Nightly-Pipeline.groovy
@@ -24,7 +24,7 @@ node {
     properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '1', daysToKeepStr: '', numToKeepStr: '3')),
                 pipelineTriggers([cron('TZ=Europe/Berlin \n # every night between 2 and 3 AM \n H 2 * * *')])])
     try {
-        utils.checkOutHonoRepoWithCredentials("master", "bebef3c5-da22-425c-8554-f62d0b3a9608", "ssh://git@github.com/eclipse/hono.git")
+        utils.checkOutHonoRepoMaster()
         nightlyBuild()
         utils.aggregateJunitResults()
         utils.captureCodeCoverageReport()

--- a/jenkins/Hono-PipelineUtils.groovy
+++ b/jenkins/Hono-PipelineUtils.groovy
@@ -31,19 +31,6 @@ void checkOutHonoRepo(String branch) {
 }
 
 /**
- * Checks out the specified branch from hono github repo
- *
- * @param branch Branch to be checked out
- * @credentialsId credentailsId Id of stored login credentials
- */
-void checkOutHonoRepoWithCredentials(String branch, String credentialsId, String url) {
-    stage('Checkout') {
-        echo "Check out branch: $branch"
-        git branch: "$branch", credentialsId: "$credentialsId", url: "$url"
-    }
-}
-
-/**
  * Checks out the master branch from hono github repo
  *
  */

--- a/jenkins/Hono-PipelineUtils.groovy
+++ b/jenkins/Hono-PipelineUtils.groovy
@@ -39,6 +39,21 @@ void checkOutHonoRepoMaster() {
 }
 
 /**
+ * Checks out the specified branch from git repo
+ *
+ * @param branch Branch to be checked out
+ * @credentialsId credentialsId Id of stored login credentials
+ * @url url of the repository
+ *
+ */
+void checkOutRepoWithCredentials(String branch, String credentialsId, String url) {
+    stage('Checkout') {
+        echo "Check out branch: $branch"
+        git branch: "$branch", credentialsId: "$credentialsId", url: "$url"
+    }
+}
+
+/**
  * Build with maven (with jdk1.8.0-latest and apache-maven-latest as configured in 'Global Tool Configuration' in Jenkins).
  *
  */


### PR DESCRIPTION
Hono repo can be checked out without credentials for the nightly build and this PR contains changes for that.