### PR TITLE
[#623] TenantService: Add support for multiple trusted certificate au…

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
@@ -294,7 +294,7 @@ public class AmqpAdapterSaslAuthenticatorFactory implements ProtonSaslAuthentica
                 tenantTracker
                         .compose(tenant -> {
                             try {
-                                final TrustAnchor trustAnchor = tenantTracker.result().getTrustAnchor();
+                                final TrustAnchor trustAnchor = tenantTracker.result().getTrustAnchors().get(0);
                                 return certValidator.validate(Collections.singletonList(deviceCert), trustAnchor);
                             } catch(final GeneralSecurityException e) {
                                 LOG.debug("cannot retrieve trust anchor of tenant [{}]", tenant.getTenantId(), e);

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -64,9 +64,9 @@ public final class TenantConstants extends RequestResponseApiConstants {
      */
     public static final String FIELD_PAYLOAD_PUBLIC_KEY = "public-key";
     /**
-     * The name of the property that contains the list of trusted certificate authorities configured for this tenant.
+     * The name of the property that contains the list of trusted certificate authorities configured for a tenant.
      */
-    public static final String FIELD_PAYLOAD_TRUSTED_CA = "trust-ca";
+    public static final String FIELD_PAYLOAD_TRUSTED_CA = "trusted-ca";
 
     /**
      * The name of the Tenant API endpoint.

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -64,9 +64,9 @@ public final class TenantConstants extends RequestResponseApiConstants {
      */
     public static final String FIELD_PAYLOAD_PUBLIC_KEY = "public-key";
     /**
-     * The name of the property that contains the trusted certificate authority configured for a tenant.
+     * The name of the property that contains the list of trusted certificate authorities configured for this tenant.
      */
-    public static final String FIELD_PAYLOAD_TRUSTED_CA = "trusted-ca";
+    public static final String FIELD_PAYLOAD_TRUSTED_CA = "trust-ca";
 
     /**
      * The name of the Tenant API endpoint.

--- a/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
@@ -29,6 +29,8 @@ import java.security.KeyStore;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
+import java.util.List;
+import java.util.Set;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -117,8 +119,12 @@ public class TenantObjectTest {
                         .put(TenantConstants.FIELD_PAYLOAD_KEY_ALGORITHM, trustedCaCert.getPublicKey().getAlgorithm()));
 
         final TenantObject tenant = config.mapTo(TenantObject.class);
-        assertThat(tenant.getTrustedCaSubjectDn(), is(trustedCaCert.getSubjectX500Principal()));
-        assertThat(tenant.getTrustAnchor().getCAPublicKey(), is(trustedCaCert.getPublicKey()));
+        final Set<X500Principal> subjectNames = tenant.getTrustedCaSubjectDns();
+        assertThat(subjectNames.size(), is(1));
+        assertTrue(subjectNames.contains(trustedCaCert.getSubjectX500Principal()));
+        final List<TrustAnchor> anchors = tenant.getTrustAnchors();
+        assertThat(anchors.size(), is(1));
+        assertThat(anchors.get(0).getCAPublicKey(), is(trustedCaCert.getPublicKey()));
     }
 
     /**
@@ -138,8 +144,12 @@ public class TenantObjectTest {
                         .put(TenantConstants.FIELD_PAYLOAD_CERT, Base64.getEncoder().encodeToString(trustedCaCert.getEncoded())));
 
         final TenantObject tenant = config.mapTo(TenantObject.class);
-        assertThat(tenant.getTrustedCaSubjectDn(), is(trustedCaCert.getSubjectX500Principal()));
-        assertThat(tenant.getTrustAnchor().getTrustedCert(), is(trustedCaCert));
+        final Set<X500Principal> subjectNames = tenant.getTrustedCaSubjectDns();
+        assertThat(subjectNames.size(), is(1));
+        assertTrue(subjectNames.contains(trustedCaCert.getSubjectX500Principal()));
+        final List<TrustAnchor> anchors = tenant.getTrustAnchors();
+        assertThat(anchors.size(), is(1));
+        assertThat(anchors.get(0).getTrustedCert(), is(trustedCaCert));
     }
 
     /**
@@ -188,10 +198,11 @@ public class TenantObjectTest {
     public void testGetTrustAnchorUsesCertificate() throws GeneralSecurityException {
 
         final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, Boolean.TRUE)
-                .setTrustAnchor(trustedCaCert);
+                .addTrustAnchor(trustedCaCert);
 
-        final TrustAnchor trustAnchor = obj.getTrustAnchor();
-        assertThat(trustAnchor.getTrustedCert(), is(trustedCaCert));
+        final List<TrustAnchor> trustAnchors = obj.getTrustAnchors();
+        assertThat(trustAnchors.size(), is(1));
+        assertThat(trustAnchors.get(0).getTrustedCert(), is(trustedCaCert));
     }
 
     /**
@@ -203,11 +214,12 @@ public class TenantObjectTest {
     public void testGetTrustAnchorUsesPublicKey() throws GeneralSecurityException {
 
         final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, Boolean.TRUE)
-                .setTrustAnchor(trustedCaCert.getPublicKey(), trustedCaCert.getSubjectX500Principal());
+                .addTrustAnchor(trustedCaCert.getPublicKey(), trustedCaCert.getSubjectX500Principal());
 
-        final TrustAnchor trustAnchor = obj.getTrustAnchor();
-        assertThat(trustAnchor.getCA(), is(trustedCaCert.getSubjectX500Principal()));
-        assertThat(trustAnchor.getCAPublicKey(), is(trustedCaCert.getPublicKey()));
+        final List<TrustAnchor> trustAnchors = obj.getTrustAnchors();
+        assertThat(trustAnchors.size(), is(1));
+        assertThat(trustAnchors.get(0).getCA(), is(trustedCaCert.getSubjectX500Principal()));
+        assertThat(trustAnchors.get(0).getCAPublicKey(), is(trustedCaCert.getPublicKey()));
     }
 
     /**
@@ -217,14 +229,16 @@ public class TenantObjectTest {
     @Test
     public void testGetTrustAnchorFailsForInvalidBase64EncodingOfPublicKey() {
 
-        final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, Boolean.TRUE)
-                .setTrustConfiguration(new JsonArray()
-                        .add(new JsonObject()
-                                .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
-                                .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, "noBase64")));
+        final JsonObject tenantPayload = new JsonObject()
+                .put(TenantConstants.FIELD_PAYLOAD_TENANT_ID, Constants.DEFAULT_TENANT)
+                .put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, new JsonObject()
+                        .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
+                        .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, "noBase64"));
+
+        final TenantObject obj = tenantPayload.mapTo(TenantObject.class);
 
         try {
-            obj.getTrustAnchor();
+            obj.getTrustAnchors();
             fail("should not have been able to read trust anchor from malformed Base64");
         } catch (final GeneralSecurityException e) {
             // as expected
@@ -238,14 +252,17 @@ public class TenantObjectTest {
     @Test
     public void testGetTrustAnchorFailsForInvalidBase64EncodingOfCert() {
 
-        final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, Boolean.TRUE)
-                .setTrustConfiguration(new JsonArray()
-                        .add(new JsonObject()
-                                .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
-                                .put(TenantConstants.FIELD_PAYLOAD_CERT, "noBase64")));
+        final JsonObject tenantPayload = new JsonObject()
+                .put(TenantConstants.FIELD_PAYLOAD_TENANT_ID, Constants.DEFAULT_TENANT)
+                .put(TenantConstants.FIELD_ENABLED, Boolean.TRUE)
+                .put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, new JsonObject()
+                        .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
+                        .put(TenantConstants.FIELD_PAYLOAD_CERT, "noBase64"));
+
+        final TenantObject obj = tenantPayload.mapTo(TenantObject.class);
 
         try {
-            obj.getTrustAnchor();
+            obj.getTrustAnchors();
             fail("should not have been able to read trust anchor from malformed Base64");
         } catch (final GeneralSecurityException e) {
             // as expected

--- a/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
@@ -218,11 +218,10 @@ public class TenantObjectTest {
     public void testGetTrustAnchorFailsForInvalidBase64EncodingOfPublicKey() {
 
         final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, Boolean.TRUE)
-                .setProperty(
-                        TenantConstants.FIELD_PAYLOAD_TRUSTED_CA,
-                        new JsonObject()
-                        .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
-                        .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, "noBase64"));
+                .setTrustConfiguration(new JsonArray()
+                        .add(new JsonObject()
+                                .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
+                                .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, "noBase64")));
 
         try {
             obj.getTrustAnchor();
@@ -240,11 +239,10 @@ public class TenantObjectTest {
     public void testGetTrustAnchorFailsForInvalidBase64EncodingOfCert() {
 
         final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, Boolean.TRUE)
-                .setProperty(
-                        TenantConstants.FIELD_PAYLOAD_TRUSTED_CA,
-                        new JsonObject()
-                        .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
-                        .put(TenantConstants.FIELD_PAYLOAD_CERT, "noBase64"));
+                .setTrustConfiguration(new JsonArray()
+                        .add(new JsonObject()
+                                .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
+                                .put(TenantConstants.FIELD_PAYLOAD_CERT, "noBase64")));
 
         try {
             obj.getTrustAnchor();

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
@@ -157,7 +157,7 @@ public final class TenantServiceBasedX509Authentication implements X509Authentic
             return tenantTracker
                     .compose(tenant -> {
                         try {
-                            final TrustAnchor trustAnchor = tenant.getTrustAnchor();
+                            final TrustAnchor trustAnchor = tenant.getTrustAnchors().get(0);
                             final List<X509Certificate> chainToValidate = Collections.singletonList(deviceCert);
                             return certPathValidator.validate(chainToValidate, trustAnchor)
                                     .recover(t -> Future.failedFuture(UNAUTHORIZED));

--- a/service-base/src/test/java/org/eclipse/hono/service/tenant/AbstractCompleteTenantServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/tenant/AbstractCompleteTenantServiceTest.java
@@ -79,11 +79,11 @@ public abstract class AbstractCompleteTenantServiceTest {
                 .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=taken")
                 .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, "NOTAKEY");
         final TenantObject tenant = TenantObject.from("tenant", true)
-                .setProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, trustedCa);
+                .addTrustedCA(trustedCa);
 
         addTenant("tenant", JsonObject.mapFrom(tenant)).map(ok -> {
             final TenantObject newTenant = TenantObject.from("newTenant", true)
-                    .setTrustConfiguration(new JsonArray().add(trustedCa));
+                    .addTrustedCA(trustedCa);
             getCompleteTenantService().add(
                     "newTenant",
                     JsonObject.mapFrom(newTenant),
@@ -149,8 +149,8 @@ public abstract class AbstractCompleteTenantServiceTest {
                 assertEquals(HttpURLConnection.HTTP_OK, s.getStatus());
                 final TenantObject obj = s.getPayload().mapTo(TenantObject.class);
                 assertEquals("tenant", obj.getTenantId());
-                final List<JsonObject> cas = obj.getTrustConfigurations();
-                assertEquals(cas.size(), 1);
+                final List<JsonObject> cas = obj.getTrustedCAs();
+                assertEquals(1, cas.size());
                 assertEquals(trustedCa, cas.get(0));
                 ctx.completeNow();
             })));
@@ -254,13 +254,13 @@ public abstract class AbstractCompleteTenantServiceTest {
                 .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=taken")
                 .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, "NOTAKEY");
         final TenantObject tenantOne = TenantObject.from("tenantOne", true)
-                .setTrustConfiguration(new JsonArray().add(trustedCa));
+                .addTrustedCA(trustedCa);
         final TenantObject tenantTwo = TenantObject.from("tenantTwo", true);
         addTenant("tenantOne", JsonObject.mapFrom(tenantOne))
         .compose(ok -> addTenant("tenantTwo", JsonObject.mapFrom(tenantTwo)))
         .compose(ok -> {
             // WHEN updating the second tenant to use the same CA as the first tenant
-            tenantTwo.setProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, trustedCa);
+            tenantTwo.addTrustedCA(trustedCa);
             final Future<TenantResult<JsonObject>> result = Future.future();
             getCompleteTenantService().update(
                     "tenantTwo",

--- a/service-base/src/test/java/org/eclipse/hono/service/tenant/CompleteBaseTenantServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/tenant/CompleteBaseTenantServiceTest.java
@@ -164,7 +164,7 @@ public class CompleteBaseTenantServiceTest {
         final JsonObject malformedTrustedCa = new JsonObject()
                 .put(TenantConstants.FIELD_PAYLOAD_CERT, "certificate");
         final JsonObject testPayload = createValidTenantPayload();
-        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, new JsonArray().add(malformedTrustedCa));
+        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, malformedTrustedCa);
 
         final EventBusMessage msg = createRequest(TenantConstants.TenantAction.add, testPayload);
         tenantService.processRequest(msg).setHandler(ctx.asyncAssertFailure(t -> {
@@ -184,7 +184,7 @@ public class CompleteBaseTenantServiceTest {
         final JsonObject malformedTrustedCa = new JsonObject()
                 .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test");
         final JsonObject testPayload = createValidTenantPayload();
-        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, new JsonArray().add(malformedTrustedCa));
+        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, new JsonArray().add(malformedTrustedCa));
 
         final EventBusMessage msg = createRequest(TenantConstants.TenantAction.add, testPayload);
         tenantService.processRequest(msg).setHandler(ctx.asyncAssertFailure(t -> {
@@ -207,7 +207,7 @@ public class CompleteBaseTenantServiceTest {
                 .put(TenantConstants.FIELD_PAYLOAD_CERT, "certificate")
                 .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, "key");
         final JsonObject testPayload = createValidTenantPayload();
-        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, new JsonArray().add(malformedTrustedCa));
+        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, malformedTrustedCa);
 
         final EventBusMessage msg = createRequest(TenantConstants.TenantAction.add, testPayload);
         tenantService.processRequest(msg).setHandler(ctx.asyncAssertFailure(t -> {
@@ -230,7 +230,7 @@ public class CompleteBaseTenantServiceTest {
                 .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
                 .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, cert.getPublicKey().getEncoded());
         final JsonObject testPayload = createValidTenantPayload();
-        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, new JsonArray().add(validTrustedCa));
+        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, validTrustedCa);
 
         final EventBusMessage msg = createRequest(TenantConstants.TenantAction.add, testPayload);
         tenantService.processRequest(msg).setHandler(ctx.asyncAssertSuccess());
@@ -251,7 +251,7 @@ public class CompleteBaseTenantServiceTest {
                 .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
                 .put(TenantConstants.FIELD_PAYLOAD_CERT, cert.getEncoded());
         final JsonObject testPayload = createValidTenantPayload();
-        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, new JsonArray().add(validTrustedCa));
+        testPayload.put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, validTrustedCa);
 
         final EventBusMessage msg = createRequest(TenantConstants.TenantAction.add, testPayload);
         tenantService.processRequest(msg).setHandler(ctx.asyncAssertSuccess());
@@ -272,7 +272,7 @@ public class CompleteBaseTenantServiceTest {
                 .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, "NOTAPUBLICKEY");
 
         final JsonObject testPayloadPK = createValidTenantPayload()
-                .put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, new JsonArray().add(malformedPKTrustedCa));
+                .put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, malformedPKTrustedCa);
 
         // WHEN there is a request to add the tenant with such malformed payload
         final EventBusMessage msgPK = createRequest(TenantConstants.TenantAction.add, testPayloadPK);
@@ -296,7 +296,7 @@ public class CompleteBaseTenantServiceTest {
                 .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "CN=test")
                 .put(TenantConstants.FIELD_PAYLOAD_CERT, "NOTACERTIFICATE");
         final JsonObject testPayloadCert = createValidTenantPayload()
-                .put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, new JsonArray().add(malformedCertTrustedCa));
+                .put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, malformedCertTrustedCa);
 
         // WHEN there is a request to add the tenant with such malformed payload
         final EventBusMessage msgCert = createRequest(TenantConstants.TenantAction.add, testPayloadCert);
@@ -330,7 +330,7 @@ public class CompleteBaseTenantServiceTest {
                 .put(TenantConstants.FIELD_PAYLOAD_CERT, "NOTACERTIFICATE");
 
         final JsonObject tenantPayload = createValidTenantPayload()
-                .put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE,
+                .put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA,
                         new JsonArray().add(validTrustedCaOne).add(validTrustedCaTwo).add(malformedCertTrustedCa));
 
         // WHEN there is a request to add the tenant with such malformed payload
@@ -361,7 +361,7 @@ public class CompleteBaseTenantServiceTest {
             trustConfigs.add(trustedCa);
         }
         final JsonObject tenantPayload = createValidTenantPayload()
-                .put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, trustConfigs);
+                .put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, trustConfigs);
 
         // WHEN there is a request to add the tenant with such valid payload
         final EventBusMessage msgCert = createRequest(TenantConstants.TenantAction.add, tenantPayload);

--- a/site/content/api/Tenant-API.md
+++ b/site/content/api/Tenant-API.md
@@ -293,7 +293,7 @@ The table below provides an overview of the standard members defined for the JSO
 | *defaults*               | *no*      | *object*      | `-`          | Arbitrary *default* properties for devices belonging to the tenant. The properties can be used by protocol adapters to augment downstream messages with missing information, e.g. setting a default content type or TTL. |
 | *enabled*                | *no*      | *boolean*     | `true`       | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
 | *resource-limits*         | *no*      | *object*     | `-`          | The resource-limits such as the maximum number of connections and the maximum data volume for a given period can be set. The format of a configuration option is described here [Resource Limits Configuration Format]({{< relref "#resource-limits-configuration-format" >}}).|
-| *trust-ca*             | *no*      | *JSON array* | `-`          | The list of trusted certificate authorities to use for validating certificates presented by devices of the tenant for authentication purposes. The JSON array consist of JSON objects, each describing the configuration information of a trusted CA. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object and an example tenant configured to use two trusted certification authorities. |
+| *trust-ca*             | *no*      | *object* or *array* | `-`          | The trusted certificate authority(ies) to use for validating certificates presented by devices of the tenant for authentication purposes. The tenant payload can contain either a single JSON object or an array of JSON objects. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
 | *adapters*               | *no*      | *array*       | `-`          | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration. |
 
 If any of the mandatory members is either missing or contains invalid data, implementations MUST NOT accept the payload and return *400 Bad Request* status code.
@@ -431,16 +431,12 @@ Below is an example for a payload of the response to a *get* request for tenant 
  {
    "tenant-id" : "TEST_TENANT",
    "enabled" : true,
-   "trust-store": [ {
+   "trusted-ca": [ {
 	    "subject-dn": "CN=ca,OU=Hono,O=Eclipse",
-	    "public-key": "NOTAPUBLICKEY",
-	    "not-before": "2015-01-01T00:00:00+0000",
-	    "not-after": "2025-01-01T00:00:00+0000"
+	    "public-key": "NOTAPUBLICKEY"
 	  }, {
 	    "subject-dn": "CN=ca,OU=Hono,O=Eclipse",
-	    "public-key": "NOTAPUBLICKEY",
-	    "not-before": "2024-01-01T00:00:00+0000",
-	    "not-after": "2034-01-01T00:00:00+0000"
+	    "public-key": "NOTAPUBLICKEY"
 	  } ]
  }
 ~~~

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.ext.unit.TestContext;
@@ -237,11 +238,11 @@ public class AmqpConnectionIT extends AmqpAdapterTestBase {
         // GIVEN a tenant configured with a trust anchor
         helper.getCertificate(deviceCert.certificatePath())
         .compose(cert -> {
-            tenant.setProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA,
-                    new JsonObject()
-                        .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, cert.getIssuerX500Principal().getName(X500Principal.RFC2253))
-                        .put(TenantConstants.FIELD_ADAPTERS_TYPE, "EC")
-                        .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded())));
+            final JsonObject trustedCa = new JsonObject()
+                    .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, cert.getIssuerX500Principal().getName(X500Principal.RFC2253))
+                    .put(TenantConstants.FIELD_ADAPTERS_TYPE, "EC")
+                    .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+            tenant.setTrustConfiguration(new JsonArray().add(trustedCa));
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         })
         .compose(ok -> {

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.ext.unit.TestContext;
@@ -242,7 +241,7 @@ public class AmqpConnectionIT extends AmqpAdapterTestBase {
                     .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, cert.getIssuerX500Principal().getName(X500Principal.RFC2253))
                     .put(TenantConstants.FIELD_ADAPTERS_TYPE, "EC")
                     .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
-            tenant.setTrustConfiguration(new JsonArray().add(trustedCa));
+            tenant.addTrustedCA(trustedCa);
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         })
         .compose(ok -> {

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
@@ -206,7 +206,7 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
 
         helper.getCertificate(deviceCert.certificatePath()).compose(cert -> {
             final TenantObject tenant = TenantObject.from(tenantId, true);
-            tenant.setTrustAnchor(cert.getPublicKey(), cert.getSubjectX500Principal());
+            tenant.addTrustAnchor(cert.getPublicKey(), cert.getSubjectX500Principal());
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         }).compose(ok -> connectToAdapter(deviceCert))
         .compose(con -> createProducer(null))

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -326,7 +326,7 @@ public abstract class HttpTestBase {
 
         helper.getCertificate(deviceCert.certificatePath()).compose(cert -> {
             final TenantObject tenant = TenantObject.from(tenantId, true);
-            tenant.setTrustAnchor(cert.getPublicKey(), cert.getSubjectX500Principal());
+            tenant.addTrustAnchor(cert.getPublicKey(), cert.getSubjectX500Principal());
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         }).setHandler(ctx.asyncAssertSuccess(ok -> setup.complete()));
 
@@ -465,12 +465,12 @@ public abstract class HttpTestBase {
         // GIVEN a tenant configured with a trust anchor
         helper.getCertificate(deviceCert.certificatePath())
         .compose(cert -> {
-            tenant.setTrustConfiguration(new JsonArray()
-                    .add(new JsonObject()
-                        .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, cert.getIssuerX500Principal().getName(X500Principal.RFC2253))
-                        .put(TenantConstants.FIELD_ADAPTERS_TYPE, "EC")
-                        .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded())))
-                    );
+                    tenant.addTrustedCA(new JsonObject()
+                            .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN,
+                                    cert.getIssuerX500Principal().getName(X500Principal.RFC2253))
+                            .put(TenantConstants.FIELD_ADAPTERS_TYPE, "EC")
+                            .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY,
+                                    Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded())));
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         })
         .setHandler(ctx.asyncAssertSuccess(ok -> setup.complete()));

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -465,11 +465,12 @@ public abstract class HttpTestBase {
         // GIVEN a tenant configured with a trust anchor
         helper.getCertificate(deviceCert.certificatePath())
         .compose(cert -> {
-            tenant.setProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA,
-                       new JsonObject()
+            tenant.setTrustConfiguration(new JsonArray()
+                    .add(new JsonObject()
                         .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, cert.getIssuerX500Principal().getName(X500Principal.RFC2253))
                         .put(TenantConstants.FIELD_ADAPTERS_TYPE, "EC")
-                        .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded())));
+                        .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded())))
+                    );
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         })
         .setHandler(ctx.asyncAssertSuccess(ok -> setup.complete()));

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
@@ -94,7 +94,7 @@ public class MqttConnectionIT extends MqttTestBase {
         helper.getCertificate(deviceCert.certificatePath())
         .compose(cert -> {
             final TenantObject tenant = TenantObject.from(tenantId, true);
-            tenant.setTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
+            tenant.addTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         }).compose(ok -> {
             return connectToAdapter(deviceCert);
@@ -177,7 +177,7 @@ public class MqttConnectionIT extends MqttTestBase {
 
         helper.getCertificate(deviceCert.certificatePath())
         .compose(cert -> {
-            tenant.setTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
+            tenant.addTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
             return helper.registry.addTenant(JsonObject.mapFrom(tenant));
         }).compose(ok -> helper.registry.registerDevice(tenant.getTenantId(), deviceId))
         .compose(ok -> {
@@ -238,7 +238,7 @@ public class MqttConnectionIT extends MqttTestBase {
 
         helper.getCertificate(deviceCert.certificatePath())
         .compose(cert -> {
-            tenant.setTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
+            tenant.addTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         })
         // WHEN a device that belongs to the tenant tries to connect to the adapter
@@ -338,7 +338,7 @@ public class MqttConnectionIT extends MqttTestBase {
         helper.getCertificate(deviceCert.certificatePath())
         .compose(cert -> {
             final TenantObject tenant = TenantObject.from(tenantId, false);
-            tenant.setTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
+            tenant.addTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         })
         .compose(ok -> connectToAdapter(deviceCert))

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -210,7 +210,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
 
         helper.getCertificate(deviceCert.certificatePath())
         .compose(cert -> {
-            tenant.setTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
+            tenant.addTrustAnchor(cert.getPublicKey(), cert.getIssuerX500Principal());
             return helper.registry.addDeviceForTenant(tenant, deviceId, cert);
         }).setHandler(ctx.asyncAssertSuccess(ok -> setup.complete()));
         setup.await();

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
@@ -39,7 +39,6 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -186,14 +185,14 @@ public class TenantAmqpIT {
         final X500Principal subjectDn = new X500Principal("CN=ca, OU=Hono, O=Eclipse");
         final TenantObject payload = new TenantObject()
                 .setTenantId(tenantId)
-                .setTrustAnchor(getRandomPublicKey(), subjectDn);
+                .addTrustAnchor(getRandomPublicKey(), subjectDn);
 
         helper.registry.addTenant(JsonObject.mapFrom(payload))
                 .compose(r -> tenantClient.get(subjectDn))
                 .setHandler(ctx.asyncAssertSuccess(tenantObject -> {
 
                     ctx.assertEquals(tenantId, tenantObject.getTenantId());
-                    final List<JsonObject> trustedCas = tenantObject.getTrustConfigurations();
+                    final List<JsonObject> trustedCas = tenantObject.getTrustedCAs();
                     ctx.assertEquals(1, trustedCas.size());
                     ctx.assertNotNull(trustedCas.get(0));
                     final X500Principal trustedSubjectDn = new X500Principal(trustedCas.get(0).getString(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN));
@@ -216,7 +215,7 @@ public class TenantAmqpIT {
         final X500Principal subjectDn = new X500Principal("CN=ca-http,OU=Hono,O=Eclipse");
         final TenantObject payload = new TenantObject()
                 .setTenantId(tenantId)
-                .setTrustAnchor(getRandomPublicKey(), subjectDn)
+                .addTrustAnchor(getRandomPublicKey(), subjectDn)
                 .addAdapterConfiguration(new JsonObject()
                         .put(TenantConstants.FIELD_ADAPTERS_TYPE, Constants.PROTOCOL_ADAPTER_TYPE_HTTP)
                         .put(TenantConstants.FIELD_ENABLED, true)
@@ -246,7 +245,7 @@ public class TenantAmqpIT {
 
         final String tenantId = Constants.DEFAULT_TENANT;
         final TenantObject payload = TenantObject.from(tenantId, true)
-                .setTrustConfiguration(new JsonArray().add(malformedTrustedCa));
+                .addTrustedCA(malformedTrustedCa);
 
         helper.registry.addTenant(JsonObject.mapFrom(payload))
         .setHandler(ctx.asyncAssertFailure(t -> {

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantHttpIT.java
@@ -253,7 +253,7 @@ public class TenantHttpIT {
                 .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "test-dn")
                 .put(TenantConstants.FIELD_PAYLOAD_CERT, "NotBased64Encoded");
         final JsonObject requestBody = buildTenantPayload(tenantId)
-                .put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, trustConfig);
+                .put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, new JsonArray().add(trustConfig));
         registry.addTenant(requestBody, "application/json", HttpURLConnection.HTTP_BAD_REQUEST).setHandler(context.asyncAssertSuccess());
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantHttpIT.java
@@ -253,7 +253,7 @@ public class TenantHttpIT {
                 .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, "test-dn")
                 .put(TenantConstants.FIELD_PAYLOAD_CERT, "NotBased64Encoded");
         final JsonObject requestBody = buildTenantPayload(tenantId)
-                .put(TenantConstants.FIELD_PAYLOAD_TRUST_STORE, new JsonArray().add(trustConfig));
+                .put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, trustConfig);
         registry.addTenant(requestBody, "application/json", HttpURLConnection.HTTP_BAD_REQUEST).setHandler(context.asyncAssertSuccess());
     }
 

--- a/tests/src/test/resources/deviceregistry/tenants.json
+++ b/tests/src/test/resources/deviceregistry/tenants.json
@@ -2,18 +2,18 @@
   {
     "tenant-id": "DEFAULT_TENANT",
     "enabled": true,
-    "trusted-ca": {
+    "trust-store": [{
       "subject-dn": "CN=ca,OU=Hono,O=Eclipse",
       "public-key": "NOTAPUBLICKEY"
-    }
+    }]
   },
   {
     "tenant-id": "HTTP_ONLY",
     "enabled": true,
-    "trusted-ca": {
+    "trust-store": [{
       "subject-dn": "CN=ca-http,OU=Hono,O=Eclipse",
       "public-key": "NOTAPUBLICKEY"
-    },
+    }],
     "adapters": [
       {
         "type": "hono-http",


### PR DESCRIPTION
This is an **initial PR** that addresses #623 . i disabled about two tests for now in the IT test module (i.e in the http and amqp adapters) because now the base tenant implementation rejects a tenant add request with payload containing trust configurations whose public key or cert property values are not base64 encoded

i decided to file this PR to get initial feedback before changing the http/amqp adapters (or adding integration tests)

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>