### PR TITLE
Fix in file `device-identities.json` in test resources

### DIFF
--- a/services/device-registry/src/test/resources/device-identities.json
+++ b/services/device-registry/src/test/resources/device-identities.json
@@ -29,9 +29,9 @@
       },
       {
         "device-id": "gw-1",
-        "comment": "this device is authorized to publish data on behalf of device 4712",
         "data": {
-          "enabled": true
+          "enabled": true,
+          "comment": "this device is authorized to publish data on behalf of device 4712"
         }
       }
     ]


### PR DESCRIPTION
Fixed the location of the comment in file `device-identities.json` in test resources of device registry.