### PR TITLE
[#929 Part-1]  Add data volume limits to the tenant config

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -75,19 +75,9 @@ public final class TenantConstants extends RequestResponseApiConstants {
     public static final String EVENT_BUS_ADDRESS_TENANT_IN = "tenant.in";
 
     /**
-     * The name of the property that contains the configuration options for limits.
+     * The name of the property that contains the configuration options for the resource limits.
      */
-    public static final String LIMITS = "limits";
-
-    /**
-     * The default value for the maximum number of connections to be allowed is -1, which implies no limit.
-     */
-    public static final long DEFAULT_MAX_CONNECTIONS = -1;
-
-    /**
-     * The name of the property that contains the maximum number of connections to be allowed for a tenant.
-     */
-    public static final String MAX_CONNECTIONS = "max-connections";
+    public static final String FIELD_RESOURCE_LIMITS = "resource-limits";
 
     /**
      * Request actions that belong to the Tenant API.

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -44,7 +44,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-
 /**
  * Encapsulates the tenant information that was found by the get operation of the
  * <a href="https://www.eclipse.org/hono/api/tenant-api/">Tenant API</a>.
@@ -498,16 +497,25 @@ public final class TenantObject extends JsonBackedValueObject {
     }
 
     /**
-     * Gets the connections limit for the tenant if configured, else returns
-     * {@link TenantConstants#DEFAULT_MAX_CONNECTIONS}.
+     * Gets the resource limits for the tenant.
      *
-     * @return The connections limit.
+     * @return The resource limits or {@code null} if not set.
      */
     @JsonIgnore
-    public long getConnectionsLimit() {
-        return Optional.ofNullable(getProperty(TenantConstants.LIMITS))
-                .map(limits -> getProperty((JsonObject) limits, TenantConstants.MAX_CONNECTIONS,
-                        (Number) TenantConstants.DEFAULT_MAX_CONNECTIONS).longValue())
-                .orElse(TenantConstants.DEFAULT_MAX_CONNECTIONS);
+    public JsonObject getResourceLimits() {
+        return getProperty(TenantConstants.FIELD_RESOURCE_LIMITS);
+    }
+
+    /**
+     * Sets the resource limits for the tenant.
+     *
+     * @param resourceLimits The resource limits configuration to add.
+     * @return The TenantObject.
+     * @throws NullPointerException if resource limits to be set is {@code null}.
+     */
+    @JsonIgnore
+    public TenantObject setResourceLimits(final JsonObject resourceLimits) {
+        Objects.requireNonNull(resourceLimits);
+        return setProperty(TenantConstants.FIELD_RESOURCE_LIMITS, resourceLimits);
     }
 }

--- a/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.util;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -288,24 +289,28 @@ public class TenantObjectTest {
     }
 
     /**
-     * Verifies that the default value for connections limit is set to {@link TenantConstants#DEFAULT_MAX_CONNECTIONS}.
+     * Verifies that the resource-limits are set based on the configuration.
      */
     @Test
-    public void testGetConnectionsLimitDefaultValue() {
-        final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, true);
-        assertThat(obj.getConnectionsLimit(), is(TenantConstants.DEFAULT_MAX_CONNECTIONS));
+    public void testGetResourceLimits() {
+        final JsonObject limitsConfig = new JsonObject()
+                .put("max-connections", 2)
+                .put("data-volume",
+                        new JsonObject().put("max-bytes", 20_000_000)
+                                .put("period-in-days", 90)
+                                .put("effective-since", "2019-04-26"));
+        final TenantObject tenantObject = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        tenantObject.setResourceLimits(limitsConfig);
+        assertThat(tenantObject.getResourceLimits(), is(limitsConfig));
     }
 
     /**
-     * Verifies if the connections limit is set based on the configuration.
+     * Verifies that {@code null} is returned when resource limits are not set.
      */
     @Test
-    public void testGetConnectionsLimit() {
-        final JsonObject limitsConfig = new JsonObject()
-                .put(TenantConstants.MAX_CONNECTIONS, 2);
-        final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, true);
-        obj.setProperty(TenantConstants.LIMITS, limitsConfig);
-        assertThat(obj.getConnectionsLimit(), is(2L));
+    public void testGetResourceLimitsWhenNotSet() {
+        final TenantObject tenantObject = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        assertThat(tenantObject.getResourceLimits(), is(nullValue()));
     }
 
     private X509Certificate getCaCertificate() {

--- a/service-base/src/test/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecksTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecksTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.service.plan;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies the behavior of {@link PrometheusBasedResourceLimitChecks}.
+ */
+public class PrometheusBasedResourceLimitChecksTest {
+
+    private PrometheusBasedResourceLimitChecks limitChecksImpl;
+
+    /**
+     * Sets up the fixture.
+     */
+    @Before
+    public void setup() {
+        limitChecksImpl = new PrometheusBasedResourceLimitChecks(mock(Vertx.class));
+    }
+
+    /**
+     * Verifies that the default value for connections limit is set to
+     * {@link PrometheusBasedResourceLimitChecks#DEFAULT_MAX_CONNECTIONS}.
+     */
+    @Test
+    public void testGetConnectionsLimitDefaultValue() {
+        final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        assertThat(limitChecksImpl.getConnectionsLimit(tenant),
+                is(PrometheusBasedResourceLimitChecks.DEFAULT_MAX_CONNECTIONS));
+    }
+
+    /**
+     * Verifies if the connections limit is set based on the configuration.
+     */
+    @Test
+    public void testGetConnectionsLimit() {
+        final JsonObject limitsConfig = new JsonObject()
+                .put(PrometheusBasedResourceLimitChecks.FIELD_MAX_CONNECTIONS, 2);
+        final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        tenant.setProperty(TenantConstants.FIELD_RESOURCE_LIMITS, limitsConfig);
+        assertThat(limitChecksImpl.getConnectionsLimit(tenant), is(2L));
+    }
+
+    /**
+     * Verifies that the default value for the parameter {@link PrometheusBasedResourceLimitChecks#FIELD_MAX_BYTES} is
+     * set to {@link PrometheusBasedResourceLimitChecks#DEFAULT_MAX_BYTES}.
+     */
+    @Test
+    public void testGetMaxBytesLimitDefaultValue() {
+        final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        assertThat(limitChecksImpl.getMaximumNumberOfBytes(tenant),
+                is(PrometheusBasedResourceLimitChecks.DEFAULT_MAX_BYTES));
+    }
+
+    /**
+     * Verifies if the value corresponding to the parameter {@link PrometheusBasedResourceLimitChecks#FIELD_MAX_BYTES}
+     * is set based on the configuration.
+     */
+    @Test
+    public void testGetMaxBytesLimit() {
+        final JsonObject dataVolumeConfig = new JsonObject()
+                .put(PrometheusBasedResourceLimitChecks.FIELD_MAX_BYTES, 20_000_000);
+        final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        tenant.setProperty(TenantConstants.FIELD_RESOURCE_LIMITS,
+                new JsonObject().put(PrometheusBasedResourceLimitChecks.FIELD_DATA_VOLUME, dataVolumeConfig));
+        assertThat(limitChecksImpl.getMaximumNumberOfBytes(tenant), is(20_000_000L));
+    }
+
+    /**
+     * Verifies that the default value for the parameter {@link PrometheusBasedResourceLimitChecks#FIELD_PERIOD_IN_DAYS}
+     * is set to {@link PrometheusBasedResourceLimitChecks#DEFAULT_PERIOD_IN_DAYS}.
+     */
+    @Test
+    public void testGetPeriodInDaysDefaultValue() {
+        final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        assertThat(limitChecksImpl.getPeriodInDays(tenant),
+                is(PrometheusBasedResourceLimitChecks.DEFAULT_PERIOD_IN_DAYS));
+    }
+
+    /**
+     * Verifies if the value corresponding to the parameter
+     * {@link PrometheusBasedResourceLimitChecks#FIELD_PERIOD_IN_DAYS} is set based on the configuration.
+     */
+    @Test
+    public void testGetPeriodInDays() {
+        final JsonObject dataVolumeConfig = new JsonObject()
+                .put(PrometheusBasedResourceLimitChecks.FIELD_PERIOD_IN_DAYS, 90);
+        final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        tenant.setProperty(TenantConstants.FIELD_RESOURCE_LIMITS,
+                new JsonObject().put(PrometheusBasedResourceLimitChecks.FIELD_DATA_VOLUME, dataVolumeConfig));
+        assertThat(limitChecksImpl.getPeriodInDays(tenant), is(90L));
+    }
+
+    /**
+     * Verifies if the value corresponding to the parameter
+     * {@link PrometheusBasedResourceLimitChecks#FIELD_EFFECTIVE_SINCE} is set based on the configuration.
+     */
+    @Test
+    public void testEffectiveSince() {
+        final JsonObject dataVolumeConfig = new JsonObject()
+                .put(PrometheusBasedResourceLimitChecks.FIELD_EFFECTIVE_SINCE, "2019-04-25");
+        final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        tenant.setProperty(TenantConstants.FIELD_RESOURCE_LIMITS,
+                new JsonObject().put(PrometheusBasedResourceLimitChecks.FIELD_DATA_VOLUME, dataVolumeConfig));
+        assertThat(limitChecksImpl.getEffectiveSince(tenant), is(LocalDate.parse("2019-04-25", ISO_LOCAL_DATE)));
+    }
+
+    /**
+     * Verifies that the default value for the parameter
+     * {@link PrometheusBasedResourceLimitChecks#FIELD_EFFECTIVE_SINCE} is {@code null} if not set.
+     */
+    @Test
+    public void testEffectiveSinceWhenNotSet() {
+        final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        assertThat(limitChecksImpl.getEffectiveSince(tenant), is(nullValue()));
+    }
+}


### PR DESCRIPTION
1. This is the first part of the PR for #929. This PR adds provision to set the volume limit (max-bytes-per-month) to the tenant configuration.
2. As [discussed](https://github.com/eclipse/hono/pull/1133#discussion_r273019726), the tenant configuration parameter `limits` has been renamed to `resource-limits`.
