### PR TITLE
[#780] Extract dedicated client factory interfaces.

### DIFF
--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -230,13 +230,11 @@ public class VertxBasedHttpProtocolAdapterTest {
         when(telemetrySender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(
                 Future.succeededFuture(mock(ProtonDelivery.class)));
         when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(telemetrySender));
-        when(messagingClient.getOrCreateTelemetrySender(anyString(), anyString())).thenReturn(Future.succeededFuture(telemetrySender));
 
         eventSender = mock(MessageSender.class);
         when(eventSender.send(any(Message.class), (SpanContext) any())).thenThrow(new UnsupportedOperationException());
         when(eventSender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
         when(messagingClient.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(eventSender));
-        when(messagingClient.getOrCreateEventSender(anyString(), anyString())).thenReturn(Future.succeededFuture(eventSender));
 
         doAnswer(invocation -> {
             final Handler<AsyncResult<User>> resultHandler = invocation.getArgument(1);

--- a/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.apache.qpid.proton.message.Message;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonDelivery;
+
+/**
+ * A factory for creating clients for Hono's north bound APIs.
+ *
+ */
+public interface ApplicationClientFactory extends ConnectionLifecycle {
+
+    /**
+     * Creates a client for consuming data from Hono's north bound <em>Telemetry API</em>.
+     *
+     * @param tenantId The tenant to consume data for.
+     * @param telemetryConsumer The handler to invoke with every message received.
+     * @param closeHandler The handler invoked when the peer detaches the link.
+     * @return A future that will complete with the consumer once the link has been established. The future will fail if
+     *         the link cannot be established, e.g. because this client is not connected.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<MessageConsumer> createTelemetryConsumer(
+            String tenantId,
+            Consumer<Message> telemetryConsumer,
+            Handler<Void> closeHandler);
+
+    /**
+     * Creates a client for consuming events from Hono's north bound <em>Event API</em>.
+     * <p>
+     * The events passed in to the event consumer will be settled automatically if the consumer does not throw an
+     * exception and does not manually handle the message disposition using the passed in delivery.
+     *
+     * @param tenantId The tenant to consume events for.
+     * @param eventConsumer The handler to invoke with every event received.
+     * @param closeHandler The handler invoked when the peer detaches the link.
+     * @return A future that will complete with the consumer once the link has been established. The future will fail if
+     *         the link cannot be established, e.g. because this client is not connected.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<MessageConsumer> createEventConsumer(
+            String tenantId,
+            BiConsumer<ProtonDelivery, Message> eventConsumer,
+            Handler<Void> closeHandler);
+
+    /**
+     * Creates a client for consuming events from Hono's north bound <em>Event API</em>.
+     * <p>
+     * The events passed in to the event consumer will be settled automatically if the consumer does not throw an
+     * exception.
+     *
+     * @param tenantId The tenant to consume events for.
+     * @param eventConsumer The handler to invoke with every event received.
+     * @param closeHandler The handler invoked when the peer detaches the link.
+     * @return A future that will complete with the consumer once the link has been established. The future will fail if
+     *         the link cannot be established, e.g. because this client is not connected.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<MessageConsumer> createEventConsumer(
+            String tenantId,
+            Consumer<Message> eventConsumer,
+            Handler<Void> closeHandler);
+
+    /**
+     * Gets a client for sending commands to a device.
+     * <p>
+     * The client returned may be either newly created or it may be an existing
+     * client for the given device.
+     * <p>
+     * This method will use an implementation specific mechanism (e.g. a UUID) to create
+     * a unique reply-to address to be included in commands sent to the device. The protocol
+     * adapters need to convey an encoding of the reply-to address to the device when delivering
+     * the command. Consequently, the number of bytes transferred to the device depends on the
+     * length of the reply-to address being used. In situations where this is a major concern it
+     * might be advisable to use {@link #getOrCreateCommandClient(String, String, String)} for
+     * creating a command client and provide custom (and shorter) <em>reply-to identifier</em>
+     * to be used in the reply-to address.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the commands to.
+     * @return A future that will complete with the command and control client (if successful) or
+     *         fail if the client cannot be created, e.g. because the underlying connection
+     *         is not established or if a concurrent request to create a client for the same
+     *         tenant and device is already being executed.
+     * @throws NullPointerException if the tenantId is {@code null}.
+     */
+    Future<CommandClient> getOrCreateCommandClient(String tenantId, String deviceId);
+
+    /**
+     * Gets a client for sending commands to a device.
+     * <p>
+     * The client returned may be either newly created or it may be an existing
+     * client for the given device.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the commands to.
+     * @param replyId An arbitrary string which (in conjunction with the tenant and device ID) uniquely
+     *                identifies this command client.
+     *                This identifier will only be used for creating a <em>new</em> client for the device.
+     *                If this method returns an existing client for the device then the client will use
+     *                the reply-to address determined during its initial creation. In particular, this
+     *                means that if the (existing) client has originally been created using the
+     *                {@link #getOrCreateCommandClient(String, String)} method, then the reply-to address
+     *                used by the client will most likely not contain the given identifier.
+     * @return A future that will complete with the command and control client (if successful) or
+     *         fail if the client cannot be created, e.g. because the underlying connection
+     *         is not established or if a concurrent request to create a client for the same
+     *         tenant and device is already being executed.
+     * @throws NullPointerException if the tenantId is {@code null}.
+     */
+    Future<CommandClient> getOrCreateCommandClient(String tenantId, String deviceId, String replyId);
+}

--- a/client/src/main/java/org/eclipse/hono/client/ConnectionLifecycle.java
+++ b/client/src/main/java/org/eclipse/hono/client/ConnectionLifecycle.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * Provides access to the life cycle events of a connection to a Hono service.
+ *
+ */
+public interface ConnectionLifecycle {
+
+    /**
+     * Adds a listener to be notified when the connection is lost unexpectedly.
+     * 
+     * @param listener The listener to add.
+     */
+    void addDisconnectListener(DisconnectListener listener);
+
+    /**
+     * Adds a listener to be notified when the connection has been re-established after
+     * it had been lost unexpectedly.
+     * 
+     * @param listener The listener to add.
+     */
+    void addReconnectListener(ReconnectListener listener);
+
+    /**
+     * Checks whether the connection is currently established.
+     *
+     * @return A succeeded future if this connection is established.
+     *         Otherwise, the future will be failed with a
+     *         {@link ServerErrorException}.
+     */
+    Future<Void> isConnected();
+
+    /**
+     * Disconnects from the service.
+     * <p>
+     * Upon terminating the connection to the server, this method does not automatically try to reconnect
+     * to the server again.
+     *
+     */
+    void disconnect();
+
+    /**
+     * Disconnects from the service.
+     * <p>
+     * Similar to {@code #disconnect()} but takes a handler to be notified about the result
+     * of the disconnect operation. The caller can use the handler to determine if the operation succeeded or failed.
+     *
+     * @param completionHandler The handler to notify about the outcome of the operation.
+     *                          A failure could occur if this method is called in the middle of a disconnect operation.
+     * @throws NullPointerException if the completionHandler is {@code null}.
+     */
+    void disconnect(Handler<AsyncResult<Void>> completionHandler);
+}

--- a/client/src/main/java/org/eclipse/hono/client/CredentialsClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/CredentialsClientFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+import io.vertx.core.Future;
+
+/**
+ * A factory for creating clients for Hono's Credentials API.
+ *
+ */
+public interface CredentialsClientFactory extends ConnectionLifecycle {
+
+    /**
+     * Gets a client for interacting with Hono's <em>Credentials</em> API.
+     * <p>
+     * The client returned may be either newly created or it may be an existing
+     * client for the given tenant.
+     *
+     * @param tenantId The tenant to manage device credentials data for.
+     * @return A future that will complete with the credentials client (if successful) or fail if the client cannot be
+     *         created, e.g. because the underlying connection is not established or if a concurrent request to create a
+     *         client for the same tenant is already being executed.
+     * @throws NullPointerException if the tenant is {@code null}.
+     */
+    Future<CredentialsClient> getOrCreateCredentialsClient(String tenantId);
+}

--- a/client/src/main/java/org/eclipse/hono/client/DisconnectListener.java
+++ b/client/src/main/java/org/eclipse/hono/client/DisconnectListener.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+
+/**
+ * A listener to be notified when a connection is lost unexpectedly.
+ *
+ */
+@FunctionalInterface
+public interface DisconnectListener {
+
+    /**
+     * Invoked when the connection to a Hono service is lost unexpectedly.
+     * 
+     * @param client The client representing the connection to the service.
+     */
+    void onDisconnect(HonoClient client);
+}

--- a/client/src/main/java/org/eclipse/hono/client/DownstreamSenderFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/DownstreamSenderFactory.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+import io.vertx.core.Future;
+
+/**
+ * A factory for creating clients for Hono's south bound Telemetry and Event APIs.
+ *
+ */
+public interface DownstreamSenderFactory extends ConnectionLifecycle {
+
+    /**
+     * Gets a client for sending data to Hono's south bound <em>Telemetry</em> API.
+     * <p>
+     * The client returned may be either newly created or it may be an existing
+     * client for the given tenant.
+     *
+     * @param tenantId The ID of the tenant to send messages for.
+     * @return A future that will complete with the sender once the link has been established. The future will fail if
+     *         the link cannot be established, e.g. because this client is not connected or if a concurrent request to
+     *         create a sender for the same tenant is already being executed.
+     * @throws NullPointerException if the tenant is {@code null}.
+     */
+    Future<MessageSender> getOrCreateTelemetrySender(String tenantId);
+
+    /**
+     * Gets a client for sending data to Hono's south bound <em>Event</em> API.
+     * <p>
+     * The client returned may be either newly created or it may be an existing
+     * client for the given tenant.
+     *
+     * @param tenantId The ID of the tenant to send messages for.
+     * @return A future that will complete with the sender once the link has been established. The future will fail if
+     *         the link cannot be established, e.g. because this client is not connected or if a concurrent request to
+     *         create a sender for the same tenant is already being executed.
+     * @throws NullPointerException if the tenant is {@code null}.
+     */
+    Future<MessageSender> getOrCreateEventSender(String tenantId);
+}

--- a/client/src/main/java/org/eclipse/hono/client/ReconnectListener.java
+++ b/client/src/main/java/org/eclipse/hono/client/ReconnectListener.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+
+/**
+ * A listener to be notified when a connection is re-established after
+ * it has been lost unexpectedly.
+ *
+ */
+@FunctionalInterface
+public interface ReconnectListener {
+
+    /**
+     * Invoked after the connection to a Hono service has been re-established
+     * after it had been lost unexpectedly.
+     * 
+     * @param client The client representing the (re-established) connection to the service.
+     */
+    void onReconnect(HonoClient client);
+}

--- a/client/src/main/java/org/eclipse/hono/client/RegistrationClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/RegistrationClientFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+import io.vertx.core.Future;
+
+/**
+ * A factory for creating clients for Hono's Device Registration API.
+ *
+ */
+public interface RegistrationClientFactory extends ConnectionLifecycle {
+
+    /**
+     * Gets a client for invoking operations on a service implementing Hono's <em>Device Registration</em> API.
+     *
+     * @param tenantId The tenant to manage device registration data for.
+     * @return A future that will complete with the registration client (if successful) or fail if the client cannot be
+     *         created, e.g. because the underlying connection is not established or if a concurrent request to create a
+     *         client for the same tenant is already being executed.
+     * @throws NullPointerException if the tenant is {@code null}.
+     */
+    Future<RegistrationClient> getOrCreateRegistrationClient(String tenantId);
+}

--- a/client/src/main/java/org/eclipse/hono/client/TenantClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/TenantClientFactory.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+import io.vertx.core.Future;
+
+/**
+ * A factory for creating clients for Hono's Credentials API.
+ *
+ */
+public interface TenantClientFactory extends ConnectionLifecycle {
+
+    /**
+     * Gets a client for interacting with Hono's <em>Tenant</em> API.
+     * <p>
+     * The client returned may be either newly created or it may be an existing
+     * client for the given tenant.
+     *
+     * @return A future that will complete with the tenant client (if successful) or fail if the client cannot be
+     *         created, e.g. because the underlying connection is not established or if a concurrent request to create a
+     *         client for the same tenant is already being executed.
+     */
+    Future<TenantClient> getOrCreateTenantClient();
+}


### PR DESCRIPTION
The factory methods for creating the arbitrary service clients have been
refactored into dedicated interfaces.

This is the first step in splitting up `HonoClient` into multiple factories with dedicated scope. In subsequent PRs, I intend to
* rename `HonoClient` to `HonoConnection` and limit its responsibility to just the establishment and maintenance of the AMQP connection and serve as a factory for sender and receiver links
* let the dedicated factories *wrap* around a `HonoConnection`
* refactor protocol adapters to use the dedicated factories instead of `HonoConnection` and be no longer directly involved with connection management