### PR TITLE
[#930] Add "last-via" property to device data on "assertRegistration"

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -85,6 +85,10 @@ public interface RegistrationService extends Verticle {
      * Implementing classes should verify, that the gateway is authorized to get an assertion for the device.
      * Such a check might be based on a specific role that the client needs to have or on an
      * explicitly defined relation between the gateway and the device(s).
+     * <br>
+     * In the case of a device configured with multiple <em>via</em> gateways, implementing classes should
+     * update the device's registration information with the given gateway in the form of a <em>last-via</em>
+     * property.
      *
      * @param tenantId The tenant the device belongs to.
      * @param deviceId The ID of the device to get the assertion for.
@@ -115,6 +119,10 @@ public interface RegistrationService extends Verticle {
      * Implementing classes should verify, that the gateway is authorized to get an assertion for the device.
      * Such a check might be based on a specific role that the client needs to have or on an
      * explicitly defined relation between the gateway and the device(s).
+     * <br>
+     * In the case of a device configured with multiple <em>via</em> gateways, implementing classes should
+     * update the device's registration information with the given gateway in the form of a <em>last-via</em>
+     * property.
      * <p>
      * This default implementation simply returns the result of {@link #assertRegistration(String, String, String, Handler)}.
      *

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/CompleteBaseRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/CompleteBaseRegistrationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,24 +13,35 @@
 
 package org.eclipse.hono.service.registration;
 
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static org.eclipse.hono.service.registration.BaseRegistrationService.PROPERTY_LAST_VIA_UPDATE_DATE;
+import static org.eclipse.hono.util.Constants.JSON_FIELD_DEVICE_ID;
 import static org.mockito.Mockito.mock;
 
 import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.config.SignatureSupportingConfigProperties;
 import org.eclipse.hono.util.Constants;
-
 import org.eclipse.hono.util.EventBusMessage;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.eclipse.hono.util.RegistrationResult;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -75,7 +86,7 @@ public class CompleteBaseRegistrationServiceTest {
     public void testStartupFailsIfNoRegistrationAssertionFactoryIsSet(final TestContext ctx) {
 
         // GIVEN a registry without an assertion factory being set
-        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationService();
+        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationServiceWithoutImpls();
 
         // WHEN starting the service
         final Async startupFailure = ctx.async();
@@ -96,13 +107,13 @@ public class CompleteBaseRegistrationServiceTest {
     public void testAddDevice(final TestContext ctx) {
 
         // GIVEN an empty registry
-        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationService();
+        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationServiceWithoutImpls();
         registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
 
         // WHEN trying to add a new device
         registrationService.addDevice(Constants.DEFAULT_TENANT, "4711", new JsonObject(), ctx.asyncAssertSuccess(result -> {
             // THEN the response contain a JWT token with an empty result with status code 501.
-            ctx.assertEquals(result.getStatus(), HttpURLConnection.HTTP_NOT_IMPLEMENTED);
+            ctx.assertEquals(HttpURLConnection.HTTP_NOT_IMPLEMENTED, result.getStatus());
             ctx.assertNull(result.getPayload());
         }));
     }
@@ -116,13 +127,13 @@ public class CompleteBaseRegistrationServiceTest {
     public void testUpdateDevice(final TestContext ctx) {
 
         // GIVEN an empty registry
-        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationService();
+        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationServiceWithoutImpls();
         registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
 
         // WHEN trying to update a device
         registrationService.updateDevice(Constants.DEFAULT_TENANT, "4711", new JsonObject(), ctx.asyncAssertSuccess(result -> {
             // THEN the response contain a JWT token with an empty result with status code 501.
-            ctx.assertEquals(result.getStatus(), HttpURLConnection.HTTP_NOT_IMPLEMENTED);
+            ctx.assertEquals(HttpURLConnection.HTTP_NOT_IMPLEMENTED, result.getStatus());
             ctx.assertNull(result.getPayload());
         }));
     }
@@ -136,13 +147,13 @@ public class CompleteBaseRegistrationServiceTest {
     public void testRemoveDevice(final TestContext ctx) {
 
         // GIVEN an empty registry
-        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationService();
+        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationServiceWithoutImpls();
         registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
 
         // WHEN trying to remove a device
         registrationService.removeDevice(Constants.DEFAULT_TENANT, "4711", ctx.asyncAssertSuccess(result -> {
             // THEN the response contain a JWT token with an empty result with status code 501.
-            ctx.assertEquals(result.getStatus(), HttpURLConnection.HTTP_NOT_IMPLEMENTED);
+            ctx.assertEquals(HttpURLConnection.HTTP_NOT_IMPLEMENTED, result.getStatus());
             ctx.assertNull(result.getPayload());
         }));
     }
@@ -156,13 +167,13 @@ public class CompleteBaseRegistrationServiceTest {
     public void testGetDevice(final TestContext ctx) {
 
         // GIVEN an empty registry
-        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationService();
+        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationServiceWithoutImpls();
         registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
 
         // WHEN trying to get a device's data
         registrationService.getDevice(Constants.DEFAULT_TENANT, "4711", ctx.asyncAssertSuccess(result -> {
             // THEN the response contain a JWT token with an empty result with status code 501.
-            ctx.assertEquals(result.getStatus(), HttpURLConnection.HTTP_NOT_IMPLEMENTED);
+            ctx.assertEquals(HttpURLConnection.HTTP_NOT_IMPLEMENTED, result.getStatus());
             ctx.assertNull(result.getPayload());
         }));
     }
@@ -176,7 +187,7 @@ public class CompleteBaseRegistrationServiceTest {
     public void testProcessRequestFailsWithUnsupportedAction(final TestContext ctx) {
 
         // GIVEN an empty registry
-        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationService();
+        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationServiceWithoutImpls();
         registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
 
         registrationService
@@ -186,10 +197,113 @@ public class CompleteBaseRegistrationServiceTest {
                 }));
     }
 
+    /**
+     * Verifies that a device's status can be asserted by an existing gateway.
+     *
+     * @param ctx The vertx unit test context.
+     */
+    @Test
+    public void testAssertDeviceRegistrationSucceedsForExistingGateway(final TestContext ctx) {
 
-    private CompleteBaseRegistrationService<ServiceConfigProperties> newCompleteRegistrationService() {
+        // GIVEN a registry that contains an enabled device that is configured to
+        // be connected to an enabled gateway
+        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationService();
+        registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
 
-        return new CompleteBaseRegistrationService<ServiceConfigProperties>() {
+        // WHEN trying to assert the device's registration status for gateway 1
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4714", "gw-1", ctx.asyncAssertSuccess(result -> {
+            // THEN the response contains a 200 status
+            ctx.assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+            final JsonObject payload = result.getPayload();
+            ctx.assertNotNull(payload);
+            // and contains a JWT token
+            ctx.assertNotNull(payload.getString(RegistrationConstants.FIELD_ASSERTION));
+        }));
+
+        // WHEN trying to assert the device's registration status for gateway 4
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4714", "gw-4", ctx.asyncAssertSuccess(result -> {
+            // THEN the response contains a 200 status
+            ctx.assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+            final JsonObject payload = result.getPayload();
+            ctx.assertNotNull(payload);
+            // and contains a JWT token
+            ctx.assertNotNull(payload.getString(RegistrationConstants.FIELD_ASSERTION));
+        }));
+    }
+
+    /**
+     * Verifies that the updateDeviceLastVia method updates the 'last-via' property.
+     *
+     * @param ctx The vertx unit test context.
+     */
+    @Test
+    public void testUpdateDeviceLastVia(final TestContext ctx) {
+
+        // GIVEN a registry that supports updating registration information
+        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationService();
+        registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
+
+        // WHEN trying to update the 'last-via' property
+        final Future<Void> updateLastViaFuture = registrationService.updateDeviceLastVia(Constants.DEFAULT_TENANT, "4714", "gw-1", new JsonObject());
+        updateLastViaFuture.setHandler(ctx.asyncAssertSuccess(result -> {
+            // THEN the device data contains a 'last-via' property
+            registrationService.getDevice(Constants.DEFAULT_TENANT, "4714", ctx.asyncAssertSuccess(getDeviceResult -> {
+                ctx.assertEquals(HttpURLConnection.HTTP_OK, getDeviceResult.getStatus());
+                ctx.assertNotNull(getDeviceResult.getPayload(), "payload not set");
+                final JsonObject data = getDeviceResult.getPayload().getJsonObject(RegistrationConstants.FIELD_DATA);
+                ctx.assertNotNull(data, "payload data not set");
+                final JsonObject lastViaObj = data.getJsonObject(BaseRegistrationService.PROPERTY_LAST_VIA);
+                ctx.assertNotNull(lastViaObj, BaseRegistrationService.PROPERTY_LAST_VIA + " property not set");
+                ctx.assertEquals("gw-1", lastViaObj.getString(JSON_FIELD_DEVICE_ID));
+                ctx.assertNotNull(lastViaObj.getString(PROPERTY_LAST_VIA_UPDATE_DATE), PROPERTY_LAST_VIA_UPDATE_DATE + " property not set");
+            }));
+        }));
+    }
+
+    /**
+     * Verifies that the <em>assertRegistration</em> operation on a device with multiple 'via' entries updates
+     * the 'last-via' property.
+     *
+     * @param ctx The vertx unit test context.
+     */
+    @Test
+    public void testAssertDeviceRegistrationUpdatesLastViaProperty(final TestContext ctx) {
+
+        // GIVEN a registry that contains an enabled device that is configured to
+        // be connected to an enabled gateway
+        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationService();
+        registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
+
+        // WHEN trying to assert the device's registration status for gateway 1
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4714", "gw-1", ctx.asyncAssertSuccess(result -> {
+            // THEN the response contains a 200 status
+            ctx.assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+            final JsonObject payload = result.getPayload();
+            ctx.assertNotNull(payload);
+            // and contains a JWT token
+            ctx.assertNotNull(payload.getString(RegistrationConstants.FIELD_ASSERTION));
+            // and the device data contains a 'last-via' property
+            registrationService.getDevice(Constants.DEFAULT_TENANT, "4714", ctx.asyncAssertSuccess(getDeviceResult -> {
+                ctx.assertEquals(HttpURLConnection.HTTP_OK, getDeviceResult.getStatus());
+                ctx.assertNotNull(getDeviceResult.getPayload(), "payload not set");
+                final JsonObject data = getDeviceResult.getPayload().getJsonObject(RegistrationConstants.FIELD_DATA);
+                ctx.assertNotNull(data, "payload data not set");
+                final JsonObject lastViaObj = data.getJsonObject(BaseRegistrationService.PROPERTY_LAST_VIA);
+                ctx.assertNotNull(lastViaObj, BaseRegistrationService.PROPERTY_LAST_VIA + " property not set");
+                ctx.assertEquals("gw-1", lastViaObj.getString(JSON_FIELD_DEVICE_ID));
+                ctx.assertNotNull(lastViaObj.getString(PROPERTY_LAST_VIA_UPDATE_DATE), PROPERTY_LAST_VIA_UPDATE_DATE + " property not set");
+            }));
+        }));
+    }
+
+    /**
+     * Returns a CompleteBaseRegistrationService without implementations of the get/add/update/remove methods.
+     * 
+     * @return CompleteBaseRegistrationService instance.
+     */
+    private CompleteBaseRegistrationService<ServiceConfigProperties> newCompleteRegistrationServiceWithoutImpls() {
+
+        return new CompleteBaseRegistrationService<>() {
 
             @Override
             protected String getEventBusAddress() {
@@ -201,5 +315,101 @@ public class CompleteBaseRegistrationServiceTest {
                 setSpecificConfig(configuration);
             }
         };
+    }
+
+    private CompleteBaseRegistrationService<ServiceConfigProperties> newCompleteRegistrationService() {
+        return newCompleteRegistrationService(this::getDevice);
+    }
+
+    private CompleteBaseRegistrationService<ServiceConfigProperties> newCompleteRegistrationService(final Function<String, Future<RegistrationResult>> devices) {
+
+        return new CompleteBaseRegistrationService<>() {
+
+            private final Map<String, JsonObject> updatedDevicesMap = new HashMap<>(); 
+
+            @Override
+            protected String getEventBusAddress() {
+                return "requests.in";
+            }
+
+            @Override
+            public void setConfig(final ServiceConfigProperties configuration) {
+                setSpecificConfig(configuration);
+            }
+
+            @Override
+            public void getDevice(final String tenantId, final String deviceId, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+                if (updatedDevicesMap.containsKey(deviceId)) {
+                    resultHandler.handle(Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK,
+                            BaseRegistrationService.getResultPayload(deviceId, updatedDevicesMap.get(deviceId)))));
+                } else {
+                    devices.apply(deviceId).setHandler(resultHandler);
+                }
+            }
+
+            @Override
+            public void updateDevice(final String tenantId, final String deviceId, final JsonObject otherKeys,
+                    final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+                updatedDevicesMap.put(deviceId, otherKeys);
+                resultHandler.handle(Future.succeededFuture(RegistrationResult.from(HTTP_NO_CONTENT)));
+            }
+        };
+    }
+
+    private Future<RegistrationResult> getDevice(final String deviceId) {
+
+        if ("4711".equals(deviceId)) {
+            final JsonObject responsePayload = BaseRegistrationService.getResultPayload(
+                    "4711",
+                    new JsonObject()
+                            .put(RegistrationConstants.FIELD_ENABLED, true)
+                            .put(RegistrationConstants.FIELD_DEFAULTS, new JsonObject()
+                                    .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, "application/default"))
+                            .put(BaseRegistrationService.PROPERTY_VIA, "gw-1"));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("4712".equals(deviceId)) {
+            final JsonObject responsePayload = BaseRegistrationService.getResultPayload(
+                    "4712",
+                    new JsonObject().put(RegistrationConstants.FIELD_ENABLED, false));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("4713".equals(deviceId)) {
+            final JsonObject responsePayload = BaseRegistrationService.getResultPayload(
+                    "4713",
+                    new JsonObject()
+                            .put(RegistrationConstants.FIELD_ENABLED, true)
+                            .put(BaseRegistrationService.PROPERTY_VIA, "gw-3"));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("4714".equals(deviceId)) {
+            final JsonObject responsePayload = BaseRegistrationService.getResultPayload(
+                    "4714",
+                    new JsonObject()
+                            .put(RegistrationConstants.FIELD_ENABLED, true)
+                            .put(RegistrationConstants.FIELD_DEFAULTS, new JsonObject()
+                                    .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, "application/default"))
+                            .put(BaseRegistrationService.PROPERTY_VIA, new JsonArray().add("gw-1").add("gw-4")));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("gw-1".equals(deviceId)) {
+            final JsonObject responsePayload = BaseRegistrationService.getResultPayload(
+                    "gw-1",
+                    new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("gw-2".equals(deviceId)) {
+            final JsonObject responsePayload = BaseRegistrationService.getResultPayload(
+                    "gw-2",
+                    new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("gw-3".equals(deviceId)) {
+            final JsonObject responsePayload = BaseRegistrationService.getResultPayload(
+                    "gw-3",
+                    new JsonObject().put(RegistrationConstants.FIELD_ENABLED, false));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("gw-4".equals(deviceId)) {
+            final JsonObject responsePayload = BaseRegistrationService.getResultPayload(
+                    "gw-4",
+                    new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else {
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_NOT_FOUND));
+        }
     }
 }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyRegistrationService.java
@@ -52,4 +52,10 @@ public class DummyRegistrationService extends BaseRegistrationService<Object> {
                 HttpURLConnection.HTTP_OK,
                 getAssertionPayload(tenantId, deviceId, deviceData))));
     }
+
+    @Override
+    protected Future<Void> updateDeviceLastVia(final String tenantId, final String deviceId, final String gatewayId,
+            final JsonObject deviceData) {
+        return Future.succeededFuture();
+    }
 }

--- a/site/content/admin-guide/device-registry-config.md
+++ b/site/content/admin-guide/device-registry-config.md
@@ -167,7 +167,7 @@ In these cases the protocol adapter will authenticate the gateway component inst
 The Device Registry will then do the following:
 1. Verify that the device exists and is enabled.
 1. Verify that the gateway exists and is enabled.
-2. Verify that the device's registration information contains a property called `via` and that its value is either the gateway's device identifier or a JSON array which contains the gateway's device identifier as one of its values.
+2. Verify that the device's registration information contains a property called `via` and that its value is either the gateway's device identifier or a JSON array which contains the gateway's device identifier as one of its values. In the latter case of a device configured for multiple gateways, the device's registration information is updated with a `last-via` property containing the gateway identifier used in this request.
 
 Only if all conditions are met, the Device Registry returns an assertion of the device's registration status. The protocol adapter can then forward the published data to the AMQP Messaging Network in the same way as for any device that connects directly to the adapter.
 


### PR DESCRIPTION
First part of the solution for #930:
When "assertRegistration" is called on a device that has multiple "via"
gateways configured, the id of the gateway doing this request is put
into a "last-via" property in the device's registration data.

Example of the updated device registration data:
````
      {
        "device-id": "4712",
        "data": {
          "enabled": true,
          "via": ["gw-1", "gw-2"],
          "last-via": {
            "device-id": "gw-1",
            "update-date": "2019-03-18T15:19:28.186970Z"
          }
        }
      }
````