### PR TITLE
[#750] PoC of HealthCheckServer that gets health pushed by verticles.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractApplication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractApplication.java
@@ -136,10 +136,10 @@ public class AbstractApplication implements ApplicationRunner {
 
         healthCheckServer = new HealthCheckServer(vertx, config);
 
-        final Future<Void> future = deployRequiredVerticles(config.getMaxInstances())
+        final Future<Void> future = healthCheckServer.start()
+             .compose(s -> deployRequiredVerticles(config.getMaxInstances()))
              .compose(s -> deployServiceVerticles())
-             .compose(s -> postRegisterServiceVerticles())
-             .compose(s -> healthCheckServer.start());
+             .compose(s -> postRegisterServiceVerticles());
 
         final CompletableFuture<Void> started = new CompletableFuture<>();
         future.setHandler(result -> {

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.hono.service;
 
+import java.time.Instant;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.eclipse.hono.config.AbstractConfig;
 import org.eclipse.hono.config.ServiceConfigProperties;
@@ -26,12 +28,14 @@ import io.netty.handler.ssl.OpenSsl;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Future;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.core.net.TrustOptions;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
 
 /**
  * A base class for implementing services binding to a secure and/or a non-secure port.
@@ -39,6 +43,9 @@ import io.vertx.ext.healthchecks.HealthCheckHandler;
  * @param <T> The type of configuration properties used by this service.
  */
 public abstract class AbstractServiceBase<T extends ServiceConfigProperties> extends ConfigurationSupportingVerticle<T> implements HealthCheckProvider {
+
+    // TODO make configurable
+    protected static final long HEARTBEAT_RATE_MILIIS = HealthCheckServer.LIVENESS_TIMEOUT_SECONDS * 500;
 
     /**
      * A logger to be shared with subclasses.
@@ -49,6 +56,11 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
      * The OpenTracing {@code Tracer} for tracking processing of requests.
      */
     protected Tracer tracer = NoopTracerFactory.create();
+
+    /**
+     * Uniquely identifies this verticle instance.
+     */
+    protected final UUID instanceID = UUID.randomUUID();
 
     /**
      * Sets the OpenTracing {@code Tracer} to use for tracking the processing
@@ -75,7 +87,36 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
      */
     @Override
     public final void start(final Future<Void> startFuture) {
+
+        if (vertx != null) {
+            vertx.setPeriodic(HEARTBEAT_RATE_MILIIS, id -> updateLiveness("heartbeat", Status.OK()));
+        }
+
         startInternal().setHandler(startFuture.completer());
+    }
+
+    protected void updateReadiness(final String procedureName, final Status status) {
+        sendHealthStatus(procedureName, status, HealthCheckServer.EVENT_BUS_ADDRESS_HEALTH_READINESS);
+    }
+
+    protected void updateLiveness(final String procedureName, final Status status) {
+        sendHealthStatus(procedureName, status, HealthCheckServer.EVENT_BUS_ADDRESS_HEALTH_LIVENESS);
+    }
+
+    protected final void sendHealthStatus(final String procedureName, final Status status, final String address) {
+        final Instant now = Instant.now();
+
+        final DeliveryOptions options = new DeliveryOptions()
+                .addHeader(HealthCheckServer.MSG_FIELD_VERTICLE_NAME, this.getClass().getName())
+                .addHeader(HealthCheckServer.MSG_FIELD_VERTICLE_INSTANCE_ID, instanceID.toString())
+                .addHeader(HealthCheckServer.MSG_FIELD_PROCEDURE_NAME, procedureName)
+                .addHeader(HealthCheckServer.MSG_FIELD_LAST_SEEN, String.valueOf(now.getEpochSecond()));
+
+        status.getData().put(HealthCheckServer.MSG_FIELD_LAST_SEEN, now.toString());
+
+        if (vertx != null && vertx.eventBus() != null) {
+            vertx.eventBus().send(address, status.toJson(), options);
+        }
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/HealthCheckServer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/HealthCheckServer.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.service;
 
+import java.time.Instant;
 import java.util.Objects;
 
 import org.eclipse.hono.config.ApplicationConfigProperties;
@@ -22,9 +23,13 @@ import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
 import io.vertx.ext.web.Router;
 
 /**
@@ -47,6 +52,18 @@ public final class HealthCheckServer implements Lifecycle {
     private static final String URI_LIVENESS_PROBE  = "/liveness";
     private static final String URI_READINESS_PROBE = "/readiness";
 
+    /**
+     * The vert.x event bus address to readiness messages are published.
+     */
+    public static final String EVENT_BUS_ADDRESS_HEALTH_READINESS = "health.readiness";
+    public static final String EVENT_BUS_ADDRESS_HEALTH_LIVENESS = "health.liveness";
+
+    public static final String MSG_FIELD_VERTICLE_NAME = "verticle-name";
+    public static final String MSG_FIELD_VERTICLE_INSTANCE_ID = "verticle-instance-id";
+    public static final String MSG_FIELD_PROCEDURE_NAME = "procedure-name";
+    public static final String MSG_FIELD_LAST_SEEN = "last-seen";
+    public static final long LIVENESS_TIMEOUT_SECONDS = 60; // TODO make configurable
+
     private HttpServer server;
 
     private HealthCheckHandler readinessHandler;
@@ -55,6 +72,9 @@ public final class HealthCheckServer implements Lifecycle {
     private final Vertx vertx;
     private final ApplicationConfigProperties config;
     private Router router;
+
+    private MessageConsumer<JsonObject> readinessConsumer;
+    private MessageConsumer<JsonObject> livenessConsumer;
 
     /**
      * Create a new HealthCheckServer for the given Vertx and configuration.
@@ -87,6 +107,60 @@ public final class HealthCheckServer implements Lifecycle {
         }
     }
 
+    private void registerConsumers() {
+        readinessConsumer = vertx.eventBus().consumer(EVENT_BUS_ADDRESS_HEALTH_READINESS);
+        readinessConsumer.handler(this::processReadinessMessage);
+        LOG.info("listening on event bus [address: {}] for readiness status", EVENT_BUS_ADDRESS_HEALTH_READINESS);
+
+        livenessConsumer = vertx.eventBus().consumer(EVENT_BUS_ADDRESS_HEALTH_LIVENESS);
+        livenessConsumer.handler(this::processLivenessMessage);
+        LOG.info("listening on event bus [address: {}] for liveness status", EVENT_BUS_ADDRESS_HEALTH_LIVENESS);
+    }
+
+    private void processReadinessMessage(final Message<JsonObject> msg) {
+
+        final String verticleName = msg.headers().get(MSG_FIELD_VERTICLE_NAME);
+        final String instanceId = msg.headers().get(MSG_FIELD_VERTICLE_INSTANCE_ID);
+        final String procedureName = msg.headers().get(MSG_FIELD_PROCEDURE_NAME);
+        final Status status = new Status(msg.body());
+
+        LOG.info("received readiness update {}/{}/{}: {}", verticleName, instanceId, procedureName, status.isOk());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("readiness update status: {}", msg.body().encodePrettily());
+        }
+
+        readinessHandler.register(verticleName + "/" + instanceId + "/" + procedureName,
+                statusFuture -> statusFuture.complete(status)
+                );
+    }
+
+    private void processLivenessMessage(final Message<JsonObject> msg) {
+
+        final String verticleName = msg.headers().get(MSG_FIELD_VERTICLE_NAME);
+        final String instanceId = msg.headers().get(MSG_FIELD_VERTICLE_INSTANCE_ID);
+        final String procedureName = msg.headers().get(MSG_FIELD_PROCEDURE_NAME);
+        final String lastSeen = msg.headers().get(MSG_FIELD_LAST_SEEN);
+        final Status status = new Status(msg.body());
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("received liveness update {}/{}/{}: {}", verticleName, instanceId, procedureName, status.isOk());
+            LOG.debug("liveness update status: {}", msg.body().encodePrettily());
+        }
+
+        livenessHandler.register(verticleName + "/" + instanceId + "/" + procedureName,
+                statusFuture -> {
+
+                    final Instant lastSeenEpochSecond = Instant.ofEpochSecond(Long.valueOf(lastSeen));
+                    if (lastSeenEpochSecond.plusSeconds(LIVENESS_TIMEOUT_SECONDS).isBefore(Instant.now())) {
+                        LOG.info("liveness check timed out for {}/{}/{}", verticleName, instanceId, procedureName);
+                        status.setKO();
+                    }
+
+                    statusFuture.complete(status);
+                }
+                );
+    }
+
     /**
      * Registers the readiness and liveness checks of the given service if health check is configured, otherwise does
      * nothing.
@@ -110,6 +184,8 @@ public final class HealthCheckServer implements Lifecycle {
 
         final Future<Void> result = Future.future();
         if (router != null) {
+            registerConsumers();
+
             final HttpServerOptions options = new HttpServerOptions()
                     .setPort(config.getHealthCheckPort())
                     .setHost(config.getHealthCheckBindAddress());
@@ -148,6 +224,16 @@ public final class HealthCheckServer implements Lifecycle {
      */
     @Override
     public Future<Void> stop() {
+
+        if (readinessConsumer != null) {
+            readinessConsumer.unregister();
+            LOG.info("unregistered readiness consumer from event bus");
+        }
+
+        if (livenessConsumer != null) {
+            livenessConsumer.unregister();
+            LOG.info("unregistered liveness consumer from event bus");
+        }
 
         final Future<Void> result = Future.future();
         if (server != null) {

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -33,7 +33,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <maven.source.skip>true</maven.source.skip>
     <maven.install.skip>true</maven.install.skip>
     <gpg.skip>true</gpg.skip>
-    <service.startup.timeout>120000</service.startup.timeout>
+    <service.startup.timeout>160000</service.startup.timeout>
     <link.establishment.timeout>5000</link.establishment.timeout>
     <max.bcrypt.iterations>10</max.bcrypt.iterations>
     <default.java.options>


### PR DESCRIPTION
This is a proposal for a solution for #750 which provides an alternative to PR #873.
This is not a complete implementation, **it is just a draft** to see if we like the direction in which it is going and so that can discuss variants of it. I hope you are OK with that.

The basic idea is that verticles actively report their health status to the `HealthCheckServer` over the eventbus. Respectively no reporting for a longer time in the case of the liveness checks could be seen as a failing check because we can not expect that the verticle will be able to send a message if it is no longer live.
The main advantages over the solution in PR #873 are that the verticles don't need to hold an object reference to `HealthCheckServer` and that the health checks on the verticles side could be implemented in a "event-driven" style.

At first I kept the results of the `Status` objects in maps but then I realized that Vert.x's `HealthCheckHandler` already does the same thing, so I simple re-register a check when a status is updated.

What is missing:

- Health check of Endpoints
- readiness checks in applications that are not protocol adapters 
- readiness updates in `AbstractProtocolAdapterBase` when connection to a service is lost
- error handling, parameter checks, JavaDoc, refactoring ...
- Removal of the old mechanism (`HealthCheckProvider`)
- cleanup and write tests
- I had to increase the property `service.startup.timeout` in the integration tests for the tests to complete (at least on my machine)

BTW: I found the comment "//TODO Event Bus support" by accident in the class `HealthCheckHandlerImpl` and wonder if something similar is planned in Vert.x.