### PR TITLE
[#876] Deleted devices should not be able to connect to the Mqtt adapter

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -64,7 +64,6 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mqtt.MqttAuth;
 import io.vertx.mqtt.MqttConnectionException;
 import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.MqttServer;
@@ -408,9 +407,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
      */
     private Future<Device> handleEndpointConnectionWithoutAuthentication(final MqttEndpoint endpoint) {
 
-        endpoint.closeHandler(v -> {
-            close(endpoint, null);
-        });
+        endpoint.closeHandler(v -> close(endpoint, null));
         endpoint.publishHandler(message -> handlePublishedMessage(new MqttContext(message, endpoint)));
 
         endpoint.subscribeHandler(subscribeMsg -> onSubscribe(endpoint, null, subscribeMsg));
@@ -421,55 +418,27 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
         return accepted();
     }
 
-    private Future<Device> handleEndpointConnectionWithAuthentication(final MqttEndpoint endpoint, final Span currentSpan) {
+    private Future<Device> handleEndpointConnectionWithAuthentication(final MqttEndpoint endpoint,
+            final Span currentSpan) {
 
-        if (endpoint.auth() == null) {
-
-            LOG.debug("connection request from device [clientId: {}] rejected: {}",
-                    endpoint.clientIdentifier(), "device did not provide credentials in CONNECT packet");
-
-            return rejected(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
-
-        } else {
-
-            final DeviceCredentials credentials = getCredentials(endpoint.auth());
-
-            if (credentials == null) {
-
-                LOG.debug("connection request from device [clientId: {}] rejected: {}",
-                        endpoint.clientIdentifier(), "device provided malformed credentials in CONNECT packet");
-                return rejected(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
-
-            } else {
-
-                return getTenantConfiguration(credentials.getTenantId(), currentSpan.context()).compose(tenantConfig -> {
-                    if (tenantConfig.isAdapterEnabled(getTypeName())) {
-                        LOG.debug("protocol adapter [{}] is enabled for tenant [{}]",
-                                getTypeName(), credentials.getTenantId());
-                        return Future.succeededFuture(tenantConfig);
-                    } else {
-                        LOG.debug("protocol adapter [{}] is disabled for tenant [{}]",
-                                getTypeName(), credentials.getTenantId());
-                        return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN,
-                                "adapter disabled for tenant"));
+        final Future<DeviceCredentials> credentialsTracker = getCredentials(endpoint);
+        return credentialsTracker
+                .compose(credentials -> authenticateCredentials(credentials))
+                .compose(device -> CompositeFuture.all(
+                        getTenantConfiguration(device.getTenantId(), currentSpan.context())
+                                .compose(tenant -> isAdapterEnabled(tenant)),
+                        isDeviceRegistered(device, credentialsTracker.result(), currentSpan))
+                        .map(result -> device))
+                .compose(device -> createLink(endpoint, device, currentSpan))
+                .recover(t -> {
+                    if (credentialsTracker.result() != null) {
+                        LOG.debug("cannot establish connection with device [tenant-id: {}, auth-id: {}]",
+                                credentialsTracker.result().getTenantId(), credentialsTracker.result().getAuthId(), t);
                     }
-                }).compose(tenantConfig -> {
-                    final Future<DeviceUser> result = Future.future();
-                    usernamePasswordAuthProvider.authenticate(credentials, result.completer());
-                    return result;
-                }).compose(authenticatedDevice -> {
-                    currentSpan.log(String.format("device authenticated"));
-                    LOG.debug("successfully authenticated device [tenant-id: {}, auth-id: {}, device-id: {}]",
-                            authenticatedDevice.getTenantId(), credentials.getAuthId(),
-                            authenticatedDevice.getDeviceId());
-                    return triggerLinkCreation(authenticatedDevice.getTenantId()).map(done -> {
-                        currentSpan.log(String.format("opened downstream links"));
-                        onAuthenticationSuccess(endpoint, authenticatedDevice);
-                        return null;
-                    }).compose(ok -> accepted(authenticatedDevice));
-                }).recover(t -> {
-                    LOG.debug("cannot establish connection with device [tenant-id: {}, auth-id: {}]",
-                            credentials.getTenantId(), credentials.getAuthId(), t);
+                    if (t instanceof MqttConnectionException) {
+                        return rejected(((MqttConnectionException) t).code());
+                    }
+
                     if (t instanceof ServerErrorException) {
                         // one of the services we depend on might not be available (yet)
                         return rejected(MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
@@ -478,22 +447,6 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
                         return rejected(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED);
                     }
                 });
-
-            }
-        }
-    }
-
-    private void onAuthenticationSuccess(final MqttEndpoint endpoint, final Device authenticatedDevice) {
-
-        endpoint.closeHandler(v -> {
-            close(endpoint, authenticatedDevice);
-        });
-
-        endpoint.publishHandler(message -> handlePublishedMessage(new MqttContext(message, endpoint, authenticatedDevice)));
-        endpoint.subscribeHandler(subscribeMsg -> onSubscribe(endpoint, authenticatedDevice, subscribeMsg));
-        endpoint.unsubscribeHandler(unsubscribeMsg -> onUnsubscribe(endpoint, authenticatedDevice, unsubscribeMsg));
-
-        metrics.incrementConnections(authenticatedDevice.getTenantId());
     }
 
     /**
@@ -692,17 +645,6 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
                     // close the MQTT connection, so the device will reconnect
                     close(mqttEndpoint, new Device(sub.getTenant(), sub.getDeviceId()));
                 });
-    }
-
-    private Future<Void> triggerLinkCreation(final String tenantId) {
-
-        final Future<MessageSender> telemetrySender = getTelemetrySender(tenantId);
-        final Future<MessageSender> eventSender = getEventSender(tenantId);
-        return CompositeFuture.all(getRegistrationClient(tenantId), telemetrySender, eventSender).map(ok -> {
-            LOG.debug("providently opened downstream links [credit telemetry: {}, credit event: {}] for tenant [{}]",
-                    telemetrySender.result().getCredit(), eventSender.result().getCredit(), tenantId);
-            return null;
-        });
     }
 
     void handlePublishedMessage(final MqttContext context) {
@@ -1101,21 +1043,38 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
     /**
      * Extracts credentials from a client's MQTT <em>CONNECT</em> packet.
      * <p>
-     * This default implementation returns {@link UsernamePasswordCredentials} created from the <em>username</em> and
-     * <em>password</em> fields of the <em>CONNECT</em> packet.
+     * This default implementation returns a future with {@link UsernamePasswordCredentials} created from the
+     * <em>username</em> and <em>password</em> fields of the <em>CONNECT</em> packet.
      * <p>
      * Subclasses should override this method if the device uses credentials that do not comply with the format expected
      * by {@link UsernamePasswordCredentials}.
-     * 
-     * @param authInfo The authentication info provided by the device.
-     * @return The credentials or {@code null} if the information provided by the device can not be processed.
+     *
+     * @param endpoint The MQTT endpoint representing the client.
+     * @return A future indicating a retrieved credentials.
      */
-    protected DeviceCredentials getCredentials(final MqttAuth authInfo) {
-        if (authInfo.userName() == null || authInfo.password() == null) {
-            return null;
+    protected Future<DeviceCredentials> getCredentials(final MqttEndpoint endpoint) {
+        if (endpoint.auth() == null) {
+            LOG.debug("connection request from device [clientId: {}] rejected: {}",
+                    endpoint.clientIdentifier(), "device did not provide credentials in CONNECT packet");
+            return rejected(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
+        }
+
+        if (endpoint.auth().userName() == null || endpoint.auth().password() == null) {
+            LOG.debug("connection request from device [clientId: {}] rejected: {}",
+                    endpoint.clientIdentifier(), "device provided malformed credentials in CONNECT packet");
+            return rejected(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
+        }
+
+        final UsernamePasswordCredentials credentials = UsernamePasswordCredentials
+                .create(endpoint.auth().userName(), endpoint.auth().password(),
+                        getConfig().isSingleTenant());
+
+        if (credentials == null) {
+            LOG.debug("connection request from device [clientId: {}] rejected: {}",
+                    endpoint.clientIdentifier(), "device provided malformed credentials in CONNECT packet");
+            return rejected(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
         } else {
-            return UsernamePasswordCredentials.create(authInfo.userName(), authInfo.password(),
-                    getConfig().isSingleTenant());
+            return Future.succeededFuture(credentials);
         }
     }
 
@@ -1226,11 +1185,75 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
         commandContext.getCurrentSpan().log(items);
     }
 
-    private static void addRetainAnnotation(final MqttContext context, final Message downstreamMessage, final Span currentSpan) {
+    private static void addRetainAnnotation(final MqttContext context, final Message downstreamMessage,
+            final Span currentSpan) {
 
         if (context.message().isRetain()) {
             currentSpan.log("device wants to retain message");
             MessageHelper.addAnnotation(downstreamMessage, MessageHelper.ANNOTATION_X_OPT_RETAIN, Boolean.TRUE);
         }
+    }
+
+    private Future<TenantObject> isAdapterEnabled(final TenantObject tenantConfig) {
+        if (tenantConfig.isAdapterEnabled(getTypeName())) {
+            LOG.debug("protocol adapter [{}] is enabled for tenant [{}]",
+                    getTypeName(), tenantConfig.getTenantId());
+            return Future.succeededFuture(tenantConfig);
+        } else {
+            LOG.debug("protocol adapter [{}] is disabled for tenant [{}]",
+                    getTypeName(), tenantConfig.getTenantId());
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN,
+                    "adapter disabled for tenant"));
+        }
+    }
+
+    private Future<DeviceUser> authenticateCredentials(final DeviceCredentials credentials) {
+        final Future<DeviceUser> result = Future.future();
+        usernamePasswordAuthProvider.authenticate(credentials, result.completer());
+        return result;
+    }
+
+    private Future<Device> isDeviceRegistered(final Device authenticatedDevice, final DeviceCredentials credentials,
+            final Span currentSpan) {
+        currentSpan.log(String.format("device authenticated"));
+        LOG.debug("successfully authenticated device [tenant-id: {}, auth-id: {}, device-id: {}]",
+                authenticatedDevice.getTenantId(), credentials.getAuthId(),
+                authenticatedDevice.getDeviceId());
+        return getRegistrationAssertion(authenticatedDevice.getTenantId(),
+                authenticatedDevice.getDeviceId(),
+                authenticatedDevice, currentSpan.context())
+                        .compose(ok -> {
+                            currentSpan.log(String.format("device registration verified"));
+                            LOG.debug("verified device registration [tenant-id: {}, device-id: {}]",
+                                    authenticatedDevice.getTenantId(), authenticatedDevice.getDeviceId());
+                            return accepted(authenticatedDevice);
+                        });
+    }
+
+    private Future<Device> createLink(final MqttEndpoint endpoint, final Device authenticatedDevice,
+            final Span currentSpan) {
+        final Future<MessageSender> telemetrySender = getTelemetrySender(authenticatedDevice.getTenantId());
+        final Future<MessageSender> eventSender = getEventSender(authenticatedDevice.getTenantId());
+
+        return CompositeFuture
+                .all(getRegistrationClient(authenticatedDevice.getTenantId()), telemetrySender, eventSender)
+                .map(ok -> {
+                    currentSpan.log(String.format("opened downstream links"));
+                    LOG.debug(
+                            "providently opened downstream links [credit telemetry: {}, credit event: {}] for tenant [{}]",
+                            telemetrySender.result().getCredit(), eventSender.result().getCredit(),
+                            authenticatedDevice.getTenantId());
+                    onAuthenticationSuccess(endpoint, authenticatedDevice);
+                    return null;
+                }).compose(ok -> accepted(authenticatedDevice));
+    }
+
+    private void onAuthenticationSuccess(final MqttEndpoint endpoint, final Device authenticatedDevice) {
+        endpoint.closeHandler(v -> close(endpoint, authenticatedDevice));
+        endpoint.publishHandler(
+                message -> handlePublishedMessage(new MqttContext(message, endpoint, authenticatedDevice)));
+        endpoint.subscribeHandler(subscribeMsg -> onSubscribe(endpoint, authenticatedDevice, subscribeMsg));
+        endpoint.unsubscribeHandler(unsubscribeMsg -> onUnsubscribe(endpoint, authenticatedDevice, unsubscribeMsg));
+        metrics.incrementConnections(authenticatedDevice.getTenantId());
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tests.mqtt;
+
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mqtt.MqttClient;
+import io.vertx.mqtt.MqttClientOptions;
+import io.vertx.mqtt.MqttConnectionException;
+import io.vertx.mqtt.messages.MqttConnAckMessage;
+import org.eclipse.hono.tests.IntegrationTestSupport;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Integration tests for checking connection to the MQTT adapter.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class MqttConnectionIT extends MqttTestBase {
+
+    /**
+     * Verifies that the adapter opens a connection to registered devices with credentials.
+     *
+     * @param ctx The test context
+     */
+    @Test
+    public void testConnectSuccess(final TestContext ctx) {
+        final String tenantId = helper.getRandomTenantId();
+        final String deviceId = helper.getRandomDeviceId(tenantId);
+        final String password = "secret";
+        final JsonObject adapterDetailsMqtt = new JsonObject()
+                .put(TenantConstants.FIELD_ADAPTERS_TYPE, Constants.PROTOCOL_ADAPTER_TYPE_MQTT)
+                .put(TenantConstants.FIELD_ENABLED, Boolean.TRUE);
+        final TenantObject tenant = TenantObject.from(tenantId, true);
+        tenant.addAdapterConfiguration(adapterDetailsMqtt);
+
+        helper.registry.addDeviceForTenant(tenant, deviceId, password)
+                .recover(t -> {
+                    return Future.failedFuture(t);
+                })
+                .compose(ok -> {
+                    final Future<MqttConnAckMessage> result = Future.future();
+                    final MqttClientOptions options = new MqttClientOptions()
+                            .setUsername(IntegrationTestSupport.getUsername(deviceId, tenantId))
+                            .setPassword(password);
+                    mqttClient = MqttClient.create(VERTX, options);
+                    // WHEN a device that belongs to the tenant tries to connect to the adapter
+                    mqttClient.connect(IntegrationTestSupport.MQTT_PORT, IntegrationTestSupport.MQTT_HOST, result);
+                    return result;
+                }).setHandler(ctx.asyncAssertSuccess());
+    }
+
+    /**
+     * Verifies that the adapter rejects connection attempts from devices that have been deleted.
+     *
+     * @param ctx The test context
+     */
+    @Test
+    public void testConnectFailsForDeletedDevices(final TestContext ctx) {
+
+        final String tenantId = helper.getRandomTenantId();
+        final String deviceId = helper.getRandomDeviceId(tenantId);
+        final String password = "secret";
+        final JsonObject adapterDetailsMqtt = new JsonObject()
+                .put(TenantConstants.FIELD_ADAPTERS_TYPE, Constants.PROTOCOL_ADAPTER_TYPE_MQTT)
+                .put(TenantConstants.FIELD_ENABLED, Boolean.TRUE);
+        final TenantObject tenant = TenantObject.from(tenantId, true);
+        tenant.addAdapterConfiguration(adapterDetailsMqtt);
+
+        helper.registry.addDeviceForTenant(tenant, deviceId, password)
+                .recover(t -> {
+                    return Future.failedFuture(t);
+                }).compose(device -> helper.registry.deregisterDevice(tenantId, deviceId))
+                .compose(ok -> {
+                    final Future<MqttConnAckMessage> result = Future.future();
+                    final MqttClientOptions options = new MqttClientOptions()
+                            .setUsername(IntegrationTestSupport.getUsername(deviceId, tenantId))
+                            .setPassword(password);
+                    mqttClient = MqttClient.create(VERTX, options);
+                    // WHEN a device that belongs to the tenant tries to connect to the adapter
+                    mqttClient.connect(IntegrationTestSupport.MQTT_PORT, IntegrationTestSupport.MQTT_HOST, result);
+                    return result;
+                }).setHandler(ctx.asyncAssertFailure(t -> {
+                    ctx.assertTrue(t instanceof MqttConnectionException);
+                    // THEN the connection is refused with a NOT_AUTHORIZED code
+                    ctx.assertEquals(((MqttConnectionException) t).code(),
+                            MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED);
+                }));
+    }
+}


### PR DESCRIPTION
When devices try to connect to the Mqtt adapter with credentials, then the Mqtt adapter checks for the device registration in addition to the credentials validation, before establishing a connection.