### PR TITLE
trivial fixes/improvements

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
@@ -110,7 +110,7 @@ public class AmqpAdapterSaslAuthenticatorFactory implements ProtonSaslAuthentica
     /**
      * Manage the SASL authentication process for the AMQP adapter.
      */
-    final static class AmqpAdapterSaslAuthenticator implements ProtonSaslAuthenticator {
+    static final class AmqpAdapterSaslAuthenticator implements ProtonSaslAuthenticator {
 
         private static final Logger LOG = LoggerFactory.getLogger(AmqpAdapterSaslAuthenticator.class);
 

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -45,8 +45,6 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TenantObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.log.Fields;
@@ -72,7 +70,6 @@ import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
  */
 public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapterBase<AmqpAdapterProperties> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(VertxBasedAmqpProtocolAdapter.class);
     // These values should be made configurable.
     private static final long DEFAULT_COMMAND_CONSUMER_CHECK_INTERVAL_MILLIS = 10000; // 10 seconds
 

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -43,8 +43,6 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.eclipse.hono.util.TenantObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import io.opentracing.Span;
@@ -74,8 +72,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      * Default file uploads directory used by Vert.x Web.
      */
     protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
-
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractVertxBasedHttpProtocolAdapter.class);
 
     private static final int AT_LEAST_ONCE = 1;
     private static final int HEADER_QOS_INVALID = -1;
@@ -736,16 +732,14 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             final String tenantId,
             final String deviceId) {
 
-        if (messageConsumer != null) {
-            if (!ctx.response().closed()) {
-                ctx.response().closeHandler(v -> {
-                    LOG.debug("device [tenant: {}, device-id: {}] closed connection before response could be sent",
-                            tenantId, deviceId);
-                    cancelCommandReceptionTimer(ctx);
-                    messageConsumer.close(null);
-                    metrics.incrementNoCommandReceivedAndTTDExpired(tenantId);
-                });
-            }
+        if (messageConsumer != null && !ctx.response().closed()) {
+            ctx.response().closeHandler(v -> {
+                LOG.debug("device [tenant: {}, device-id: {}] closed connection before response could be sent",
+                        tenantId, deviceId);
+                cancelCommandReceptionTimer(ctx);
+                messageConsumer.close(null);
+                metrics.incrementNoCommandReceivedAndTTDExpired(tenantId);
+            });
         }
     }
 

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandler.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandler.java
@@ -67,7 +67,7 @@ public class HonoBasicAuthHandler extends HonoAuthHandler {
           // decode the payload
             final String decoded = new String(Base64.getDecoder().decode(parseAuthorization.result()));
 
-            final int colonIdx = decoded.indexOf(":");
+            final int colonIdx = decoded.indexOf(':');
           if (colonIdx != -1) {
             suser = decoded.substring(0, colonIdx);
             spass = decoded.substring(colonIdx + 1);

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
@@ -21,16 +21,14 @@ import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
 import org.eclipse.hono.adapter.http.HonoBasicAuthHandler;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.http.X509AuthHandler;
-import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.auth.device.HonoChainAuthHandler;
 import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
 import org.eclipse.hono.service.auth.device.X509AuthProvider;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.util.Constants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
@@ -46,10 +44,12 @@ import io.vertx.ext.web.handler.CorsHandler;
  */
 public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(VertxBasedHttpProtocolAdapter.class);
     private static final String PARAM_TENANT = "tenant";
     private static final String PARAM_DEVICE_ID = "device_id";
     private static final String PARAM_COMMAND_REQUEST_ID = "cmd_req_id";
+
+    private static final String ROUTE_TELEMETRY_ENDPOINT = "/telemetry";
+    private static final String ROUTE_EVENT_ENDPOINT = "/event";
 
     private HonoClientBasedAuthProvider usernamePasswordAuthProvider;
     private HonoClientBasedAuthProvider clientCertAuthProvider;
@@ -133,7 +133,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
         if (getConfig().isAuthenticationRequired()) {
 
             // support CORS headers for POSTing telemetry
-            router.route("/telemetry").handler(CorsHandler.create(getConfig().getCorsAllowedOrigin())
+            router.route(ROUTE_TELEMETRY_ENDPOINT).handler(CorsHandler.create(getConfig().getCorsAllowedOrigin())
                     .allowedMethod(HttpMethod.POST)
                     .allowedHeader(Constants.HEADER_QOS_LEVEL)
                     .allowedHeader(Constants.HEADER_TIME_TIL_DISCONNECT)
@@ -141,11 +141,11 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
                     .allowedHeader(HttpHeaders.CONTENT_TYPE.toString()));
 
             // require auth for POSTing telemetry
-            router.route(HttpMethod.POST, "/telemetry").handler(authHandler);
+            router.route(HttpMethod.POST, ROUTE_TELEMETRY_ENDPOINT).handler(authHandler);
 
             // route for posting telemetry data using tenant and device ID determined as part of
             // device authentication
-            router.route(HttpMethod.POST, "/telemetry").handler(this::handlePostTelemetry);
+            router.route(HttpMethod.POST, ROUTE_TELEMETRY_ENDPOINT).handler(this::handlePostTelemetry);
 
             // require auth for PUTing telemetry
             router.route(HttpMethod.PUT, "/telemetry/*").handler(authHandler);
@@ -171,18 +171,18 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
         if (getConfig().isAuthenticationRequired()) {
 
             // support CORS headers for POSTing events
-            router.route("/event").handler(CorsHandler.create(getConfig().getCorsAllowedOrigin())
+            router.route(ROUTE_EVENT_ENDPOINT).handler(CorsHandler.create(getConfig().getCorsAllowedOrigin())
                     .allowedMethod(HttpMethod.POST)
                     .allowedHeader(Constants.HEADER_TIME_TIL_DISCONNECT)
                     .allowedHeader(HttpHeaders.AUTHORIZATION.toString())
                     .allowedHeader(HttpHeaders.CONTENT_TYPE.toString()));
 
             // require auth for POSTing events
-            router.route(HttpMethod.POST, "/event").handler(authHandler);
+            router.route(HttpMethod.POST, ROUTE_EVENT_ENDPOINT).handler(authHandler);
 
             // route for posting events using tenant and device ID determined as part of
             // device authentication
-            router.route(HttpMethod.POST, "/event").handler(this::handlePostEvent);
+            router.route(HttpMethod.POST, ROUTE_EVENT_ENDPOINT).handler(this::handlePostEvent);
 
             // require auth for PUTing events
             router.route(HttpMethod.PUT, "/event/*").handler(authHandler);

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -23,15 +23,15 @@ import java.util.stream.Collectors;
 
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.MessageConsumer;
-import org.eclipse.hono.client.MessageSender;
-import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.Command;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandSubscription;
-import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.client.MessageSender;
+import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.auth.DeviceUser;
@@ -49,8 +49,6 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.eclipse.hono.util.TenantObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
@@ -87,11 +85,6 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
 
     private static final int IANA_MQTT_PORT = 1883;
     private static final int IANA_SECURE_MQTT_PORT = 8883;
-
-    /**
-     * A logger to be used by concrete subclasses.
-     */
-    protected final Logger LOG = LoggerFactory.getLogger(getClass());
 
     private MqttAdapterMetrics metrics = MqttAdapterMetrics.NOOP;
 
@@ -346,7 +339,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
 
             final Throwable t = authenticationAttempt.cause();
             TracingHelper.TAG_AUTHENTICATED.set(currentSpan, false);
-            LOG.debug("connection request from client [clientId: {}] rejected: ",
+            LOG.debug("connection request from client [clientId: {}] rejected due to {} ",
                     endpoint.clientIdentifier(), t.getMessage());
 
             final MqttConnectReturnCode code = getConnectReturnCode(t);

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/sampleresult/HonoCommanderSampleResult.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/sampleresult/HonoCommanderSampleResult.java
@@ -25,10 +25,12 @@ public class HonoCommanderSampleResult extends SampleResult {
 
     private int errorCount = 0;
 
+    @Override
     public int getErrorCount() {
         return errorCount;
     }
 
+    @Override
     public void setErrorCount(final int errorCount) {
         this.errorCount = errorCount;
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoChainAuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoChainAuthHandler.java
@@ -16,6 +16,7 @@
 
 package org.eclipse.hono.service.auth.device;
 
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -106,10 +107,10 @@ public class HonoChainAuthHandler extends HonoAuthHandler implements ChainAuthHa
           if (res.cause() instanceof HttpStatusException) {
             final HttpStatusException exception = (HttpStatusException) res.cause();
             switch (exception.getStatusCode()) {
-              case 302:
-              case 400:
-              case 401:
-              case 403:
+              case HttpURLConnection.HTTP_MOVED_TEMP:
+              case HttpURLConnection.HTTP_BAD_REQUEST:
+              case HttpURLConnection.HTTP_UNAUTHORIZED:
+              case HttpURLConnection.HTTP_FORBIDDEN:
                 // try again with next provider since we know what kind of error it is
                 iterate(idx + 1, ctx, exception, handler);
                 return;

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
@@ -147,6 +147,7 @@ public final class HttpUtils {
      * @throws NullPointerException if routing context is {@code null}.
      * @deprecated Use {@link #failWithHeaders(RoutingContext, ServiceInvocationException, Map)} instead.
      */
+    @Deprecated
     public static void failWithStatus(
             final RoutingContext ctx,
             final int status,

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/device/UsernamePasswordCredentialsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/device/UsernamePasswordCredentialsTest.java
@@ -46,10 +46,10 @@ public class UsernamePasswordCredentialsTest {
 
         final UsernamePasswordCredentials mqttUsernamePassword = UsernamePasswordCredentials.create(TEST_USER_OTHER_TENANT, TEST_PASSWORD, false);
 
-        assertEquals(mqttUsernamePassword.getType(), CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD);
-        assertEquals(mqttUsernamePassword.getTenantId(), TEST_OTHER_TENANT);
-        assertEquals(mqttUsernamePassword.getAuthId(), TEST_USER);
-        assertEquals(mqttUsernamePassword.getPassword(), TEST_PASSWORD);
+        assertEquals(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, mqttUsernamePassword.getType());
+        assertEquals(TEST_OTHER_TENANT, mqttUsernamePassword.getTenantId());
+        assertEquals(TEST_USER, mqttUsernamePassword.getAuthId());
+        assertEquals(TEST_PASSWORD, mqttUsernamePassword.getPassword());
     }
 
     /**
@@ -80,10 +80,10 @@ public class UsernamePasswordCredentialsTest {
 
         final UsernamePasswordCredentials mqttUsernamePassword = UsernamePasswordCredentials.create(TEST_USER, TEST_PASSWORD, true);
 
-        assertEquals(mqttUsernamePassword.getType(), CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD);
-        assertEquals(mqttUsernamePassword.getTenantId(), Constants.DEFAULT_TENANT);
-        assertEquals(mqttUsernamePassword.getAuthId(), TEST_USER);
-        assertEquals(mqttUsernamePassword.getPassword(), TEST_PASSWORD);
+        assertEquals(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, mqttUsernamePassword.getType());
+        assertEquals(Constants.DEFAULT_TENANT, mqttUsernamePassword.getTenantId());
+        assertEquals(TEST_USER, mqttUsernamePassword.getAuthId());
+        assertEquals(TEST_PASSWORD, mqttUsernamePassword.getPassword());
     }
 
     /**

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/FileBasedAuthenticationService.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/FileBasedAuthenticationService.java
@@ -58,6 +58,7 @@ public final class FileBasedAuthenticationService extends AbstractHonoAuthentica
     private static final String FIELD_ACTIVITIES = "activities";
     private static final String FIELD_AUTHORITIES = "authorities";
     private static final String FIELD_MECHANISM = "mechanism";
+    private static final String UNAUTHORIZED = "unauthorized";
 
     private static final Map<String, Authorities> roles = new HashMap<>();
     private static final Map<String, JsonObject> users = new HashMap<>();
@@ -228,12 +229,12 @@ public final class FileBasedAuthenticationService extends AbstractHonoAuthentica
             final JsonObject user = getUser(username, AuthenticationConstants.MECHANISM_PLAIN);
             if (user == null) {
                 log.debug("no such user [{}]", username);
-                authenticationResultHandler.handle(Future.failedFuture("unauthorized"));
+                authenticationResultHandler.handle(Future.failedFuture(UNAUTHORIZED));
             } else if (password.equals(user.getString("password"))) {
                 verify(username, user, authzid, authenticationResultHandler);
             } else {
                 log.debug("password mismatch");
-                authenticationResultHandler.handle(Future.failedFuture("unauthorized"));
+                authenticationResultHandler.handle(Future.failedFuture(UNAUTHORIZED));
             }
         }
     }
@@ -250,7 +251,7 @@ public final class FileBasedAuthenticationService extends AbstractHonoAuthentica
             } else {
                 final JsonObject user = getUser(commonName, AuthenticationConstants.MECHANISM_EXTERNAL);
                 if (user == null) {
-                    authenticationResultHandler.handle(Future.failedFuture("unauthorized"));
+                    authenticationResultHandler.handle(Future.failedFuture(UNAUTHORIZED));
                 } else {
                     verify(commonName, user, authzid, authenticationResultHandler);
                 }

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.service.auth.impl;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -59,6 +60,7 @@ public final class SimpleAuthenticationServer extends AmqpServiceBase<ServiceCon
         return "Hono-Auth";
     }
 
+    @Override
     protected void setRemoteConnectionOpenHandler(final ProtonConnection connection) {
         connection.sessionOpenHandler(remoteOpenSession -> handleSessionOpen(connection, remoteOpenSession));
         connection.senderOpenHandler(remoteOpenSender -> handleSenderOpen(connection, remoteOpenSender));
@@ -147,7 +149,7 @@ public final class SimpleAuthenticationServer extends AmqpServiceBase<ServiceCon
             default:
                 return null;
             }
-        }).filter(s -> s != null).collect(Collectors.toSet());
+        }).filter(Objects::nonNull).collect(Collectors.toSet());
         return result.toArray(new String[result.size()]);
     }
 

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/ForwardingDownstreamAdapter.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/ForwardingDownstreamAdapter.java
@@ -523,7 +523,7 @@ public abstract class ForwardingDownstreamAdapter implements DownstreamAdapter {
      * @return {@code true} if there are.
      */
     protected final boolean isActiveSendersEmpty() {
-        return activeSenders != null && activeSenders.isEmpty();
+        return activeSenders.isEmpty();
     }
 
     /**
@@ -532,7 +532,7 @@ public abstract class ForwardingDownstreamAdapter implements DownstreamAdapter {
      * @return {@code true} if there are.
      */
     protected final boolean isSendersPerConnectionEmpty() {
-        return receiversPerConnection != null && receiversPerConnection.isEmpty();
+        return receiversPerConnection.isEmpty();
     }
 
     /**

--- a/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplication.java
+++ b/services/messaging/src/main/java/org/eclipse/hono/messaging/HonoMessagingApplication.java
@@ -15,8 +15,6 @@ package org.eclipse.hono.messaging;
 import org.eclipse.hono.service.AbstractApplication;
 import org.eclipse.hono.service.HealthCheckProvider;
 import org.eclipse.hono.service.auth.AuthenticationService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -39,8 +37,6 @@ import io.vertx.core.Verticle;
 @Configuration
 @EnableAutoConfiguration
 public class HonoMessagingApplication extends AbstractApplication {
-
-    private static final Logger LOG = LoggerFactory.getLogger(HonoMessagingApplication.class);
 
     private AuthenticationService authenticationService;
 
@@ -78,7 +74,7 @@ public class HonoMessagingApplication extends AbstractApplication {
         if (!Verticle.class.isInstance(authenticationService)) {
             result.fail("authentication service is not a verticle");
         } else {
-            LOG.info("Starting authentication service {}", authenticationService);
+            log.info("Starting authentication service {}", authenticationService);
             getVertx().deployVerticle((Verticle) authenticationService, result.completer());
         }
         return result;


### PR DESCRIPTION
* In some tests, the arguments to `assertEqual(expected, actual)` are swapped, resulting in `assertEqual(actual, expected)`
* `AbstractServiceBase` defines a logger instance to be shared by all subclasses. child classes (esp. protocol adapters) can simply use that instance.
* `receiversPerConnection` and `activeSenders` instances can never be null
* ...

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>