### PR TITLE
[#888] Added interface CreditBasedSender with methods to check credits and to set a drain handler

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/CreditBasedSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/CreditBasedSender.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.client;
+
+import io.vertx.core.Handler;
+
+/**
+ *  A client with methods to retrieve flow credits and also to set queueDrainHandler.
+ *
+ */
+public interface CreditBasedSender {
+    /**
+     * Gets the number of messages this sender can send based on its current number of credits.
+     * <p>
+     * Note that the value returned is valid during execution of the current vert.x handler only.
+     *
+     * @return The number of messages.
+     */
+    int getCredit();
+
+    /**
+     * Sets a handler to be notified once this sender has capacity available to send a message.
+     * <p>
+     * The handler registered using this method will be invoked <em>exactly once</em> when this sender is replenished
+     * with more credit from the peer. For subsequent notifications to be received, a new handler must be registered.
+     * <p>
+     * Client code can use this method to register a handler after it has checked this sender's capacity to send
+     * messages using {@link #getCredit()}, e.g.
+     *
+     * <pre>
+     * MessageSender sender;
+     * ...
+     *
+     * if (sender.getCredit() &lt;= 0) {
+     *     sender.sendQueueDrainHandler(replenished -&gt; {
+     *         sender.send(msg);
+     *     });
+     * } else {
+     *     sender.send(msg);
+     * }
+     * </pre>
+     * <p>
+     * Note that all the <em>send</em> methods fail if no credit is available.
+     * 
+     * @param handler The handler to invoke when this sender has been replenished with credit.
+     * @throws IllegalStateException if there already is a handler registered. Note that this means that this sender is
+     *             already waiting for credit.
+     */
+    void sendQueueDrainHandler(Handler<Void> handler);
+}

--- a/client/src/main/java/org/eclipse/hono/client/MessageSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/MessageSender.java
@@ -27,7 +27,7 @@ import io.vertx.proton.ProtonDelivery;
  * A client for publishing messages to Hono.
  *
  */
-public interface MessageSender extends CreditBasedSender{
+public interface MessageSender extends CreditBasedSender {
 
     /**
      * Gets the name of the endpoint this sender sends messages to.

--- a/client/src/main/java/org/eclipse/hono/client/MessageSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/MessageSender.java
@@ -27,7 +27,7 @@ import io.vertx.proton.ProtonDelivery;
  * A client for publishing messages to Hono.
  *
  */
-public interface MessageSender {
+public interface MessageSender extends CreditBasedSender{
 
     /**
      * Gets the name of the endpoint this sender sends messages to.
@@ -35,19 +35,10 @@ public interface MessageSender {
      * The name returned is implementation specific, e.g. an implementation
      * that can be used to upload telemetry data to Hono will return
      * the value <em>telemetry</em>.
-     * 
+     *
      * @return The endpoint name.
      */
     String getEndpoint();
-
-    /**
-     * Gets the number of messages this sender can send based on its current number of credits.
-     * <p>
-     * Note that the value returned is valid during execution of the current vert.x handler only.
-     * 
-     * @return The number of messages.
-     */
-    int getCredit();
 
     /**
      * Checks if this sender can send or buffer (and send later) a message.
@@ -55,41 +46,10 @@ public interface MessageSender {
      * Note that the value returned is valid during execution of the current vert.x handler only.
      * 
      * @return {@code true} if a message can not be sent or buffered at the moment.
-     * @deprecated Explicitly check availability of credit using {@link #getCredit()}.
+     * @deprecated Explicitly check availability of credit using {@link CreditBasedSender#getCredit()}.
      */
     @Deprecated
     boolean sendQueueFull();
-
-    /**
-     * Sets a handler to be notified once this sender has capacity available to send a message.
-     * <p>
-     * The handler registered using this method will be invoked <em>exactly once</em> when
-     * this sender is replenished with more credit from the peer. For subsequent notifications
-     * to be received, a new handler must be registered.
-     * <p>
-     * Client code can use this method to register a handler after it has checked this sender's
-     * capacity to send messages using {@link #getCredit()}, e.g.
-     * <pre>
-     * MessageSender sender;
-     * ...
-     * 
-     * sender.send(msg);
-     * if (sender.getCredit() &lt;= 0) {
-     *     sender.sendQueueDrainHandler(replenished -&gt; {
-     *         sender.send(msg);
-     *     });
-     * } else {
-     *     sender.send(msg);
-     * }
-     * </pre>
-     * <p>
-     * Note that all the <em>send</em> methods fail if no credit is available.
-     * 
-     * @param handler The handler to invoke when this sender has been replenished with credit.
-     * @throws IllegalStateException if there already is a handler registered. Note that this means
-     *                               that this sender is already waiting for credit.
-     */
-    void sendQueueDrainHandler(Handler<Void> handler);
 
     /**
      * Closes the AMQP link with the Hono server this sender is using.
@@ -402,7 +362,7 @@ public interface MessageSender {
      *         depending on the reason for the failure to process the message.
      * @throws NullPointerException if the message is {@code null}.
      * @deprecated Use {@link #send(Message)} instead, optionally checking availability of credit
-     *             first using {@link #getCredit()}.
+     *             first using {@link CreditBasedSender#getCredit()}.
      */
     @Deprecated
     Future<ProtonDelivery> send(Message message, Handler<Void> capacityAvailableHandler);
@@ -448,7 +408,7 @@ public interface MessageSender {
      * @throws NullPointerException if any of device id, payload, content type or registration assertion is {@code null}.
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      * @deprecated Use {@link #send(String, String, String, String)} instead, optionally checking
-     *             availability of credit first using {@link #getCredit()}.
+     *             availability of credit first using {@link CreditBasedSender#getCredit()}.
      */
     @Deprecated
     Future<ProtonDelivery> send(
@@ -496,7 +456,7 @@ public interface MessageSender {
      * @throws NullPointerException if any of device id, payload, content type or registration assertion is {@code null}.
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      * @deprecated Use {@link #send(String, byte[], String, String)} instead, optionally checking
-     *             availability of credit first using {@link #getCredit()}.
+     *             availability of credit first using {@link CreditBasedSender#getCredit()}.
      */
     @Deprecated
     Future<ProtonDelivery> send(
@@ -550,7 +510,7 @@ public interface MessageSender {
      * @throws NullPointerException if any of device id, payload, content type or registration assertion is {@code null}.
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      * @deprecated Use {@link #send(String, Map, String, String, String)} instead, optionally checking
-     *             availability of credit first using {@link #getCredit()}.
+     *             availability of credit first using {@link CreditBasedSender#getCredit()}.
      */
     @Deprecated
     Future<ProtonDelivery> send(
@@ -602,7 +562,7 @@ public interface MessageSender {
      * @throws NullPointerException if any of device id, payload, content type or registration assertion is {@code null}.
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      * @deprecated Use {@link #send(String, Map, byte[], String, String)} instead, optionally checking
-     *             availability of credit first using {@link #getCredit()}.
+     *             availability of credit first using {@link CreditBasedSender#getCredit()}.
      */
     @Deprecated
     Future<ProtonDelivery> send(

--- a/client/src/main/java/org/eclipse/hono/client/RequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/RequestResponseClient.java
@@ -18,7 +18,7 @@ import io.vertx.core.Handler;
 /**
  * Interface for common methods that all clients that follow the request response pattern need to implement.
  */
-public interface RequestResponseClient {
+public interface RequestResponseClient extends CreditBasedSender {
     /**
      * Closes the AMQP link(s) with the Hono server this client is configured to use.
      * <p>

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -323,7 +323,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
     }
 
     @Override
-    public int getCredit() {
+    public final int getCredit() {
         if (sender == null) {
             return 0;
         } else {
@@ -332,7 +332,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
     }
 
     @Override
-    public void sendQueueDrainHandler(final Handler<Void> handler) {
+    public final void sendQueueDrainHandler(final Handler<Void> handler) {
         if (this.drainHandler != null) {
             throw new IllegalStateException("already waiting for replenishment with credit");
         } else {

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
@@ -132,7 +132,6 @@ abstract public class AbstractSender extends AbstractHonoClient implements Messa
     }
 
     @Override
-    @Deprecated
     public final void sendQueueDrainHandler(final Handler<Void> handler) {
         if (this.drainHandler != null) {
             throw new IllegalStateException("already waiting for replenishment with credit");

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
@@ -56,7 +56,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
      * <p>
      * The client will be ready to use after invoking {@link #createLinks(ProtonConnection)} or
      * {@link #createLinks(ProtonConnection, Handler, Handler)} only.
-     * 
+     *
      * @param context The vert.x context to run message exchanges with the peer on.
      * @param config The configuration properties to use.
      * @param tenantId The tenant that the device belongs to.
@@ -76,7 +76,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
 
     /**
      * Creates a request-response client.
-     * 
+     *
      * @param context The vert.x context to run message exchanges with the peer on.
      * @param config The configuration properties to use.
      * @param tenantId The tenant that the device belongs to.
@@ -112,7 +112,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
      * exchanged with the device.
      * <p>
      * This methods creates message IDs based on a counter that is increased on each invocation.
-     * 
+     *
      * @return The message ID.
      */
     @Override
@@ -204,7 +204,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
      * address is set to <em>control/${tenantId}/${deviceId}/${replyId}</em>.
      * This address is also used as the value of the <em>reply-to</em>
      * property of all command request messages sent by this client.
-     * 
+     *
      * @param context The vert.x context to run all interactions with the server on.
      * @param clientConfig The configuration properties to use.
      * @param con The AMQP connection to the server.

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
@@ -484,4 +484,17 @@ public class AbstractRequestResponseClientTest  {
             }
         };
     }
+
+    /**
+     * Verifies credits available.
+     *
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCredits() {
+        when(sender.getCredit()).thenReturn(10);
+        assertThat(client.getCredit(), is(10));
+        when(sender.getCredit()).thenReturn(0);
+        assertThat(client.getCredit(), is(0));
+    }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
@@ -13,14 +13,13 @@
 
 package org.eclipse.hono.client.impl;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.impl.AbstractSender;
-import org.eclipse.hono.client.impl.HonoClientUnitTestHelper;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
@@ -123,6 +122,20 @@ public class AbstractSenderTest {
         // THEN the message is not sent
         assertFalse(result.succeeded());
         verify(protonSender, never()).send(any(Message.class));
+    }
+
+    /**
+     * Verifies credits available.
+     *
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCredits() {
+        final AbstractSender sender = newSender("tenant", "endpoint");
+        when(protonSender.getCredit()).thenReturn(10);
+        assertThat(sender.getCredit(), is(10));
+        when(protonSender.getCredit()).thenReturn(0);
+        assertThat(sender.getCredit(), is(0));
     }
 
     private AbstractSender newSender(final String tenantId, final String targetAddress) {

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -10,6 +10,7 @@ title = "Release Notes"
   opens a link for uploading messages and for each message sent by the device. It also adds information to traces created
   for command messages to be sent to a device.
 * The AMQP adapter command line client now uses property names that match those of the HonoClient.
+* The Command client now has the provision to check the available credits before sending any commands using `getCredit()`. Also a handler can be set using `sendQueueDrainHandler(Handler<Void> handler)`, so that the client is notified when credits are replenished. 
 
 ### API Changes
 


### PR DESCRIPTION
Added interface `CreditBasedSender` with methods to check credits and to set a drain handler. With reference to the issue #888, this PR also provides possibility for the command client to retrieve the _available credits_ and also to set a _drain handler_.