### PR TITLE
DR - forward the complete payload to credential service

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CompleteBaseCredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CompleteBaseCredentialsService.java
@@ -111,7 +111,7 @@ public abstract class CompleteBaseCredentialsService<T> extends BaseCredentialsS
         try {
             payload.checkValidity(this::checkSecret);
             final Future<CredentialsResult<JsonObject>> result = Future.future();
-            add(tenantId, JsonObject.mapFrom(payload), result.completer());
+            add(tenantId, request.getJsonPayload(), result.completer());
             return result.map(res -> {
                 return request.getResponse(res.getStatus())
                         .setDeviceId(payload.getDeviceId())


### PR DESCRIPTION
when a request to create credentials containing client context is forwarded to tje device registry, the payload is mapped into a `CredentialObject`, which prune the additional properties. The mapping is useful to do some checks on the payload.

This simple fix simply forward the original payload once it have been checked.

Signed-off-by: Trystram Jean-Baptiste <jbtrystram@redhat.com>