### PR TITLE
Handle command connection loss

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -69,6 +69,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
     // These values should be made configurable.
     private static final int DEFAULT_MAX_FRAME_SIZE = 32 * 1024; // 32 KB
     private static final int DEFAULT_MAX_SESSION_WINDOW = 100 * DEFAULT_MAX_FRAME_SIZE;
+    private static final long DEFAULT_COMMAND_CONSUMER_CHECK_INTERVAL_MILLIS = 10000; // 10 seconds
 
     /**
      * The AMQP server instance that maps to a secure port.
@@ -509,7 +510,8 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                     } else {
                         onCommandReceived(sender, commandContext);
                     }
-                }, closeHandler -> {});
+                }, closeHandler -> {},
+                DEFAULT_COMMAND_CONSUMER_CHECK_INTERVAL_MILLIS);
     }
 
     /**

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.adapter.amqp;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -302,7 +303,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         // WHEN an unauthenticated device opens a receiver link with a valid source address
         final ProtonConnection deviceConnection = mock(ProtonConnection.class);
         when(deviceConnection.attachments()).thenReturn(mock(Record.class));
-        when(commandConnection.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class)))
+        when(commandConnection.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class), anyLong()))
             .thenReturn(Future.succeededFuture(mock(MessageConsumer.class)));
         final String sourceAddress = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, TEST_TENANT_ID, TEST_DEVICE);
         final ProtonSender sender = getSender(sourceAddress);
@@ -335,8 +336,8 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
         // and a device that wants to receive commands
         final MessageConsumer commandConsumer = mock(MessageConsumer.class);
-        when(commandConnection.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class))).thenReturn(
-                Future.succeededFuture(commandConsumer));
+        when(commandConnection.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class), anyLong()))
+            .thenReturn(Future.succeededFuture(commandConsumer));
         final String sourceAddress = String.format("%s", CommandConstants.COMMAND_ENDPOINT);
         final ProtonSender sender = getSender(sourceAddress);
         final Device authenticatedDevice = new Device(TEST_TENANT_ID, TEST_DEVICE);
@@ -431,7 +432,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
         // that wants to receive commands
         final MessageConsumer commandConsumer = mock(MessageConsumer.class);
-        when(commandConnection.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class)))
+        when(commandConnection.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class), anyLong()))
             .thenReturn(Future.succeededFuture(commandConsumer));
         final String sourceAddress = CommandConstants.COMMAND_ENDPOINT;
         final ProtonSender sender = getSender(sourceAddress);

--- a/client/src/main/java/org/eclipse/hono/client/CommandConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandConnection.java
@@ -40,7 +40,8 @@ public interface CommandConnection extends HonoClient {
      * @param deviceId The device for which the consumer will be created.
      * @param commandHandler The handler to invoke with every command received.
      * @param remoteCloseHandler A handler to be invoked after the link has been closed
-     *                     at the peer's request.
+     *                     at the peer's request or {@code null} if no handler should
+     *                     be invoked.
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be completed with the newly created consumer once the link
@@ -53,13 +54,59 @@ public interface CommandConnection extends HonoClient {
      *         <li>a {@link ServiceInvocationException} with an error code indicating
      *         the cause of the failure</li>
      *         </ul>
-     * @throws NullPointerException if any of tenant, device ID or message consumer are {@code null}.
+     * @throws NullPointerException if any of tenant, device ID or command handler are {@code null}.
      */
     Future<MessageConsumer> createCommandConsumer(
             String tenantId,
             String deviceId,
             Handler<CommandContext> commandHandler,
             Handler<Void> remoteCloseHandler);
+
+    /**
+     * Creates a command consumer for a device.
+     * <p>
+     * For each device only one command consumer may be active at any given time.
+     * It is the responsibility of the calling code to properly close a consumer
+     * once it is no longer needed. The preferred way of doing so is to invoke the
+     * instance's {@link CommandConsumer#close(Handler)} method. Alternatively, if
+     * no reference to the instance is held, the {@link #closeCommandConsumer(String, String)}
+     * method can be used instead.
+     * <p>
+     * The underlying link for receiving the commands will be checked periodically
+     * after the given number of milliseconds. If the link is no longer active, e.g.
+     * because the underlying connection to the peer has been lost or the peer has
+     * closed the link, then this client will try to re-establish the link using the
+     * given parameters.
+     * 
+     * @param tenantId The tenant to consume commands from.
+     * @param deviceId The device for which the consumer will be created.
+     * @param commandHandler The handler to invoke with every command received.
+     * @param remoteCloseHandler A handler to be invoked after the link has been closed
+     *                     at the peer's request.
+     * @param livenessCheckInterval The number of milliseconds to wait between checking
+     *                              liveness of the created link. If the check fails,
+     *                              an attempt will be made to re-establish the link.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be completed with the newly created consumer once the link
+     *         has been established.
+     *         <p>
+     *         The future will be failed with
+     *         <ul>
+     *         <li>a {@link ResourceConflictException} if there already is
+     *         a command consumer active for the given device</li>
+     *         <li>a {@link ServiceInvocationException} with an error code indicating
+     *         the cause of the failure</li>
+     *         </ul>
+     * @throws NullPointerException if tenant, device ID or command handler are {@code null}.
+     * @throws IllegalArgumentException if the checkInterval is negative.
+     */
+    Future<MessageConsumer> createCommandConsumer(
+            String tenantId,
+            String deviceId,
+            Handler<CommandContext> commandHandler,
+            Handler<Void> remoteCloseHandler,
+            long livenessCheckInterval);
 
     /**
      * Closes the command consumer for a given device.

--- a/client/src/main/java/org/eclipse/hono/client/StatusCodeMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/StatusCodeMapper.java
@@ -100,6 +100,8 @@ public abstract class StatusCodeMapper {
             return new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, error.getDescription());
         } else if (AmqpError.UNAUTHORIZED_ACCESS.equals(error.getCondition())) {
             return new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, error.getDescription());
+        } else if (AmqpError.INTERNAL_ERROR.equals(error.getCondition())) {
+            return new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, error.getDescription());
         } else {
             return new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND, error.getDescription());
         }

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClient.java
@@ -366,7 +366,7 @@ public abstract class AbstractHonoClient {
      * @param sourceAddress The address to receive messages from.
      * @param qos The quality of service to use for the link.
      * @param messageHandler The handler to invoke with every message received.
-     * @param closeHook The handler to invoke when the link is closed by the peer (may be {@code null}).
+     * @param remoteCloseHook The handler to invoke when the link is closed at the peer's request (may be {@code null}).
      * @return A future for the created link. The future will be completed once the link is open.
      *         The future will fail with a {@link ServiceInvocationException} if the link cannot be opened.
      * @throws NullPointerException if any of the arguments other than close hook is {@code null}.
@@ -378,7 +378,7 @@ public abstract class AbstractHonoClient {
             final String sourceAddress,
             final ProtonQoS qos,
             final ProtonMessageHandler messageHandler,
-            final Handler<String> closeHook) {
+            final Handler<String> remoteCloseHook) {
 
         Objects.requireNonNull(ctx);
         Objects.requireNonNull(clientConfig);
@@ -429,8 +429,8 @@ public abstract class AbstractHonoClient {
                     result.tryFail(new ServerErrorException(HttpsURLConnection.HTTP_UNAVAILABLE));
                 }
             });
-            HonoProtonHelper.setDetachHandler(receiver, remoteDetached -> onRemoteDetach(receiver, con.getRemoteContainer(), false, closeHook));
-            HonoProtonHelper.setCloseHandler(receiver, remoteClosed -> onRemoteDetach(receiver, con.getRemoteContainer(), true, closeHook));
+            HonoProtonHelper.setDetachHandler(receiver, remoteDetached -> onRemoteDetach(receiver, con.getRemoteContainer(), false, remoteCloseHook));
+            HonoProtonHelper.setCloseHandler(receiver, remoteClosed -> onRemoteDetach(receiver, con.getRemoteContainer(), true, remoteCloseHook));
             receiver.open();
             ctx.owner().setTimer(clientConfig.getLinkEstablishmentTimeout(), tid -> onTimeOut(receiver, clientConfig, result));
         });

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
@@ -95,6 +95,10 @@ public class HonoClientImpl implements HonoClient {
      * The target address is used as the key, e.g. <em>telemetry/DEFAULT_TENANT</em>.
      */
     protected final Map<String, MessageSender> activeSenders = new HashMap<>();
+    /**
+     * The vert.x instance to run on.
+     */
+    protected final Vertx vertx;
 
     /**
      * The AMQP connection to the peer.
@@ -112,7 +116,6 @@ public class HonoClientImpl implements HonoClient {
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
     private final AtomicBoolean disconnecting = new AtomicBoolean(false);
     private final ConnectionFactory connectionFactory;
-    private final Vertx vertx;
     private final Object connectionLock = new Object();
 
     private ProtonClientOptions clientOptions;
@@ -252,8 +255,27 @@ public class HonoClientImpl implements HonoClient {
         }
     }
 
-    private boolean isConnectedInternal() {
+    /**
+     * Checks if this client is currently connected to the server.
+     * <p>
+     * Note that the result returned by this method is only meaningful
+     * if running on the vert.x event loop context that this client has been
+     * created on.
+     * 
+     * @return {@code true} if the connection is established.
+     */
+    protected boolean isConnectedInternal() {
         return connection != null && !connection.isDisconnected();
+    }
+
+    /**
+     * Checks if this client is shut down.
+     * 
+     * @return {@code true} if this client is shut down already or is
+     *         in the process of shutting down.
+     */
+    protected final boolean isShutdown() {
+        return shuttingDown.get();
     }
 
     /**


### PR DESCRIPTION
This PR addresses #830 

A straightforward approach for solving the issue would be to simply re-create all links once the connection is re-restablished. However, with a large number of devices connected to the adapter instance, this might result in a *burst* of link establishment traffic whose outcome is hard to predict.

The approach taken by this PR is therefore a different one: when a device subscribes to commands and a corresponding CommandConsumer is created, a device specific liveness check is registered which periodically checks for the link to be *alive* and, if not, tries to re-create the link. This should provide for much better distribution of re-creation attempts while being able to automatically recover from the connection loss.