### PR TITLE
Hono command receiver links reconnects

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
@@ -336,7 +336,7 @@ public class HonoClientImpl implements HonoClient {
         return result;
     }
 
-    private void connect(
+    protected void connect(
             final ProtonClientOptions options,
             final Handler<AsyncResult<HonoClient>> connectionHandler,
             final Handler<ProtonConnection> disconnectHandler) {

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -9,6 +9,7 @@ title = "Release Notes"
 * HonoClientImpl now waits a limited amount of time for the peer's *attach* frame during link establishment before considering the attempt to have failed. The time-out value (default is 1000ms) can be configured using the *linkEstablishmentTimeout* property of `org.eclipse.hono.config.ClientConfigProperties`. See [Hono Client Configuration]({{< ref "/admin-guide/hono-client-configuration.md" >}}) for details.
 * The example Device Registry service now supports limiting the number of iterations that are supported in BCrypt based hashed-password credentials. This way the processing time required for verifying credentials can be effectively limited. The `org.eclipse.hono.service.credentials.CompleteBaseCredentialsService` class defines a new method `getMaxBcryptIterations` which subclasses may override to provide a reasonable default value or determine the value based on a configuration property (as `FileBasedCredentialsService` of the demo Device Registry does).
 * Hono now uses OpenJDK 11 as the JVM in the service Docker images. Because OpenJDK 11 has better support for detecting resource limits when running in a container, this also has an impact on the command line parameters passed to the JVM. See [Limiting Resource Usage]({{< ref "/deployment/resource-limitation.md" >}}) for details.
+* The protocol adapters now fully recover from network connection losses in their command receivers, meaning they reopen all command receiver links that have been open at the time of the connection loss.
 
 ### API Changes
 


### PR DESCRIPTION
Contained is the recreation of command receiver links after connection losses in protocol adapters
Previously a connection loss recovered but did not reopen the command receivers again, so applications could not send commands anymore.
