### PR TITLE
Fix unpack hono-demo-certs docker deploy

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -115,7 +115,6 @@
                                 hono-demo-certs
                             </includeArtifactIds>
                             <outputDirectory>${project.build.directory}/config</outputDirectory>
-                            <outputDirectory>${project.build.directory}/deploy/helm</outputDirectory>
                             <includes>
                                 *.pem,
                                 *.jks,
@@ -181,6 +180,11 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/config</directory>
+                                    <targetPath>deploy/helm</targetPath>
+                                    <filtering>true</filtering>
+                                </resource>
                                 <resource>
                                     <directory>${project.basedir}/src/main/config</directory>
                                     <targetPath>deploy/helm/config</targetPath>


### PR DESCRIPTION
Hi,

I was running https://www.eclipse.org/hono/getting-started/ and the swarm deploy script did not work due to missing certificates.

It seems that by adding helm you overrit `outputDirectory`. I changed it by copy into helm directory instead.

Let me know if that works for you.

Kai

Signed-off-by: Kai Zimmermann <kai.zimmermann@microsoft.com>