### PR TITLE
Enforce Java 11 during the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4.1</version>
+        <version>3.0.0-M2</version>
         <executions>
           <execution>
             <!-- Make sure that only non-snapshot versions are used for the dependencies. 
@@ -409,6 +409,19 @@
                 <requireReleaseVersion>
                   <message>Cannot release snapshot version!</message>
                 </requireReleaseVersion>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-java-11</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>11</version>
+                </requireJavaVersion>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
We do know that Hono no longer builds with the Java 8 compiler. And we moved on to Java 11 in general.

So I think it makes sense enforcing this in the maven build, so that you get a proper error instead of a weird compiler error.