### PR TITLE
[#974] Add Tracing support for CredentialsClient

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -109,6 +109,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                                 getTenantServiceClient(),
                                 getCredentialsServiceClient(),
                                 getConfig(),
+                                tracer,
                                 () -> tracer.buildSpan("open connection")
                                     .ignoreActiveSpan()
                                     .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandlerTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandlerTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -56,7 +57,7 @@ public class HonoBasicAuthHandlerTest {
     @Before
     public void setUp() {
         authProvider = mock(AuthProvider.class);
-        authHandler = new HonoBasicAuthHandler(authProvider, "test") {
+        authHandler = new HonoBasicAuthHandler(authProvider, "test", NoopTracerFactory.create()) {
 
             @Override
             public void parseCredentials(final RoutingContext context, final Handler<AsyncResult<JsonObject>> handler) {

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/vertx/VertxBasedHttpProtocolAdapter.java
@@ -103,11 +103,11 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
             authHandler.append(new X509AuthHandler(
                     new TenantServiceBasedX509Authentication(getTenantServiceClient(), tracer),
                     Optional.ofNullable(clientCertAuthProvider).orElse(
-                            new X509AuthProvider(getCredentialsServiceClient(), getConfig()))));
+                            new X509AuthProvider(getCredentialsServiceClient(), getConfig(), tracer))));
             authHandler.append(new HonoBasicAuthHandler(
                     Optional.ofNullable(usernamePasswordAuthProvider).orElse(
-                            new UsernamePasswordAuthProvider(getCredentialsServiceClient(), getConfig())),
-                    getConfig().getRealm()));
+                            new UsernamePasswordAuthProvider(getCredentialsServiceClient(), getConfig(), tracer)),
+                    getConfig().getRealm(), tracer));
             addTelemetryApiRoutes(router, authHandler);
             addEventApiRoutes(router, authHandler);
             addCommandResponseRoutes(router, authHandler);

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -154,11 +154,12 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends ProtocolAd
         return new ChainAuthHandler<MqttContext>()
                 .append(new X509AuthHandler(
                         new TenantServiceBasedX509Authentication(getTenantServiceClient(), tracer),
-                        new X509AuthProvider(getCredentialsServiceClient(), getConfig())))
+                        new X509AuthProvider(getCredentialsServiceClient(), getConfig(), tracer)))
                 .append(new ConnectPacketAuthHandler(
                         new UsernamePasswordAuthProvider(
                                 getCredentialsServiceClient(),
-                                getConfig())));
+                                getConfig(),
+                                tracer)));
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/CredentialsClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/CredentialsClient.java
@@ -13,10 +13,11 @@
 
 package org.eclipse.hono.client;
 
-import io.vertx.core.json.JsonObject;
 import org.eclipse.hono.util.CredentialsObject;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 
 /**
  * A client for accessing Hono's Credentials API.
@@ -68,4 +69,32 @@ public interface CredentialsClient extends RequestResponseClient {
      * @see RequestResponseClient#setRequestTimeout(long)
      */
     Future<CredentialsObject> get(String type, String authId, JsonObject clientContext);
+
+    /**
+     * Gets credentials for a device by type and authentication identifier.
+     * <p>
+     * This default implementation simply returns the result of {@link #get(String, String, JsonObject)}.
+     *
+     * @param type The type of credentials to retrieve.
+     * @param authId The authentication identifier used in the credentials to retrieve.
+     * @param clientContext Optional bag of properties that can be used to identify the device
+     * @param spanContext The currently active OpenTracing span (may be {@code null}). An implementation
+     *                    should use this as the parent for any span it creates for tracing
+     *                    the execution of this operation.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed if a response with status 200 has been received from the
+     *         credentials service. The JSON object will then contain values as defined in
+     *         <a href="https://www.eclipse.org/hono/api/credentials-api/#get-credentials">
+     *         Get Credentials</a>.
+     *         <p>
+     *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code returned by the service.
+     * @throws NullPointerException if any of the parameters (except spanContext) is {@code null}.
+     * @see RequestResponseClient#setRequestTimeout(long)
+     */
+    default Future<CredentialsObject> get(final String type, final String authId, final JsonObject clientContext,
+            final SpanContext spanContext) {
+        return get(type, authId, clientContext);
+    }
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -746,6 +746,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
             sendRequest(request, resultHandler, cacheKey, currentSpan);
         } else {
             TracingHelper.logError(currentSpan, "sender and/or receiver link is not open");
+            Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_UNAVAILABLE);
             resultHandler.handle(Future.failedFuture(new ServerErrorException(
                     HttpURLConnection.HTTP_UNAVAILABLE, "sender and/or receiver link is not open")));
         }

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoClientImpl.java
@@ -810,6 +810,7 @@ public class HonoClientImpl implements HonoClient {
             CredentialsClientImpl.create(
                     context,
                     clientConfigProperties,
+                    tracer,
                     connection,
                     tenantId,
                     this::removeCredentialsClient,

--- a/core/src/main/java/org/eclipse/hono/tracing/JsonObjectExtractAdapter.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/JsonObjectExtractAdapter.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tracing;
+
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import io.opentracing.propagation.TextMap;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * An adapter for extracting properties from a JSON object.
+ *
+ */
+public class JsonObjectExtractAdapter implements TextMap {
+
+    private final JsonObject jsonObject;
+
+    /**
+     * Creates an adapter for a JSON object.
+     * 
+     * @param jsonObject The JSON object.
+     */
+    public JsonObjectExtractAdapter(final JsonObject jsonObject) {
+        this.jsonObject = Objects.requireNonNull(jsonObject);
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+
+        final Iterator<Entry<String, Object>> propertiesIterator = jsonObject.iterator();
+        return new Iterator<Entry<String, String>>() {
+
+            @Override
+            public boolean hasNext() {
+                return propertiesIterator.hasNext();
+            }
+
+            @Override
+            public Entry<String, String> next() {
+                final Entry<String, Object> nextEntry = propertiesIterator.next();
+                return new AbstractMap.SimpleEntry<>(nextEntry.getKey(),
+                        nextEntry.getValue().toString());
+            }
+        };
+    }
+
+    @Override
+    public void put(final String key, final String value) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/core/src/main/java/org/eclipse/hono/tracing/JsonObjectInjectAdapter.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/JsonObjectInjectAdapter.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tracing;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import io.opentracing.propagation.TextMap;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * An adapter for injecting properties into a JSON object.
+ *
+ */
+public class JsonObjectInjectAdapter implements TextMap {
+
+    private final JsonObject jsonObject;
+
+    /**
+     * Creates an adapter for a JSON object.
+     * 
+     * @param jsonObject The JSON object.
+     */
+    public JsonObjectInjectAdapter(final JsonObject jsonObject) {
+        this.jsonObject = Objects.requireNonNull(jsonObject);
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void put(final String key, final String value) {
+        jsonObject.put(key, value);
+    }
+}

--- a/core/src/test/java/org/eclipse/hono/tracing/JsonObjectInjectExtractAdapterTest.java
+++ b/core/src/test/java/org/eclipse/hono/tracing/JsonObjectInjectExtractAdapterTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tracing;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests verifying the behavior of {@link JsonObjectInjectAdapter} and {@link JsonObjectExtractAdapter}.
+ *
+ */
+public class JsonObjectInjectExtractAdapterTest {
+
+    /**
+     * Verifies that the same entries injected via the {@code JsonObjectInjectAdapter} are extracted via the
+     * {@code JsonObjectExtractAdapter}.
+     */
+    @Test
+    public void testInjectAndExtract() {
+        final Map<String, String> testEntries = new HashMap<>();
+        testEntries.put("key1", "value1");
+        testEntries.put("key2", "value2");
+
+        final JsonObject jsonObject = new JsonObject();
+        final JsonObjectInjectAdapter injectAdapter = new JsonObjectInjectAdapter(jsonObject);
+        testEntries.forEach((key, value) -> {
+            injectAdapter.put(key, value);
+        });
+
+        final JsonObjectExtractAdapter extractAdapter = new JsonObjectExtractAdapter(jsonObject);
+        extractAdapter.iterator().forEachRemaining(extractedEntry -> {
+            assertThat(extractedEntry.getValue(), is(testEntries.get(extractedEntry.getKey())));
+        });
+    }
+
+    /**
+     * Verifies that extracting entries from an empty JSON object returns an empty iterator.
+     */
+    @Test
+    public void testExtractWithEmptyIterator() {
+        final JsonObject jsonObject = new JsonObject();
+        final JsonObjectExtractAdapter extractAdapter = new JsonObjectExtractAdapter(jsonObject);
+        assertThat(extractAdapter.iterator().hasNext(), is(false));
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoClientBasedAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoClientBasedAuthProvider.java
@@ -13,10 +13,12 @@
 
 package org.eclipse.hono.service.auth.device;
 
+import org.eclipse.hono.service.auth.DeviceUser;
+
+import io.opentracing.SpanContext;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.ext.auth.AuthProvider;
-import org.eclipse.hono.service.auth.DeviceUser;
 
 
 /**
@@ -35,9 +37,10 @@ public interface HonoClientBasedAuthProvider<T extends AbstractDeviceCredentials
      *  <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
      *
      * @param credentials The credentials provided by the device.
+     * @param spanContext The SpanContext (may be null).
      * @param resultHandler The handler to notify about the outcome of the validation. If validation succeeds,
      *                      the result contains an object representing the authenticated device.
      * @throws NullPointerException if credentials or result handler are {@code null}.
      */
-    void authenticate(T credentials, Handler<AsyncResult<DeviceUser>> resultHandler);
+    void authenticate(T credentials, SpanContext spanContext, Handler<AsyncResult<DeviceUser>> resultHandler);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
@@ -25,6 +25,7 @@ import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.util.CredentialsObject;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import io.opentracing.Tracer;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -45,11 +46,12 @@ public final class UsernamePasswordAuthProvider extends CredentialsApiAuthProvid
      * 
      * @param credentialsServiceClient The client.
      * @param config The configuration.
+     * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
-    public UsernamePasswordAuthProvider(final HonoClient credentialsServiceClient, final ServiceConfigProperties config) {
-        this(credentialsServiceClient, new SpringBasedHonoPasswordEncoder(), config);
+    public UsernamePasswordAuthProvider(final HonoClient credentialsServiceClient, final ServiceConfigProperties config, final Tracer tracer) {
+        this(credentialsServiceClient, new SpringBasedHonoPasswordEncoder(), config, tracer);
     }
 
     /**
@@ -58,15 +60,17 @@ public final class UsernamePasswordAuthProvider extends CredentialsApiAuthProvid
      * @param credentialsServiceClient The client.
      * @param pwdEncoder The object to use for validating hashed passwords.
      * @param config The configuration.
+     * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
     public UsernamePasswordAuthProvider(
             final HonoClient credentialsServiceClient,
             final HonoPasswordEncoder pwdEncoder,
-            final ServiceConfigProperties config) {
+            final ServiceConfigProperties config,
+            final Tracer tracer) {
 
-        super(credentialsServiceClient);
+        super(credentialsServiceClient, tracer);
         this.config = Objects.requireNonNull(config);
         this.pwdEncoder = Objects.requireNonNull(pwdEncoder);
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsObject;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import io.opentracing.Tracer;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
@@ -42,11 +43,12 @@ public class X509AuthProvider extends CredentialsApiAuthProvider<SubjectDnCreden
      * 
      * @param credentialsServiceClient The client.
      * @param config The configuration.
+     * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
-    public X509AuthProvider(final HonoClient credentialsServiceClient, final ServiceConfigProperties config) {
-        super(credentialsServiceClient);
+    public X509AuthProvider(final HonoClient credentialsServiceClient, final ServiceConfigProperties config, final Tracer tracer) {
+        super(credentialsServiceClient, tracer);
         this.config = Objects.requireNonNull(config);
     }
 


### PR DESCRIPTION
The `CredentialsClient` interface has been extended here to include a `SpanContext` param. The span context is used in the `CredentialsClientImpl` to create a span for the `get Credentials` operation.

In order to get the span context in the `CredentialsClient`, it has to be passed along via the `io.vertx.ext.auth.AuthProvider` interface implementation. 
As it was desired to keep using the standard `io.vertx.ext.web.handler.AuthHandler` implementation (and therefore only the standard `io.vertx.ext.auth.AuthProvider#authenticate` method could be used), the SpanContext is serialized and passed along via the 'authInfo' JsonObject param of the `io.vertx.ext.auth.AuthProvider#authenticate` method (see `CredentialsApiAuthProvider#injectSpanContextIntoAuthInfo` and `CredentialsApiAuthProvider#extractSpanContextFromAuthInfo`).
To get rid of this serialization overhead, it should be considered to maybe adapt the `io.vertx.ext.auth.AuthProvider#authenticate` method upstream with an extra param for context information like the span context.

This fixes #974.