### PR TITLE
[#961] Use "timer" meter for downstream messages.

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterMetrics.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterMetrics.java
@@ -30,6 +30,9 @@ public interface CoapAdapterMetrics extends Metrics {
         }
     }
 
+    /**
+     * The no-op implementation.
+     */
     CoapAdapterMetrics NOOP = new Noop();
 
     // nothing for now

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.coap;
+
+import java.util.Objects;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.hono.util.MapBasedExecutionContext;
+
+import io.micrometer.core.instrument.Timer.Sample;
+
+
+/**
+ * A dictionary of relevant information required during the
+ * processing of a CoAP request message published by a device.
+ *
+ */
+public final class CoapContext extends MapBasedExecutionContext {
+
+    private final CoapExchange exchange;
+    private Sample timer;
+
+    private CoapContext(final CoapExchange exchange) {
+        this.exchange = exchange;
+    }
+
+    /**
+     * Creates a new context for a CoAP request.
+     * 
+     * @param request The CoAP exchange representing the request.
+     * @return The context.
+     * @throws NullPointerException if request is {@code null}.
+     */
+    public static CoapContext fromRequest(final CoapExchange request) {
+        Objects.requireNonNull(request);
+        return new CoapContext(request);
+    }
+
+    /**
+     * Creates a new context for a CoAP request.
+     * 
+     * @param request The CoAP exchange representing the request.
+     * @param timer The object to use for measuring the time it takes to
+     *              process the request.
+     * @return The context.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public static CoapContext fromRequest(final CoapExchange request, final Sample timer) {
+        Objects.requireNonNull(request);
+        Objects.requireNonNull(timer);
+
+        final CoapContext result = new CoapContext(request);
+        result.timer = timer;
+        return result;
+    }
+
+    /**
+     * Gets the CoAP exchange.
+     * 
+     * @return The exchange.
+     */
+    public CoapExchange getExchange() {
+        return exchange;
+    }
+
+    /**
+     * Gets the object used for measuring the time it takes to
+     * process this request.
+     * 
+     * @return The timer or {@code null} if not set.
+     */
+    public Sample getTimer() {
+        return timer;
+    }
+
+    /**
+     * Sends a response to the device.
+     * 
+     * @param responseCode The code to set in the response.
+     */
+    public void respondWithCode(final ResponseCode responseCode) {
+        exchange.respond(responseCode);
+    }
+}

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -234,8 +234,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload);
         final Device authenticatedDevice = new Device("my-tenant", "the-device");
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange);
 
-        adapter.uploadTelemetryMessage(coapExchange, authenticatedDevice, authenticatedDevice, false);
+        adapter.uploadTelemetryMessage(ctx, authenticatedDevice, authenticatedDevice, false);
 
         // THEN the device gets a 4.03
 
@@ -265,8 +266,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload);
         final Device authenticatedDevice = new Device("tenant", "device");
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange);
 
-        adapter.uploadEventMessage(coapExchange, authenticatedDevice, authenticatedDevice);
+        adapter.uploadEventMessage(ctx, authenticatedDevice, authenticatedDevice);
 
         // THEN the device does not get a response
         verify(coapExchange, never()).respond(ResponseCode.CHANGED);
@@ -294,8 +296,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload);
         final Device authenticatedDevice = new Device("tenant", "device");
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange);
 
-        adapter.uploadEventMessage(coapExchange, authenticatedDevice, authenticatedDevice);
+        adapter.uploadEventMessage(ctx, authenticatedDevice, authenticatedDevice);
         outcome.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "malformed message"));
 
         // THEN the device gets a 4.00
@@ -323,8 +326,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload);
         final Device authenticatedDevice = new Device("tenant", "device");
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange);
 
-        adapter.uploadTelemetryMessage(coapExchange, authenticatedDevice, authenticatedDevice, false);
+        adapter.uploadTelemetryMessage(ctx, authenticatedDevice, authenticatedDevice, false);
 
         // THEN the device does not get a response
         verify(coapExchange, never()).respond(ResponseCode.CHANGED);
@@ -352,8 +356,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload);
         final Device authenticatedDevice = new Device("tenant", "device");
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange);
 
-        adapter.uploadTelemetryMessage(coapExchange, authenticatedDevice, authenticatedDevice, true);
+        adapter.uploadTelemetryMessage(ctx, authenticatedDevice, authenticatedDevice, true);
 
         // THEN the device does not get a response
         verify(coapExchange, never()).respond(ResponseCode.CHANGED);

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/VertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/VertxBasedCoapAdapter.java
@@ -22,6 +22,7 @@ import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.hono.adapter.coap.AbstractVertxBasedCoapAdapter;
 import org.eclipse.hono.adapter.coap.CoapAdapterProperties;
 import org.eclipse.hono.adapter.coap.CoapAuthenticationHandler;
+import org.eclipse.hono.adapter.coap.CoapContext;
 import org.eclipse.hono.adapter.coap.CoapErrorResponse;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.util.Constants;
@@ -122,7 +123,8 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
                 getAuthenticatedExtendedDevice(null, exchange,
                         (device) -> {
                             final boolean waitForOutcome = useWaitForOutcome(exchange);
-                            uploadTelemetryMessage(exchange, device.authenticatedDevice, device.originDevice,
+                            final CoapContext ctx = CoapContext.fromRequest(exchange);
+                            uploadTelemetryMessage(ctx, device.authenticatedDevice, device.originDevice,
                                     waitForOutcome);
                         });
             }
@@ -132,7 +134,8 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
                 getExtendedDevice(exchange,
                         (extDevice) -> {
                             final boolean waitForOutcome = useWaitForOutcome(exchange);
-                            uploadTelemetryMessage(exchange, extDevice.authenticatedDevice, extDevice.originDevice,
+                            final CoapContext ctx = CoapContext.fromRequest(exchange);
+                            uploadTelemetryMessage(ctx, extDevice.authenticatedDevice, extDevice.originDevice,
                                     waitForOutcome);
                         });
             }
@@ -143,13 +146,19 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
             @Override
             public void handlePOST(final CoapExchange exchange) {
                 getAuthenticatedExtendedDevice(null, exchange,
-                        (device) -> uploadEventMessage(exchange, device.authenticatedDevice, device.originDevice));
+                        (device) -> {
+                            final CoapContext ctx = CoapContext.fromRequest(exchange);
+                            uploadEventMessage(ctx, device.authenticatedDevice, device.originDevice);
+                        });
             }
 
             @Override
             public void handlePUT(final CoapExchange exchange) {
                 getExtendedDevice(exchange,
-                        (device) -> uploadEventMessage(exchange, device.authenticatedDevice, device.originDevice));
+                        (device) -> {
+                            final CoapContext ctx = CoapContext.fromRequest(exchange);
+                            uploadEventMessage(ctx, device.authenticatedDevice, device.originDevice);
+                        });
             }
         };
 

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -35,15 +35,16 @@ import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.http.DefaultFailureHandler;
 import org.eclipse.hono.service.http.HttpUtils;
+import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.EndpointType;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
-import org.eclipse.hono.util.TelemetryConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import io.micrometer.core.instrument.Timer.Sample;
 import io.opentracing.Span;
 import io.opentracing.contrib.vertx.ext.web.TracingHandler;
 import io.opentracing.contrib.vertx.ext.web.WebSpanDecorator;
@@ -72,9 +73,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      */
     protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
 
-    private static final int AT_LEAST_ONCE = 1;
-    private static final int HEADER_QOS_INVALID = -1;
-
+    private static final String KEY_MICROMETER_SAMPLE = "micrometer.sample";
     private static final String KEY_TIMER_ID = "timerId";
 
     private HttpServer server;
@@ -192,7 +191,8 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
     }
 
     /**
-     * Adds a handler for adding an OpenTracing Span to the routing context.
+     * Adds a handler for adding an OpenTracing {@code Span}
+     * and a Micrometer {@code Timer.Sample} to the routing context.
      *
      * @param router The router to add the handler to.
      * @param position The position to add the tracing handler at.
@@ -206,6 +206,22 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
         addCustomSpanDecorators(decorators);
         final TracingHandler tracingHandler = new TracingHandler(tracer, decorators);
         router.route().order(position).handler(tracingHandler).failureHandler(tracingHandler);
+        router.route().order(position - 1).handler(ctx -> {
+            ctx.put(KEY_MICROMETER_SAMPLE, getMetrics().startTimer());
+            ctx.next();
+        });
+    }
+
+    private Sample getMicrometerSample(final RoutingContext ctx) {
+        return ctx.get(KEY_MICROMETER_SAMPLE);
+    }
+
+    private void setTtdStatus(final RoutingContext ctx, final MetricsTags.TtdStatus status) {
+        ctx.put(MetricsTags.TtdStatus.class.getName(), status);
+    }
+
+    private MetricsTags.TtdStatus getTtdStatus(final RoutingContext ctx) {
+        return ctx.get(MetricsTags.TtdStatus.class.getName());
     }
 
     /**
@@ -495,7 +511,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                 payload,
                 contentType,
                 getTelemetrySender(tenant),
-                TelemetryConstants.TELEMETRY_ENDPOINT);
+                EndpointType.TELEMETRY);
     }
 
     /**
@@ -544,23 +560,29 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                 payload,
                 contentType,
                 getEventSender(tenant),
-                EventConstants.EVENT_ENDPOINT);
+                EndpointType.EVENT);
     }
 
-    private void doUploadMessage(final RoutingContext ctx, final String tenant, final String deviceId,
-            final Buffer payload, final String contentType, final Future<MessageSender> senderTracker, final String endpointName) {
+    private void doUploadMessage(
+            final RoutingContext ctx,
+            final String tenant,
+            final String deviceId,
+            final Buffer payload,
+            final String contentType,
+            final Future<MessageSender> senderTracker,
+            final EndpointType endpoint) {
 
         if (!isPayloadOfIndicatedType(payload, contentType)) {
             HttpUtils.badRequest(ctx, String.format("content type [%s] does not match payload", contentType));
         } else {
             final String qosHeaderValue = ctx.request().getHeader(Constants.HEADER_QOS_LEVEL);
-            final Integer qos = getQoSLevel(qosHeaderValue);
-            if (qos != null && qos == HEADER_QOS_INVALID) {
+            final MetricsTags.QoS qos = getQoSLevel(qosHeaderValue);
+            if (MetricsTags.QoS.UNKNOWN.equals(qos)) {
                 HttpUtils.badRequest(ctx, "unsupported QoS-Level header value");
             } else {
 
                 final Device authenticatedDevice = getAuthenticatedDevice(ctx);
-                final Span currentSpan = tracer.buildSpan("upload " + endpointName)
+                final Span currentSpan = tracer.buildSpan("upload " + endpoint.getCanonicalName())
                         .asChildOf(TracingHandler.serverSpanContext(ctx))
                         .ignoreActiveSpan()
                         .withTag(Tags.COMPONENT.getKey(), getTypeName())
@@ -568,6 +590,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                         .withTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenant)
                         .withTag(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId)
                         .withTag(TracingHelper.TAG_AUTHENTICATED.getKey(), authenticatedDevice != null)
+                        .withTag(Constants.HEADER_QOS_LEVEL, qos.asTag().getValue())
                         .start();
 
                 final Future<Void> responseReady = Future.future();
@@ -580,7 +603,9 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                 final Future<Integer> ttdTracker = tenantConfigTracker.compose(tenantObj -> {
                     final Integer ttdParam = HttpUtils.getTimeTilDisconnect(ctx);
                     return getTimeUntilDisconnect(tenantObj, ttdParam).map(effectiveTtd -> {
-                        if (effectiveTtd != null) {
+                        if (effectiveTtd == null) {
+                            setTtdStatus(ctx, MetricsTags.TtdStatus.NONE);
+                        } else {
                             currentSpan.setTag(MessageHelper.APP_PROPERTY_DEVICE_TTD, effectiveTtd);
                         }
                         return effectiveTtd;
@@ -597,7 +622,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                         final Integer ttd = Optional.ofNullable(commandConsumerTracker.result()).map(c -> ttdTracker.result())
                                 .orElse(null);
                         final Message downstreamMessage = newMessage(
-                                ResourceIdentifier.from(endpointName, tenant, deviceId),
+                                ResourceIdentifier.from(endpoint.getCanonicalName(), tenant, deviceId),
                                 sender.isRegistrationAssertionRequired(),
                                 ctx.request().uri(),
                                 contentType,
@@ -608,13 +633,13 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
 
                         addConnectionCloseHandler(ctx, commandConsumerTracker.result(), tenant, deviceId, currentSpan);
 
-                        if (qos == null) {
+                        if (MetricsTags.QoS.AT_MOST_ONCE.equals(qos)) {
                             return CompositeFuture.all(
                                     sender.send(downstreamMessage, currentSpan.context()),
                                     responseReady)
                                     .map(s -> (Void) null);
                         } else {
-                            currentSpan.setTag(Constants.HEADER_QOS_LEVEL, qosHeaderValue);
+                            // unsettled
                             return CompositeFuture.all(
                                     sender.sendAndWaitForOutcome(downstreamMessage, currentSpan.context()),
                                     responseReady)
@@ -640,7 +665,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
 
                     if (ctx.response().closed()) {
                         LOG.debug("failed to send http response for [{}] message from device [tenantId: {}, deviceId: {}]: response already closed",
-                                endpointName, tenant, deviceId);
+                                endpoint, tenant, deviceId);
                         TracingHelper.logError(currentSpan, "failed to send HTTP response to device: response already closed");
                         currentSpan.finish();
                     } else {
@@ -648,14 +673,20 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                         setResponsePayload(ctx.response(), commandContext, currentSpan);
                         ctx.addBodyEndHandler(ok -> {
                             LOG.trace("successfully processed [{}] message for device [tenantId: {}, deviceId: {}]",
-                                    endpointName, tenant, deviceId);
-                            metrics.incrementProcessedMessages(endpointName, tenant);
-                            metrics.incrementProcessedPayload(endpointName, tenant, messagePayloadSize(ctx));
+                                    endpoint, tenant, deviceId);
                             if (commandContext != null) {
                                 commandContext.getCurrentSpan().log("forwarded command to device in HTTP response body");
                                 commandContext.accept();
                                 metrics.incrementCommandDeliveredToDevice(tenant);
                             }
+                            metrics.reportTelemetry(
+                                    endpoint,
+                                    tenant,
+                                    MetricsTags.ProcessingOutcome.FORWARDED,
+                                    qos,
+                                    getTtdStatus(ctx),
+                                    getMicrometerSample(ctx));
+                            metrics.incrementProcessedPayload(endpoint, tenant, messagePayloadSize(ctx));
                             currentSpan.finish();
                             // the command consumer is used for a single request only
                             // we can close the consumer only AFTER we have accepted a
@@ -664,7 +695,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                         });
                         ctx.response().exceptionHandler(t -> {
                             LOG.debug("failed to send http response for [{}] message from device [tenantId: {}, deviceId: {}]",
-                                    endpointName, tenant, deviceId, t);
+                                    endpoint, tenant, deviceId, t);
                             if (commandContext != null) {
                                 commandContext.getCurrentSpan().log("failed to forward command to device in HTTP response body");
                                 TracingHelper.logError(commandContext.getCurrentSpan(), t);
@@ -687,7 +718,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                 .recover(t -> {
 
                     LOG.debug("cannot process [{}] message from device [tenantId: {}, deviceId: {}]",
-                            endpointName, tenant, deviceId, t);
+                            endpoint, tenant, deviceId, t);
                     final CommandContext commandContext = ctx.get(CommandContext.KEY_COMMAND_CONTEXT);
                     if (commandContext != null) {
                         commandContext.release();
@@ -698,10 +729,11 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                     Optional.ofNullable(commandConsumerTracker.result()).ifPresent(consumer -> consumer.close(null));
 
                     if (ClientErrorException.class.isInstance(t)) {
+                        metrics.reportTelemetry(endpoint, tenant, MetricsTags.ProcessingOutcome.UNPROCESSABLE, qos, getTtdStatus(ctx), getMicrometerSample(ctx));
                         final ClientErrorException e = (ClientErrorException) t;
                         ctx.fail(e);
                     } else {
-                        metrics.incrementUndeliverableMessages(endpointName, tenant);
+                        metrics.reportTelemetry(endpoint, tenant, MetricsTags.ProcessingOutcome.UNDELIVERABLE, qos, getTtdStatus(ctx), getMicrometerSample(ctx));
                         HttpUtils.serviceUnavailable(ctx, 2, "temporarily unavailable");
                     }
                     TracingHelper.logError(currentSpan, t);
@@ -754,7 +786,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                 currentSpan.log("device closed connection");
                 cancelCommandReceptionTimer(ctx);
                 messageConsumer.close(null);
-                metrics.incrementNoCommandReceivedAndTTDExpired(tenantId);
             });
         }
     }
@@ -841,6 +872,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                                 // put command context to routing context and notify
                                 ctx.put(CommandContext.KEY_COMMAND_CONTEXT, commandContext);
                                 cancelCommandReceptionTimer(ctx);
+                                setTtdStatus(ctx, MetricsTags.TtdStatus.COMMAND);
                                 responseReady.tryComplete();
                             }
                         } else {
@@ -904,6 +936,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             } else {
                 // no command to be sent,
                 // send empty response
+                setTtdStatus(ctx, MetricsTags.TtdStatus.EXPIRED);
                 responseReady.complete();
             }
         });
@@ -1009,15 +1042,16 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
         }
     }
 
-    private static Integer getQoSLevel(final String qosValue) {
-        try {
-            if (qosValue == null) {
-                return null;
-            } else {
-                return Integer.parseInt(qosValue) != AT_LEAST_ONCE ? HEADER_QOS_INVALID : AT_LEAST_ONCE;
+    private static MetricsTags.QoS getQoSLevel(final String qosValue) {
+
+        if (qosValue == null) {
+            return MetricsTags.QoS.AT_MOST_ONCE;
+        } else {
+            try {
+                return MetricsTags.QoS.from(Integer.parseInt(qosValue));
+            } catch (final NumberFormatException e) {
+                return MetricsTags.QoS.UNKNOWN;
             }
-        } catch (final NumberFormatException e) {
-            return HEADER_QOS_INVALID;
         }
     }
 }

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
@@ -30,6 +30,9 @@ public interface HttpAdapterMetrics extends Metrics {
         }
     }
 
+    /**
+     * The no-op implementation.
+     */
     HttpAdapterMetrics NOOP = new Noop();
 
     // empty for now

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
@@ -30,6 +30,9 @@ public interface MqttAdapterMetrics extends Metrics {
         }
     }
 
+    /**
+     * The no-op implementation.
+     */
     MqttAdapterMetrics NOOP = new Noop();
 
     // empty for now

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/MqttContextTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/MqttContextTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.EndpointType;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.Test;
@@ -65,16 +66,16 @@ public class MqttContextTest {
 
         assertEndpoint(
                 newMessage(TelemetryConstants.TELEMETRY_ENDPOINT_SHORT, "tenant", "device"),
-                TelemetryConstants.TELEMETRY_ENDPOINT);
+                EndpointType.TELEMETRY);
         assertEndpoint(
                 newMessage(EventConstants.EVENT_ENDPOINT_SHORT, "tenant", "device"),
-                EventConstants.EVENT_ENDPOINT);
+                EndpointType.EVENT);
         assertEndpoint(
                 newMessage(CommandConstants.COMMAND_ENDPOINT_SHORT, "tenant", "device"),
-                CommandConstants.COMMAND_ENDPOINT);
+                EndpointType.CONTROL);
     }
 
-    private static void assertEndpoint(final MqttPublishMessage msg, final String expectedEndpoint) {
+    private static void assertEndpoint(final MqttPublishMessage msg, final EndpointType expectedEndpoint) {
         final MqttContext context = MqttContext.fromPublishPacket(msg, mock(MqttEndpoint.class));
         assertThat(context.endpoint(), is(expectedEndpoint));
     }

--- a/core/src/main/java/org/eclipse/hono/util/EndpointType.java
+++ b/core/src/main/java/org/eclipse/hono/util/EndpointType.java
@@ -45,7 +45,7 @@ public enum EndpointType {
      * 
      * @return The name.
      */
-    public String canonicalName() {
+    public String getCanonicalName() {
         return canonicalName;
     }
 

--- a/deploy/src/main/config/grafana/dashboard-definitions/message-details.json
+++ b/deploy/src/main/config/grafana/dashboard-definitions/message-details.json
@@ -57,7 +57,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(hono_messages_processed_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range])",
+          "expr": "irate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{component_name}} - {{type}} - {{host}}",
@@ -165,7 +165,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_processed_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
+          "expr": "sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -246,7 +246,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_processed_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
+          "expr": "sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -327,7 +327,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_processed_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
+          "expr": "sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -824,7 +824,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_undeliverable_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))\n/\n(\n  sum(rate(hono_messages_undeliverable_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))\n  +\n  sum(rate(hono_messages_processed_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))\n)",
+          "expr": "sum(rate(hono_messages_undeliverable_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))\n/\n(\n  sum(rate(hono_messages_undeliverable_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))\n  +\n  sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))\n)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,

--- a/deploy/src/main/config/grafana/dashboard-definitions/overview.json
+++ b/deploy/src/main/config/grafana/dashboard-definitions/overview.json
@@ -142,7 +142,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_processed_total{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -385,7 +385,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_processed_total{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -869,7 +869,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_processed_total{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -984,7 +984,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_processed_total{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -1553,7 +1553,7 @@
         "multi": true,
         "name": "tenant",
         "options": [],
-        "query": "label_values(hono_messages_processed_total,tenant)",
+        "query": "label_values(hono_messages_received_seconds_count,tenant)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/AbstractLegacyMetricsConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/AbstractLegacyMetricsConfig.java
@@ -142,9 +142,10 @@ public abstract class AbstractLegacyMetricsConfig {
      */
     public MeterFilter[] getMeterFilters() {
         return new MeterFilter[] {
+                                MeterFilter.denyNameStartsWith(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED),
                                 MeterFilter.replaceTagValues(MetricsTags.TAG_HOST, host -> host.replace('.', '_')),
                                 MeterFilter.replaceTagValues(MetricsTags.TAG_TENANT, tenant -> tenant.replace('.', '_')),
-                                MeterFilter.ignoreTags(MetricsTags.TAG_COMPONENT_TYPE),
+                                MeterFilter.ignoreTags(MetricsTags.ComponentType.TAG_NAME),
                                 meterTypeMapper() };
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/LegacyMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/LegacyMetrics.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.metric;
+
+import org.eclipse.hono.util.EndpointType;
+
+/**
+ * A service for reporting legacy metrics.
+ */
+public interface LegacyMetrics {
+
+    /**
+     * Reports a message received from a device as <em>processed</em>.
+     *
+     * @param type The type of message received, e.g. <em>telemetry</em> or <em>event</em>.
+     * @param tenantId The tenant that the device belongs to.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    void incrementProcessedMessages(EndpointType type, String tenantId);
+
+    /**
+     * Reports a message received from a device as <em>undeliverable</em>.
+     * <p>
+     * A message is considered undeliverable if the failure to deliver has not been caused by the device
+     * that the message originates from. In particular, messages that cannot be authorized or
+     * that are published to an unsupported/unrecognized endpoint do not fall into this category.
+     * Such messages should be silently discarded instead.
+     * 
+     * @param type The type of message received, e.g. <em>telemetry</em> or <em>event</em>.
+     * @param tenantId The tenant that the device belongs to.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    void incrementUndeliverableMessages(EndpointType type, String tenantId);
+
+    /**
+     * Reports a TTD having expired without a command being delivered
+     * to a device.
+     * 
+     * @param tenantId The tenant that the device belongs to.
+     * @throws NullPointerException if tenant is {@code null}.
+     */
+    void incrementNoCommandReceivedAndTTDExpired(String tenantId);
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/LegacyMetricsConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/LegacyMetricsConfig.java
@@ -60,7 +60,7 @@ public class LegacyMetricsConfig extends AbstractLegacyMetricsConfig {
                     // itself
                     newTags.add(Tag.of(TAG_TYPE_SUFFIX, "count"));
 
-                } else if (MicrometerBasedMetrics.METER_MESSAGES_UNDELIVERABLE.equals(id.getName())) {
+                } else if (MicrometerBasedLegacyMetrics.METER_MESSAGES_UNDELIVERABLE.equals(id.getName())) {
 
                     // map component name to protocol
                     mapComponentName(id, newTags);

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MetricsTags.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MetricsTags.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.hono.service.metric;
 
+import java.util.Objects;
+
+import org.eclipse.hono.util.EndpointType;
 import org.eclipse.hono.util.Hostnames;
 
 import io.micrometer.core.instrument.Tag;
@@ -24,38 +27,224 @@ import io.micrometer.core.instrument.Tags;
 public final class MetricsTags {
 
     /**
-     * The tag that holds the name of the host that the component
-     * reporting a metric is running on.
+     * The type of component.
      */
-    public static final String TAG_HOST = "host";
+    public enum ComponentType {
+
+        /**
+         * A service component.
+         */
+        SERVICE,
+        /**
+         * A protocol adapter.
+         */
+        ADAPTER();
+
+        static final String TAG_NAME = "component-type";
+
+        private final Tag tag;
+
+        ComponentType() {
+            this.tag = Tag.of(TAG_NAME, name().toLowerCase());
+        }
+
+        /**
+         * Gets a <em>Micrometer</em> tag for the component type.
+         * 
+         * @return The tag.
+         */
+        public Tag asTag() {
+            return tag;
+        }
+    }
+
     /**
-     * The name of the tag that holds the type of component that
-     * reports a metric.
+     * A status indicating the outcome of processing a message received from a device.
+     *
      */
-    public static final String TAG_COMPONENT_TYPE = "component-type";
+    public enum ProcessingOutcome {
+
+        /**
+         * The outcome indicating that a message has been forwarded to the receiver.
+         */
+        FORWARDED("forwarded"),
+        /**
+         * The outcome indicating that a message could not be delivered to the receiver.
+         */
+        UNDELIVERABLE("undeliverable"),
+        /**
+         * The outcome indicating that a message could not be processed, e.g. because it is malformed.
+         */
+        UNPROCESSABLE("unprocessable");
+
+        static final String TAG_NAME = "status";
+
+        private final Tag tag;
+
+        ProcessingOutcome(final String tagValue) {
+            this.tag = Tag.of(TAG_NAME, tagValue);
+        }
+
+        /**
+         * Gets a <em>Micrometer</em> tag for the outcome.
+         * 
+         * @return The tag.
+         */
+        public Tag asTag() {
+            return tag;
+        }
+    }
+
     /**
-     * The name of the tag that holds the name of the component
-     * that reports a metric.
+     * Status indicating the outcome of processing a TTD value contained in a message received from a device.
+     *
      */
-    public static final String TAG_COMPONENT_NAME = "component-name";
+    public enum TtdStatus {
+
+        /**
+         * Status indicating that the message from the device did not contain a TTD value.
+         */
+        NONE(),
+        /**
+         * Status indicating that the TTD expired without any pending commands for the device.
+         */
+        EXPIRED("expired"),
+        /**
+         * Status indicating a pending command for the device before the TTD expired.
+         */
+        COMMAND("command");
+
+        static final String TAG_NAME = "ttd";
+
+        private final Tag tag;
+
+        TtdStatus() {
+            this.tag = null;
+        }
+
+        TtdStatus(final String tagValue) {
+            this.tag = Tag.of(TAG_NAME, tagValue);
+        }
+
+        /**
+         * Gets a <em>Micrometer</em> tag for the TTD status.
+         * 
+         * @return The tag or {@code null} if the status is {@link #NONE}.
+         */
+        public Tag asTag() {
+            return tag;
+        }
+
+        /**
+         * Adds a tag for the TTD status to a given set of tags.
+         * <p>
+         * The tag is only added if the status is not {@link #NONE}.
+         * 
+         * @param tags The tags to add to.
+         * @return The tags.
+         * @throws NullPointerException if tags is {@code null}.
+         */
+        public Tags add(final Tags tags) {
+            Objects.requireNonNull(tags);
+            if (tag == null) {
+                return tags;
+            } else {
+                return tags.and(tag);
+            }
+        }
+    }
+
     /**
-     * The name of the tag that holds the identifier of the tenant
-     * that a metric has been reported for.
+     * Quality of service used for sending a message.
      */
-    public static final String TAG_TENANT = "tenant";
+    public enum QoS {
+
+        /**
+         * QoS indicating unknown delivery semantics.
+         */
+        UNKNOWN(),
+        /**
+         * QoS (level 0) indicating at-most-once delivery semantics.
+         */
+        AT_MOST_ONCE("0"),
+        /**
+         * QoS (level 1) indicating at-least-once delivery semantics.
+         */
+        AT_LEAST_ONCE("1");
+
+        static final String TAG_NAME = "qos";
+
+        private Tag tag;
+
+        QoS() {
+            this.tag = null;
+        }
+
+        QoS(final String tagValue) {
+            this.tag = Tag.of(TAG_NAME, tagValue);
+        }
+
+        /**
+         * Gets the QoS for a level.
+         * 
+         * @param level The level.
+         * @return The corresponding quality of service.
+         */
+        public static QoS from(final int level) {
+            switch (level) {
+            case 0:
+                return AT_MOST_ONCE;
+            case 1:
+                return AT_LEAST_ONCE;
+            default:
+                return UNKNOWN;
+            }
+        }
+
+        /**
+         * Gets a <em>Micrometer</em> tag for the QoS level.
+         * 
+         * @return The tag or {@code null} if the status is {@link #UNKNOWN}.
+         */
+        public Tag asTag() {
+            return tag;
+        }
+
+        /**
+         * Adds a tag for the QoS level to a given set of tags.
+         * <p>
+         * The tag is only added if the status is not {@link #UNKNOWN}.
+         * 
+         * @param tags The tags to add to.
+         * @return The tags.
+         * @throws NullPointerException if tags is {@code null}.
+         */
+        public Tags add(final Tags tags) {
+            Objects.requireNonNull(tags);
+            if (tag == null) {
+                return tags;
+            } else {
+                return tags.and(tag);
+            }
+        }
+    }
+
     /**
-     * The name of the tag that holds the type of message
-     * that a metric has been reported for.
+     * The name of the tag that holds the name of the component that reports a metric.
      */
-    public static final String TAG_TYPE = "type";
+    static final String TAG_COMPONENT_NAME = "component-name";
     /**
-     * The component type indicating a protocol adapter.
+     * The tag that holds the name of the host that the component reporting a metric is running on.
      */
-    public static final String VALUE_COMPONENT_TYPE_ADAPTER = "adapter";
+    static final String TAG_HOST           = "host";
     /**
-     * The component type indicating a service component.
+     * The name of the tag that holds the identifier of the tenant that a metric has been reported for.
      */
-    public static final String VALUE_COMPONENT_TYPE_SERVICE = "service";
+    static final String TAG_TENANT         = "tenant";
+    /**
+     * The name of the tag that holds the type of message that a metric has been reported for.
+     */
+    static final String TAG_TYPE           = "type";
 
     private MetricsTags() {
     }
@@ -69,7 +258,7 @@ public final class MetricsTags {
     public static Tags forProtocolAdapter(final String name) {
         return Tags.of(
                 Tag.of(MetricsTags.TAG_HOST, Hostnames.getHostname()),
-                Tag.of(MetricsTags.TAG_COMPONENT_TYPE, MetricsTags.VALUE_COMPONENT_TYPE_ADAPTER),
+                MetricsTags.ComponentType.ADAPTER.asTag(),
                 Tag.of(MetricsTags.TAG_COMPONENT_NAME, name));
     }
 
@@ -82,8 +271,31 @@ public final class MetricsTags {
     public static Tags forService(final String name) {
         return Tags.of(
                 Tag.of(MetricsTags.TAG_HOST, Hostnames.getHostname()),
-                Tag.of(MetricsTags.TAG_COMPONENT_TYPE, MetricsTags.VALUE_COMPONENT_TYPE_SERVICE),
+                MetricsTags.ComponentType.SERVICE.asTag(),
                 Tag.of(MetricsTags.TAG_COMPONENT_NAME, name));
     }
 
+    /**
+     * Creates a tag for a tenant identifier.
+     * 
+     * @param tenant The tenant.
+     * @return The tag.
+     * @throws NullPointerException if outcome is {@code null}.
+     */
+    public static Tag getTenantTag(final String tenant) {
+        Objects.requireNonNull(tenant);
+        return Tag.of(MetricsTags.TAG_TENANT, tenant);
+    }
+
+    /**
+     * Creates a tag for an endpoint type.
+     * 
+     * @param type The type.
+     * @return The tag.
+     * @throws NullPointerException if type is {@code null}.
+     */
+    public static Tag getTypeTag(final EndpointType type) {
+        Objects.requireNonNull(type);
+        return Tag.of(MetricsTags.TAG_TYPE, type.getCanonicalName());
+    }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedLegacyMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedLegacyMetrics.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.metric;
+
+import java.util.Objects;
+
+import org.eclipse.hono.util.EndpointType;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+
+/**
+ * Micrometer based legacy metrics implementation.
+ */
+@Component
+@ConditionalOnProperty(name = "hono.metrics.legacy", havingValue = "true")
+public final class MicrometerBasedLegacyMetrics implements LegacyMetrics {
+
+    /**
+     * The name of the meter for processed messages.
+     */
+    public static final String METER_MESSAGES_PROCESSED = "hono.messages.processed";
+
+    static final String METER_COMMANDS_TTD_EXPIRED = "hono.commands.ttd.expired";
+    static final String METER_MESSAGES_UNDELIVERABLE = "hono.messages.undeliverable";
+
+    /**
+     * The meter registry.
+     */
+    private final MeterRegistry registry;
+
+    /**
+     * Creates a new metrics instance.
+     * 
+     * @param registry The meter registry to use.
+     * @throws NullPointerException if registry is {@code null}.
+     */
+    public MicrometerBasedLegacyMetrics(final MeterRegistry registry) {
+
+        this.registry = Objects.requireNonNull(registry);
+    }
+
+    @Override
+    public void incrementProcessedMessages(final EndpointType type, final String tenantId) {
+
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(tenantId);
+        this.registry.counter(METER_MESSAGES_PROCESSED,
+                Tags.of(MetricsTags.TAG_TENANT, tenantId).and(MetricsTags.TAG_TYPE, type.getCanonicalName()))
+                .increment();
+    }
+
+    @Override
+    public void incrementUndeliverableMessages(final EndpointType type, final String tenantId) {
+
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(tenantId);
+        this.registry.counter(METER_MESSAGES_UNDELIVERABLE,
+                Tags.of(MetricsTags.TAG_TENANT, tenantId).and(MetricsTags.TAG_TYPE, type.getCanonicalName()))
+                .increment();
+    }
+
+    @Override
+    public void incrementNoCommandReceivedAndTTDExpired(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+        this.registry.counter(METER_COMMANDS_TTD_EXPIRED,
+                Tags.of(MetricsTags.TAG_TENANT, tenantId))
+                .increment();
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,13 +19,17 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
+import org.eclipse.hono.util.EndpointType;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Sample;
 
 /**
  * Micrometer based metrics implementation.
  */
-public abstract class MicrometerBasedMetrics implements Metrics {
+public class MicrometerBasedMetrics implements Metrics {
 
     /**
      * The name of the meter for authenticated connections.
@@ -36,14 +40,12 @@ public abstract class MicrometerBasedMetrics implements Metrics {
      */
     public static final String METER_CONNECTIONS_UNAUTHENTICATED = "hono.connections.unauthenticated";
     /**
-     * The name of the meter for processed messages.
+     * The name of the meter for messages received from devices.
      */
-    public static final String METER_MESSAGES_PROCESSED = "hono.messages.processed";
+    public static final String METER_MESSAGES_RECEIVED = "hono.messages.received";
 
     static final String METER_COMMANDS_DEVICE_DELIVERED = "hono.commands.device.delivered";
     static final String METER_COMMANDS_RESPONSE_DELIVERED = "hono.commands.response.delivered";
-    static final String METER_COMMANDS_TTD_EXPIRED = "hono.commands.ttd.expired";
-    static final String METER_MESSAGES_UNDELIVERABLE = "hono.messages.undeliverable";
 
     /**
      * The meter registry.
@@ -54,18 +56,29 @@ public abstract class MicrometerBasedMetrics implements Metrics {
     private final AtomicLong unauthenticatedConnections;
     private final AtomicLong totalCurrentConnections = new AtomicLong();
 
+    private LegacyMetrics legacyMetrics;
+
     /**
      * Creates a new metrics instance.
      * 
      * @param registry The meter registry to use.
      * @throws NullPointerException if registry is {@code null}.
      */
-    public MicrometerBasedMetrics(final MeterRegistry registry) {
+    protected MicrometerBasedMetrics(final MeterRegistry registry) {
 
         Objects.requireNonNull(registry);
 
         this.registry = registry;
         this.unauthenticatedConnections = registry.gauge(METER_CONNECTIONS_UNAUTHENTICATED, new AtomicLong());
+    }
+
+    /**
+     * Sets the legacy metrics.
+     * 
+     * @param legacyMetrics The additional legacy metrics to report.
+     */
+    public final void setLegacyMetrics(final LegacyMetrics legacyMetrics) {
+        this.legacyMetrics = legacyMetrics;
     }
 
     @Override
@@ -106,29 +119,82 @@ public abstract class MicrometerBasedMetrics implements Metrics {
     }
 
     @Override
-    public final void incrementProcessedMessages(final String type, final String tenantId) {
-
-        Objects.requireNonNull(type);
-        Objects.requireNonNull(tenantId);
-        this.registry.counter(METER_MESSAGES_PROCESSED,
-                Tags.of(MetricsTags.TAG_TENANT, tenantId).and(MetricsTags.TAG_TYPE, type))
-                .increment();
-
+    public Sample startTimer() {
+        return Timer.start(registry);
     }
 
     @Override
-    public final void incrementUndeliverableMessages(final String type, final String tenantId) {
+    public final void reportTelemetry(
+            final EndpointType type,
+            final String tenantId,
+            final MetricsTags.ProcessingOutcome outcome,
+            final MetricsTags.QoS qos,
+            final Sample timer) {
 
-        Objects.requireNonNull(type);
-        Objects.requireNonNull(tenantId);
-        this.registry.counter(METER_MESSAGES_UNDELIVERABLE,
-                Tags.of(MetricsTags.TAG_TENANT, tenantId).and(MetricsTags.TAG_TYPE, type))
-                .increment();
-
+        reportTelemetry(type, tenantId, outcome, qos, MetricsTags.TtdStatus.NONE, timer);
     }
 
     @Override
-    public final void incrementProcessedPayload(final String type, final String tenantId,
+    public final void reportTelemetry(
+            final EndpointType type,
+            final String tenantId,
+            final MetricsTags.ProcessingOutcome outcome,
+            final MetricsTags.QoS qos,
+            final MetricsTags.TtdStatus ttdStatus,
+            final Sample timer) {
+
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(outcome);
+        Objects.requireNonNull(qos);
+        Objects.requireNonNull(ttdStatus);
+        Objects.requireNonNull(timer);
+
+        if (!EndpointType.TELEMETRY.equals(type) && !EndpointType.EVENT.equals(type)) {
+            throw new IllegalArgumentException("invalid type, must be either telemetry or event");
+        }
+
+        final Tags tags = 
+                ttdStatus.add(
+                        qos.add(
+                            Tags.of(MetricsTags.getTypeTag(type))
+                                .and(MetricsTags.getTenantTag(tenantId))
+                                .and(outcome.asTag())));
+
+        timer.stop(this.registry.timer(METER_MESSAGES_RECEIVED, tags));
+
+        if (legacyMetrics != null) {
+
+             // The legacy metric for processed messages is based on a counter
+             // instead of a timer. It is necessary to report the legacy
+             // metric in addition to the new one because the value types
+             // are incompatible (duration vs. occurrences).
+            switch(outcome) {
+            case FORWARDED:
+                legacyMetrics.incrementProcessedMessages(type, tenantId);
+                break;
+            case UNDELIVERABLE:
+                legacyMetrics.incrementUndeliverableMessages(type, tenantId);
+                break;
+            case UNPROCESSABLE:
+                // no corresponding legacy metric
+            }
+
+            // The legacy metrics contain a separate metric for
+            // counting the number of messages that contained
+            // an expired TTD value.
+            switch(ttdStatus) {
+            case EXPIRED:
+                legacyMetrics.incrementNoCommandReceivedAndTTDExpired(tenantId);
+                break;
+            default:
+                // nothing to do
+            }
+        }
+    }
+
+    @Override
+    public final void incrementProcessedPayload(final EndpointType type, final String tenantId,
             final long payloadSize) {
 
         Objects.requireNonNull(type);
@@ -139,7 +205,7 @@ public abstract class MicrometerBasedMetrics implements Metrics {
         }
 
         this.registry.counter("hono.messages.processed.payload",
-                Tags.of(MetricsTags.TAG_TENANT, tenantId).and(MetricsTags.TAG_TYPE, type))
+                Tags.of(MetricsTags.getTenantTag(tenantId)).and(MetricsTags.getTypeTag(type)))
                 .increment(payloadSize);
     }
 
@@ -148,17 +214,7 @@ public abstract class MicrometerBasedMetrics implements Metrics {
 
         Objects.requireNonNull(tenantId);
         this.registry.counter(METER_COMMANDS_DEVICE_DELIVERED,
-                Tags.of(MetricsTags.TAG_TENANT, tenantId))
-                .increment();
-
-    }
-
-    @Override
-    public final void incrementNoCommandReceivedAndTTDExpired(final String tenantId) {
-
-        Objects.requireNonNull(tenantId);
-        this.registry.counter(METER_COMMANDS_TTD_EXPIRED,
-                Tags.of(MetricsTags.TAG_TENANT, tenantId))
+                Tags.of(MetricsTags.getTenantTag(tenantId)))
                 .increment();
 
     }
@@ -168,7 +224,7 @@ public abstract class MicrometerBasedMetrics implements Metrics {
 
         Objects.requireNonNull(tenantId);
         this.registry.counter(METER_COMMANDS_RESPONSE_DELIVERED,
-                Tags.of(MetricsTags.TAG_TENANT, tenantId))
+                Tags.of(MetricsTags.getTenantTag(tenantId)))
                 .increment();
 
     }
@@ -203,7 +259,7 @@ public abstract class MicrometerBasedMetrics implements Metrics {
      * Gets a gauge value for a tenant.
      * <p>
      * If no gauge value exists for the given tenant yet, a new value
-     * is created using the given name and the {@link MetricsTags#TAG_TENANT} tag.
+     * is created using the given name and a tag for the tenant.
      * 
      * @param <V> The type of the gauge's value.
      * @param name The metric name.
@@ -215,7 +271,7 @@ public abstract class MicrometerBasedMetrics implements Metrics {
     protected <V extends Number> V gaugeForTenant(final String name, final Map<String, V> map, final String tenant,
             final Supplier<V> instanceSupplier) {
 
-        return gaugeForKey(name, map, tenant, Tags.of(MetricsTags.TAG_TENANT, tenant), instanceSupplier);
+        return gaugeForKey(name, map, tenant, Tags.of(MetricsTags.getTenantTag(tenant)), instanceSupplier);
 
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
@@ -13,16 +13,19 @@
 
 package org.eclipse.hono.service.metric;
 
+import org.eclipse.hono.util.EndpointType;
+
+import io.micrometer.core.instrument.Timer.Sample;
+
 /**
  * A no-op metrics implementation.
  */
 public class NoopBasedMetrics implements Metrics {
 
+    /**
+     * Creates a new instance.
+     */
     protected NoopBasedMetrics() {
-    }
-
-    @Override
-    public void incrementUndeliverableMessages(final String type, final String tenantId) {
     }
 
     @Override
@@ -30,15 +33,7 @@ public class NoopBasedMetrics implements Metrics {
     }
 
     @Override
-    public void incrementProcessedPayload(final String type, final String tenantId, final long payloadSize) {
-    }
-
-    @Override
-    public void incrementProcessedMessages(final String type, final String tenantId) {
-    }
-
-    @Override
-    public void incrementNoCommandReceivedAndTTDExpired(final String tenantId) {
+    public void incrementProcessedPayload(final EndpointType type, final String tenantId, final long payloadSize) {
     }
 
     @Override
@@ -64,5 +59,29 @@ public class NoopBasedMetrics implements Metrics {
     @Override
     public long getNumberOfConnections() {
         return 0;
+    }
+
+    @Override
+    public Sample startTimer() {
+        return null;
+    }
+
+    @Override
+    public void reportTelemetry(
+            final EndpointType type,
+            final String tenantId,
+            final MetricsTags.ProcessingOutcome outcome,
+            final MetricsTags.QoS qos,
+            final Sample timer) {
+    }
+
+    @Override
+    public void reportTelemetry(
+            final EndpointType type,
+            final String tenantId,
+            final MetricsTags.ProcessingOutcome outcome,
+            final MetricsTags.QoS qos,
+            final MetricsTags.TtdStatus ttdStatus,
+            final Sample timer) {
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NoopLegacyMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NoopLegacyMetrics.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.metric;
+
+import org.eclipse.hono.util.EndpointType;
+
+/**
+ * A no-op legacy metrics implementation.
+ */
+public class NoopLegacyMetrics implements LegacyMetrics {
+
+    /**
+     * Creates a new instance.
+     */
+    protected NoopLegacyMetrics() {
+    }
+
+    @Override
+    public void incrementUndeliverableMessages(final EndpointType type, final String tenantId) {
+    }
+
+    @Override
+    public void incrementProcessedMessages(final EndpointType type, final String tenantId) {
+    }
+
+    @Override
+    public void incrementNoCommandReceivedAndTTDExpired(final String tenantId) {
+    }
+}

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/LegacyMetricsConfigTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/LegacyMetricsConfigTest.java
@@ -75,7 +75,7 @@ public class LegacyMetricsConfigTest {
     public void testMappingOfHttpAdapterMetrics() {
 
         final Tags httpTags = defaultTags
-                .and(MetricsTags.TAG_COMPONENT_TYPE, MetricsTags.VALUE_COMPONENT_TYPE_ADAPTER)
+                .and(MetricsTags.ComponentType.ADAPTER.asTag())
                 .and(MetricsTags.TAG_COMPONENT_NAME, Constants.PROTOCOL_ADAPTER_TYPE_HTTP)
                 .and(MetricsTags.TAG_TENANT, TENANT);
 
@@ -90,7 +90,7 @@ public class LegacyMetricsConfigTest {
     public void testMappingOfMqttAdapterMetrics() {
 
         final Tags mqttTags = defaultTags
-                .and(MetricsTags.TAG_COMPONENT_TYPE, MetricsTags.VALUE_COMPONENT_TYPE_ADAPTER)
+                .and(MetricsTags.ComponentType.ADAPTER.asTag())
                 .and(MetricsTags.TAG_COMPONENT_NAME, Constants.PROTOCOL_ADAPTER_TYPE_MQTT);
         assertConnectionMetrics("mqtt", mqttTags);
 
@@ -108,7 +108,7 @@ public class LegacyMetricsConfigTest {
                         HOSTNAME_MAPPED, protocol, TENANT));
 
         assertMapping(
-                new Id(MicrometerBasedMetrics.METER_COMMANDS_TTD_EXPIRED, tags, null, null, Type.COUNTER),
+                new Id(MicrometerBasedLegacyMetrics.METER_COMMANDS_TTD_EXPIRED, tags, null, null, Type.COUNTER),
                 String.format("%s.meter.hono.%s.commands.%s.ttd.expired",
                         HOSTNAME_MAPPED, protocol, TENANT));
 
@@ -122,11 +122,11 @@ public class LegacyMetricsConfigTest {
         final Tags telemetryTags = tags.and(MetricsTags.TAG_TYPE, TelemetryConstants.TELEMETRY_ENDPOINT);
 
         assertMapping(
-                new Id(MicrometerBasedMetrics.METER_MESSAGES_PROCESSED, telemetryTags, null, null, Type.COUNTER),
+                new Id(MicrometerBasedLegacyMetrics.METER_MESSAGES_PROCESSED, telemetryTags, null, null, Type.COUNTER),
                 String.format("%s.meter.hono.%s.messages.telemetry.%s.processed",
                         HOSTNAME_MAPPED, protocol, TENANT));
         assertMapping(
-                new Id(MicrometerBasedMetrics.METER_MESSAGES_UNDELIVERABLE, telemetryTags, null, null, Type.COUNTER),
+                new Id(MicrometerBasedLegacyMetrics.METER_MESSAGES_UNDELIVERABLE, telemetryTags, null, null, Type.COUNTER),
                 String.format("%s.counter.hono.%s.messages.telemetry.%s.undeliverable",
                         HOSTNAME_MAPPED, protocol, TENANT));
 
@@ -135,11 +135,11 @@ public class LegacyMetricsConfigTest {
         final Tags eventTags = tags.and(MetricsTags.TAG_TYPE, EventConstants.EVENT_ENDPOINT);
 
         assertMapping(
-                new Id(MicrometerBasedMetrics.METER_MESSAGES_PROCESSED, eventTags, null, null, Type.COUNTER),
+                new Id(MicrometerBasedLegacyMetrics.METER_MESSAGES_PROCESSED, eventTags, null, null, Type.COUNTER),
                 String.format("%s.meter.hono.%s.messages.event.%s.processed",
                         HOSTNAME_MAPPED, protocol, TENANT));
         assertMapping(
-                new Id(MicrometerBasedMetrics.METER_MESSAGES_UNDELIVERABLE, eventTags, null, null, Type.COUNTER),
+                new Id(MicrometerBasedLegacyMetrics.METER_MESSAGES_UNDELIVERABLE, eventTags, null, null, Type.COUNTER),
                 String.format("%s.counter.hono.%s.messages.event.%s.undeliverable",
                         HOSTNAME_MAPPED, protocol, TENANT));
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.service.metric;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.eclipse.hono.service.metric.MetricsTags.QoS;
+import org.eclipse.hono.service.metric.MetricsTags.TtdStatus;
+import org.eclipse.hono.util.EndpointType;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+
+/**
+ * Verifies behavior of {@link MicrometerBasedMetrics}.
+ *
+ */
+public class MicrometerBasedMetricsTest {
+
+    private MeterRegistry registry;
+    private MicrometerBasedMetrics metrics;
+
+    /**
+     * Sets up the fixture.
+     */
+    @Before
+    public void setUp() {
+        registry = new SimpleMeterRegistry();
+        metrics = new MicrometerBasedMetrics(registry);
+    }
+
+    /**
+     * Verifies that when reporting a downstream message no tags for
+     * {@link QoS#UNKNOWN} nor {@link TtdStatus#NONE} are included.
+     */
+    @Test
+    public void testReportTelemetryOmitsOptionalTags() {
+
+        metrics.reportTelemetry(
+                EndpointType.TELEMETRY,
+                "tenant",
+                MetricsTags.ProcessingOutcome.FORWARDED,
+                MetricsTags.QoS.UNKNOWN,
+                MetricsTags.TtdStatus.NONE,
+                metrics.startTimer());
+
+        final Tags expectedTags = Tags.of(MetricsTags.getTypeTag(EndpointType.TELEMETRY))
+                .and(MetricsTags.getTenantTag("tenant"))
+                .and(MetricsTags.ProcessingOutcome.FORWARDED.asTag());
+
+        assertNotNull(registry.find(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED).tags(expectedTags).timer());
+
+        assertNull(registry.find(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED)
+                .tags(expectedTags).tagKeys(MetricsTags.QoS.TAG_NAME).timer());
+        assertNull(registry.find(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED)
+                .tags(expectedTags).tagKeys(MetricsTags.TtdStatus.TAG_NAME).timer());
+    }
+}

--- a/site/content/api/Metrics.md
+++ b/site/content/api/Metrics.md
@@ -56,23 +56,26 @@ The names of Hono's standard components are as follows:
 
 Additional tags for protocol adapters are:
 
-| Tag        | Value                              | Description |
-| ---------- | ---------------------------------- | ----------- |
-| *tenant*   | *string*                           | The name of the tenant that the metric is being reported for |
-| *type*     | `telemetry`, `event`             | The type of message that the metric is being reported for |
+| Tag        | Value                                                  | Description |
+| ---------- | ------------------------------------------------------ | ----------- |
+| *qos*      | `0`, `1`                                              | The quality of service used for a message. `0` indicates *at most once*, `1` indicates *at least once* delivery semantics. |
+| *status*   | `processed`, `unprocessable`, `undeliverable`     | The processing status of a message. |
+| *tenant*   | *string*                                               | The name of the tenant that the metric is being reported for |
+| *type*     | `telemetry`, `event`                                 | The type of (downstream) message that the metric is being reported for |
+| *ttd*      | `expired`, `command`                                 | A status indicating the outcome of processing a TTD value contained in a message received from a device. The value `command` indicates that a command for the device has been included in the response to the device's request for uploading the message. Note that this value can only be used by protocol adapters which use a request/response based transport protocol like HTTP. |
 
 Metrics provided by the protocol adapters are:
 
-| Metric                             | Type    | Tags                                                         | Description |
-| ---------------------------------- | ------- | ------------------------------------------------------------ | ----------- |
-| *hono.connections.authenticated*   | Gauge   | *host*, *component-type*, *component-name*, *tenant*         | Current number of connected, authenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
-| *hono.connections.unauthenticated* | Gauge   | *host*, *component-type*, *component-name*                   | Current number of connected, unauthenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
-| *hono.messages.undeliverable*      | Counter | *host*, *component-type*, *component-name*, *tenant*, *type* | Total number of undeliverable messages |
-| *hono.messages.processed*          | Counter | *host*, *component-type*, *component-name*, *tenant*, *type* | Total number of processed messages |
-| *hono.messages.processed.payload*  | Counter | *host*, *component-type*, *component-name*, *tenant*, *type* | Total number of processed payload bytes |
-| *hono.commands.device.delivered*   | Counter | *host*, *component-type*, *component-name*, *tenant*         | Total number of delivered commands |
-| *hono.commands.ttd.expired*        | Counter | *host*, *component-type*, *component-name*, *tenant*         | Total number of expired TTDs |
-| *hono.commands.response.delivered* | Counter | *host*, *component-type*, *component-name*, *tenant*         | Total number of delivered responses to commands |
+| Metric                             | Type    | Tags                                                                                         | Description |
+| ---------------------------------- | ------- | -------------------------------------------------------------------------------------------- | ----------- |
+| *hono.connections.authenticated*   | Gauge   | *host*, *component-type*, *component-name*, *tenant*                                         | Current number of connected, authenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
+| *hono.connections.unauthenticated* | Gauge   | *host*, *component-type*, *component-name*                                                   | Current number of connected, unauthenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
+| *hono.messages.received*           | Timer   | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*, \[*qos*,\] \[*ttd*\] | The time it took to process a message. |
+| *hono.messages.processed.payload*  | Counter | *host*, *component-type*, *component-name*, *tenant*, *type*                                 | Total number of processed payload bytes |
+| *hono.commands.device.delivered*   | Counter | *host*, *component-type*, *component-name*, *tenant*                                         | Total number of delivered commands |
+| *hono.commands.response.delivered* | Counter | *host*, *component-type*, *component-name*, *tenant*                                         | Total number of delivered responses to commands |
+
+Tag names in square brackets indicate that the tag is optional.
 
 ### Service Metrics
 


### PR DESCRIPTION
Use a Micrometer "timer" instead of a "counter" for the metrics reported
for downstream telemetry messages and events.
This way we can also monitor the avg time if takes to process messages
instead of tracking just the message rate itself.

The name of the metric has been changed to "hono.messages.received".
The following additional tags are used:
- status: indicates the processing status
- qos: the QoS level used for the message
- ttd: outcome of handling the TTD value provided by a device

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>