### PR TITLE
[#914] Create span for TenantService.get

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantService.java
@@ -17,7 +17,7 @@ import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.hono.util.TenantResult;
 
-import io.opentracing.SpanContext;
+import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Verticle;
@@ -55,9 +55,9 @@ public interface TenantService extends Verticle {
      * This default implementation simply returns the result of {@link #get(String, Handler)}.
      *
      * @param tenantId The identifier of the tenant.
-     * @param spanContext The currently active OpenTracing span (may be {@code null}). An implementation
-     *                    should use this as the parent for any span it creates for tracing
-     *                    the execution of this operation.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
      * @param resultHandler The handler to invoke with the result of the operation.
      *             The <em>status</em> will be
      *             <ul>
@@ -65,11 +65,11 @@ public interface TenantService extends Verticle {
      *             The <em>payload</em> will contain the tenant's configuration information.</li>
      *             <li><em>404 Not Found</em> if no tenant with the given identifier exists.</li>
      *             </ul>
-     * @throws NullPointerException if any of the parameters (except spanContext) are {@code null}.
+     * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/api/tenant-api/#get-tenant-information">
      *      Tenant API - Get Tenant Information</a>
      */
-    default void get(final String tenantId, final SpanContext spanContext,
+    default void get(final String tenantId, final Span span,
             final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
         get(tenantId, resultHandler);
     }
@@ -109,9 +109,9 @@ public interface TenantService extends Verticle {
      * 
      * @param subjectDn The <em>subject DN</em> of the trusted CA certificate
      *                  that has been configured for the tenant.
-     * @param spanContext The currently active OpenTracing span (may be {@code null}). An implementation
-     *                    should use this as the parent for any span it creates for tracing
-     *                    the execution of this operation.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
      * @param resultHandler The handler to invoke with the result of the operation.
      *             The <em>status</em> will be
      *             <ul>
@@ -119,11 +119,11 @@ public interface TenantService extends Verticle {
      *             The <em>payload</em> will contain the tenant's configuration information.</li>
      *             <li><em>404 Not Found</em> if no matching tenant exists.</li>
      *             </ul>
-     * @throws NullPointerException if any of the parameters (except spanContext) are {@code null}.
+     * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/api/tenant-api/#get-tenant-information">
      *      Tenant API - Get Tenant Information</a>
      */
-    default void get(final X500Principal subjectDn, final SpanContext spanContext,
+    default void get(final X500Principal subjectDn, final Span span,
             final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
         get(subjectDn, resultHandler);
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/tenant/BaseTenantServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/tenant/BaseTenantServiceTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
-import io.opentracing.SpanContext;
+import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -131,7 +131,7 @@ public class BaseTenantServiceTest {
         return new BaseTenantService<ServiceConfigProperties>() {
 
             @Override
-            public void get(final String tenantId, final SpanContext spanContext,
+            public void get(final String tenantId, final Span span,
                     final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
 
                 final TenantObject tenant = TenantObject.from(tenantId, true);
@@ -140,7 +140,7 @@ public class BaseTenantServiceTest {
             }
 
             @Override
-            public void get(final X500Principal subjectDn, final SpanContext spanContext,
+            public void get(final X500Principal subjectDn, final Span span,
                     final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
 
                 final TenantObject tenant = TenantObject.from(subjectDn.getName(X500Principal.RFC2253), true);

--- a/service-base/src/test/java/org/eclipse/hono/service/tenant/CompleteBaseTenantServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/tenant/CompleteBaseTenantServiceTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
-import io.opentracing.SpanContext;
+import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -158,7 +158,7 @@ public class CompleteBaseTenantServiceTest {
             }
 
             @Override
-            public void get(final String tenantId, final SpanContext spanContext, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
+            public void get(final String tenantId, final Span span, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
 
                 final TenantObject tenant = TenantObject.from(tenantId, true);
                 tenant.setProperty("operation", "getById");
@@ -166,7 +166,7 @@ public class CompleteBaseTenantServiceTest {
             }
 
             @Override
-            public void get(final X500Principal subjectDn, final SpanContext spanContext,
+            public void get(final X500Principal subjectDn, final Span span,
                             final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
 
                 final TenantObject tenant = TenantObject.from(subjectDn.getName(X500Principal.RFC2253), true);

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyTenantService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyTenantService.java
@@ -20,7 +20,7 @@ import org.eclipse.hono.util.TenantResult;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
-import io.opentracing.SpanContext;
+import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -38,7 +38,7 @@ public class DummyTenantService extends BaseTenantService<Object> {
     }
 
     @Override
-    public void get(final String tenantId, final SpanContext spanContext,
+    public void get(final String tenantId, final Span span,
             final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
         final TenantObject tenant = new TenantObject();
         tenant.setTenantId(tenantId);

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -11,10 +11,11 @@ title = "Release Notes"
 
 ### API Changes
 
-* New variants of the `RegistrationService.assertRegistration` methods have been added which also accept an OpenTracing 
-  span as a parameter. The default implementations of these methods still default to the previously existing methods.
-  In `RegistrationService` implementations based on `BaseRegistrationService` an OpenTracing span will be created, 
-  passed on to the `assertRegistration` method and finished eventually.
+* New variants of the `RegistrationService.assertRegistration` and `TenantService.get` methods have been added which also
+  accept an OpenTracing span as a parameter. The default implementations of these methods still default to the previously existing methods.
+  In `RegistrationService` implementations based on `BaseRegistrationService` an OpenTracing span will be created,
+  passed on to the `assertRegistration` method and finished eventually. The same applies to `TenantService` implementations
+  based on `BaseTenantService` concerning the `get` method.
 
 ## 0.8
 


### PR DESCRIPTION
Create and pass on span in "TenantService#processGetRequest" method.
Use Span instead of SpanContext parameter in "TenantService#get" methods.

This is for #914.