### PR TITLE
[#349] Add integration tests for X.509 based authentication.

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -701,6 +701,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <run>
                     <ports>
                       <port>+mqtt.ip:mqtt.port:1883</port>
+                      <port>mqtts.port:8883</port>
                       <port>+mqtt.ip:mqtt.health.port:8088</port>
                     </ports>
                     <network>
@@ -917,6 +918,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 <https.port>${https.port}</https.port>
                 <mqtt.host>${mqtt.ip}</mqtt.host>
                 <mqtt.port>${mqtt.port}</mqtt.port>
+                <mqtts.port>${mqtts.port}</mqtts.port>
                 <adapter.amqp.host>${adapter.amqp.ip}</adapter.amqp.host>
                 <adapter.amqp.port>${adapter.amqp.port}</adapter.amqp.port>
                 <adapter.amqps.port>${adapter.amqps.port}</adapter.amqps.port>

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -68,6 +68,7 @@ public final class IntegrationTestSupport {
     public static final int    DEFAULT_HTTPS_PORT = 8443;
     public static final int    DEFAULT_MAX_BCRYPT_ITERATIONS = 10;
     public static final int    DEFAULT_MQTT_PORT = 1883;
+    public static final int    DEFAULT_MQTTS_PORT = 8883;
 
     public static final String PROPERTY_AUTH_HOST = "auth.host";
     public static final String PROPERTY_AUTH_PORT = "auth.amqp.port";
@@ -87,6 +88,7 @@ public final class IntegrationTestSupport {
     public static final String PROPERTY_HTTPS_PORT = "https.port";
     public static final String PROPERTY_MQTT_HOST = "mqtt.host";
     public static final String PROPERTY_MQTT_PORT = "mqtt.port";
+    public static final String PROPERTY_MQTTS_PORT = "mqtts.port";
     public static final String PROPERTY_AMQP_HOST = "adapter.amqp.host";
     public static final String PROPERTY_AMQP_PORT = "adapter.amqp.port";
     public static final String PROPERTY_AMQPS_PORT = "adapter.amqps.port";
@@ -117,6 +119,7 @@ public final class IntegrationTestSupport {
     public static final int    HTTPS_PORT = Integer.getInteger(PROPERTY_HTTPS_PORT, DEFAULT_HTTPS_PORT);
     public static final String MQTT_HOST = System.getProperty(PROPERTY_MQTT_HOST, DEFAULT_HOST);
     public static final int    MQTT_PORT = Integer.getInteger(PROPERTY_MQTT_PORT, DEFAULT_MQTT_PORT);
+    public static final int    MQTTS_PORT = Integer.getInteger(PROPERTY_MQTTS_PORT, DEFAULT_MQTTS_PORT);
     public static final String AMQP_HOST = System.getProperty(PROPERTY_AMQP_HOST, DEFAULT_HOST);
     public static final int    AMQP_PORT = Integer.getInteger(PROPERTY_AMQP_PORT, DEFAULT_AMQP_PORT);
     public static final int    AMQPS_PORT = Integer.getInteger(PROPERTY_AMQPS_PORT, DEFAULT_AMQPS_PORT);

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -26,6 +26,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.tests.GenericMessageSender;
+import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
@@ -167,7 +168,10 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         final Async setup = ctx.async();
         final Async notificationReceived = ctx.async();
 
-        connectToAdapter(tenant, deviceId, password, () -> createConsumer(tenantId, msg -> {
+        helper.registry
+        .addDeviceForTenant(tenant, deviceId, password)
+        .compose(ok -> connectToAdapter(IntegrationTestSupport.getUsername(deviceId, tenantId), password))
+        .compose(ok -> createConsumer(tenantId, msg -> {
             // expect empty notification with TTD -1
             ctx.assertEquals(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION, msg.getContentType());
             final TimeUntilDisconnectNotification notification = TimeUntilDisconnectNotification.fromMessage(msg).orElse(null);
@@ -235,7 +239,10 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         final Async setup = ctx.async();
         final Async notificationReceived = ctx.async();
 
-        connectToAdapter(tenant, deviceId, password, () -> createConsumer(tenantId, msg -> {
+        helper.registry
+        .addDeviceForTenant(tenant, deviceId, password)
+        .compose(ok -> connectToAdapter(IntegrationTestSupport.getUsername(deviceId, tenantId), password))
+        .compose(ok -> createConsumer(tenantId, msg -> {
             // expect empty notification with TTD -1
             ctx.assertEquals(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION, msg.getContentType());
             final TimeUntilDisconnectNotification notification = TimeUntilDisconnectNotification.fromMessage(msg).orElse(null);

--- a/tests/src/test/resources/mqtt/logback-spring.xml
+++ b/tests/src/test/resources/mqtt/logback-spring.xml
@@ -37,7 +37,7 @@
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
     <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
-    <logger name="org.eclipse.hono.service.auth.device" level="DEBUG"/>
+    <logger name="org.eclipse.hono.service.auth" level="DEBUG"/>
   </springProfile>
 
   <springProfile name="prod">


### PR DESCRIPTION
Added tests for verifying connection establishment using an X.509 client
certificate with the MQTT adapter and for publishing messages.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>