### PR TITLE
Fix Release Notes: Connection limit for AMQP is not Hono 0.9.

### DIFF
--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -2,6 +2,14 @@
 title = "Release Notes"
 +++
 
+## 1.0-M1 (not released yet)
+
+### New Features
+
+* The AMQP adapter now supports limiting the number of concurrent connections in order
+  to prevent Out of Memory errors. Please refer to
+  [AMQP Adapter Configuration]({{< relref "/admin-guide/amqp-adapter-config.md" >}}) for details.
+
 ## 0.9
 
 ### New Features
@@ -13,9 +21,6 @@ title = "Release Notes"
   [MQTT Adapter Configuration]({{< relref "/admin-guide/mqtt-adapter-config.md" >}}) for details.
 * The new *Helm deployment* for Kubernetes has been added. Please refer to
   [Kubernetes deployment guide]({{< relref "/deployment/kubernetes.md" >}}) for details.
-* The AMQP adapter now supports limiting the number of concurrent connections in order
-  to prevent Out of Memory errors. Please refer to
-  [AMQP Adapter Configuration]({{< relref "/admin-guide/amqp-adapter-config.md" >}}) for details.
 
 ### Fixes & Enhancements
 


### PR DESCRIPTION
The PR that adds support for connection limits to the AMQP protocol
adapter has been merged after the release of 0.9, but the release notes
mentioned it under 0.9.

Signed-off-by: Abel Buechner-Mihaljevic <Abel.Buechner@bosch-si.com>