### PR TITLE
Fix checking logic of connection limit.

### DIFF
--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -180,7 +180,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
         authHandler = mock(AuthHandler.class);
         resourceLimitChecks = mock(ResourceLimitChecks.class);
-        when(resourceLimitChecks.isConnectionLimitExceeded(any(TenantObject.class))).thenReturn(Future.succeededFuture(Boolean.FALSE));
+        when(resourceLimitChecks.isConnectionLimitReached(any(TenantObject.class))).thenReturn(Future.succeededFuture(Boolean.FALSE));
     }
 
     /**
@@ -1021,7 +1021,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         // WHEN a device tries to establish a connection
         when(authHandler.authenticateDevice(any(MqttContext.class)))
                 .thenReturn(Future.succeededFuture(new DeviceUser("DEFAULT_TENANT", "4711")));
-        when(resourceLimitChecks.isConnectionLimitExceeded(any(TenantObject.class)))
+        when(resourceLimitChecks.isConnectionLimitReached(any(TenantObject.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         final MqttEndpoint endpoint = getMqttEndpointAuthenticated();
         adapter.handleEndpointConnection(endpoint);

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -482,7 +482,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * Checks if this adapter may accept another connection from a device.
      * <p>
      * This default implementation uses the
-     * {@link ResourceLimitChecks#isConnectionLimitExceeded(TenantObject)} method
+     * {@link ResourceLimitChecks#isConnectionLimitReached(TenantObject)} method
      * to verify if the tenant's connection limit has been reached.
      * 
      * @param tenantConfig The tenant to check the connection limit for.
@@ -495,7 +495,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     protected Future<Void> checkConnectionLimit(final TenantObject tenantConfig) {
 
         Objects.requireNonNull(tenantConfig);
-        return resourceLimitChecks.isConnectionLimitExceeded(tenantConfig)
+        return resourceLimitChecks.isConnectionLimitReached(tenantConfig)
                 .recover(t -> Future.succeededFuture(Boolean.FALSE))
                 .compose(isExceeded -> {
                     if (isExceeded) {

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/NoopResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/NoopResourceLimitChecks.java
@@ -21,7 +21,7 @@ import org.eclipse.hono.util.TenantObject;
 public class NoopResourceLimitChecks implements ResourceLimitChecks {
 
     @Override
-    public Future<Boolean> isConnectionLimitExceeded(final TenantObject tenantObject) {
+    public Future<Boolean> isConnectionLimitReached(final TenantObject tenantObject) {
         return Future.succeededFuture(Boolean.FALSE);
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
@@ -70,7 +70,7 @@ public final class PrometheusBasedResourceLimitChecks implements ResourceLimitCh
                     tenant.getTenantId());
             return executeQuery(queryParams)
                     .map(currentConnections -> {
-                        if (currentConnections <= tenant.getConnectionsLimit()) {
+                        if (currentConnections < tenant.getConnectionsLimit()) {
                             return Boolean.FALSE;
                         } else {
                             log.trace(

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
@@ -57,7 +57,7 @@ public final class PrometheusBasedResourceLimitChecks implements ResourceLimitCh
     }
 
     @Override
-    public Future<Boolean> isConnectionLimitExceeded(final TenantObject tenant) {
+    public Future<Boolean> isConnectionLimitReached(final TenantObject tenant) {
 
         Objects.requireNonNull(tenant);
 

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/ResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/ResourceLimitChecks.java
@@ -24,7 +24,7 @@ public interface ResourceLimitChecks {
 
     /**
      * Checks if the maximum number of connections configured for a tenant
-     * have been exceeded.
+     * have been reached.
      * 
      * @param tenantObject The tenant configuration to check the limit against.
      * @return A future indicating the outcome of the check.
@@ -32,5 +32,5 @@ public interface ResourceLimitChecks {
      *         The future will be failed with a {@link ServiceInvocationException}
      *         if the check could not be performed.
      */
-    Future<Boolean> isConnectionLimitExceeded(TenantObject tenantObject);
+    Future<Boolean> isConnectionLimitReached(TenantObject tenantObject);
 }


### PR DESCRIPTION
AMQP and MQTT Protocol adapters check the _connection limit_, if configured, before accepting any new connections. The issue is that they allow one more connection above the configured limit. i.e if the _limit_ `max-connection` is set as 2, then the adapters allow 3 connections for that tenant. This PR fixes this issue.
