### PR TITLE
Do not include registration assertion in downstream messages anymore.

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -869,7 +869,6 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                     final Message downstreamMessage = addProperties(
                             context.getMessage(),
                             ResourceIdentifier.from(context.getEndpoint().getCanonicalName(), resource.getTenantId(), resource.getResourceId()),
-                            sender.isRegistrationAssertionRequired(),
                             context.getAddress().toString(),
                             tokenFuture.result(),
                             null); // no TTD

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -515,7 +515,6 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                     final MessageSender sender = senderTracker.result();
                     final Message downstreamMessage = newMessage(
                             ResourceIdentifier.from(endpoint.getCanonicalName(), device.getTenantId(), device.getDeviceId()),
-                            sender.isRegistrationAssertionRequired(),
                             "/" + context.getExchange().getRequestOptions().getUriPathString(),
                             contentType,
                             payload,

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -631,7 +631,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                                 .orElse(null);
                         final Message downstreamMessage = newMessage(
                                 ResourceIdentifier.from(endpoint.getCanonicalName(), tenant, deviceId),
-                                sender.isRegistrationAssertionRequired(),
                                 ctx.request().uri(),
                                 contentType,
                                 payload,

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1009,7 +1009,6 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     final MessageSender sender = senderTracker.result();
                     final Message downstreamMessage = newMessage(
                             ResourceIdentifier.from(endpoint.getCanonicalName(), tenant, deviceId),
-                            sender.isRegistrationAssertionRequired(),
                             ctx.message().topicName(),
                             ctx.contentType(),
                             payload,

--- a/client/src/main/java/org/eclipse/hono/client/MessageSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/MessageSender.java
@@ -60,18 +60,6 @@ public interface MessageSender extends CreditBasedSender {
     boolean isOpen();
 
     /**
-     * Checks if the peer that this sender is connected to
-     * requires messages to contain a registration assertion.
-     * <p>
-     * The result of this method should only be considered
-     * if this sender is open.
-     * 
-     * @return {@code true} if messages must contain an assertion,
-     *         {@code false} otherwise.
-     */
-    boolean isRegistrationAssertionRequired();
-
-    /**
      * Sends an AMQP 1.0 message to the endpoint configured for this client.
      * 
      * @param message The message to send.
@@ -179,11 +167,6 @@ public interface MessageSender extends CreditBasedSender {
      *                    This parameter will be used as the value for the message's <em>content-type</em> property.
      *                    If the content type specifies a particular character set, this character set will be used to
      *                    encode the payload to its byte representation. Otherwise, UTF-8 will be used.
-     * @param registrationAssertion A JSON Web Token asserting that the device is enabled and belongs to the tenant that
-     *                              this sender has been created for.
-     *                              <p>
-     *                              The {@linkplain RegistrationClient#assertRegistration(String) registration
-     *                              client} can be used to obtain such an assertion.
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded if the message has been sent to the endpoint.
@@ -197,10 +180,10 @@ public interface MessageSender extends CreditBasedSender {
      *         If an event is sent which cannot be processed by the peer the future will
      *         be failed with either a {@code ServerErrorException} or a {@link ClientErrorException}
      *         depending on the reason for the failure to process the message.
-     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws NullPointerException if any of the parameters are {@code null}.
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      */
-    Future<ProtonDelivery> send(String deviceId, String payload, String contentType, String registrationAssertion);
+    Future<ProtonDelivery> send(String deviceId, String payload, String contentType);
 
     /**
      * Sends a message for a given device to the endpoint configured for this client.
@@ -214,11 +197,6 @@ public interface MessageSender extends CreditBasedSender {
      * @param contentType The content type of the payload.
      *                    <p>
      *                    This parameter will be used as the value for the message's <em>content-type</em> property.
-     * @param registrationAssertion A JSON Web Token asserting that the device is enabled and belongs to the tenant that
-     *                              this sender has been created for.
-     *                              <p>
-     *                              The {@linkplain RegistrationClient#assertRegistration(String) registration
-     *                              client} can be used to obtain such an assertion.
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded if the message has been sent to the endpoint.
@@ -232,10 +210,10 @@ public interface MessageSender extends CreditBasedSender {
      *         If an event is sent which cannot be processed by the peer the future will
      *         be failed with either a {@code ServerErrorException} or a {@link ClientErrorException}
      *         depending on the reason for the failure to process the message.
-     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws NullPointerException if any of the parameters are {@code null}.
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      */
-    Future<ProtonDelivery> send(String deviceId, byte[] payload, String contentType, String registrationAssertion);
+    Future<ProtonDelivery> send(String deviceId, byte[] payload, String contentType);
 
     /**
      * Sends a message for a given device to the endpoint configured for this client.
@@ -255,11 +233,6 @@ public interface MessageSender extends CreditBasedSender {
      *                    This parameter will be used as the value for the message's <em>content-type</em> property.
      *                    If the content type specifies a particular character set, this character set will be used to
      *                    encode the payload to its byte representation. Otherwise, UTF-8 will be used.
-     * @param registrationAssertion A JSON Web Token asserting that the device is enabled and belongs to the tenant that
-     *                              this sender has been created for.
-     *                              <p>
-     *                              The {@linkplain RegistrationClient#assertRegistration(String) registration
-     *                              client} can be used to obtain such an assertion.
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded if the message has been sent to the endpoint.
@@ -273,16 +246,14 @@ public interface MessageSender extends CreditBasedSender {
      *         If an event is sent which cannot be processed by the peer the future will
      *         be failed with either a {@code ServerErrorException} or a {@link ClientErrorException}
      *         depending on the reason for the failure to process the message.
-     * @throws NullPointerException if any of device id, payload, content type or registration assertion
-     *                              is {@code null}.
+     * @throws NullPointerException if any of device id, payload or content type are {@code null}.
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      */
     Future<ProtonDelivery> send(
             String deviceId,
             Map<String, ?> properties,
             String payload,
-            String contentType,
-            String registrationAssertion);
+            String contentType);
 
     /**
      * Sends a message for a given device to the endpoint configured for this client.
@@ -299,11 +270,6 @@ public interface MessageSender extends CreditBasedSender {
      * @param contentType The content type of the payload.
      *                    <p>
      *                    This parameter will be used as the value for the message's <em>content-type</em> property.
-     * @param registrationAssertion A JSON Web Token asserting that the device is enabled and belongs to the tenant that
-     *                              this sender has been created for.
-     *                              <p>
-     *                              The {@linkplain RegistrationClient#assertRegistration(String) registration
-     *                              client} can be used to obtain such an assertion.
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded if the message has been sent to the endpoint.
@@ -317,13 +283,12 @@ public interface MessageSender extends CreditBasedSender {
      *         If an event is sent which cannot be processed by the peer the future will
      *         be failed with either a {@code ServerErrorException} or a {@link ClientErrorException}
      *         depending on the reason for the failure to process the message.
-     * @throws NullPointerException if any of device id, payload, content type or registration assertion is {@code null}.
+     * @throws NullPointerException if any of device id, payload or content type are {@code null}.
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      */
     Future<ProtonDelivery> send(
             String deviceId,
             Map<String, ?> properties,
             byte[] payload,
-            String contentType,
-            String registrationAssertion);
+            String contentType);
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
@@ -154,9 +154,6 @@ public final class TelemetrySenderImpl extends AbstractSender {
         span.setTag(MessageHelper.APP_PROPERTY_DEVICE_ID, MessageHelper.getDeviceId(rawMessage));
         TracingHelper.injectSpanContext(tracer, span.context(), rawMessage);
 
-        if (!isRegistrationAssertionRequired()) {
-            MessageHelper.getAndRemoveRegistrationAssertion(rawMessage);
-        }
         return executeOrRunOnContext(result -> {
             if (sender.sendQueueFull()) {
                 final ServiceInvocationException e = new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no credit available");

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
@@ -14,17 +14,23 @@
 package org.eclipse.hono.client.impl;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.HttpURLConnection;
 
-import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,31 +69,6 @@ public class AbstractSenderTest {
     }
 
     /**
-     * Verifies that registration assertions are not required if
-     * the peer does not support validation of assertions.
-     */
-    @Test
-    public void testIsRegistrationAssertionRequiredReturnsFalse() {
-
-        when(protonSender.getRemoteOfferedCapabilities()).thenReturn(null);
-        final AbstractSender sender = newSender("tenant", "endpoint");
-        assertFalse(sender.isRegistrationAssertionRequired());
-    }
-
-    /**
-     * Verifies that registration assertions are required if
-     * the peer supports validation of assertions.
-     */
-    @Test
-    public void testIsRegistrationAssertionRequiredReturnsTrue() {
-
-        when(protonSender.getRemoteOfferedCapabilities())
-            .thenReturn(new Symbol[] { Constants.CAP_REG_ASSERTION_VALIDATION });
-        final AbstractSender sender = newSender("tenant", "endpoint");
-        assertTrue(sender.isRegistrationAssertionRequired());
-    }
-
-    /**
      * Verifies that the sender removes the registration assertion
      * from a message if the peer does not support validation of
      * assertions.
@@ -103,7 +84,7 @@ public class AbstractSenderTest {
         final AbstractSender sender = newSender("tenant", "endpoint");
 
         // WHEN sending a message
-        sender.send("device", "some payload", "application/text", "token");
+        sender.send("device", "some payload", "application/text");
 
         // THEN the message is sent without the registration assertion
         final ArgumentCaptor<Message> sentMessage = ArgumentCaptor.forClass(Message.class);
@@ -122,7 +103,7 @@ public class AbstractSenderTest {
         final AbstractSender sender = newSender("tenant", "endpoint");
 
         // WHEN trying to send a message
-        final Future<ProtonDelivery> result = sender.send("device", "some payload", "application/text", "token");
+        final Future<ProtonDelivery> result = sender.send("device", "some payload", "application/text");
 
         // THEN the message is not sent
         assertFalse(result.succeeded());

--- a/client/src/test/java/org/eclipse/hono/client/impl/EventSenderImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/EventSenderImplTest.java
@@ -84,7 +84,7 @@ public class EventSenderImplTest {
         }).when(sender).send(any(Message.class), any(Handler.class));
 
         // WHEN trying to send a message
-        final Future<ProtonDelivery> result = messageSender.send("device", "some payload", "application/text", "token");
+        final Future<ProtonDelivery> result = messageSender.send("device", "some payload", "application/text");
 
         // THEN the message has been sent
         // and the result is not completed yet
@@ -119,7 +119,7 @@ public class EventSenderImplTest {
         }).when(sender).send(any(Message.class), any(Handler.class));
 
         // WHEN trying to send a message
-        final Future<ProtonDelivery> result = messageSender.send("device", "some payload", "application/text", "token");
+        final Future<ProtonDelivery> result = messageSender.send("device", "some payload", "application/text");
 
         // THEN the message has been sent
         // and the result is not completed yet

--- a/client/src/test/java/org/eclipse/hono/client/impl/TelemetrySenderImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/TelemetrySenderImplTest.java
@@ -83,7 +83,7 @@ public class TelemetrySenderImplTest {
         }).when(sender).send(any(Message.class), any(Handler.class));
 
         // WHEN trying to send a message
-        final Future<ProtonDelivery> result = messageSender.send("device", "some payload", "application/text", "token");
+        final Future<ProtonDelivery> result = messageSender.send("device", "some payload", "application/text");
         // which gets rejected by the peer
         final ProtonDelivery rejected = mock(ProtonDelivery.class);
         when(rejected.remotelySettled()).thenReturn(Boolean.TRUE);

--- a/jmeter/src/jmeter/amqp_messaging_throughput_test.jmx
+++ b/jmeter/src/jmeter/amqp_messaging_throughput_test.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.3 r1808647">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="AMQP throughput test" enabled="true">
       <boolProp name="TestPlan.functional_mode">false</boolProp>
@@ -106,54 +106,6 @@
         <boolProp name="ThreadGroup.delayedStart">true</boolProp>
       </ThreadGroup>
       <hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Register Device" enabled="true">
-          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="" elementType="HTTPArgument">
-                <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{&quot;device-id&quot;: &quot;device_${__threadNum}&quot;}</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
-          <stringProp name="HTTPSampler.domain">${__P(registration.host, 127.0.0.1)}</stringProp>
-          <stringProp name="HTTPSampler.port">${__P(registration.http.port, 28080)}</stringProp>
-          <stringProp name="HTTPSampler.protocol">http</stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/registration/${honoTenant}</stringProp>
-          <stringProp name="HTTPSampler.method">POST</stringProp>
-          <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
-          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-          <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="TestPlan.comments">Registers a device with the configured tenant using a device identifier based on the thread number.</stringProp>
-        </HTTPSamplerProxy>
-        <hashTree>
-          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
-            <collectionProp name="HeaderManager.headers">
-              <elementProp name="" elementType="Header">
-                <stringProp name="Header.name">content-type</stringProp>
-                <stringProp name="Header.value">application/json</stringProp>
-              </elementProp>
-            </collectionProp>
-          </HeaderManager>
-          <hashTree/>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assert success" enabled="true">
-            <collectionProp name="Asserion.test_strings">
-              <stringProp name="49587">201</stringProp>
-              <stringProp name="51517">409</stringProp>
-            </collectionProp>
-            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-            <boolProp name="Assertion.assume_success">true</boolProp>
-            <intProp name="Assertion.test_type">40</intProp>
-          </ResponseAssertion>
-          <hashTree/>
-        </hashTree>
         <RunTime guiclass="RunTimeGui" testclass="RunTime" testname="Run n seconds" enabled="true">
           <stringProp name="RunTime.seconds">${honoTestRuntime}</stringProp>
         </RunTime>
@@ -175,13 +127,10 @@
             <stringProp name="waitForReceiversTimeout">5000</stringProp>
             <boolProp name="waitForCredits">true</boolProp>
             <stringProp name="endpoint">telemetry</stringProp>
-            <stringProp name="registryHost">${__P(registration.host, 127.0.0.1)}</stringProp>
-            <stringProp name="registryPort">${__P(registration.port, 25671)}</stringProp>
-            <stringProp name="registryUser">${__P(registration.user, hono-client@HONO)}</stringProp>
-            <stringProp name="registryPwd">${__P(registration.password, secret)}</stringProp>
-            <stringProp name="registryTrustStorePath">${__P(registration.trustStorePath, ${honoTrustStorePath})}</stringProp>
-            <stringProp name="PROPERTY_REGISTRATION_ASSERTION">${__P(staticAssertion, )}</stringProp>
             <stringProp name="TestPlan.comments">Sends a Telemetry message or Event to a service implementing the southbound operations of the Telemetry and/or Event APIs.</stringProp>
+            <boolProp name="waitForDeliveryResult">true</boolProp>
+            <stringProp name="sendTimeout">1000</stringProp>
+            <stringProp name="messageCountPerSamplerRun">1</stringProp>
           </org.eclipse.hono.jmeter.HonoSenderSampler>
           <hashTree/>
           <Summariser guiclass="SummariserGui" testclass="Summariser" testname="sent" enabled="true"/>
@@ -190,38 +139,6 @@
             <stringProp name="ConstantTimer.delay">5</stringProp>
             <stringProp name="TestPlan.comments">Only needed if you do not wait for credits - adjust this together with the threads to not overload Hono</stringProp>
           </ConstantTimer>
-          <hashTree/>
-        </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Unregister Device" enabled="true">
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
-            <collectionProp name="Arguments.arguments"/>
-          </elementProp>
-          <stringProp name="HTTPSampler.domain">${__P(registration.host, 127.0.0.1)}</stringProp>
-          <stringProp name="HTTPSampler.port">${__P(registration.http.port, 28080)}</stringProp>
-          <stringProp name="HTTPSampler.protocol"></stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/registration/${honoTenant}/device_${__threadNum}</stringProp>
-          <stringProp name="HTTPSampler.method">DELETE</stringProp>
-          <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
-          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-          <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="TestPlan.comments">Unregisters the device that has been registered during startup of the thread group.</stringProp>
-        </HTTPSamplerProxy>
-        <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assert success" enabled="true">
-            <collectionProp name="Asserion.test_strings">
-              <stringProp name="49590">204</stringProp>
-              <stringProp name="51512">404</stringProp>
-            </collectionProp>
-            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-            <boolProp name="Assertion.assume_success">true</boolProp>
-            <intProp name="Assertion.test_type">40</intProp>
-          </ResponseAssertion>
           <hashTree/>
         </hashTree>
       </hashTree>
@@ -262,9 +179,5 @@
       </ResultCollector>
       <hashTree/>
     </hashTree>
-    <WorkBench guiclass="WorkBenchGui" testclass="WorkBench" testname="WorkBench" enabled="true">
-      <boolProp name="WorkBench.save">true</boolProp>
-    </WorkBench>
-    <hashTree/>
   </hashTree>
 </jmeterTestPlan>

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSenderSampler.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/HonoSenderSampler.java
@@ -13,17 +13,16 @@
 
 package org.eclipse.hono.jmeter;
 
+import static org.eclipse.hono.jmeter.HonoSamplerUtils.getIntValueOrDefault;
+
 import java.util.concurrent.CompletionException;
 
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.eclipse.hono.jmeter.client.HonoSender;
-import org.eclipse.hono.jmeter.ui.ServerOptionsPanel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.eclipse.hono.jmeter.HonoSamplerUtils.getIntValueOrDefault;
 
 /**
  * JMeter creates an instance of a sampler class for every occurrence of the element in every thread. [some additional
@@ -42,12 +41,6 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HonoSenderSampler.class);
 
-    private static final String REGISTRY_HOST = "registryHost";
-    private static final String REGISTRY_USER = "registryUser";
-    private static final String REGISTRY_PWD = "registryPwd";
-    private static final String REGISTRY_PORT = "registryPort";
-    private static final String REGISTRY_TRUSTSTORE_PATH = "registryTrustStorePath";
-
     private static final String DEVICE_ID = "deviceId";
     private static final String SET_SENDER_TIME = "setSenderTime";
     private static final String CONTENT_TYPE = "contentType";
@@ -57,109 +50,8 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
     private static final String WAIT_FOR_RECEIVERS_TIMEOUT = "waitForReceiversTimeout";
     private static final String SEND_TIMEOUT = "sendTimeout";
     private static final String MESSAGE_COUNT_PER_SAMPLER_RUN = "messageCountPerSamplerRun";
-    private static final String PROPERTY_REGISTRATION_ASSERTION = "PROPERTY_REGISTRATION_ASSERTION";
 
     private HonoSender honoSender;
-
-    /**
-     * Applies the options to the local UI.
-     * 
-     * @param serverOptions The options to apply.
-     */
-    public void modifyRegistrationServiceOptions(final ServerOptionsPanel serverOptions) {
-        setRegistryHost(serverOptions.getHost());
-        setRegistryPort(serverOptions.getPort());
-        setRegistryUser(serverOptions.getUser());
-        setRegistryPwd(serverOptions.getPwd());
-        setRegistryTrustStorePath(serverOptions.getTrustStorePath());
-    }
-
-    /**
-     * Apply the local UI options to the provided object.
-     * 
-     * @param serverOptions The options to change.
-     */
-    public void configureRegistrationServiceOptions(final ServerOptionsPanel serverOptions) {
-        serverOptions.setHost(getRegistryHost());
-        serverOptions.setPort(getRegistryPort());
-        serverOptions.setUser(getRegistryUser());
-        serverOptions.setPwd(getRegistryPwd());
-        serverOptions.setTrustStorePath(getRegistryTrustStorePath());
-    }
-
-    public String getRegistryTrustStorePath() {
-        return getPropertyAsString(REGISTRY_TRUSTSTORE_PATH);
-    }
-
-    /**
-     * Sets the path to the trust store of the registry.
-     * 
-     * @param trustStorePath The path to the registry trust store.
-     */
-    public void setRegistryTrustStorePath(final String trustStorePath) {
-        setProperty(REGISTRY_TRUSTSTORE_PATH, trustStorePath);
-    }
-
-    public String getRegistryHost() {
-        return getPropertyAsString(REGISTRY_HOST);
-    }
-
-    /**
-     * Sets the host of the registry.
-     * 
-     * @param host The hostname of the registry.
-     */
-    public void setRegistryHost(final String host) {
-        setProperty(REGISTRY_HOST, host);
-    }
-
-    public String getRegistryUser() {
-        return getPropertyAsString(REGISTRY_USER);
-    }
-
-    /**
-     * Get the user to use for the registry.
-     * 
-     * @param user The username to use.
-     */
-    public void setRegistryUser(final String user) {
-        setProperty(REGISTRY_USER, user);
-    }
-
-    public String getRegistryPwd() {
-        return getPropertyAsString(REGISTRY_PWD);
-    }
-
-    /**
-     * Get the password to use for the registry.
-     * 
-     * @param pwd The password to use.
-     */
-    public void setRegistryPwd(final String pwd) {
-        setProperty(REGISTRY_PWD, pwd);
-    }
-
-    /**
-     * Gets the port of the registry as integer.
-     * 
-     * @return The registry port as integer, {@code 0} if the value cannot be parsed as an integer.
-     */
-    public int getRegistryPortAsInt() {
-        return getIntValueOrDefault(getRegistryPort(), 0);
-    }
-
-    public String getRegistryPort() {
-        return getPropertyAsString(REGISTRY_PORT);
-    }
-
-    /**
-     * Sets the port of the registry.
-     * 
-     * @param port The port of the registry.
-     */
-    public void setRegistryPort(final String port) {
-        setProperty(REGISTRY_PORT, port);
-    }
 
     /**
      * Gets the number of receivers as integer.
@@ -338,19 +230,6 @@ public class HonoSenderSampler extends HonoSampler implements ThreadListener {
      */
     public void setData(final String data) {
         setProperty(DATA, data);
-    }
-
-    public String getRegistrationAssertion() {
-        return getPropertyAsString(PROPERTY_REGISTRATION_ASSERTION);
-    }
-
-    /**
-     * Sets the registration assertion to use.
-     * 
-     * @param assertion The registration assertion.
-     */
-    public void setRegistrationAssertion(final String assertion) {
-        setProperty(PROPERTY_REGISTRATION_ASSERTION, assertion);
     }
 
     @Override

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSenderSamplerUI.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/ui/HonoSenderSamplerUI.java
@@ -36,11 +36,9 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
     private final JCheckBox          waitForDeliveryResult;
     private final JLabeledTextField  contentType;
     private final JLabeledTextArea   data;
-    private final JLabeledTextField  assertion;
     private final JLabeledTextField  waitForReceivers;
     private final JLabeledTextField  waitForReceiversTimeout;
     private final JLabeledTextField  sampleSendTimeout;
-    private final ServerOptionsPanel registrationServiceOptions;
     private final JLabeledTextField  tenant;
     private final JLabeledTextField  container;
     private final JLabeledChoice     endpoint;
@@ -63,8 +61,6 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
         endpoint.setToolTipText("<html>The name of the endpoint to send the AMQP message to.</html>");
         deviceId = new JLabeledTextField("Device ID");
         deviceId.setToolTipText("<html>The device identifier to put into the <em>device_id</em> application property of the AMQP message to send.</html>");
-        registrationServiceOptions = new ServerOptionsPanel("Device Registration Service");
-        assertion = new JLabeledTextField("Registration Assertion");
         contentType = new JLabeledTextField("Content type");
         data = new JLabeledTextArea("Message data");
         waitForDeliveryResult = new JCheckBox("Wait for delivery result");
@@ -91,8 +87,6 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
         addOption(deviceId);
         addOption(contentType);
         addOption(data);
-        addOption(assertion);
-        addOption(registrationServiceOptions);
         addOption(waitForDeliveryResult);
         addOption(setSenderTime);
         addOption(waitForReceivers);
@@ -131,9 +125,6 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
         sampler.setMessageCountPerSamplerRun(msgCountPerSamplerRun.getText());
         sampler.setContentType(contentType.getText());
         sampler.setData(data.getText());
-        sampler.setRegistrationAssertion(assertion.getText());
-        // device registration service
-        sampler.modifyRegistrationServiceOptions(registrationServiceOptions);
     }
 
     @Override
@@ -153,9 +144,6 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
         waitForDeliveryResult.setSelected(sampler.isWaitForDeliveryResult());
         contentType.setText(sampler.getContentType());
         data.setText(sampler.getData());
-        assertion.setText(sampler.getRegistrationAssertion());
-        // device registration service
-        sampler.configureRegistrationServiceOptions(registrationServiceOptions);
     }
 
     @Override
@@ -169,13 +157,10 @@ public class HonoSenderSamplerUI extends HonoSamplerUI {
         setSenderTime.setSelected(true);
         contentType.setText("text/plain");
         data.setText("");
-        assertion.setText("");
         waitForDeliveryResult.setSelected(true);
         waitForReceivers.setText("0");
         waitForReceiversTimeout.setText("5000");
         sampleSendTimeout.setText(Integer.toString(HonoSenderSampler.DEFAULT_SEND_TIMEOUT));
         msgCountPerSamplerRun.setText("1");
-        // device registration service
-        registrationServiceOptions.clearGui();
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
@@ -83,8 +83,7 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                     return sender.send(
                             authenticatedDevice.getDeviceId(),
                             payload.encode().getBytes(StandardCharsets.UTF_8),
-                            EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE,
-                            ""
+                            EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE
                             );
                 });
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.hono.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -225,29 +224,6 @@ public class AbstractProtocolAdapterBaseTest {
     }
 
     /**
-     * Verifies that the registration assertion is set on a downstream message.
-     */
-    @Test
-    public void testAddPropertiesAddsRegistrationAssertion() {
-
-        final Message message = ProtonHelper.message();
-        adapter.addProperties(message, newRegistrationAssertionResult("token"));
-        assertThat(MessageHelper.getRegistrationAssertion(message), is("token"));
-    }
-
-    /**
-     * Verifies that the registration assertion is not set on a downstream message
-     * if the downstream peer does not require it.
-     */
-    @Test
-    public void testAddPropertiesOmitsRegistrationAssertion() {
-
-        final Message message = ProtonHelper.message();
-        adapter.addProperties(message, newRegistrationAssertionResult("token"), false);
-        assertNull(MessageHelper.getRegistrationAssertion(message));
-    }
-
-    /**
      * Verifies that the adapter's name is set on a downstream message.
      */
     @Test
@@ -271,7 +247,6 @@ public class AbstractProtocolAdapterBaseTest {
 
         final Message message = ProtonHelper.message();
         adapter.addProperties(message, newRegistrationAssertionResult("token", "application/hono"));
-        assertThat(MessageHelper.getRegistrationAssertion(message), is("token"));
         assertThat(message.getContentType(), is("application/hono"));
     }
 
@@ -285,7 +260,6 @@ public class AbstractProtocolAdapterBaseTest {
         final Message message = ProtonHelper.message();
         message.setContentType("application/existing");
         adapter.addProperties(message, newRegistrationAssertionResult("token", "application/hono"));
-        assertThat(MessageHelper.getRegistrationAssertion(message), is("token"));
         assertThat(message.getContentType(), is("application/existing"));
     }
 
@@ -298,7 +272,6 @@ public class AbstractProtocolAdapterBaseTest {
 
         final Message message = ProtonHelper.message();
         adapter.addProperties(message, newRegistrationAssertionResult("token"));
-        assertThat(MessageHelper.getRegistrationAssertion(message), is("token"));
         assertThat(message.getContentType(), is(AbstractProtocolAdapterBase.CONTENT_TYPE_OCTET_STREAM));
     }
 

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -17,6 +17,17 @@ title = "Release Notes"
   and Device Registration APIs now create an OpenTracing Span for tracking the
   processing of requests at a high level.
 
+### API Changes
+
+* The `org.eclipse.hono.client.MessageSender` interface's *send* methods have been changed
+  to no longer accept a *registration assertion token* which became obsolete with the removal
+  of the *Hono Messaging* component. The *isRegistrationAssertionRequired* method has also been
+  removed from the interface.
+* Consequently, the `org.eclipse.hono.service.AbstractProtocolAdapterBase` class's
+  *newMessage* and *addProperties* methods no longer require a boolean parameter indicating
+  whether to include the assertion token in the message being created/amended.
+  Custom protocol adapters should simply omit the corresponding parameter.
+
 ## 1.0-M1
 
 ### New Features


### PR DESCRIPTION
MessageSender's send methods no longer accept a registration assertion
token which became obsolete with the removal of the Hono Messaging
component.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>