### PR TITLE
[#914] Create span in "assertRegistration" methods (2)

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
@@ -15,7 +15,7 @@ package org.eclipse.hono.service.registration;
 
 import org.eclipse.hono.util.RegistrationResult;
 
-import io.opentracing.SpanContext;
+import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Verticle;
@@ -55,9 +55,9 @@ public interface RegistrationService extends Verticle {
      *
      * @param tenantId The tenant the device belongs to.
      * @param deviceId The ID of the device to get the assertion for.
-     * @param spanContext The currently active OpenTracing span (may be {@code null}). An implementation
-     *                    should use this as the parent for any span it creates for tracing
-     *                    the execution of this operation.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
      * @param resultHandler The handler to invoke with the result of the operation.
      *             The <em>status</em> will be
      *             <ul>
@@ -67,11 +67,11 @@ public interface RegistrationService extends Verticle {
      *             <li><em>404 Not Found</em> if no device with the given identifier is
      *             registered for the tenant or its <em>enabled</em> property is {@code false}.</li>
      *             </ul>
-     * @throws NullPointerException if any of the parameters (except spanContext) is {@code null}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/api/device-registration-api/#assert-device-registration">
      *      Device Registration API - Assert Device Registration</a>
      */
-    default void assertRegistration(final String tenantId, final String deviceId, final SpanContext spanContext,
+    default void assertRegistration(final String tenantId, final String deviceId, final Span span,
             final Handler<AsyncResult<RegistrationResult>> resultHandler) {
         assertRegistration(tenantId, deviceId, resultHandler);
     }
@@ -121,9 +121,9 @@ public interface RegistrationService extends Verticle {
      * @param tenantId The tenant the device belongs to.
      * @param deviceId The ID of the device to get the assertion for.
      * @param gatewayId The gateway that wants to act on behalf of the device.
-     * @param spanContext The currently active OpenTracing span (may be {@code null}). An implementation
-     *                    should use this as the parent for any span it creates for tracing
-     *                    the execution of this operation.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
      * @param resultHandler The handler to invoke with the result of the operation.
      *             The <em>status</em> will be
      *             <ul>
@@ -135,12 +135,12 @@ public interface RegistrationService extends Verticle {
      *             <li><em>404 Not Found</em> if no device with the given identifier is
      *             registered for the tenant or its <em>enabled</em> property is {@code false}.</li>
      *             </ul>
-     * @throws NullPointerException if any of the parameters (except spanContext) is {@code null}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/api/device-registration-api/#assert-device-registration">
      *      Device Registration API - Assert Device Registration</a>
      */
     default void assertRegistration(final String tenantId, final String deviceId, final String gatewayId,
-            final SpanContext spanContext,
+            final Span span,
             final Handler<AsyncResult<RegistrationResult>> resultHandler) {
         assertRegistration(tenantId, deviceId, gatewayId, resultHandler);
     }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyRegistrationService.java
@@ -19,7 +19,7 @@ import org.eclipse.hono.util.RegistrationResult;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
-import io.opentracing.SpanContext;
+import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -38,14 +38,14 @@ public class DummyRegistrationService extends BaseRegistrationService<Object> {
     }
 
     @Override
-    public void assertRegistration(final String tenantId, final String deviceId, final SpanContext spanContext,
+    public void assertRegistration(final String tenantId, final String deviceId, final Span span,
             final Handler<AsyncResult<RegistrationResult>> resultHandler) {
-        assertRegistration(tenantId, deviceId, null, spanContext, resultHandler);
+        assertRegistration(tenantId, deviceId, null, span, resultHandler);
     }
 
     @Override
     public void assertRegistration(final String tenantId, final String deviceId, final String gatewayId,
-            final SpanContext spanContext, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+            final Span span, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
        final JsonObject deviceData = new JsonObject();
 
         resultHandler.handle(Future.succeededFuture(RegistrationResult.from(

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -9,6 +9,13 @@ title = "Release Notes"
 * The default Micrometer backend is now Prometheus, the new dashboards are also
   using Prometheus as a backend
 
+### API Changes
+
+* New variants of the `RegistrationService.assertRegistration` methods have been added which also accept an OpenTracing 
+  span as a parameter. The default implementations of these methods still default to the previously existing methods.
+  In `RegistrationService` implementations based on `BaseRegistrationService` an OpenTracing span will be created, 
+  passed on to the `assertRegistration` method and finished eventually.
+
 ## 0.8
 
 ### New Features


### PR DESCRIPTION
Alternative to #955.
Create and pass on span in "processAssertRequest" method.
Use Span instead of SpanContext parameter in "assertRegistration" methods.

This is for #914.