### PR TITLE
Do not return cached command consumers

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
@@ -301,8 +301,8 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
         // WHEN an unauthenticated device opens a receiver link with a valid source address
         final ProtonConnection deviceConnection = mock(ProtonConnection.class);
-        when(commandConnection.getOrCreateCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class))).thenReturn(
-                Future.succeededFuture(mock(MessageConsumer.class)));
+        when(commandConnection.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class)))
+            .thenReturn(Future.succeededFuture(mock(MessageConsumer.class)));
         final String sourceAddress = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, TEST_TENANT_ID, TEST_DEVICE);
         final ProtonSender sender = getSender(sourceAddress);
 
@@ -335,7 +335,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         // and a device that wants to receive commands
         final ProtonConnection deviceConnection = mock(ProtonConnection.class);
         final MessageConsumer commandConsumer = mock(MessageConsumer.class);
-        when(commandConnection.getOrCreateCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class))).thenReturn(
+        when(commandConnection.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class))).thenReturn(
                 Future.succeededFuture(commandConsumer));
         final String sourceAddress = String.format("%s", CommandConstants.COMMAND_ENDPOINT);
         final ProtonSender sender = getSender(sourceAddress);
@@ -426,7 +426,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
         // that wants to receive commands
         final MessageConsumer commandConsumer = mock(MessageConsumer.class);
-        when(commandConnection.getOrCreateCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class)))
+        when(commandConnection.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class)))
             .thenReturn(Future.succeededFuture(commandConsumer));
         final String sourceAddress = CommandConstants.COMMAND_ENDPOINT;
         final ProtonSender sender = getSender(sourceAddress);
@@ -436,9 +436,6 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
         // WHEN the connection to the device is lost
         connectionLossTrigger.handle(deviceConnection);
-//        final ArgumentCaptor<Handler<ProtonConnection>> disconnectHandler = ArgumentCaptor.forClass(Handler.class);
-//        verify(deviceConnection).disconnectHandler(disconnectHandler.capture());
-//        disconnectHandler.getValue().handle(deviceConnection);
 
         // THEN the adapter closes the command consumer
         verify(commandConsumer).close(any());

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -694,7 +694,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         final MqttEndpoint endpoint = mockEndpoint();
 
         // WHEN a device subscribes to commands
-        when(commandConnection.getOrCreateCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class), any(Handler.class))).thenReturn(
+        when(commandConnection.createCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class), any(Handler.class))).thenReturn(
                 Future.succeededFuture(mock(MessageConsumer.class)));
         final List<MqttTopicSubscription> subscriptions = Collections.singletonList(
                 newMockTopicSubsription("control/tenant/deviceId/req/#", MqttQoS.AT_MOST_ONCE));
@@ -741,7 +741,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         subscriptions.add(newMockTopicSubsription("bumlux/+/+/#", MqttQoS.AT_MOST_ONCE));
         subscriptions.add(newMockTopicSubsription("bumlux/+/+/#", MqttQoS.AT_MOST_ONCE));
         // and for subscribing to commands
-        when(commandConnection.getOrCreateCommandConsumer(eq("tenant-1"), eq("device-A"), any(Handler.class), any(Handler.class))).thenReturn(
+        when(commandConnection.createCommandConsumer(eq("tenant-1"), eq("device-A"), any(Handler.class), any(Handler.class))).thenReturn(
                 Future.succeededFuture(mock(MessageConsumer.class)));
         subscriptions.add(newMockTopicSubsription("control/tenant-1/device-A/req/#", MqttQoS.AT_MOST_ONCE));
         subscriptions.add(newMockTopicSubsription("control/tenant-1/device-B/req/#", MqttQoS.EXACTLY_ONCE));

--- a/client/src/main/java/org/eclipse/hono/client/ResourceConflictException.java
+++ b/client/src/main/java/org/eclipse/hono/client/ResourceConflictException.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Indicates a resource conflict that occurred as the outcome of a service invocation.
+ * <p>
+ * Instances will always have an error code of 409 (Conflict).
+ */
+public class ResourceConflictException extends ClientErrorException {
+
+    private static final long serialVersionUID = 6746508124520882989L;
+
+    /**
+     * Creates a new exception for a detail message.
+     * 
+     * @param msg The detail message.
+     */
+    public ResourceConflictException(final String msg) {
+        super(HttpURLConnection.HTTP_CONFLICT, msg);
+    }
+
+    /**
+     * Creates a new exception for a root cause.
+     * 
+     * @param cause The root cause.
+     */
+    public ResourceConflictException(final Throwable cause) {
+        super(HttpURLConnection.HTTP_CONFLICT, cause);
+    }
+
+    /**
+     * Creates a new exception for a detail message and a root cause.
+     * 
+     * @param msg The detail message.
+     * @param cause The root cause.
+     */
+    public ResourceConflictException(final String msg, final Throwable cause) {
+        super(HttpURLConnection.HTTP_CONFLICT, msg, cause);
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/StatusCodeMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/StatusCodeMapper.java
@@ -72,7 +72,12 @@ public abstract class StatusCodeMapper {
         if (200 <= statusCode && statusCode < 300) {
             throw new IllegalArgumentException("status code " + statusCode + " does not represent an error");
         } else if (400 <= statusCode && statusCode < 500) {
-            return new ClientErrorException(statusCode, detailMessage);
+            switch(statusCode) {
+            case HttpURLConnection.HTTP_CONFLICT:
+                return new ResourceConflictException(detailMessage);
+            default:
+                return new ClientErrorException(statusCode, detailMessage);
+            }
         } else if (500 <= statusCode && statusCode < 600) {
             return new ServerErrorException(statusCode, detailMessage);
         } else {

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandConnectionImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandConnectionImplTest.java
@@ -108,7 +108,7 @@ public class CommandConnectionImplTest {
         commandConnection.connect(new ProtonClientOptions())
             .compose(c -> {
                 final ArgumentCaptor<Handler<AsyncResult<ProtonReceiver>>> linkOpenHandler = ArgumentCaptor.forClass(Handler.class);
-                final Future<MessageConsumer> consumer = commandConnection.getOrCreateCommandConsumer("theTenant", "theDevice", commandHandler, closeHandler);
+                final Future<MessageConsumer> consumer = commandConnection.createCommandConsumer("theTenant", "theDevice", commandHandler, closeHandler);
                 verify(con).createReceiver("control/theTenant/theDevice");
                 verify(receiver).openHandler(linkOpenHandler.capture());
                 verify(receiver).open();
@@ -140,7 +140,7 @@ public class CommandConnectionImplTest {
         commandConnection.connect(new ProtonClientOptions())
             .compose(c -> {
                 final ArgumentCaptor<Handler<AsyncResult<ProtonReceiver>>> linkOpenHandler = ArgumentCaptor.forClass(Handler.class);
-                final Future<MessageConsumer> consumer = commandConnection.getOrCreateCommandConsumer("theTenant", "theDevice", commandHandler, closeHandler);
+                final Future<MessageConsumer> consumer = commandConnection.createCommandConsumer("theTenant", "theDevice", commandHandler, closeHandler);
                 verify(con).createReceiver(address);
                 verify(receiver).openHandler(linkOpenHandler.capture());
                 verify(receiver).open();
@@ -171,7 +171,7 @@ public class CommandConnectionImplTest {
         // has been registered
         commandConnection.connect(new ProtonClientOptions())
             .compose(c -> {
-                final Future<MessageConsumer> consumer = commandConnection.getOrCreateCommandConsumer("theTenant", "theDevice", commandHandler, closeHandler);
+                final Future<MessageConsumer> consumer = commandConnection.createCommandConsumer("theTenant", "theDevice", commandHandler, closeHandler);
                 verify(con).createReceiver(address);
                 final ArgumentCaptor<Handler<AsyncResult<ProtonReceiver>>> linkOpenHandler = ArgumentCaptor.forClass(Handler.class);
                 verify(receiver).openHandler(linkOpenHandler.capture());
@@ -210,7 +210,7 @@ public class CommandConnectionImplTest {
         // GIVEN a command consumer
         commandConnection.connect(new ProtonClientOptions())
             .compose(client -> {
-                final Future<MessageConsumer> consumer = commandConnection.getOrCreateCommandConsumer("theTenant", "theDevice", commandHandler, null);
+                final Future<MessageConsumer> consumer = commandConnection.createCommandConsumer("theTenant", "theDevice", commandHandler, null);
                 verify(con).createReceiver(address);
                 final ArgumentCaptor<Handler<AsyncResult<ProtonReceiver>>> linkOpenHandler = ArgumentCaptor.forClass(Handler.class);
                 verify(receiver).closeHandler(any(Handler.class));
@@ -231,7 +231,7 @@ public class CommandConnectionImplTest {
                 return localCloseHandler;
             }).map(ok -> {
                 // THEN the next attempt to create a command consumer for the same address
-                final Future<MessageConsumer> newConsumer = commandConnection.getOrCreateCommandConsumer("theTenant", "theDevice", commandHandler, null);
+                final Future<MessageConsumer> newConsumer = commandConnection.createCommandConsumer("theTenant", "theDevice", commandHandler, null);
                 // results in a new link to be opened
                 verify(con, times(2)).createReceiver(address);
                 final ArgumentCaptor<Handler<AsyncResult<ProtonReceiver>>> linkOpenHandler = ArgumentCaptor.forClass(Handler.class);

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -555,7 +555,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             final Handler<CommandContext> commandConsumer,
             final Handler<Void> closeHandler) {
 
-        return commandConnection.getOrCreateCommandConsumer(tenantId, deviceId, commandConsumer, closeHandler);
+        return commandConnection.createCommandConsumer(tenantId, deviceId, commandConsumer, closeHandler);
     }
 
     /**

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -24,6 +24,13 @@ title = "Release Notes"
   Hono clients from the current protocol adapter instance, in the same threading
   context. The default implementation of the *connection events* still defaults
   to the logging producer.
+* The `CommandConnection.getOrCreateCommandConsumer` method has been renamed to `createCommandConsumer`. The new name
+  also reflects a change in the method's semantics. The method will no longer return an already existing instance of a command
+  consumer for a given device but will instead fail the returned future with a `org.eclipse.hono.client.ResourceConflictException`
+  to indicate that a consumer for the given device is already in use. The original behavior allowed an implementation to return
+  a consumer that was scoped to another message handler than the one passed into the method as an argument. However, client code
+  had no chance to determine whether it got back a newly created instance or an existing one. This has been resolved with the
+  new method semantics.
 
 ### Deprecations
 

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -169,6 +169,7 @@ public final class IntegrationTestSupport {
         downstreamProps.setPort(IntegrationTestSupport.DOWNSTREAM_PORT);
         downstreamProps.setUsername(IntegrationTestSupport.DOWNSTREAM_USER);
         downstreamProps.setPassword(IntegrationTestSupport.DOWNSTREAM_PWD);
+        downstreamProps.setFlowLatency(200);
         init(ctx, downstreamProps);
     }
 


### PR DESCRIPTION
The CommandConnection.getOrCreatedCommandConsumer method has been renamed to
createCommandConsumer and will no longer return an already existing
instance of a command consumer for a given device but will instead fail
the returned future with an
org.eclipse.hono.client.ResourceConflictException to indicate that a
consumer for the given device is already in use.

The original behavior allowed an implementation to return a consumer
that was scoped to another message handler than the one passed into the
method as an argument. However, client code had no chance to determine
whether it got back a newly created instance or an existing one. This
has been resolved with the new method semantics.

There is now also an integration test for the HTTP adapter which
verifies the correct behavior when a device issues multiple requests
with a TTD without waiting for a response before sending the next
request. The HTTP adapter will in this case ignore the TTD in the subsequent
requests and simply return a 202.

This should also implicitly fix #754