### PR TITLE
Drop the vert.x metrics options, and allow disabling vertx metrics.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/VertxProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/VertxProperties.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.config;
 
 import io.vertx.core.VertxOptions;
+import io.vertx.core.metrics.MetricsOptions;
 
 /**
  * Vertx properties.
@@ -23,15 +24,37 @@ public class VertxProperties {
     private boolean preferNative = VertxOptions.DEFAULT_PREFER_NATIVE_TRANSPORT;
 
     /**
-     * Prefer to use native networking or not.
+     * Prefer to use native networking, or not.
      * <p>
      * Also see {@link VertxOptions#setPreferNativeTransport(boolean)}.
+     * </p>
+     * <p>
+     * The default is to not prefer native networking.
      * </p>
      * 
      * @param preferNative {@code true} to prefer native networking, {@code false} otherwise.
      */
     public void setPreferNative(final boolean preferNative) {
         this.preferNative = preferNative;
+    }
+
+    private boolean enableMetrics = MetricsOptions.DEFAULT_METRICS_ENABLED;
+
+    /**
+     * Enable the vert.x metrics system, or not.
+     * 
+     * <p>
+     * This decides if the vert.x metrics system will be enabled. Hono uses the Spring Boot integration with Micrometer,
+     * so enabling the vert.x metrics will only enable the contribution of vert.x internal metrics to this system.
+     * </p>
+     * <p>
+     * The default is to not enable vert.x metrics.
+     * </p>
+     * 
+     * @param enableMetrics {@code true} to enable the metrics system, {@code false} otherwise.
+     */
+    public void setEnableMetrics(final boolean enableMetrics) {
+        this.enableMetrics = enableMetrics;
     }
 
     /**
@@ -42,6 +65,10 @@ public class VertxProperties {
     public void configureVertx(final VertxOptions options) {
 
         options.setPreferNativeTransport(this.preferNative);
+
+        if (this.enableMetrics) {
+            options.setMetricsOptions(new MetricsOptions().setEnabled(true));
+        }
 
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -29,7 +29,6 @@ import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.TenantConstants;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cache.guava.GuavaCacheManager;
@@ -38,21 +37,17 @@ import org.springframework.context.annotation.Scope;
 
 import com.google.common.cache.CacheBuilder;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.tracerresolver.TracerResolver;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.dns.AddressResolverOptions;
-import io.vertx.core.metrics.MetricsOptions;
 
 /**
  * Minimum Spring Boot configuration class defining beans required by protocol adapters.
  */
 public abstract class AbstractAdapterConfig {
-
-    private MetricsOptions metricsOptions;
 
     /**
      * Exposes an OpenTracing {@code Tracer} as a Spring Bean.
@@ -71,16 +66,6 @@ public abstract class AbstractAdapterConfig {
     }
 
     /**
-     * Vert.x metrics options, if configured.
-     *
-     * @param metricsOptions Vert.x metrics options
-     */
-    @Autowired(required = false)
-    public void setMetricsOptions(final MetricsOptions metricsOptions) {
-        this.metricsOptions = metricsOptions;
-    }
-
-    /**
      * Exposes a Vert.x instance as a Spring bean.
      *
      * @return The Vert.x instance.
@@ -94,36 +79,9 @@ public abstract class AbstractAdapterConfig {
                         .setCacheMaxTimeToLive(0) // support DNS based service resolution
                         .setQueryTimeout(1000));
 
-        configureMetrics(options);
-
         vertxProperties().configureVertx(options);
 
         return Vertx.vertx(options);
-    }
-
-    /**
-     * Configure metrics system of vertx.
-     * <p>
-     * This method will apply the configured metrics options. If no metrics options are configured, then metrics will be
-     * enabled without further configuration. When vertx-micrometer support is found, then this will trigger the use of
-     * the global {@link MeterRegistry}.
-     * </p>
-     * 
-     * @param options The options object used to configure the vertx instance.
-     */
-    protected void configureMetrics(final VertxOptions options) {
-
-        if (this.metricsOptions != null) {
-
-            options.setMetricsOptions(this.metricsOptions);
-
-        } else {
-
-            options.setMetricsOptions(
-                    new MetricsOptions()
-                            .setEnabled(true));
-
-        }
     }
 
     /**


### PR DESCRIPTION
This disables the external vertx metrics configurations, as Spring Boot is the main driver of this now. Vertx itself can be enabled, using the vertx options of Hono. However it is disabled by default, as some of the vertx metrics can really blow the metrics backends.