### PR TITLE
[#961] Use "Timer" meter for command messages.

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandHandler.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandHandler.java
@@ -94,9 +94,11 @@ public final class CommandHandler<T extends MqttProtocolAdapterProperties> {
     public void addToWaitingForAcknowledgement(final Integer msgId,
             final CommandSubscription subscription,
             final CommandContext commandContext) {
+
         Objects.requireNonNull(msgId);
         Objects.requireNonNull(subscription);
         Objects.requireNonNull(commandContext);
+
         waitingForAcknowledgement.put(msgId, TriTuple.of(startTimer(msgId), subscription, commandContext));
     }
 
@@ -172,9 +174,9 @@ public final class CommandHandler<T extends MqttProtocolAdapterProperties> {
     }
 
     private long startTimer(final Integer msgId) {
-        LOG.trace("Start a timer for [{}] ms", config.getCommandAckTimeout());
+
         return vertx.setTimer(config.getCommandAckTimeout(), timerId -> {
-            LOG.trace("Timer [{}] expired", timerId);
+
             Optional.ofNullable(removeFromWaitingForAcknowledgement(msgId)).ifPresent(value -> {
                 final CommandSubscription subscription = value.two();
                 final CommandContext commandContext = value.three();

--- a/client/src/main/java/org/eclipse/hono/client/Command.java
+++ b/client/src/main/java/org/eclipse/hono/client/Command.java
@@ -240,6 +240,22 @@ public final class Command {
     }
 
     /**
+     * Gets the size of this command's payload.
+     *
+     * @return The payload size in bytes, 0 if the command has no payload.
+     * @throws IllegalStateException if this command is invalid.
+     */
+    public int getPayloadSize() {
+        if (isValid()) {
+            return Optional.ofNullable(MessageHelper.getPayload(message))
+                    .map(b -> b.length())
+                    .orElse(0);
+        } else {
+            throw new IllegalStateException("command is invalid");
+        }
+    }
+
+    /**
      * Gets the type of this command's payload.
      *
      * @return The content type or {@code null} if not set.

--- a/deploy/src/main/config/grafana/dashboard-definitions/overview.json
+++ b/deploy/src/main/config/grafana/dashboard-definitions/overview.json
@@ -15,7 +15,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1549031221494,
   "links": [
     {
       "icon": "external link",
@@ -81,755 +80,18 @@
       "type": "text"
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "hono_metrics",
-      "decimals": 1,
-      "format": "ops",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 2
-      },
-      "id": 4,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"forwarded\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "title": "forwarded",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "hono_metrics",
-      "decimals": 1,
-      "format": "ops",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 3,
-        "y": 2
-      },
-      "id": 35,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"undeliverable\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "title": "undeliverable",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "hono_metrics",
-      "decimals": 0,
-      "format": "Bps",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 5,
-        "y": 2
-      },
-      "id": 56,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "title": "payload",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "hono_metrics",
-      "decimals": 1,
-      "format": "ops",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 8,
-        "y": 2
-      },
-      "id": 14,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"forwarded\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "title": "forwarded",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "hono_metrics",
-      "decimals": 1,
-      "format": "ops",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 11,
-        "y": 2
-      },
-      "id": 36,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status!=\"forwarded\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "title": "undeliverable",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "hono_metrics",
-      "decimals": 0,
-      "format": "Bps",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 13,
-        "y": 2
-      },
-      "id": 57,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "title": "payload",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "hono_metrics",
-      "decimals": 1,
-      "format": "ops",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 16,
-        "y": 2
-      },
-      "id": 16,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(irate(hono_commands_device_delivered_total{component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "title": "requests",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "hono_metrics",
-      "decimals": 1,
-      "format": "ops",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 19,
-        "y": 2
-      },
-      "id": 58,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(irate(hono_commands_response_delivered_total{component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "title": "responses",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "hono_metrics",
-      "decimals": 1,
-      "format": "ops",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 22,
-        "y": 2
-      },
-      "id": 37,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(irate(hono_commands_ttd_expired_total{component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "title": "TTD expired",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "hono_metrics",
+      "description": "average rate of telemetry messages received from devices",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 5
+        "y": 2
       },
       "id": 2,
       "legend": {
@@ -877,32 +139,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"forwarded\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"unprocessable\"}[$__range]))",
           "format": "time_series",
-          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "forwarded",
-          "refId": "A"
+          "legendFormat": "unprocessable",
+          "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"undeliverable\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"undeliverable\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"unprocessable\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",status=\"forwarded\"}[$__range]))",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "unprocessable",
-          "refId": "C"
+          "legendFormat": "forwarded",
+          "refId": "A"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "message rate",
+      "title": "messages",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -919,9 +181,10 @@
       },
       "yaxes": [
         {
-          "format": "ops",
-          "label": "",
-          "logBase": 10,
+          "decimals": 0,
+          "format": "none",
+          "label": "messages/sec",
+          "logBase": 1,
           "max": null,
           "min": "0",
           "show": true
@@ -946,12 +209,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "hono_metrics",
+      "description": "average rate of events received from devices",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 5
+        "y": 2
       },
       "id": 17,
       "legend": {
@@ -999,32 +263,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"forwarded\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"unprocessable\"}[$__range]))",
           "format": "time_series",
-          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "forwarded",
-          "refId": "A"
+          "legendFormat": "unprocessable",
+          "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"undeliverable\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"undeliverable\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"unprocessable\",component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"forwarded\"}[$__range]))",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "unprocessable",
-          "refId": "C"
+          "legendFormat": "forwarded",
+          "refId": "A"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "message rate",
+      "title": "messages",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1041,9 +305,10 @@
       },
       "yaxes": [
         {
-          "format": "ops",
-          "label": "",
-          "logBase": 10,
+          "decimals": 0,
+          "format": "none",
+          "label": "messages/sec",
+          "logBase": 1,
           "max": null,
           "min": "0",
           "show": true
@@ -1068,17 +333,20 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "hono_metrics",
+      "description": "average rate of commands sent to devices",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 5
+        "y": 2
       },
       "id": 20,
       "legend": {
         "avg": false,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
         "show": false,
@@ -1099,18 +367,35 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_commands_device_delivered_total{component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_commands_received_seconds_count{direction=~\"one-way|request\",status=\"unprocessable\"}[$__range]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "unprocessable",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(irate(hono_commands_received_seconds_count{direction=~\"one-way|request\",status=\"undeliverable\"}[$__range]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "undeliverable",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(irate(hono_commands_received_seconds_count{direction=~\"one-way|request\",status=\"forwarded\"}[$__range]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "requests",
+          "legendFormat": "forwarded",
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Requests",
+      "title": "messages",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1127,19 +412,21 @@
       },
       "yaxes": [
         {
-          "format": "reqps",
-          "label": "",
-          "logBase": 10,
+          "decimals": 0,
+          "format": "none",
+          "label": "messages/sec",
+          "logBase": 1,
           "max": null,
           "min": "0",
           "show": true
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
+          "decimals": 1,
+          "format": "none",
+          "label": "bytes/sec",
+          "logBase": 10,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": false
         }
       ],
@@ -1154,12 +441,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "hono_metrics",
+      "description": "average rate of data received from devices as payload of telemetry messages",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 13
+        "y": 10
       },
       "id": 55,
       "legend": {
@@ -1185,26 +473,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"forwarded\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",status=\"unprocessable\"}[$__range]))",
           "format": "time_series",
-          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "forwarded",
-          "refId": "A"
+          "legendFormat": "unprocessable",
+          "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"undeliverable\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",status=\"undeliverable\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"unprocessable\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"telemetry\",status=\"forwarded\"}[$__range]))",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "unprocessable",
-          "refId": "C"
+          "legendFormat": "forwarded",
+          "refId": "A"
         }
       ],
       "thresholds": [],
@@ -1227,9 +515,10 @@
       },
       "yaxes": [
         {
-          "format": "Bps",
-          "label": "",
-          "logBase": 10,
+          "decimals": 0,
+          "format": "none",
+          "label": "bytes/sec",
+          "logBase": 1,
           "max": null,
           "min": "0",
           "show": true
@@ -1254,12 +543,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "hono_metrics",
+      "description": "average rate of data received from devices as payload of events",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 13
+        "y": 10
       },
       "id": 59,
       "legend": {
@@ -1285,26 +575,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"forwarded\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",status=\"unprocessable\"}[$__range]))",
           "format": "time_series",
-          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "forwarded",
-          "refId": "A"
+          "legendFormat": "unprocessable",
+          "refId": "C"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"undeliverable\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",status=\"undeliverable\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "undeliverable",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",component_name=~\"$componentname\",tenant=~\"$tenant\",status=\"unprocessable\"}[$__range]))",
+          "expr": "sum(irate(hono_messages_payload_bytes_sum{type=\"event\",status=\"forwarded\"}[$__range]))",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "unprocessable",
-          "refId": "C"
+          "legendFormat": "forwarded",
+          "refId": "A"
         }
       ],
       "thresholds": [],
@@ -1327,9 +617,10 @@
       },
       "yaxes": [
         {
-          "format": "Bps",
-          "label": "",
-          "logBase": 10,
+          "decimals": 0,
+          "format": "none",
+          "label": "bytes/sec",
+          "logBase": 1,
           "max": null,
           "min": "0",
           "show": true
@@ -1354,21 +645,22 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "hono_metrics",
+      "description": "average rate of data sent to devices as payload of commands",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 13
+        "y": 10
       },
       "id": 60,
       "legend": {
-        "alignAsTable": true,
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "rightSide": true,
+        "rightSide": false,
         "show": false,
         "total": false,
         "values": false
@@ -1387,25 +679,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(hono_commands_response_delivered_total{component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
+          "expr": "sum(irate(hono_commands_payload_bytes_sum{direction=~\"one-way|request\",status=\"unprocessable\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "unprocessable",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(irate(hono_commands_payload_bytes_sum{direction=~\"one-way|request\",status=\"undeliverable\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "undeliverable",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(irate(hono_commands_payload_bytes_sum{direction=~\"one-way|request\",status=\"forwarded\"}[$__range]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "responses",
+          "legendFormat": "forwarded",
           "refId": "A"
-        },
-        {
-          "expr": "sum(irate(hono_commands_ttd_expired_total{component_name=~\"$componentname\",tenant=~\"$tenant\"}[$__range]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "TTD expired",
-          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Outcome",
+      "title": "payload",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1422,9 +721,10 @@
       },
       "yaxes": [
         {
-          "format": "ops",
-          "label": "",
-          "logBase": 10,
+          "decimals": 0,
+          "format": "none",
+          "label": "bytes/sec",
+          "logBase": 1,
           "max": null,
           "min": "0",
           "show": true
@@ -1444,99 +744,403 @@
       }
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "id": 46,
-      "panels": [],
-      "title": "Instances",
-      "type": "row"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorPrefix": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "hono_metrics",
-      "description": "Number of protocol adapter instances of the selected type.",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
+      "description": "average rate of valid telemetry messages received from devices which could not be delivered downstream",
+      "fill": 1,
       "gridPos": {
-        "h": 3,
-        "w": 2,
+        "h": 8,
+        "w": 8,
         "x": 0,
-        "y": 22
+        "y": 18
       },
-      "id": 54,
-      "interval": null,
+      "id": 61,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
       "targets": [
         {
-          "expr": "count(count by (host)(hono_connections_unauthenticated{component_name=~\"$componentname\"}))",
+          "expr": "(100 * sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",qos=\"0\",status=\"undeliverable\"}[$__range])))\n/\nsum(irate(hono_messages_received_seconds_count{type=\"telemetry\",qos=\"0\"}[$__range]))",
           "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "QoS 0",
+          "refId": "C"
+        },
+        {
+          "expr": "(100 * sum(irate(hono_messages_received_seconds_count{type=\"telemetry\",qos=\"1\",status=\"undeliverable\"}[$__range])))\n/\nsum(irate(hono_messages_received_seconds_count{type=\"telemetry\",qos=\"1\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "QoS 1",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "warning",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 5,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 15,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "undeliverable rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "hono_metrics",
+      "description": "average rate of valid events received from devices which could not be delivered downstream",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "id": 62,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(100 * sum(irate(hono_messages_received_seconds_count{type=\"event\",status=\"undeliverable\"}[$__range])))\n/\nsum(irate(hono_messages_received_seconds_count{type=\"event\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "not forwarded",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "warning",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 1,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 5,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "undeliverable rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "hono_metrics",
+      "description": "average rate of valid commands received from applications which could not be delivered to devices",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 63,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(100 * sum(irate(hono_commands_received_seconds_count{direction=~\"one-way|request\",status=\"undeliverable\"}[$__range])))\n/\nsum(irate(hono_commands_received_seconds_count{direction=\"one-way|request\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "not forwarded",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "warning",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 5,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 15,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "undeliverable rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "columns": [],
+      "datasource": "hono_metrics",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "id": 65,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 1,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Adapter Type",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "component_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "#Instances",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 0,
+          "pattern": "Value",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "Time",
+          "thresholds": [],
+          "type": "date",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "count(hono_connections_unauthenticated{component_type=\"adapter\"}) by (component_name)",
+          "format": "table",
+          "instant": true,
           "intervalFactor": 1,
           "refId": "A"
         }
       ],
-      "thresholds": "",
       "title": "Protocol Adapters",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "0",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
+      "transform": "table",
+      "type": "table"
     }
   ],
   "refresh": "10s",
@@ -1544,52 +1148,7 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": [
-      {
-        "allValue": null,
-        "current": {
-          "text": "All",
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": "hono_metrics",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Adapter",
-        "multi": true,
-        "name": "componentname",
-        "options": [],
-        "query": "label_values(hono_messages_received_seconds_count,component_name)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
-          "text": ".+",
-          "value": ".+"
-        },
-        "hide": 0,
-        "label": "Tenant",
-        "name": "tenant",
-        "options": [
-          {
-            "text": ".+",
-            "value": ".+"
-          }
-        ],
-        "query": ".+",
-        "skipUrlSync": false,
-        "type": "textbox"
-      }
-    ]
+    "list": []
   },
   "time": {
     "from": "now-5m",
@@ -1620,7 +1179,7 @@
       "30d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "Overview",
   "uid": "QpiDB0Bmz",
   "version": 1

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -48,6 +48,7 @@ import org.eclipse.hono.util.TenantObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import io.micrometer.core.instrument.Timer.Sample;
 import io.opentracing.SpanContext;
 import io.opentracing.tag.Tags;
 import io.vertx.core.CompositeFuture;
@@ -77,6 +78,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * The <em>application/octet-stream</em> content type.
      */
     protected static final String CONTENT_TYPE_OCTET_STREAM = "application/octet-stream";
+    /**
+     * The key used for storing a Micrometer {@code Sample} in an
+     * execution context.
+     */
+    protected static final String KEY_MICROMETER_SAMPLE = "micrometer.sample";
 
     private HonoClient messagingClient;
     private HonoClient registrationServiceClient;
@@ -99,6 +105,32 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         }
 
     };
+
+    /**
+     * Adds a Micrometer sample to a command context.
+     * 
+     * @param ctx The context to add the sample to.
+     * @param sample The sample.
+     * @throws NullPointerException if ctx is {@code null}.
+     */
+    protected static final void addMicrometerSample(final CommandContext ctx, final Sample sample) {
+        Objects.requireNonNull(ctx);
+        ctx.put(KEY_MICROMETER_SAMPLE, sample);
+    }
+
+    /**
+     * Gets the Micrometer used to track the processing
+     * of a command message.
+     * 
+     * @param ctx The command context to extract the sample from.
+     * @return The sample or {@code null} if the context does not
+     *         contain a sample.
+     * @throws NullPointerException if ctx is {@code null}.
+     */
+    protected static final Sample getMicrometerSample(final CommandContext ctx) {
+        Objects.requireNonNull(ctx);
+        return ctx.get(KEY_MICROMETER_SAMPLE);
+    }
 
     /**
      * Sets the configuration by means of Spring dependency injection.

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/LegacyMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/LegacyMetrics.java
@@ -16,7 +16,7 @@ package org.eclipse.hono.service.metric;
 /**
  * A service for reporting legacy metrics.
  */
-public interface LegacyMetrics {
+interface LegacyMetrics {
 
     /**
      * Reports a message received from a device as <em>processed</em>.
@@ -49,4 +49,21 @@ public interface LegacyMetrics {
      * @throws NullPointerException if tenant is {@code null}.
      */
     void incrementNoCommandReceivedAndTTDExpired(String tenantId);
+
+    /**
+     * Reports a response to a command being delivered to an application.
+     * 
+     * @param tenantId The tenant to which the device belongs from which the response
+     *                 has been received.
+     * @throws NullPointerException if tenant is {@code null}.
+     */
+    void incrementCommandResponseDeliveredToApplication(String tenantId);
+
+    /**
+     * Reports a command being delivered to a device.
+     * 
+     * @param tenantId The tenant that the device belongs to.
+     * @throws NullPointerException if tenant is {@code null}.
+     */
+    void incrementCommandDeliveredToDevice(String tenantId);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -107,19 +107,21 @@ public interface Metrics {
             Sample timer);
 
     /**
-     * Reports a command being delivered to a device.
-     * 
+     * Reports a command &amp; control message being transferred to/from a device.
+     *
+     * @param direction The command message's direction.
      * @param tenantId The tenant that the device belongs to.
-     * @throws NullPointerException if tenant is {@code null}.
+     * @param outcome The outcome of processing the message.
+     * @param payloadSize The number of bytes contained in the message's payload.
+     * @param timer The timer indicating the amount of time used
+     *              for processing the message.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @throws IllegalArgumentException if payload size is negative.
      */
-    void incrementCommandDeliveredToDevice(String tenantId);
-
-    /**
-     * Reports a response to a command being delivered to an application.
-     * 
-     * @param tenantId The tenant to which the device belongs from which the response
-     *                 has been received.
-     * @throws NullPointerException if tenant is {@code null}.
-     */
-    void incrementCommandResponseDeliveredToApplication(String tenantId);
+    void reportCommand(
+            MetricsTags.Direction direction,
+            String tenantId,
+            MetricsTags.ProcessingOutcome outcome,
+            int payloadSize,
+            Sample timer);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MetricsTags.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MetricsTags.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.service.metric;
 
 import java.util.Objects;
 
+import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.Hostnames;
@@ -163,6 +164,20 @@ public final class MetricsTags {
         }
 
         /**
+         * Gets an outcome for an error.
+         * 
+         * @param t The error.
+         * @return The outcome.
+         */
+        public static ProcessingOutcome from(final Throwable t) {
+            if (t instanceof ClientErrorException) {
+                return UNPROCESSABLE;
+            } else {
+                return UNDELIVERABLE;
+            }
+        }
+
+        /**
          * Gets a <em>Micrometer</em> tag for the outcome.
          * 
          * @return The tag.
@@ -303,6 +318,43 @@ public final class MetricsTags {
             } else {
                 return tags.and(tag);
             }
+        }
+    }
+
+    /**
+     * The direction of a message.
+     *
+     */
+    public enum Direction {
+
+        /**
+         * A one-way message.
+         */
+        ONE_WAY("one-way"),
+        /**
+         * A request message.
+         */
+        REQUEST("request"),
+        /**
+         * A response message.
+         */
+        RESPONSE("response");
+
+        static final String TAG_NAME = "direction";
+
+        private final Tag tag;
+
+        Direction(final String tagValue) {
+            this.tag = Tag.of(TAG_NAME, tagValue);
+        }
+
+        /**
+         * Gets a <em>Micrometer</em> tag for the direction.
+         * 
+         * @return The tag.
+         */
+        public Tag asTag() {
+            return tag;
         }
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedLegacyMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedLegacyMetrics.java
@@ -33,7 +33,9 @@ public final class MicrometerBasedLegacyMetrics implements LegacyMetrics {
      */
     public static final String METER_MESSAGES_PROCESSED = "hono.messages.processed";
 
+    static final String METER_COMMANDS_DEVICE_DELIVERED = "hono.commands.device.delivered";
     static final String METER_COMMANDS_TTD_EXPIRED = "hono.commands.ttd.expired";
+    static final String METER_COMMANDS_RESPONSE_DELIVERED = "hono.commands.response.delivered";
     static final String METER_MESSAGES_UNDELIVERABLE = "hono.messages.undeliverable";
 
     /**
@@ -78,6 +80,24 @@ public final class MicrometerBasedLegacyMetrics implements LegacyMetrics {
         Objects.requireNonNull(tenantId);
         this.registry.counter(METER_COMMANDS_TTD_EXPIRED,
                 Tags.of(MetricsTags.TAG_TENANT, tenantId))
+                .increment();
+    }
+
+    @Override
+    public void incrementCommandResponseDeliveredToApplication(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+        this.registry.counter(METER_COMMANDS_RESPONSE_DELIVERED,
+                Tags.of(MetricsTags.getTenantTag(tenantId)))
+                .increment();
+    }
+
+    @Override
+    public void incrementCommandDeliveredToDevice(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+        this.registry.counter(METER_COMMANDS_DEVICE_DELIVERED,
+                Tags.of(MetricsTags.getTenantTag(tenantId)))
                 .increment();
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.hono.service.metric;
 
+import org.eclipse.hono.service.metric.MetricsTags.Direction;
+import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
+
 import io.micrometer.core.instrument.Timer.Sample;
 
 /**
@@ -32,14 +35,6 @@ public class NoopBasedMetrics implements Metrics {
 
     @Override
     public void incrementConnections(final String tenantId) {
-    }
-
-    @Override
-    public void incrementCommandResponseDeliveredToApplication(final String tenantId) {
-    }
-
-    @Override
-    public void incrementCommandDeliveredToDevice(final String tenantId) {
     }
 
     @Override
@@ -78,6 +73,15 @@ public class NoopBasedMetrics implements Metrics {
             final MetricsTags.QoS qos,
             final int payloadSize,
             final MetricsTags.TtdStatus ttdStatus,
+            final Sample timer) {
+    }
+
+    @Override
+    public void reportCommand(
+            final Direction direction,
+            final String tenantId,
+            final ProcessingOutcome outcome,
+            final int payloadSize,
             final Sample timer) {
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NoopLegacyMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NoopLegacyMetrics.java
@@ -35,4 +35,12 @@ public class NoopLegacyMetrics implements LegacyMetrics {
     @Override
     public void incrementNoCommandReceivedAndTTDExpired(final String tenantId) {
     }
+
+    @Override
+    public void incrementCommandResponseDeliveredToApplication(final String tenantId) {
+    }
+
+    @Override
+    public void incrementCommandDeliveredToDevice(final String tenantId) {
+    }
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/LegacyMetricsConfigTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/LegacyMetricsConfigTest.java
@@ -103,7 +103,7 @@ public class LegacyMetricsConfigTest {
         // Command related meters
 
         assertMapping(
-                new Id(MicrometerBasedMetrics.METER_COMMANDS_DEVICE_DELIVERED, tags, null, null, Type.COUNTER),
+                new Id(MicrometerBasedLegacyMetrics.METER_COMMANDS_DEVICE_DELIVERED, tags, null, null, Type.COUNTER),
                 String.format("%s.meter.hono.%s.commands.%s.device.delivered",
                         HOSTNAME_MAPPED, protocol, TENANT));
 
@@ -113,7 +113,7 @@ public class LegacyMetricsConfigTest {
                         HOSTNAME_MAPPED, protocol, TENANT));
 
         assertMapping(
-                new Id(MicrometerBasedMetrics.METER_COMMANDS_RESPONSE_DELIVERED, tags, null, null, Type.COUNTER),
+                new Id(MicrometerBasedLegacyMetrics.METER_COMMANDS_RESPONSE_DELIVERED, tags, null, null, Type.COUNTER),
                 String.format("%s.meter.hono.%s.commands.%s.response.delivered",
                         HOSTNAME_MAPPED, protocol, TENANT));
 

--- a/site/content/api/Metrics.md
+++ b/site/content/api/Metrics.md
@@ -56,24 +56,25 @@ The names of Hono's standard components are as follows:
 
 Additional tags for protocol adapters are:
 
-| Name       | Value                                              | Description |
-| ---------- | -------------------------------------------------- | ----------- |
-| *qos*      | `0`, `1`                                          | The quality of service used for a message. `0` indicates *at most once*, `1` indicates *at least once* delivery semantics. This tag will be omitted if the quality of service cannot be determined. |
-| *status*   | `forwarded`, `unprocessable`, `undeliverable` | The processing status of a message.<br>`forwarded` indicates that the message has been forwarded to a downstream consumer<br>`unprocessable` indicates that the message has not been processed not forwarded, e.g. because the message was malformed<br>`undeliverable` indicates that the message could not be forwarded, e.g. because there is no downstream consumer or due to an infrastructure problem |
-| *tenant*   | *string*                                           | The name of the tenant that the metric is being reported for |
-| *type*     | `telemetry`, `event`                             | The type of (downstream) message that the metric is being reported for |
-| *ttd*      | `expired`, `command`                             | A status indicating the outcome of processing a TTD value contained in a message received from a device.<br>`command` indicates that a command for the device has been included in the response to the device's request for uploading the message.<br>`expired` indicates that a response without a command has been sent to the device<br>Note that this tag is only used by protocol adapters which use a request/response based transport protocol like HTTP. The tag will be omitted if the device did not specify a TTD value in its message. |
+| Name        | Value                                              | Description |
+| ----------- | -------------------------------------------------- | ----------- |
+| *direction* | `one-way`, `request`, `response`               | The direction in which a Command &amp; Control message is being sent:<br>`one-way` indicates a command sent to a device for which the sending application doesn't expect to receive a response.<br>`request` indicates a command request message sent to a device.<br>`response` indicates a command response received from a device. |
+| *qos*       | `0`, `1`                                          | The quality of service used for a telemetry or event message.<br>`0` indicates *at most once*,<br>`1` indicates *at least once* delivery semantics.<br>This tag will be omitted if the quality of service cannot be determined. |
+| *status*    | `forwarded`, `unprocessable`, `undeliverable` | The processing status of a message.<br>`forwarded` indicates that the message has been forwarded to a downstream consumer<br>`unprocessable` indicates that the message has not been processed not forwarded, e.g. because the message was malformed<br>`undeliverable` indicates that the message could not be forwarded, e.g. because there is no downstream consumer or due to an infrastructure problem |
+| *tenant*    | *string*                                           | The identifier of the tenant that the metric is being reported for |
+| *ttd*       | `command`, `expired`                             | A status indicating the outcome of processing a TTD value contained in a message received from a device.<br>`command` indicates that a command for the device has been included in the response to the device's request for uploading the message.<br>`expired` indicates that a response without a command has been sent to the device<br>Note that this tag is only used by protocol adapters which use a request/response based transport protocol like HTTP. The tag will be omitted if the device did not specify a TTD value in its message. |
+| *type*      | `telemetry`, `event`                             | The type of (downstream) message that the metric is being reported for. |
 
 Metrics provided by the protocol adapters are:
 
 | Metric                             | Type                | Tags                                                                                         | Description |
-| ---------------------------------- | ------- | -------------------------------------------------------------------------------------------- | ----------- |
+| ---------------------------------- | ------------------- | -------------------------------------------------------------------------------------------- | ----------- |
+| *hono.commands.received*           | Timer               | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*, *direction*          | The time it took to process a message conveying a command or a response to a command. |
+| *hono.commands.payload*            | DistributionSummary | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*, *direction*          | The number of bytes conveyed in the payload of a command message. |
 | *hono.connections.authenticated*   | Gauge               | *host*, *component-type*, *component-name*, *tenant*                                         | Current number of connected, authenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
 | *hono.connections.unauthenticated* | Gauge               | *host*, *component-type*, *component-name*                                                   | Current number of connected, unauthenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
-| *hono.messages.received*           | Timer               | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*, \[*qos*,\] \[*ttd*\] | The time it took to process a message. |
-| *hono.messages.payload*            | DistributionSummary | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*                       | The number of bytes contained in the payload of a message. |
-| *hono.commands.device.delivered*   | Counter             | *host*, *component-type*, *component-name*, *tenant*                                         | Total number of delivered commands |
-| *hono.commands.response.delivered* | Counter             | *host*, *component-type*, *component-name*, *tenant*                                         | Total number of delivered responses to commands |
+| *hono.messages.received*           | Timer               | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*, \[*qos*,\] \[*ttd*\] | The time it took to process a message conveying telemetry data or an event. |
+| *hono.messages.payload*            | DistributionSummary | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*                       | The number of bytes conveyed in the payload of a telemetry or event message. |
 
 A tag name in square brackets indicates that the tag may not be used with each reported value.
 


### PR DESCRIPTION
Command messages are now tracked analogously to telemetry and events
using a Timer meter and tags indicating the direction and outcome of
processing the messages.

The Overview dashboard has been changed to display C&C related
information alogously to telemetry and event messages.

Here's the adapted Overview dashboard with a separate graph for the rate of messages which could not be processed/delivered and threshold markers:
![dashboard_overview_with commands_new](https://user-images.githubusercontent.com/5682135/52637733-69865f80-2ed0-11e9-8e8e-6978962290d2.png)

Here's the original dashboard:
![dashboard_overview_orig](https://user-images.githubusercontent.com/5682135/52637734-69865f80-2ed0-11e9-880a-9be22d895c82.png)

FMPOV the numerical displays do not provide any information in addition to the graphs but require more queries being run on the Prometheus back end.
