### PR TITLE
[#927] Limit number of connections per tenant

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -103,6 +103,11 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-proton</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web-client</artifactId>
         <version>${vertx.version}</version>
       </dependency>
       <dependency>

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -73,6 +73,21 @@ public final class TenantConstants extends RequestResponseApiConstants {
      * The vert.x event bus address to which inbound registration messages are published.
      */
     public static final String EVENT_BUS_ADDRESS_TENANT_IN = "tenant.in";
+
+    /**
+     * The name of the property that contains the configuration options for limits.
+     */
+    public static final String LIMITS = "limits";
+
+    /**
+     * The default value for the maximum number of connections to be allowed is -1, which implies no limit.
+     */
+    public static final long DEFAULT_MAX_CONNECTIONS = -1;
+
+    /**
+     * The name of the property that contains the maximum number of connections to be allowed for a tenant.
+     */
+    public static final String MAX_CONNECTIONS = "max-connections";
 
     /**
      * Request actions that belong to the Tenant API.

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -496,4 +496,18 @@ public final class TenantObject extends JsonBackedValueObject {
                 .put(TenantConstants.FIELD_ADAPTERS_TYPE, type)
                 .put(TenantConstants.FIELD_ENABLED, enabled);
     }
+
+    /**
+     * Gets the connections limit for the tenant if configured, else returns
+     * {@link TenantConstants#DEFAULT_MAX_CONNECTIONS}.
+     *
+     * @return The connections limit.
+     */
+    @JsonIgnore
+    public long getConnectionsLimit() {
+        return Optional.ofNullable(getProperty(TenantConstants.LIMITS))
+                .map(limits -> getProperty((JsonObject) limits, TenantConstants.MAX_CONNECTIONS,
+                        (Number) TenantConstants.DEFAULT_MAX_CONNECTIONS).longValue())
+                .orElse(TenantConstants.DEFAULT_MAX_CONNECTIONS);
+    }
 }

--- a/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -285,6 +285,27 @@ public class TenantObjectTest {
         final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, true);
         obj.setProperty(TenantConstants.FIELD_MAX_TTD, -2);
         assertThat(obj.getMaxTimeUntilDisconnect("custom"), is(TenantConstants.DEFAULT_MAX_TTD));
+    }
+
+    /**
+     * Verifies that the default value for connections limit is set to {@link TenantConstants#DEFAULT_MAX_CONNECTIONS}.
+     */
+    @Test
+    public void testGetConnectionsLimitDefaultValue() {
+        final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        assertThat(obj.getConnectionsLimit(), is(TenantConstants.DEFAULT_MAX_CONNECTIONS));
+    }
+
+    /**
+     * Verifies if the connections limit is set based on the configuration.
+     */
+    @Test
+    public void testGetConnectionsLimit() {
+        final JsonObject limitsConfig = new JsonObject()
+                .put(TenantConstants.MAX_CONNECTIONS, 2);
+        final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        obj.setProperty(TenantConstants.LIMITS, limitsConfig);
+        assertThat(obj.getConnectionsLimit(), is(2L));
     }
 
     private X509Certificate getCaCertificate() {

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -34,6 +34,10 @@
         <artifactId>jackson-databind</artifactId>
        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,12 +25,15 @@ import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.VertxProperties;
 import org.eclipse.hono.service.cache.SpringCacheProvider;
+import org.eclipse.hono.service.plan.ResourceLimitChecks;
+import org.eclipse.hono.service.plan.PrometheusBasedResourceLimitChecks;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.TenantConstants;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cache.guava.GuavaCacheManager;
 import org.springframework.context.annotation.Bean;
@@ -55,7 +58,7 @@ public abstract class AbstractAdapterConfig {
      * The Tracer will be resolved by means of a Java service lookup.
      * If no tracer can be resolved this way, the {@code NoopTracer} is
      * returned.
-     * 
+     *
      * @return The tracer.
      */
     @Bean
@@ -71,7 +74,7 @@ public abstract class AbstractAdapterConfig {
      * This method creates new Vert.x default options and invokes
      * {@link VertxProperties#configureVertx(VertxOptions)} on the object returned
      * by {@link #vertxProperties()}.
-     * 
+     *
      * @return The Vert.x instance.
      */
     @Bean
@@ -272,7 +275,7 @@ public abstract class AbstractAdapterConfig {
 
     /**
      * Exposes the provider for caches as a Spring bean.
-     * 
+     *
      * @return The provider instance.
      */
     @Bean
@@ -307,7 +310,7 @@ public abstract class AbstractAdapterConfig {
 
     /**
      * Exposes configuration options for vertx.
-     * 
+     *
      * @return The Properties.
      */
     @ConfigurationProperties("hono.vertx")
@@ -318,7 +321,7 @@ public abstract class AbstractAdapterConfig {
 
     /**
      * Create a new cache provider based on Guava and Spring Cache.
-     * 
+     *
      * @param config The configuration to use as base for this cache.
      * @return A new cache provider or {@code null} if no cache should be used.
      */
@@ -361,5 +364,17 @@ public abstract class AbstractAdapterConfig {
     @Bean
     public HealthCheckServer healthCheckServer() {
         return new VertxBasedHealthCheckServer(vertx(), applicationConfigProperties());
+    }
+
+    /**
+     * Creates a new instance of {@link ResourceLimitChecks} based on prometheus metrics data.
+     * 
+     * @return A ResourceLimitChecks instance.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.plan.prometheusBased")
+    @ConditionalOnProperty(name = "hono.plan.prometheusBased.host")
+    public ResourceLimitChecks resourceLimitChecks() {
+        return new PrometheusBasedResourceLimitChecks(vertx());
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/NoopResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/NoopResourceLimitChecks.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.plan;
+
+import io.vertx.core.Future;
+import org.eclipse.hono.util.TenantObject;
+
+/**
+ * A no-op implementation for the limit check which always passes all checks.
+ */
+public class NoopResourceLimitChecks implements ResourceLimitChecks {
+
+    @Override
+    public Future<?> isConnectionLimitExceeded(final TenantObject tenantObject) {
+        return Future.succeededFuture(tenantObject);
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.plan;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
+import org.eclipse.hono.util.PortConfigurationHelper;
+import org.eclipse.hono.util.TenantObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link ResourceLimitChecks} which uses metrics data from the prometheus backend to check if
+ * further connections or messages are allowed by comparing with the configured limits.
+ */
+public final class PrometheusBasedResourceLimitChecks implements ResourceLimitChecks {
+    private static final String CONNECTIONS_METRIC_NAME = MicrometerBasedMetrics.METER_CONNECTIONS_AUTHENTICATED
+            .replace(".", "_");
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final WebClient client;
+    private String host;
+    private int port = 9090;
+
+    /**
+     * Creates a new PrometheusBasedResourceLimitChecks instance.
+     *
+     * @param vertx The Vertx instance to use.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public PrometheusBasedResourceLimitChecks(final Vertx vertx) {
+        this.client = WebClient.create(Objects.requireNonNull(vertx));
+    }
+
+    @Override
+    public Future<?> isConnectionLimitExceeded(final TenantObject tenant) {
+        Objects.requireNonNull(tenant);
+        log.trace("Connections limit for tenant [{}] is [{}]", tenant.getTenantId(), tenant.getConnectionsLimit());
+        if (tenant.getConnectionsLimit() != -1) {
+            return queryForSumInPrometheus(CONNECTIONS_METRIC_NAME, tenant)
+                    .recover(failure -> Future.succeededFuture(0L))
+                    .compose(noOfConnections -> {
+                        if (Optional.ofNullable(noOfConnections).orElse(0L) < tenant.getConnectionsLimit()) {
+                            return Future.succeededFuture();
+                        } else {
+                            log.trace(
+                                    "Connections limit exceeded for tenant. [tenant: {}, no.-Connections:{}, connections-limit:{}]",
+                                    tenant.getTenantId(), noOfConnections, tenant.getConnectionsLimit());
+                            return Future
+                                    .failedFuture(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN,
+                                            String.format("Connections limit exceeded for tenant: [%s]",
+                                                    tenant.getTenantId())));
+                        }
+                    });
+        }
+        return Future.succeededFuture(tenant);
+    }
+
+    /**
+     * Gets the host of the prometheus backend.
+     *
+     * @return host The host of the Prometheus backend.
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Sets the host of the prometheus backend. The default value of this property is empty.
+     *
+     * @param host The host of the Prometheus backend.
+     */
+    public void setHost(final String host) {
+        this.host = Objects.requireNonNull(host);
+    }
+
+    /**
+     * Gets the port of the prometheus backend.
+     *
+     * @return port The port of the Prometheus backend.
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Sets the port of the prometheus backend. The default value of this property is 9090.
+     *
+     * @param port The port of the Prometheus backend.
+     * @throws IllegalArgumentException if the port number is &lt; 0 or &gt; 2^16 - 1
+     */
+    public void setPort(final int port) {
+        if (PortConfigurationHelper.isValidPort(port)) {
+            this.port = port;
+        } else {
+            throw new IllegalArgumentException("invalid port number");
+        }
+    }
+
+    private Future<Long> queryForSumInPrometheus(final String metricName, final TenantObject tenant) {
+        final Future<Long> result = Future.future();
+        final String queryUrl = String.format("http://%s:%s/api/v1/query", getHost(), getPort());
+        final String queryParams = String.format("sum(%s{tenant=\"%s\"})", metricName, tenant.getTenantId());
+        log.debug("Prometheus backend url: {}, queryParams: {}", queryUrl, queryParams);
+        client.getAbs(queryUrl)
+                .addQueryParam("query", queryParams)
+                .expect(ResponsePredicate.SC_OK)
+                .send(sendResult -> {
+                    if (sendResult.succeeded()) {
+                        final HttpResponse<Buffer> response = sendResult.result();
+                        try {
+                            Objects.requireNonNull(response);
+                            result.complete(extractValue(response.bodyAsJsonObject()));
+                        } catch (final Exception e) {
+                            log.warn("Error fetching result from prometheus for tenant [{}]. Reason [{}]",
+                                    tenant.getTenantId(), e.getMessage());
+                            result.fail(String.format("Error fetching result from prometheus [%s]", e.getMessage()));
+                        }
+                    } else {
+                        log.warn("Error fetching result from prometheus for tenant [{}]. Reason [{}]",
+                                tenant.getTenantId(), sendResult.cause().getMessage());
+                        result.fail(String.format("Error fetching result from prometheus [%s]",
+                                sendResult.cause().getMessage()));
+                    }
+                });
+        return result;
+    }
+
+    private Long extractValue(final JsonObject jsonObject) {
+        Objects.requireNonNull(jsonObject);
+        final String status = jsonObject.getString("status");
+        if ("success".equals(status)) {
+            final JsonObject data = jsonObject.getJsonObject("data");
+            if (data != null) {
+                final JsonArray result = data.getJsonArray("result");
+                if (result != null && result.size() == 1 && result.getJsonObject(0) != null) {
+                    final JsonArray valueArray = result.getJsonObject(0).getJsonArray("value");
+                    if (valueArray != null && valueArray.size() == 2) {
+                        final String value = valueArray.getString(1);
+                        if (value != null && !value.isEmpty()) {
+                            return Long.parseLong(value);
+                        }
+                    }
+                }
+            }
+            log.debug("No value available.");
+        } else {
+            log.warn("Error in query execution. [status:{}]", status);
+        }
+        return null;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/ResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/ResourceLimitChecks.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.plan;
+
+import io.vertx.core.Future;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.util.TenantObject;
+
+/**
+ * Interface to check if further connections or messages are allowed based on the configured limits.
+ */
+public interface ResourceLimitChecks {
+
+    /**
+     * Check if the number of connections exceeded the configured limit.
+     * 
+     * @param tenantObject The TenantObject that contains the connections limit configured.
+     * @return A future indicating the outcome of the check. If the connection limit exceeds, then the future will fail
+     *         with a {@link ClientErrorException} containing <em>403 Forbidden</em> status.
+     */
+    Future<?> isConnectionLimitExceeded(TenantObject tenantObject);
+}


### PR DESCRIPTION
This PR introduces an interface `TenantPlanValidator` which contains methods to check if further connections are allowed. A default Implementation of this interface based on the metrics data retrieved from the prometheus back end is provided. This validates the number of connections by comparing with the configured limit. Mqtt adapter uses the above method to limit the number of connections. 






