### PR TITLE
Switch OpenShift S2I to Java 11

### DIFF
--- a/deploy/src/main/deploy/openshift_s2i/containers/custom-base/Dockerfile
+++ b/deploy/src/main/deploy/openshift_s2i/containers/custom-base/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER Jens Reimann <jreimann@redhat.com>
 LABEL maintainer "Jens Reimann <jreimann@redhat.com>"
 
 ENV \
-    NETTY_TCNATIVE_VERSION=2.0.10.Final
+    NETTY_TCNATIVE_VERSION=2.0.17.Final
 
 USER root
 

--- a/deploy/src/main/deploy/openshift_s2i/containers/custom-base/Dockerfile
+++ b/deploy/src/main/deploy/openshift_s2i/containers/custom-base/Dockerfile
@@ -1,7 +1,7 @@
 # The FROM field will be overridden by our build configuration
 # in the Hono template and is here just for completeness.
 
-FROM fabric8/s2i-java:2.3
+FROM fabric8/s2i-java:3.0-java11
 
 #
 # A custom base image for running our applications
@@ -17,7 +17,7 @@ USER root
 
 RUN yum update -y
 RUN yum install -y iproute less
-RUN yum install -y --enablerepo=base-debuginfo java-1.8.0-openjdk-debuginfo
+RUN yum install -y --enablerepo=base-debuginfo java-11-openjdk-debuginfo
 
 #
 # Install APR for performance improved TLS/SSL
@@ -31,12 +31,12 @@ RUN yum install -y apr
 #
 
 RUN \
-    yum install -y git autoconf automake libtool which apr-devel make openssl-devel java-1.8.0-openjdk-devel && \
+    yum install -y git autoconf automake libtool which apr-devel make openssl-devel java-11-openjdk-devel && \
     git clone https://github.com/netty/netty-tcnative && \
     cd netty-tcnative && \
     git checkout netty-tcnative-parent-$NETTY_TCNATIVE_VERSION && \
     cd .. && \
-    JAVA_HOME=/usr/lib/jvm/java-1.8.0 mvn -B clean install -f netty-tcnative/openssl-dynamic/pom.xml -am -DskipTests && \
+    JAVA_HOME=/usr/lib/jvm/java-11 mvn -B clean install -f netty-tcnative/openssl-dynamic/pom.xml -am -DskipTests && \
     install -m 0755 netty-tcnative/openssl-dynamic/target/native-lib-only/META-INF/native/linux64/libnetty_tcnative.so /usr/lib64/libnetty_tcnative.so && \
     rm -Rf ~/.m2/repository && \
     rm -Rf netty-tcnative && \

--- a/deploy/src/main/deploy/openshift_s2i/hono-template.yml
+++ b/deploy/src/main/deploy/openshift_s2i/hono-template.yml
@@ -200,10 +200,10 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: fabric8/s2i-java:2.3
+        name: fabric8/s2i-java:3.0-java11
       importPolicy:
         scheduled: true
-      name: "2.3"
+      name: "3.0"
       referencePolicy:
         type: Source
 
@@ -233,13 +233,12 @@ objects:
         dockerfilePath: deploy/src/main/deploy/openshift_s2i/containers/custom-base/Dockerfile
         from:
           kind: ImageStreamTag
-          name: fabric8-s2i-java:2.3
+          name: fabric8-s2i-java:3.0
     postCommit:
     output: 
       to:
         kind: ImageStreamTag
-        name: fabric8-s2i-java-custom:2.3
-
+        name: fabric8-s2i-java-custom:3.0
 
 # hono-adapter-amqp-vertx
 
@@ -270,10 +269,10 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: fabric8-s2i-java-custom:2.3
+          name: fabric8-s2i-java-custom:3.0
         env:
         - name: MAVEN_ARGS_APPEND
-          value: -B -pl org.eclipse.hono:hono-adapter-amqp-vertx --also-make -Pnetty-tcnative -Pmetrics-prometheus -Dmaven.test.skip=true
+          value: -B -pl org.eclipse.hono:hono-adapter-amqp-vertx --also-make -Pnetty-tcnative -Pmetrics-prometheus
         - name: ARTIFACT_DIR
           value: adapters/amqp-vertx/target
         - name: ARTIFACT_COPY_ARGS
@@ -602,10 +601,10 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: fabric8-s2i-java-custom:2.3
+          name: fabric8-s2i-java-custom:3.0
         env:
         - name: MAVEN_ARGS_APPEND
-          value: -B -pl org.eclipse.hono:hono-adapter-mqtt-vertx --also-make -Pnetty-tcnative -Pmetrics-prometheus -Dmaven.test.skip=true
+          value: -B -pl org.eclipse.hono:hono-adapter-mqtt-vertx --also-make -Pnetty-tcnative -Pmetrics-prometheus
         - name: ARTIFACT_DIR
           value: adapters/mqtt-vertx/target
         - name: ARTIFACT_COPY_ARGS
@@ -965,10 +964,10 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: fabric8-s2i-java-custom:2.3
+          name: fabric8-s2i-java-custom:3.0
         env:
         - name: MAVEN_ARGS_APPEND
-          value: -B -pl org.eclipse.hono:hono-adapter-http-vertx --also-make -Pnetty-tcnative -Pmetrics-prometheus -Dmaven.test.skip=true
+          value: -B -pl org.eclipse.hono:hono-adapter-http-vertx --also-make -Pnetty-tcnative -Pmetrics-prometheus
         - name: ARTIFACT_DIR
           value: adapters/http-vertx/target
         - name: ARTIFACT_COPY_ARGS
@@ -1309,10 +1308,10 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: fabric8-s2i-java-custom:2.3
+          name: fabric8-s2i-java-custom:3.0
         env:
         - name: MAVEN_ARGS_APPEND
-          value: -B -pl org.eclipse.hono:hono-service-device-registry --also-make -Pnetty-tcnative -Pmetrics-prometheus -Dmaven.test.skip=true
+          value: -B -pl org.eclipse.hono:hono-service-device-registry --also-make -Pnetty-tcnative -Pmetrics-prometheus
         - name: ARTIFACT_DIR
           value: services/device-registry/target
         - name: ARTIFACT_COPY_ARGS
@@ -1652,10 +1651,10 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: fabric8-s2i-java-custom:2.3
+          name: fabric8-s2i-java-custom:3.0
         env:
         - name: MAVEN_ARGS_APPEND
-          value: -B -pl org.eclipse.hono:hono-service-auth --also-make -Pnetty-tcnative -Pmetrics-prometheus -Dmaven.test.skip=true
+          value: -B -pl org.eclipse.hono:hono-service-auth --also-make -Pnetty-tcnative -Pmetrics-prometheus
         - name: ARTIFACT_DIR
           value: services/auth/target
         - name: ARTIFACT_COPY_ARGS


### PR DESCRIPTION
This PR changes the OpenShift S2I deployment to use Java 11 as a JRE.