### PR TITLE
Use maven properties for HealthCheckServer and Spring Actuator ports 

### DIFF
--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -39,10 +39,6 @@
   <name>Hono Protocol Adapters</name>
   <description>An arbitrary collection of example protocol adapters for Hono. These adapters are mainly intended to be used for demonstration or PoCs. </description>
 
-  <properties>
-    <vertx.health.port>8088</vertx.health.port>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -60,6 +60,8 @@
     <truth.version>0.28</truth.version>
     <vertx.version>3.6.3</vertx.version>
 
+    <!-- The port at which the Prometheus scraping endpoint is exposed -->
+    <prometheus.scraping.port>8081</prometheus.scraping.port>
     <!-- The port at which the health check server should expose its resources -->
     <vertx.health.port>8088</vertx.health.port>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -59,6 +59,10 @@
     <spring-security-crypto.version>4.2.11.RELEASE</spring-security-crypto.version>
     <truth.version>0.28</truth.version>
     <vertx.version>3.6.3</vertx.version>
+
+    <!-- The port at which the health check server should expose its resources -->
+    <vertx.health.port>8088</vertx.health.port>
+
   </properties>
 
   <dependencyManagement>

--- a/deploy/src/main/config/hono-adapter-amqp-vertx-config.yml
+++ b/deploy/src/main/config/hono-adapter-amqp-vertx-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   amqp:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/config/hono-adapter-coap-vertx-config.yml
+++ b/deploy/src/main/config/hono-adapter-coap-vertx-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   coap:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/config/hono-adapter-http-vertx-config-enmasse.yml
+++ b/deploy/src/main/config/hono-adapter-http-vertx-config-enmasse.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   http:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/config/hono-adapter-http-vertx-config.yml
+++ b/deploy/src/main/config/hono-adapter-http-vertx-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   http:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/config/hono-adapter-kura-config-enmasse.yml
+++ b/deploy/src/main/config/hono-adapter-kura-config-enmasse.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   kura:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/config/hono-adapter-kura-config.yml
+++ b/deploy/src/main/config/hono-adapter-kura-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   kura:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/config/hono-adapter-mqtt-vertx-config-enmasse.yml
+++ b/deploy/src/main/config/hono-adapter-mqtt-vertx-config-enmasse.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   mqtt:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/config/hono-adapter-mqtt-vertx-config.yml
+++ b/deploy/src/main/config/hono-adapter-mqtt-vertx-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   mqtt:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/config/hono-service-auth-config.yml
+++ b/deploy/src/main/config/hono-service-auth-config.yml
@@ -1,6 +1,8 @@
 hono:
   app:
     maxInstances: 1
+    healthCheckBindAddress: 0.0.0.0
+    healthCheckPort: ${vertx.health.port}
   auth:
     amqp:
       bindAddress: 0.0.0.0

--- a/deploy/src/main/config/hono-service-device-registry-config.yml
+++ b/deploy/src/main/config/hono-service-device-registry-config.yml
@@ -2,7 +2,7 @@ hono:
   app:
     maxInstances: 1
     healthCheckBindAddress: 0.0.0.0
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
   auth:
     host: ${hono.auth.host}
     port: 5671

--- a/deploy/src/main/deploy/docker/prometheus/prometheus.yml
+++ b/deploy/src/main/deploy/docker/prometheus/prometheus.yml
@@ -13,7 +13,7 @@ scrape_configs:
   - names:
       - tasks.hono-service-auth.hono
     type: A
-    port: 8081
+    port: ${prometheus.scraping.port}
     refresh_interval: 10s
 
 - job_name: hono-service-device-registry
@@ -22,7 +22,7 @@ scrape_configs:
   - names:
       - tasks.hono-service-device-registry.hono
     type: A
-    port: 8081
+    port: ${prometheus.scraping.port}
     refresh_interval: 10s
 
 - job_name: hono-adapter-amqp-vertx
@@ -31,7 +31,7 @@ scrape_configs:
   - names:
       - tasks.hono-adapter-amqp-vertx.hono
     type: A
-    port: 8081
+    port: ${prometheus.scraping.port}
     refresh_interval: 10s
 
 - job_name: hono-adapter-http-vertx
@@ -40,7 +40,7 @@ scrape_configs:
   - names:
       - tasks.hono-adapter-http-vertx.hono
     type: A
-    port: 8081
+    port: ${prometheus.scraping.port}
     refresh_interval: 10s
 
 - job_name: hono-adapter-mqtt-vertx
@@ -49,7 +49,7 @@ scrape_configs:
   - names:
       - tasks.hono-adapter-mqtt-vertx.hono
     type: A
-    port: 8081
+    port: ${prometheus.scraping.port}
     refresh_interval: 10s
 
 - job_name: hono-adapter-kura-vertx
@@ -58,5 +58,5 @@ scrape_configs:
   - names:
       - tasks.hono-adapter-kura-vertx.hono
     type: A
-    port: 8081
+    port: ${prometheus.scraping.port}
     refresh_interval: 10s

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-amqp-vertx
         ports:
-        - containerPort: 8088
+        - containerPort: {{ .Values.healthCheckPort }}
           protocol: TCP
         - containerPort: 5671
           protocol: TCP
@@ -56,13 +56,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 180
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 10
       volumes:

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-svc.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-svc.yaml
@@ -21,7 +21,7 @@ spec:
     protocol: TCP
     targetPort: 5671
   - name: actuator
-    port: 8081
+    port: {{ .Values.monitoring.prometheus.port }}
   selector:
     app: hono-adapter-amqp-vertx
     group: {{ .Values.project.groupId }}

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-http-vertx
         ports:
-        - containerPort: 8088
+        - containerPort: {{ .Values.healthCheckPort }}
           protocol: TCP
         - containerPort: 8080
           protocol: TCP
@@ -56,13 +56,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 180
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 10
       volumes:

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-svc.yml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-svc.yml
@@ -21,7 +21,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   - name: actuator
-    port: 8081
+    port: {{ .Values.monitoring.prometheus.port }}
   selector:
     app: hono-adapter-http-vertx
     group: {{ .Values.project.groupId }}

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-kura
         ports:
-        - containerPort: 8088
+        - containerPort: {{ .Values.healthCheckPort }}
           protocol: TCP
         - containerPort: 8883
           protocol: TCP
@@ -56,13 +56,13 @@ spec:
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 10
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 180
       volumes:

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-svc.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-svc.yaml
@@ -21,7 +21,7 @@ spec:
     protocol: TCP
     targetPort: 8883
   - name: actuator
-    port: 8081
+    port: {{ .Values.monitoring.prometheus.port }}
   selector:
     app: hono-adapter-kura
     group: {{ .Values.project.groupId }}

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-mqtt-vertx
         ports:
-        - containerPort: 8088
+        - containerPort: {{ .Values.healthCheckPort }}
           protocol: TCP
         - containerPort: 8883
           protocol: TCP
@@ -56,13 +56,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 180
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 10
       volumes:

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-svc.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-svc.yaml
@@ -21,7 +21,7 @@ spec:
     protocol: TCP
     targetPort: 8883
   - name: actuator
-    port: 8081
+    port: {{ .Values.monitoring.prometheus.port }}
   selector:
     app: hono-adapter-mqtt-vertx
     group: {{ .Values.project.groupId }}

--- a/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -25,6 +25,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-auth
         ports:
+        - containerPort: {{ .Values.healthCheckPort }}
+          protocol: TCP
         - containerPort: 5671
           protocol: TCP
         - containerPort: 5672

--- a/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-svc.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-svc.yaml
@@ -15,7 +15,7 @@ spec:
     protocol: TCP
     targetPort: 5671
   - name: actuator
-    port: 8081
+    port: {{ .Values.monitoring.prometheus.port }}
   selector:
     app: hono-service-auth
     group: {{ .Values.project.groupId }}

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
@@ -25,6 +25,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-registry
         ports:
+        - containerPort: {{ .Values.healthCheckPort }}
+          protocol: TCP
         - containerPort: 8080
           protocol: TCP
         - containerPort: 8443
@@ -60,13 +62,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 180
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: {{ .Values.healthCheckPort }}
             scheme: HTTP
           initialDelaySeconds: 10
       initContainers:

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-svc.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-svc.yaml
@@ -26,7 +26,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   - name: actuator
-    port: 8081
+    port: {{ .Values.monitoring.prometheus.port }}
   selector:
     app: hono-service-device-registry
     group: {{ .Values.project.groupId }}

--- a/deploy/src/main/deploy/helm/values.yaml
+++ b/deploy/src/main/deploy/helm/values.yaml
@@ -15,6 +15,11 @@ artemis:
 
 defaultJavaOptions: ${default-java-options}
 
+# the port that the Hono components' health check resources are exposed at
+healthCheckPort: ${vertx.health.port}
+
+# whether we are deploying to OpenShift (true) or plain Kubernetes (false)
+# this flag is used to determine whether we need to deploy Route resources as well
 openshift: false
 
 # Default values for prometheus-operator.

--- a/deploy/src/main/deploy/helm/values.yaml
+++ b/deploy/src/main/deploy/helm/values.yaml
@@ -15,6 +15,11 @@ artemis:
 
 defaultJavaOptions: ${default-java-options}
 
+# the port that the Hono components' Prometheus scraping endpoint is exposed
+monitoring:
+  prometheus:
+    port: ${prometheus.scraping.port}
+
 # the port that the Hono components' health check resources are exposed at
 healthCheckPort: ${vertx.health.port}
 

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-amqp-vertx
         ports:
-        - containerPort: 8088
+        - containerPort: ${vertx.health.port}
           protocol: TCP
         - containerPort: 5671
           protocol: TCP
@@ -56,13 +56,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 180
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 10
       volumes:

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-amqp/hono-adapter-amqp-vertx-svc.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-amqp/hono-adapter-amqp-vertx-svc.yaml
@@ -21,7 +21,7 @@ spec:
     protocol: TCP
     targetPort: 5671
   - name: actuator
-    port: 8081
+    port: ${prometheus.scraping.port}
   selector:
     app: hono-adapter-amqp-vertx
     group: ${project.groupId}

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-http-vertx
         ports:
-        - containerPort: 8088
+        - containerPort: ${vertx.health.port}
           protocol: TCP
         - containerPort: 8080
           protocol: TCP
@@ -56,13 +56,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 180
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 10
       volumes:

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-http/hono-adapter-http-vertx-svc.yml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-http/hono-adapter-http-vertx-svc.yml
@@ -21,7 +21,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   - name: actuator
-    port: 8081
+    port: ${prometheus.scraping.port}
   selector:
     app: hono-adapter-http-vertx
     group: ${project.groupId}

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-kura
         ports:
-        - containerPort: 8088
+        - containerPort: ${vertx.health.port}
           protocol: TCP
         - containerPort: 8883
           protocol: TCP
@@ -56,13 +56,13 @@ spec:
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 10
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 180
       volumes:

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-kura/hono-adapter-kura-svc.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-kura/hono-adapter-kura-svc.yaml
@@ -21,7 +21,7 @@ spec:
     protocol: TCP
     targetPort: 8883
   - name: actuator
-    port: 8081
+    port: ${prometheus.scraping.port}
   selector:
     app: hono-adapter-kura
     group: ${project.groupId}

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-mqtt-vertx
         ports:
-        - containerPort: 8088
+        - containerPort: ${vertx.health.port}
           protocol: TCP
         - containerPort: 8883
           protocol: TCP
@@ -56,13 +56,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 180
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 10
       volumes:

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-mqtt/hono-adapter-mqtt-vertx-svc.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-mqtt/hono-adapter-mqtt-vertx-svc.yaml
@@ -21,7 +21,7 @@ spec:
     protocol: TCP
     targetPort: 8883
   - name: actuator
-    port: 8081
+    port: ${prometheus.scraping.port}
   selector:
     app: hono-adapter-mqtt-vertx
     group: ${project.groupId}

--- a/deploy/src/main/deploy/resource-descriptors/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-service-auth/hono-service-auth-deployment.yaml
@@ -25,6 +25,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-auth
         ports:
+        - containerPort: ${vertx.health.port}
+          protocol: TCP
         - containerPort: 5671
           protocol: TCP
         - containerPort: 5672

--- a/deploy/src/main/deploy/resource-descriptors/hono-service-auth/hono-service-auth-svc.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-service-auth/hono-service-auth-svc.yaml
@@ -15,7 +15,7 @@ spec:
     protocol: TCP
     targetPort: 5671
   - name: actuator
-    port: 8081
+    port: ${prometheus.scraping.port}
   selector:
     app: hono-service-auth
     group: ${project.groupId}

--- a/deploy/src/main/deploy/resource-descriptors/hono-service-device-registry/hono-service-device-registry-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-service-device-registry/hono-service-device-registry-deployment.yaml
@@ -25,6 +25,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-registry
         ports:
+        - containerPort: ${vertx.health.port}
+          protocol: TCP
         - containerPort: 8080
           protocol: TCP
         - containerPort: 8443
@@ -60,13 +62,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /liveness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 180
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8088
+            port: ${vertx.health.port}
             scheme: HTTP
           initialDelaySeconds: 10
       initContainers:

--- a/deploy/src/main/deploy/resource-descriptors/hono-service-device-registry/hono-service-device-registry-svc.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-service-device-registry/hono-service-device-registry-svc.yaml
@@ -26,7 +26,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   - name: actuator
-    port: 8081
+    port: ${prometheus.scraping.port}
   selector:
     app: hono-service-device-registry
     group: ${project.groupId}

--- a/deploy/src/main/sandbox/hono-adapter-amqp-vertx-config.yml
+++ b/deploy/src/main/sandbox/hono-adapter-amqp-vertx-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   amqp:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/sandbox/hono-adapter-http-vertx-config.yml
+++ b/deploy/src/main/sandbox/hono-adapter-http-vertx-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   http:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/sandbox/hono-adapter-kura-config.yml
+++ b/deploy/src/main/sandbox/hono-adapter-kura-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   kura:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/sandbox/hono-adapter-mqtt-vertx-config.yml
+++ b/deploy/src/main/sandbox/hono-adapter-mqtt-vertx-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   mqtt:
     bindAddress: 0.0.0.0

--- a/deploy/src/main/sandbox/hono-service-auth-config.yml
+++ b/deploy/src/main/sandbox/hono-service-auth-config.yml
@@ -1,6 +1,8 @@
 hono:
   app:
     maxInstances: 1
+    healthCheckPort: ${vertx.health.port}
+    healthCheckBindAddress: 0.0.0.0
   auth:
     amqp:
       bindAddress: 0.0.0.0

--- a/deploy/src/main/sandbox/hono-service-device-registry-config.yml
+++ b/deploy/src/main/sandbox/hono-service-device-registry-config.yml
@@ -1,7 +1,7 @@
 hono:
   app:
     maxInstances: 1
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     healthCheckBindAddress: 0.0.0.0
   auth:
     host: ${hono.auth.host}

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -192,6 +192,22 @@
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
+            <id>copy resources</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/src/main/resources</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
             <id>copy_legal_docs_for_test_jar</id>
             <phase>prepare-package</phase>
             <goals>

--- a/service-base/src/main/resources/config/application-prometheus.yml
+++ b/service-base/src/main/resources/config/application-prometheus.yml
@@ -1,4 +1,4 @@
-# Endpoint configuration for prometheus
+# Configuration for Prometheus scraping endpoint
 
 ## Disable global server
 
@@ -8,7 +8,7 @@ server:
 ## Enable management server
 
 management:
-  port: 8081
+  port: ${prometheus.scraping.port}
   security:
     enabled: false
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -35,10 +35,6 @@
   <description>Micro services implementing APIs that Hono depends on only and which are therefore not part of the Hono server process itself.
   The service components included here can be replaced by other (custom) components as long as they implement the required API(s).</description>
 
-  <properties>
-    <vertx.health.port>8088</vertx.health.port>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -318,7 +318,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <ports>
                       <port>+deviceregistry.ip:deviceregistry.amqp.port:5672</port>
                       <port>+deviceregistry.ip:deviceregistry.http.port:8080</port>
-                      <port>+deviceregistry.ip:deviceregistry.health.port:8088</port>
+                      <port>+deviceregistry.ip:deviceregistry.health.port:${vertx.health.port}</port>
                     </ports>
                     <network>
                       <mode>custom</mode>
@@ -532,7 +532,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <ports>
                       <port>+http.ip:http.port:8080</port>
                       <port>https.port:8443</port>
-                      <port>+http.ip:http.health.port:8088</port>
+                      <port>+http.ip:http.health.port:${vertx.health.port}</port>
                     </ports>
                     <network>
                       <mode>custom</mode>
@@ -618,7 +618,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <ports>
                       <port>+mqtt.ip:mqtt.port:1883</port>
                       <port>mqtts.port:8883</port>
-                      <port>+mqtt.ip:mqtt.health.port:8088</port>
+                      <port>+mqtt.ip:mqtt.health.port:${vertx.health.port}</port>
                     </ports>
                     <network>
                       <mode>custom</mode>
@@ -696,7 +696,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <ports>
                       <port>+adapter.amqp.ip:adapter.amqp.port:5672</port>
                       <port>+adapter.amqps.ip:adapter.amqps.port:5671</port>
-                      <port>+adapter.amqp.ip:adapter.amqp.health.port:8088</port>
+                      <port>+adapter.amqp.ip:adapter.amqp.health.port:${vertx.health.port}</port>
                     </ports>
                     <network>
                       <mode>custom</mode>


### PR DESCRIPTION
Use a Maven property in BOM pom.xml to define the ports that the HealthCheckServer and the Spring Actuator (Prometheus Scraping) endpoints are bound to.

Would be good if we could use these properties for the S2I templates as well?!