### PR TITLE
[#1056] Populate the device registry with the expected data before running Integration Tests

### DIFF
--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AbstractFileBasedRegistryConfigProperties.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AbstractFileBasedRegistryConfigProperties.java
@@ -23,6 +23,7 @@ abstract class AbstractFileBasedRegistryConfigProperties {
     private String filename = getDefaultFileName();
     private boolean saveToFile = false;
     private boolean modificationEnabled = true;
+    private boolean startEmpty = false;
 
     /**
      * Gets the path to the file that the registry should be persisted to periodically.
@@ -105,4 +106,27 @@ abstract class AbstractFileBasedRegistryConfigProperties {
         this.filename = filename;
     }
 
+    /**
+     * Checks whether this registry should ignore the provided JSON file when starting up.
+     * <p>
+     * If set to {@code true} then the starting process will result in an empty registry, even if populated JSON file are provided.
+     * <p>
+     * The default value of this property is {@code false}.
+     *
+     * @return The flag.
+     */
+    public boolean isStartEmpty() {
+        return startEmpty;
+    }
+
+    /**
+     * Sets whether this registry should ignore the provided JSON file when starting up.
+     * <p>
+     * Default value is {@code false}.
+     *
+     * @param flag {@code true} if registry content should be persisted.
+     */
+    public void setStartEmpty(final boolean flag) {
+        this.startEmpty = flag;
+    }
 }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
@@ -137,8 +137,9 @@ public final class FileBasedCredentialsService extends CompleteBaseCredentialsSe
 
     Future<Void> loadCredentials() {
 
-        if (getConfig().getFilename() == null) {
+        if (getConfig().getFilename() == null || getConfig().isStartEmpty()) {
             // no need to load anything
+            log.info("Either filename is null or empty start is set, won't load any credentials");
             return Future.succeededFuture();
         } else {
             final Future<Buffer> readResult = Future.future();

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
@@ -105,7 +105,8 @@ public final class FileBasedRegistrationService extends CompleteBaseRegistration
 
     Future<Void> loadRegistrationData() {
 
-        if (getConfig().getFilename() == null) {
+        if (getConfig().getFilename() == null || getConfig().isStartEmpty()) {
+            log.info("Either filename is null or empty start is set, won't load any device identities");
             return Future.succeededFuture();
         } else {
             final Future<Buffer> readResult = Future.future();

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
@@ -97,7 +97,8 @@ public final class FileBasedTenantService extends CompleteBaseTenantService<File
 
     Future<Void> loadTenantData() {
 
-        if (getConfig().getFilename() == null) {
+        if (getConfig().getFilename() == null || getConfig().isStartEmpty()) {
+            log.info("Either filename is null or empty start is set, won't load any tenants");
             return Future.succeededFuture();
         } else {
             final Future<Buffer> readResult = Future.future();

--- a/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationServiceTest.java
+++ b/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationServiceTest.java
@@ -262,6 +262,33 @@ public class FileBasedRegistrationServiceTest extends AbstractCompleteRegistrati
     }
 
     /**
+     * Verifies that device identities in file are ignored if startEmpty is set to true.
+     *
+     * @param ctx The test context.
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testDoStartIgnoreIdentitiesIfStartEmptyIsSet(final TestContext ctx) {
+
+        // GIVEN a service configured with a file name and startEmpty set to true
+        props.setFilename(FILE_NAME);
+        props.setStartEmpty(true);
+        when(fileSystem.existsBlocking(props.getFilename())).thenReturn(Boolean.TRUE);
+
+        // WHEN the service is started
+        final Async startup = ctx.async();
+        final Future<Void> startFuture = Future.future();
+        startFuture.setHandler(ctx.asyncAssertSuccess(s -> {
+            startup.complete();
+        }));
+        registrationService.doStart(startFuture);
+
+        // THEN the device identities from the file are not loaded
+        startup.await();
+        verify(fileSystem, never()).readFile(anyString(), any(Handler.class));
+    }
+
+    /**
      * Verifies that the registry enforces the maximum devices per tenant limit.
      */
     @Test

--- a/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedTenantServiceTest.java
+++ b/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedTenantServiceTest.java
@@ -214,6 +214,33 @@ public class FileBasedTenantServiceTest extends AbstractCompleteTenantServiceTes
     }
 
     /**
+     * Verifies that tenants are successfully loaded from file during startup.
+     *
+     * @param ctx The test context.
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testDoStartwithStartEmptyIgnoreTenants(final TestContext ctx) {
+
+        // GIVEN a service configured with a file name
+        props.setFilename(FILE_NAME);
+        props.setStartEmpty(true);
+        when(fileSystem.existsBlocking(props.getFilename())).thenReturn(Boolean.TRUE);
+
+        // WHEN the service is started
+        final Async startup = ctx.async();
+        final Future<Void> startFuture = Future.future();
+        startFuture.setHandler(ctx.asyncAssertSuccess(s -> {
+            startup.complete();
+        }));
+        svc.doStart(startFuture);
+
+        // THEN the credentials from the file are loaded
+        startup.await();
+        verify(fileSystem, never()).readFile(anyString(), any(Handler.class));
+    }
+
+    /**
      * Verifies that the tenants file written by the registry when persisting the contents can
      * be loaded in again.
      *

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
@@ -89,13 +89,19 @@ public class AmqpConnectionIT extends AmqpAdapterTestBase {
     @Test
     public void testConnectFailsForNonExistingDevice(final TestContext ctx) {
 
-        // GIVEN an adapter
-        // WHEN an unknown device tries to connect
-        connectToAdapter(IntegrationTestSupport.getUsername("non-existing", Constants.DEFAULT_TENANT), "secret")
-        .setHandler(ctx.asyncAssertFailure(t -> {
-            // THEN the connection is refused
-            ctx.assertTrue(t instanceof SaslException);
-        }));
+        // GIVEN an existing tenant
+        final String tenantId = helper.getRandomTenantId();
+        final TenantObject tenant = TenantObject.from(tenantId, true);
+
+        helper.registry.addTenant(JsonObject.mapFrom(tenant)).compose( r ->
+
+            // GIVEN an adapter
+            // WHEN an unknown device tries to connect
+            connectToAdapter(IntegrationTestSupport.getUsername("non-existing", tenantId), "secret")
+            .setHandler(ctx.asyncAssertFailure(t -> {
+                // THEN the connection is refused
+                ctx.assertTrue(t instanceof SaslException);
+            })));
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationAmqpIT.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.tests.registry;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.proton.ProtonClientOptions;
@@ -39,14 +40,6 @@ import java.util.concurrent.TimeUnit;
 @RunWith(VertxUnitRunner.class)
 public class DeviceRegistrationAmqpIT {
 
-    static final String DEVICE_ID_ENABLED_WITH_ENABLED_GATEWAY = "4712";
-    static final String GATEWAY_ID_ENABLED = "gw-1";
-    static final String GATEWAY_ID_ENABLED_2 = "gw-3";
-    static final String DEVICE_ID_ENABLED_WITH_DISABLED_GATEWAY = "4713";
-    static final String GATEWAY_ID_DISABLED = "gw-2";
-
-    private static final String DEVICE_ID_ENABLED = "4711";
-    private static final String DEVICE_ID_DISABLED = "disabled-device";
     private static final String NON_EXISTING_DEVICE_ID = "non-existing-device";
     private static final String NON_EXISTING_GATWAY_ID = "non-existing-gateway";
     private static final Vertx vertx = Vertx.vertx();
@@ -105,11 +98,13 @@ public class DeviceRegistrationAmqpIT {
     @Test
     public void testAssertRegistrationSucceedsForDevice(final TestContext ctx) {
 
-        deviceRegistryclient
-                .getOrCreateRegistrationClient(Constants.DEFAULT_TENANT)
-                .compose(client -> client.assertRegistration(DEVICE_ID_ENABLED))
+        final String deviceId = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+
+         helper.registry.registerDevice(Constants.DEFAULT_TENANT, deviceId)
+                .compose(r -> deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT))
+                .compose(client -> client.assertRegistration(deviceId))
                 .setHandler(ctx.asyncAssertSuccess(resp -> {
-                    ctx.assertEquals(DEVICE_ID_ENABLED, resp.getString(RegistrationConstants.FIELD_PAYLOAD_DEVICE_ID));
+                    ctx.assertEquals(deviceId, resp.getString(RegistrationConstants.FIELD_PAYLOAD_DEVICE_ID));
                     ctx.assertNotNull(resp.getString(RegistrationConstants.FIELD_ASSERTION));
                 }));
     }
@@ -136,10 +131,15 @@ public class DeviceRegistrationAmqpIT {
     @Test
     public void testAssertRegistrationFailsForDisabledDevice(final TestContext ctx) {
 
-        deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT)
-            .compose(ok -> deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT))
-            .compose(client -> client.assertRegistration(DEVICE_ID_DISABLED))
-            .setHandler(ctx.asyncAssertFailure(t -> assertErrorCode(t, HttpURLConnection.HTTP_NOT_FOUND, ctx)));
+        final String deviceId = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+
+        helper.registry.registerDevice(Constants.DEFAULT_TENANT, deviceId,
+                    new JsonObject().put(RegistrationConstants.FIELD_ENABLED, false))
+                .compose(r -> deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT))
+                .compose(client -> client.assertRegistration(deviceId))
+                .setHandler(ctx.asyncAssertFailure( t -> {
+                    assertErrorCode(t, HttpURLConnection.HTTP_NOT_FOUND, ctx);
+                }));
     }
 
     /**
@@ -151,9 +151,14 @@ public class DeviceRegistrationAmqpIT {
     @Test
     public void testAssertRegistrationFailsForNonExistingGateway(final TestContext ctx) {
 
-        deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT)
-                .compose(client -> client.assertRegistration(DEVICE_ID_ENABLED, NON_EXISTING_GATWAY_ID))
-                .setHandler(ctx.asyncAssertFailure(t -> assertErrorCode(t, HttpURLConnection.HTTP_FORBIDDEN, ctx)));
+        final String deviceId = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+
+        helper.registry.registerDevice(Constants.DEFAULT_TENANT, deviceId)
+                .compose(r -> deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT))
+                .compose(client -> client.assertRegistration(deviceId, NON_EXISTING_GATWAY_ID))
+                .setHandler(ctx.asyncAssertFailure(t -> {
+                    assertErrorCode(t, HttpURLConnection.HTTP_FORBIDDEN, ctx);
+                }));
     }
 
     private static void assertErrorCode(final Throwable error, final int expectedErrorCode, final TestContext ctx) {

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationOptionalAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationOptionalAmqpIT.java
@@ -16,10 +16,14 @@ package org.eclipse.hono.tests.registry;
 import java.net.HttpURLConnection;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.RegistrationConstants;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -96,10 +100,19 @@ public class DeviceRegistrationOptionalAmqpIT {
     @Test
     public void testAssertRegistrationSucceedsForGateway(final TestContext ctx) {
 
-        deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT)
-            .compose(client -> client.assertRegistration(DeviceRegistrationAmqpIT.DEVICE_ID_ENABLED_WITH_ENABLED_GATEWAY,
-                    DeviceRegistrationAmqpIT.GATEWAY_ID_ENABLED))
-            .setHandler(ctx.asyncAssertSuccess());
+        final String deviceId = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+        final String gatewayId = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+
+        final Future deviceRegistration = helper.registry.registerDevice(Constants.DEFAULT_TENANT, deviceId,
+                new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true)
+                        .put("via", gatewayId));
+        final Future gatewayRegistration = helper.registry.registerDevice(Constants.DEFAULT_TENANT, gatewayId,
+                new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true));
+
+        CompositeFuture.all(deviceRegistration, gatewayRegistration)
+                .compose(r -> deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT))
+                .compose(client -> client.assertRegistration(deviceId, gatewayId))
+                .setHandler(ctx.asyncAssertSuccess());
     }
 
     /**
@@ -111,10 +124,21 @@ public class DeviceRegistrationOptionalAmqpIT {
     @Test
     public void testAssertRegistrationFailsForDisabledGateway(final TestContext ctx) {
 
-        deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT)
-            .compose(client -> client.assertRegistration(DeviceRegistrationAmqpIT.DEVICE_ID_ENABLED_WITH_DISABLED_GATEWAY,
-                    DeviceRegistrationAmqpIT.GATEWAY_ID_DISABLED))
-            .setHandler(ctx.asyncAssertFailure(t -> assertErrorCode(t, HttpURLConnection.HTTP_FORBIDDEN, ctx)));
+        final String deviceId = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+        final String gatewayId = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+
+        final Future deviceRegistration = helper.registry.registerDevice(Constants.DEFAULT_TENANT, deviceId,
+                new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true)
+                        .put("via", gatewayId));
+        final Future gatewayRegistration = helper.registry.registerDevice(Constants.DEFAULT_TENANT, gatewayId,
+                new JsonObject().put(RegistrationConstants.FIELD_ENABLED, false));
+
+        CompositeFuture.all(deviceRegistration, gatewayRegistration)
+                .compose(r -> deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT))
+                .compose(client -> client.assertRegistration(deviceId, gatewayId))
+                .setHandler(ctx.asyncAssertFailure(t -> {
+                    assertErrorCode(t, HttpURLConnection.HTTP_FORBIDDEN, ctx);
+        }));
     }
 
     /**
@@ -126,10 +150,25 @@ public class DeviceRegistrationOptionalAmqpIT {
     @Test
     public void testAssertRegistrationFailsForUnauthorizedGateway(final TestContext ctx) {
 
-        deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT)
-            .compose(client -> client.assertRegistration(DeviceRegistrationAmqpIT.DEVICE_ID_ENABLED_WITH_ENABLED_GATEWAY,
-                    DeviceRegistrationAmqpIT.GATEWAY_ID_ENABLED_2))
-            .setHandler(ctx.asyncAssertFailure(t -> assertErrorCode(t, HttpURLConnection.HTTP_FORBIDDEN, ctx)));
+        // Prepare the identities to insert
+        final String deviceId = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+        final String gatewayId = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+        final String gatewayId2 = helper.getRandomDeviceId(Constants.DEFAULT_TENANT);
+
+        final Future deviceRegistration = helper.registry.registerDevice(Constants.DEFAULT_TENANT, deviceId,
+                new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true)
+                        .put("via", gatewayId));
+        final Future gatewayRegistration = helper.registry.registerDevice(Constants.DEFAULT_TENANT, gatewayId,
+                new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true));
+        final Future gatewayTwoRegistration = helper.registry.registerDevice(Constants.DEFAULT_TENANT, gatewayId2,
+                new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true));
+
+        CompositeFuture.all(deviceRegistration, gatewayRegistration, gatewayTwoRegistration)
+                .compose(r -> deviceRegistryclient.getOrCreateRegistrationClient(Constants.DEFAULT_TENANT))
+                .compose(client -> client.assertRegistration(deviceId, gatewayId2))
+                .setHandler(ctx.asyncAssertFailure( t -> {
+                    assertErrorCode(t, HttpURLConnection.HTTP_FORBIDDEN, ctx);
+                }));
     }
 
     private static void assertErrorCode(final Throwable error, final int expectedErrorCode, final TestContext ctx) {

--- a/tests/src/test/resources/deviceregistry/application.yml
+++ b/tests/src/test/resources/deviceregistry/application.yml
@@ -20,6 +20,7 @@ hono:
     svc:
       filename: /etc/hono/device-identities.json
       saveToFile: false
+      startEmpty: true
       signing:
         sharedSecret: sdgfsdafazufgsdafjhfgsdajfgwhriojsdafjlksdhfgsa8fg452368gdf
   credentials:
@@ -27,10 +28,12 @@ hono:
       filename: /etc/hono/credentials.json
       maxBcryptIterations: ${max.bcrypt.iterations}
       saveToFile: false
+      startEmpty: true
   tenant:
     svc:
       filename: /etc/hono/tenants.json
       saveToFile: false
+      startEmpty: true
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
 


### PR DESCRIPTION
Hi, 

This is a quick draft to raise some discussion on how to implement a way to populate the device registry with the data needed for the integration tests, as stated in issue #1056. 
Here I used a `@Before` method and used the `DeviceRegistryHttpClient` to push the data in the device registry. 

Maybe a it would be better to directly load the Json file and push it as it is in the DR, to have a single source of data. Imo, that would improve maintainability (and readibility, as creating those JSON object programatically isn't very pleasant)..
What do you guys thinks ?
