### PR TITLE
Finish Span created in createAndSendRequest()

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -687,7 +687,11 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
             final Handler<AsyncResult<R>> resultHandler,
             final Object cacheKey) {
 
-        createAndSendRequest(action, properties, payload, contentType, resultHandler, cacheKey, newChildSpan(null, action));
+        final Span currentSpan = newChildSpan(null, action);
+        createAndSendRequest(action, properties, payload, contentType, ar -> {
+            currentSpan.finish();
+            resultHandler.handle(ar);
+        }, cacheKey, currentSpan);
     }
 
     /**


### PR DESCRIPTION
This adds a missing `finish()` invocation on the `Span` created in `AbstractRequestResponseClient.createAndSendRequest()`.