### PR TITLE
[#927] Rename limits to resource-limits in tenant config.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -75,9 +75,9 @@ public final class TenantConstants extends RequestResponseApiConstants {
     public static final String EVENT_BUS_ADDRESS_TENANT_IN = "tenant.in";
 
     /**
-     * The name of the property that contains the configuration options for limits.
+     * The name of the property that contains the configuration options for the resource limits.
      */
-    public static final String LIMITS = "limits";
+    public static final String RESOURCE_LIMITS = "resource-limits";
 
     /**
      * The default value for the maximum number of connections to be allowed is -1, which implies no limit.

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -505,7 +505,7 @@ public final class TenantObject extends JsonBackedValueObject {
      */
     @JsonIgnore
     public long getConnectionsLimit() {
-        return Optional.ofNullable(getProperty(TenantConstants.LIMITS))
+        return Optional.ofNullable(getProperty(TenantConstants.RESOURCE_LIMITS))
                 .map(limits -> getProperty((JsonObject) limits, TenantConstants.MAX_CONNECTIONS,
                         (Number) TenantConstants.DEFAULT_MAX_CONNECTIONS).longValue())
                 .orElse(TenantConstants.DEFAULT_MAX_CONNECTIONS);

--- a/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
@@ -304,7 +304,7 @@ public class TenantObjectTest {
         final JsonObject limitsConfig = new JsonObject()
                 .put(TenantConstants.MAX_CONNECTIONS, 2);
         final TenantObject obj = TenantObject.from(Constants.DEFAULT_TENANT, true);
-        obj.setProperty(TenantConstants.LIMITS, limitsConfig);
+        obj.setProperty(TenantConstants.RESOURCE_LIMITS, limitsConfig);
         assertThat(obj.getConnectionsLimit(), is(2L));
     }
 


### PR DESCRIPTION
As [discussed](https://github.com/eclipse/hono/pull/1133#discussion_r273019726), the tenant configuration parameter `limits` has been renamed to `resource-limits`.