### PR TITLE
[#669] Provide one-way pattern for commands.

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/Command.java
+++ b/client/src/main/java/org/eclipse/hono/client/Command.java
@@ -111,9 +111,7 @@ public final class Command {
 
         String replyToId = null;
 
-        if (message.getReplyTo() == null) {
-            valid = false;
-        } else {
+        if (message.getReplyTo() != null) {
             try {
                 final ResourceIdentifier replyTo = ResourceIdentifier.fromString(message.getReplyTo());
                 if (!CommandConstants.COMMAND_ENDPOINT.equals(replyTo.getEndpoint())) {
@@ -152,6 +150,15 @@ public final class Command {
      */
     public Message getCommandMessage() {
         return message;
+    }
+
+    /**
+     * Checks if this command is a <em>one-way</em> command (meaning there is no response expected).
+     *
+     * @return {@code true} if this is a valid command.
+     */
+    public boolean isOneWay() {
+        return replyToId == null;
     }
 
     /**
@@ -297,11 +304,11 @@ public final class Command {
      * @param correlationId The identifier to use for correlating the response with the request.
      * @param replyToId An arbitrary identifier to encode into the request ID.
      * @param deviceId The target of the command.
-     * @return The request identifier or {@code null} if any of the parameters are {@code null}.
+     * @return The request identifier or {@code null} if any the correlationId or the deviceId is {@code null}.
      */
     public static String getRequestId(final String correlationId, final String replyToId, final String deviceId) {
 
-        if (correlationId == null || replyToId == null || deviceId == null) {
+        if (correlationId == null || deviceId == null) {
             return null;
         }
 

--- a/client/src/main/java/org/eclipse/hono/client/CommandClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandClient.java
@@ -68,4 +68,44 @@ public interface CommandClient extends RequestResponseClient {
      * @see RequestResponseClient#setRequestTimeout(long)
      */
     Future<BufferResult> sendCommand(String command, String contentType, Buffer data, Map<String, Object> properties);
+
+    /**
+     * Sends a <em>one-way command</em> to a device, i.e. there is no response expected from the device.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected for a successful delivery.
+     *
+     * @param command The one-way command name.
+     * @param data The command data to send to the device or {@code null} if the one-way command has no input data.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed with the status code from the protocol adapter that received the one-way command.
+     *         <p>
+     *         If the one-way command could not be processed by the protocol adapter, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code. Status codes are defined at <a href="https://www.eclipse.org/hono/api/command-and-control-api">Command and Control API</a>.
+     * @throws NullPointerException if command is {@code null}.
+     * @see RequestResponseClient#setRequestTimeout(long)
+     */
+    Future<Integer> sendOneWayCommand(String command, Buffer data);
+
+    /**
+     * Sends a <em>one-way command</em> to a device, i.e. there is no response from the device expected.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected for a successful delivery.
+     *
+     * @param command The one-way command name.
+     * @param contentType The type of the data submitted as part of the one-way command or {@code null} if unknown.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @param properties The headers to include in the one-way command message as AMQP application properties.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed with the status code from the protocol adapter that received the one-way command.
+     *         <p>
+     *         If the one-way command could not be processed by the protocol adapter, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code. Status codes are defined at <a href="https://www.eclipse.org/hono/api/command-and-control-api">Command and Control API</a>.
+     * @throws NullPointerException if oneWayCommand is {@code null}.
+     * @see RequestResponseClient#setRequestTimeout(long)
+     */
+    Future<Integer> sendOneWayCommand(String command, String contentType, Buffer data, Map<String, Object> properties);
 }

--- a/client/src/test/java/org/eclipse/hono/client/CommandTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -55,6 +56,25 @@ public class CommandTest {
         assertThat(cmd.getName(), is("doThis"));
         assertThat(cmd.getReplyToId(), is(String.format("4711/%s", replyToId)));
         assertThat(cmd.getCorrelationId(), is(correlationId));
+        assertFalse(cmd.isOneWay());
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message that has an empty reply-to property.
+     * Verifies that the replyToId is {@code null} and the command reports that it is a one-way command.
+     */
+    @Test
+    public void testFromMessageSucceedsWithoutReplyTo() {
+        final String correlationId = "the-correlation-id";
+        final Message message = mock(Message.class);
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        final Command cmd = Command.from(message, Constants.DEFAULT_TENANT, "4711");
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getName(), is("doThis"));
+        assertThat(cmd.getCorrelationId(), is(correlationId));
+        assertNull(cmd.getReplyToId());
+        assertTrue(cmd.isOneWay());
     }
 
     /**
@@ -114,19 +134,6 @@ public class CommandTest {
         when(message.getSubject()).thenReturn("doThis");
         when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s",
                 CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
-        assertFalse(Command.from(message, Constants.DEFAULT_TENANT, "4711").isValid());
-    }
-
-    /**
-     * Verifies that a command cannot be created from a message that does not
-     * contain a reply-to address.
-     */
-    @Test
-    public void testFromMessageFailsForMissingReplyToAddress() {
-        final String correlationId = "the-correlation-id";
-        final Message message = mock(Message.class);
-        when(message.getSubject()).thenReturn("doThis");
-        when(message.getCorrelationId()).thenReturn(correlationId);
         assertFalse(Command.from(message, Constants.DEFAULT_TENANT, "4711").isValid());
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/Constants.java
+++ b/core/src/main/java/org/eclipse/hono/util/Constants.java
@@ -217,6 +217,11 @@ public final class Constants {
     public static final String HEADER_COMMAND = "hono-command";
 
     /**
+     * The header name defined for setting the <em>one-way command</em> that is sent to the device.
+     */
+    public static final String HEADER_ONE_WAY_COMMAND = "hono-one-way-command";
+
+    /**
      * The header name defined for setting the <em>status code</em> of a device respond to a command that was previously received by the device.
      */
     public static final String HEADER_COMMAND_RESPONSE_STATUS = "hono-cmd-status";

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -16,6 +16,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -105,6 +106,11 @@ public final class MessageHelper {
      * reported the data belongs to.
      */
     public static final String APP_PROPERTY_TENANT_ID = "tenant_id";
+
+    /**
+     * The name of the AMQP 1.0 message application property denoting that a request does not expect a response.
+     */
+    public static final String APP_PROPERTY_ONE_WAY_REQUEST = "one_way_req";
 
     /**
      * The AMQP 1.0 <em>absolute-expiry-time</em> message property.
@@ -478,6 +484,22 @@ public final class MessageHelper {
      */
     public static Integer getTimeUntilDisconnect(final Message msg) {
         return getApplicationProperty(msg.getApplicationProperties(), APP_PROPERTY_DEVICE_TTD, Integer.class);
+    }
+
+    /**
+     * Returns {@code true} if the given property map contains the key for declaring the message to be
+     * <em>one-way</em>, i.e. that no response is expected.
+     * @param appProperties The application properties for the message (that may contain a {@link #APP_PROPERTY_ONE_WAY_REQUEST} property). The map may be null.
+     *
+     * @return {@code true} if the one-way property is found, {@code false} otherwise.
+     */
+    public static boolean isOneWay(final Map<String, Object> appProperties) {
+        return Optional.ofNullable(appProperties).
+                map(v ->
+                        Optional.ofNullable(appProperties.get(APP_PROPERTY_ONE_WAY_REQUEST)).
+                                map(val -> (Boolean) val).
+                                orElse(false)
+        ).orElse(false);
     }
 
     /**

--- a/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
@@ -16,11 +16,15 @@ package org.eclipse.hono.util;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.qpid.proton.message.Message;
 import org.junit.Test;
 
 import io.vertx.proton.ProtonHelper;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Tests MessageHelper.
@@ -79,4 +83,19 @@ public class MessageHelperTest {
         assertNull(msg.getApplicationProperties());
     }
 
+    /**
+     * Verifies that the helper detects a one-way message by the appropriate application property key.
+     */
+    @Test
+    public void testOneWayMessageIsDetected() {
+
+        assertTrue(!MessageHelper.isOneWay(null));
+
+        final Map<String, Object> appProperties = new HashMap<>();
+        assertTrue(!MessageHelper.isOneWay(appProperties));
+        appProperties.put(MessageHelper.APP_PROPERTY_ONE_WAY_REQUEST, Boolean.TRUE);
+        assertTrue(MessageHelper.isOneWay(appProperties));
+        appProperties.put(MessageHelper.APP_PROPERTY_ONE_WAY_REQUEST, Boolean.FALSE);
+        assertTrue(!MessageHelper.isOneWay(appProperties));
+    }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -230,13 +230,5 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         sender.get().sendAndWaitForOutcome(messageWithoutId).setHandler(ctx.asyncAssertFailure(t -> {
             ctx.assertTrue(t instanceof ClientErrorException);
         }));
-
-        // send a message without reply-to address
-        final Message messageWithoutReplyTo = ProtonHelper.message("input data");
-        messageWithoutReplyTo.setSubject("setValue");
-        messageWithoutReplyTo.setMessageId("message-id");
-        sender.get().sendAndWaitForOutcome(messageWithoutReplyTo).setHandler(ctx.asyncAssertFailure(t -> {
-            ctx.assertTrue(t instanceof ClientErrorException);
-        }));
     }
 }


### PR DESCRIPTION
This is step 1 of a sequence of PRs for implementing #669 : it provides the base for sending one-way commands by using the slightly extended AbstractRequestResponseClient.
The commandClient can decide for each command if a response from the device is expected or not by choosing different send methods:
`sendCommand` or `sendOneWayCommand`.

It was tested with the HTTP adapter and an extended example app - both are not part of this PR though and follow in a subsequent PR.