### PR TITLE
[#930] Set 'last-via' also for devices with a single 'via' property

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
@@ -86,7 +86,7 @@ public interface RegistrationService extends Verticle {
      * Such a check might be based on a specific role that the client needs to have or on an
      * explicitly defined relation between the gateway and the device(s).
      * <br>
-     * In the case of a device configured with multiple <em>via</em> gateways, implementing classes should
+     * In the case of a device configured with one or more <em>via</em> gateways, implementing classes should
      * update the device's registration information with the given gateway in the form of a <em>last-via</em>
      * property.
      *
@@ -120,7 +120,7 @@ public interface RegistrationService extends Verticle {
      * Such a check might be based on a specific role that the client needs to have or on an
      * explicitly defined relation between the gateway and the device(s).
      * <br>
-     * In the case of a device configured with multiple <em>via</em> gateways, implementing classes should
+     * In the case of a device configured with one or more <em>via</em> gateways, implementing classes should
      * update the device's registration information with the given gateway in the form of a <em>last-via</em>
      * property.
      * <p>

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
@@ -92,33 +92,6 @@ public class BaseRegistrationServiceTest {
     }
 
     /**
-     * Verifies that an enabled device's status can be asserted successfully.
-     * 
-     * @param ctx The vertx unit test context.
-     */
-    @Test
-    public void testAssertDeviceRegistrationReturnsToken(final TestContext ctx) {
-
-        // GIVEN a registry that contains an enabled device with a default content type set
-        final BaseRegistrationService<ServiceConfigProperties> registrationService = newRegistrationService();
-        registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
-
-        // WHEN trying to assert the device's registration status
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4711", ctx.asyncAssertSuccess(result -> {
-            ctx.assertEquals(result.getStatus(), HttpURLConnection.HTTP_OK);
-            final JsonObject payload = result.getPayload();
-            ctx.assertNotNull(payload);
-            // THEN the response contains a JWT token asserting the device's registration status
-            final String compactJws = payload.getString(RegistrationConstants.FIELD_ASSERTION);
-            ctx.assertNotNull(compactJws);
-            // and contains the registered default content type
-            final JsonObject defaults = payload.getJsonObject(RegistrationConstants.FIELD_DEFAULTS);
-            ctx.assertNotNull(defaults);
-            ctx.assertEquals("application/default", defaults.getString(MessageHelper.SYS_PROPERTY_CONTENT_TYPE));
-        }));
-    }
-
-    /**
      * Verifies that a disabled device's status cannot be asserted.
      * 
      * @param ctx The vertx unit test context.
@@ -155,30 +128,6 @@ public class BaseRegistrationServiceTest {
             // THEN the response does not contain a JWT token
             ctx.assertEquals(result.getStatus(), HttpURLConnection.HTTP_NOT_FOUND);
             ctx.assertNull(result.getPayload());
-        }));
-    }
-
-    /**
-     * Verifies that a device's status can be asserted by an existing gateway.
-     * 
-     * @param ctx The vertx unit test context.
-     */
-    @Test
-    public void testAssertDeviceRegistrationSucceedsForExistingGateway(final TestContext ctx) {
-
-        // GIVEN a registry that contains an enabled device that is configured to
-        // be connected to an enabled gateway
-        final BaseRegistrationService<ServiceConfigProperties> registrationService = newRegistrationService();
-        registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
-
-        // WHEN trying to assert the device's registration status for gateway 1
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4711", "gw-1", ctx.asyncAssertSuccess(result -> {
-            // THEN the response contains a 200 status
-            ctx.assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
-            final JsonObject payload = result.getPayload();
-            ctx.assertNotNull(payload);
-            // and contains a JWT token
-            ctx.assertNotNull(payload.getString(RegistrationConstants.FIELD_ASSERTION));
         }));
     }
 

--- a/site/content/admin-guide/device-registry-config.md
+++ b/site/content/admin-guide/device-registry-config.md
@@ -166,8 +166,9 @@ In these cases the protocol adapter will authenticate the gateway component inst
 
 The Device Registry will then do the following:
 1. Verify that the device exists and is enabled.
-1. Verify that the gateway exists and is enabled.
-2. Verify that the device's registration information contains a property called `via` and that its value is either the gateway's device identifier or a JSON array which contains the gateway's device identifier as one of its values. In the latter case of a device configured for multiple gateways, the device's registration information is updated with a `last-via` property containing the gateway identifier used in this request.
+2. Verify that the gateway exists and is enabled.
+3. Verify that the device's registration information contains a property called `via` and that its value is either the gateway's device identifier or a JSON array which contains the gateway's device identifier as one of its values. 
+4. Update the device's registration information with a `last-via` property containing the gateway identifier used in this request.
 
 Only if all conditions are met, the Device Registry returns an assertion of the device's registration status. The protocol adapter can then forward the published data to the AMQP Messaging Network in the same way as for any device that connects directly to the adapter.
 


### PR DESCRIPTION
Set 'last-via' also for devices with a single 'via' property.

This is needed to distinguish between the cases where a device connects via the gateway and where it connects directly.