### PR TITLE
Fix for #775 Support tenant-scoped command response link in HonoClient

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
@@ -81,6 +81,42 @@ public interface ApplicationClientFactory extends ConnectionLifecycle {
             Handler<Void> closeHandler);
 
     /**
+     * Creates a client for consuming async command responses from Hono's north bound <em>Command API</em>.
+     * <p>
+     * The command responses passed in to the consumer will be settled automatically if the consumer does not
+     * throw an exception.
+     *
+     * @param tenantId The tenant to consume command responses for.
+     * @param replyId The replyId of commands to consume command responses for.
+     * @param consumer The handler to invoke with every command response received.
+     * @param closeHandler The handler invoked when the peer detaches the link.
+     * @return A future that will complete with the consumer once the link has been established. The future will fail if
+     *         the link cannot be established, e.g. because this client is not connected.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @see org.eclipse.hono.client.AsyncCommandClient
+     */
+    Future<MessageConsumer> createAsyncCommandResponseConsumer(String tenantId, String replyId,
+            Consumer<Message> consumer, Handler<Void> closeHandler);
+
+    /**
+     * Creates a client for consuming async command responses from Hono's north bound <em>Command API</em>.
+     * <p>
+     * The command responses passed in to the responses consumer will be settled automatically if the consumer does not
+     * throw an exception and does not manually handle the message disposition using the passed in delivery.
+     *
+     * @param tenantId The tenant to consume command responses for.
+     * @param replyId The replyId of commands to consume command responses for.
+     * @param consumer The handler to invoke with every command response received.
+     * @param closeHandler The handler invoked when the peer detaches the link.
+     * @return A future that will complete with the consumer once the link has been established. The future will fail if
+     *         the link cannot be established, e.g. because this client is not connected.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @see org.eclipse.hono.client.AsyncCommandClient
+     */
+    Future<MessageConsumer> createAsyncCommandResponseConsumer(String tenantId, String replyId,
+            BiConsumer<ProtonDelivery, Message> consumer, Handler<Void> closeHandler);
+
+    /**
      * Gets a client for sending commands to a device.
      * <p>
      * The client returned may be either newly created or it may be an existing
@@ -128,4 +164,20 @@ public interface ApplicationClientFactory extends ConnectionLifecycle {
      * @throws NullPointerException if the tenantId is {@code null}.
      */
     Future<CommandClient> getOrCreateCommandClient(String tenantId, String deviceId, String replyId);
+
+    /**
+     * Gets a client for sending commands to a device asynchronously, i.e. command responses get received by a
+     * separate receiver.
+     * <p>
+     * The client returned may be either newly created or it may be an existing client for the given device.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the commands to.
+     * @return A future that will complete with the async command client (if successful) or
+     *         fail if the client cannot be created, e.g. because the underlying connection
+     *         is not established or if a concurrent request to create a client for the same
+     *         tenant and device is already being executed.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<AsyncCommandClient> getOrCreateAsyncCommandClient(String tenantId, String deviceId);
 }

--- a/client/src/main/java/org/eclipse/hono/client/AsyncCommandClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/AsyncCommandClient.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client;
+
+import java.util.Map;
+
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A client for sending asynchronous request response commands.
+ * <p>
+ * An instance of this interface is always scoped to a specific tenant and device.
+ * </p>
+ *
+ * @see org.eclipse.hono.client.HonoClient#createAsyncCommandResponseConsumer(String, String,
+ *      java.util.function.Consumer, io.vertx.core.Handler)
+ * @see org.eclipse.hono.client.HonoClient#createAsyncCommandResponseConsumer(String, String,
+ *      java.util.function.BiConsumer, io.vertx.core.Handler)
+ */
+public interface AsyncCommandClient extends MessageSender {
+
+    /**
+     * Sends an async command to a device, i.e. there is no immediate response expected from the device, but
+     * asynchronously via a separate consumer.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload any data for it. The device also needs
+     * to be connected for a successful delivery.
+     *
+     * @param command The command name.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @param correlationId The identifier to use for correlating the response with the request. Note: This parameter
+     * is security sensitive. To ensure secure request response mapping choose correlationId carefully, e.g.
+     * {@link java.util.UUID#randomUUID()}.
+     * @param replyId An arbitrary string which gets used for response link address in the form of <em>control/${
+     * tenantId}/${replyId}</em> Must match the {@code replyId} passed to the command response receiver, see also below.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         If the command was accepted, the future will succeed.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the command could not be forwarded to
+     *         the device.
+     * @throws NullPointerException if command, correlationId or replyId is {@code null}.
+     * @see org.eclipse.hono.client.HonoClient#createAsyncCommandResponseConsumer(String, String,
+     *      java.util.function.Consumer, io.vertx.core.Handler)
+     * @see org.eclipse.hono.client.HonoClient#createAsyncCommandResponseConsumer(String, String,
+     *      java.util.function.BiConsumer, io.vertx.core.Handler)
+     */
+    Future<Void> sendAsyncCommand(String command, Buffer data, String correlationId, String replyId);
+
+    /**
+     * Sends an async command to a device, i.e. there is no immediate response expected from the device, but
+     * asynchronously via a separate consumer.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload any data for it. The device also needs
+     * to be connected for a successful delivery.
+     *
+     * @param command The command name.
+     * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @param correlationId The identifier to use for correlating the response with the request. Note: This parameter
+     * is security sensitive. To ensure secure request response mapping choose correlationId carefully, e.g.
+     * {@link java.util.UUID#randomUUID()}.
+     * @param replyId An arbitrary string which gets used for response link address in the form of <em>control/${
+     * tenantId}/${replyId}</em>. Must match the {@code replyId} passed to the command response receiver, see also below.
+     * @param properties The headers to include in the command message as AMQP application properties
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         If the command was accepted, the future will succeed.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the command could not be forwarded to
+     *         the device.
+     * @throws NullPointerException if command, correlationId or replyId is {@code null}.
+     * @see org.eclipse.hono.client.HonoClient#createAsyncCommandResponseConsumer(String, String,
+     *      java.util.function.Consumer, io.vertx.core.Handler)
+     * @see org.eclipse.hono.client.HonoClient#createAsyncCommandResponseConsumer(String, String,
+     *      java.util.function.BiConsumer, io.vertx.core.Handler)
+     */
+    Future<Void> sendAsyncCommand(String command, String contentType, Buffer data, String correlationId, String replyId,
+            Map<String, Object> properties);
+}

--- a/client/src/main/java/org/eclipse/hono/client/HonoClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoClient.java
@@ -214,7 +214,7 @@ public interface HonoClient extends ConnectionLifecycle,
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * To re-connect to the server, an explicit call to {@code #connect()} should be made.
      * Unlike {@code #shutdown()}, which does not allow to connect back to the server,
      * this method allows to connect back to the server.

--- a/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandClientImpl.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.impl;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.AsyncCommandClient;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.tag.Tags;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * Sender for commands with asynchronous responses.
+ */
+public class AsyncCommandClientImpl extends AbstractSender implements AsyncCommandClient {
+
+    private AsyncCommandClientImpl(
+            final ClientConfigProperties config,
+            final ProtonSender sender,
+            final String tenantId,
+            final String targetAddress,
+            final Context context) {
+        super(config, sender, tenantId, targetAddress, context, null);
+    }
+
+    @Override
+    protected Future<ProtonDelivery> sendMessage(final Message message, final Span currentSpan) {
+        return sendMessageAndWaitForOutcome(message, currentSpan);
+    }
+
+    @Override
+    protected Span startSpan(final SpanContext parent, final Message message) {
+        if (tracer == null) {
+            throw new IllegalStateException("no tracer configured");
+        } else {
+            final Span span = newFollowingSpan(parent, "sending async command");
+            Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_PRODUCER);
+            return span;
+        }
+    }
+
+    @Override
+    protected String getTo(final String deviceId) {
+        return null;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return CommandConstants.COMMAND_ENDPOINT;
+    }
+
+    static String getTargetAddress(final String tenantId, final String deviceId) {
+        return String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId);
+    }
+
+    @Override
+    public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message) {
+        return send(message);
+    }
+
+    @Override
+    public Future<Void> sendAsyncCommand(final String command, final Buffer data, final String correlationId,
+            final String replyId) {
+        return sendAsyncCommand(command, null, data, correlationId, replyId, null);
+    }
+
+    @Override
+    public Future<Void> sendAsyncCommand(final String command, final String contentType, final Buffer data,
+            final String correlationId, final String replyId, final Map<String, Object> properties) {
+        Objects.requireNonNull(command);
+        Objects.requireNonNull(correlationId);
+        Objects.requireNonNull(replyId);
+
+        final Message message = ProtonHelper.message();
+        message.setCorrelationId(correlationId);
+        MessageHelper.setCreationTime(message);
+        MessageHelper.setPayload(message, contentType, data);
+        message.setSubject(command);
+        final String replyToAddress = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId, replyId);
+        message.setReplyTo(replyToAddress);
+
+        return sendAndWaitForOutcome(message).compose(ignore -> Future.succeededFuture());
+    }
+
+    /**
+     * Creates a new async command client for a tenant and device.
+     * <p>
+     * The instance created is scoped to the given device. In particular, the sender link's target address is set to
+     * <em>control/${tenantId}/${deviceId}</em>.
+     *
+     * @param context The vert.x context to run all interactions with the server on.
+     * @param clientConfig The configuration properties to use.
+     * @param con The AMQP connection to the server.
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to create the client for.
+     * @param closeHook A handler to invoke if the peer closes the sender link unexpectedly.
+     * @param creationHandler The handler to invoke with the outcome of the creation attempt.
+     * @throws NullPointerException if any of context, clientConfig, con, tenantId, deviceId or creationHandler are
+     *             {@code null}.
+     */
+    public static void create(
+            final Context context,
+            final ClientConfigProperties clientConfig,
+            final ProtonConnection con,
+            final String tenantId,
+            final String deviceId,
+            final Handler<String> closeHook,
+            final Handler<AsyncResult<AsyncCommandClient>> creationHandler) {
+
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(clientConfig);
+        Objects.requireNonNull(con);
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(creationHandler);
+
+        final String targetAddress = AsyncCommandClientImpl.getTargetAddress(tenantId, deviceId);
+        createSender(context, clientConfig, con, targetAddress, ProtonQoS.AT_LEAST_ONCE, closeHook)
+                .compose(sender -> Future.<AsyncCommandClient> succeededFuture(
+                        new AsyncCommandClientImpl(clientConfig, sender, tenantId, targetAddress, context)))
+                .setHandler(creationHandler);
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandResponseConsumerImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandResponseConsumerImpl.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.impl;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.Constants;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+
+/**
+ * A Vertx-Proton based client for consuming async command response messages from a Hono server.
+ */
+public class AsyncCommandResponseConsumerImpl extends AbstractConsumer implements MessageConsumer {
+
+    private static final String ASYNC_COMMAND_RESPONSE_ADDRESS_TEMPLATE = CommandConstants.COMMAND_ENDPOINT
+            + "%s%s%s%s";
+
+    private AsyncCommandResponseConsumerImpl(final Context context, final ClientConfigProperties config,
+            final ProtonReceiver receiver) {
+        super(context, config, receiver);
+    }
+
+    /**
+     * Creates a new async command response consumer for a tenant for commands with the given {@code replyId}.
+     *
+     * @param context The vert.x context to run all interactions with the server on.
+     * @param clientConfig The configuration properties to use.
+     * @param con The AMQP connection to the server.
+     * @param tenantId The tenant to consume async command responses for.
+     * @param replyId The {@code replyId} of commands to consume async responses for.
+     * @param asyncCommandResponseConsumer The consumer to invoke with async command response received.
+     * @param creationHandler The handler to invoke with the outcome of the creation attempt.
+     * @param closeHook The handler to invoke when the link is closed by the peer (may be {@code null}).
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static void create(
+            final Context context,
+            final ClientConfigProperties clientConfig,
+            final ProtonConnection con,
+            final String tenantId,
+            final String replyId,
+            final BiConsumer<ProtonDelivery, Message> asyncCommandResponseConsumer,
+            final Handler<AsyncResult<MessageConsumer>> creationHandler,
+            final Handler<String> closeHook) {
+
+        create(context, clientConfig, con, tenantId, replyId, Constants.DEFAULT_PATH_SEPARATOR, asyncCommandResponseConsumer,
+                creationHandler, closeHook);
+    }
+
+    /**
+     * Creates a new async command response consumer for a tenant for commands with the given {@code replyId}.
+     *
+     * @param context The vert.x context to run all interactions with the server on.
+     * @param clientConfig The configuration properties to use.
+     * @param con The AMQP connection to the server.
+     * @param tenantId The tenant to consume async command responses for.
+     * @param replyId The {@code replyId} of commands to consume async responses for.
+     * @param pathSeparator The address path separator character used by the server.
+     * @param asyncCommandResponseConsumer The consumer to invoke with async command response received.
+     * @param creationHandler The handler to invoke with the outcome of the creation attempt.
+     * @param closeHook The handler to invoke when the link is closed by the peer (may be {@code null}).
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static void create(
+            final Context context,
+            final ClientConfigProperties clientConfig,
+            final ProtonConnection con,
+            final String tenantId,
+            final String replyId,
+            final String pathSeparator,
+            final BiConsumer<ProtonDelivery, Message> asyncCommandResponseConsumer,
+            final Handler<AsyncResult<MessageConsumer>> creationHandler,
+            final Handler<String> closeHook) {
+
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(clientConfig);
+        Objects.requireNonNull(con);
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(replyId);
+        Objects.requireNonNull(pathSeparator);
+        Objects.requireNonNull(asyncCommandResponseConsumer);
+        Objects.requireNonNull(creationHandler);
+
+        createReceiver(context, clientConfig, con, String.format(ASYNC_COMMAND_RESPONSE_ADDRESS_TEMPLATE, pathSeparator,
+                tenantId, pathSeparator, replyId),
+                ProtonQoS.AT_LEAST_ONCE, asyncCommandResponseConsumer::accept, closeHook).setHandler(created -> {
+                    if (created.succeeded()) {
+                        creationHandler.handle(Future.succeededFuture(
+                                new AsyncCommandResponseConsumerImpl(context, clientConfig, created.result())));
+                    } else {
+                        creationHandler.handle(Future.failedFuture(created.cause()));
+                    }
+                });
+    }
+
+}


### PR DESCRIPTION
This PR is not intended do be merged (yet), but to discuss API for fix of #775!

Idea is to have a consumer that receives all command responses to address control/<tenantId>/<replyId> and to have a sender to send commands with reply-to set to control/<tenantId>/<replyId>.

I am fine with the consumer part, but I am not happy with the sender part regarding 2 points myself:
- I not have found a better name as "sendCommandWithTenantScopedResponse" in the CommandClient interface to send commands with according reply-to
- If someone creates a command client without setting replyId explicitly he ends up with a CommandClient that sends commands with tenant scoped responses with a random reply-to and therefore is not able to receive the response at all.

WDYT?

Signed-off-by: Daniel Maier <daniel.maier@bosch-si.com>