### PR TITLE
[#669] Alternative implementation for one-way pattern for commands.

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/Command.java
+++ b/client/src/main/java/org/eclipse/hono/client/Command.java
@@ -107,9 +107,7 @@ public final class Command {
 
         String replyToId = null;
 
-        if (message.getReplyTo() == null) {
-            valid = false;
-        } else {
+        if (message.getReplyTo() != null) {
             try {
                 final ResourceIdentifier replyTo = ResourceIdentifier.fromString(message.getReplyTo());
                 if (!CommandConstants.COMMAND_ENDPOINT.equals(replyTo.getEndpoint())) {
@@ -148,6 +146,15 @@ public final class Command {
      */
     public Message getCommandMessage() {
         return message;
+    }
+
+    /**
+     * Checks if this command is a <em>one-way</em> command (meaning there is no response expected).
+     *
+     * @return {@code true} if this is a valid command.
+     */
+    public boolean isOneWay() {
+        return replyToId == null;
     }
 
     /**
@@ -293,11 +300,11 @@ public final class Command {
      * @param correlationId The identifier to use for correlating the response with the request.
      * @param replyToId An arbitrary identifier to encode into the request ID.
      * @param deviceId The target of the command.
-     * @return The request identifier or {@code null} if any of the parameters are {@code null}.
+     * @return The request identifier or {@code null} if any the correlationId or the deviceId is {@code null}.
      */
     public static String getRequestId(final String correlationId, final String replyToId, final String deviceId) {
 
-        if (correlationId == null || replyToId == null || deviceId == null) {
+        if (correlationId == null || deviceId == null) {
             return null;
         }
 

--- a/client/src/main/java/org/eclipse/hono/client/CommandClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandClient.java
@@ -68,4 +68,42 @@ public interface CommandClient extends RequestResponseClient {
      * @see RequestResponseClient#setRequestTimeout(long)
      */
     Future<BufferResult> sendCommand(String command, String contentType, Buffer data, Map<String, Object> properties);
+
+    /**
+     * Sends a <em>one-way command</em> to a device, i.e. there is no response expected from the device.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected for a successful delivery.
+     *
+     * @param command The one-way command name.
+     * @param data The command data to send to the device or {@code null} if the one-way command has no input data.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         If the one-way command was accepted, the future will succeed.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the one-way command could not be forwarded to the device.
+     * @throws NullPointerException if command is {@code null}.
+     * @see RequestResponseClient#setRequestTimeout(long)
+     */
+    Future<Void> sendOneWayCommand(String command, Buffer data);
+
+    /**
+     * Sends a <em>one-way command</em> to a device, i.e. there is no response from the device expected.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected for a successful delivery.
+     *
+     * @param command The one-way command name.
+     * @param contentType The type of the data submitted as part of the one-way command or {@code null} if unknown.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @param properties The headers to include in the one-way command message as AMQP application properties.
+     * @return A future indicating the result of the operation:
+     *         <p>
+     *         If the one-way command was accepted, the future will succeed.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the one-way command could not be forwarded to the device.
+     * @throws NullPointerException if command is {@code null}.
+     * @see RequestResponseClient#setRequestTimeout(long)
+     */
+    Future<Void> sendOneWayCommand(String command, String contentType, Buffer data, Map<String, Object> properties);
 }

--- a/client/src/test/java/org/eclipse/hono/client/CommandTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -55,6 +56,25 @@ public class CommandTest {
         assertThat(cmd.getName(), is("doThis"));
         assertThat(cmd.getReplyToId(), is(String.format("4711/%s", replyToId)));
         assertThat(cmd.getCorrelationId(), is(correlationId));
+        assertFalse(cmd.isOneWay());
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message that has an empty reply-to property.
+     * Verifies that the replyToId is {@code null} and the command reports that it is a one-way command.
+     */
+    @Test
+    public void testFromMessageSucceedsWithoutReplyTo() {
+        final String correlationId = "the-correlation-id";
+        final Message message = mock(Message.class);
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        final Command cmd = Command.from(message, Constants.DEFAULT_TENANT, "4711");
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getName(), is("doThis"));
+        assertThat(cmd.getCorrelationId(), is(correlationId));
+        assertNull(cmd.getReplyToId());
+        assertTrue(cmd.isOneWay());
     }
 
     /**
@@ -114,19 +134,6 @@ public class CommandTest {
         when(message.getSubject()).thenReturn("doThis");
         when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s",
                 CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
-        assertFalse(Command.from(message, Constants.DEFAULT_TENANT, "4711").isValid());
-    }
-
-    /**
-     * Verifies that a command cannot be created from a message that does not
-     * contain a reply-to address.
-     */
-    @Test
-    public void testFromMessageFailsForMissingReplyToAddress() {
-        final String correlationId = "the-correlation-id";
-        final Message message = mock(Message.class);
-        when(message.getSubject()).thenReturn("doThis");
-        when(message.getCorrelationId()).thenReturn(correlationId);
         assertFalse(Command.from(message, Constants.DEFAULT_TENANT, "4711").isValid());
     }
 

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractHonoClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractHonoClientTest.java
@@ -14,6 +14,8 @@
 package org.eclipse.hono.client.impl;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,16 +29,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.client.impl.AbstractHonoClient;
-import org.eclipse.hono.client.impl.HonoClientUnitTestHelper;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.junit.Before;
 import org.junit.Rule;
@@ -253,4 +257,31 @@ public class AbstractHonoClientTest {
         verify(closeHook, never()).handle(anyString());
     }
 
+    /**
+     * Verifies that the given application properties are propagated to
+     * the message.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testApplicationPropertiesAreSetAtTheMessage(final TestContext ctx) {
+
+        final Message msg = mock(Message.class);
+        final Map<String, Object> applicationProps = new HashMap<>();
+        applicationProps.put("key", "value");
+        applicationProps.put("key2", "otherValue");
+
+        final ArgumentCaptor<ApplicationProperties> applicationPropsCaptor = ArgumentCaptor.forClass(ApplicationProperties.class);
+
+        AbstractHonoClient.setApplicationProperties(msg, applicationProps);
+
+        verify(msg).setApplicationProperties(applicationPropsCaptor.capture());
+        assertNotNull(applicationPropsCaptor.getValue());
+        assertNotNull(applicationPropsCaptor.getValue().getValue());
+        assertTrue(applicationPropsCaptor.getValue().getValue().size() == 2);
+        assertEquals(applicationPropsCaptor.getValue().getValue().get("key"), "value");
+        assertEquals(applicationPropsCaptor.getValue().getValue().get("key2"), "otherValue");
+
+    }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
@@ -23,9 +23,13 @@ import static org.mockito.Mockito.*;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
+import io.opentracing.Span;
 import io.vertx.core.buffer.Buffer;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.Target;
@@ -33,9 +37,6 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.ServerErrorException;
-import org.eclipse.hono.client.impl.AbstractRequestResponseClient;
-import org.eclipse.hono.client.impl.HonoClientUnitTestHelper;
-import org.eclipse.hono.client.impl.SimpleRequestResponseResult;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.MessageHelper;
@@ -417,6 +418,46 @@ public class AbstractRequestResponseClientTest  {
         // THEN the response is not put to the cache
         invocation.await();
         verify(cache, never()).put(eq("cacheKey"), any(SimpleRequestResponseResult.class), any(Duration.class));
+    }
+
+    /**
+     * Verifies that the client succeeds the result handler if the peer accepts
+     * the request message for a one-way request.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testSendOneWayRequestSucceedsOnAcceptedMessage(final TestContext ctx) {
+
+        // GIVEN a request-response client that times out requests after 200 ms
+        client.setRequestTimeout(200);
+
+        // WHEN sending a one-way request message with some headers and payload
+        final Async sendSuccess = ctx.async();
+        final JsonObject payload = new JsonObject().put("key", "value");
+        final Map<String, Object> applicationProps = new HashMap<>();
+
+        final Message request = ProtonHelper.message();
+        request.setMessageId("12345");
+        request.setCorrelationId("23456");
+        request.setSubject("aRequest");
+        request.setApplicationProperties(new ApplicationProperties(applicationProps));
+        MessageHelper.setPayload(request, "application/json", payload.toBuffer());
+
+        client.sendRequest(request, ctx.asyncAssertSuccess(t -> {
+            sendSuccess.complete();
+        }), null, mock(Span.class));
+        // and the peer accepts the message
+        final Accepted accepted = new Accepted();
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        when(delivery.getRemoteState()).thenReturn(accepted);
+        final ArgumentCaptor<Handler> dispositionHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(sender).send(any(Message.class), dispositionHandlerCaptor.capture());
+        dispositionHandlerCaptor.getValue().handle(delivery);
+
+        // THEN the result handler is succeeded
+        sendSuccess.await();
     }
 
     private AbstractRequestResponseClient<SimpleRequestResponseResult> getClient(final String tenant, final ProtonSender sender, final ProtonReceiver receiver) {

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.impl;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -41,7 +42,6 @@ import io.vertx.proton.ProtonSender;
 
 import java.util.HashMap;
 import java.util.Map;
-
 
 /**
  * Tests verifying behavior of {@link CommandClientImpl}.
@@ -112,6 +112,36 @@ public class CommandClientImplTest {
         assertThat(messageCaptor.getValue().getContentType(), is("text/plain"));
         assertThat(messageCaptor.getValue().getReplyTo(),
                 is(String.format("%s/%s/%s/%s", client.getName(), Constants.DEFAULT_TENANT, DEVICE_ID, REPLY_ID)));
+        assertNotNull(messageCaptor.getValue().getApplicationProperties());
+        assertThat(messageCaptor.getValue().getApplicationProperties().getValue().get("appKey"), is("appValue"));
+    }
+
+    /**
+     * Verifies that a one-way command sends a message with an empty reply-to property.
+     *
+     * <ul>
+     * <li>subject set to given command</li>
+     * <li>message-id not null</li>
+     * <li>content-type set to given type</li>
+     * <li>reply-to address set to {@code null}</li>
+     * <li>correlationId set to a UUID</li>
+     * </ul>
+     *
+     * @param ctx The vert.x test context.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSendOneWayCommandSetsCorrelationIdAndEmptyReplyTo(final TestContext ctx) {
+        final Map<String, Object> applicationProperties = new HashMap<String, Object>();
+        applicationProperties.put("appKey", "appValue");
+
+        client.sendOneWayCommand("doSomething", "text/plain", Buffer.buffer("payload"), applicationProperties);
+        final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(sender).send(messageCaptor.capture(), any(Handler.class));
+        assertThat(messageCaptor.getValue().getSubject(), is("doSomething"));
+        assertNotNull(messageCaptor.getValue().getMessageId());
+        assertThat(messageCaptor.getValue().getContentType(), is("text/plain"));
+        assertNull(messageCaptor.getValue().getReplyTo());
         assertNotNull(messageCaptor.getValue().getApplicationProperties());
         assertThat(messageCaptor.getValue().getApplicationProperties().getValue().get("appKey"), is("appValue"));
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -253,14 +253,6 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         sender.get().sendAndWaitForOutcome(messageWithoutId).setHandler(ctx.asyncAssertFailure(t -> {
             ctx.assertTrue(t instanceof ClientErrorException);
         }));
-
-        log.debug("sending command message lacking reply-to address");
-        final Message messageWithoutReplyTo = ProtonHelper.message("input data");
-        messageWithoutReplyTo.setSubject("setValue");
-        messageWithoutReplyTo.setMessageId("message-id");
-        sender.get().sendAndWaitForOutcome(messageWithoutReplyTo).setHandler(ctx.asyncAssertFailure(t -> {
-            ctx.assertTrue(t instanceof ClientErrorException);
-        }));
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -230,13 +230,5 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         sender.get().sendAndWaitForOutcome(messageWithoutId).setHandler(ctx.asyncAssertFailure(t -> {
             ctx.assertTrue(t instanceof ClientErrorException);
         }));
-
-        // send a message without reply-to address
-        final Message messageWithoutReplyTo = ProtonHelper.message("input data");
-        messageWithoutReplyTo.setSubject("setValue");
-        messageWithoutReplyTo.setMessageId("message-id");
-        sender.get().sendAndWaitForOutcome(messageWithoutReplyTo).setHandler(ctx.asyncAssertFailure(t -> {
-            ctx.assertTrue(t instanceof ClientErrorException);
-        }));
     }
 }


### PR DESCRIPTION
This is step 1 of a sequence of PRs for implementing #669 : it provides the base for sending one-way commands in a different implementation (not using `createAndSend` methods anymore, but still sharing the `sendRequest` method with the AbstractRequestResponseClient).
The commandClient can decide for each command if a response from the device is expected or not by choosing different send methods:
`sendCommand` or `sendOneWayCommand`.

It was tested with the HTTP adapter and an extended example app - both are not part of this PR though and follow in a subsequent PR.