### PR TITLE
[#961] Include payload size in reporting of telemetry messages.

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -494,7 +494,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                         device.getTenantId(),
                         MetricsTags.ProcessingOutcome.FORWARDED,
                         waitForOutcome ? MetricsTags.QoS.AT_LEAST_ONCE : MetricsTags.QoS.AT_MOST_ONCE,
-                        MetricsTags.TtdStatus.NONE,
+                        payload.length(),
                         context.getTimer());
                 context.respondWithCode(ResponseCode.CHANGED);
                 return delivery;
@@ -506,7 +506,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                         device.getTenantId(),
                         ClientErrorException.class.isInstance(t) ? MetricsTags.ProcessingOutcome.UNPROCESSABLE : MetricsTags.ProcessingOutcome.UNDELIVERABLE,
                         waitForOutcome ? MetricsTags.QoS.AT_LEAST_ONCE : MetricsTags.QoS.AT_MOST_ONCE,
-                        MetricsTags.TtdStatus.NONE,
+                        payload.length(),
                         context.getTimer());
                 CoapErrorResponse.respond(context.getExchange(), t);
                 return Future.failedFuture(t);

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -281,6 +281,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
                     anyString(),
                     eq(MetricsTags.ProcessingOutcome.FORWARDED),
                     any(MetricsTags.QoS.class),
+                    anyInt(),
                     any(MetricsTags.TtdStatus.class),
                     any());
     }
@@ -320,6 +321,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
                 anyString(),
                 eq(MetricsTags.ProcessingOutcome.FORWARDED),
                 any(MetricsTags.QoS.class),
+                anyInt(),
                 any(MetricsTags.TtdStatus.class),
                 any());
 
@@ -332,9 +334,9 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
                 eq("tenant"),
                 eq(MetricsTags.ProcessingOutcome.FORWARDED),
                 any(MetricsTags.QoS.class),
+                eq(payload.length()),
                 any(MetricsTags.TtdStatus.class),
                 any());
-        verify(metrics).incrementProcessedPayload(any(MetricsTags.EndpointType.class), eq("tenant"), eq((long) payload.length()));
     }
 
     /**
@@ -366,6 +368,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
                 anyString(),
                 eq(MetricsTags.ProcessingOutcome.FORWARDED),
                 any(MetricsTags.QoS.class),
+                anyInt(),
                 any(MetricsTags.TtdStatus.class),
                 any());
     }
@@ -535,9 +538,9 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
                 eq("tenant"),
                 eq(MetricsTags.ProcessingOutcome.FORWARDED),
                 any(MetricsTags.QoS.class),
+                eq(payload.length()),
                 any(MetricsTags.TtdStatus.class),
                 any());
-        verify(metrics).incrementProcessedPayload(any(MetricsTags.EndpointType.class), eq("tenant"), eq((long) payload.length()));
     }
 
     /**

--- a/deploy/src/main/config/grafana/dashboard-definitions/message-details.json
+++ b/deploy/src/main/config/grafana/dashboard-definitions/message-details.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1549016699588,
+  "iteration": 1549025382653,
   "links": [],
   "panels": [
     {
@@ -68,7 +68,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Forwarded",
+      "title": "Succeeded",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -383,21 +383,35 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_processed_payload_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",status=\"forwarded\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{component_name}} - {{type}} - {{host}}",
+          "legendFormat": "forwarded",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",status=\"undeliverable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "undeliverable",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",status=\"unprocessable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "unprocessable",
+          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Processed payload",
+      "title": "Payload",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -495,7 +509,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_processed_payload_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
+          "expr": "sum(rate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -576,7 +590,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_processed_payload_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
+          "expr": "sum(rate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -657,7 +671,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_processed_payload_total{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
+          "expr": "sum(rate(hono_messages_payload_bytes_sum{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -712,15 +726,22 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status!=\"forwarded\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status=\"undeliverable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{component_name}} - {{type}} - {{host}}",
+          "legendFormat": "undeliverable",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status=\"unprocessable\",tenant=~\"$tenant\",host=~\"$instance\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "unprocessable",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -769,14 +790,14 @@
       "colorValue": true,
       "colors": [
         "#299c46",
-        "rgba(237, 129, 40, 0.89)",
+        "#e5ac0e",
         "#d44a3a"
       ],
       "datasource": "hono_metrics",
       "decimals": 0,
-      "format": "percentunit",
+      "format": "percent",
       "gauge": {
-        "maxValue": 0.2,
+        "maxValue": 30,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -825,7 +846,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status!=\"forwarded\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))\n/\n sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))\n",
+          "expr": "(sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",status!=\"forwarded\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval]))\n/\n sum(rate(hono_messages_received_seconds_count{component_name=~\"$componentname\",type=~\"$type\",tenant=~\"$tenant\",host=~\"$instance\"}[$__interval])))\n* 100\n",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -833,7 +854,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": ".05,.15",
+      "thresholds": "5,15",
       "title": "Failure Rate",
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -864,11 +885,56 @@
         "datasource": "hono_metrics",
         "hide": 0,
         "includeAll": true,
-        "label": "Component Name",
+        "label": "Adapter",
         "multi": true,
         "name": "componentname",
         "options": [],
-        "query": "label_values(component_name)",
+        "query": "label_values(hono_messages_received_seconds_count,component_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Tenant",
+        "name": "tenant",
+        "options": [
+          {
+            "text": ".+",
+            "value": ".+"
+          }
+        ],
+        "query": ".+",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "hono_metrics",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Type",
+        "multi": true,
+        "name": "type",
+        "options": [],
+        "query": "label_values(hono_messages_received_seconds_count,type)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -890,72 +956,11 @@
         "datasource": "hono_metrics",
         "hide": 0,
         "includeAll": true,
-        "label": "Tenant",
-        "multi": true,
-        "name": "tenant",
-        "options": [],
-        "query": "label_values(tenant)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "All",
-          "value": [
-            "$__all"
-          ]
-        },
-        "hide": 0,
-        "includeAll": true,
-        "label": "Type",
-        "multi": true,
-        "name": "type",
-        "options": [
-          {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": false,
-            "text": "telemetry",
-            "value": "telemetry"
-          },
-          {
-            "selected": false,
-            "text": "event",
-            "value": "event"
-          }
-        ],
-        "query": "telemetry,event",
-        "skipUrlSync": false,
-        "type": "custom"
-      },
-      {
-        "allValue": null,
-        "current": {
-          "text": "All",
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": "hono_metrics",
-        "hide": 0,
-        "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(host)",
+        "query": "label_values(hono_messages_received_seconds_count,host)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/deploy/src/main/config/grafana/dashboard-definitions/overview.json
+++ b/deploy/src/main/config/grafana/dashboard-definitions/overview.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1549018998349,
+  "iteration": 1549031221494,
   "links": [
     {
       "icon": "external link",
@@ -306,7 +306,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_processed_payload_total{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -552,7 +552,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_processed_payload_total{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -873,7 +873,7 @@
         }
       ],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
@@ -902,7 +902,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "received",
+      "title": "message rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -995,7 +995,7 @@
         }
       ],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
@@ -1024,7 +1024,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "received",
+      "title": "message rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1185,12 +1185,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_processed_payload_total{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"forwarded\"}[$__range]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "processed",
+          "legendFormat": "forwarded",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"undeliverable\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "undeliverable",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"unprocessable\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "unprocessable",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -1271,12 +1285,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_processed_payload_total{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"forwarded\"}[$__range]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "{{component_name}} - {{host}}",
+          "legendFormat": "forwarded",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"undeliverable\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "undeliverable",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"unprocessable\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "unprocessable",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -1520,72 +1548,46 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
-          "tags": [],
           "text": "All",
           "value": [
             "$__all"
           ]
         },
-        "hide": 0,
-        "includeAll": true,
-        "label": "Component Name",
-        "multi": true,
-        "name": "componentname",
-        "options": [
-          {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": false,
-            "text": "hono-http",
-            "value": "hono-http"
-          },
-          {
-            "selected": false,
-            "text": "hono-mqtt",
-            "value": "hono-mqtt"
-          },
-          {
-            "selected": false,
-            "text": "hono-amqp",
-            "value": "hono-amqp"
-          },
-          {
-            "selected": false,
-            "text": "hono-coap",
-            "value": "hono-coap"
-          }
-        ],
-        "query": "hono-http,hono-mqtt,hono-amqp,hono-coap",
-        "skipUrlSync": false,
-        "type": "custom"
-      },
-      {
-        "allValue": "",
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
         "datasource": "hono_metrics",
         "hide": 0,
         "includeAll": true,
-        "label": "Tenant",
+        "label": "Adapter",
         "multi": true,
-        "name": "tenant",
+        "name": "componentname",
         "options": [],
-        "query": "label_values(hono_messages_received_seconds_count,tenant)",
-        "refresh": 2,
+        "query": "label_values(hono_messages_received_seconds_count,component_name)",
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "current": {
+          "text": ".+",
+          "value": ".+"
+        },
+        "hide": 0,
+        "label": "Tenant",
+        "name": "tenant",
+        "options": [
+          {
+            "text": ".+",
+            "value": ".+"
+          }
+        ],
+        "query": ".+",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/AbstractLegacyMetricsConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/AbstractLegacyMetricsConfig.java
@@ -143,9 +143,14 @@ public abstract class AbstractLegacyMetricsConfig {
     public MeterFilter[] getMeterFilters() {
         return new MeterFilter[] {
                                 MeterFilter.denyNameStartsWith(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED),
+                                MeterFilter.denyNameStartsWith(MicrometerBasedMetrics.METER_MESSAGES_PAYLOAD),
                                 MeterFilter.replaceTagValues(MetricsTags.TAG_HOST, host -> host.replace('.', '_')),
                                 MeterFilter.replaceTagValues(MetricsTags.TAG_TENANT, tenant -> tenant.replace('.', '_')),
-                                MeterFilter.ignoreTags(MetricsTags.ComponentType.TAG_NAME),
+                                MeterFilter.ignoreTags(
+                                        MetricsTags.ComponentType.TAG_NAME,
+                                        MetricsTags.QoS.TAG_NAME,
+                                        MetricsTags.ProcessingOutcome.TAG_NAME,
+                                        MetricsTags.TtdStatus.TAG_NAME),
                                 meterTypeMapper() };
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -67,16 +67,19 @@ public interface Metrics {
      * @param tenantId The tenant that the device belongs to.
      * @param outcome The outcome of processing the message.
      * @param qos The delivery semantics used for sending the message downstream.
+     * @param payloadSize The number of bytes contained in the message's payload.
      * @param timer The timer indicating the amount of time used
      *              for processing the message.
      * @throws NullPointerException if any of the parameters are {@code null}.
-     * @throws IllegalArgumentException if type is neither telemetry nor event.
+     * @throws IllegalArgumentException if type is neither telemetry nor event or
+     *                    if payload size is negative.
      */
     void reportTelemetry(
             MetricsTags.EndpointType type,
             String tenantId,
             MetricsTags.ProcessingOutcome outcome,
             MetricsTags.QoS qos,
+            int payloadSize,
             Sample timer);
 
     /**
@@ -86,30 +89,22 @@ public interface Metrics {
      * @param tenantId The tenant that the device belongs to.
      * @param outcome The outcome of processing the message.
      * @param qos The delivery semantics used for sending the message downstream.
+     * @param payloadSize The number of bytes contained in the message's payload.
      * @param ttdStatus The outcome of processing the TTD value contained in the message.
      * @param timer The timer indicating the amount of time used
      *              for processing the message.
      * @throws NullPointerException if any of the parameters are {@code null}.
-     * @throws IllegalArgumentException if type is neither telemetry nor event.
+     * @throws IllegalArgumentException if type is neither telemetry nor event or
+     *                    if payload size is negative.
      */
     void reportTelemetry(
             MetricsTags.EndpointType type,
             String tenantId,
             MetricsTags.ProcessingOutcome outcome,
             MetricsTags.QoS qos,
+            int payloadSize,
             MetricsTags.TtdStatus ttdStatus,
             Sample timer);
-
-    /**
-     * Reports the size of a processed message's payload that has been received
-     * from a device.
-     *
-     * @param type The type of message received, e.g. <em>telemetry</em> or <em>event</em>.
-     * @param tenantId The tenant that the device belongs to.
-     * @param payloadSize The size of the payload in bytes.
-     * @throws NullPointerException if any of the parameters are {@code null}.
-     */
-    void incrementProcessedPayload(MetricsTags.EndpointType type, String tenantId, long payloadSize);
 
     /**
      * Reports a command being delivered to a device.

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
@@ -31,10 +31,6 @@ public class NoopBasedMetrics implements Metrics {
     }
 
     @Override
-    public void incrementProcessedPayload(final MetricsTags.EndpointType type, final String tenantId, final long payloadSize) {
-    }
-
-    @Override
     public void incrementConnections(final String tenantId) {
     }
 
@@ -70,6 +66,7 @@ public class NoopBasedMetrics implements Metrics {
             final String tenantId,
             final MetricsTags.ProcessingOutcome outcome,
             final MetricsTags.QoS qos,
+            final int payloadSize,
             final Sample timer) {
     }
 
@@ -79,6 +76,7 @@ public class NoopBasedMetrics implements Metrics {
             final String tenantId,
             final MetricsTags.ProcessingOutcome outcome,
             final MetricsTags.QoS qos,
+            final int payloadSize,
             final MetricsTags.TtdStatus ttdStatus,
             final Sample timer) {
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
@@ -57,6 +57,7 @@ public class MicrometerBasedMetricsTest {
                 "tenant",
                 MetricsTags.ProcessingOutcome.FORWARDED,
                 MetricsTags.QoS.UNKNOWN,
+                1024,
                 MetricsTags.TtdStatus.NONE,
                 metrics.startTimer());
 

--- a/site/content/api/Metrics.md
+++ b/site/content/api/Metrics.md
@@ -66,14 +66,14 @@ Additional tags for protocol adapters are:
 
 Metrics provided by the protocol adapters are:
 
-| Metric                             | Type    | Tags                                                                                         | Description |
+| Metric                             | Type                | Tags                                                                                         | Description |
 | ---------------------------------- | ------- | -------------------------------------------------------------------------------------------- | ----------- |
-| *hono.connections.authenticated*   | Gauge   | *host*, *component-type*, *component-name*, *tenant*                                         | Current number of connected, authenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
-| *hono.connections.unauthenticated* | Gauge   | *host*, *component-type*, *component-name*                                                   | Current number of connected, unauthenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
-| *hono.messages.received*           | Timer   | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*, \[*qos*,\] \[*ttd*\] | The time it took to process a message. |
-| *hono.messages.processed.payload*  | Counter | *host*, *component-type*, *component-name*, *tenant*, *type*                                 | Total number of processed payload bytes |
-| *hono.commands.device.delivered*   | Counter | *host*, *component-type*, *component-name*, *tenant*                                         | Total number of delivered commands |
-| *hono.commands.response.delivered* | Counter | *host*, *component-type*, *component-name*, *tenant*                                         | Total number of delivered responses to commands |
+| *hono.connections.authenticated*   | Gauge               | *host*, *component-type*, *component-name*, *tenant*                                         | Current number of connected, authenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
+| *hono.connections.unauthenticated* | Gauge               | *host*, *component-type*, *component-name*                                                   | Current number of connected, unauthenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
+| *hono.messages.received*           | Timer               | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*, \[*qos*,\] \[*ttd*\] | The time it took to process a message. |
+| *hono.messages.payload*            | DistributionSummary | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*                       | The number of bytes contained in the payload of a message. |
+| *hono.commands.device.delivered*   | Counter             | *host*, *component-type*, *component-name*, *tenant*                                         | Total number of delivered commands |
+| *hono.commands.response.delivered* | Counter             | *host*, *component-type*, *component-name*, *tenant*                                         | Total number of delivered responses to commands |
 
 A tag name in square brackets indicates that the tag may not be used with each reported value.
 


### PR DESCRIPTION
The payload size has been added as a parameter to the reportTelemetry
methods. The type of the meter for the payload size has been changed to
DistributionSummary in order to be able to track the distribution of
payload sizes as well.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>