### PR TITLE
[#914] Put extracted SpanContext into EventBusMessage delivery headers

### DIFF
--- a/core/src/main/java/org/eclipse/hono/tracing/MultiMapExtractAdapter.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/MultiMapExtractAdapter.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tracing;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import io.opentracing.propagation.TextMap;
+import io.vertx.core.MultiMap;
+
+/**
+ * An adapter for extracting properties from a {@code MultiMap} object.
+ *
+ */
+public class MultiMapExtractAdapter implements TextMap {
+
+    private final MultiMap multiMap;
+
+    /**
+     * Creates an adapter for a {@code MultiMap} object.
+     * 
+     * @param multiMap The {@code MultiMap} object.
+     */
+    public MultiMapExtractAdapter(final MultiMap multiMap) {
+        this.multiMap = Objects.requireNonNull(multiMap);
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        return multiMap.iterator();
+    }
+
+    @Override
+    public void put(final String key, final String value) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/core/src/main/java/org/eclipse/hono/tracing/MultiMapInjectAdapter.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/MultiMapInjectAdapter.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tracing;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import io.opentracing.propagation.TextMap;
+import io.vertx.core.MultiMap;
+
+/**
+ * An adapter for injecting properties into a {@code MultiMap} object.
+ *
+ */
+public class MultiMapInjectAdapter implements TextMap {
+
+    private final MultiMap multiMap;
+
+    /**
+     * Creates an adapter for a {@code MultiMap} object.
+     *
+     * @param multiMap The {@code MultiMap} object.
+     */
+    public MultiMapInjectAdapter(final MultiMap multiMap) {
+        this.multiMap = Objects.requireNonNull(multiMap);
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void put(final String key, final String value) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+        multiMap.add(key, value);
+    }
+}

--- a/core/src/test/java/org/eclipse/hono/tracing/MultiMapInjectExtractAdapterTest.java
+++ b/core/src/test/java/org/eclipse/hono/tracing/MultiMapInjectExtractAdapterTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tracing;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import org.junit.Test;
+
+import io.vertx.core.MultiMap;
+
+/**
+ * Tests verifying the behavior of {@link MultiMapInjectAdapter} and {@link MultiMapExtractAdapter}.
+ *
+ */
+public class MultiMapInjectExtractAdapterTest {
+
+    /**
+     * Verifies that the same entries injected via the {@code MultiMapInjectAdapter} are extracted via the
+     * {@code MultiMapExtractAdapter}.
+     */
+    @Test
+    public void testInjectAndExtract() {
+        final Map<String, String> testEntries = new HashMap<>();
+        testEntries.put("key1", "value1");
+        testEntries.put("key2", "value2");
+
+        final MultiMap multiMap = new CaseInsensitiveHeaders();
+        final MultiMapInjectAdapter injectAdapter = new MultiMapInjectAdapter(multiMap);
+        testEntries.forEach((key, value) -> {
+            injectAdapter.put(key, value);
+        });
+
+        final MultiMapExtractAdapter extractAdapter = new MultiMapExtractAdapter(multiMap);
+        extractAdapter.iterator().forEachRemaining(extractedEntry -> {
+            assertThat(extractedEntry.getValue(), is(testEntries.get(extractedEntry.getKey())));
+        });
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsAmqpEndpoint.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 
 /**
  * An {@code AmqpEndpoint} for managing device credential information.
@@ -61,7 +62,8 @@ public class CredentialsAmqpEndpoint extends RequestResponseEndpoint<ServiceConf
                 .setTenant(targetAddress.getTenantId())
                 .setJsonPayload(msg);
 
-        vertx.eventBus().send(CredentialsConstants.EVENT_BUS_ADDRESS_CREDENTIALS_IN, credentialsMsg.toJson());
+        final DeliveryOptions options = createEventBusMessageDeliveryOptions(extractSpanContext(msg));
+        vertx.eventBus().send(CredentialsConstants.EVENT_BUS_ADDRESS_CREDENTIALS_IN, credentialsMsg.toJson(), options);
     }
 
     @Override

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAmqpEndpoint.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 
 /**
  * An {@code AmqpEndpoint} for managing device registration information.
@@ -61,7 +62,8 @@ public class RegistrationAmqpEndpoint extends RequestResponseEndpoint<ServiceCon
                 .setGatewayId(msg)
                 .setJsonPayload(msg);
 
-        vertx.eventBus().send(RegistrationConstants.EVENT_BUS_ADDRESS_REGISTRATION_IN, registrationMsg.toJson());
+        final DeliveryOptions options = createEventBusMessageDeliveryOptions(extractSpanContext(msg));
+        vertx.eventBus().send(RegistrationConstants.EVENT_BUS_ADDRESS_REGISTRATION_IN, registrationMsg.toJson(), options);
     }
 
     @Override

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 
 /**
  * An {@code AmqpEndpoint} for managing tenant information.
@@ -138,7 +139,8 @@ public class TenantAmqpEndpoint extends RequestResponseEndpoint<ServiceConfigPro
                 .setTenant(msg)
                 .setJsonPayload(msg);
 
-        vertx.eventBus().send(TenantConstants.EVENT_BUS_ADDRESS_TENANT_IN, request.toJson());
+        final DeliveryOptions options = createEventBusMessageDeliveryOptions(extractSpanContext(msg));
+        vertx.eventBus().send(TenantConstants.EVENT_BUS_ADDRESS_TENANT_IN, request.toJson(), options);
     }
 
     @Override

--- a/service-base/src/test/java/org/eclipse/hono/service/credentials/CredentialsAmqpEndpointTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/credentials/CredentialsAmqpEndpointTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonHelper;
@@ -76,6 +77,6 @@ public class CredentialsAmqpEndpointTest {
 
         endpoint.processRequest(msg, resource, Constants.PRINCIPAL_ANONYMOUS);
 
-        verify(eventBus).send(eq(CredentialsConstants.EVENT_BUS_ADDRESS_CREDENTIALS_IN), any(JsonObject.class));
+        verify(eventBus).send(eq(CredentialsConstants.EVENT_BUS_ADDRESS_CREDENTIALS_IN), any(JsonObject.class), any(DeliveryOptions.class));
     }
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationAmqpEndpointTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationAmqpEndpointTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonHelper;
@@ -72,6 +73,6 @@ public class RegistrationAmqpEndpointTest {
         MessageHelper.annotate(msg, resource);
         endpoint.processRequest(msg, resource, Constants.PRINCIPAL_ANONYMOUS);
 
-        verify(eventBus).send(eq(RegistrationConstants.EVENT_BUS_ADDRESS_REGISTRATION_IN), any(JsonObject.class));
+        verify(eventBus).send(eq(RegistrationConstants.EVENT_BUS_ADDRESS_REGISTRATION_IN), any(JsonObject.class), any(DeliveryOptions.class));
     }
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/tenant/TenantAmqpEndpointTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/tenant/TenantAmqpEndpointTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonHelper;
@@ -72,6 +73,6 @@ public class TenantAmqpEndpointTest {
 
         endpoint.processRequest(msg, resource, Constants.PRINCIPAL_ANONYMOUS);
 
-        verify(eventBus).send(eq(TenantConstants.EVENT_BUS_ADDRESS_TENANT_IN), any(JsonObject.class));
+        verify(eventBus).send(eq(TenantConstants.EVENT_BUS_ADDRESS_TENANT_IN), any(JsonObject.class), any(DeliveryOptions.class));
     }
 }


### PR DESCRIPTION
Put the `SpanContext`, extracted from an AMQP message received at a `RequestResponseEndpoint`, into the delivery headers of the vert.x event bus message.

This is for #914.