### PR TITLE
Log the exception when parsing the trust anchor from the tenant.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -247,7 +247,7 @@ public final class TenantObject {
                     return (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(derEncodedCert));
                 } catch (final IllegalArgumentException e) {
                     // Base64 decoding failed
-                    throw new CertificateParsingException("cert proptery does not contain valid Base64 scheme", e);
+                    throw new CertificateParsingException("cert property does not contain valid Base64 scheme", e);
                 }
             } else {
                 return null;

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
@@ -163,7 +163,7 @@ public final class TenantServiceBasedX509Authentication implements X509Authentic
                             return certPathValidator.validate(chainToValidate, trustAnchor)
                                     .recover(t -> Future.failedFuture(UNAUTHORIZED));
                         } catch (final GeneralSecurityException e) {
-                            // cannot de-serialize trust anchor from tenant
+                            log.debug("cannot de-serialize trust anchor from tenant: {}", e.getMessage());
                             return Future.failedFuture(UNAUTHORIZED);
                         }
                     }).compose(ok -> getCredentials(x509chain, tenantTracker.result()));


### PR DESCRIPTION
When the parsing of the trusted-ca cert (trust anchor) of the tenant failed this did not show up in the logs of the protocol adapter. It's is helpful to see this in logs when trying of client certs locally. 