### PR TITLE
 [#750] PoC of HealthCheckServer that gets health pushed by verticles.

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
@@ -29,6 +29,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.EventBus;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
@@ -110,6 +114,10 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
     private ProtocolAdapterProperties config;
 
+    private Context ctx;
+    private Vertx vertx;
+    private EventBus eventBus;
+
     /**
      * Setups the protocol adapter.
      * 
@@ -151,6 +159,13 @@ public class VertxBasedAmqpProtocolAdapterTest {
         when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
         when(commandConnection.closeCommandConsumer(anyString(), anyString())).thenReturn(Future.succeededFuture(null));
 
+        ctx = mock(Context.class);
+        vertx = mock(Vertx.class);
+
+        eventBus = mock(EventBus.class);
+        when(eventBus.send(anyString(), any(), any(DeliveryOptions.class))).thenReturn(eventBus);
+        when(vertx.eventBus()).thenReturn(eventBus);
+
         config = new ProtocolAdapterProperties();
         config.setAuthenticationRequired(false);
         config.setInsecurePort(4040);
@@ -175,6 +190,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         startupTracker.setHandler(ctx.asyncAssertSuccess(result -> {
             startup.complete();
         }));
+        adapter.init(vertx, this.ctx);
         adapter.start(startupTracker);
 
         // THEN the client provided server is started

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.when;
 
 import java.net.HttpURLConnection;
 
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.EventBus;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoClient;
@@ -97,6 +99,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     private Vertx                         vertx;
     private Context                       context;
     private HttpAdapterMetrics            metrics;
+    private EventBus                      eventBus;
 
     /**
      * Sets up common fixture.
@@ -148,6 +151,11 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         commandConsumer = mock(CommandConsumer.class);
         when(commandConnection.getOrCreateCommandConsumer(anyString(), anyString(), any(Handler.class), any(Handler.class)))
             .thenReturn(Future.succeededFuture(commandConsumer));
+
+
+        eventBus = mock(EventBus.class);
+        when(eventBus.send(anyString(), any(), any(DeliveryOptions.class))).thenReturn(eventBus);
+        when(vertx.eventBus()).thenReturn(eventBus);
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/HealthCheckServer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/HealthCheckServer.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.service;
 
+import java.time.Instant;
 import java.util.Objects;
 
 import org.eclipse.hono.config.ApplicationConfigProperties;
@@ -22,9 +23,13 @@ import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
 import io.vertx.ext.web.Router;
 
 /**
@@ -47,6 +52,18 @@ public final class HealthCheckServer implements Lifecycle {
     private static final String URI_LIVENESS_PROBE  = "/liveness";
     private static final String URI_READINESS_PROBE = "/readiness";
 
+    /**
+     * The vert.x event bus address to readiness messages are published.
+     */
+    public static final String EVENT_BUS_ADDRESS_HEALTH_READINESS = "health.readiness";
+    public static final String EVENT_BUS_ADDRESS_HEALTH_LIVENESS = "health.liveness";
+
+    public static final String MSG_FIELD_VERTICLE_NAME = "verticle-name";
+    public static final String MSG_FIELD_VERTICLE_INSTANCE_ID = "verticle-instance-id";
+    public static final String MSG_FIELD_PROCEDURE_NAME = "procedure-name";
+    public static final String MSG_FIELD_LAST_SEEN = "last-seen";
+    public static final long LIVENESS_TIMEOUT_SECONDS = 60; // TODO make configurable
+
     private HttpServer server;
 
     private HealthCheckHandler readinessHandler;
@@ -55,6 +72,9 @@ public final class HealthCheckServer implements Lifecycle {
     private final Vertx vertx;
     private final ApplicationConfigProperties config;
     private Router router;
+
+    private MessageConsumer<JsonObject> readinessConsumer;
+    private MessageConsumer<JsonObject> livenessConsumer;
 
     /**
      * Create a new HealthCheckServer for the given Vertx and configuration.
@@ -87,6 +107,60 @@ public final class HealthCheckServer implements Lifecycle {
         }
     }
 
+    private void registerConsumers() {
+        readinessConsumer = vertx.eventBus().consumer(EVENT_BUS_ADDRESS_HEALTH_READINESS);
+        readinessConsumer.handler(this::processReadinessMessage);
+        LOG.info("listening on event bus [address: {}] for readiness status", EVENT_BUS_ADDRESS_HEALTH_READINESS);
+
+        livenessConsumer = vertx.eventBus().consumer(EVENT_BUS_ADDRESS_HEALTH_LIVENESS);
+        livenessConsumer.handler(this::processLivenessMessage);
+        LOG.info("listening on event bus [address: {}] for liveness status", EVENT_BUS_ADDRESS_HEALTH_LIVENESS);
+    }
+
+    private void processReadinessMessage(final Message<JsonObject> msg) {
+
+        final String verticleName = msg.headers().get(MSG_FIELD_VERTICLE_NAME);
+        final String instanceId = msg.headers().get(MSG_FIELD_VERTICLE_INSTANCE_ID);
+        final String procedureName = msg.headers().get(MSG_FIELD_PROCEDURE_NAME);
+        final Status status = new Status(msg.body());
+
+        LOG.info("received readiness update {}/{}/{}: {}", verticleName, instanceId, procedureName, status.isOk());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("readiness update status: {}", msg.body().encodePrettily());
+        }
+
+        readinessHandler.register(verticleName + "/" + instanceId + "/" + procedureName,
+                statusFuture -> statusFuture.complete(status)
+                );
+    }
+
+    private void processLivenessMessage(final Message<JsonObject> msg) {
+
+        final String verticleName = msg.headers().get(MSG_FIELD_VERTICLE_NAME);
+        final String instanceId = msg.headers().get(MSG_FIELD_VERTICLE_INSTANCE_ID);
+        final String procedureName = msg.headers().get(MSG_FIELD_PROCEDURE_NAME);
+        final String lastSeen = msg.headers().get(MSG_FIELD_LAST_SEEN);
+        final Status status = new Status(msg.body());
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("received liveness update {}/{}/{}: {}", verticleName, instanceId, procedureName, status.isOk());
+            LOG.debug("liveness update status: {}", msg.body().encodePrettily());
+        }
+
+        livenessHandler.register(verticleName + "/" + instanceId + "/" + procedureName,
+                statusFuture -> {
+
+                    final Instant lastSeenEpochSecond = Instant.ofEpochSecond(Long.valueOf(lastSeen));
+                    if (lastSeenEpochSecond.plusSeconds(LIVENESS_TIMEOUT_SECONDS).isBefore(Instant.now())) {
+                        LOG.info("liveness check timed out for {}/{}/{}", verticleName, instanceId, procedureName);
+                        status.setKO();
+                    }
+
+                    statusFuture.complete(status);
+                }
+                );
+    }
+
     /**
      * Registers the readiness and liveness checks of the given service if health check is configured, otherwise does
      * nothing.
@@ -110,6 +184,8 @@ public final class HealthCheckServer implements Lifecycle {
 
         final Future<Void> result = Future.future();
         if (router != null) {
+            registerConsumers();
+
             final HttpServerOptions options = new HttpServerOptions()
                     .setPort(config.getHealthCheckPort())
                     .setHost(config.getHealthCheckBindAddress());
@@ -148,6 +224,16 @@ public final class HealthCheckServer implements Lifecycle {
      */
     @Override
     public Future<Void> stop() {
+
+        if (readinessConsumer != null) {
+            readinessConsumer.unregister();
+            LOG.info("unregistered readiness consumer from event bus");
+        }
+
+        if (livenessConsumer != null) {
+            livenessConsumer.unregister();
+            LOG.info("unregistered liveness consumer from event bus");
+        }
 
         final Future<Void> result = Future.future();
         if (server != null) {

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -20,6 +20,10 @@ import static org.mockito.Mockito.*;
 
 import java.net.HttpURLConnection;
 
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.EventBus;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoClient;
@@ -69,6 +73,9 @@ public class AbstractProtocolAdapterBaseTest {
     private HonoClient credentialsService;
     private HonoClient messagingService;
     private CommandConnection commandConnection;
+    private Context context;
+    private Vertx vertx;
+    private EventBus eventBus;
 
     /**
      * Sets up the fixture.
@@ -94,6 +101,13 @@ public class AbstractProtocolAdapterBaseTest {
 
         commandConnection = mock(CommandConnection.class);
         when(commandConnection.connect(any(Handler.class))).thenReturn(Future.succeededFuture(commandConnection));
+
+        context = mock(Context.class);
+        vertx = mock(Vertx.class);
+
+        eventBus = mock(EventBus.class);
+        when(eventBus.send(anyString(), any(), any(DeliveryOptions.class))).thenReturn(eventBus);
+        when(vertx.eventBus()).thenReturn(eventBus);
 
         properties = new ProtocolAdapterProperties();
         adapter = newProtocolAdapter(properties);
@@ -141,6 +155,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.setRegistrationServiceClient(registrationService);
         adapter.setTenantServiceClient(tenantService);
         adapter.setCommandConnection(commandConnection);
+        adapter.init(vertx, context);
 
         // WHEN starting the adapter
         adapter.startInternal().setHandler(ctx.asyncAssertSuccess(ok -> {


### PR DESCRIPTION
This is not ready, **it is just a draft** to see if we like the direction in which it is going and so that can discuss variants of it. I hope you are OK with that.

The basic idea is that verticles actively report their health status to the `HealthCheckServer` over the eventbus. Respectively no reporting for a longer time in the case of the liveness checks could be seen as a failing check because we can not expect that the verticle will be able to send a message if it is no longer live.
The main advantage over the solution in PR #873 is that the verticles don't need to hold an object reference to `HealthCheckServer`.

At first I kept the results of the `Status` objects in maps but then I realized that Vert.x's `HealthCheckHandler` already does the same thing, so I simple re-register a check when a status is updated.

What is missing:

- Health check of Endpoints
- readiness updates in `AbstractProtocolAdapterBase` when connection to a service is lost
- error handling, parameter checks, JavaDoc, refactoring ...
- Removal of the old mechanism (`HealthCheckProvider`)
- cleanup and write tests

*Please ignore the changed test classes, they were just hacked to let the changes pass.*

BTW: I found the comment "//TODO Event Bus support" by accident in the class `HealthCheckHandlerImpl` and wonder if something similar is planned in Vert.x.