### PR TITLE
[#930] Add tenant-scoped command consumer

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/CommandConsumerFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandConsumerFactory.java
@@ -28,12 +28,13 @@ public interface CommandConsumerFactory extends ConnectionLifecycle {
     /**
      * Creates a new factory for an existing connection.
      *
-     * @param connection The connection to use.
+     * @param connection The connection to the AMQP network.
+     * @param gatewayMapper The component mapping a command device id to the corresponding gateway device id.
      * @return The factory.
-     * @throws NullPointerException if connection is {@code null}
+     * @throws NullPointerException if connection or gatewayMapper is {@code null}.
      */
-    static CommandConsumerFactory create(final HonoConnection connection) {
-        return new CommandConsumerFactoryImpl(connection);
+    static CommandConsumerFactory create(final HonoConnection connection, final GatewayMapper gatewayMapper) {
+        return new CommandConsumerFactoryImpl(connection, gatewayMapper);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/CommandContext.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandContext.java
@@ -97,6 +97,24 @@ public final class CommandContext extends MapBasedExecutionContext {
     }
 
     /**
+     * Gets the AMQP link over which the command has been received.
+     *
+     * @return The receiver.
+     */
+    public ProtonReceiver getReceiver() {
+        return receiver;
+    }
+
+    /**
+     * Gets the delivery corresponding to the command message.
+     *
+     * @return The delivery.
+     */
+    public ProtonDelivery getDelivery() {
+        return delivery;
+    }
+
+    /**
      * Gets the OpenTracing span to use for tracking the processing of the command.
      * 
      * @return The span.
@@ -249,7 +267,7 @@ public final class CommandContext extends MapBasedExecutionContext {
      */
     private void flow(final int credits) {
         if (credits < 1) {
-            throw new IllegalArgumentException("credits must be positve");
+            throw new IllegalArgumentException("credits must be positive");
         }
         currentSpan.log(String.format("flowing %d credits to sender", credits));
         receiver.flow(credits);

--- a/client/src/main/java/org/eclipse/hono/client/DelegatedCommandSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/DelegatedCommandSender.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client;
+
+import org.eclipse.hono.config.ClientConfigProperties;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.proton.ProtonDelivery;
+
+/**
+ * A sender to send command messages that are delegated to be processed by another command consumer.
+ * <p>
+ * This usually involves command messages first retrieved via a tenant-scoped consumer and then delegated back to the
+ * downstream peer so that they can be consumed by the device-specific consumer.
+ */
+public interface DelegatedCommandSender extends MessageSender {
+
+    /**
+     * Sends a command message to the downstream peer to be consumed by a device-specific consumer.
+     *
+     * @param command The command to send.
+     * @param context The currently active OpenTracing span or {@code null} if no
+     *         span is currently active. An implementation should use this as the
+     *         parent for any new span(s) it creates for tracing the execution of
+     *         this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will succeed if the message has been accepted (and settled)
+     *         by the consumer.
+     *         <p>
+     *         The future will be failed with a {@link ServiceInvocationException} if the
+     *         message could not be sent or if no delivery update
+     *         was received from the peer within the configured timeout period
+     *         (see {@link ClientConfigProperties#getSendMessageTimeout()}).
+     * @throws NullPointerException if command is {@code null}.
+     */
+    Future<ProtonDelivery> sendCommandMessage(Command command, SpanContext context);
+}

--- a/client/src/main/java/org/eclipse/hono/client/GatewayMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/GatewayMapper.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client;
+
+import io.vertx.core.Future;
+
+/**
+ * A component that maps a given device to the gateway through which data was last published for the given device.
+ *
+ */
+public interface GatewayMapper extends ConnectionLifecycle {
+
+    /**
+     * Determines the gateway device id for the given device id (if applicable).
+     * <p>
+     * The value of the returned Future can be either
+     * <ul>
+     * <li>the gateway device id</li>
+     * <li>{@code null} if the device is configured to be accessed via a gateway (i.e. one or more 'via' devices are
+     * set), but no 'last-via' device is set, meaning that no message has been sent yet for this device.</li>
+     * <li>the given device id if the device is not configured to be accessed via a gateway</li>
+     * </ul>
+     *
+     * @param tenantId The tenant identifier.
+     * @param deviceId The device identifier.
+     * @return A succeeded Future containing the mapped gateway device id or {@code null};
+     *         or a failed Future if there was an error determining the mapped gateway device.
+     */
+    Future<String> getMappedGatewayDevice(String tenantId, String deviceId);
+
+}

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
@@ -242,11 +242,12 @@ public abstract class AbstractSender extends AbstractHonoClient implements Messa
      *         message could not be sent or has not been accepted by the peer or if no delivery update
      *         was received from the peer within the configured timeout period
      *         (see {@link ClientConfigProperties#getSendMessageTimeout()}).
-     * @throws NullPointerException if the message is {@code null}.
+     * @throws NullPointerException if either of the parameters is {@code null}.
      */
     protected Future<ProtonDelivery> sendMessageAndWaitForOutcome(final Message message, final Span currentSpan) {
 
         Objects.requireNonNull(message);
+        Objects.requireNonNull(currentSpan);
 
         final Future<ProtonDelivery> result = Future.future();
         final String messageId = String.format("%s-%d", getClass().getSimpleName(), MESSAGE_COUNTER.getAndIncrement());

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
@@ -18,22 +18,42 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.client.Command;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponseSender;
+import org.eclipse.hono.client.ConnectionLifecycle;
+import org.eclipse.hono.client.DelegatedCommandSender;
+import org.eclipse.hono.client.GatewayMapper;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.ResourceConflictException;
-import org.eclipse.hono.client.impl.CommandConsumer;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.ResourceIdentifier;
 
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.proton.ProtonReceiver;
 
 /**
- * A factory for creating clients for the <em>AMQP 1.0 Messaging Network</em> to
- * receive commands and send responses.
+ * A factory for creating clients for the <em>AMQP 1.0 Messaging Network</em> to receive commands and send responses.
+ * <p>
+ * The <em>createCommandConsumer()</em> methods will create one tenant-scoped consumer (if not existing yet) and one
+ * device-specific consumer by which the command will be eventually sent to the device.
+ * <p>
+ * Command messages are first received on the tenant-scoped consumer address. If applicable, the device id of a received
+ * command is mapped to the id of the gateway through which the device has last sent messages. Then the command message
+ * is either handled by an already existing command handler for the (mapped) device id, or the message is sent back to
+ * the downstream peer to be handled by a device-specific consumer.
  */
 public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implements CommandConsumerFactory {
 
@@ -43,27 +63,49 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
      */
     public static final long MIN_LIVENESS_CHECK_INTERVAL_MILLIS = 2000;
 
-    private final CachingClientFactory<MessageConsumer> commandConsumerFactory;
+    private static final String RESOURCE_KEY_DELEGATED_COMMAND_SENDER = "DelegatedCommandSender";
 
+    private final CachingClientFactory<MessageConsumer> deviceSpecificCommandConsumerFactory;
+
+    private final CachingClientFactory<MessageConsumer> tenantScopedCommandConsumerFactory;
+
+    private final CachingClientFactory<DelegatedCommandSender> delegatedCommandSenderFactory;
+    /**
+     * The handlers for the received command messages.
+     * The device address is used as the key, e.g. <em>DEFAULT_TENANT/4711</em>.
+     */
+    private final Map<String, Handler<CommandContext>> deviceSpecificCommandHandlers = new HashMap<>();
     /**
      * A mapping of command consumer addresses to vert.x timer IDs which represent the
      * liveness checks for the consumers.
      */
     private final Map<String, Long> livenessChecks = new HashMap<>();
+    private final GatewayMapper gatewayMapper;
 
     /**
      * Creates a new factory for an existing connection.
+     * <p>
+     * Note: The connection lifecycle of the given {@link GatewayMapper} instance will be managed by this
+     * <em>CommandConsumerFactoryImpl</em> instance via the {@link ConnectionLifecycle#connect()} and
+     * {@link ConnectionLifecycle#disconnect()} methods.
      * 
-     * @param connection The connection to use.
+     * @param connection The connection to the AMQP network.
+     * @param gatewayMapper The component mapping a command device id to the corresponding gateway device id.
+     * @throws NullPointerException if connection or gatewayMapper is {@code null}.
      */
-    public CommandConsumerFactoryImpl(final HonoConnection connection) {
+    public CommandConsumerFactoryImpl(final HonoConnection connection, final GatewayMapper gatewayMapper) {
         super(connection);
-        commandConsumerFactory = new CachingClientFactory<>(c -> true);
+        this.gatewayMapper = Objects.requireNonNull(gatewayMapper);
+        deviceSpecificCommandConsumerFactory = new CachingClientFactory<>(c -> true);
+        tenantScopedCommandConsumerFactory = new CachingClientFactory<>(c -> true);
+        delegatedCommandSenderFactory = new CachingClientFactory<>(s -> s.isOpen());
     }
 
     @Override
     protected void onDisconnect() {
-        commandConsumerFactory.clearState();
+        deviceSpecificCommandConsumerFactory.clearState();
+        tenantScopedCommandConsumerFactory.clearState();
+        deviceSpecificCommandHandlers.clear();
     }
 
     private String getKey(final String tenantId, final String deviceId) {
@@ -86,16 +128,94 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
 
         return connection.executeOrRunOnContext(result -> {
             final String key = getKey(tenantId, deviceId);
-            final MessageConsumer commandConsumer = commandConsumerFactory.getClient(key);
+            final MessageConsumer commandConsumer = deviceSpecificCommandConsumerFactory.getClient(key);
             if (commandConsumer != null) {
                 log.debug("cannot create concurrent command consumer [tenant: {}, device-id: {}]", tenantId, deviceId);
                 result.fail(new ResourceConflictException("message consumer already in use"));
             } else {
-                commandConsumerFactory.getOrCreateClient(
+                // create the device specific consumer
+                final Future<MessageConsumer> deviceSpecificConsumerFuture = Future.future();
+                deviceSpecificCommandConsumerFactory.getOrCreateClient(
                         key,
                         () -> newCommandConsumer(tenantId, deviceId, commandHandler, remoteCloseHandler),
+                        deviceSpecificConsumerFuture);
+                // create the tenant-scoped consumer that delegates/maps incoming commands to the right handler/consumer
+                final Future<MessageConsumer> tenantScopedCommandConsumerFuture = getOrCreateTenantScopedCommandConsumer(tenantId);
+                CompositeFuture.all(deviceSpecificConsumerFuture, tenantScopedCommandConsumerFuture).map(res -> {
+                    deviceSpecificCommandHandlers.put(key, commandHandler);
+                    return deviceSpecificConsumerFuture.result();
+                }).setHandler(result);
+            }
+        });
+    }
+
+    private Future<MessageConsumer> getOrCreateTenantScopedCommandConsumer(final String tenantId) {
+        Objects.requireNonNull(tenantId);
+        return connection.executeOrRunOnContext(result -> {
+            final MessageConsumer messageConsumer = tenantScopedCommandConsumerFactory.getClient(tenantId);
+            if (messageConsumer != null) {
+                result.complete(messageConsumer);
+            } else {
+                tenantScopedCommandConsumerFactory.getOrCreateClient(tenantId,
+                        () -> newTenantScopedCommandConsumer(tenantId),
                         result);
             }
+        });
+    }
+
+    private Future<MessageConsumer> newTenantScopedCommandConsumer(final String tenantId) {
+
+        final AtomicReference<ProtonReceiver> receiverRefHolder = new AtomicReference<>();
+
+        final DelegatingCommandHandler delegatingCommandHandler = new DelegatingCommandHandler(
+                deviceIdParam -> deviceSpecificCommandHandlers.get(getKey(tenantId, deviceIdParam)),
+                tenantIdParam -> getOrCreateDelegatedCommandSender(tenantIdParam));
+
+        final GatewayMappingCommandHandler gatewayMappingCommandHandler = new GatewayMappingCommandHandler(
+                gatewayMapper, delegatingCommandHandler);
+
+        return TenantScopedCommandConsumer.create(
+                connection,
+                tenantId,
+                (originalMessageDelivery, message) -> {
+                    final String deviceId = ResourceIdentifier.fromString(message.getAddress()).getResourceId();
+                    final Command command = Command.from(message, tenantId, deviceId);
+                    final SpanContext spanContext = TracingHelper.extractSpanContext(connection.getTracer(), message);
+                    final Span currentSpan = CommandConsumer.createSpan("delegate and send command", tenantId, deviceId, connection.getTracer(), spanContext);
+                    CommandConsumer.logReceivedCommandToSpan(command, currentSpan);
+                    final CommandContext commandContext = CommandContext.from(command, originalMessageDelivery, receiverRefHolder.get(), currentSpan);
+                    if (command.isValid()) {
+                        gatewayMappingCommandHandler.handle(commandContext);
+                    } else {
+                        final Handler<CommandContext> commandHandler = deviceSpecificCommandHandlers.get(getKey(tenantId, deviceId));
+                        if (commandHandler != null) {
+                            // let the device specific handler reject the command
+                            commandHandler.handle(commandContext);
+                        } else {
+                            commandContext.reject(new ErrorCondition(Constants.AMQP_BAD_REQUEST, "malformed command message"));
+                        }
+                    }
+                },
+                sourceAddress -> { // local close hook
+                    tenantScopedCommandConsumerFactory.removeClient(tenantId);
+                },
+                sourceAddress -> { // remote close hook
+                    tenantScopedCommandConsumerFactory.removeClient(tenantId);
+                },
+                receiverRefHolder)
+                .map(c -> (MessageConsumer) c);
+    }
+
+    private Future<DelegatedCommandSender> getOrCreateDelegatedCommandSender(final String tenantId) {
+        Objects.requireNonNull(tenantId);
+        return connection.executeOrRunOnContext(result -> {
+            delegatedCommandSenderFactory.getOrCreateClient(
+                    RESOURCE_KEY_DELEGATED_COMMAND_SENDER,
+                    () -> DelegatedCommandSenderImpl.create(connection,
+                            onSenderClosed -> {
+                                delegatedCommandSenderFactory.removeClient(RESOURCE_KEY_DELEGATED_COMMAND_SENDER);
+                            }),
+                    result);
         });
     }
 
@@ -110,25 +230,25 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
     public final Future<MessageConsumer> createCommandConsumer(
             final String tenantId,
             final String deviceId,
-            final Handler<CommandContext> commandConsumer,
+            final Handler<CommandContext> commandHandler,
             final Handler<Void> remoteCloseHandler,
             final long checkInterval) {
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
-        Objects.requireNonNull(commandConsumer);
+        Objects.requireNonNull(commandHandler);
         if (checkInterval < 0) {
             throw new IllegalArgumentException("liveness check interval must be > 0");
         }
 
-        return createCommandConsumer(tenantId, deviceId, commandConsumer, remoteCloseHandler)
+        return createCommandConsumer(tenantId, deviceId, commandHandler, remoteCloseHandler)
                 .map(c -> {
 
                     final String key = getKey(tenantId, deviceId);
                     final long effectiveCheckInterval = Math.max(MIN_LIVENESS_CHECK_INTERVAL_MILLIS, checkInterval);
                     final long livenessCheckId = connection.getVertx().setPeriodic(
                             effectiveCheckInterval,
-                            newLivenessCheck(tenantId, deviceId, key, commandConsumer, remoteCloseHandler));
+                            newLivenessCheck(tenantId, deviceId, key, commandHandler, remoteCloseHandler));
                     livenessChecks.put(key, livenessCheckId);
                     return c;
                 });
@@ -138,16 +258,17 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
             final String tenantId,
             final String deviceId,
             final String key,
-            final Handler<CommandContext> commandConsumer,
+            final Handler<CommandContext> commandHandler,
             final Handler<Void> remoteCloseHandler) {
 
         final AtomicBoolean recreating = new AtomicBoolean(false);
+        final AtomicBoolean recreatingTenantScopedCommandConsumer = new AtomicBoolean(false);
         return timerId -> {
             if (connection.isShutdown()) {
                 connection.getVertx().cancelTimer(timerId);
             } else {
                 connection.isConnected().map(ok -> {
-                    if (commandConsumerFactory.getClient(key) == null) {
+                    if (deviceSpecificCommandConsumerFactory.getClient(key) == null) {
                         // when a connection is lost unexpectedly,
                         // all consumers will have been removed from the cache
                         // so we need to recreate the consumer
@@ -158,7 +279,7 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
                                     tenantId, deviceId);
                             // we try to re-create the link using the original parameters
                             // which will put the consumer into the cache again, if successful
-                            createCommandConsumer(tenantId, deviceId, commandConsumer, remoteCloseHandler)
+                            createCommandConsumer(tenantId, deviceId, commandHandler, remoteCloseHandler)
                             .map(consumer -> {
                                 log.debug("successfully re-created command consumer [tenant: {}, device-id: {}]",
                                         tenantId, deviceId);
@@ -175,6 +296,25 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
                                     tenantId, deviceId);
                         }
                     }
+
+                    if (tenantScopedCommandConsumerFactory.getClient(tenantId) == null) {
+                        if (recreatingTenantScopedCommandConsumer.compareAndSet(false, true)) {
+                            log.debug("trying to re-create tenant scoped command consumer [tenant: {}]", tenantId);
+                            getOrCreateTenantScopedCommandConsumer(tenantId)
+                                    .map(consumer -> {
+                                        log.debug("successfully re-created tenant scoped command consumer [tenant: {}]", tenantId);
+                                        return consumer;
+                                    })
+                                    .otherwise(t -> {
+                                        log.info("failed to re-create tenant scoped command consumer [tenant: {}]: {}",
+                                                tenantId, t.getMessage());
+                                        return null;
+                                    })
+                                    .setHandler(s -> recreatingTenantScopedCommandConsumer.compareAndSet(true, false));
+                        } else {
+                            log.debug("already trying to re-create tenant scoped command consumer [tenant: {}], yielding ...", tenantId);
+                        }
+                    }
                     return null;
                 });
             }
@@ -184,22 +324,24 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
     private Future<MessageConsumer> newCommandConsumer(
             final String tenantId,
             final String deviceId,
-            final Handler<CommandContext> commandConsumer,
+            final Handler<CommandContext> commandHandler,
             final Handler<Void> remoteCloseHandler) {
 
-        final String key = Device.asAddress(tenantId, deviceId);
-        return CommandConsumer.create(
+        final String key = getKey(tenantId, deviceId);
+        return DeviceSpecificCommandConsumer.create(
                     connection,
                     tenantId,
                     deviceId,
-                    commandConsumer,
+                    commandHandler,
                     sourceAddress -> { // local close hook
                         // stop liveness check
                         Optional.ofNullable(livenessChecks.remove(key)).ifPresent(connection.getVertx()::cancelTimer);
-                        commandConsumerFactory.removeClient(key);
+                        deviceSpecificCommandConsumerFactory.removeClient(key);
+                        deviceSpecificCommandHandlers.remove(key);
                     },
                     sourceAddress -> { // remote close hook
-                        commandConsumerFactory.removeClient(key);
+                        deviceSpecificCommandConsumerFactory.removeClient(key);
+                        deviceSpecificCommandHandlers.remove(key);
                         remoteCloseHandler.handle(null);
                     }).map(c -> (MessageConsumer) c);
     }
@@ -241,10 +383,35 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
             final String key = getKey(tenantId, deviceId);
             // stop liveness check
             Optional.ofNullable(livenessChecks.remove(key)).ifPresent(connection.getVertx()::cancelTimer);
-            // close and remove link from cache 
-            commandConsumerFactory.removeClient(key, consumer -> {
+            // close and remove link from cache
+            deviceSpecificCommandConsumerFactory.removeClient(key, consumer -> {
                 consumer.close(result);
             });
         });
+    }
+
+    // ------------- Override AbstractHonoClientFactory methods to also connect/disconnect the gatewayMapper ------------
+
+    @Override
+    public Future<HonoConnection> connect() {
+        final Future<HonoConnection> amqpNetworkConnectionFuture = super.connect();
+        return CompositeFuture.all(amqpNetworkConnectionFuture, gatewayMapper.connect())
+                .map(obj -> amqpNetworkConnectionFuture.result());
+    }
+
+    @Override
+    public void disconnect() {
+        super.disconnect();
+        gatewayMapper.disconnect();
+    }
+
+    @Override
+    public void disconnect(final Handler<AsyncResult<Void>> completionHandler) {
+        final Future<Void> amqpNetworkDisconnectFuture = Future.future();
+        super.disconnect(amqpNetworkDisconnectFuture);
+        final Future<Void> gatewayMapperDisconnectFuture = Future.future();
+        gatewayMapper.disconnect(gatewayMapperDisconnectFuture);
+        CompositeFuture.all(amqpNetworkDisconnectFuture, gatewayMapperDisconnectFuture)
+                .map(obj -> amqpNetworkDisconnectFuture.result()).setHandler(completionHandler);
     }
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/ConnectionLifecycleWrapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ConnectionLifecycleWrapper.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import org.eclipse.hono.client.ConnectionLifecycle;
+import org.eclipse.hono.client.DisconnectListener;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.ReconnectListener;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * ConnectionLifecycle base class that delegates all method invocations to a given
+ * ConnectionLifecycle instance.
+ */
+public abstract class ConnectionLifecycleWrapper implements ConnectionLifecycle {
+
+    private final ConnectionLifecycle delegate;
+
+    /**
+     * Creates a new ConnectionLifecycleWrapper instance.
+     *
+     * @param delegate The object to invoke the ConnectionLifecycle methods on.
+     */
+    public ConnectionLifecycleWrapper(final ConnectionLifecycle delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Future<HonoConnection> connect() {
+        return delegate.connect();
+    }
+
+    @Override
+    public void addDisconnectListener(final DisconnectListener listener) {
+        delegate.addDisconnectListener(listener);
+    }
+
+    @Override
+    public void addReconnectListener(final ReconnectListener listener) {
+        delegate.addReconnectListener(listener);
+    }
+
+    @Override
+    public Future<Void> isConnected() {
+        return delegate.isConnected();
+    }
+
+    @Override
+    public void disconnect() {
+        delegate.disconnect();
+    }
+
+    @Override
+    public void disconnect(final Handler<AsyncResult<Void>> completionHandler) {
+        delegate.disconnect(completionHandler);
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.Command;
+import org.eclipse.hono.client.DelegatedCommandSender;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * A Vertx-Proton based sender to send command messages to the downstream peer as part of delegating them to be
+ * processed by another command consumer.
+ */
+public class DelegatedCommandSenderImpl extends AbstractSender implements DelegatedCommandSender {
+
+    DelegatedCommandSenderImpl(
+            final HonoConnection connection,
+            final ProtonSender sender) {
+
+        super(connection, sender, "", "");
+    }
+
+    @Override
+    protected String getTo(final String deviceId) {
+        return null;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return CommandConstants.COMMAND_ENDPOINT;
+    }
+
+    @Override
+    protected Future<ProtonDelivery> sendMessage(final Message message, final Span currentSpan) {
+        return runSendAndWaitForOutcomeOnContext(message, currentSpan);
+    }
+
+    @Override
+    public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message) {
+        return sendAndWaitForOutcome(message, null);
+    }
+
+    @Override
+    public Future<ProtonDelivery> sendAndWaitForOutcome(final Message rawMessage, final SpanContext parent) {
+        Objects.requireNonNull(rawMessage);
+
+        final Span span = startSpan(parent, rawMessage);
+        span.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, MessageHelper.getTenantId(rawMessage));
+        span.setTag(MessageHelper.APP_PROPERTY_DEVICE_ID, MessageHelper.getDeviceId(rawMessage));
+        TracingHelper.injectSpanContext(connection.getTracer(), span.context(), rawMessage);
+
+        return runSendAndWaitForOutcomeOnContext(rawMessage, span);
+    }
+
+    private Future<ProtonDelivery> runSendAndWaitForOutcomeOnContext(final Message rawMessage, final Span span) {
+        return connection.executeOrRunOnContext(result -> {
+            if (sender.sendQueueFull()) {
+                final ServiceInvocationException e = new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no credit available");
+                logError(span, e);
+                span.finish();
+                result.fail(e);
+            } else {
+                // TODO improve error-handling: we have to use a different kind of sendMessageAndWaitForOutcome() here
+                //  where a non-Accepted updatedProtonDelivery.getRemoteState() does not fail the returned Future
+                //  (we want to transfer such errors as is, not by way of translating them to/from ServiceInvocationExceptions)
+                sendMessageAndWaitForOutcome(rawMessage, span).setHandler(result);
+            }
+        });
+    }
+
+    @Override
+    public Future<ProtonDelivery> sendCommandMessage(final Command command, final SpanContext spanContext) {
+        Objects.requireNonNull(command);
+        final String tenantId = command.getTenant();
+        final String deviceId = command.getDeviceId();
+        final String targetAddress = getTargetAddress(tenantId, deviceId);
+        final String replyToAddress = command.isOneWay() ? null
+                : String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, tenantId, command.getReplyToId());
+        return sendAndWaitForOutcome(
+                createDelegatedCommandMessage(command.getCommandMessage(), targetAddress, replyToAddress),
+                spanContext);
+    }
+
+    /**
+     * Gets the AMQP <em>target</em> address to use for sending the delegated command messages to.
+     *
+     * @param tenantId The tenant identifier.
+     * @param deviceId The device identifier.
+     * @return The target address.
+     * @throws NullPointerException if tenant or device id is {@code null}.
+     */
+    static String getTargetAddress(final String tenantId, final String deviceId) {
+        return String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, Objects.requireNonNull(tenantId),
+                Objects.requireNonNull(deviceId));
+    }
+
+    private static Message createDelegatedCommandMessage(final Message originalMessage, final String targetAddress,
+            final String replyToAddress) {
+        Objects.requireNonNull(targetAddress);
+        Objects.requireNonNull(originalMessage);
+        // copy original message
+        final Message msg = MessageHelper.getShallowCopy(originalMessage);
+        // set target address
+        msg.setAddress(targetAddress);
+        msg.setReplyTo(replyToAddress);
+        // use original message id as correlation id
+        msg.setCorrelationId(originalMessage.getMessageId());
+        return msg;
+    }
+
+    /**
+     * Creates a new sender for sending the delegated command messages to the AMQP network.
+     *
+     * @param con The connection to the AMQP network.
+     * @param closeHook A handler to invoke if the peer closes the link unexpectedly.
+     * @return A future indicating the result of the creation attempt.
+     * @throws NullPointerException if con is {@code null}.
+     */
+    public static Future<DelegatedCommandSender> create(
+            final HonoConnection con,
+            final Handler<String> closeHook) {
+
+        Objects.requireNonNull(con);
+
+        final String targetAddress = ""; // use anonymous relay (ie. use empty address)
+        return con.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, closeHook)
+                .map(sender -> (DelegatedCommandSender) new DelegatedCommandSenderImpl(con, sender));
+    }
+
+    @Override
+    protected Span startSpan(final SpanContext parent, final Message rawMessage) {
+
+        if (connection.getTracer() == null) {
+            throw new IllegalStateException("no tracer configured");
+        } else {
+            final Span span = newChildSpan(parent, "delegate Command request");
+            Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_CLIENT);
+            return span;
+        }
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/impl/DelegatingCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DelegatingCommandHandler.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import java.util.function.Function;
+
+import org.apache.qpid.proton.amqp.messaging.Modified;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.eclipse.hono.client.Command;
+import org.eclipse.hono.client.CommandContext;
+import org.eclipse.hono.client.DelegatedCommandSender;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonDelivery;
+
+/**
+ * Handler for command messages that delegates command handling either to a given command handler or
+ * to a matching consumer via the downstream peer.
+ */
+public class DelegatingCommandHandler implements Handler<CommandContext> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DelegatingCommandHandler.class);
+
+    private final Function<String, Handler<CommandContext>> deviceSpecificCommandHandlerSupplier;
+    private final Function<String, Future<DelegatedCommandSender>> delegatedCommandSenderSupplier;
+
+    /**
+     * Creates a new DelegatingCommandHandler.
+     *
+     * @param deviceSpecificCommandHandlerSupplier Function to get an existing command handler. The function parameter
+     *            is the device id.
+     * @param delegatedCommandSenderSupplier Function to get a Future with a sender to send the delegated command via
+     *            the downstream peer. The function parameter is the tenant id. The function is supposed to get or
+     *            create such a sender and, if successful, succeed the returned Future with it. If sender creation
+     *            failed, a failed Future is to be returned.
+     */
+    public DelegatingCommandHandler(final Function<String, Handler<CommandContext>> deviceSpecificCommandHandlerSupplier,
+                                    final Function<String, Future<DelegatedCommandSender>> delegatedCommandSenderSupplier) {
+        this.deviceSpecificCommandHandlerSupplier = deviceSpecificCommandHandlerSupplier;
+        this.delegatedCommandSenderSupplier = delegatedCommandSenderSupplier;
+    }
+
+
+    @Override
+    public void handle(final CommandContext commandContext) {
+        final String deviceId = commandContext.getCommand().getDeviceId();
+        final Handler<CommandContext> commandHandler = deviceSpecificCommandHandlerSupplier.apply(deviceId);
+        if (commandHandler != null) {
+            // delegate to existing local device-specific handler
+            LOG.trace("use existing command handler for device {}", deviceId);
+            commandHandler.handle(commandContext);
+        } else {
+            // delegate to matching consumer via downstream peer
+            LOG.trace("delegate command for device {} to matching consumer via downstream peer", deviceId);
+            delegateReceivedCommandMessageViaDownstreamPeer(commandContext);
+        }
+    }
+
+    private void delegateReceivedCommandMessageViaDownstreamPeer(final CommandContext commandContext) {
+
+        final Command command = commandContext.getCommand();
+        final String tenantId = command.getTenant();
+        final String deviceId = command.getDeviceId();
+        // send message to AMQP network
+        final Future<DelegatedCommandSender> delegatedCommandSender = delegatedCommandSenderSupplier.apply(tenantId);
+        delegatedCommandSender.setHandler(cmdSenderResult -> {
+            if (cmdSenderResult.succeeded()) {
+                final DelegatedCommandSender sender = cmdSenderResult.result();
+                sender.sendCommandMessage(command, commandContext.getTracingContext()).setHandler(sendResult -> {
+                    if (sendResult.succeeded()) {
+                        // send succeeded - handle outcome
+                        final ProtonDelivery delegatedMsgDelivery = sendResult.result();
+                        LOG.trace("command for device {} sent to downstream peer; remote state of delivery: {}",
+                                deviceId, delegatedMsgDelivery.getRemoteState());
+                        applyDelegatedMessageDeliveryResultToCommandContext(delegatedMsgDelivery, commandContext);
+                    } else {
+                        // failed to send message
+                        LOG.error("failed to send command message to downstream peer", sendResult.cause());
+                        TracingHelper.logError(commandContext.getCurrentSpan(),
+                                "failed to send command message to downstream peer: " + sendResult.cause());
+                        commandContext.release();
+                    }
+                });
+            } else {
+                // failed to create sender
+                LOG.error("failed to create sender for sending command message to downstream peer", cmdSenderResult.cause());
+                TracingHelper.logError(commandContext.getCurrentSpan(),
+                        "failed to create sender for sending command message to downstream peer: " + cmdSenderResult.cause());
+                commandContext.release();
+            }
+        });
+    }
+
+    private void applyDelegatedMessageDeliveryResultToCommandContext(final ProtonDelivery delegatedMsgDelivery, final CommandContext commandContext) {
+        switch (delegatedMsgDelivery.getRemoteState().getType()) {
+            case Accepted:
+                commandContext.accept();
+                break;
+            case Rejected:
+                final Rejected rejected = (Rejected) delegatedMsgDelivery.getRemoteState();
+                commandContext.reject(rejected.getError());
+                break;
+            case Modified:
+                final Modified modified = (Modified) delegatedMsgDelivery.getRemoteState();
+                commandContext.modify(modified.getDeliveryFailed(), modified.getUndeliverableHere(), 0);
+                break;
+            case Released:
+                commandContext.release();
+                break;
+            default:
+                LOG.warn("got unexpected delivery outcome; remote state: {}", delegatedMsgDelivery.getRemoteState());
+                TracingHelper.logError(commandContext.getCurrentSpan(), "got unexpected delivery outcome; remote state: "
+                        + delegatedMsgDelivery.getRemoteState());
+                commandContext.release();
+                break;
+        }
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/impl/DeviceSpecificCommandConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DeviceSpecificCommandConsumer.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.hono.client.Command;
+import org.eclipse.hono.client.CommandContext;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+
+/**
+ * A wrapper around an AMQP receiver link for consuming commands.
+ */
+public class DeviceSpecificCommandConsumer extends CommandConsumer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceSpecificCommandConsumer.class);
+
+    private DeviceSpecificCommandConsumer(final HonoConnection connection, final ProtonReceiver receiver) {
+        super(connection, receiver);
+    }
+
+    /**
+     * Creates a new command consumer.
+     * <p>
+     * The underlying receiver link will be created with the following properties:
+     * <ul>
+     * <li><em>auto accept</em> will be set to {@code true}</li>
+     * <li><em>pre-fetch size</em> will be set to {@code 0} to enforce manual flow control.
+     * However, the sender will be issued one credit on link establishment.</li>
+     * </ul>
+     *
+     * @param con The connection to the server.
+     * @param tenantId The tenant to consume commands from.
+     * @param deviceId The device for which the commands should be consumed.
+     * @param commandHandler The handler to invoke for each command received.
+     * @param localCloseHandler A handler to be invoked after the link has been closed
+     *                     at this peer's request using the {@link #close(Handler)} method.
+     *                     The handler will be invoked with the link's source address <em>after</em>
+     *                     the link has been closed but <em>before</em> the handler that has been
+     *                     passed into the <em>close</em> method is invoked.
+     * @param remoteCloseHandler A handler to be invoked after the link has been closed
+     *                     at the remote peer's request. The handler will be invoked with the
+     *                     link's source address.
+     * @return A future indicating the outcome of the creation attempt.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public static final Future<DeviceSpecificCommandConsumer> create(
+            final HonoConnection con,
+            final String tenantId,
+            final String deviceId,
+            final Handler<CommandContext> commandHandler,
+            final Handler<String> localCloseHandler,
+            final Handler<String> remoteCloseHandler) {
+
+        Objects.requireNonNull(con);
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(commandHandler);
+        Objects.requireNonNull(remoteCloseHandler);
+
+        LOG.trace("creating new command consumer [tenant-id: {}, device-id: {}]", tenantId, deviceId);
+
+        final String address = ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId).toString();
+
+        final AtomicReference<ProtonReceiver> receiverRef = new AtomicReference<>();
+
+        return con.createReceiver(
+                address,
+                ProtonQoS.AT_LEAST_ONCE,
+                (delivery, msg) -> {
+
+                    final Command command = Command.from(msg, tenantId, deviceId);
+                    final Tracer tracer = con.getTracer();
+                    // try to extract Span context from incoming message
+                    final SpanContext spanContext = TracingHelper.extractSpanContext(tracer, msg);
+                    final Span currentSpan = createSpan("send command", tenantId, deviceId,
+                            tracer, spanContext);
+                    logReceivedCommandToSpan(command, currentSpan);
+                    commandHandler.handle(CommandContext.from(command, delivery, receiverRef.get(), currentSpan));
+                },
+                0, // no pre-fetching
+                sourceAddress -> {
+                    LOG.debug("command receiver link [tenant-id: {}, device-id: {}] closed remotely",
+                            tenantId, deviceId);
+                    remoteCloseHandler.handle(sourceAddress);
+                }).map(receiver -> {
+                    LOG.debug("successfully created command consumer [{}]", address);
+                    receiverRef.set(receiver);
+                    receiver.flow(1); // allow sender to send one command
+                    final DeviceSpecificCommandConsumer consumer = new DeviceSpecificCommandConsumer(con, receiver);
+                    consumer.setLocalCloseHandler(sourceAddress -> {
+                        LOG.debug("command receiver link [tenant-id: {}, device-id: {}] closed locally",
+                                tenantId, deviceId);
+                        localCloseHandler.handle(sourceAddress);
+                    });
+                    return consumer;
+                }).recover(t -> {
+                    LOG.debug("failed to create command consumer [tenant-id: {}, device-id: {}]",
+                            tenantId, deviceId, t);
+                    return Future.failedFuture(t);
+                });
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/impl/GatewayMapperImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/GatewayMapperImpl.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import java.util.Objects;
+
+import org.eclipse.hono.client.GatewayMapper;
+import org.eclipse.hono.client.RegistrationClientFactory;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.RegistrationConstants;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A component that maps a given device to the gateway through which data was last published for the given device.
+ */
+public class GatewayMapperImpl extends ConnectionLifecycleWrapper implements GatewayMapper {
+
+    private final RegistrationClientFactory registrationClientFactory;
+
+    /**
+     * Creates a new GatewayMapperImpl instance.
+     *
+     * @param registrationClientFactory The factory to create a registration client instance.
+     */
+    public GatewayMapperImpl(final RegistrationClientFactory registrationClientFactory) {
+        super(registrationClientFactory);
+        this.registrationClientFactory = registrationClientFactory;
+    }
+
+    @Override
+    public Future<String> getMappedGatewayDevice(final String tenantId, final String deviceId) {
+        return registrationClientFactory.getOrCreateRegistrationClient(tenantId).compose(client -> {
+            return client.get(deviceId);
+        }).map(deviceData -> {
+            return getDeviceLastVia(deviceId, deviceData);
+        });
+    }
+
+    /**
+     * Extracts the 'last-via' field content from the given device registration data JSON.
+     * <p>
+     * If the given device has no 'via' device(s) defined, the given device id is returned.
+     *
+     * @param deviceId The device identifier.
+     * @param deviceData The device registration data JSON.
+     * @return The content of the "last-via" field (or {@code null} if field doesn't exist) if a "via" is defined;
+     *         otherwise the deviceId.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected static String getDeviceLastVia(final String deviceId, final JsonObject deviceData) {
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(deviceData);
+        if (deviceData.containsKey(RegistrationConstants.FIELD_VIA)) {
+            final JsonObject lastViaObj = deviceData.getJsonObject(RegistrationConstants.FIELD_LAST_VIA);
+            return lastViaObj != null ? lastViaObj.getString(Constants.JSON_FIELD_DEVICE_ID) : null;
+        } else {
+            // device not configured to connect via gateway - return device id itself
+            return deviceId;
+        }
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandler.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.eclipse.hono.client.Command;
+import org.eclipse.hono.client.CommandContext;
+import org.eclipse.hono.client.GatewayMapper;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * Command handler that maps commands to gateway devices (if applicable) and passes the commands to a given
+ * next command handler.
+ */
+public class GatewayMappingCommandHandler implements Handler<CommandContext> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GatewayMappingCommandHandler.class);
+
+    private final GatewayMapper gatewayMapper;
+    private final Handler<CommandContext> nextCommandHandler;
+
+    /**
+     * Creates a new GatewayMappingCommandHandler instance.
+     * 
+     * @param gatewayMapper The component mapping a command device id to the corresponding gateway device id.
+     * @param nextCommandHandler The handler to invoke with the mapped command.
+     */
+    public GatewayMappingCommandHandler(final GatewayMapper gatewayMapper, final Handler<CommandContext> nextCommandHandler) {
+        this.gatewayMapper = gatewayMapper;
+        this.nextCommandHandler = nextCommandHandler;
+    }
+
+    @Override
+    public void handle(final CommandContext originalCommandContext) {
+        final Command originalCommand = originalCommandContext.getCommand();
+        if (!originalCommand.isValid()) {
+            originalCommandContext.reject(new ErrorCondition(Constants.AMQP_BAD_REQUEST, "malformed command message"));
+            return;
+        }
+        final String tenantId = originalCommand.getTenant();
+        final String originalDeviceId = originalCommand.getDeviceId();
+        // determine last used gateway device id
+        LOG.trace("determine 'via' device to use for received command [{}]", originalCommand);
+        final Future<String> lastViaDeviceIdFuture = gatewayMapper.getMappedGatewayDevice(tenantId, originalDeviceId);
+
+        lastViaDeviceIdFuture.setHandler(deviceIdFutureResult -> {
+            if (deviceIdFutureResult.succeeded()) {
+                final String lastViaDeviceId = deviceIdFutureResult.result();
+                if (lastViaDeviceId != null) {
+                    LOG.trace("determined 'via' device {} for device {}", lastViaDeviceId, originalDeviceId);
+                    final CommandContext commandContext;
+                    if (lastViaDeviceId.equals(originalDeviceId)) {
+                        commandContext = originalCommandContext;
+                    } else {
+                        originalCommandContext.getCurrentSpan().log("determined 'via' device " + lastViaDeviceId);
+                        if (!originalCommand.isOneWay()) {
+                            originalCommand.getCommandMessage().setReplyTo(String.format("%s/%s/%s",
+                                    CommandConstants.COMMAND_ENDPOINT, tenantId, originalCommand.getReplyToId()));
+                        }
+                        final Command command = Command.from(originalCommand.getCommandMessage(), tenantId, lastViaDeviceId);
+                        commandContext = CommandContext.from(command, originalCommandContext.getDelivery(), originalCommandContext.getReceiver(), originalCommandContext.getCurrentSpan());
+                    }
+                    nextCommandHandler.handle(commandContext);
+                } else {
+                    // lastViaDeviceId is null - device hasn't connected yet
+                    LOG.error("last-via for device {} is not set", originalDeviceId);
+                    TracingHelper.logError(originalCommandContext.getCurrentSpan(), "last-via for device " + originalDeviceId + " is not set");
+                    originalCommandContext.release();
+                }
+            } else {
+                // failed to get last-via; a common cause for this is a lost connection to the device registry - automatic reconnects should resolve such a situation for subsequent requests
+                LOG.error("error getting last-via for device {}", originalDeviceId, deviceIdFutureResult.cause());
+                TracingHelper.logError(originalCommandContext.getCurrentSpan(),
+                        "error getting last-via for device: " + deviceIdFutureResult.cause());
+                originalCommandContext.release();
+            }
+        });
+    }
+
+}

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantScopedCommandConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantScopedCommandConsumer.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.hono.client.CommandConsumerFactory;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonMessageHandler;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+
+/**
+ * A wrapper around an AMQP receiver link for consuming commands on a tenant-scoped address.
+ * <p>
+ * This class is used by the default {@link CommandConsumerFactory} implementation to receive commands from northbound
+ * applications.
+ */
+public class TenantScopedCommandConsumer extends CommandConsumer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TenantScopedCommandConsumer.class);
+
+    private TenantScopedCommandConsumer(final HonoConnection connection, final ProtonReceiver receiver) {
+
+        super(connection, receiver);
+    }
+
+    /**
+     * Creates a new command consumer.
+     *
+     * @param con The connection to the server.
+     * @param tenantId The tenant to consume commands from.
+     * @param messageHandler The handler to invoke for each message received.
+     * @param localCloseHandler A handler to be invoked after the link has been closed
+     *                     at this peer's request using the {@link #close(Handler)} method.
+     *                     The handler will be invoked with the link's source address <em>after</em>
+     *                     the link has been closed but <em>before</em> the handler that has been
+     *                     passed into the <em>close</em> method is invoked.
+     * @param remoteCloseHandler A handler to be invoked after the link has been closed
+     *                     at the remote peer's request. The handler will be invoked with the
+     *                     link's source address.
+     * @param receiverRefHolder A reference object to set the created ProtonReceiver object in.
+     * @return A future indicating the outcome of the creation attempt.
+     * @throws NullPointerException if any of the parameters other than tracer are {@code null}.
+     */
+    public static Future<TenantScopedCommandConsumer> create(
+            final HonoConnection con,
+            final String tenantId,
+            final ProtonMessageHandler messageHandler,
+            final Handler<String> localCloseHandler,
+            final Handler<String> remoteCloseHandler,
+            final AtomicReference<ProtonReceiver> receiverRefHolder) {
+
+        Objects.requireNonNull(con);
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(messageHandler);
+        Objects.requireNonNull(remoteCloseHandler);
+        Objects.requireNonNull(receiverRefHolder);
+
+        LOG.trace("creating new tenant scoped command consumer [tenant-id: {}]", tenantId);
+
+        final String address = ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, null).toString();
+
+        return con.createReceiver(
+                address,
+                ProtonQoS.AT_LEAST_ONCE,
+                messageHandler,
+                sourceAddress -> {
+                    LOG.debug("command receiver link [tenant-id: {}] closed remotely", tenantId);
+                    remoteCloseHandler.handle(sourceAddress);
+                }).map(receiver -> {
+                    LOG.debug("successfully created tenant scoped command consumer [{}]", address);
+                    receiverRefHolder.set(receiver);
+                    final TenantScopedCommandConsumer consumer = new TenantScopedCommandConsumer(con, receiver);
+                    consumer.setLocalCloseHandler(sourceAddress -> {
+                        LOG.debug("command receiver link [tenant-id: {}] closed locally", tenantId);
+                        localCloseHandler.handle(sourceAddress);
+                    });
+                    return consumer;
+                }).recover(t -> {
+                    LOG.debug("failed to create tenant scoped command consumer [tenant-id: {}]", tenantId, t);
+                    return Future.failedFuture(t);
+                });
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -25,6 +25,7 @@ import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Properties;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
@@ -35,6 +36,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
 
 /**
  * Utility methods for working with Proton {@code Message}s.
@@ -737,4 +739,24 @@ public final class MessageHelper {
         return message.getBody() instanceof Data;
     }
 
+    /**
+     * Returns a copy of the given message.
+     * <p>
+     * This is a shallow copy of the <em>Message</em> object, except for the copied <em>Properties</em>.
+     *
+     * @param message The message to copy.
+     * @return The message copy.
+     */
+    public static Message getShallowCopy(final Message message) {
+        final Message copy = ProtonHelper.message();
+        copy.setDeliveryAnnotations(message.getDeliveryAnnotations());
+        copy.setMessageAnnotations(message.getMessageAnnotations());
+        if (message.getProperties() != null) {
+            copy.setProperties(new Properties(message.getProperties()));
+        }
+        copy.setApplicationProperties(message.getApplicationProperties());
+        copy.setBody(message.getBody());
+        copy.setFooter(message.getFooter());
+        return copy;
+    }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -19,10 +19,12 @@ import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.DownstreamSenderFactory;
+import org.eclipse.hono.client.GatewayMapper;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.TenantClientFactory;
+import org.eclipse.hono.client.impl.GatewayMapperImpl;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.VertxProperties;
@@ -342,7 +344,7 @@ public abstract class AbstractAdapterConfig {
     @Bean
     @Scope("prototype")
     public CommandConsumerFactory commandConsumerFactory() {
-        return CommandConsumerFactory.create(commandConsumerConnection());
+        return CommandConsumerFactory.create(commandConsumerConnection(), gatewayMapper());
     }
 
     /**
@@ -354,6 +356,17 @@ public abstract class AbstractAdapterConfig {
     @Scope("prototype")
     public HonoConnection commandConsumerConnection() {
         return HonoConnection.newConnection(vertx(), commandConsumerFactoryConfig());
+    }
+
+    /**
+     * Exposes the component for mapping a device id to a corresponding gateway id.
+     *
+     * @return New GatewayMapper instance.
+     */
+    @Bean
+    @Scope("prototype")
+    public GatewayMapper gatewayMapper() {
+        return new GatewayMapperImpl(registrationClientFactory());
     }
 
     /**


### PR DESCRIPTION
For #930:
This introduces a new command consumer on a tenant-scoped address.

This consumer handler will map the device id in the command message 'To' address to a corresponding 'via' device id (if applicable) and delegate the command either to a local command handler or to a consumer on another protocol adapter instance by way of the AMQP network.
As the existing command consumer address scheme isn't changed (yet), this change doesn't cause any incompatibilities.

Additional changes for getting this to work are in #1156 and #1157.