### PR TITLE
Fix description of device registry in readme: add tenant API.

### DIFF
--- a/services/device-registry/readme.md
+++ b/services/device-registry/readme.md
@@ -1,5 +1,5 @@
 This module contains an implementation of Hono's Device Registry as a separate microservice.
-It implements the Credentials API and the Registration API - both based on a file.
+It implements the Credentials API, the Registration API and the Tenant API - all of them based on a file.
 
 Production ready implementations can replace the file mechanism by better persistence layers (that are prepared for horizontal scalability e.g.).
 The file implementation only serves as a blueprint and to have a fully working (but not scalable) implementation.


### PR DESCRIPTION
The readme of module `device-registry` mentioned that it implements the Credentials and the Registration APIs. Added the Tenant API to the description for more clarity on this level of information.