### PR TITLE
[#927] Add an IT test for connection limit

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
@@ -256,4 +256,29 @@ public class AmqpConnectionIT extends AmqpAdapterTestBase {
         }));
     }
 
+    /**
+     * Verifies that the adapter opens a connection to registered devices even though the Prometheus backend is not
+     * reachable.
+     *
+     * @param context The Vert.x test context.
+     */
+    @Test
+    public void testConnectSucceedsPrometheusNotReachable(final TestContext context) {
+
+        final String tenantId = helper.getRandomTenantId();
+        final String password = "secret";
+        final TenantObject tenant = TenantObject.from(tenantId, true);
+        final JsonObject limitsConfig = new JsonObject()
+                .put(TenantConstants.MAX_CONNECTIONS, 1);
+        tenant.setProperty(TenantConstants.LIMITS, limitsConfig);
+
+        final String device1Id = helper.getRandomDeviceId(tenantId);
+        final String device2Id = helper.getRandomDeviceId(tenantId);
+        helper.registry.addTenant(JsonObject.mapFrom(tenant))
+                .compose(ok -> helper.registry.addDeviceToTenant(tenantId, device1Id, password))
+                .compose(ok -> helper.registry.addDeviceToTenant(tenantId, device2Id, password))
+                .compose(ok -> connectToAdapter(IntegrationTestSupport.getUsername(device1Id, tenantId), password))
+                .compose(ok -> connectToAdapter(IntegrationTestSupport.getUsername(device2Id, tenantId), password))
+                .setHandler(context.asyncAssertSuccess());
+    }
 }

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -56,6 +56,10 @@ hono:
     flowLatency: ${flow.latency}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+  plan:
+    prometheusBased:
+      host: prometheus-operated
+      port: 9090
 
 spring:
   jmx:

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -57,6 +57,10 @@ hono:
     flowLatency: ${flow.latency}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+  plan:
+    prometheusBased:
+      host: prometheus-operated
+      port: 9090
 
 spring:
   jmx:


### PR DESCRIPTION
When Prometheus backend is not reachable, check that the connections to Mqtt and Amqp adapters are accepted irrespective of the limits configured.
