### PR TITLE
[#1137] Use Java target level 1.8 for core and client modules.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -29,6 +29,10 @@
   <description>A library providing a Vert.x based client for accessing Hono's APIs.</description>
   <url>https://www.eclipse.org/hono</url>
 
+  <properties>
+    <java.level>1.8</java.level>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -86,6 +90,28 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.level}</source>
+          <target>${java.level}</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verify_java8_compatibility</id>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <!-- 
           Copy legal documents from "legal" module to "target/classes" folder
           so that we make sure to include legal docs in all modules.
@@ -106,6 +132,9 @@
             <Export-Package>
               {local-packages}
             </Export-Package>
+            <Require-Capability>
+              osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=${java.level}))"
+            </Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -28,6 +28,10 @@
   <description>Basic classes used by all other modules.</description>
   <inceptionYear>2016</inceptionYear>
   <url>https://www.eclipse.org/hono</url>
+
+  <properties>
+    <java.level>1.8</java.level>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -111,6 +115,28 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.level}</source>
+          <target>${java.level}</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verify_java8_compatibility</id>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <!-- 
           Copy legal documents from "legal" module to "target/classes" folder
           so that we make sure to include legal docs in all modules.
@@ -160,6 +186,9 @@
               opentracing-noop;inline=true,
               spring-security-crypto;inline=true
             </Embed-Dependency>
+            <Require-Capability>
+              osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=${java.level}))"
+            </Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/core/src/main/java/org/eclipse/hono/tracing/MessageAnnotationsExtractAdapter.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/MessageAnnotationsExtractAdapter.java
@@ -59,7 +59,7 @@ public class MessageAnnotationsExtractAdapter implements TextMap {
             return Collections.emptyIterator();
         }
         final Iterator<? extends Entry<?, ?>> entriesIterator = propertiesMap.entrySet().iterator();
-        return new Iterator<>() {
+        return new Iterator<Entry<String, String>>() {
 
             @Override
             public boolean hasNext() {

--- a/core/src/main/java/org/eclipse/hono/util/AuthenticationConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/AuthenticationConstants.java
@@ -162,7 +162,7 @@ public final class AuthenticationConstants {
         } else if (fields.get(2) == null || fields.get(2).length() == 0) {
             throw new CredentialException("PLAIN response must contain a password");
         } else {
-            return fields.toArray(String[]::new);
+            return fields.toArray(new String[fields.size()]);
         }
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/Hostnames.java
+++ b/core/src/main/java/org/eclipse/hono/util/Hostnames.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -24,13 +24,13 @@ public final class Hostnames {
     static {
 
         // works on Linux
-        var hostname = System.getenv("HOSTNAME");
+        String hostname = System.getenv("HOSTNAME");
 
         if (hostname == null) {
             // this can produce all kinds of unexpected results
             // but better than nothing
             try {
-                final var localhost = InetAddress.getLocalHost();
+                final InetAddress localhost = InetAddress.getLocalHost();
                 hostname = localhost.getHostAddress();
             } catch (final Exception e) {
             }

--- a/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -60,7 +60,7 @@ public final class ResourceIdentifier {
         if (assumeDefaultTenant) {
             pathSegments.add(1, Constants.DEFAULT_TENANT);
         }
-        setResourcePath(pathSegments.toArray(String[]::new));
+        setResourcePath(pathSegments.toArray(new String[pathSegments.size()]));
     }
 
     private ResourceIdentifier(final String endpoint, final String tenantId, final String resourceId) {
@@ -94,7 +94,7 @@ public final class ResourceIdentifier {
                 pathSegments.add(segment);
             }
         }
-        this.resourcePath = pathSegments.toArray(String[]::new);
+        this.resourcePath = pathSegments.toArray(new String[pathSegments.size()]);
         if (resourcePath.length > IDX_TENANT_ID && resourcePath[IDX_TENANT_ID].length() == 0) {
             resourcePath[IDX_TENANT_ID] = null;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,18 @@
           <artifactId>maven-bundle-plugin</artifactId>
           <version>3.5.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-maven-plugin</artifactId>
+          <version>1.17</version>
+          <configuration>
+            <signature>
+              <groupId>org.codehaus.mojo.signature</groupId>
+              <artifactId>java18</artifactId>
+              <version>1.0</version>
+            </signature>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -16,6 +16,8 @@ title = "Release Notes"
 * The base classes for implementing the AMQP and HTTP endpoints for the Credentials, Tenant
   and Device Registration APIs now create an OpenTracing Span for tracking the
   processing of requests at a high level.
+* The `hono-client` and `hono-core` artifacts use Java 8 level again so that they
+  can be used in applications using Java 8.
 
 ### API Changes
 


### PR DESCRIPTION
The target level of the core and client modules has been reduced to Java
8 level in order to still allow the Hono client to be used in existing
applications.

The Anmial Sniffer Maven plugin is used to check that only Java 8 API is
used by these modules.
