### PR TITLE
[#780] Use RegistrationClientFactory instead of HonoClient.

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
@@ -57,7 +57,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties config) {
+    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties config) {
         if (config.getName() == null) {
             config.setName(CONTAINER_ID_HONO_AMQP_ADAPTER);
         }

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -54,6 +54,7 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
@@ -116,7 +117,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
     private TenantClientFactory tenantClientFactory;
     private HonoClient credentialsServiceClient;
     private HonoClient messagingServiceClient;
-    private HonoClient registrationServiceClient;
+    private RegistrationClientFactory registrationClientFactory;
     private CommandConsumerFactory commandConsumerFactory;
 
     private RegistrationClient registrationClient;
@@ -158,10 +159,9 @@ public class VertxBasedAmqpProtocolAdapterTest {
         when(registrationClient.assertRegistration(anyString(), any(), (SpanContext) any()))
                 .thenReturn(Future.succeededFuture(regAssertion));
 
-        registrationServiceClient = mock(HonoClient.class);
-        when(registrationServiceClient.connect(any(Handler.class)))
-                .thenReturn(Future.succeededFuture(registrationServiceClient));
-        when(registrationServiceClient.getOrCreateRegistrationClient(anyString()))
+        registrationClientFactory = mock(RegistrationClientFactory.class);
+        when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
+        when(registrationClientFactory.getOrCreateRegistrationClient(anyString()))
                 .thenReturn(Future.succeededFuture(registrationClient));
 
         commandConsumerFactory = mock(CommandConsumerFactory.class);
@@ -855,7 +855,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         adapter.setInsecureAmqpServer(server);
         adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setHonoMessagingClient(messagingServiceClient);
-        adapter.setRegistrationServiceClient(registrationServiceClient);
+        adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsServiceClient(credentialsServiceClient);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setMetrics(metrics);

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -47,6 +47,7 @@ import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.util.RegistrationConstants;
@@ -90,7 +91,7 @@ public class AbstractVertxBasedCoapAdapterTest {
     private HonoClient credentialsServiceClient;
     private TenantClientFactory tenantClientFactory;
     private HonoClient messagingClient;
-    private HonoClient registrationServiceClient;
+    private RegistrationClientFactory registrationClientFactory;
     private RegistrationClient regClient;
     private TenantClient tenantClient;
     private CoapAdapterProperties config;
@@ -127,10 +128,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         messagingClient = mock(HonoClient.class);
         when(messagingClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingClient));
 
-        registrationServiceClient = mock(HonoClient.class);
-        when(registrationServiceClient.connect(any(Handler.class)))
-                .thenReturn(Future.succeededFuture(registrationServiceClient));
-        when(registrationServiceClient.getOrCreateRegistrationClient(anyString()))
+        registrationClientFactory = mock(RegistrationClientFactory.class);
+        when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
+        when(registrationClientFactory.getOrCreateRegistrationClient(anyString()))
                 .thenReturn(Future.succeededFuture(regClient));
 
         commandConsumerFactory = mock(CommandConsumerFactory.class);
@@ -515,7 +515,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         adapter.setCoapServer(server);
         adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setHonoMessagingClient(messagingClient);
-        adapter.setRegistrationServiceClient(registrationServiceClient);
+        adapter.setRegistrationClientFactory(registrationClientFactory);
         if (complete) {
             adapter.setCredentialsServiceClient(credentialsServiceClient);
         }

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
@@ -56,7 +56,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
         }

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -40,6 +40,7 @@ import org.eclipse.hono.client.CommandResponseSender;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.ResourceConflictException;
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.client.TenantClientFactory;
@@ -104,7 +105,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     private HonoClient                    credentialsServiceClient;
     private TenantClientFactory           tenantClientFactory;
     private HonoClient                    messagingClient;
-    private HonoClient                    registrationServiceClient;
+    private RegistrationClientFactory     registrationClientFactory;
     private RegistrationClient            regClient;
     private TenantClient                  tenantClient;
     private HttpProtocolAdapterProperties config;
@@ -154,9 +155,9 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         messagingClient = mock(HonoClient.class);
         when(messagingClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingClient));
 
-        registrationServiceClient = mock(HonoClient.class);
-        when(registrationServiceClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(registrationServiceClient));
-        when(registrationServiceClient.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(regClient));
+        registrationClientFactory = mock(RegistrationClientFactory.class);
+        when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
+        when(registrationClientFactory.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(regClient));
 
         commandConsumer = mock(CommandConsumer.class);
         doAnswer(invocation -> {
@@ -848,7 +849,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         adapter.setInsecureHttpServer(server);
         adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setHonoMessagingClient(messagingClient);
-        adapter.setRegistrationServiceClient(registrationServiceClient);
+        adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsServiceClient(credentialsServiceClient);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         return adapter;

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
@@ -56,7 +56,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
         }

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
@@ -57,7 +57,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_KURA_ADAPTER);
         }

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/Config.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/Config.java
@@ -71,7 +71,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_LORA_ADAPTER);
         }

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -45,6 +45,7 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.client.TenantClientFactory;
@@ -109,7 +110,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     private TenantClientFactory tenantClientFactory;
     private HonoClient credentialsServiceClient;
     private HonoClient messagingClient;
-    private HonoClient deviceRegistrationServiceClient;
+    private RegistrationClientFactory registrationClientFactory;
     private RegistrationClient regClient;
     private TenantClient tenantClient;
     private AuthHandler<MqttContext> authHandler;
@@ -164,12 +165,11 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(messagingClient.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(mock(MessageSender.class)));
         when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(mock(MessageSender.class)));
 
-        deviceRegistrationServiceClient = mock(HonoClient.class);
-        when(deviceRegistrationServiceClient.isConnected()).thenReturn(
+        registrationClientFactory = mock(RegistrationClientFactory.class);
+        when(registrationClientFactory.isConnected()).thenReturn(
                 Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
-        when(deviceRegistrationServiceClient.connect(any(Handler.class)))
-                .thenReturn(Future.succeededFuture(deviceRegistrationServiceClient));
-        when(deviceRegistrationServiceClient.getOrCreateRegistrationClient(anyString()))
+        when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
+        when(registrationClientFactory.getOrCreateRegistrationClient(anyString()))
                 .thenReturn(Future.succeededFuture(regClient));
 
         commandConsumerFactory = mock(CommandConsumerFactory.class);
@@ -1034,7 +1034,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     private void forceClientMocksToConnected() {
         when(tenantClientFactory.isConnected()).thenReturn(Future.succeededFuture());
         when(messagingClient.isConnected()).thenReturn(Future.succeededFuture());
-        when(deviceRegistrationServiceClient.isConnected()).thenReturn(Future.succeededFuture());
+        when(registrationClientFactory.isConnected()).thenReturn(Future.succeededFuture());
         when(credentialsServiceClient.isConnected()).thenReturn(Future.succeededFuture());
         when(commandConsumerFactory.isConnected()).thenReturn(Future.succeededFuture());
     }
@@ -1091,7 +1091,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         adapter.setMetrics(metrics);
         adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setHonoMessagingClient(messagingClient);
-        adapter.setRegistrationServiceClient(deviceRegistrationServiceClient);
+        adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsServiceClient(credentialsServiceClient);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setAuthHandler(authHandler);

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
@@ -60,7 +60,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.client.impl.CommandConsumerFactoryImpl;
@@ -137,14 +138,14 @@ public abstract class AbstractAdapterConfig {
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @ConfigurationProperties(prefix = "hono.registration")
     @Bean
-    public RequestResponseClientConfigProperties registrationServiceClientConfig() {
+    public RequestResponseClientConfigProperties registrationClientFactoryConfig() {
         final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
-        customizeRegistrationServiceClientConfig(config);
+        customizeRegistrationClientFactoryConfig(config);
         return config;
     }
 
     /**
-     * Further customizes the properties provided by the {@link #registrationServiceClientConfig()}
+     * Further customizes the properties provided by the {@link #registrationClientFactoryConfig()}
      * method.
      * <p>
      * This method does nothing by default. Subclasses may override this method to set additional
@@ -152,21 +153,21 @@ public abstract class AbstractAdapterConfig {
      *
      * @param config The configuration to customize.
      */
-    protected void customizeRegistrationServiceClientConfig(final RequestResponseClientConfigProperties config) {
+    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties config) {
         // empty by default
     }
 
     /**
-     * Exposes a client for the <em>Device Registration</em> API as a Spring bean.
+     * Exposes a factory for creating clients for the <em>Device Registration</em> API as a Spring bean.
      *
-     * @return The client.
+     * @return The factory.
      */
     @Bean
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
-    public HonoClient registrationServiceClient() {
+    public RegistrationClientFactory registrationClientFactory() {
         final HonoClientImpl result =
-                new HonoClientImpl(vertx(), registrationServiceClientConfig());
+                new HonoClientImpl(vertx(), registrationClientFactoryConfig());
 
         final CacheProvider cacheProvider = registrationCacheProvider();
         if (cacheProvider != null) {
@@ -185,7 +186,7 @@ public abstract class AbstractAdapterConfig {
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
     public CacheProvider registrationCacheProvider() {
-        return newGuavaCache(registrationServiceClientConfig());
+        return newGuavaCache(registrationClientFactoryConfig());
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -35,6 +35,7 @@ import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.ReconnectListener;
 import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
@@ -83,7 +84,7 @@ public class AbstractProtocolAdapterBaseTest {
     private AbstractProtocolAdapterBase<ProtocolAdapterProperties> adapter;
     private RegistrationClient registrationClient;
     private TenantClientFactory tenantService;
-    private HonoClient registrationService;
+    private RegistrationClientFactory registrationClientFactory;
     private HonoClient credentialsService;
     private HonoClient messagingService;
     private CommandConsumerFactory commandConsumerFactory;
@@ -98,11 +99,11 @@ public class AbstractProtocolAdapterBaseTest {
         tenantService = mock(TenantClientFactory.class);
         when(tenantService.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
-        registrationService = mock(HonoClient.class);
-        when(registrationService.connect(any(Handler.class))).thenReturn(Future.succeededFuture(registrationService));
+        registrationClientFactory = mock(RegistrationClientFactory.class);
+        when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         registrationClient = mock(RegistrationClient.class);
-        when(registrationService.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(registrationClient));
+        when(registrationClientFactory.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(registrationClient));
 
         credentialsService = mock(HonoClient.class);
         when(credentialsService.connect(any(Handler.class))).thenReturn(Future.succeededFuture(credentialsService));
@@ -116,7 +117,7 @@ public class AbstractProtocolAdapterBaseTest {
         properties = new ProtocolAdapterProperties();
         adapter = newProtocolAdapter(properties);
         adapter.setTenantClientFactory(tenantService);
-        adapter.setRegistrationServiceClient(registrationService);
+        adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsServiceClient(credentialsService);
         adapter.setHonoMessagingClient(messagingService);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
@@ -143,7 +144,7 @@ public class AbstractProtocolAdapterBaseTest {
 
         // GIVEN an adapter that does not define a type name
         adapter = newProtocolAdapter(properties, null);
-        adapter.setRegistrationServiceClient(mock(HonoClient.class));
+        adapter.setRegistrationClientFactory(mock(HonoClient.class));
 
         // WHEN starting the adapter
         // THEN startup fails
@@ -171,7 +172,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.startInternal().setHandler(ctx.asyncAssertSuccess(ok -> {
             // THEN the service clients have connected
             verify(tenantService).connect();
-            verify(registrationService).connect(any(Handler.class));
+            verify(registrationClientFactory).connect();
             verify(messagingService).connect(any(Handler.class));
             verify(credentialsService).connect(any(Handler.class));
             verify(commandConsumerFactory).connect();
@@ -225,7 +226,7 @@ public class AbstractProtocolAdapterBaseTest {
                 commandConnectionEstablishedHandler, commandConnectionLostHandler);
         adapter.setCredentialsServiceClient(credentialsService);
         adapter.setHonoMessagingClient(messagingService);
-        adapter.setRegistrationServiceClient(registrationService);
+        adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setTenantClientFactory(tenantService);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
     }

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -31,15 +31,21 @@ title = "Release Notes"
   `org.eclipse.hono.client.CommandConsumerFactory` instead of
   `org.eclipse.hono.client.CommandConnection` for creating
   `org.eclipse.hono.client.CommandConsumer` instances.
-  The `setCommandConnection` and `getCommandConnection` methods have been
-  renamed to `setCommandConsumerFactory` and `getCommandConsumerFactory`
+  The *setCommandConnection* and *getCommandConnection* methods have been
+  renamed to *setCommandConsumerFactory* and *getCommandConsumerFactory*
   correspondingly.
 * The `org.eclipse.hono.service.AbstractProtocolAdapterBase` class now uses
   `org.eclipse.hono.client.TenantClientFactory` instead of
   `org.eclipse.hono.client.HonoClient` for creating `org.eclipse.hono.client.TenantClient`
   instances.
-  The `setTenantServiceClient` and `getTenantServiceClient` methods have been
-  renamed to `setTenantClientFactory` and `getTenantClientFactory` correspondingly.
+  The *setTenantServiceClient* and *getTenantServiceClient* methods have been
+  renamed to *setTenantClientFactory* and *getTenantClientFactory* correspondingly.
+* The `org.eclipse.hono.service.AbstractProtocolAdapterBase` class now uses
+  `org.eclipse.hono.client.RegistrationClientFactory` instead of
+  `org.eclipse.hono.client.HonoClient` for creating
+  `org.eclipse.hono.client.RegistrationClient` instances.
+  The *setRegistrationServiceClient* and *getRegistrationServiceClient* methods have been
+  renamed to *setRegistrationClientFactory* and *getRegistrationClientFactory* correspondingly.
 
 ## 1.0-M1
 


### PR DESCRIPTION
The protocol adapters have been changed to use the
RegistrationClientFactory instead of the HonoClient
for creating RegistrationClient instances.
