### PR TITLE
Replace Spring Boot Actuator with vertx-web based Prometheus endpoint.

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/Application.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * The Hono AMQP main application class.
  */
-@ComponentScan(basePackages = "org.eclipse.hono.adapter.amqp")
+@ComponentScan(basePackages = { "org.eclipse.hono.adapter.amqp", "org.eclipse.hono.service.metric" })
 @Configuration
 @EnableAutoConfiguration
 public class Application extends AbstractApplication {

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -146,24 +146,6 @@
           <groupId>io.micrometer</groupId>
           <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
-        <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-web</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-webmvc</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-actuator</artifactId>
-          <version>${spring-boot.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-jetty</artifactId>
-          <version>${spring-boot.version}</version>
-        </dependency>
       </dependencies>
     </profile>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -61,7 +61,7 @@
     <vertx.version>3.6.3</vertx.version>
 
     <!-- The port at which the Prometheus scraping endpoint is exposed -->
-    <prometheus.scraping.port>8081</prometheus.scraping.port>
+    <prometheus.scraping.port>8088</prometheus.scraping.port>
     <!-- The port at which the health check server should expose its resources -->
     <vertx.health.port>8088</vertx.health.port>
 
@@ -120,11 +120,6 @@
         <artifactId>spring-boot-starter-logging</artifactId>
         <version>${spring-boot.version}</version>
         <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-actuator</artifactId>
-        <version>${spring-boot.version}</version>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>

--- a/deploy/src/main/config/grafana/dashboard-definitions/overview.json
+++ b/deploy/src/main/config/grafana/dashboard-definitions/overview.json
@@ -1132,7 +1132,7 @@
       ],
       "targets": [
         {
-          "expr": "count(up) by (job)",
+          "expr": "sum(up) by (job)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,

--- a/deploy/src/main/deploy/docker/swarm_deploy.sh
+++ b/deploy/src/main/deploy/docker/swarm_deploy.sh
@@ -155,7 +155,7 @@ docker service create $CREATE_OPTIONS --name hono-service-auth \
   --limit-memory 196m \
   --env _JAVA_OPTIONS="${default-java-options}" \
   --env SPRING_CONFIG_LOCATION=file:///run/secrets/hono-service-auth-config.yml \
-  --env SPRING_PROFILES_ACTIVE=authentication-impl,dev,prometheus \
+  --env SPRING_PROFILES_ACTIVE=authentication-impl,dev \
   --env LOGGING_CONFIG=classpath:logback-spring.xml \
   ${docker.image.org-name}/hono-service-auth:${project.version}
 echo ... done
@@ -189,7 +189,7 @@ docker service create $CREATE_OPTIONS --name hono-service-device-registry -p 256
   --env _JAVA_OPTIONS="${default-java-options}" \
   --env SPRING_CONFIG_LOCATION=file:///run/secrets/hono-service-device-registry-config.yml \
   --env LOGGING_CONFIG=classpath:logback-spring.xml \
-  --env SPRING_PROFILES_ACTIVE=dev,prometheus \
+  --env SPRING_PROFILES_ACTIVE=dev \
   --mount type=volume,source=device-registry,target=/var/lib/hono/device-registry \
   ${docker.image.org-name}/hono-service-device-registry:${project.version}
 
@@ -211,7 +211,7 @@ docker service create $CREATE_OPTIONS --name hono-adapter-http-vertx -p 8080:808
   --limit-memory 256m \
   --env _JAVA_OPTIONS="${default-java-options}" \
   --env SPRING_CONFIG_LOCATION=file:///run/secrets/hono-adapter-http-vertx-config.yml \
-  --env SPRING_PROFILES_ACTIVE=dev,prometheus \
+  --env SPRING_PROFILES_ACTIVE=dev \
   --env LOGGING_CONFIG=classpath:logback-spring.xml \
   ${docker.image.org-name}/hono-adapter-http-vertx:${project.version}
 echo ... done
@@ -231,7 +231,7 @@ docker service create $CREATE_OPTIONS --name hono-adapter-mqtt-vertx -p 1883:188
   --limit-memory 256m \
   --env _JAVA_OPTIONS="${default-java-options}" \
   --env SPRING_CONFIG_LOCATION=file:///run/secrets/hono-adapter-mqtt-vertx-config.yml \
-  --env SPRING_PROFILES_ACTIVE=dev,prometheus \
+  --env SPRING_PROFILES_ACTIVE=dev \
   --env LOGGING_CONFIG=classpath:logback-spring.xml \
   ${docker.image.org-name}/hono-adapter-mqtt-vertx:${project.version}
 echo ... done
@@ -251,7 +251,7 @@ docker service create $CREATE_OPTIONS --name hono-adapter-amqp-vertx -p 4040:567
   --limit-memory 256m \
   --env _JAVA_OPTIONS="${default-java-options}" \
   --env SPRING_CONFIG_LOCATION=file:///run/secrets/hono-adapter-amqp-vertx-config.yml \
-  --env SPRING_PROFILES_ACTIVE=dev,prometheus \
+  --env SPRING_PROFILES_ACTIVE=dev \
   --env LOGGING_CONFIG=classpath:logback-spring.xml \
   ${docker.image.org-name}/hono-adapter-amqp-vertx:${project.version}
 echo ... done
@@ -271,7 +271,7 @@ docker service create $CREATE_OPTIONS --name hono-adapter-kura -p 1884:1883 -p 8
   --limit-memory 256m \
   --env _JAVA_OPTIONS="${default-java-options}" \
   --env SPRING_CONFIG_LOCATION=file:///run/secrets/hono-adapter-kura-config.yml \
-  --env SPRING_PROFILES_ACTIVE=dev,prometheus \
+  --env SPRING_PROFILES_ACTIVE=dev \
   --env LOGGING_CONFIG=classpath:logback-spring.xml \
   ${docker.image.org-name}/hono-adapter-kura:${project.version}
 echo ... done
@@ -293,7 +293,7 @@ docker service create $CREATE_OPTIONS --name hono-adapter-coap-vertx -p 5683:568
   --limit-memory 4096m \
   --env _JAVA_OPTIONS="${default-java-options}" \
   --env SPRING_CONFIG_LOCATION=file:///run/secrets/hono-adapter-coap-vertx-config.yml \
-  --env SPRING_PROFILES_ACTIVE=dev,prometheus \
+  --env SPRING_PROFILES_ACTIVE=dev \
   --env LOGGING_CONFIG=classpath:logback-spring.xml \
   ${docker.image.org-name}/hono-adapter-coap-vertx:${project.version}
 echo ... done

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: authentication-impl,dev,prometheus
+          value: authentication-impl,dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS
@@ -54,17 +54,17 @@ spec:
           limits:
             memory: "196Mi"
         livenessProbe:
-          initialDelaySeconds: 25
-          periodSeconds: 9
-          tcpSocket:
-            port: 5672
-          timeoutSeconds: 1
+          httpGet:
+            path: /liveness
+            port: {{ .Values.healthCheckPort }}
+            scheme: HTTP
+          initialDelaySeconds: 180
         readinessProbe:
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          tcpSocket:
-            port: 5672
-          timeoutSeconds: 1
+          httpGet:
+            path: /readiness
+            port: {{ .Values.healthCheckPort }}
+            scheme: HTTP
+          initialDelaySeconds: 10
       volumes:
       - name: conf
         secret:

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/deploy/src/main/deploy/resource-descriptors/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/deploy/src/main/deploy/resource-descriptors/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-service-auth/hono-service-auth-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: authentication-impl,dev,prometheus
+          value: authentication-impl,dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS
@@ -54,17 +54,17 @@ spec:
           limits:
             memory: "196Mi"
         livenessProbe:
-          initialDelaySeconds: 25
-          periodSeconds: 9
-          tcpSocket:
-            port: 5672
-          timeoutSeconds: 1
+          httpGet:
+            path: /liveness
+            port: ${vertx.health.port}
+            scheme: HTTP
+          initialDelaySeconds: 180
         readinessProbe:
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          tcpSocket:
-            port: 5672
-          timeoutSeconds: 1
+          httpGet:
+            path: /readiness
+            port: ${vertx.health.port}
+            scheme: HTTP
+          initialDelaySeconds: 10
       volumes:
       - name: conf
         secret:

--- a/deploy/src/main/deploy/resource-descriptors/hono-service-device-registry/hono-service-device-registry-deployment.yaml
+++ b/deploy/src/main/deploy/resource-descriptors/hono-service-device-registry/hono-service-device-registry-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: SPRING_CONFIG_LOCATION
           value: file:///etc/hono/
         - name: SPRING_PROFILES_ACTIVE
-          value: dev,prometheus
+          value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
         - name: _JAVA_OPTIONS

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -100,16 +100,6 @@
       <artifactId>vertx-micrometer-metrics</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-actuator</artifactId>
-      <exclusions>
-       <exclusion>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-       </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -144,11 +134,21 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
   </dependencies>
 

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/PrometheusScrapingResource.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/PrometheusScrapingResource.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.service.metric;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A vert.x HTTP resource for scraping Micrometer's {@code PrometheusMeterRegistry}.
+ *
+ */
+@Component
+@Qualifier("healthchecks")
+@ConditionalOnClass(name = "io.micrometer.prometheus.PrometheusMeterRegistry")
+public class PrometheusScrapingResource implements Handler<Router> {
+
+    private final PrometheusMeterRegistry registry;
+
+    private String uri = "/prometheus";
+
+    /**
+     * Creates a new resource for a registry.
+     * 
+     * @param registry The registry.
+     * @throws NullPointerException if the registry is {@code null}.
+     */
+    public PrometheusScrapingResource(final PrometheusMeterRegistry registry) {
+        this.registry = Objects.requireNonNull(registry);
+    }
+
+    /**
+     * Scrapes the registry.
+     * 
+     * @param event The request.
+     */
+    private void scrape(final RoutingContext event) {
+        final String stats = registry.scrape();
+        event.response().setStatusCode(HttpURLConnection.HTTP_OK).end(stats);
+    }
+
+    /**
+     * Registers this resource.
+     * 
+     * @param router The router to register on.
+     */
+    @Override
+    public void handle(final Router router) {
+        Objects.requireNonNull(router);
+        router.get(uri).handler(this::scrape);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Prometheus Registry Scraper [endpoint: %s]", uri);
+    }
+}

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/Application.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,7 +29,7 @@ import io.vertx.core.Future;
  * a connection that has been authenticated using SASL.
  *
  */
-@ComponentScan(basePackages = "org.eclipse.hono.service.auth")
+@ComponentScan(basePackages = { "org.eclipse.hono.service.auth", "org.eclipse.hono.service.metric" })
 @Configuration
 @EnableAutoConfiguration
 public class Application extends AbstractApplication {

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/ApplicationConfig.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/ApplicationConfig.java
@@ -16,6 +16,8 @@ package org.eclipse.hono.service.auth.impl;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.config.VertxProperties;
+import org.eclipse.hono.service.HealthCheckServer;
+import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.auth.AuthTokenHelper;
 import org.eclipse.hono.service.auth.AuthTokenHelperImpl;
 import org.eclipse.hono.service.metric.MetricsTags;
@@ -169,6 +171,15 @@ public class ApplicationConfig {
     public MeterRegistryCustomizer<MeterRegistry> commonTags() {
 
         return r -> r.config().commonTags(MetricsTags.forService(Constants.SERVICE_NAME_AUTH));
+    }
 
+    /**
+     * Exposes the health check server as a Spring bean.
+     *
+     * @return The health check server.
+     */
+    @Bean
+    public HealthCheckServer healthCheckServer() {
+        return new VertxBasedHealthCheckServer(vertx(), applicationConfigProperties());
     }
 }

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -130,24 +130,6 @@
           <groupId>io.micrometer</groupId>
           <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
-        <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-web</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-webmvc</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-actuator</artifactId>
-          <version>${spring-boot.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-jetty</artifactId>
-          <version>${spring-boot.version}</version>
-        </dependency>
       </dependencies>
     </profile>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -243,6 +243,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <run>
                     <ports>
                       <port>+auth.ip:auth.amqp.port:5672</port>
+                      <port>+auth.ip:auth.health.port:${vertx.health.port}</port>
                     </ports>
                     <network>
                       <mode>custom</mode>
@@ -269,7 +270,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </volumes>
                     <wait>
                       <time>${service.startup.timeout}</time>
-                      <log>^.*(Started Application).*$</log>
+                      <http>
+                        <method>GET</method>
+                        <url>http://${auth.ip}:${auth.health.port}/readiness</url>
+                        <status>200..299</status>
+                      </http>
                     </wait>
                   </run>
                 </image>

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -2,7 +2,7 @@ hono:
   app:
     maxInstances: 1
     healthCheckBindAddress: 0.0.0.0
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     startupTimeout: 120
   amqp:
     bindAddress: 0.0.0.0

--- a/tests/src/test/resources/auth/application.yml
+++ b/tests/src/test/resources/auth/application.yml
@@ -1,6 +1,8 @@
 hono:
   app:
     maxInstances: 1
+    healthCheckBindAddress: 0.0.0.0
+    healthCheckPort: ${vertx.health.port}
   auth:
     amqp:
       insecurePortEnabled: true

--- a/tests/src/test/resources/deviceregistry/application.yml
+++ b/tests/src/test/resources/deviceregistry/application.yml
@@ -2,7 +2,7 @@ hono:
   app:
     maxInstances: 1
     healthCheckBindAddress: 0.0.0.0
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     startupTimeout: 90
   auth:
     host: hono-service-auth.hono

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -2,7 +2,7 @@ hono:
   app:
     maxInstances: 1
     healthCheckBindAddress: 0.0.0.0
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     startupTimeout: 120
   http:
     bindAddress: 0.0.0.0

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -2,7 +2,7 @@ hono:
   app:
     maxInstances: 1
     healthCheckBindAddress: 0.0.0.0
-    healthCheckPort: 8088
+    healthCheckPort: ${vertx.health.port}
     startupTimeout: 120
   mqtt:
     bindAddress: 0.0.0.0


### PR DESCRIPTION
Use the vertx-web based HealthCheckServer's HTTP server to expose a
resource for scraping the PrometheusMeterRegistry of Hono components.

This way we do not need to spawn up a jetty server just for serving the Prometheus scraping endpoint and can prevent including a bunch of additional jars when we already have a (running) HTTP server in place.

In this initial version, the scraping and health check endpoints are exposed on an unsecured port (no TLS) without authentication. However, this can be added in a subsequent PR.