### PR TITLE
[#780] Use CredentialsClientFactory instead of HonoClient.

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
@@ -64,7 +64,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties config) {
+    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties config) {
         if (config.getName() == null) {
             config.setName(CONTAINER_ID_HONO_AMQP_ADAPTER);
         }

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -153,7 +153,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                         setConnectionLimitManager(connectionLimitManager);
                         authenticatorFactory = new AmqpAdapterSaslAuthenticatorFactory(
                                 getTenantClientFactory(),
-                                getCredentialsServiceClient(),
+                                getCredentialsClientFactory(),
                                 getConfig(),
                                 tracer,
                                 () -> tracer.buildSpan("open connection")

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -50,6 +50,7 @@ import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.MessageSender;
@@ -115,7 +116,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
     public Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);
 
     private TenantClientFactory tenantClientFactory;
-    private HonoClient credentialsServiceClient;
+    private CredentialsClientFactory credentialsClientFactory;
     private HonoClient messagingServiceClient;
     private RegistrationClientFactory registrationClientFactory;
     private CommandConsumerFactory commandConsumerFactory;
@@ -146,9 +147,8 @@ public class VertxBasedAmqpProtocolAdapterTest {
         when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
         when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
 
-        credentialsServiceClient = mock(HonoClient.class);
-        when(credentialsServiceClient.connect(any(Handler.class)))
-                .thenReturn(Future.succeededFuture(credentialsServiceClient));
+        credentialsClientFactory = mock(CredentialsClientFactory.class);
+        when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         messagingServiceClient = mock(HonoClient.class);
         when(messagingServiceClient.connect(any(Handler.class)))
@@ -856,7 +856,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setHonoMessagingClient(messagingServiceClient);
         adapter.setRegistrationClientFactory(registrationClientFactory);
-        adapter.setCredentialsServiceClient(credentialsServiceClient);
+        adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setMetrics(metrics);
         return adapter;

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -218,7 +218,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
     private void bindSecureEndpoint(final CoapServer startingServer, final NetworkConfig config) {
 
         final CoapPreSharedKeyHandler pskHandler = new CoapPreSharedKeyHandler(context, getConfig(),
-                getCredentialsServiceClient());
+                getCredentialsClientFactory());
         authenticationHandlerMap.put(pskHandler.getType(), pskHandler);
 
         final DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder();

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -44,6 +44,7 @@ import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandConsumerFactory;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
@@ -88,7 +89,7 @@ public class AbstractVertxBasedCoapAdapterTest {
     @Rule
     public final Timeout globalTimeout = Timeout.seconds(5);
 
-    private HonoClient credentialsServiceClient;
+    private CredentialsClientFactory credentialsClientFactory;
     private TenantClientFactory tenantClientFactory;
     private HonoClient messagingClient;
     private RegistrationClientFactory registrationClientFactory;
@@ -121,9 +122,8 @@ public class AbstractVertxBasedCoapAdapterTest {
         when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
         when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
 
-        credentialsServiceClient = mock(HonoClient.class);
-        when(credentialsServiceClient.connect(any(Handler.class)))
-                .thenReturn(Future.succeededFuture(credentialsServiceClient));
+        credentialsClientFactory = mock(CredentialsClientFactory.class);
+        when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         messagingClient = mock(HonoClient.class);
         when(messagingClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingClient));
@@ -517,7 +517,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         adapter.setHonoMessagingClient(messagingClient);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         if (complete) {
-            adapter.setCredentialsServiceClient(credentialsServiceClient);
+            adapter.setCredentialsClientFactory(credentialsClientFactory);
         }
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setMetrics(mock(CoapAdapterMetrics.class));

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
@@ -63,7 +63,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
         }

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -37,6 +37,7 @@ import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
@@ -102,7 +103,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     @Rule
     public Timeout globalTimeout = Timeout.seconds(5);
 
-    private HonoClient                    credentialsServiceClient;
+    private CredentialsClientFactory      credentialsClientFactory;
     private TenantClientFactory           tenantClientFactory;
     private HonoClient                    messagingClient;
     private RegistrationClientFactory     registrationClientFactory;
@@ -149,8 +150,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
         when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
 
-        credentialsServiceClient = mock(HonoClient.class);
-        when(credentialsServiceClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(credentialsServiceClient));
+        credentialsClientFactory = mock(CredentialsClientFactory.class);
+        when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         messagingClient = mock(HonoClient.class);
         when(messagingClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingClient));
@@ -850,7 +851,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setHonoMessagingClient(messagingClient);
         adapter.setRegistrationClientFactory(registrationClientFactory);
-        adapter.setCredentialsServiceClient(credentialsServiceClient);
+        adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         return adapter;
     }

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
@@ -63,7 +63,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
         }

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
@@ -103,10 +103,10 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
             authHandler.append(new X509AuthHandler(
                     new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
                     Optional.ofNullable(clientCertAuthProvider).orElse(
-                            new X509AuthProvider(getCredentialsServiceClient(), getConfig(), tracer))));
+                            new X509AuthProvider(getCredentialsClientFactory(), getConfig(), tracer))));
             authHandler.append(new HonoBasicAuthHandler(
                     Optional.ofNullable(usernamePasswordAuthProvider).orElse(
-                            new UsernamePasswordAuthProvider(getCredentialsServiceClient(), getConfig(), tracer)),
+                            new UsernamePasswordAuthProvider(getCredentialsClientFactory(), getConfig(), tracer)),
                     getConfig().getRealm(), tracer));
             addTelemetryApiRoutes(router, authHandler);
             addEventApiRoutes(router, authHandler);

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -33,6 +33,7 @@ import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.MessageSender;
@@ -89,7 +90,7 @@ public class VertxBasedHttpProtocolAdapterTest {
     private static final String CMD_REQ_ID = "12fcmd-client-c925910f-ea2a-455c-a3f9-a339171f335474f48a55-c60d-4b99-8950-a2fbb9e8f1b6";
 
     private static TenantClientFactory tenantClientFactory;
-    private static HonoClient credentialsServiceClient;
+    private static CredentialsClientFactory credentialsClientFactory;
     private static HonoClient messagingClient;
     private static MessageSender telemetrySender;
     private static MessageSender eventSender;
@@ -135,13 +136,13 @@ public class VertxBasedHttpProtocolAdapterTest {
             return null;
         }).when(tenantClientFactory).disconnect(any(Handler.class));
 
-        credentialsServiceClient = mock(HonoClient.class);
-        when(credentialsServiceClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(credentialsServiceClient));
+        credentialsClientFactory = mock(CredentialsClientFactory.class);
+        when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
         doAnswer(invocation -> {
             final Handler<AsyncResult<Void>> shutdownHandler = invocation.getArgument(0);
             shutdownHandler.handle(Future.succeededFuture());
             return null;
-        }).when(credentialsServiceClient).shutdown(any(Handler.class));
+        }).when(credentialsClientFactory).disconnect(any(Handler.class));
 
         messagingClient = mock(HonoClient.class);
         when(messagingClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingClient));
@@ -181,7 +182,7 @@ public class VertxBasedHttpProtocolAdapterTest {
         httpAdapter = new VertxBasedHttpProtocolAdapter();
         httpAdapter.setConfig(config);
         httpAdapter.setTenantClientFactory(tenantClientFactory);
-        httpAdapter.setCredentialsServiceClient(credentialsServiceClient);
+        httpAdapter.setCredentialsClientFactory(credentialsClientFactory);
         httpAdapter.setHonoMessagingClient(messagingClient);
         httpAdapter.setRegistrationClientFactory(registrationClientFactory);
         httpAdapter.setCommandConsumerFactory(commandConsumerFactory);

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
@@ -64,7 +64,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_KURA_ADAPTER);
         }

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/Config.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/Config.java
@@ -78,7 +78,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_LORA_ADAPTER);
         }

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraProtocolAdapter.java
@@ -171,10 +171,10 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
         authHandler.append(new X509AuthHandler(
                 new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
                 Optional.ofNullable(clientCertAuthProvider).orElse(
-                        new X509AuthProvider(getCredentialsServiceClient(), getConfig(), tracer))));
+                        new X509AuthProvider(getCredentialsClientFactory(), getConfig(), tracer))));
         authHandler.append(new HonoBasicAuthHandler(
                 Optional.ofNullable(usernamePasswordAuthProvider).orElse(
-                        new UsernamePasswordAuthProvider(getCredentialsServiceClient(), getConfig(), tracer)),
+                        new UsernamePasswordAuthProvider(getCredentialsClientFactory(), getConfig(), tracer)),
                 getConfig().getRealm(), tracer));
 
         router.route().handler(authHandler);
@@ -521,7 +521,7 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
 
     private Future<CredentialsObject> getGatewayCredentials(final String tenantId, final JsonObject data) {
         final String authId = data.getString(LoraConstants.FIELD_AUTH_ID);
-        return getCredentialsServiceClient().getOrCreateCredentialsClient(tenantId)
+        return getCredentialsClientFactory().getOrCreateCredentialsClient(tenantId)
                 .compose(credentialsClient -> credentialsClient.get(LoraConstants.FIELD_PSK, authId));
     }
 

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -170,10 +170,10 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         return new ChainAuthHandler<MqttContext>()
                 .append(new X509AuthHandler(
                         new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
-                        new X509AuthProvider(getCredentialsServiceClient(), getConfig(), tracer)))
+                        new X509AuthProvider(getCredentialsClientFactory(), getConfig(), tracer)))
                 .append(new ConnectPacketAuthHandler(
                         new UsernamePasswordAuthProvider(
-                                getCredentialsServiceClient(),
+                                getCredentialsClientFactory(),
                                 getConfig(),
                                 tracer)));
     }

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -41,6 +41,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandConsumerFactory;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.MessageSender;
@@ -108,7 +109,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     public Timeout globalTimeout = new Timeout(5000, TimeUnit.SECONDS);
 
     private TenantClientFactory tenantClientFactory;
-    private HonoClient credentialsServiceClient;
+    private CredentialsClientFactory credentialsClientFactory;
     private HonoClient messagingClient;
     private RegistrationClientFactory registrationClientFactory;
     private RegistrationClient regClient;
@@ -154,10 +155,9 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
         when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
 
-        credentialsServiceClient = mock(HonoClient.class);
-        when(credentialsServiceClient.isConnected()).thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
-        when(credentialsServiceClient.connect(any(Handler.class)))
-                .thenReturn(Future.succeededFuture(credentialsServiceClient));
+        credentialsClientFactory = mock(CredentialsClientFactory.class);
+        when(credentialsClientFactory.isConnected()).thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
+        when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         messagingClient = mock(HonoClient.class);
         when(messagingClient.isConnected()).thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
@@ -1035,7 +1035,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(tenantClientFactory.isConnected()).thenReturn(Future.succeededFuture());
         when(messagingClient.isConnected()).thenReturn(Future.succeededFuture());
         when(registrationClientFactory.isConnected()).thenReturn(Future.succeededFuture());
-        when(credentialsServiceClient.isConnected()).thenReturn(Future.succeededFuture());
+        when(credentialsClientFactory.isConnected()).thenReturn(Future.succeededFuture());
         when(commandConsumerFactory.isConnected()).thenReturn(Future.succeededFuture());
     }
 
@@ -1092,7 +1092,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setHonoMessagingClient(messagingClient);
         adapter.setRegistrationClientFactory(registrationClientFactory);
-        adapter.setCredentialsServiceClient(credentialsServiceClient);
+        adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setAuthHandler(authHandler);
         adapter.setResourceLimitChecks(resourceLimitChecks);

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
@@ -67,7 +67,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties props) {
+    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.CommandConsumerFactory;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
@@ -197,14 +198,14 @@ public abstract class AbstractAdapterConfig {
     @Qualifier(CredentialsConstants.CREDENTIALS_ENDPOINT)
     @ConfigurationProperties(prefix = "hono.credentials")
     @Bean
-    public ClientConfigProperties credentialsServiceClientConfig() {
+    public ClientConfigProperties credentialsClientFactoryConfig() {
         final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
-        customizeCredentialsServiceClientConfig(config);
+        customizeCredentialsClientFactoryConfig(config);
         return config;
     }
 
     /**
-     * Further customizes the properties provided by the {@link #credentialsServiceClientConfig()}
+     * Further customizes the properties provided by the {@link #credentialsClientFactoryConfig()}
      * method.
      * <p>
      * This method does nothing by default. Subclasses may override this method to set additional
@@ -212,20 +213,20 @@ public abstract class AbstractAdapterConfig {
      *
      * @param config The configuration to customize.
      */
-    protected void customizeCredentialsServiceClientConfig(final RequestResponseClientConfigProperties config) {
+    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties config) {
         // empty by default
     }
 
     /**
-     * Exposes a client for the <em>Credentials</em> API as a Spring bean.
+     * Exposes a factory for creating clients for the <em>Credentials</em> API as a Spring bean.
      *
-     * @return The client.
+     * @return The factory.
      */
     @Bean
     @Qualifier(CredentialsConstants.CREDENTIALS_ENDPOINT)
     @Scope("prototype")
-    public HonoClient credentialsServiceClient() {
-        return new HonoClientImpl(vertx(), credentialsServiceClientConfig());
+    public CredentialsClientFactory credentialsClientFactory() {
+        return new HonoClientImpl(vertx(), credentialsClientFactoryConfig());
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/CredentialsApiAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/CredentialsApiAuthProvider.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CredentialsClient;
-import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.auth.DeviceUser;
@@ -52,18 +52,18 @@ public abstract class CredentialsApiAuthProvider<T extends AbstractDeviceCredent
      * A logger to be used by subclasses.
      */
     protected final Logger log = LoggerFactory.getLogger(getClass());
-    private final HonoClient credentialsServiceClient;
+    private final CredentialsClientFactory credentialsServiceClient;
     private final Tracer tracer;
 
     /**
-     * Creates a new authentication provider for a credentials service client.
+     * Creates a new authentication provider for a credentials client factory.
      * 
-     * @param credentialsServiceClient The client.
+     * @param credentialsClientFactory The factory.
      * @param tracer The tracer instance.
-     * @throws NullPointerException if the client or the tracer is {@code null}
+     * @throws NullPointerException if the factory or the tracer are {@code null}
      */
-    public CredentialsApiAuthProvider(final HonoClient credentialsServiceClient, final Tracer tracer) {
-        this.credentialsServiceClient = Objects.requireNonNull(credentialsServiceClient);
+    public CredentialsApiAuthProvider(final CredentialsClientFactory credentialsClientFactory, final Tracer tracer) {
+        this.credentialsServiceClient = Objects.requireNonNull(credentialsClientFactory);
         this.tracer = Objects.requireNonNull(tracer);
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,7 +20,7 @@ import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.util.CredentialsObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,20 +44,20 @@ public final class UsernamePasswordAuthProvider extends CredentialsApiAuthProvid
     /**
      * Creates a new provider for a given configuration.
      * 
-     * @param credentialsServiceClient The client.
+     * @param credentialsClientFactory The factory to use for creating a Credentials service client.
      * @param config The configuration.
      * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
-    public UsernamePasswordAuthProvider(final HonoClient credentialsServiceClient, final ServiceConfigProperties config, final Tracer tracer) {
-        this(credentialsServiceClient, new SpringBasedHonoPasswordEncoder(), config, tracer);
+    public UsernamePasswordAuthProvider(final CredentialsClientFactory credentialsClientFactory, final ServiceConfigProperties config, final Tracer tracer) {
+        this(credentialsClientFactory, new SpringBasedHonoPasswordEncoder(), config, tracer);
     }
 
     /**
      * Creates a new provider for a given configuration.
      * 
-     * @param credentialsServiceClient The client.
+     * @param credentialsClientFactory The factory to use for creating a Credentials service client.
      * @param pwdEncoder The object to use for validating hashed passwords.
      * @param config The configuration.
      * @param tracer The tracer instance.
@@ -65,12 +65,12 @@ public final class UsernamePasswordAuthProvider extends CredentialsApiAuthProvid
      */
     @Autowired
     public UsernamePasswordAuthProvider(
-            final HonoClient credentialsServiceClient,
+            final CredentialsClientFactory credentialsClientFactory,
             final HonoPasswordEncoder pwdEncoder,
             final ServiceConfigProperties config,
             final Tracer tracer) {
 
-        super(credentialsServiceClient, tracer);
+        super(credentialsClientFactory, tracer);
         this.config = Objects.requireNonNull(config);
         this.pwdEncoder = Objects.requireNonNull(pwdEncoder);
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
@@ -41,14 +41,14 @@ public class X509AuthProvider extends CredentialsApiAuthProvider<SubjectDnCreden
     /**
      * Creates a new provider for a given configuration.
      * 
-     * @param credentialsServiceClient The client.
+     * @param credentialsClientFactory The factory to use for creating a Credentials service client.
      * @param config The configuration.
      * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
-    public X509AuthProvider(final HonoClient credentialsServiceClient, final ServiceConfigProperties config, final Tracer tracer) {
-        super(credentialsServiceClient, tracer);
+    public X509AuthProvider(final CredentialsClientFactory credentialsClientFactory, final ServiceConfigProperties config, final Tracer tracer) {
+        super(credentialsClientFactory, tracer);
         this.config = Objects.requireNonNull(config);
     }
 

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -31,6 +31,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandConsumerFactory;
+import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.ReconnectListener;
@@ -85,7 +86,7 @@ public class AbstractProtocolAdapterBaseTest {
     private RegistrationClient registrationClient;
     private TenantClientFactory tenantService;
     private RegistrationClientFactory registrationClientFactory;
-    private HonoClient credentialsService;
+    private CredentialsClientFactory credentialsClientFactory;
     private HonoClient messagingService;
     private CommandConsumerFactory commandConsumerFactory;
 
@@ -105,8 +106,8 @@ public class AbstractProtocolAdapterBaseTest {
         registrationClient = mock(RegistrationClient.class);
         when(registrationClientFactory.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(registrationClient));
 
-        credentialsService = mock(HonoClient.class);
-        when(credentialsService.connect(any(Handler.class))).thenReturn(Future.succeededFuture(credentialsService));
+        credentialsClientFactory = mock(CredentialsClientFactory.class);
+        when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         messagingService = mock(HonoClient.class);
         when(messagingService.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingService));
@@ -118,7 +119,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter = newProtocolAdapter(properties);
         adapter.setTenantClientFactory(tenantService);
         adapter.setRegistrationClientFactory(registrationClientFactory);
-        adapter.setCredentialsServiceClient(credentialsService);
+        adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setHonoMessagingClient(messagingService);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
 
@@ -174,7 +175,7 @@ public class AbstractProtocolAdapterBaseTest {
             verify(tenantService).connect();
             verify(registrationClientFactory).connect();
             verify(messagingService).connect(any(Handler.class));
-            verify(credentialsService).connect(any(Handler.class));
+            verify(credentialsClientFactory).connect();
             verify(commandConsumerFactory).connect();
             verify(commandConsumerFactory).addDisconnectListener(any(DisconnectListener.class));
             verify(commandConsumerFactory).addReconnectListener(any(ReconnectListener.class));
@@ -224,7 +225,7 @@ public class AbstractProtocolAdapterBaseTest {
 
         adapter = newProtocolAdapter(properties, "test", startupHandler,
                 commandConnectionEstablishedHandler, commandConnectionLostHandler);
-        adapter.setCredentialsServiceClient(credentialsService);
+        adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setHonoMessagingClient(messagingService);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setTenantClientFactory(tenantService);

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -46,6 +46,16 @@ title = "Release Notes"
   `org.eclipse.hono.client.RegistrationClient` instances.
   The *setRegistrationServiceClient* and *getRegistrationServiceClient* methods have been
   renamed to *setRegistrationClientFactory* and *getRegistrationClientFactory* correspondingly.
+* The `org.eclipse.hono.service.AbstractProtocolAdapterBase` class now uses
+  `org.eclipse.hono.client.CredentialsClientFactory` instead of
+  `org.eclipse.hono.client.HonoClient` for creating
+  `org.eclipse.hono.client.CredentialsClient` instances.
+  The *setCredentialsServiceClient* and *getCredentialsServiceClient* methods have been
+  renamed to *setCredentialsClientFactory* and *getCredentialsClientFactory* correspondingly.
+* The `org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider` and the
+  `org.eclipse.hono.service.auth.device.X509AuthProvider` now accept a
+  `org.eclipse.hono.client.CredentialsClientFactory` instead of a
+  `org.eclipse.hono.client.HonoClient` in their constructors.
 
 ## 1.0-M1
 


### PR DESCRIPTION
The protocol adapters have been changed to use the
CredentialsClientFactory instead of the HonoClient
for creating CredentialsClient instances.
