### PR TITLE
Http/Mqtt adapter: Add getter for metrics.

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -92,6 +92,15 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
     }
 
     /**
+     * Gets the metrics for this service.
+     *
+     * @return The metrics
+     */
+    protected final HttpAdapterMetrics getMetrics() {
+        return metrics;
+    }
+
+    /**
      * @return 8443
      */
     @Override

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -133,6 +133,15 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
     }
 
     /**
+     * Gets the metrics for this service.
+     *
+     * @return The metrics
+     */
+    protected final MqttAdapterMetrics getMetrics() {
+        return metrics;
+    }
+
+    /**
      * Sets the MQTT server to use for handling secure MQTT connections.
      * 
      * @param server The server.


### PR DESCRIPTION
Expose metrics to sub classes of `AbstractVertxBasedHttpProtocolAdapter`.