### PR TITLE
Set Java 11 as source+target version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: java
 
 jdk:
-#  - openjdk8
   - openjdk11
 
 script:

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/VertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/vertx/VertxBasedCoapAdapter.java
@@ -58,7 +58,7 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
     public void getExtendedDevice(final CoapExchange exchange, final Handler<ExtendedDevice> handler) {
         try {
             final List<String> pathList = exchange.getRequestOptions().getUriPath();
-            final String[] path = pathList.toArray(new String[pathList.size()]);
+            final String[] path = pathList.toArray(String[]::new);
             final ResourceIdentifier identifier = ResourceIdentifier.fromPath(path);
             final Device device = new Device(identifier.getTenantId(), identifier.getResourceId());
             final Principal peer = exchange.advanced().getRequest().getSourceContext().getPeerIdentity();
@@ -69,9 +69,9 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
             } else {
                 getAuthenticatedExtendedDevice(device, exchange, handler);
             }
-        } catch (NullPointerException cause) {
+        } catch (final NullPointerException cause) {
             CoapErrorResponse.respond(exchange, "missing tenant and device!", ResponseCode.BAD_REQUEST);
-        } catch (Throwable cause) {
+        } catch (final Throwable cause) {
             CoapErrorResponse.respond(exchange, cause, ResponseCode.INTERNAL_SERVER_ERROR);
         }
     }

--- a/core/src/main/java/org/eclipse/hono/util/AuthenticationConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/AuthenticationConstants.java
@@ -162,7 +162,7 @@ public final class AuthenticationConstants {
         } else if (fields.get(2) == null || fields.get(2).length() == 0) {
             throw new CredentialException("PLAIN response must contain a password");
         } else {
-            return fields.toArray(new String[3]);
+            return fields.toArray(String[]::new);
         }
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/Hostnames.java
+++ b/core/src/main/java/org/eclipse/hono/util/Hostnames.java
@@ -24,13 +24,13 @@ public final class Hostnames {
     static {
 
         // works on Linux
-        String hostname = System.getenv("HOSTNAME");
+        var hostname = System.getenv("HOSTNAME");
 
         if (hostname == null) {
             // this can produce all kinds of unexpected results
             // but better than nothing
             try {
-                final InetAddress localhost = InetAddress.getLocalHost();
+                final var localhost = InetAddress.getLocalHost();
                 hostname = localhost.getHostAddress();
             } catch (final Exception e) {
             }

--- a/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
@@ -60,7 +60,7 @@ public final class ResourceIdentifier {
         if (assumeDefaultTenant) {
             pathSegments.add(1, Constants.DEFAULT_TENANT);
         }
-        setResourcePath(pathSegments.toArray(new String[pathSegments.size()]));
+        setResourcePath(pathSegments.toArray(String[]::new));
     }
 
     private ResourceIdentifier(final String endpoint, final String tenantId, final String resourceId) {
@@ -94,7 +94,7 @@ public final class ResourceIdentifier {
                 pathSegments.add(segment);
             }
         }
-        this.resourcePath = pathSegments.toArray(new String[pathSegments.size()]);
+        this.resourcePath = pathSegments.toArray(String[]::new);
         if (resourcePath.length > IDX_TENANT_ID && resourcePath[IDX_TENANT_ID].length() == 0) {
             resourcePath[IDX_TENANT_ID] = null;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -236,10 +236,10 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.8.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>11</source>
+            <target>11</target>
             <encoding>UTF-8</encoding>
           </configuration>
         </plugin>

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/FileBasedAuthenticationService.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/FileBasedAuthenticationService.java
@@ -196,7 +196,7 @@ public final class FileBasedAuthenticationService extends AbstractHonoAuthentica
                           activityList.add(act);
                       }
                   });
-                  result.addResource(resource, activityList.toArray(new Activity[activityList.size()]));
+                        result.addResource(resource, activityList.toArray(Activity[]::new));
               } else if (operation != null) {
                   final String[] parts = operation.split(":", 2);
                   if (parts.length == 2) {

--- a/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
+++ b/services/auth/src/main/java/org/eclipse/hono/service/auth/impl/SimpleAuthenticationServer.java
@@ -177,7 +177,7 @@ public final class SimpleAuthenticationServer extends AmqpServiceBase<ServiceCon
             default:
                 // return 0.0.0
             }
-        } catch (NumberFormatException e) {
+        } catch (final NumberFormatException e) {
             // return 0.0.0
         }
         return result;
@@ -204,7 +204,7 @@ public final class SimpleAuthenticationServer extends AmqpServiceBase<ServiceCon
                 return null;
             }
         }).filter(Objects::nonNull).collect(Collectors.toSet());
-        return result.toArray(new String[result.size()]);
+        return result.toArray(String[]::new);
     }
 
     @Override


### PR DESCRIPTION
As Hono has problems building on Java 8, and we already ship Java 11
images, we decided to fully switch to Java 11. But keeping the
classpath model.

This PR switches to Java 11 for source+target, and also makes use
of a few Java 11-only features, just test it.