### PR TITLE
[#930] Add "registration/*:get" permissions for protocol adapters

### DIFF
--- a/deploy/src/main/deploy/example-permissions.json
+++ b/deploy/src/main/deploy/example-permissions.json
@@ -18,6 +18,10 @@
         "activities": [ "EXECUTE" ]
       },
       {
+        "operation": "registration/*:get",
+        "activities": [ "EXECUTE" ]
+      },
+      {
         "resource": "credentials/*",
         "activities": [ "READ", "WRITE" ]
       },

--- a/deploy/src/main/sandbox/sandbox-permissions.json
+++ b/deploy/src/main/sandbox/sandbox-permissions.json
@@ -18,6 +18,10 @@
         "activities": [ "EXECUTE" ]
       },
       {
+        "operation": "registration/*:get",
+        "activities": [ "EXECUTE" ]
+      },
+      {
         "resource": "credentials/*",
         "activities": [ "READ", "WRITE" ]
       },

--- a/services/auth/src/main/resources/permissions.json
+++ b/services/auth/src/main/resources/permissions.json
@@ -18,6 +18,10 @@
         "activities": [ "EXECUTE" ]
       },
       {
+        "operation": "registration/*:get",
+        "activities": [ "EXECUTE" ]
+      },
+      {
         "resource": "credentials/*",
         "activities": [ "READ", "WRITE" ]
       },

--- a/services/auth/src/test/resources/authentication-service-test-permissions.json
+++ b/services/auth/src/test/resources/authentication-service-test-permissions.json
@@ -18,6 +18,10 @@
         "activities": [ "EXECUTE" ]
       },
       {
+        "operation": "registration/*:get",
+        "activities": [ "EXECUTE" ]
+      },
+      {
         "resource": "credentials/*",
         "activities": [ "READ", "WRITE" ]
       },

--- a/tests/src/test/resources/auth/permissions.json
+++ b/tests/src/test/resources/auth/permissions.json
@@ -3,148 +3,103 @@
     "protocol-adapter": [
       {
         "resource": "telemetry/*",
-        "activities": [
-          "WRITE"
-        ]
+        "activities": [ "WRITE" ]
       },
       {
         "resource": "event/*",
-        "activities": [
-          "WRITE"
-        ]
+        "activities": [ "WRITE" ]
       },
       {
         "resource": "registration/*",
-        "activities": [
-          "READ",
-          "WRITE"
-        ]
+        "activities": [ "READ", "WRITE" ]
       },
       {
         "operation": "registration/*:assert",
-        "activities": [
-          "EXECUTE"
-        ]
+        "activities": [ "EXECUTE" ]
+      },
+      {
+        "operation": "registration/*:get",
+        "activities": [ "EXECUTE" ]
       },
       {
         "resource": "credentials/*",
-        "activities": [
-          "READ",
-          "WRITE"
-        ]
+        "activities": [ "READ", "WRITE" ]
       },
       {
         "operation": "credentials/*:get",
-        "activities": [
-          "EXECUTE"
-        ]
+        "activities": [ "EXECUTE" ]
       },
       {
         "resource": "tenant",
-        "activities": [
-          "READ",
-          "WRITE"
-        ]
+        "activities": [ "READ", "WRITE" ]
       },
       {
         "operation": "tenant/*:*",
-        "activities": [
-          "EXECUTE"
-        ]
+        "activities": [ "EXECUTE" ]
       }
     ],
     "DEFAULT_TENANT-manager": [
       {
         "resource": "registration/DEFAULT_TENANT",
-        "activities": [
-          "READ",
-          "WRITE"
-        ]
+        "activities": [ "READ", "WRITE" ]
       },
       {
         "operation": "registration/DEFAULT_TENANT:*",
-        "activities": [
-          "EXECUTE"
-        ]
+        "activities": [ "EXECUTE" ]
       },
       {
         "resource": "credentials/DEFAULT_TENANT",
-        "activities": [
-          "READ",
-          "WRITE"
-        ]
+        "activities": [ "READ", "WRITE" ]
       },
       {
         "operation": "credentials/DEFAULT_TENANT:*",
-        "activities": [
-          "EXECUTE"
-        ]
+        "activities": [ "EXECUTE" ]
       },
       {
         "resource": "telemetry/DEFAULT_TENANT",
-        "activities": [
-          "WRITE"
-        ]
+        "activities": [ "WRITE" ]
       },
       {
         "resource": "event/DEFAULT_TENANT",
-        "activities": [
-          "WRITE"
-        ]
+        "activities": [ "WRITE" ]
       },
       {
         "resource": "tenant",
-        "activities": [
-          "READ",
-          "WRITE"
-        ]
+        "activities": [ "READ", "WRITE" ]
       },
       {
         "operation": "tenant/DEFAULT_TENANT:*",
-        "activities": [
-          "EXECUTE"
-        ]
+        "activities": [ "EXECUTE" ]
       },
       {
         "operation": "tenant/NON_EXISTING_TENANT:*",
-        "activities": [
-          "EXECUTE"
-        ]
+        "activities": [ "EXECUTE" ]
       }
     ],
     "connector": [
       {
         "resource": "telemetry/DEFAULT_TENANT/fluxcapacitor",
-        "activities": [
-          "WRITE"
-        ]
+        "activities": [ "WRITE" ]
       }
     ],
     "provisioner": [
       {
         "resource": "registration/DEFAULT_TENANT",
-        "activities": [
-          "READ"
-        ]
+        "activities": [ "READ" ]
       },
       {
         "resource": "registration/DEFAULT_TENANT/fluxcapacitor",
-        "activities": [
-          "WRITE"
-        ]
+        "activities": [ "WRITE" ]
       }
     ],
     "application": [
       {
         "resource": "telemetry/*",
-        "activities": [
-          "READ"
-        ]
-      }, {
+        "activities": [ "READ" ]
+      },
+      {
         "resource": "event/*",
-        "activities": [
-          "READ"
-        ]
+        "activities": [ "READ" ]
       },
       {
         "resource": "control/*",
@@ -154,14 +109,10 @@
     "DEFAULT_TENANT-application": [
       {
         "resource": "telemetry/DEFAULT_TENANT",
-        "activities": [
-          "READ"
-        ]
+        "activities": [ "READ" ]
       }, {
         "resource": "event/DEFAULT_TENANT",
-        "activities": [
-          "READ"
-        ]
+        "activities": [ "READ" ]
       },
       {
         "resource": "control/DEFAULT_TENANT",


### PR DESCRIPTION
This is for #930 / #1145, allowing protocol adapters to invoke `getDevice` from the Device Registration API.