### PR TITLE
#780] Use DownstreamSenderFactory instead of HonoClient.

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
@@ -50,7 +50,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeMessagingClientConfig(final ClientConfigProperties config) {
+    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties config) {
         if (config.getName() == null) {
             config.setName(CONTAINER_ID_HONO_AMQP_ADAPTER);
         }

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -51,6 +51,7 @@ import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.MessageSender;
@@ -117,7 +118,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
     private TenantClientFactory tenantClientFactory;
     private CredentialsClientFactory credentialsClientFactory;
-    private HonoClient messagingServiceClient;
+    private DownstreamSenderFactory downstreamSenderFactory;
     private RegistrationClientFactory registrationClientFactory;
     private CommandConsumerFactory commandConsumerFactory;
 
@@ -132,7 +133,6 @@ public class VertxBasedAmqpProtocolAdapterTest {
      * 
      * @param context The vert.x test context.
      */
-    @SuppressWarnings("unchecked")
     @Before
     public void setup(final TestContext context) {
 
@@ -150,9 +150,8 @@ public class VertxBasedAmqpProtocolAdapterTest {
         credentialsClientFactory = mock(CredentialsClientFactory.class);
         when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
-        messagingServiceClient = mock(HonoClient.class);
-        when(messagingServiceClient.connect(any(Handler.class)))
-                .thenReturn(Future.succeededFuture(messagingServiceClient));
+        downstreamSenderFactory = mock(DownstreamSenderFactory.class);
+        when(downstreamSenderFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         registrationClient = mock(RegistrationClient.class);
         final JsonObject regAssertion = new JsonObject().put(RegistrationConstants.FIELD_ASSERTION, "assert-token");
@@ -812,7 +811,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
     private MessageSender givenATelemetrySenderForAnyTenant() {
         final MessageSender sender = mock(MessageSender.class);
-        when(messagingServiceClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
         return sender;
     }
 
@@ -827,7 +826,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         final MessageSender sender = mock(MessageSender.class);
         when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(outcome);
 
-        when(messagingServiceClient.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
         return sender;
     }
 
@@ -854,7 +853,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         adapter.setConfig(config);
         adapter.setInsecureAmqpServer(server);
         adapter.setTenantClientFactory(tenantClientFactory);
-        adapter.setHonoMessagingClient(messagingServiceClient);
+        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -45,6 +45,7 @@ import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
@@ -91,7 +92,7 @@ public class AbstractVertxBasedCoapAdapterTest {
 
     private CredentialsClientFactory credentialsClientFactory;
     private TenantClientFactory tenantClientFactory;
-    private HonoClient messagingClient;
+    private DownstreamSenderFactory downstreamSenderFactory;
     private RegistrationClientFactory registrationClientFactory;
     private RegistrationClient regClient;
     private TenantClient tenantClient;
@@ -101,7 +102,6 @@ public class AbstractVertxBasedCoapAdapterTest {
     /**
      * Sets up common fixture.
      */
-    @SuppressWarnings("unchecked")
     @Before
     public void setup() {
 
@@ -125,8 +125,8 @@ public class AbstractVertxBasedCoapAdapterTest {
         credentialsClientFactory = mock(CredentialsClientFactory.class);
         when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
-        messagingClient = mock(HonoClient.class);
-        when(messagingClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingClient));
+        downstreamSenderFactory = mock(DownstreamSenderFactory.class);
+        when(downstreamSenderFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         registrationClientFactory = mock(RegistrationClientFactory.class);
         when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
@@ -313,7 +313,7 @@ public class AbstractVertxBasedCoapAdapterTest {
 
         // GIVEN an adapter
         final MessageSender sender = mock(MessageSender.class);
-        when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
         // which is disabled for tenant "my-tenant"
         final TenantObject myTenantConfig = TenantObject.from("my-tenant", true);
         myTenantConfig.addAdapterConfiguration(new JsonObject()
@@ -514,7 +514,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         adapter.setConfig(config);
         adapter.setCoapServer(server);
         adapter.setTenantClientFactory(tenantClientFactory);
-        adapter.setHonoMessagingClient(messagingClient);
+        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         if (complete) {
             adapter.setCredentialsClientFactory(credentialsClientFactory);
@@ -531,7 +531,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final MessageSender sender = mock(MessageSender.class);
         when(sender.sendAndWaitForOutcome(any(Message.class))).thenReturn(outcome);
 
-        when(messagingClient.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
     }
 
     private void givenATelemetrySenderForOutcome(final Future<ProtonDelivery> outcome) {
@@ -539,7 +539,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final MessageSender sender = mock(MessageSender.class);
         when(sender.sendAndWaitForOutcome(any(Message.class))).thenReturn(outcome);
 
-        when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
     }
 
     private void givenATelemetrySender(final Future<ProtonDelivery> outcome) {
@@ -547,7 +547,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final MessageSender sender = mock(MessageSender.class);
         when(sender.send(any(Message.class))).thenReturn(outcome);
 
-        when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
     }
 
 }

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
@@ -49,7 +49,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeMessagingClientConfig(final ClientConfigProperties props) {
+    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
         }

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -38,6 +38,7 @@ import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.RegistrationClient;
@@ -105,7 +106,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
 
     private CredentialsClientFactory      credentialsClientFactory;
     private TenantClientFactory           tenantClientFactory;
-    private HonoClient                    messagingClient;
+    private DownstreamSenderFactory       downstreamSenderFactory;
     private RegistrationClientFactory     registrationClientFactory;
     private RegistrationClient            regClient;
     private TenantClient                  tenantClient;
@@ -153,8 +154,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         credentialsClientFactory = mock(CredentialsClientFactory.class);
         when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
-        messagingClient = mock(HonoClient.class);
-        when(messagingClient.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingClient));
+        downstreamSenderFactory = mock(DownstreamSenderFactory.class);
+        when(downstreamSenderFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         registrationClientFactory = mock(RegistrationClientFactory.class);
         when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
@@ -849,7 +850,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         adapter.setMetrics(metrics);
         adapter.setInsecureHttpServer(server);
         adapter.setTenantClientFactory(tenantClientFactory);
-        adapter.setHonoMessagingClient(messagingClient);
+        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
@@ -870,7 +871,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         final MessageSender sender = mock(MessageSender.class);
         when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(outcome);
 
-        when(messagingClient.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
         return sender;
     }
 
@@ -879,7 +880,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         final MessageSender sender = mock(MessageSender.class);
         when(sender.send(any(Message.class), (SpanContext) any())).thenReturn(outcome);
 
-        when(messagingClient.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
         return sender;
     }
 

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
@@ -49,7 +49,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeMessagingClientConfig(final ClientConfigProperties props) {
+    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
         }

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
@@ -50,7 +50,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeMessagingClientConfig(final ClientConfigProperties props) {
+    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_KURA_ADAPTER);
         }

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/Config.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/Config.java
@@ -64,7 +64,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeMessagingClientConfig(final ClientConfigProperties props) {
+    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_LORA_ADAPTER);
         }

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
@@ -53,7 +53,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeMessagingClientConfig(final ClientConfigProperties props) {
+    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
         if (props.getName() == null) {
             props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CredentialsClientFactory;
-import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.TenantClientFactory;
@@ -28,8 +28,8 @@ import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.VertxProperties;
 import org.eclipse.hono.service.cache.SpringCacheProvider;
-import org.eclipse.hono.service.plan.ResourceLimitChecks;
 import org.eclipse.hono.service.plan.PrometheusBasedResourceLimitChecks;
+import org.eclipse.hono.service.plan.ResourceLimitChecks;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
@@ -89,21 +89,21 @@ public abstract class AbstractAdapterConfig {
      * Exposes configuration properties for accessing the AMQP Messaging Network as a Spring bean.
      * <p>
      * The properties can be customized in subclasses by means of overriding the
-     * {@link #customizeMessagingClientConfig(ClientConfigProperties)} method.
+     * {@link #customizeDownstreamSenderFactoryConfig(ClientConfigProperties)} method.
      *
      * @return The properties.
      */
     @Qualifier(Constants.QUALIFIER_MESSAGING)
     @ConfigurationProperties(prefix = "hono.messaging")
     @Bean
-    public ClientConfigProperties messagingClientConfig() {
+    public ClientConfigProperties downstreamSenderFactoryConfig() {
         final ClientConfigProperties config = new ClientConfigProperties();
-        customizeMessagingClientConfig(config);
+        customizeDownstreamSenderFactoryConfig(config);
         return config;
     }
 
     /**
-     * Further customizes the client properties provided by the {@link #messagingClientConfig()}
+     * Further customizes the client properties provided by the {@link #downstreamSenderFactoryConfig()}
      * method.
      * <p>
      * This method does nothing by default. Subclasses may override this method to set additional
@@ -111,22 +111,22 @@ public abstract class AbstractAdapterConfig {
      *
      * @param config The client configuration to customize.
      */
-    protected void customizeMessagingClientConfig(final ClientConfigProperties config) {
+    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties config) {
         // empty by default
     }
 
     /**
-     * Exposes a client for the <em>AMQP Messaging Network</em> as a Spring bean.
+     * Exposes a factory for creating clients for the <em>AMQP Messaging Network</em> as a Spring bean.
      * <p>
-     * The client is configured with the properties provided by {@link #messagingClientConfig()}.
+     * The factory is configured with the properties provided by {@link #downstreamSenderFactoryConfig()}.
      *
-     * @return The client.
+     * @return The factory.
      */
     @Qualifier(Constants.QUALIFIER_MESSAGING)
     @Bean
     @Scope("prototype")
-    public HonoClient messagingClient() {
-        return new HonoClientImpl(vertx(), messagingClientConfig());
+    public DownstreamSenderFactory downstreamSenderFactory() {
+        return new HonoClientImpl(vertx(), downstreamSenderFactoryConfig());
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 
 import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.util.EventConstants;
 
@@ -30,9 +30,9 @@ import io.vertx.core.json.JsonObject;
 public abstract class AbstractMessageSenderConnectionEventProducer implements ConnectionEventProducer {
 
     /**
-     * The function to derive the {@link MessageSender} from the provided <em>Message Sender Client</em>.
+     * The function to derive the {@link MessageSender} from the provided sender factory.
      */
-    private final BiFunction<HonoClient, String, Future<MessageSender>> messageSenderSource;
+    private final BiFunction<DownstreamSenderFactory, String, Future<MessageSender>> messageSenderSource;
 
     /**
      * A {@link ConnectionEventProducer} which will send events using a provided {@link MessageSender}.
@@ -41,7 +41,8 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
      *            should be used for actually sending the events.
      */
     protected AbstractMessageSenderConnectionEventProducer(
-            final BiFunction<HonoClient, String, Future<MessageSender>> messageSenderSource) {
+            final BiFunction<DownstreamSenderFactory,
+            String, Future<MessageSender>> messageSenderSource) {
 
         Objects.requireNonNull(messageSenderSource);
 
@@ -49,19 +50,34 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
     }
 
     @Override
-    public Future<?> connected(final Context context, final String remoteId, final String protocolAdapter,
-            final Device authenticatedDevice, final JsonObject data) {
+    public Future<?> connected(
+            final Context context,
+            final String remoteId,
+            final String protocolAdapter,
+            final Device authenticatedDevice,
+            final JsonObject data) {
+
         return sendNotificationEvent(context, authenticatedDevice, protocolAdapter, remoteId, "connected", data);
     }
 
     @Override
-    public Future<?> disconnected(final Context context, final String remoteId, final String protocolAdapter,
-            final Device authenticatedDevice, final JsonObject data) {
+    public Future<?> disconnected(
+            final Context context,
+            final String remoteId,
+            final String protocolAdapter,
+            final Device authenticatedDevice,
+            final JsonObject data) {
+
         return sendNotificationEvent(context, authenticatedDevice, protocolAdapter, remoteId, "disconnected", data);
     }
 
-    private Future<?> sendNotificationEvent(final Context context, final Device authenticatedDevice,
-            final String protocolAdapter, final String remoteId, final String cause, final JsonObject data) {
+    private Future<?> sendNotificationEvent(
+            final Context context,
+            final Device authenticatedDevice,
+            final String protocolAdapter,
+            final String remoteId,
+            final String cause,
+            final JsonObject data) {
 
         if (authenticatedDevice == null) {
             // we only handle authenticated devices
@@ -88,7 +104,7 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                 });
     }
 
-    private Future<MessageSender> getOrCreateSender(final HonoClient messageSenderClient, final String tenant) {
+    private Future<MessageSender> getOrCreateSender(final DownstreamSenderFactory messageSenderClient, final String tenant) {
         return messageSenderSource.apply(messageSenderClient, tenant);
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
@@ -13,10 +13,11 @@
 package org.eclipse.hono.service.monitoring;
 
 
+import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.client.DownstreamSenderFactory;
+
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.HonoClient;
 
 /**
  * Produces connection events.
@@ -50,7 +51,7 @@ public interface ConnectionEventProducer {
          * @return The instance of the message sender client which the {@link ConnectionEventProducer} method should
          *         use. This client has to be initialized and started.
          */
-        HonoClient getMessageSenderClient();
+        DownstreamSenderFactory getMessageSenderClient();
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/HonoEventConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/HonoEventConnectionEventProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.service.monitoring;
 
-import org.eclipse.hono.client.HonoClient;
+import org.eclipse.hono.client.DownstreamSenderFactory;
 
 /**
  * A connection event producer based on the Hono <em>Event API</em>.
@@ -23,7 +23,6 @@ public class HonoEventConnectionEventProducer extends AbstractMessageSenderConne
      * Create a new <em>connection event producer</em> based on the Hono <em>Event API</em>.
      */
     public HonoEventConnectionEventProducer() {
-        super(HonoClient::getOrCreateEventSender);
+        super(DownstreamSenderFactory::getOrCreateEventSender);
     }
-
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -33,6 +33,7 @@ import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.DisconnectListener;
+import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.ReconnectListener;
 import org.eclipse.hono.client.RegistrationClient;
@@ -87,7 +88,7 @@ public class AbstractProtocolAdapterBaseTest {
     private TenantClientFactory tenantService;
     private RegistrationClientFactory registrationClientFactory;
     private CredentialsClientFactory credentialsClientFactory;
-    private HonoClient messagingService;
+    private DownstreamSenderFactory downstreamSenderFactory;
     private CommandConsumerFactory commandConsumerFactory;
 
     /**
@@ -109,8 +110,8 @@ public class AbstractProtocolAdapterBaseTest {
         credentialsClientFactory = mock(CredentialsClientFactory.class);
         when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
-        messagingService = mock(HonoClient.class);
-        when(messagingService.connect(any(Handler.class))).thenReturn(Future.succeededFuture(messagingService));
+        downstreamSenderFactory = mock(DownstreamSenderFactory.class);
+        when(downstreamSenderFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
 
         commandConsumerFactory = mock(CommandConsumerFactory.class);
         when(commandConsumerFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoClient.class)));
@@ -120,7 +121,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.setTenantClientFactory(tenantService);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsClientFactory(credentialsClientFactory);
-        adapter.setHonoMessagingClient(messagingService);
+        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
 
         vertx = mock(Vertx.class);
@@ -174,7 +175,7 @@ public class AbstractProtocolAdapterBaseTest {
             // THEN the service clients have connected
             verify(tenantService).connect();
             verify(registrationClientFactory).connect();
-            verify(messagingService).connect(any(Handler.class));
+            verify(downstreamSenderFactory).connect();
             verify(credentialsClientFactory).connect();
             verify(commandConsumerFactory).connect();
             verify(commandConsumerFactory).addDisconnectListener(any(DisconnectListener.class));
@@ -226,7 +227,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter = newProtocolAdapter(properties, "test", startupHandler,
                 commandConnectionEstablishedHandler, commandConnectionLostHandler);
         adapter.setCredentialsClientFactory(credentialsClientFactory);
-        adapter.setHonoMessagingClient(messagingService);
+        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setTenantClientFactory(tenantService);
         adapter.setCommandConsumerFactory(commandConsumerFactory);

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -58,6 +58,12 @@ title = "Release Notes"
   `org.eclipse.hono.client.CredentialsClient` instances.
   The *setCredentialsServiceClient* and *getCredentialsServiceClient* methods have been
   renamed to *setCredentialsClientFactory* and *getCredentialsClientFactory* correspondingly.
+* The `org.eclipse.hono.service.AbstractProtocolAdapterBase` class now uses
+  `org.eclipse.hono.client.DownstreamSendertFactory` instead of
+  `org.eclipse.hono.client.HonoClient` for creating
+  `org.eclipse.hono.client.MessageSender` instances.
+  The *setHonoMessagingClient* and *getHonoMessagingClient* methods have been
+  renamed to *setDownstreamSenderFactory* and *getDownstreamSenderFactory* correspondingly.
 * The `org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider` and the
   `org.eclipse.hono.service.auth.device.X509AuthProvider` now accept a
   `org.eclipse.hono.client.CredentialsClientFactory` instead of a


### PR DESCRIPTION
The protocol adapters have been changed to use the
DownstreamSenderFactory instead of the HonoClient
for creating MessageSender instances.
