### PR TITLE
[#1083] Unified file paths in documentation, removed shell prompts.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The easiest way to contribute code/patches/whatever is by creating a GitHub pull
 
 You do this by adding the `-s` flag when you make the commit(s), e.g.
 
-    $> git commit -s -m "Shave the yak some more"
+    git commit -s -m "Shave the yak some more"
 
 You can find all the details in the [Contributing via Git](http://wiki.eclipse.org/Development_Resources/Contributing_via_Git) document on the Eclipse web site.
 

--- a/demo-certs/README.md
+++ b/demo-certs/README.md
@@ -37,6 +37,7 @@ You can also use the script to create your own certificates for use with Hono. S
 
 Then simply run the script from the command line:
 
-    $~/hono/demo-certs> ./create_certs.sh
+    # in base directory of Hono repository:
+    ./demo-certs/create_certs.sh
 
 The script will create the `certs` subfolder (if it already exists it will be removed first) and then create all keys and certificates in that subfolder.

--- a/site/content/admin-guide/amqp-adapter-config.md
+++ b/site/content/admin-guide/amqp-adapter-config.md
@@ -127,35 +127,36 @@ See [Monitoring & Tracing Admin Guide]({{< ref "monitoring-tracing-config.md" >}
 The AMQP adapter can be run as a Docker container from the command line. The following commands create and start the AMQP adapter as a Docker Swarm service using the default keys contained in the `demo-certs` module:
 
 ~~~sh
-~/hono$ docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
-~/hono$ docker secret create amqp-adapter-key.pem demo-certs/certs/amqp-adapter-key.pem
-~/hono$ docker secret create amqp-adapter-cert.pem demo-certs/certs/amqp-adapter-cert.pem
-~/hono$ docker service create --detach --name hono-adapter-amqp-vertx --network hono-net -p 4040:4040 -p 4041:4041 \
-> --secret trusted-certs.pem \
-> --secret amqp-adapter-key.pem \
-> --secret amqp-adapter-cert.pem \
-> -e 'HONO_MESSAGING_HOST=hono-service-messaging.hono' \
-> -e 'HONO_MESSAGING_USERNAME=amqp-adapter@HONO' \
-> -e 'HONO_MESSAGING_PASSWORD=amqp-secret' \
-> -e 'HONO_MESSAGING_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_TENANT_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_TENANT_USERNAME=amqp-adapter@HONO' \
-> -e 'HONO_TENANT_PASSWORD=amqp-secret' \
-> -e 'HONO_TENANT_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_REGISTRATION_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_REGISTRATION_USERNAME=amqp-adapter@HONO' \
-> -e 'HONO_REGISTRATION_PASSWORD=amqp-secret' \
-> -e 'HONO_REGISTRATION_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_CREDENTIALS_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_CREDENTIALS_USERNAME=amqp-adapter@HONO' \
-> -e 'HONO_CREDENTIALS_PASSWORD=amqp-secret' \
-> -e 'HONO_CREDENTIALS_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_AMQP_BIND_ADDRESS=0.0.0.0' \
-> -e 'HONO_AMQP_KEY_PATH=/run/secrets/amqp-adapter-key.pem' \
-> -e 'HONO_AMQP_CERT_PATH=/run/secrets/amqp-adapter-cert.pem' \
-> -e 'HONO_AMQP_INSECURE_PORT_ENABLED=true' \
-> -e 'HONO_AMQP_INSECURE_PORT_BIND_ADDRESS=0.0.0.0'
-> eclipse/hono-adapter-amqp-vertx:latest
+# in base directory of Hono repository:
+docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
+docker secret create amqp-adapter-key.pem demo-certs/certs/amqp-adapter-key.pem
+docker secret create amqp-adapter-cert.pem demo-certs/certs/amqp-adapter-cert.pem
+docker service create --detach --name hono-adapter-amqp-vertx --network hono-net -p 4040:4040 -p 4041:4041 \
+ --secret trusted-certs.pem \
+ --secret amqp-adapter-key.pem \
+ --secret amqp-adapter-cert.pem \
+ -e 'HONO_MESSAGING_HOST=hono-service-messaging.hono' \
+ -e 'HONO_MESSAGING_USERNAME=amqp-adapter@HONO' \
+ -e 'HONO_MESSAGING_PASSWORD=amqp-secret' \
+ -e 'HONO_MESSAGING_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_TENANT_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_TENANT_USERNAME=amqp-adapter@HONO' \
+ -e 'HONO_TENANT_PASSWORD=amqp-secret' \
+ -e 'HONO_TENANT_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_REGISTRATION_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_REGISTRATION_USERNAME=amqp-adapter@HONO' \
+ -e 'HONO_REGISTRATION_PASSWORD=amqp-secret' \
+ -e 'HONO_REGISTRATION_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_CREDENTIALS_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_CREDENTIALS_USERNAME=amqp-adapter@HONO' \
+ -e 'HONO_CREDENTIALS_PASSWORD=amqp-secret' \
+ -e 'HONO_CREDENTIALS_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_AMQP_BIND_ADDRESS=0.0.0.0' \
+ -e 'HONO_AMQP_KEY_PATH=/run/secrets/amqp-adapter-key.pem' \
+ -e 'HONO_AMQP_CERT_PATH=/run/secrets/amqp-adapter-cert.pem' \
+ -e 'HONO_AMQP_INSECURE_PORT_ENABLED=true' \
+ -e 'HONO_AMQP_INSECURE_PORT_BIND_ADDRESS=0.0.0.0' \
+ eclipse/hono-adapter-amqp-vertx:latest
 ~~~
 
 {{% note %}}
@@ -189,26 +190,27 @@ In order to do so, the adapter can be started using the `spring-boot:run` maven 
 The corresponding command to start up the adapter with the configuration used in the Docker example above looks like this:
 
 ~~~sh
-~/hono/adapters/amqp-vertx$ mvn spring-boot:run -Drun.arguments=\
-> --hono.messaging.host=hono-service-messaging.hono,\
-> --hono.messaging.username=amqp-adapter@HONO,\
-> --hono.messaging.password=amqp-secret,\
-> --hono.messaging.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.tenant.host=hono-service-device-registry.hono,\
-> --hono.tenant.username=amqp-adapter@HONO,\
-> --hono.tenant.password=amqp-secret,\
-> --hono.tenant.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.registration.host=hono-service-device-registry.hono,\
-> --hono.registration.username=amqp-adapter@HONO,\
-> --hono.registration.password=amqp-secret,\
-> --hono.registration.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.credentials.host=hono-service-device-registry.hono,\
-> --hono.credentials.username=amqp-adapter@HONO,\
-> --hono.credentials.password=amqp-secret,\
-> --hono.credentials.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.amqp.bindAddress=0.0.0.0,\
-> --hono.amqp.insecurePortEnabled=true,\
-> --hono.amqp.insecurePortBindAddress=0.0.0.0
+# in directory: hono/adapters/amqp-vertx/
+mvn spring-boot:run -Dhono.app.healthCheckPort=8088 -Dhono.app.maxInstances=1 -Drun.arguments=\
+--hono.messaging.host=hono-service-messaging.hono,\
+--hono.messaging.username=amqp-adapter@HONO,\
+--hono.messaging.password=amqp-secret,\
+--hono.messaging.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.tenant.host=hono-service-device-registry.hono,\
+--hono.tenant.username=amqp-adapter@HONO,\
+--hono.tenant.password=amqp-secret,\
+--hono.tenant.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.registration.host=hono-service-device-registry.hono,\
+--hono.registration.username=amqp-adapter@HONO,\
+--hono.registration.password=amqp-secret,\
+--hono.registration.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.credentials.host=hono-service-device-registry.hono,\
+--hono.credentials.username=amqp-adapter@HONO,\
+--hono.credentials.password=amqp-secret,\
+--hono.credentials.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.amqp.bindAddress=0.0.0.0,\
+--hono.amqp.insecurePortEnabled=true,\
+--hono.amqp.insecurePortBindAddress=0.0.0.0
 ~~~
 
 {{% note %}}

--- a/site/content/admin-guide/amqp-network-config.md
+++ b/site/content/admin-guide/amqp-network-config.md
@@ -21,16 +21,17 @@ The Dispatch Router can be configured by means of configuration files. Hono incl
 The Dispatch Router can be run as a Docker container from the command line. The following commands create and start the Dispatch Router as a Docker Swarm service using the default keys and configuration file contained in the `example` and `demo-certs` modules:
 
 ~~~sh
-~/hono$ docker secret create qdrouter-key.pem demo-certs/certs/qdrouter-key.pem
-~/hono$ docker secret create qdrouter-cert.pem demo-certs/certs/qdrouter-cert.pem
-~/hono$ docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
-~/hono$ docker secret create qdrouterd.json deploy/src/main/config/qpid/qdrouterd-with-broker.json
-~/hono$ docker service create --detach --name hono-dispatch-router --network hono-net -p 15671:5671 -p 15672:5672 -p 15673:5673 \
->  --secret qdrouter-key.pem \
->  --secret qdrouter-cert.pem \
->  --secret trusted-certs.pem \
->  --secret qdrouterd.json \
->  enmasseproject/qdrouterd-base:1.1.0 /sbin/qdrouterd -c /run/secrets/qdrouterd.json
+# in base directory of Hono repository:
+docker secret create qdrouter-key.pem demo-certs/certs/qdrouter-key.pem
+docker secret create qdrouter-cert.pem demo-certs/certs/qdrouter-cert.pem
+docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
+docker secret create qdrouterd.json deploy/src/main/config/qpid/qdrouterd-with-broker.json
+docker service create --detach --name hono-dispatch-router --network hono-net -p 15671:5671 -p 15672:5672 -p 15673:5673 \
+  --secret qdrouter-key.pem \
+  --secret qdrouter-cert.pem \
+  --secret trusted-certs.pem \
+  --secret qdrouterd.json \
+  enmasseproject/qdrouterd-base:1.1.0 /sbin/qdrouterd -c /run/secrets/qdrouterd.json
 ~~~
 
 {{% note %}}

--- a/site/content/admin-guide/auth-server-config.md
+++ b/site/content/admin-guide/auth-server-config.md
@@ -101,16 +101,17 @@ See [Monitoring & Tracing Admin Guide]({{< ref "/admin-guide/monitoring-tracing-
 The Auth Server can be run as a Docker container from the command line. The following commands create and start the Auth Server as a Docker Swarm service using the default keys and configuration files contained in the `services/auth` and `demo-certs` modules:
 
 ~~~sh
-~/hono$ docker secret create auth-server-key.pem demo-certs/certs/auth-server-key.pem
-~/hono$ docker secret create auth-server-cert.pem demo-certs/certs/auth-server-cert.pem
-~/hono$ docker service create --detach --name auth-server --network hono-net -p5671:5671 \
-> --secret auth-server-key.pem \
-> --secret auth-server-cert.pem \
-> -e 'HONO_AUTH_AMQP_BIND_ADDRESS=0.0.0.0'
-> -e 'HONO_AUTH_AMQP_KEY_PATH=/run/secrets/auth-server-key.pem' \
-> -e 'HONO_AUTH_AMQP_CERT_PATH=/run/secrets/auth-server-cert.pem' \
-> -e 'SPRING_PROFILES_ACTIVE=authentication-impl' \
-> eclipse/hono-service-auth:latest
+# in base directory of Hono repository:
+docker secret create auth-server-key.pem demo-certs/certs/auth-server-key.pem
+docker secret create auth-server-cert.pem demo-certs/certs/auth-server-cert.pem
+docker service create --detach --name auth-server --network hono-net -p5671:5671 \
+ --secret auth-server-key.pem \
+ --secret auth-server-cert.pem \
+ -e 'HONO_AUTH_AMQP_BIND_ADDRESS=0.0.0.0' \
+ -e 'HONO_AUTH_AMQP_KEY_PATH=/run/secrets/auth-server-key.pem' \
+ -e 'HONO_AUTH_AMQP_CERT_PATH=/run/secrets/auth-server-cert.pem' \
+ -e 'SPRING_PROFILES_ACTIVE=authentication-impl' \
+ eclipse/hono-service-auth:latest
 ~~~
 
 {{% note %}}
@@ -130,8 +131,8 @@ Using the example from above, the following environment variable definition need
 
 ~~~sh
 ...
-> -e '_JAVA_OPTIONS=-Xmx64m' \
-> eclipse/hono-service-auth:latest
+ -e '_JAVA_OPTIONS=-Xmx64m' \
+ eclipse/hono-service-auth:latest
 ~~~
 
 ## Run using the Docker Swarm Deployment Script
@@ -145,11 +146,12 @@ In order to do so, the server can be started using the `spring-boot:run` maven g
 The corresponding command to start up the server with the configuration used in the Docker example above looks like this:
 
 ~~~sh
-~/hono/services/auth$ mvn spring-boot:run -Drun.profiles=authentication-impl -Drun.arguments=\
-> --hono.auth.amqp.bindAddress=0.0.0.0,\
-> --hono.auth.amqp.keyPath=target/certs/auth-server-key.pem,\
-> --hono.auth.amqp.certPath=target/certs/auth-server-cert.pem,\
-> --hono.auth.amqp.trustStorePath=target/certs/trusted-certs.pem
+# in directory: hono/services/auth/
+mvn spring-boot:run -Drun.profiles=authentication-impl -Dhono.app.healthCheckPort=8088 -Dhono.app.maxInstances=1 -Drun.arguments=\
+--hono.auth.amqp.bindAddress=0.0.0.0,\
+--hono.auth.amqp.keyPath=../../demo-certs/certs/auth-server-key.pem,\
+--hono.auth.amqp.certPath=../../demo-certs/certs/auth-server-cert.pem,\
+--hono.auth.amqp.trustStorePath=../../demo-certs/certs/trusted-certs.pem
 ~~~
 
 {{% note %}}

--- a/site/content/admin-guide/device-registry-config.md
+++ b/site/content/admin-guide/device-registry-config.md
@@ -178,33 +178,34 @@ The example configuration file (located at `/deploy/src/main/deploy/example-devi
 The Device Registry can be run as a Docker container from the command line. The following commands create and start the Device Registry as a Docker Swarm service using the default keys and configuration files contained in the `demo-certs` and `services/device-registry` modules:
 
 ~~~sh
-~/hono$ docker secret create auth-server-key.pem demo-certs/certs/auth-server-key.pem
-~/hono$ docker secret create auth-server-cert.pem demo-certs/certs/auth-server-cert.pem
-~/hono$ docker secret create device-registry-key.pem demo-certs/certs/device-registry-key.pem
-~/hono$ docker secret create device-registry-cert.pem demo-certs/certs/device-registry-cert.pem
-~/hono$ docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
-~/hono$ docker secret create device-identities.json services/device-registry/src/test/resources/device-identities.json
-~/hono$ docker service create --detach --name hono-service-device-registry --network hono-net -p 25671:5671 \
-> --secret auth-server-key.pem \
-> --secret auth-server-cert.pem \
-> --secret device-registry-key.pem \
-> --secret device-registry-cert.pem \
-> --secret trusted-certs.pem \
-> --secret tenants.json \
-> --secret device-identities.json \
-> --secret credentials.json \
-> -e 'HONO_AUTH_HOST=<name or address of the auth-server>' \
-> -e 'HONO_AUTH_NAME=device-registry' \
-> -e 'HONO_AUTH_VALIDATION_CERT_PATH=/run/secrets/auth-server-cert.pem' \
-> -e 'HONO_AUTH_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_REGISTRY_AMQP_BIND_ADDRESS=0.0.0.0'
-> -e 'HONO_REGISTRY_AMQP_KEY_PATH=/run/secrets/device-registry-key.pem' \
-> -e 'HONO_REGISTRY_AMQP_CERT_PATH=/run/secrets/device-registry-cert.pem' \
-> -e 'HONO_TENANT_SVC_FILENAME=file:/run/secrets/tenants.json' \
-> -e 'HONO_REGISTRY_SVC_FILENAME=file:/run/secrets/device-identities.json' \
-> -e 'HONO_CREDENTIALS_SVC_FILENAME=file:/run/secrets/credentials.json' \
-> -e 'HONO_REGISTRY_SVC_SIGNING_SHARED_SECRET=asharedsecretforvalidatingassertions' \
-> eclipse/hono-service-device-registry:latest
+# in base directory of Hono repository:
+docker secret create auth-server-key.pem demo-certs/certs/auth-server-key.pem
+docker secret create auth-server-cert.pem demo-certs/certs/auth-server-cert.pem
+docker secret create device-registry-key.pem demo-certs/certs/device-registry-key.pem
+docker secret create device-registry-cert.pem demo-certs/certs/device-registry-cert.pem
+docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
+docker secret create device-identities.json services/device-registry/src/test/resources/device-identities.json
+docker service create --detach --name hono-service-device-registry --network hono-net -p 25671:5671 \
+ --secret auth-server-key.pem \
+ --secret auth-server-cert.pem \
+ --secret device-registry-key.pem \
+ --secret device-registry-cert.pem \
+ --secret trusted-certs.pem \
+ --secret tenants.json \
+ --secret device-identities.json \
+ --secret credentials.json \
+ -e 'HONO_AUTH_HOST=<name or address of the auth-server>' \
+ -e 'HONO_AUTH_NAME=device-registry' \
+ -e 'HONO_AUTH_VALIDATION_CERT_PATH=/run/secrets/auth-server-cert.pem' \
+ -e 'HONO_AUTH_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_REGISTRY_AMQP_BIND_ADDRESS=0.0.0.0' \
+ -e 'HONO_REGISTRY_AMQP_KEY_PATH=/run/secrets/device-registry-key.pem' \
+ -e 'HONO_REGISTRY_AMQP_CERT_PATH=/run/secrets/device-registry-cert.pem' \
+ -e 'HONO_TENANT_SVC_FILENAME=file:/run/secrets/tenants.json' \
+ -e 'HONO_REGISTRY_SVC_FILENAME=file:/run/secrets/device-identities.json' \
+ -e 'HONO_CREDENTIALS_SVC_FILENAME=file:/run/secrets/credentials.json' \
+ -e 'HONO_REGISTRY_SVC_SIGNING_SHARED_SECRET=asharedsecretforvalidatingassertions' \
+ eclipse/hono-service-device-registry:latest
 ~~~
 
 {{% note %}}
@@ -224,8 +225,8 @@ Using the example from above, the following environment variable definition need
 
 ~~~sh
 ...
-> -e '_JAVA_OPTIONS=-Xmx128m' \
-> eclipse/hono-service-device-registry:latest
+ -e '_JAVA_OPTIONS=-Xmx128m' \
+ eclipse/hono-service-device-registry:latest
 ~~~
 
 ## Run using the Docker Swarm Deployment Script
@@ -239,15 +240,17 @@ In order to do so, the server can be started using the `spring-boot:run` maven g
 The corresponding command to start up the server with the configuration used in the Docker example above looks like this:
 
 ~~~sh
-~/hono/services/device-registry $ mvn spring-boot:run -Drun.arguments=\
-> --hono.registry.amqp.bindAddress=0.0.0.0,\
-> --hono.registry.amqp.keyPath=target/certs/device-registry-key.pem,\
-> --hono.registry.amqp.certPath=target/certs/device-registry-cert.pem,\
-> --hono.registry.amqp.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.auth.host=localhost,\
-> --hono.auth.name='device-registry',\
-> --hono.auth.validation.certPath=target/certs/auth-server-cert.pem,\
-> --hono.auth.trustStorePath=target/certs/trusted-certs.pem
+# in directory: hono/services/device-registry/
+mvn spring-boot:run -Dhono.app.healthCheckPort=8088 -Dhono.app.maxInstances=1 -Drun.arguments=\
+--hono.registry.amqp.bindAddress=0.0.0.0,\
+--hono.registry.amqp.keyPath=../../demo-certs/certs/device-registry-key.pem,\
+--hono.registry.amqp.certPath=../../demo-certs/certs/device-registry-cert.pem,\
+--hono.registry.amqp.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.registry.rest.insecurePortEnabled=true,\
+--hono.auth.host=localhost,\
+--hono.auth.name='device-registry',\
+--hono.auth.validation.certPath=../../demo-certs/certs/auth-server-cert.pem,\
+--hono.auth.trustStorePath=../../demo-certs/certs/trusted-certs.pem
 ~~~
 
 {{% note %}}

--- a/site/content/admin-guide/http-adapter-config.md
+++ b/site/content/admin-guide/http-adapter-config.md
@@ -128,35 +128,36 @@ See [Monitoring & Tracing Admin Guide]({{< ref "monitoring-tracing-config.md" >}
 The HTTP adapter can be run as a Docker container from the command line. The following commands create and start the HTTP adapter as a Docker Swarm service using the default keys  contained in the `demo-certs` module:
 
 ~~~sh
-~/hono$ docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
-~/hono$ docker secret create http-adapter-key.pem demo-certs/certs/http-adapter-key.pem
-~/hono$ docker secret create http-adapter-cert.pem demo-certs/certs/http-adapter-cert.pem
-~/hono$ docker service create --detach --name hono-adapter-http-vertx --network hono-net -p 8080:8080 -p 8443:8443  \
-> --secret trusted-certs.pem \
-> --secret http-adapter-key.pem \
-> --secret http-adapter-cert.pem \
-> -e 'HONO_MESSAGING_HOST=hono-service-messaging.hono' \
-> -e 'HONO_MESSAGING_USERNAME=http-adapter@HONO' \
-> -e 'HONO_MESSAGING_PASSWORD=http-secret' \
-> -e 'HONO_MESSAGING_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_TENANT_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_TENANT_USERNAME=http-adapter@HONO' \
-> -e 'HONO_TENANT_PASSWORD=http-secret' \
-> -e 'HONO_TENANT_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_REGISTRATION_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_REGISTRATION_USERNAME=http-adapter@HONO' \
-> -e 'HONO_REGISTRATION_PASSWORD=http-secret' \
-> -e 'HONO_REGISTRATION_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_CREDENTIALS_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_CREDENTIALS_USERNAME=http-adapter@HONO' \
-> -e 'HONO_CREDENTIALS_PASSWORD=http-secret' \
-> -e 'HONO_CREDENTIALS_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_HTTP_BIND_ADDRESS=0.0.0.0' \
-> -e 'HONO_HTTP_KEY_PATH=/run/secrets/http-adapter-key.pem' \
-> -e 'HONO_HTTP_CERT_PATH=/run/secrets/http-adapter-cert.pem' \
-> -e 'HONO_HTTP_INSECURE_PORT_ENABLED=true' \
-> -e 'HONO_HTTP_INSECURE_PORT_BIND_ADDRESS=0.0.0.0'
-> eclipse/hono-adapter-http-vertx:latest
+# in base directory of Hono repository:
+docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
+docker secret create http-adapter-key.pem demo-certs/certs/http-adapter-key.pem
+docker secret create http-adapter-cert.pem demo-certs/certs/http-adapter-cert.pem
+docker service create --detach --name hono-adapter-http-vertx --network hono-net -p 8080:8080 -p 8443:8443 \
+ --secret trusted-certs.pem \
+ --secret http-adapter-key.pem \
+ --secret http-adapter-cert.pem \
+ -e 'HONO_MESSAGING_HOST=hono-service-messaging.hono' \
+ -e 'HONO_MESSAGING_USERNAME=http-adapter@HONO' \
+ -e 'HONO_MESSAGING_PASSWORD=http-secret' \
+ -e 'HONO_MESSAGING_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_TENANT_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_TENANT_USERNAME=http-adapter@HONO' \
+ -e 'HONO_TENANT_PASSWORD=http-secret' \
+ -e 'HONO_TENANT_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_REGISTRATION_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_REGISTRATION_USERNAME=http-adapter@HONO' \
+ -e 'HONO_REGISTRATION_PASSWORD=http-secret' \
+ -e 'HONO_REGISTRATION_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_CREDENTIALS_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_CREDENTIALS_USERNAME=http-adapter@HONO' \
+ -e 'HONO_CREDENTIALS_PASSWORD=http-secret' \
+ -e 'HONO_CREDENTIALS_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_HTTP_BIND_ADDRESS=0.0.0.0' \
+ -e 'HONO_HTTP_KEY_PATH=/run/secrets/http-adapter-key.pem' \
+ -e 'HONO_HTTP_CERT_PATH=/run/secrets/http-adapter-cert.pem' \
+ -e 'HONO_HTTP_INSECURE_PORT_ENABLED=true' \
+ -e 'HONO_HTTP_INSECURE_PORT_BIND_ADDRESS=0.0.0.0' \
+ eclipse/hono-adapter-http-vertx:latest
 ~~~
 
 {{% note %}}
@@ -175,8 +176,8 @@ Using the example from above, the following environment variable definition need
 
 ~~~sh
 ...
-> -e '_JAVA_OPTIONS=-Xmx128m' \
-> eclipse/hono-adapter-http-vertx:latest
+ -e '_JAVA_OPTIONS=-Xmx128m' \
+ eclipse/hono-adapter-http-vertx:latest
 ~~~
 
 ## Run using the Docker Swarm Deployment Script
@@ -190,26 +191,27 @@ In order to do so, the adapter can be started using the `spring-boot:run` maven 
 The corresponding command to start up the adapter with the configuration used in the Docker example above looks like this:
 
 ~~~sh
-~/hono/adapters/http-vertx$ mvn spring-boot:run -Drun.arguments=\
-> --hono.messaging.host=hono-service-messaging.hono,\
-> --hono.messaging.username=http-adapter@HONO,\
-> --hono.messaging.password=http-secret,\
-> --hono.messaging.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.tenant.host=hono-service-device-registry.hono,\
-> --hono.tenant.username=http-adapter@HONO,\
-> --hono.tenant.password=http-secret,\
-> --hono.tenant.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.registration.host=hono-service-device-registry.hono,\
-> --hono.registration.username=http-adapter@HONO,\
-> --hono.registration.password=http-secret,\
-> --hono.registration.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.credentials.host=hono-service-device-registry.hono,\
-> --hono.credentials.username=http-adapter@HONO,\
-> --hono.credentials.password=http-secret,\
-> --hono.credentials.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.http.bindAddress=0.0.0.0,\
-> --hono.http.insecurePortEnabled=true,\
-> --hono.http.insecurePortBindAddress=0.0.0.0
+# in directory: hono/adapters/http-vertx/
+mvn spring-boot:run -Dhono.app.healthCheckPort=8088 -Dhono.app.maxInstances=1 -Drun.arguments=\
+--hono.messaging.host=hono-service-messaging.hono,\
+--hono.messaging.username=http-adapter@HONO,\
+--hono.messaging.password=http-secret,\
+--hono.messaging.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.tenant.host=hono-service-device-registry.hono,\
+--hono.tenant.username=http-adapter@HONO,\
+--hono.tenant.password=http-secret,\
+--hono.tenant.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.registration.host=hono-service-device-registry.hono,\
+--hono.registration.username=http-adapter@HONO,\
+--hono.registration.password=http-secret,\
+--hono.registration.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.credentials.host=hono-service-device-registry.hono,\
+--hono.credentials.username=http-adapter@HONO,\
+--hono.credentials.password=http-secret,\
+--hono.credentials.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.http.bindAddress=0.0.0.0,\
+--hono.http.insecurePortEnabled=true,\
+--hono.http.insecurePortBindAddress=0.0.0.0
 ~~~
 
 {{% note %}}

--- a/site/content/admin-guide/kura-adapter-config.md
+++ b/site/content/admin-guide/kura-adapter-config.md
@@ -128,35 +128,36 @@ See [Monitoring & Tracing Admin Guide]({{< ref "monitoring-tracing-config.md" >}
 The adapter can be run as a Docker container from the command line. The following commands create and start the adapter as a Docker Swarm service using the default keys  contained in the `demo-certs` module:
 
 ~~~sh
-~/hono$ docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
-~/hono$ docker secret create kura-adapter-key.pem demo-certs/certs/kura-adapter-key.pem
-~/hono$ docker secret create kura-adapter-cert.pem demo-certs/certs/kura-adapter-cert.pem
-~/hono$ docker service create --detach --name hono-adapter-kura --network hono-net -p 1883:1883 -p 8883:8883 \
-> --secret trusted-certs.pem \
-> --secret kura-adapter-key.pem \
-> --secret kura-adapter-cert.pem \
-> -e 'HONO_MESSAGING_HOST=hono-service-messaging.hono' \
-> -e 'HONO_MESSAGING_USERNAME=kura-adapter@HONO' \
-> -e 'HONO_MESSAGING_PASSWORD=kura-secret' \
-> -e 'HONO_MESSAGING_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_TENANT_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_TENANT_USERNAME=kura-adapter@HONO' \
-> -e 'HONO_TENANT_PASSWORD=kura-secret' \
-> -e 'HONO_TENANT_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_REGISTRATION_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_REGISTRATION_USERNAME=kura-adapter@HONO' \
-> -e 'HONO_REGISTRATION_PASSWORD=kura-secret' \
-> -e 'HONO_REGISTRATION_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_CREDENTIALS_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_CREDENTIALS_USERNAME=kura-adapter@HONO' \
-> -e 'HONO_CREDENTIALS_PASSWORD=kura-secret' \
-> -e 'HONO_CREDENTIALS_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_KURA_BIND_ADDRESS=0.0.0.0' \
-> -e 'HONO_KURA_KEY_PATH=/run/secrets/kura-adapter-key.pem' \
-> -e 'HONO_KURA_CERT_PATH=/run/secrets/kura-adapter-cert.pem' \
-> -e 'HONO_KURA_INSECURE_PORT_ENABLED=true' \
-> -e 'HONO_KURA_INSECURE_PORT_BIND_ADDRESS=0.0.0.0'
-> eclipse/hono-adapter-kura:latest
+# in base directory of Hono repository:
+docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
+docker secret create kura-adapter-key.pem demo-certs/certs/kura-adapter-key.pem
+docker secret create kura-adapter-cert.pem demo-certs/certs/kura-adapter-cert.pem
+docker service create --detach --name hono-adapter-kura --network hono-net -p 1883:1883 -p 8883:8883 \
+ --secret trusted-certs.pem \
+ --secret kura-adapter-key.pem \
+ --secret kura-adapter-cert.pem \
+ -e 'HONO_MESSAGING_HOST=hono-service-messaging.hono' \
+ -e 'HONO_MESSAGING_USERNAME=kura-adapter@HONO' \
+ -e 'HONO_MESSAGING_PASSWORD=kura-secret' \
+ -e 'HONO_MESSAGING_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_TENANT_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_TENANT_USERNAME=kura-adapter@HONO' \
+ -e 'HONO_TENANT_PASSWORD=kura-secret' \
+ -e 'HONO_TENANT_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_REGISTRATION_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_REGISTRATION_USERNAME=kura-adapter@HONO' \
+ -e 'HONO_REGISTRATION_PASSWORD=kura-secret' \
+ -e 'HONO_REGISTRATION_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_CREDENTIALS_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_CREDENTIALS_USERNAME=kura-adapter@HONO' \
+ -e 'HONO_CREDENTIALS_PASSWORD=kura-secret' \
+ -e 'HONO_CREDENTIALS_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_KURA_BIND_ADDRESS=0.0.0.0' \
+ -e 'HONO_KURA_KEY_PATH=/run/secrets/kura-adapter-key.pem' \
+ -e 'HONO_KURA_CERT_PATH=/run/secrets/kura-adapter-cert.pem' \
+ -e 'HONO_KURA_INSECURE_PORT_ENABLED=true' \
+ -e 'HONO_KURA_INSECURE_PORT_BIND_ADDRESS=0.0.0.0' \
+ eclipse/hono-adapter-kura:latest
 ~~~
 
 {{% note %}}
@@ -175,8 +176,8 @@ Using the example from above, the following environment variable definition need
 
 ~~~sh
 ...
-> -e '_JAVA_OPTIONS=-Xmx128m' \
-> eclipse/hono-adapter-kura:latest
+ -e '_JAVA_OPTIONS=-Xmx128m' \
+ eclipse/hono-adapter-kura:latest
 ~~~
 
 ## Run using the Docker Swarm Deployment Script
@@ -190,26 +191,27 @@ In order to do so, the adapter can be started using the `spring-boot:run` maven 
 The corresponding command to start up the adapter with the configuration used in the Docker example above looks like this:
 
 ~~~sh
-~/hono/adapters/kura$ mvn spring-boot:run -Drun.arguments=\
-> --hono.messaging.host=hono-service-messaging.hono,\
-> --hono.messaging.username=kura-adapter@HONO,\
-> --hono.messaging.password=kura-secret,\
-> --hono.messaging.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.tenant.host=hono-service-device-registry.hono,\
-> --hono.tenant.username=kura-adapter@HONO,\
-> --hono.tenant.password=kura-secret,\
-> --hono.tenant.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.registration.host=hono-service-device-registry.hono,\
-> --hono.registration.username=kura-adapter@HONO,\
-> --hono.registration.password=kura-secret,\
-> --hono.registration.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.credentials.host=hono-service-device-registry.hono,\
-> --hono.credentials.username=kura-adapter@HONO,\
-> --hono.credentials.password=kura-secret,\
-> --hono.credentials.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.kura.bindAddress=0.0.0.0,\
-> --hono.kura.insecurePortEnabled=true,\
-> --hono.kura.insecurePortBindAddress=0.0.0.0
+# in directory: hono/adapters/kura/
+mvn spring-boot:run -Dhono.app.healthCheckPort=8088 -Dhono.app.maxInstances=1 -Drun.arguments=\
+--hono.messaging.host=hono-service-messaging.hono,\
+--hono.messaging.username=kura-adapter@HONO,\
+--hono.messaging.password=kura-secret,\
+--hono.messaging.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.tenant.host=hono-service-device-registry.hono,\
+--hono.tenant.username=kura-adapter@HONO,\
+--hono.tenant.password=kura-secret,\
+--hono.tenant.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.registration.host=hono-service-device-registry.hono,\
+--hono.registration.username=kura-adapter@HONO,\
+--hono.registration.password=kura-secret,\
+--hono.registration.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.credentials.host=hono-service-device-registry.hono,\
+--hono.credentials.username=kura-adapter@HONO,\
+--hono.credentials.password=kura-secret,\
+--hono.credentials.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.kura.bindAddress=0.0.0.0,\
+--hono.kura.insecurePortEnabled=true,\
+--hono.kura.insecurePortBindAddress=0.0.0.0
 ~~~
 
 {{% note %}}

--- a/site/content/admin-guide/monitoring-tracing-config.md
+++ b/site/content/admin-guide/monitoring-tracing-config.md
@@ -99,7 +99,7 @@ Assuming that the HTTP adapter should be configured to use [Jaeger tracing](http
 3. Start the HTTP adapter Docker image mounting the host folder:
 
     ```sh
-    $> docker run --name hono-adapter-http-vertx \
+    docker run --name hono-adapter-http-vertx \
     --mount type=bind,src=/tmp/jaeger,dst=/opt/hono/extensions,ro \
     ... \
     eclipse/hono-adapter-http-vertx
@@ -113,9 +113,7 @@ Using a Docker *volume* instead of a *bind mount* works the same way but require
 
 **Hint**: to resolve all dependencies for `jaeger-tracerresolver` in order to provide them to `/opt/hono/extensions`, you may want to rely on Maven's dependency plugin. To obtain all jar files you can invoke the following command in a simple Maven project that contains only the dependency to `jaeger-tracerresolver`:
 
-   ```bash
-   $> mvn dependency:copy-dependencies
-   ```
+    mvn dependency:copy-dependencies
     
 All jar files can then be found in the directory `target/dependency`.    
 
@@ -126,8 +124,7 @@ This is to have the Jaeger tracing jar files be included in the Hono Docker imag
 
 For example, building the HTTP adapter image with the Jaeger client included:
 
-   ```bash
-   ~/hono/adapters/http-vertx$ mvn clean install -Pbuild-docker-image,jaeger
-   ```
+    # in directory: hono/adapters/http-vertx/
+    mvn clean install -Pbuild-docker-image,jaeger
 
 Note that when running the created docker image, the environment variables for configuring the Jaeger client still need to be set. Please refer to the [Jaeger documentation](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/README.md) for details.

--- a/site/content/admin-guide/mqtt-adapter-config.md
+++ b/site/content/admin-guide/mqtt-adapter-config.md
@@ -127,35 +127,36 @@ See [Monitoring & Tracing Admin Guide]({{< ref "monitoring-tracing-config.md" >}
 The MQTT adapter can be run as a Docker container from the command line. The following commands create and start the MQTT adapter as a Docker Swarm service using the default keys  contained in the `demo-certs` module:
 
 ~~~sh
-~/hono$ docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
-~/hono$ docker secret create mqtt-adapter-key.pem demo-certs/certs/mqtt-adapter-key.pem
-~/hono$ docker secret create mqtt-adapter-cert.pem demo-certs/certs/mqtt-adapter-cert.pem
-~/hono$ docker service create --detach --name hono-adapter-mqtt-vertx --network hono-net -p 1883:1883 -p 8883:8883 \
-> --secret trusted-certs.pem \
-> --secret mqtt-adapter-key.pem \
-> --secret mqtt-adapter-cert.pem \
-> -e 'HONO_MESSAGING_HOST=hono-service-messaging.hono' \
-> -e 'HONO_MESSAGING_USERNAME=mqtt-adapter@HONO' \
-> -e 'HONO_MESSAGING_PASSWORD=mqtt-secret' \
-> -e 'HONO_MESSAGING_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_TENANT_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_TENANT_USERNAME=mqtt-adapter@HONO' \
-> -e 'HONO_TENANT_PASSWORD=mqtt-secret' \
-> -e 'HONO_TENANT_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_REGISTRATION_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_REGISTRATION_USERNAME=mqtt-adapter@HONO' \
-> -e 'HONO_REGISTRATION_PASSWORD=mqtt-secret' \
-> -e 'HONO_REGISTRATION_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_CREDENTIALS_HOST=hono-service-device-registry.hono' \
-> -e 'HONO_CREDENTIALS_USERNAME=mqtt-adapter@HONO' \
-> -e 'HONO_CREDENTIALS_PASSWORD=mqtt-secret' \
-> -e 'HONO_CREDENTIALS_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
-> -e 'HONO_MQTT_BIND_ADDRESS=0.0.0.0' \
-> -e 'HONO_MQTT_KEY_PATH=/run/secrets/mqtt-adapter-key.pem' \
-> -e 'HONO_MQTT_CERT_PATH=/run/secrets/mqtt-adapter-cert.pem' \
-> -e 'HONO_MQTT_INSECURE_PORT_ENABLED=true' \
-> -e 'HONO_MQTT_INSECURE_PORT_BIND_ADDRESS=0.0.0.0'
-> eclipse/hono-adapter-mqtt-vertx:latest
+# in base directory of Hono repository:
+docker secret create trusted-certs.pem demo-certs/certs/trusted-certs.pem
+docker secret create mqtt-adapter-key.pem demo-certs/certs/mqtt-adapter-key.pem
+docker secret create mqtt-adapter-cert.pem demo-certs/certs/mqtt-adapter-cert.pem
+docker service create --detach --name hono-adapter-mqtt-vertx --network hono-net -p 1883:1883 -p 8883:8883 \
+ --secret trusted-certs.pem \
+ --secret mqtt-adapter-key.pem \
+ --secret mqtt-adapter-cert.pem \
+ -e 'HONO_MESSAGING_HOST=hono-service-messaging.hono' \
+ -e 'HONO_MESSAGING_USERNAME=mqtt-adapter@HONO' \
+ -e 'HONO_MESSAGING_PASSWORD=mqtt-secret' \
+ -e 'HONO_MESSAGING_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_TENANT_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_TENANT_USERNAME=mqtt-adapter@HONO' \
+ -e 'HONO_TENANT_PASSWORD=mqtt-secret' \
+ -e 'HONO_TENANT_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_REGISTRATION_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_REGISTRATION_USERNAME=mqtt-adapter@HONO' \
+ -e 'HONO_REGISTRATION_PASSWORD=mqtt-secret' \
+ -e 'HONO_REGISTRATION_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_CREDENTIALS_HOST=hono-service-device-registry.hono' \
+ -e 'HONO_CREDENTIALS_USERNAME=mqtt-adapter@HONO' \
+ -e 'HONO_CREDENTIALS_PASSWORD=mqtt-secret' \
+ -e 'HONO_CREDENTIALS_TRUST_STORE_PATH=/run/secrets/trusted-certs.pem' \
+ -e 'HONO_MQTT_BIND_ADDRESS=0.0.0.0' \
+ -e 'HONO_MQTT_KEY_PATH=/run/secrets/mqtt-adapter-key.pem' \
+ -e 'HONO_MQTT_CERT_PATH=/run/secrets/mqtt-adapter-cert.pem' \
+ -e 'HONO_MQTT_INSECURE_PORT_ENABLED=true' \
+ -e 'HONO_MQTT_INSECURE_PORT_BIND_ADDRESS=0.0.0.0' \
+ eclipse/hono-adapter-mqtt-vertx:latest
 ~~~
 
 {{% note %}}
@@ -174,8 +175,8 @@ Using the example from above, the following environment variable definition need
 
 ~~~sh
 ...
-> -e '_JAVA_OPTIONS=-Xmx128m' \
-> eclipse/hono-adapter-mqtt-vertx:latest
+ -e '_JAVA_OPTIONS=-Xmx128m' \
+ eclipse/hono-adapter-mqtt-vertx:latest
 ~~~
 
 ## Run using the Docker Swarm Deployment Script
@@ -189,26 +190,27 @@ In order to do so, the adapter can be started using the `spring-boot:run` maven 
 The corresponding command to start up the adapter with the configuration used in the Docker example above looks like this:
 
 ~~~sh
-~/hono/adapters/mqtt-vertx$ mvn spring-boot:run -Drun.arguments=\
-> --hono.messaging.host=hono-service-messaging.hono,\
-> --hono.messaging.username=mqtt-adapter@HONO,\
-> --hono.messaging.password=mqtt-secret,\
-> --hono.messaging.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.tenant.host=hono-service-device-registry.hono,\
-> --hono.tenant.username=mqtt-adapter@HONO,\
-> --hono.tenant.password=mqtt-secret,\
-> --hono.tenant.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.registration.host=hono-service-device-registry.hono,\
-> --hono.registration.username=mqtt-adapter@HONO,\
-> --hono.registration.password=mqtt-secret,\
-> --hono.registration.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.credentials.host=hono-service-device-registry.hono,\
-> --hono.credentials.username=mqtt-adapter@HONO,\
-> --hono.credentials.password=mqtt-secret,\
-> --hono.credentials.trustStorePath=target/certs/trusted-certs.pem,\
-> --hono.mqtt.bindAddress=0.0.0.0,\
-> --hono.mqtt.insecurePortEnabled=true,\
-> --hono.mqtt.insecurePortBindAddress=0.0.0.0
+# in directory: hono/adapters/mqtt-vertx/
+mvn spring-boot:run -Dhono.app.healthCheckPort=8088 -Dhono.app.maxInstances=1 -Drun.arguments=\
+--hono.messaging.host=hono-service-messaging.hono,\
+--hono.messaging.username=mqtt-adapter@HONO,\
+--hono.messaging.password=mqtt-secret,\
+--hono.messaging.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.tenant.host=hono-service-device-registry.hono,\
+--hono.tenant.username=mqtt-adapter@HONO,\
+--hono.tenant.password=mqtt-secret,\
+--hono.tenant.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.registration.host=hono-service-device-registry.hono,\
+--hono.registration.username=mqtt-adapter@HONO,\
+--hono.registration.password=mqtt-secret,\
+--hono.registration.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.credentials.host=hono-service-device-registry.hono,\
+--hono.credentials.username=mqtt-adapter@HONO,\
+--hono.credentials.password=mqtt-secret,\
+--hono.credentials.trustStorePath=../../demo-certs/certs/trusted-certs.pem,\
+--hono.mqtt.bindAddress=0.0.0.0,\
+--hono.mqtt.insecurePortEnabled=true,\
+--hono.mqtt.insecurePortBindAddress=0.0.0.0
 ~~~
 
 {{% note %}}

--- a/site/content/admin-guide/secure_communication.md
+++ b/site/content/admin-guide/secure_communication.md
@@ -130,7 +130,7 @@ Assuming that the Auth Server should be run with the statically linked, BoringSS
 3. Start the Auth Server Docker image mounting the host folder:
 
     ```sh
-    $> docker run --name hono-auth-server --mount type=bind,src=/tmp/tcnative,dst=/opt/hono/extensions,ro ... eclipse/hono-service-auth
+    docker run --name hono-auth-server --mount type=bind,src=/tmp/tcnative,dst=/opt/hono/extensions,ro ... eclipse/hono-service-auth
     ```
 
 Note that the command given above does not contain the environment variables and secrets that are usually required to configure the service properly.

--- a/site/content/community/contributing.md
+++ b/site/content/community/contributing.md
@@ -38,7 +38,7 @@ The easiest way to contribute code/patches/whatever is by creating a GitHub pull
 
 You do this by adding the `-s` flag when you make the commit(s), e.g.
 
-    $> git commit -s -m "Shave the yak some more"
+    git commit -s -m "Shave the yak some more"
 
 You can find all the details in the [Contributing via Git](http://wiki.eclipse.org/Development_Resources/Contributing_via_Git) document on the Eclipse web site.
 

--- a/site/content/deployment/docker-swarm.md
+++ b/site/content/deployment/docker-swarm.md
@@ -17,8 +17,9 @@ The only requirement for this guide is a working cluster of Docker Engine nodes 
 It is very easy to deploy the containers comprising a Hono instance to an existing Docker Swarm based on a script. The remainder of this guide will use the example deploy script created in the `deploy/target/deploy/docker` folder during the build process for that purpose. Once the build has finished, the process of deploying Hono to a cloud based, multi-node cluster is similar to the way described in the [Getting started guide]({{< relref "getting-started.md" >}}):
 
 ~~~sh
-~/hono/deploy$ export DOCKER_HOST=tcp://my-swarm.my-domain.com:2375
-~/hono/deploy$ target/deploy/docker/swarm_deploy.sh
+# in base directory of Hono repository:
+export DOCKER_HOST=tcp://my-swarm.my-domain.com:2375
+bash deploy/target/deploy/docker/swarm_deploy.sh
 ~~~
 
 Make sure to replace `my-swarm.my-domain.com:2375` with the host name or IP address and port of one of the Docker Swarm managers of the cluster to deploy to. When deploying to a swarm running on cloud infrastructure, direct access to the swarm manager(s) might not be possible, e.g. because the swarm runs on a private network behind a firewall. In such cases an `ssh` tunnel can usually be established with one of the swarm managers, providing a local TCP socket which can be used to transparently communicate with the Docker daemon running on the (remote) swarm manager. The Docker documentation contains details on how to set up and use such an `ssh` tunnel to [deploy an application to Docker for AWS](https://docs.docker.com/docker-for-aws/deploy/).
@@ -71,7 +72,8 @@ The `swarm_deploy.sh` script already creates and uses Docker secrets for providi
 1. Create a copy of the default `services/auth/src/main/resources/permissions.json` file:
 
        ~~~sh
-       ~/tmp$ cp ~/hono/services/auth/src/main/resources/permissions.json ./my-permissions.json
+       # in base directory of Hono repository:
+       cp services/auth/src/main/resources/permissions.json ~/tmp/my-permissions.json
        ~~~
 
 1. Open the `my-permissions.json` file and authorize a `new-user` with password `mypassword` to act as a protocol adapter, i.e. write telemetry data and events for all tenants, and manage device registration information. In order to do so, simply add a `new-user@HONO` element at the end of the file as shown below:
@@ -108,7 +110,7 @@ The `swarm_deploy.sh` script already creates and uses Docker secrets for providi
 
 ### Modifying the Deploy Script
 
-1. Open the default `~/hono/deploy/src/main/deploy/docker/swarm_deploy.sh` file in a text editor and add a `docker secret create` command for `my-permissions.json` to the already existing ones for the Auth Service. Make sure to specify the correct path to the `my-permissions.json` file you have created.
+1. Open the default `hono/deploy/src/main/deploy/docker/swarm_deploy.sh` file in a text editor and add a `docker secret create` command for `my-permissions.json` to the already existing ones for the Auth Service. Make sure to specify the correct path to the `my-permissions.json` file you have created.
 
        ~~~sh
        ...
@@ -142,7 +144,7 @@ The `swarm_deploy.sh` script already creates and uses Docker secrets for providi
 
 1. Save the file.
 
-1. Open the `~/hono/deploy/src/main/config/hono-service-auth-config.yml` file in a text editor and add the *hono.auth.svc.permissionsPath* property pointing to the custom property file:
+1. Open the `hono/deploy/src/main/config/hono-service-auth-config.yml` file in a text editor and add the *hono.auth.svc.permissionsPath* property pointing to the custom property file:
 
        ~~~json
        hono:
@@ -167,7 +169,8 @@ The `swarm_deploy.sh` script already creates and uses Docker secrets for providi
 1. Build the deploy script.
 
        ~~~sh
-       ~/hono/deploy$ mvn install
+       # in directory: hono/deploy/
+       mvn install
        ~~~
 
 
@@ -177,8 +180,9 @@ Now that the deploy script has been updated, it is time to deploy and start up t
 Make sure to replace `my-swarm.my-domain.com` with the host name or IP address of one of the Docker Swarm managers you want to deploy the stack to.
 
 ~~~sh
-~/hono/deploy$ export DOCKER_HOST=tcp://my-swarm.my-domain.com:2375
-~/hono/deploy$ target/deploy/docker/swarm_deploy.sh
+# in base directory of Hono repository:
+export DOCKER_HOST=tcp://my-swarm.my-domain.com:2375
+bash deploy/target/deploy/docker/swarm_deploy.sh
 ~~~
 
 The log output of the *Auth Server* should contain a line similar to this:
@@ -190,7 +194,8 @@ The log output of the *Auth Server* should contain a line similar to this:
 Once the stack is up and running, start up a consumer as described by the [Getting started Guide]({{< relref "getting-started.md#starting-a-consumer" >}}). You should then be able to connect to the Hono server using the example sender from the `example` module, specifying `new-user@HONO` as the user name.
 
 ~~~sh
-~/hono/example$ mvn spring-boot:run -Drun.profiles=sender,ssl -Drun.arguments=--hono.client.username=new-user@HONO,--hono.client.password=mypassword,--hono.client.hostname=my-swarm.my-domain.com
+# in directory: hono/example/
+mvn spring-boot:run -Drun.profiles=sender,ssl -Drun.arguments=--hono.client.username=new-user@HONO,--hono.client.password=mypassword,--hono.client.hostname=my-swarm.my-domain.com
 ~~~
 
 Again, make sure to replace `my.swarm.my-domain.com` with the host name or IP address of one of the Swarm nodes.
@@ -212,7 +217,7 @@ Alex Ellis has blogged about [Docker Secrets in Action](http://blog.alexellis.io
 If during deployment to docker swarm there are error messages about a wrong API version 1.23, this might come from a previous deployment to `minikube` (Kubernetes).
 Please check in this case the following command:
 
-    $ docker secret ls
+    docker secret ls
     
 If the output is 
 
@@ -220,10 +225,6 @@ If the output is
 
 then try to unset the environment variable `DOCKER_API_VERSION` by 
 
-    $ unset DOCKER_API_VERSION
+    unset DOCKER_API_VERSION
     
 Afterwards `docker secret ls` should work without error and you can retry the deployment.
-    
-     
-
-     

--- a/site/content/deployment/kubernetes.md
+++ b/site/content/deployment/kubernetes.md
@@ -17,14 +17,15 @@ The other prerequisite is to have the Kubectl command line tool for interacting 
 After launching Minikube and before building the Eclipse Hono images, it's necessary to execute the following command:
 
 ~~~sh
-$ eval $(minikube docker-env)
+eval $(minikube docker-env)
 ~~~
 
 In this way, the `DOCKER_HOST` environment variable is set to the Docker daemon running inside the Minikube VM. Launching the following command for building the Eclipse Hono images,
 such daemon will be used and the final images will be available inside the Minikube VM, ready for the deployment.
 
 ~~~sh
-~/hono$ mvn clean install -Pbuild-docker-image,metrics-prometheus
+# in base directory of Hono repository:
+mvn clean install -Pbuild-docker-image,metrics-prometheus
 ~~~
 
 ## Helm based Deployment
@@ -38,7 +39,8 @@ You can deploy Hono using Helm with or without the *Tiller* service.
 To deploy Eclipse Hono to the cluster with installed Tiller service, simply run
 
 ~~~sh
-~hono/deploy$ helm install --dep-up --name eclipse-hono --namespace hono target/deploy/helm/
+# in directory: hono/deploy/
+helm install --dep-up --name eclipse-hono --namespace hono target/deploy/helm/
 ~~~
 
 This will create a new `hono` namespace in the cluster and install all the components to that namespace. The name of the Helm release will be `eclipse-hono`.
@@ -46,9 +48,9 @@ This will create a new `hono` namespace in the cluster and install all the compo
 You can check the status of the deployment with one of the following commands
 
 ~~~sh
-$ helm list
-$ helm status eclipse-hono
-$ helm get eclipse-hono
+helm list
+helm status eclipse-hono
+helm get eclipse-hono
 ~~~
 
 ### Deploying Hono without using Helm's Tiller Service
@@ -57,14 +59,16 @@ If, for whatever reason, you can't or don't want to install Helm's Tiller servic
 To generate the resources locally with Helm, run
 
 ~~~sh
-~hono/deploy$ helm dep update target/deploy/helm/
-~hono/deploy$ helm template --name eclipse-hono --namespace hono --output-dir . target/deploy/helm/
+# in directory: hono/deploy/
+helm dep update target/deploy/helm/
+helm template --name eclipse-hono --namespace hono --output-dir . target/deploy/helm/
 ~~~
 
 This should create an `eclipse-hono` folder with all the resources. Now, you can use `kubectl` to deploy them to any Kubernetes cluster
 
 ~~~sh
-~hono/deploy$ kubectl apply -f ./eclipse-hono --namespace hono
+# in directory: hono/deploy/
+kubectl apply -f ./eclipse-hono --namespace hono
 ~~~
 
 ### Using Hono
@@ -76,8 +80,9 @@ After successful installation, you can proceed and [access your Hono services](#
 To undeploy a Hono instance that has been deployed using Helm's Tiller service, run
 
 ~~~sh
-~hono/deploy$ helm delete --purge eclipse-hono
-~hono/deploy$ kubectl delete crd prometheuses.monitoring.coreos.com prometheusrules.monitoring.coreos.com servicemonitors.monitoring.coreos.com alertmanagers.monitoring.coreos.com
+# in directory: hono/deploy/
+helm delete --purge eclipse-hono
+kubectl delete crd prometheuses.monitoring.coreos.com prometheusrules.monitoring.coreos.com servicemonitors.monitoring.coreos.com alertmanagers.monitoring.coreos.com
 ~~~
 
 The additional `kubectl delete` command is necessary to remove [Prometheus operator CRDs](https://github.com/helm/charts/tree/master/stable/prometheus-operator#uninstalling-the-chart).
@@ -85,7 +90,8 @@ The additional `kubectl delete` command is necessary to remove [Prometheus opera
 To undeploy a Hono instance that has been deployed manually from the resource files, run
 
 ~~~sh
-~hono/deploy$ kubectl delete -f ./eclipse-hono --namespace hono
+# in directory: hono/deploy/
+kubectl delete -f ./eclipse-hono --namespace hono
 ~~~
 
 ## Script based Deployment
@@ -106,8 +112,9 @@ metrics, or want to deploy Prometheus yourself.
 From the directory `deploy/target/deploy/kubernetes` run:
 
 ~~~sh
-~hono/deploy/target/deploy/kubernetes$ chmod +x *.sh
-~hono/deploy/target/deploy/kubernetes$ ./olm_deploy.sh
+# in directory: hono/deploy/target/deploy/kubernetes/
+chmod +x *.sh
+./olm_deploy.sh
 ~~~
 
 ### Deploying Hono
@@ -115,14 +122,15 @@ From the directory `deploy/target/deploy/kubernetes` run:
 After having the Kubernetes cluster up and running and the `kubectl` command line tool in the PATH, the deployment can be done by running the following bash script from the `deploy/target/deploy/kubernetes` folder.
 
 ~~~sh
-~hono/deploy/target/deploy/kubernetes$ chmod +x *.sh
-~hono/deploy/target/deploy/kubernetes$ ./kubernetes_deploy.sh
+# in directory: hono/deploy/target/deploy/kubernetes/
+chmod +x *.sh
+./kubernetes_deploy.sh
 ~~~
 
 In order to see the deployed components, you can launch Kubernetes' web UI in a browser by issuing:
 
 ~~~sh
-$ minikube dashboard
+minikube dashboard
 ~~~
 
 Be sure to switch to the `hono` namespace in the UI in order to see the components deployed as part of Hono.
@@ -135,7 +143,8 @@ In the following pictures an Eclipse Hono deployment on Kubernetes is running wi
 There also is a script for shutting down and undeploying Hono:
 
 ~~~sh
-~hono/deploy/target/deploy/kubernetes$ ./kubernetes_undeploy.sh
+# in directory: hono/deploy/target/deploy/kubernetes/
+./kubernetes_undeploy.sh
 ~~~
 
 ## Deploying individual Components
@@ -155,7 +164,7 @@ The Kubernetes deployment provides access to Hono by means of *services* and the
 You can get a list of these services running:
 
 ~~~sh
-$ minikube service list -n hono
+minikube service list -n hono
 
 |-----------|---------------------------------------|--------------------------------|
 | NAMESPACE |                 NAME                  |              URL               |
@@ -199,7 +208,8 @@ As described in the [Getting Started]({{< relref "getting-started.md" >}}) guide
 You can start the client from the `cli` folder as follows:
 
 ~~~sh
-~/hono/cli$ mvn spring-boot:run -Drun.arguments=--hono.client.host=$(minikube ip),--hono.client.port=30671,--hono.client.username=consumer@HONO,--hono.client.password=verysecret
+# in directory: hono/cli/
+mvn spring-boot:run -Drun.arguments=--hono.client.host=$(minikube ip),--hono.client.port=30671,--hono.client.username=consumer@HONO,--hono.client.password=verysecret
 ~~~
 
 ### Uploading Telemetry
@@ -208,19 +218,19 @@ In order to upload telemetry data to Hono, the device needs to be registered wit
 *Device Registry* by running the following command (i.e. for a device with ID `4711`):
 
 ~~~sh
-$ curl -X POST -i -H 'Content-Type: application/json' --data-binary '{"device-id": "4711"}' http://$(minikube ip):31080/registration/DEFAULT_TENANT
+curl -X POST -i -H 'Content-Type: application/json' --data-binary '{"device-id": "4711"}' http://$(minikube ip):31080/registration/DEFAULT_TENANT
 ~~~
 
 After having the device registered, uploading telemetry is just a simple HTTP POST command to the *HTTP Adapter*:
 
 ~~~sh
-$ curl -X POST -i -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' --data-binary '{"temp": 5}' http://$(minikube ip):30080/telemetry
+curl -X POST -i -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' --data-binary '{"temp": 5}' http://$(minikube ip):30080/telemetry
 ~~~
 
 Other than using the *HTTP Adapter*, it's possible to upload telemetry data using the *MQTT Adapter* as well:
 
 ~~~sh
-$ mosquitto_pub -h $(minikube ip) -p 31883 -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t telemetry -m '{"temp": 5}'
+mosquitto_pub -h $(minikube ip) -p 31883 -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t telemetry -m '{"temp": 5}'
 ~~~
 
 The username and password used above for device `4711` are part of the example configuration that comes with Hono. See [Device Identity]({{< relref "concepts/device-identity.md" >}}) for an explanation of how devices are identified in Hono and how device identity is related to authentication.

--- a/site/content/deployment/resource-limitation.md
+++ b/site/content/deployment/resource-limitation.md
@@ -42,7 +42,7 @@ The following JVM options can be used in Java 9 and later in order to change thi
 As stated above, the Docker images provided by Hono run on OpenJDK 11. Options can be passed to the JVM during startup by means of setting the `_JAVA_OPTIONS` environment variable on the container. The following example from the Docker Swarm deployment script illustrates this mechanism:
 
 ~~~sh
-$ docker service create --name hono-adapter-http-vertx -p 8080:8080 \
+docker service create --name hono-adapter-http-vertx -p 8080:8080 \
   --secret http-adapter.credentials \
   --secret hono-adapter-http-vertx-config.yml \
   --limit-memory 256m \

--- a/site/content/dev-guide/java_client_consumer.md
+++ b/site/content/dev-guide/java_client_consumer.md
@@ -46,11 +46,12 @@ The application waits for messages until you press any key or kill it.
 
 It is started by
 
-`$ mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoExampleApplication`
+    # in directory: hono/example/
+    mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoExampleApplication
 
 or - if e.g. the host of the AMQP network should be changed - 
  
-`$ mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoExampleApplication -Dconsumer.host=192.168.99.100`
+    mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoExampleApplication -Dconsumer.host=192.168.99.100
 
 
 ### Telemetry and Event messages
@@ -70,10 +71,7 @@ Inside this callback an arbitrary simple command is sent down to the device (onc
   
 For the encrypted communication with Hono, the necessary truststore is already installed and used by the Hono client.
 
-If you want to integrate the code with your own software, please copy the provided truststore from the Hono project, e.g. like
-
-    $ mkdir -p ${yourProjectDir}/src/main/resources/certs
-    $ cp ${honoProjectDir}/demo-certs/certs/trusted-certs.pem ${yourProjectDir}/src/main/resources/certs
-
+If you want to integrate the code with your own software, please copy the provided truststore (`hono/demo-certs/certs/trusted-certs.pem`) 
+from the Hono project to the `resources` directory of your project
 and adopt the code pointing to the file location.
 

--- a/site/content/download.md
+++ b/site/content/download.md
@@ -16,7 +16,7 @@ The most convenient way to both pull the images and start corresponding containe
 After downloading the archive, extract it to a local folder, change into that folder and run the following from the command line (assuming that your local Docker client is configured to connect to a Docker Swarm manager):
 
 ~~~sh
-eclipse-hono-deploy-0.9$ deploy/docker/swarm_deploy.sh
+deploy/docker/swarm_deploy.sh
 ~~~
 
 Hono supports deployment to the following container orchestration platforms:
@@ -32,7 +32,7 @@ A Java based command line client for consuming telemetry data and events from Ho
 The client can be run from the command line like this:
 
 ~~~sh
-$ java -jar hono-cli-0.9-exec.jar --hono.client.host=hono.eclipse.org --hono.client.port=15671 \
+java -jar hono-cli-0.9-exec.jar --hono.client.host=hono.eclipse.org --hono.client.port=15671 \
 --hono.client.tlsEnabled=true --hono.client.username=consumer@HONO --hono.client.password=verysecret \
 --spring.profiles.active=receiver --tenant.id=DEFAULT_TENANT
 ~~~

--- a/site/content/getting-started.md
+++ b/site/content/getting-started.md
@@ -15,7 +15,7 @@ In order to build and run the images you need access to a [Docker](http://www.do
 As noted above, Hono consists of multiple service components that together comprise a Hono instance. The remainder of this guide employs Docker's *Swarm Mode* for configuring, running and managing all Hono components as a whole.
 In order to enable *Swarm Mode* on your *Docker Engine* run the following command
 
-    $ docker swarm init
+    docker swarm init
 
 Please refer to the [Docker Swarm Mode documentation](https://docs.docker.com/engine/swarm/swarm-mode/) for details.
 
@@ -32,7 +32,7 @@ If you do not already have a working Maven installation on your system, please f
 
 Then run the following from the project's root folder
 
-    ~/hono$ mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus
+    mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus
 
 with `${host}` and `${port}` reflecting the name/IP address and port of the host where Docker is running on. This will build all libraries, Docker images and example code. If you are running on Linux and Docker is installed locally or you have set the `DOCKER_HOST` environment variable, you can omit the `-Ddocker.host` property definition.
 
@@ -48,8 +48,9 @@ As part of the build process, a set of scripts for deploying and undeploying Hon
 To deploy and start Hono simply run the following from the `deploy/target/deploy/docker` directory
 
 ~~~sh
-~/hono/deploy/target/deploy/docker$ chmod +x swarm_*.sh
-~/hono/deploy/target/deploy/docker$ ./swarm_deploy.sh
+# in base directory of Hono repository:
+chmod +x deploy/target/deploy/docker/swarm_*.sh
+deploy/target/deploy/docker/swarm_deploy.sh
 ~~~
 
 The first command makes the generated scripts executable. This needs to be done once after each build.
@@ -74,7 +75,7 @@ The second command creates and starts up Docker Swarm *services* for all compone
 You can list all services by executing
 
 ~~~sh
-~/hono/deploy/target/deploy/docker$ docker service ls
+docker service ls
 ~~~
 
 ## Starting a Consumer
@@ -84,7 +85,8 @@ In this example we will use a simple command line client that logs all telemetry
 You can start the client from the `cli` folder as follows:
 
 ~~~sh
-~/hono/cli$ mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,--message.type=telemetry
+# in directory: hono/cli/
+mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,--message.type=telemetry
 ~~~
 
 Event messages are very similar to telemetry ones, except that they use `AT LEAST ONCE` quality of service. You can receive and log event messages uploaded to Hono using the same client.
@@ -92,13 +94,15 @@ Event messages are very similar to telemetry ones, except that they use `AT LEAS
 In order to do so, run the client from the `cli` folder as follows:
 
 ~~~sh
-~/hono/cli$ mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,--message.type=event
+# in directory: hono/cli/
+mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,--message.type=event
 ~~~
 
 In order to receive and log both telemetry and event messages, run the client from the `cli` folder as follows:
 
 ~~~sh
-~/hono/cli$ mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret
+# in directory: hono/cli/
+mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret
 ~~~
 
 {{% warning %}}
@@ -124,14 +128,14 @@ The first thing to do is registering a device identity with Hono. Hono uses this
 The following command registers a device with ID `4711` with the Device Registry.
 
 ~~~sh
-$ curl -X POST -i -H 'Content-Type: application/json' -d '{"device-id": "4711"}' \
+curl -X POST -i -H 'Content-Type: application/json' -d '{"device-id": "4711"}' \
 http://localhost:28080/registration/DEFAULT_TENANT
 ~~~
 
 or (using HTTPie):
 
 ~~~sh
-$ http POST http://localhost:28080/registration/DEFAULT_TENANT device-id=4711
+http POST http://localhost:28080/registration/DEFAULT_TENANT device-id=4711
 ~~~
 
 The result will contain a `Location` header containing the resource path created for the device. In this example it will look like this:
@@ -145,13 +149,13 @@ Content-Length: 0
 You can then retrieve registration data for the device using
 
 ~~~sh
-$ curl -i http://localhost:28080/registration/DEFAULT_TENANT/4711
+curl -i http://localhost:28080/registration/DEFAULT_TENANT/4711
 ~~~
 
 or (using HTTPie):
 
 ~~~sh
-$ http http://localhost:28080/registration/DEFAULT_TENANT/4711
+http http://localhost:28080/registration/DEFAULT_TENANT/4711
 ~~~
 
 which will result in something like this:
@@ -172,14 +176,14 @@ Content-Length: 35
 ### Uploading Telemetry Data using the HTTP Adapter
 
 ~~~sh
-$ curl -X POST -i -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
+curl -X POST -i -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
 --data-binary '{"temp": 5}' http://localhost:8080/telemetry
 ~~~
 
 or (using HTTPie):
 
 ~~~sh
-$ http --auth sensor1@DEFAULT_TENANT:hono-secret POST http://localhost:8080/telemetry temp:=5
+http --auth sensor1@DEFAULT_TENANT:hono-secret POST http://localhost:8080/telemetry temp:=5
 ~~~
 
 The username and password used above for device `4711` are part of the example configuration that comes with Hono. See [Device Identity]({{< relref "concepts/device-identity.md" >}}) for an explanation of how devices are identified in Hono and how device identity is related to authentication.
@@ -214,14 +218,14 @@ The HTTP Adapter also supports publishing telemetry messages using *at least onc
 In a similar way you can upload event data, using curl
 
 ~~~sh
-$ curl -X POST -i -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
+curl -X POST -i -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
 --data-binary '{"alarm": "fire"}' http://localhost:8080/event
 ~~~
 
 or (using HTTPie):
 
 ~~~sh
-$ http --auth sensor1@DEFAULT_TENANT:hono-secret POST http://localhost:8080/event alarm=fire
+http --auth sensor1@DEFAULT_TENANT:hono-secret POST http://localhost:8080/event alarm=fire
 ~~~
 
 ## Using Command & Control
@@ -248,7 +252,7 @@ Note that it is the responsibility of the application to send a command - to ill
 To simulate an HTTP device, we use the standard tool `curl` to publish some JSON data for the device `4711`.
 To signal that the device is willing to receive and process a command, the device uploads a telemetry or event message and includes the `hono-ttd` request parameter to indicate the number of seconds it will wait for the response:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
     --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry?hono-ttd=30
 
 Watch the example application that receives the message - on the console you will find a line looking similar to the following:
@@ -285,7 +289,7 @@ Thus, you need to make sure that the clocks of the node running the application 
 
 If the received command was *not* a *one-way command*, and the device has received the command and has processed it, it needs to inform the application about the outcome. For this purpose the device uploads the result to the HTTP adapter using a new HTTP request. The following command simulates the device uploading some JSON payload indicating a successful result:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
     -H 'hono-cmd-status: 200' --data-binary '{"success": true}' \
     http://127.0.0.1:8080/control/res/10117f669c12-09ef-416d-88c1-1787f894856d
     
@@ -300,7 +304,8 @@ The command line client from the `cli` module supports the interactive sending o
 In order to do so, the client needs to be run with the `command` profile as follows:
  
 ~~~sh
-~/hono/cli$ mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret -Drun.profiles=command,ssl
+# in directory: hono/cli/
+mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret -Drun.profiles=command,ssl
 ~~~
 
 The client will prompt the user to enter the command's name, the payload to send and the payload's content type. For more information about command and payload refer to [Command and Control Concepts]({{< relref "concepts/command-and-control.md" >}}).
@@ -332,7 +337,8 @@ a response from the device but will consider the sending of the command successf
  The command line argument `command.timeoutInSeconds` can be used to set the timeout period (default is 60 seconds). The command line arguments `device.id` and `tenant.id` provide the device and tenant ID of the device that you want to send commands to.
 
 ~~~sh
-~/hono/cli$ mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,--command.timeoutInSeconds=10,--device.id=4711,--tenant.id=DEFAULT_TENANT -Drun.profiles=command,ssl
+# in directory: hono/cli/
+mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,--command.timeoutInSeconds=10,--device.id=4711,--tenant.id=DEFAULT_TENANT -Drun.profiles=command,ssl
 ~~~
 
 ### Summary
@@ -368,7 +374,7 @@ If you do not run Docker on localhost, replace *localhost* in the link with the 
 The Hono instance's Docker services can be stopped and removed using the following command:
 
 ~~~sh
-~/hono/deploy/target/deploy/docker$ ./swarm_undeploy.sh
+hono/deploy/target/deploy/docker/swarm_undeploy.sh
 ~~~
 
 Please refer to the [Docker Swarm documentation](https://docs.docker.com/engine/swarm/services/) for details regarding the management of individual services.
@@ -378,5 +384,5 @@ Please refer to the [Docker Swarm documentation](https://docs.docker.com/engine/
 In order to start up the instance again:
 
 ~~~sh
-~/hono/deploy/target/deploy/docker$ ./swarm_deploy.sh
+hono/deploy/target/deploy/docker/swarm_deploy.sh
 ~~~

--- a/site/content/user-guide/amqp-adapter.md
+++ b/site/content/user-guide/amqp-adapter.md
@@ -68,7 +68,8 @@ The command-line client supports the following parameters (with default values):
 
 To run the client using the above default values, open a terminal and execute the following:
 
-    $ /hono/cli/target$ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=sensor1@DEFAULT_TENANT --hono.client.password=hono-secret
+    # in directory: hono/cli/target/
+    java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=sensor1@DEFAULT_TENANT --hono.client.password=hono-secret
     
     Accepted{}
 
@@ -114,7 +115,8 @@ When a device publishes data to the `telemetry` address, the AMQP adapter automa
 
 Publish some JSON data for device `4711`:
 
-    $ /hono/cli/target$ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=sensor1@DEFAULT_TENANT --hono.client.password=hono-secret
+    # in directory: hono/cli/target/
+    java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=sensor1@DEFAULT_TENANT --hono.client.password=hono-secret
 
 Notice that we only supplied a new value for the message address, leaving the other default values.
 
@@ -145,7 +147,8 @@ Note how verbose the address is for unauthenticated devices. This address can be
 
 Publish some JSON data for device `4711`:
 
-    $ /hono/cli/target$ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --message.address=t/DEFAULT_TENANT/4711
+    # in directory: hono/cli/target/
+    java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --message.address=t/DEFAULT_TENANT/4711
 
 ## Publish Telemetry Data (authenticated Gateway)
 
@@ -155,7 +158,8 @@ A device that publishes data on behalf of another device is called a gateway dev
 
 A Gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing some JSON data for device `4711`:
 
-    $ /hono/cli/target$ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=t/DEFAULT_TENANT/4711
+    # in directory: hono/cli/target/
+    java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=t/DEFAULT_TENANT/4711
 
 In this example, we are using message address `t/DEFAULT_TENANT/4711` which contains the device that the gateway is publishing the message for.
 
@@ -186,7 +190,8 @@ This is the preferred way for devices to publish events. It is available only if
 
 Upload a JSON string for device `4711`:
 
-    $ /hono/cli/target$ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=sensor1@DEFAULT_TENANT --hono.client.password=hono-secret --message.address=event --message.payload='{"alarm": 1}'
+    # in directory: hono/cli/target/
+    java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=sensor1@DEFAULT_TENANT --hono.client.password=hono-secret --message.address=event --message.payload='{"alarm": 1}'
 
 ## Publish an Event (unauthenticated Device)
 
@@ -211,7 +216,8 @@ This address format is used by devices that have not authenticated to the protoc
 
 Publish some JSON data for device `4711`:
 
-    $ /hono/cli/target$ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --message.address=e/DEFAULT_TENANT/4711 --message.payload='{"alarm": 1}'
+    # in directory: hono/cli/target/
+    java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --message.address=e/DEFAULT_TENANT/4711 --message.payload='{"alarm": 1}'
 
 ## Publish an Event (authenticated Gateway)
 
@@ -219,7 +225,8 @@ Publish some JSON data for device `4711`:
 
 A Gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing some JSON data for device `4711`:
 
-    $ /hono/cli/target$ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=e/DEFAULT_TENANT/4711
+    # in directory: hono/cli/target/
+    java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-adapter-cli --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=e/DEFAULT_TENANT/4711
 
 In this example, we are using message address `e/DEFAULT_TENANT/4711` which contains the device that the gateway is publishing the message for.
 

--- a/site/content/user-guide/device-registry.md
+++ b/site/content/user-guide/device-registry.md
@@ -46,7 +46,7 @@ The following commands add some tenants with different adapter configurations:
 
 Add a tenant that has all adapters set to enabled:
 
-    $ curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
+    curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
         "tenant-id": "tenantAllAdapters"
       }' http://localhost:28080/tenant
     
@@ -56,7 +56,7 @@ Add a tenant that has all adapters set to enabled:
 
 Add a tenant that can only use the MQTT adapter:
 
-    $ curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
+    curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
         "tenant-id": "tenantMqttAdapter",
         "adapters" : [ {
             "type" : "hono-mqtt",
@@ -80,7 +80,7 @@ Add a tenant that can only use the MQTT adapter:
 
 The following command retrieves the details for the tenant `tenantMqttAdapter`:
 
-    $ curl -i http://localhost:28080/tenant/tenantMqttAdapter
+    curl -i http://localhost:28080/tenant/tenantMqttAdapter
     
     HTTP/1.1 200 OK
     Content-Type: application/json; charset=utf-8
@@ -114,7 +114,7 @@ This resource can be used to change the configuration of a particular tenant.
 
 The following command disables the MQTT adapter for devices that belong to the tenant `tenantMqttAdapter`:
 
-    $ curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{
+    curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{
           "adapters" : [ {
               "type" : "hono-mqtt",
               "enabled" : true
@@ -135,7 +135,7 @@ The following command disables the MQTT adapter for devices that belong to the t
 
 **Example**
 
-    $ curl -i -X DELETE http://localhost:28080/tenant/tenantMqttAdapter
+    curl -i -X DELETE http://localhost:28080/tenant/tenantMqttAdapter
     
     HTTP/1.1 204 No Content
     Content-Length: 0
@@ -161,7 +161,7 @@ The following sections describe the resources representing the operations of the
 
 The following command registers a device with ID `4711`
 
-    $ curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
+    curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
         "device-id": "4711",
         "ep": "IMEI4711"
     }' http://localhost:28080/registration/DEFAULT_TENANT
@@ -185,7 +185,7 @@ like this:
 
 The following command retrieves registration data for device `4711`:
 
-    $ curl -i http://localhost:28080/registration/DEFAULT_TENANT/4711
+    curl -i http://localhost:28080/registration/DEFAULT_TENANT/4711
     
     HTTP/1.1 200 OK
     Content-Type: application/json; charset=utf-8
@@ -215,7 +215,7 @@ The following command retrieves registration data for device `4711`:
 
 **Example**
 
-    $ curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{
+    curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{
         "ep": "IMEI4711",
         "psk-id": "psk4711"
     }' http://localhost:28080/registration/DEFAULT_TENANT/4711
@@ -233,7 +233,7 @@ The following command retrieves registration data for device `4711`:
 
 **Example**
 
-    $ curl -i -X DELETE http://localhost:28080/registration/DEFAULT_TENANT/4711
+    curl -i -X DELETE http://localhost:28080/registration/DEFAULT_TENANT/4711
     
     HTTP/1.1 204 No Content
     Content-Length: 0
@@ -262,7 +262,7 @@ Please refer to the [Credentials API]({{< relref "api/Credentials-API.md" >}}) f
 
 The following command adds some `hashed-password` credentials from a given plain text password for device `4710` using authentication identifier `sensor10`: 
 
-    $ curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
+    curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
       "device-id": "4710",
       "type": "hashed-password",
       "auth-id": "sensor10",
@@ -278,7 +278,7 @@ The following command adds some `hashed-password` credentials from a given plain
 This uses a convenient option which lets the Device Registry do the hashing of the password. The following command retrieves the credentials that are stored by the Device Registry as a result of the command above: 
     
     
-    $ curl -i http://localhost:28080/credentials/DEFAULT_TENANT/4710
+    curl -i http://localhost:28080/credentials/DEFAULT_TENANT/4710
     
     HTTP/1.1 200 OK
     Content-Type: application/json; charset=utf-8
@@ -305,8 +305,8 @@ This uses a convenient option which lets the Device Registry do the hashing of t
     
 The following commands add some `hashed-password` credentials for device `4720` using authentication identifier `sensor20`:
 
-    $ PWD_HASH=$(echo -n "mylittlesecret" | openssl dgst -binary -sha512 | base64 -w 0)
-    $ curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
+    PWD_HASH=$(echo -n "mylittlesecret" | openssl dgst -binary -sha512 | base64 -w 0)
+    curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
         "device-id": "4720",
         "type": "hashed-password",
         "auth-id": "sensor20",
@@ -323,8 +323,8 @@ The following commands add some `hashed-password` credentials for device `4720` 
 Multiple credentials of different type can be registered for the same authentication identifier.
 The following commands add `psk` credentials for the same device `4720` using authentication identifier `sensor20`:
 
-    $ SHARED_KEY=$(echo -n "TheSharedKey" | base64 -w 0)
-    $ curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
+    SHARED_KEY=$(echo -n "TheSharedKey" | base64 -w 0)
+    curl -i -X POST -H 'Content-Type: application/json' --data-binary '{
        "device-id": "4720",
        "type": "psk",
        "auth-id": "sensor20",
@@ -354,7 +354,7 @@ properties against the properties defined in the credentials record. It will ret
 
 The following command retrieves credentials data of type `hashed-password` for the authentication identifier `sensor20`:
 
-    $ curl -i http://localhost:28080/credentials/DEFAULT_TENANT/sensor20/hashed-password
+    curl -i http://localhost:28080/credentials/DEFAULT_TENANT/sensor20/hashed-password
     
     HTTP/1.1 200 OK
     Content-Length: 268
@@ -387,7 +387,7 @@ The following command retrieves credentials data of type `hashed-password` for t
 
 The following command retrieves credentials for device `4720`:
 
-    $ curl -i http://localhost:28080/credentials/DEFAULT_TENANT/4720
+    curl -i http://localhost:28080/credentials/DEFAULT_TENANT/4720
     
     HTTP/1.1 200 OK
     Content-Length: 491
@@ -442,8 +442,8 @@ This resource can be used to change values of a particular set of credentials. H
 
 The following command adds an expiration date to the `hashed-password` credentials for authentication identifier `sensor20`:
 
-    $ PWD_HASH=$(echo -n "mylittlesecret" | openssl dgst -binary -sha512 | base64 -w 0)
-    $ curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{
+    PWD_HASH=$(echo -n "mylittlesecret" | openssl dgst -binary -sha512 | base64 -w 0)
+    curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{
         "device-id": "4720",
         "type": "hashed-password",
         "auth-id": "sensor20",
@@ -468,7 +468,7 @@ The following command adds an expiration date to the `hashed-password` credentia
 
 **Example**
 
-    $ curl -i -X DELETE http://localhost:28080/credentials/DEFAULT_TENANT/sensor20/hashed-password
+    curl -i -X DELETE http://localhost:28080/credentials/DEFAULT_TENANT/sensor20/hashed-password
     
     HTTP/1.1 204 No Content
     Content-Length: 0
@@ -486,7 +486,7 @@ Removes all credentials registered for a particular device.
 
 **Example**
 
-    $ curl -i -X DELETE http://localhost:28080/credentials/DEFAULT_TENANT/4720
+    curl -i -X DELETE http://localhost:28080/credentials/DEFAULT_TENANT/4720
     
     HTTP/1.1 204 No Content
     Content-Length: 0

--- a/site/content/user-guide/http-adapter.md
+++ b/site/content/user-guide/http-adapter.md
@@ -63,24 +63,24 @@ This is the preferred way for devices to publish telemetry data. It is available
 
 Publish some JSON data for device `4711`:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
-    $ --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
+     --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
 
 Publish some JSON data for device `4711` using *at least once* QoS:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' -H 'QoS-Level: 1' \
-    $ --data-binary '{"temp": 5}' http://localhost:8080/telemetry
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' -H 'QoS-Level: 1' \
+     --data-binary '{"temp": 5}' http://localhost:8080/telemetry
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
 
 Publish some JSON data for device `4711`, indicating that the device will wait for 10 seconds to receive the response:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' -H 'hono-ttd: 10' \
-    $ --data-binary '{"temp": 5}' http://localhost:8080/telemetry
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' -H 'hono-ttd: 10' \
+     --data-binary '{"temp": 5}' http://localhost:8080/telemetry
 
     HTTP/1.1 200 OK
     hono-command: set
@@ -91,9 +91,10 @@ Publish some JSON data for device `4711`, indicating that the device will wait f
       "brightness" : 87
     }
 
-Publish some JSON data for device `4711` using a client certificate for authentication (in the directory that contains the certificates, e.g. `hono/demo-certs/certs/`):
+Publish some JSON data for device `4711` using a client certificate for authentication:
 
-    $ curl -i --cert device-4711-cert.pem --key device-4711-key.pem --cacert trusted-certs.pem \
+    # in base directory of Hono repository:
+    curl -i --cert demo-certs/certs/device-4711-cert.pem --key demo-certs/certs/device-4711-key.pem --cacert demo-certs/certs/trusted-certs.pem \
     -H 'Content-Type: application/json' --data-binary '{"temp": 5}' https://localhost:8443/telemetry
 
     HTTP/1.1 202 Accepted
@@ -137,24 +138,24 @@ This resource MUST be used by devices that have not authenticated to the protoco
 
 Publish some JSON data for device `4711`:
 
-    $ curl -i -X PUT -H 'Content-Type: application/json' \
-    $ --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4711
+    curl -i -X PUT -H 'Content-Type: application/json' \
+     --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4711
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
 
 Publish some JSON data for device `4711` using *at least once* QoS:
 
-    $ curl -i -X PUT -H 'Content-Type: application/json' -H 'QoS-Level: 1' \
-    $ --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4711
+    curl -i -X PUT -H 'Content-Type: application/json' -H 'QoS-Level: 1' \
+     --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4711
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
 
 Publish some JSON data for device `4711`, indicating that the device will wait for 10 seconds to receive the response:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' -H 'hono-ttd: 10' \
-    $ --data-binary '{"temp": 5}' http://localhost:8080/telemetry
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' -H 'hono-ttd: 10' \
+     --data-binary '{"temp": 5}' http://localhost:8080/telemetry
 
     HTTP/1.1 200 OK
     hono-command: set
@@ -208,24 +209,24 @@ The protocol adapter checks the gateway's authority to publish data on behalf of
 
 Publish some JSON data for device `4712`:
 
-    $ curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' \
-    $ --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4712
+    curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' \
+     --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4712
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
 
 Publish some JSON data for device `4712` using *at least once* QoS:
 
-    $ curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' -H 'QoS-Level: 1' \
-    $ --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4712
+    curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' -H 'QoS-Level: 1' \
+     --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry/DEFAULT_TENANT/4712
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
 
 Publish some JSON data for device `4712`, indicating that the gateway will wait for 10 seconds to receive the response:
 
-    $ curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' -H 'hono-ttd: 10' \
-    $ --data-binary '{"temp": 5}' http://localhost:8080/telemetry/DEFAULT_TENANT/4712
+    curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' -H 'hono-ttd: 10' \
+     --data-binary '{"temp": 5}' http://localhost:8080/telemetry/DEFAULT_TENANT/4712
 
     HTTP/1.1 200 OK
     hono-command: set
@@ -273,8 +274,8 @@ This is the preferred way for devices to publish events. It is available only if
 
 Publish some JSON data for device `4711`:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
-    $ --data-binary '{"alarm": true}' http://127.0.0.1:8080/event
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
+     --data-binary '{"alarm": true}' http://127.0.0.1:8080/event
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
@@ -313,8 +314,8 @@ This resource MUST be used by devices that have not authenticated to the protoco
 
 Publish some JSON data for device `4711`:
 
-    $ curl -i -X PUT -H 'Content-Type: application/json' \
-    $ --data-binary '{"alarm": true}' http://127.0.0.1:8080/event/DEFAULT_TENANT/4711
+    curl -i -X PUT -H 'Content-Type: application/json' \
+     --data-binary '{"alarm": true}' http://127.0.0.1:8080/event/DEFAULT_TENANT/4711
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
@@ -359,8 +360,8 @@ The protocol adapter checks the gateway's authority to publish data on behalf of
 
 Publish some JSON data for device `4712`:
 
-    $ curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' \
-    $ --data-binary '{"temp": 5}' http://127.0.0.1:8080/event/DEFAULT_TENANT/4712
+    curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' \
+     --data-binary '{"temp": 5}' http://127.0.0.1:8080/event/DEFAULT_TENANT/4712
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
@@ -384,8 +385,8 @@ The optional header `hono-ttd` can be set for any downstream message.
 
 Example:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' -H 'hono-ttd: 60' \
-    $ --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' -H 'hono-ttd: 60' \
+     --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
@@ -396,8 +397,8 @@ Alternatively the value for `hono-ttd` can be set by using a query parameter.
 
 Example:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
-    $ --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry?hono-ttd=60
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
+     --data-binary '{"temp": 5}' http://127.0.0.1:8080/telemetry?hono-ttd=60
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
@@ -431,9 +432,9 @@ This is the preferred way for devices to respond to commands. It is available on
 
 Send a response to a previously received command with the command-request-id `req-id-uuid` for device `4711`:
 
-    $ curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
-    $ --data-binary '{"brightness-changed": true}' \
-    $ http://127.0.0.1:8080/control/res/req-id-uuid?hono-cmd-status=200
+    curl -i -X POST -u sensor1@DEFAULT_TENANT:hono-secret -H 'Content-Type: application/json' \
+     --data-binary '{"brightness-changed": true}' \
+     http://127.0.0.1:8080/control/res/req-id-uuid?hono-cmd-status=200
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
@@ -468,8 +469,8 @@ This resource MUST be used by devices that have not authenticated to the protoco
 
 Send a response to a previously received command with the command-request-id `req-id-uuid` for the unauthenticated device `4711`:
 
-    $ curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{"brightness-changed": true}' \
-    $ http://127.0.0.1:8080/control/res/DEFAULT_TENANT/4711/req-id-uuid?hono-cmd-status=200
+    curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{"brightness-changed": true}' \
+     http://127.0.0.1:8080/control/res/DEFAULT_TENANT/4711/req-id-uuid?hono-cmd-status=200
 
     HTTP/1.1 202 Accepted
     Content-Length: 0
@@ -508,9 +509,9 @@ The protocol adapter checks the gateway's authority to send responses to a comma
 
 Send a response to a previously received command with the command-request-id `req-id-uuid` for device `4712`:
 
-    $ curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' \
-    $ --data-binary '{"brightness-changed": true}' \
-    $ http://127.0.0.1:8080/control/res/DEFAULT_TENANT/4712/req-id-uuid?hono-cmd-status=200
+    curl -i -X PUT -u gw@DEFAULT_TENANT:gw-secret -H 'Content-Type: application/json' \
+     --data-binary '{"brightness-changed": true}' \
+     http://127.0.0.1:8080/control/res/DEFAULT_TENANT/4712/req-id-uuid?hono-cmd-status=200
 
     HTTP/1.1 202 Accepted
     Content-Length: 0

--- a/site/content/user-guide/mqtt-adapter.md
+++ b/site/content/user-guide/mqtt-adapter.md
@@ -60,11 +60,12 @@ This is the preferred way for devices to publish telemetry data. It is available
 
 Publish some JSON data for device `4711`:
 
-    $ mosquitto_pub -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t telemetry -m '{"temp": 5}'
+    mosquitto_pub -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t telemetry -m '{"temp": 5}'
 
-Publish some JSON data for device `4711` using a client certificate for authentication (in the directory that contains the certificates, e.g. `hono/demo-certs/certs/`):
+Publish some JSON data for device `4711` using a client certificate for authentication:
 
-    $ mosquitto_pub -p 8883 -t telemetry -m '{"temp": 5}' --cert device-4711-cert.pem --key device-4711-key.pem --cafile trusted-certs.pem
+    # in base directory of Hono repository:
+    mosquitto_pub -p 8883 -t telemetry -m '{"temp": 5}' --cert demo-certs/certs/device-4711-cert.pem --key demo-certs/certs/device-4711-key.pem --cafile demo-certs/certs/trusted-certs.pem
 
 **NB**: The example above assumes that the MQTT adapter is [configured for TLS]({{< ref "/admin-guide/secure_communication.md#mqtt-adapter" >}}) and the secure port is used.
 
@@ -82,7 +83,7 @@ This topic can be used by devices that have not authenticated to the protocol ad
 
 Publish some JSON data for device `4711`:
 
-    $ mosquitto_pub -t telemetry/DEFAULT_TENANT/4711 -m '{"temp": 5}'
+    mosquitto_pub -t telemetry/DEFAULT_TENANT/4711 -m '{"temp": 5}'
 
 
 ## Publish Telemetry Data (authenticated Gateway)
@@ -100,7 +101,7 @@ The protocol adapter checks the gateway's authority to publish data on behalf of
 
 Publish some JSON data for device `4712` via gateway `gw-1`:
 
-    $ mosquitto_pub -u 'gw@DEFAULT_TENANT' -P gw-secret -t telemetry/DEFAULT_TENANT/4712 -m '{"temp": 5}'
+    mosquitto_pub -u 'gw@DEFAULT_TENANT' -P gw-secret -t telemetry/DEFAULT_TENANT/4712 -m '{"temp": 5}'
 
 **NB**: The example above assumes that a gateway device with ID `gw-1` has been registered with `hashed-password` credentials with *auth-id* `gw` and password `gw-secret`.
 
@@ -127,7 +128,7 @@ This is the preferred way for devices to publish events. It is available only if
 
 Upload a JSON string for device `4711`:
 
-    $ mosquitto_pub -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t event -q 1 -m '{"alarm": 1}'
+    mosquitto_pub -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t event -q 1 -m '{"alarm": 1}'
 
 ## Publish an Event (unauthenticated Device)
 
@@ -143,7 +144,7 @@ This topic can be used by devices that have not authenticated to the protocol ad
 
 Publish some JSON data for device `4711`:
 
-    $ mosquitto_pub -t event/DEFAULT_TENANT/4711 -q 1 -m '{"alarm": 1}'
+    mosquitto_pub -t event/DEFAULT_TENANT/4711 -q 1 -m '{"alarm": 1}'
 
 ## Publish an Event (authenticated Gateway)
 
@@ -160,7 +161,7 @@ The protocol adapter checks the gateway's authority to publish data on behalf of
 
 Publish some JSON data for device `4712` via gateway `gw-1`:
 
-    $ mosquitto_pub -u 'gw@DEFAULT_TENANT' -P gw-secret -t event/DEFAULT_TENANT/4712 -q 1 -m '{"temp": 5}'
+    mosquitto_pub -u 'gw@DEFAULT_TENANT' -P gw-secret -t event/DEFAULT_TENANT/4712 -q 1 -m '{"temp": 5}'
 
 **NB**: The example above assumes that a gateway device with ID `gw-1` has been registered with `hashed-password` credentials with *auth-id* `gw` and password `gw-secret`.
 
@@ -200,7 +201,7 @@ An authenticated device MUST use the following topic filter to subscribe to comm
 
 **Example**
 
-    $ mosquitto_sub -v -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t control/+/+/req/#
+    mosquitto_sub -v -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t control/+/+/req/#
 
 The adapter will then publish commands for the device to topic:
 
@@ -212,13 +213,13 @@ The adapter will then publish commands for the device to topic:
 
 For example, if the [HonoExampleApplication]({{< relref "dev-guide/java_client_consumer.md" >}}) was started, after the `ttd` event requested by the subscription of mosquitto_sub, it layers a command that arrives as follows:  
 
-    $ control///q/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/setBrightness {
+    control///q/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/setBrightness {
        "brightness" : 79
     }
 
 If the command is a *one-way* command, it will arrive as follows:
 
-    $ control///q//setBrightness {
+    control///q//setBrightness {
        "brightness" : 79
     }
 
@@ -231,7 +232,7 @@ An unauthenticated device MUST use the following topic filter to subscribe to co
 
 **Example**
 
-    $ mosquitto_sub -v -t control/DEFAULT_TENANT/4711/req/#
+    mosquitto_sub -v -t control/DEFAULT_TENANT/4711/req/#
 
 The adapter will then publish *Request/Response* commands for the device to topic:
 
@@ -253,7 +254,7 @@ An authenticated device MUST send the response to a previously received command 
 
 After a command has arrived as in the above example, you send a response using the arrived `${req-id}`:
 
-    $ mosquitto_pub -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t control///res/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/200 -m '{"lumen": 200}'
+    mosquitto_pub -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t control///res/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/200 -m '{"lumen": 200}'
 
 ### Sending a Response to a Command (unauthenticated Device)
 
@@ -265,7 +266,7 @@ An unauthenticated device MUST send the response to a previously received comman
 
 After a command has arrived as in the above example, you send a response using the arrived `${req-id}`:
 
-    $ mosquitto_pub -t control/DEFAULT_TENANT/4711/res/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/200 -m '{"lumen": 200}'
+    mosquitto_pub -t control/DEFAULT_TENANT/4711/res/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/200 -m '{"lumen": 200}'
 
 ## Downstream Meta Data
 

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -13,7 +13,8 @@ In order to run the tests you will need the following:
 
 Run the tests by executing the following command from the `tests` directory (add `-Ddocker.host=tcp://${host}:${port}` if Docker is not installed locally)
 
-    $ mvn verify -Prun-tests
+    # in directory: hono/tests/
+    mvn verify -Prun-tests
 
 This starts the following Docker containers and runs the test cases against them
 


### PR DESCRIPTION
Prompts are completely removed in front of shell commands to enable easy
copy & paste. Paths are usually relative to the base directory of the
Hono repository. Where relevant the directory in which a command needs
to be executed is given in a comment.
Some commands (starting adapters with Spring Boot) are fixed.

Signed-off-by: Abel Buechner-Mihaljevic <Abel.Buechner@bosch-si.com>