### PR TITLE
[#931] Limit number of connections in MQTT adapter

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
@@ -23,6 +23,7 @@ public class ProtocolAdapterProperties extends ServiceConfigProperties {
     private boolean jmsVendorPropsEnabled = false;
     private boolean defaultsEnabled = true;
     private long eventLoopBlockedCheckTimeout = 5000L;
+    private int maxConcurrentConnections = Integer.MAX_VALUE;
 
     /**
      * Checks whether the protocol adapter always authenticates devices using their provided credentials as defined
@@ -153,5 +154,30 @@ public class ProtocolAdapterProperties extends ServiceConfigProperties {
      */
     public final void setEventLoopBlockedCheckTimeout(final long eventLoopBlockedCheckTimeout) {
         this.eventLoopBlockedCheckTimeout = eventLoopBlockedCheckTimeout;
+    }
+
+    /**
+     * Gets the number of maximal concurrent connections the protocol adapter should accept.
+     * <p>
+     * Default is {@link Integer#MAX_VALUE}.
+     * 
+     * @return The maximal number of concurrent connections.
+     */
+    public int getMaxConcurrentConnections() {
+        return maxConcurrentConnections;
+    }
+
+    /**
+     * Sets the number of maximal concurrent connections the protocol adapter should accept.
+     * 
+     * @param maxConcurrentConnections The maximal number of concurrent connections.
+     * @throws IllegalArgumentException if the number is &lt;= 0.
+     */
+    
+    public void setMaxConcurrentConnections(final int maxConcurrentConnections) {
+        if (maxConcurrentConnections <= 0) {
+            throw new IllegalArgumentException("connection limit must be greater than zero");
+        }
+        this.maxConcurrentConnections = maxConcurrentConnections;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -45,6 +45,13 @@ public interface Metrics {
     void decrementUnauthenticatedConnections();
 
     /**
+     * Gets the total number of current connections - authenticated for all tenants and unauthenticated.
+     *
+     * @return total number of connections.
+     */
+    long getNumberOfConnections();
+
+    /**
      * Reports a message received from a device as <em>processed</em>.
      *
      * @param type The type of message received, e.g. <em>telemetry</em> or <em>event</em>.

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
@@ -34,6 +34,7 @@ public abstract class MicrometerBasedMetrics implements Metrics {
 
     private final Map<String, AtomicLong> authenticatedConnections = new ConcurrentHashMap<>();
     private final AtomicLong unauthenticatedConnections;
+    private final AtomicLong totalCurrentConnections = new AtomicLong();
 
     /**
      * Creates a new metrics instance.
@@ -55,6 +56,7 @@ public abstract class MicrometerBasedMetrics implements Metrics {
         Objects.requireNonNull(tenantId);
         gaugeForTenant("hono.connections.authenticated", this.authenticatedConnections, tenantId, AtomicLong::new)
                 .incrementAndGet();
+        this.totalCurrentConnections.incrementAndGet();
 
     }
 
@@ -64,17 +66,25 @@ public abstract class MicrometerBasedMetrics implements Metrics {
         Objects.requireNonNull(tenantId);
         gaugeForTenant("hono.connections.authenticated", this.authenticatedConnections, tenantId, AtomicLong::new)
                 .decrementAndGet();
+        this.totalCurrentConnections.decrementAndGet();
 
     }
 
     @Override
     public final void incrementUnauthenticatedConnections() {
         this.unauthenticatedConnections.incrementAndGet();
+        this.totalCurrentConnections.incrementAndGet();
     }
 
     @Override
     public final void decrementUnauthenticatedConnections() {
         this.unauthenticatedConnections.decrementAndGet();
+        this.totalCurrentConnections.decrementAndGet();
+    }
+
+    @Override
+    public long getNumberOfConnections() {
+        return this.totalCurrentConnections.get();
     }
 
     @Override

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
@@ -60,4 +60,9 @@ public class NoopBasedMetrics implements Metrics {
     @Override
     public void decrementConnections(final String tenantId) {
     }
+
+    @Override
+    public long getNumberOfConnections() {
+        return 0;
+    }
 }


### PR DESCRIPTION
Connections are rejected once the connection limit is reached.
Currently the limit is fixed on Long.MAX_VALUE, needs to be made
configurable and/or auto-configurable later on.

Signed-off-by: Abel Buechner-Mihaljevic <Abel.Buechner@bosch-si.com>