### PR TITLE
[#930] Allow creation of anonymous sender links

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
@@ -144,7 +144,10 @@ public final class HonoProtonHelper {
      */
     public static boolean isLinkEstablished(final ProtonLink<?> link) {
         if (link instanceof ProtonSender) {
-            return link.getRemoteTarget() != null && link.getRemoteTarget().getAddress() != null;
+            // check for non-null remote target address - or if it is null, for an anonymous sender link (with empty local target address)
+            return link.getRemoteTarget() != null
+                    && (link.getRemoteTarget().getAddress() != null
+                            || (link.getTarget() != null && link.getTarget().getAddress() != null && link.getTarget().getAddress().isEmpty()));
         } else if (link instanceof ProtonReceiver) {
             return link.getRemoteSource() != null && link.getRemoteSource().getAddress() != null;
         } else {

--- a/deploy/src/main/config/qpid/qdrouterd-with-broker.json
+++ b/deploy/src/main/config/qpid/qdrouterd-with-broker.json
@@ -113,6 +113,7 @@
           "maxSessionWindow": 6553600,
           "maxMessageSize": 131072,
           "allowUserIdProxy": true,
+          "allowAnonymousSender": true,
           "sources": "control/*",
           "targets": "telemetry/*, event/*, control/*"
         }

--- a/deploy/src/main/sandbox/qpid/sandbox-qdrouterd.json
+++ b/deploy/src/main/sandbox/qpid/sandbox-qdrouterd.json
@@ -104,6 +104,7 @@
         "$default": {
           "remoteHosts": "*",
           "allowUserIdProxy": true,
+          "allowAnonymousSender": true,
           "targets": "telemetry/*, event/*, control/*",
           "sources": "control/*"
         }

--- a/tests/src/test/resources/qpid/qdrouterd-with-broker.json
+++ b/tests/src/test/resources/qpid/qdrouterd-with-broker.json
@@ -115,6 +115,7 @@
           "maxSessions": 2,
           "maxMessageSize": 131072,
           "allowUserIdProxy": true,
+          "allowAnonymousSender": true,
           "targets": "telemetry/*, event/*, control/*",
           "sources": "control/*"
         }


### PR DESCRIPTION
This is for #930 / #1145, allowing protocol adapters to create anonymous sender links. 
These sender links are used for forwarding the commands, that were received on the tenant-scoped address, back to the AMQP network, so that they can be consumed by the device-specific consumers.