### PR TITLE
[#927] Limit the number of simultaneously connected devices per tenant in Amqp adapter.

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -161,7 +161,8 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                                     .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
                                     .withTag(Tags.COMPONENT.getKey(), getTypeName())
                                     .start(),
-                                connectionLimitManager);
+                                connectionLimitManager,
+                                getResourceLimitChecks());
                     }
                     return Future.succeededFuture();
                 }).compose(succcess -> {


### PR DESCRIPTION
With this PR, in the AMQP adapter before accepting connection from any device it is being checked that if the maximum number of existing connections exceeded the configured limit or not.