### PR TITLE
Add missing tags to Hono Messaging metrics.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/metric/AbstractLegacyMetricsConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/AbstractLegacyMetricsConfig.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.metric;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.util.HierarchicalNameMapper;
+import io.micrometer.graphite.GraphiteConfig;
+import io.micrometer.graphite.GraphiteHierarchicalNameMapper;
+import io.micrometer.graphite.GraphiteMeterRegistry;
+import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
+import io.vertx.core.metrics.MetricsOptions;
+
+/**
+ * Configuration for using legacy style metrics.
+ */
+@PropertySource("classpath:org/eclipse/hono/service/metric/legacy.properties")
+public abstract class AbstractLegacyMetricsConfig {
+
+    protected static final String TAG_HONO = "hono";
+    protected static final String TAG_METER_TYPE = "meterType";
+    protected static final String TAG_SUB_NAME = "subName";
+    protected static final String TAG_TYPE_SUFFIX = "typeSuffix";
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Provide Vert.x metrics options for the legacy metrics setup.
+     * 
+     * @return Metrics options for the legacy setup.
+     */
+    @Bean
+    public MetricsOptions metricsOptions() {
+        return new MetricsOptions();
+    }
+
+    /**
+     * Create a new graphite meter registry, using the legacy format.
+     * 
+     * @param config The config to use.
+     * @param clock The clock to use.
+     * @return The new meter registry.
+     */
+    @Bean
+    public GraphiteMeterRegistry graphiteMeterRegistry(final GraphiteConfig config, final Clock clock) {
+        return new GraphiteMeterRegistry(config, clock,
+                legacyGraphiteFormatMapper(new GraphiteHierarchicalNameMapper(config.tagsAsPrefix())));
+    }
+
+    /**
+     * Gets the object to use for mapping a Micrometer meter name and tags
+     * to a hierarchical Graphite-compliant meter name.
+     * 
+     * @param defaultMapper The default mapper to use for non-Hono specific
+     *                      meters.
+     * @return The mapper.
+     */
+    protected HierarchicalNameMapper legacyGraphiteFormatMapper(
+            final GraphiteHierarchicalNameMapper defaultMapper) {
+
+        return (id, convention) -> {
+
+            if (id.getTag(TAG_HONO) == null) {
+                return defaultMapper.toHierarchicalName(id, convention);
+            }
+
+            return amendWithTags(id.getConventionName(convention), id,
+                    new String[] { MetricsTags.TAG_HOST, TAG_METER_TYPE, TAG_HONO, MetricsTags.TAG_PROTOCOL },
+                    new String[] { MetricsTags.TAG_TYPE, MetricsTags.TAG_TENANT, TAG_SUB_NAME, TAG_TYPE_SUFFIX });
+        };
+    }
+
+    /**
+     * Meter registry customizer for the legacy metrics model.
+     * 
+     * @return The customizer for the legacy model.
+     */
+    @Bean
+    public MeterRegistryCustomizer<GraphiteMeterRegistry> legacyMeterFilters() {
+        return r -> r.config()
+                .namingConvention(NamingConvention.dot)
+                .meterFilter(MeterFilter.replaceTagValues(MetricsTags.TAG_HOST, host -> host.replace('.', '_')))
+                .meterFilter(MeterFilter.replaceTagValues(MetricsTags.TAG_TENANT, tenant -> tenant.replace('.', '_')))
+                .meterFilter(MeterFilter.ignoreTags(MetricsTags.TAG_COMPONENT))
+                .meterFilter(meterTypeMapper());
+    }
+
+    /**
+     * Gets a filter for mapping an original meter name with tags (as reported by Hono)
+     * to a meter name and tags that can be used to derive the corresponding legacy Graphite meter name.
+     * 
+     * @return The filter.
+     */
+    protected abstract MeterFilter meterTypeMapper();
+
+    private String amendWithTags(
+            final String name,
+            final Meter.Id id,
+            final String[] prefixTags,
+            final String[] suffixTags) {
+
+        final StringBuilder sb = new StringBuilder();
+
+        addTags(sb, id, prefixTags);
+
+        if (sb.length() > 0) {
+            sb.append('.');
+            sb.append(name);
+        }
+
+        addTags(sb, id, suffixTags);
+
+        final String result = sb.toString();
+        log.trace("mapping meter [{}] and tags to [{}]", name, result);
+        return result;
+    }
+
+    private static void addTags(final StringBuilder sb, final Meter.Id id, final String[] tags) {
+        for (final String tag : tags) {
+            final String value = id.getTag(tag);
+            if (value != null) {
+                if (sb.length() > 0) {
+                    sb.append('.');
+                }
+                sb.append(value.replace(' ', '_'));
+            }
+        }
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
@@ -27,6 +27,9 @@ import io.micrometer.core.instrument.Tags;
  */
 public abstract class MicrometerBasedMetrics implements Metrics {
 
+    /**
+     * The meter registry.
+     */
     protected final MeterRegistry registry;
 
     private final Map<String, AtomicLong> authenticatedConnections = new ConcurrentHashMap<>();

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplication.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplication.java
@@ -35,8 +35,7 @@ import io.vertx.core.Verticle;
                         "org.eclipse.hono.messaging",
                         "org.eclipse.hono.telemetry",
                         "org.eclipse.hono.event",
-                        "org.eclipse.hono.service.auth",
-                        "org.eclipse.hono.service.metric" })
+                        "org.eclipse.hono.service.auth" })
 @Configuration
 @EnableAutoConfiguration
 public class HonoMessagingApplication extends AbstractApplication {

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplicationConfig.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplicationConfig.java
@@ -27,14 +27,16 @@ import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.metrics.MetricsOptions;
-import org.springframework.context.annotation.Scope;
 
 /**
  * Spring bean definitions required by the Hono application.
@@ -199,9 +201,11 @@ public class HonoMessagingApplicationConfig {
     @Bean
     public MeterRegistryCustomizer<MeterRegistry> commonTags() {
 
-        return r -> r.config().commonTags(
-                MetricsTags.forService(MetricsTags.VALUE_SERVICE_MESSAGING)
-                .and(MetricsTags.TAG_PROTOCOL, "messaging"));
-
+        return r -> r.config()
+                .commonTags(MetricsTags.forService(MetricsTags.VALUE_SERVICE_MESSAGING)
+                        .and(Tags.of(MetricsTags.TAG_PROTOCOL, "messaging")))
+                // Hono Messaging does not have any connections to devices
+                .meterFilter(MeterFilter.denyNameStartsWith("hono.connections.authenticated"))
+                .meterFilter(MeterFilter.denyNameStartsWith("hono.connections.unauthenticated"));
     }
 }

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/MicrometerBasedMessagingMetrics.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/MicrometerBasedMessagingMetrics.java
@@ -53,7 +53,7 @@ public class MicrometerBasedMessagingMetrics extends MicrometerBasedMetrics impl
 
         Objects.requireNonNull(registry);
 
-        this.downstreamConnections = registry.gauge("connections.downstream", new AtomicLong());
+        this.downstreamConnections = registry.gauge("hono.connections.downstream", new AtomicLong());
     }
 
     @Override

--- a/services/messaging/src/test/java/org/eclipse/hono/messaging/MicrometerBasedMessagingMetricsTest.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/messaging/MicrometerBasedMessagingMetricsTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.messaging;
+
+import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TelemetryConstants;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.graphite.GraphiteConfig;
+import io.micrometer.graphite.GraphiteMeterRegistry;
+
+
+/**
+ * Tests verifying behavior of {@link LegacyMetricsConfig}.
+ *
+ */
+public class MicrometerBasedMessagingMetricsTest {
+
+    private final ResourceIdentifier event = ResourceIdentifier.from(
+            EventConstants.EVENT_ENDPOINT, Constants.DEFAULT_TENANT, null);
+    private final ResourceIdentifier telemetry = ResourceIdentifier.from(
+            TelemetryConstants.TELEMETRY_ENDPOINT, Constants.DEFAULT_TENANT, null);
+
+
+    private LegacyMetricsConfig legacyMetricsConfig;
+    private CompositeMeterRegistry registry;
+    private MicrometerBasedMessagingMetrics metrics;
+
+    /**
+     * Creates fixture.
+     */
+    @Before
+    public void setUp() {
+
+        legacyMetricsConfig = new LegacyMetricsConfig();
+
+        final GraphiteMeterRegistry graphiteRegistry = legacyMetricsConfig.graphiteMeterRegistry(GraphiteConfig.DEFAULT, Clock.SYSTEM);
+        legacyMetricsConfig.legacyMeterFilters().customize(graphiteRegistry);
+        graphiteRegistry.config().commonTags(Tags.of(MetricsTags.TAG_PROTOCOL, "messaging"));
+
+        registry = new CompositeMeterRegistry();
+        registry.add(graphiteRegistry);
+        metrics = new MicrometerBasedMessagingMetrics(registry);
+    }
+
+    /**
+     * Verifies that metrics for different target addresses can
+     * be reported without naming conflicts.
+     */
+    @Test
+    public void testReportMetricsWithDifferentTargetAddressesSucceeds() {
+
+        metrics.incrementUpstreamLinks(event);
+        metrics.incrementUpstreamLinks(telemetry);
+
+        metrics.incrementDownstreamSenders(event);
+        metrics.incrementDownstreamSenders(telemetry);
+
+        metrics.submitDownstreamLinkCredits(event, 100);
+        metrics.submitDownstreamLinkCredits(telemetry, 100);
+
+        metrics.incrementDiscardedMessages(event);
+        metrics.incrementDiscardedMessages(telemetry);
+
+        metrics.incrementProcessedMessages(event);
+        metrics.incrementProcessedMessages(telemetry);
+
+        metrics.incrementUndeliverableMessages(event);
+        metrics.incrementUndeliverableMessages(telemetry);
+
+        metrics.incrementDownStreamConnections();
+    }
+}


### PR DESCRIPTION
Use separate LegacyMetricsConfig component for mapping Hono Messaging
metrics to Graphite meter names to minimize dependencies.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>