### PR TITLE
[#1066] Add client certificate based authentication to CLI.

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/AmqpSend.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/AmqpSend.java
@@ -164,7 +164,15 @@ public class AmqpSend extends AbstractCliClient {
                     properties.getPassword(),
                     connectAttempt);
         } else {
-            // SASL ANONYMOUS auth
+            if (properties.getKeyCertOptions() != null && properties.getTrustOptions() != null) {
+                // SASL EXTERNAL auth
+                options.setSsl(true);
+                options.setKeyCertOptions(properties.getKeyCertOptions());
+                options.setTrustOptions(properties.getTrustOptions());
+            } else {
+                // SASL ANONYMOUS auth
+            }
+
             LOG.info("connecting to AMQP adapter [host: {}, port: {}]", properties.getHost(), properties.getPort());
             client.connect(options, properties.getHost(), properties.getPort(), connectAttempt);
         }

--- a/site/content/user-guide/amqp-adapter.md
+++ b/site/content/user-guide/amqp-adapter.md
@@ -118,6 +118,10 @@ Publish some JSON data for device `4711`:
 
 Notice that we only supplied a new value for the message address, leaving the other default values.
 
+Publish some JSON data for device `4711` using a client certificate for authentication:
+
+    ~/hono/cli/target$ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.port=5671 --hono.client.certPath=config/hono-demo-certs-jar/device-4711-cert.pem --hono.client.keyPath=config/hono-demo-certs-jar/device-4711-key.pem --hono.client.trustStorePath=config/hono-demo-certs-jar/trusted-certs.pem --hono.client.hostnameVerificationRequired=false
+
 ## Publish Telemetry Data (unauthenticated Device)
 
 * Message Address: `telemetry/${tenant-id}/${device-id}` or `t/${tenant-id}/${device-id}`


### PR DESCRIPTION
The AMQP CLI application can now be used for client certificate based
authentication against the AMQP protocol adapter.
+ Added example to User Guide.

Signed-off-by: Abel Buechner-Mihaljevic <Abel.Buechner@bosch-si.com>