### PR TITLE
[#1046][#1012] Fix encoding of OpenTracing span context in AMQP message

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/CommandConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandConsumer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.hono.client.impl.AbstractConsumer;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.tracing.MessageAnnotationsExtractAdapter;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
@@ -32,7 +31,6 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.log.Fields;
-import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -128,7 +126,7 @@ public class CommandConsumer extends AbstractConsumer {
                     final Command command = Command.from(msg, tenantId, deviceId);
 
                     // try to extract Span context from incoming message
-                    final SpanContext spanContext = tracer.extract(Format.Builtin.TEXT_MAP, new MessageAnnotationsExtractAdapter(msg));
+                    final SpanContext spanContext = TracingHelper.extractSpanContext(tracer, msg);
                     // start a Span to use for tracing the delivery of the command to the device
                     // we set the component tag to the class name because we have no access to
                     // the name of the enclosing component we are running in

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -36,7 +36,6 @@ import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.tracing.MessageAnnotationsInjectAdapter;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.MessageHelper;
@@ -48,7 +47,6 @@ import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -809,7 +807,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
                 details.put(TracingHelper.TAG_QOS.getKey(), sender.getQoS().toString());
                 currentSpan.log(details);
                 final TriTuple<Handler<AsyncResult<R>>, Object, Span> handler = TriTuple.of(resultHandler, cacheKey, currentSpan);
-                tracer.inject(currentSpan.context(), Format.Builtin.TEXT_MAP, new MessageAnnotationsInjectAdapter(request));
+                TracingHelper.injectSpanContext(tracer, currentSpan.context(), request);
                 replyMap.put(correlationId, handler);
 
                 sender.send(request, deliveryUpdated -> {

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
@@ -37,7 +37,6 @@ import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.tracing.MessageAnnotationsInjectAdapter;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
@@ -47,7 +46,6 @@ import org.slf4j.LoggerFactory;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -175,7 +173,7 @@ public abstract class AbstractSender extends AbstractHonoClient implements Messa
         Tags.MESSAGE_BUS_DESTINATION.set(span, targetAddress);
         span.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
         span.setTag(MessageHelper.APP_PROPERTY_DEVICE_ID, MessageHelper.getDeviceId(rawMessage));
-        tracer.inject(span.context(), Format.Builtin.TEXT_MAP, new MessageAnnotationsInjectAdapter(rawMessage));
+        TracingHelper.injectSpanContext(tracer, span.context(), rawMessage);
 
         return executeOrRunOnContext(result -> {
             if (sender.sendQueueFull()) {

--- a/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,7 +29,6 @@ import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.tracing.MessageAnnotationsInjectAdapter;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.TelemetryConstants;
@@ -38,7 +37,6 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.log.Fields;
-import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -154,7 +152,7 @@ public final class TelemetrySenderImpl extends AbstractSender {
         Tags.MESSAGE_BUS_DESTINATION.set(span, targetAddress);
         span.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
         span.setTag(MessageHelper.APP_PROPERTY_DEVICE_ID, MessageHelper.getDeviceId(rawMessage));
-        tracer.inject(span.context(), Format.Builtin.TEXT_MAP, new MessageAnnotationsInjectAdapter(rawMessage));
+        TracingHelper.injectSpanContext(tracer, span.context(), rawMessage);
 
         if (!isRegistrationAssertionRequired()) {
             MessageHelper.getAndRemoveRegistrationAssertion(rawMessage);

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
@@ -26,8 +26,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.opentracing.Span;
-import io.vertx.core.buffer.Buffer;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.messaging.Data;
@@ -47,9 +45,12 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -445,9 +446,13 @@ public class AbstractRequestResponseClientTest  {
         request.setApplicationProperties(new ApplicationProperties(applicationProps));
         MessageHelper.setPayload(request, "application/json", payload.toBuffer());
 
+        final SpanContext spanContext = mock(SpanContext.class);
+        final Span span = mock(Span.class);
+        when(span.context()).thenReturn(spanContext);
+
         client.sendRequest(request, ctx.asyncAssertSuccess(t -> {
             sendSuccess.complete();
-        }), null, mock(Span.class));
+        }), null, span);
         // and the peer accepts the message
         final Accepted accepted = new Accepted();
         final ProtonDelivery delivery = mock(ProtonDelivery.class);

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -215,7 +215,10 @@ public class AbstractSenderTest {
 
             @Override
             protected Span startSpan(final SpanContext context, final Message rawMessage) {
-                return mock(Span.class);
+                final SpanContext spanContext = mock(SpanContext.class);
+                final Span span = mock(Span.class);
+                when(span.context()).thenReturn(spanContext);
+                return span;
             }
         };
     }

--- a/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -49,6 +49,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
 import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.tag.Tags;
@@ -93,7 +94,10 @@ public class TenantClientImplTest {
     @Before
     public void setUp() {
 
+        final SpanContext spanContext = mock(SpanContext.class);
+
         span = mock(Span.class);
+        when(span.context()).thenReturn(spanContext);
         final SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
 
         tracer = mock(Tracer.class);

--- a/core/src/test/java/org/eclipse/hono/tracing/MessageAnnotationsInjectExtractAdapterTest.java
+++ b/core/src/test/java/org/eclipse/hono/tracing/MessageAnnotationsInjectExtractAdapterTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tracing;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.qpid.proton.codec.WritableBuffer;
+import org.apache.qpid.proton.message.Message;
+import org.apache.qpid.proton.message.impl.MessageImpl;
+import org.junit.Test;
+
+/**
+ * Tests verifying the behavior of {@link MessageAnnotationsInjectAdapter} and {@link MessageAnnotationsExtractAdapter}.
+ *
+ */
+public class MessageAnnotationsInjectExtractAdapterTest {
+
+    /**
+     * Verifies that the same entries injected via the {@code MessageAnnotationsInjectAdapter} are extracted via the
+     * {@code MessageAnnotationsExtractAdapter}.
+     * Also verifies that there are no errors during encoding/decoding of the message with the injected entries.
+     */
+    @Test
+    public void testInjectAndExtract() {
+        final String propertiesMapName = "map";
+        final Map<String, String> testEntries = new HashMap<>();
+        testEntries.put("key1", "value1");
+        testEntries.put("key2", "value2");
+
+        final Message message = new MessageImpl();
+        // inject the properties
+        final MessageAnnotationsInjectAdapter injectAdapter = new MessageAnnotationsInjectAdapter(message, propertiesMapName);
+        testEntries.forEach((key, value) -> {
+            injectAdapter.put(key, value);
+        });
+
+        // encode the message
+        final WritableBuffer.ByteBufferWrapper buffer = WritableBuffer.ByteBufferWrapper.allocate(100);
+        message.encode(buffer);
+
+        // decode the message
+        final Message decodedMessage = new MessageImpl();
+        decodedMessage.decode(buffer.toReadableBuffer());
+        // extract the properties from the decoded message
+        final MessageAnnotationsExtractAdapter extractAdapter = new MessageAnnotationsExtractAdapter(decodedMessage, propertiesMapName);
+        extractAdapter.iterator().forEachRemaining(extractedEntry -> {
+            assertThat(extractedEntry.getValue(), is(testEntries.get(extractedEntry.getKey())));
+        });
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/RequestResponseEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/RequestResponseEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,8 +25,8 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.auth.AuthorizationService;
 import org.eclipse.hono.service.auth.ClaimsBasedAuthorizationService;
-import org.eclipse.hono.tracing.MessageAnnotationsExtractAdapter;
 import org.eclipse.hono.tracing.MultiMapInjectAdapter;
+import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.AmqpErrorException;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventBusMessage;
@@ -547,13 +547,13 @@ public abstract class RequestResponseEndpoint<T extends ServiceConfigProperties>
     }
 
     /**
-     * Extracts a {@code SpanContext} out of the delivery annotations of the given {@code Message}.
+     * Extracts a {@code SpanContext} out of the message annotations of the given {@code Message}.
      * 
      * @param message The AMQP message.
      * @return The extracted {@code SpanContext} (may be {@code null}).
      * @throws NullPointerException if the message is {@code null}.
      */
     protected final SpanContext extractSpanContext(final Message message) {
-        return tracer.extract(Format.Builtin.TEXT_MAP, new MessageAnnotationsExtractAdapter(message));
+        return TracingHelper.extractSpanContext(tracer, message);
     }
 }


### PR DESCRIPTION
The span context will now be injected in and extracted from the map value of a "x-opt-trace-context" message annotation.

Fix for #1046 and #1012.