### PR TITLE
Allow tenant service to participate in the health checks

### DIFF
--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
@@ -159,6 +159,9 @@ public class Application extends AbstractApplication {
         if (HealthCheckProvider.class.isInstance(registrationService)) {
             registerHealthchecks((HealthCheckProvider) registrationService);
         }
+        if (HealthCheckProvider.class.isInstance(tenantService)) {
+            registerHealthchecks((HealthCheckProvider) tenantService);
+        }
         return Future.succeededFuture();
     }
 


### PR DESCRIPTION
Currently the tenant service is not considered for health checks. I know that currently it doesn't implement it, but the pattern is the same for the other services.