### PR TITLE
Device Registry HTTP API

### DIFF
--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -18,6 +18,10 @@ title = "Release Notes"
   type *hashed-password* and *x509-cert* for a configurable amount of time. Please refer to the
   [Device Registry Admin Guide]({{< ref "/admin-guide/device-registry-config.md" >}}) for details
   regarding the configuration properties to use.
+* There is now an official HTTP API for managing devices served by the
+  device registry. The API is defined using an OpenAPI v3 specification and is
+  part of the Git repository, and served at
+  https://eclipse.org/hono/api/device-registry-v1.yaml.
 
 ### API Changes
 

--- a/site/static/api/device-registry-v1.yaml
+++ b/site/static/api/device-registry-v1.yaml
@@ -1,0 +1,745 @@
+openapi: 3.0.1
+info:
+   title: Eclipse Hono™ Device Registry API
+   description: |
+      This API defines how to manage *Tenants*, *Devices*, and *Credentials*.
+      It acts as a common basis which all Hono device registries should
+      implement.
+
+      ## Required APIs
+
+      All operations, except the `tenants` resource are required. The tenant
+      management might be outside of the scope of the device registry and
+      managed by a higher level system. In this case all calls should simply
+      return `404`. However, if the `tenants` resource is implemented, then all
+      operations of it must be implemented.
+
+      ## Security
+
+      This specification explicitly leaves out the part of authenticating and
+      authorizing users with the device registry. It is assumed that some form
+      of token exchange between the user agent and the backend service will
+      take place. Like for example HTTP basic authentication, or a bearer token.
+
+      ## Code generation
+
+      This model is not optimized for generating code from it. Code generators
+      try to understand the model and then translate this into the require
+      programming language. Even if the there would be no bugs in the code
+      generators, that process would be already only be an approximation. So
+      this model does focus in the description of the API, and doesn't tweak
+      the specification in a way to please code generators.
+
+   contact:
+      name: Contact details
+      url: https://www.eclipse.org/hono/community/get-in-touch/
+   license:
+      name: EPL-2.0
+      url: https://www.eclipse.org/legal/epl-2.0/
+   version: 1.0.0
+
+externalDocs:
+   description: Eclipse Hono™ web page
+   url: https://eclipse.org/hono
+
+tags:
+   - name: tenants
+     description: Tenant Management (optional)
+     externalDocs:
+        description: Hono Multi-Tenancy
+        url: https://www.eclipse.org/hono/concepts/tenancy/
+   - name: devices
+     description: Device registration
+     externalDocs:
+        description: Hono device identity
+        url: https://www.eclipse.org/hono/concepts/device-identity/
+   - name: credentials
+     description: Device credentials
+     externalDocs:
+        description: Hono device identity
+        url: https://www.eclipse.org/hono/concepts/device-identity/
+
+servers:
+   - url: '{corsProxy}{server}/v1'
+     variables:
+        server:
+           default: http://hono.eclipse.org:28080
+        corsProxy:
+           default: https://cors-anywhere.herokuapp.com/
+
+security:
+   - BearerAuth: []
+   - BasicAuth: []
+
+paths:
+
+# Tenant API
+
+   /tenants:
+
+      post:
+         tags:
+            - tenants
+         summary: Create new tenant with auto-generated ID
+         operationId: createTenant
+         requestBody:
+            description: New tenant information
+            content:
+               application/json:
+                  schema:
+                     $ref: '#/components/schemas/Tenant'
+            required: true
+         responses:
+            201:
+               $ref: '#/components/responses/Created'
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+
+   /tenants/{tenantId}:
+
+      parameters:
+         - $ref: '#/components/parameters/tenantId'
+
+      post:
+         tags:
+            - tenants
+         summary: Create new tenant
+         operationId: createTenantWithId
+         requestBody:
+            description: New tenant registration
+            content:
+               application/json:
+                  schema:
+                     $ref: '#/components/schemas/Tenant'
+            required: true
+         responses:
+            201:
+               $ref: '#/components/responses/Created'
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+            409:
+               $ref: '#/components/responses/AlreadyExists'
+
+      get:
+         tags:
+            - tenants
+         summary: Get tenant information
+         operationId: getTenant
+         responses:
+            200:
+               description: operation successful
+               content:
+                  application/json:
+                     schema:
+                        $ref: '#/components/schemas/Tenant'
+               headers:
+                  ETag:
+                     description: Version of the resource
+                     schema:
+                        type: string
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            404:
+               $ref: '#/components/responses/NotFound'
+
+      put:
+         tags:
+            - tenants
+         summary: Update tenant information
+         operationId: updateTenant
+         parameters:
+            - $ref: '#/components/parameters/resourceVersion'
+         requestBody:
+            description: Tenant information
+            content:
+               application/json:
+                  schema:
+                     $ref: '#/components/schemas/Tenant'
+            required: true
+         responses:
+            204:
+               $ref: '#/components/responses/Updated'
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+            404:
+               $ref: '#/components/responses/NotFound'
+            412:
+               $ref: '#/components/responses/ResourceVersionMismatch'
+
+      delete:
+         tags:
+            - tenants
+         summary: Delete tenant
+         operationId: deleteTenant
+         parameters:
+            - $ref: '#/components/parameters/resourceVersion'
+         responses:
+            204:
+               description: object deleted
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+            404:
+               $ref: '#/components/responses/NotFound'
+            412:
+               $ref: '#/components/responses/ResourceVersionMismatch'
+
+# Device API
+
+   /devices/{tenantId}:
+
+      parameters:
+         - $ref: '#/components/parameters/tenantId'
+
+      post:
+         tags:
+            - devices
+         summary: Create new device registration with auto-generated ID
+         operationId: createDeviceRegistration
+         requestBody:
+            description: New device
+            content:
+               application/json:
+                  schema:
+                     $ref: '#/components/schemas/Device'
+            required: true
+         responses:
+            201:
+               $ref: '#/components/responses/Created'
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+
+   /devices/{tenantId}/{deviceId}:
+
+      parameters:
+         - $ref: '#/components/parameters/tenantId'
+         - $ref: '#/components/parameters/deviceId'
+
+      post:
+         tags:
+            - devices
+         summary: Create new device registration
+         operationId: createDeviceRegistrationWithId
+         requestBody:
+            description: New device
+            content:
+               application/json:
+                  schema:
+                     $ref: '#/components/schemas/Device'
+            required: true
+         responses:
+            201:
+               $ref: '#/components/responses/Created'
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+            409:
+               $ref: '#/components/responses/AlreadyExists'
+
+      get:
+         tags:
+            - devices
+         summary: Get device registration information
+         operationId: getRegistration
+         responses:
+            200:
+               description: operation successful
+               content:
+                  application/json:
+                     schema:
+                        $ref: '#/components/schemas/Device'
+               headers:
+                  ETag:
+                     description: Version of the resource
+                     schema:
+                        type: string
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            404:
+               $ref: '#/components/responses/NotFound'
+
+      put:
+         tags:
+            - devices
+         summary: Update existing device registration
+         operationId: updateRegistration
+         parameters:
+            - $ref: '#/components/parameters/resourceVersion'
+         requestBody:
+            description: Updated device registration
+            content:
+               application/json:
+                  schema:
+                     $ref: '#/components/schemas/Device'
+            required: true
+         responses:
+            204:
+               $ref: '#/components/responses/Updated'
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+            404:
+               $ref: '#/components/responses/NotFound'
+            412:
+               $ref: '#/components/responses/ResourceVersionMismatch'
+
+      delete:
+         tags:
+            - devices
+         summary: Delete device registration
+         operationId: deleteRegistration
+         parameters:
+            - $ref: '#/components/parameters/resourceVersion'
+         responses:
+            204:
+               $ref: '#/components/responses/Delete'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+            404:
+               $ref: '#/components/responses/NotFound'
+            412:
+               $ref: '#/components/responses/ResourceVersionMismatch'
+
+   /credentials/{tenantId}/{deviceId}:
+
+      parameters:
+         - $ref: '#/components/parameters/tenantId'
+         - $ref: '#/components/parameters/deviceId'
+
+      get:
+         tags:
+            - credentials
+         summary: Get credentials set of a device.
+         description: |
+            Get the credentials set of a device. As long as the device is
+            registered and the user has read access to it, this call should
+            never return "not found".
+         operationId: getAllCredentials
+         responses:
+            200:
+               description: Operation successful
+               content:
+                  application/json:
+                     schema:
+                        $ref: '#/components/schemas/CredentialsSet'
+               headers:
+                  ETag:
+                     description: Version of the resource
+                     schema:
+                        type: string
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            404:
+               $ref: '#/components/responses/NotFound'
+
+      put:
+         tags:
+            - credentials
+         summary: Update credentials set for registered device
+         operationId: setAllCredentials
+         parameters:
+            - $ref: '#/components/parameters/resourceVersion'
+         requestBody:
+            content:
+               application/json:
+                  schema:
+                     $ref: '#/components/schemas/CredentialsSet'
+            required: true
+         responses:
+            204:
+               $ref: '#/components/responses/Updated'
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+            404:
+               $ref: '#/components/responses/NotFound'
+            412:
+               $ref: '#/components/responses/ResourceVersionMismatch'
+
+      delete:
+         tags:
+            - credentials
+         summary: Delete all credentials of a device
+         description: |
+             Deletes all credentials from a device registration. The device is
+             still registered, and a following call to *get* credentials must
+             not return `404`, as the device is still registered. Instead an
+             empty result must be returned.
+         operationId: deleteAllCredentials
+         parameters:
+            - $ref: '#/components/parameters/resourceVersion'
+         responses:
+            204:
+               $ref: '#/components/responses/Delete'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+            403:
+               $ref: '#/components/responses/NotAllowed'
+            404:
+               $ref: '#/components/responses/NotFound'
+            412:
+               $ref: '#/components/responses/ResourceVersionMismatch'
+
+components:
+
+   schemas:
+
+# Common schema
+
+      Error:
+         type: object
+         additionalProperties: true
+         required:
+            - error
+         properties:
+            "error":
+               type: string
+               description: A human readable error message of what went wrong.
+
+      Extensions:
+         type: object
+         additionalProperties: true
+         description: Allows arbitrary properties as extension to the ones
+                      specified by the Hono API.
+
+# Tenant schema
+
+      Tenant:
+         type: object
+         additionalProperties: false
+         properties:
+            "enabled":
+               type: boolean
+               default: true
+            "ext":
+               $ref: '#/components/schemas/Extensions'
+            "adapters":
+               type: array
+               description: Only a single entry per type is allowed. If multiple entries for the same type are present it is handled as an error.
+               items:
+                  $ref: '#/components/schemas/Adapter'
+            "limits":
+               $ref: '#/components/schemas/ResourceLimit'
+            "trusted-ca":
+               $ref: '#/components/schemas/TrustedCA'
+
+      TrustedCA:
+         type: object
+         additionalProperties: false
+         required:
+            - "subject-dn"
+         properties:
+            "subject-dn":
+               type: string
+               description: The subject DN of the trusted root certificate in
+                            the format defined by RFC 2253.
+            "public-key":
+               type: string
+               format: byte
+               description: The Base64 encoded binary DER encoding of the
+                            trusted root certificate’s public key.
+                            Either this property or `cert` must be set.
+            "cert":
+               type: string
+               format: byte
+               description: The Base64 encoded binary DER encoding of the
+                            trusted root certificate. Either this property
+                            or `public-key` must be set.
+
+      Adapter:
+         type: object
+         additionalProperties: true
+         required:
+            - type
+         properties:
+            "type":
+               type: string
+            "enabled":
+               type: boolean
+               default: false
+            "device-authentication-required":
+               type: boolean
+               default: true
+            "ext":
+               $ref: '#/components/schemas/Extensions'
+
+      ResourceLimit:
+         type: object
+         additionalProperties: false
+         properties:
+            "max-connections":
+               type: integer
+               default: -1
+               description: The maximum number of concurrent connections allowed
+                            from devices of this tenant. The default value -1
+                            indicates that no limit is set.
+            "ext":
+               $ref: '#/components/schemas/Extensions'
+
+# Devices schema
+
+      Device:
+         type: object
+         additionalProperties: false
+         properties:
+            "enabled":
+               type: boolean
+               default: true
+            "ext":
+               $ref: '#/components/schemas/Extensions'
+
+# Credentials
+
+      CredentialsSet:
+         type: array
+         items:
+            $ref: '#/components/schemas/TypedSecret'
+
+      TypedSecret:
+         additionalProperties: false
+         oneOf:
+            - $ref: '#/components/schemas/PasswordSecret'
+            - $ref: '#/components/schemas/PSKSecret'
+            - $ref: '#/components/schemas/X509CertificateSecret'
+         discriminator:
+            propertyName: type
+            mapping:
+               "hashed-password": '#/components/schemas/PasswordSecret'
+               "psk": '#/components/schemas/PSKSecret'
+               "x509-cert": '#/components/schemas/X509CertificateSecret'
+
+      CommonSecret:
+         type: object
+         additionalProperties: false
+         required:
+            - auth-id
+            - type
+         properties:
+            "type":
+               type: string
+            "auth-id":
+               type: string
+            "enabled":
+               type: boolean
+               default: true
+            "not-before":
+               type: string
+               format: date-time
+            "not-after":
+               type: string
+               format: date-time
+            "comment":
+               type: string
+
+      X509CertificateSecret:
+         additionalProperties: false
+         allOf:
+            - $ref: '#/components/schemas/CommonSecret'
+
+      PasswordSecret:
+         additionalProperties: false
+         allOf:
+            - $ref: '#/components/schemas/CommonSecret'
+            - type: object
+              additionalProperties: false
+              properties:
+                 "hash-function":
+                    type: string
+                    example: sha-512
+                 "pwd-hash":
+                    type: string
+                    format: byte
+                 "salt":
+                    type: string
+                    format: byte
+
+      PSKSecret:
+         additionalProperties: false
+         allOf:
+            - $ref: '#/components/schemas/CommonSecret'
+            - type: object
+              additionalProperties: false
+              required:
+                 - key
+              properties:
+                 "key":
+                    type: string
+                    format: byte
+
+   parameters:
+
+      resourceVersion:
+         name: If-Match
+         in: header
+         description: The expected resource version
+         required: false
+         schema:
+            type: string
+
+      tenantId:
+         name: tenantId
+         in: path
+         description: The ID of the tenant
+         required: true
+         schema:
+            type: string
+         example: DEFAULT_TENANT
+
+      deviceId:
+         name: deviceId
+         in: path
+         description: The ID of the device
+         required: true
+         schema:
+            type: string
+         example: 4711
+
+      authId:
+         name: authId
+         in: path
+         description: The authentication ID of the device
+         required: true
+         schema:
+            type: string
+         example: sensor1
+
+      type:
+         name: type
+         in: path
+         description: The credentials type
+         required: true
+         schema:
+            type: string
+         example: sha-256
+
+   responses:
+
+      Unauthorized:
+         description: Authentication credentials are required, but missing.
+         headers:
+            "WWW-Authenticate":
+               schema:
+                  type: string
+
+      Created:
+         description: Object created.
+         headers:
+            Location:
+               description: URL to the resource
+               schema:
+                  type: string
+                  format: uri
+            ETag:
+               description: The new version of the resource
+               schema:
+                  type: string
+         content:
+            application/json:
+               schema:
+                  type: object
+                  additionalProperties: false
+                  required:
+                     - id
+                  properties:
+                     id:
+                        type: string
+                        description: The ID of the created object
+
+      Updated:
+         description: Object updated.
+         headers:
+            ETag:
+               description: The new version of the resource
+               schema:
+                  type: string
+
+      Deleted:
+         description: Object deleted.
+
+      NotFound:
+         description: |
+            Object not found. This may also be returned for some operations
+            if the user misses read access for the object.
+         content:
+            application/json:
+               schema:
+                  $ref: '#/components/schemas/Error'
+
+      NotAllowed:
+         description: |
+            Operation not allowed. If the user does not have read access
+            for this object, then `404` will be returned instead.
+         content:
+            application/json:
+               schema:
+                  $ref: '#/components/schemas/Error'
+
+      MalformedRequest:
+         description: Malformed request
+         content:
+            application/json:
+               schema:
+                  $ref: '#/components/schemas/Error'
+
+      AlreadyExists:
+         description: |
+            Object already exists. If the user has no read access for
+            the existing object, then `403` should be returned instead.
+         content:
+            application/json:
+               schema:
+                  $ref: '#/components/schemas/Error'
+
+      ResourceVersionMismatch:
+         description: |
+            Expected resource version does not match current.
+            This can only happen when the request header `If-Match`
+            was set.
+         content:
+            application/json:
+               schema:
+                  $ref: '#/components/schemas/Error'
+
+   securitySchemes:
+
+      BearerAuth:
+         type: http
+         scheme: bearer
+
+      BasicAuth:
+         type: http
+         scheme: basic


### PR DESCRIPTION
Documented:
 * [X] Registration API
 * [x] Credentials API
 * [x] Tenant API
 * [x] Authentication

This PR contains an OpenAPI 3 model, which can be rendered and tested using the following command:

~~~
# cd hono/site/static/api
docker run -ti --rm -p 8080:8080 -e SWAGGER_JSON=/foo/device-registry.yaml  -v "$(pwd):/foo:z" swaggerapi/swagger-ui
~~~

Or directly from GitHub (without the option to make local changes):

~~~
docker run -ti --rm -p 8080:8080 -e URL=https://raw.githubusercontent.com/ctron/hono/feature/devreg_api_1/site/static/api/device-registry.yaml swaggerapi/swagger-ui
~~~

You can also directly use the hosted version here:

* Current API – https://current-api-hono-device-registry-api.wonderful.iot-playground.org
* Revised API – https://revised-api-hono-device-registry-api.wonderful.iot-playground.org

You can actually use the "Try it out" feature, as currently the API describes the "as is" situation. However I would like to change this for the final version. You can already see in the definition why, but let's wait with the discussion until all the current APIs are mapped.