### PR TITLE
[#929 Part-2] Extend ResourceLimitChecks API to verify the messages limit.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/plan/NoopResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/NoopResourceLimitChecks.java
@@ -24,4 +24,10 @@ public class NoopResourceLimitChecks implements ResourceLimitChecks {
     public Future<Boolean> isConnectionLimitReached(final TenantObject tenantObject) {
         return Future.succeededFuture(Boolean.FALSE);
     }
+
+    @Override
+    public Future<Boolean> isMessageLimitReached(final TenantObject tenantObject,
+            final long payloadSize) {
+        return Future.succeededFuture(Boolean.FALSE);
+    }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecksConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecksConfig.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.plan;
+
+import java.util.Objects;
+
+import org.eclipse.hono.util.PortConfigurationHelper;
+
+/**
+ * The configuration properties required for the PrometheusBasedResourceLimitChecks.
+ */
+public final class PrometheusBasedResourceLimitChecksConfig {
+
+    /**
+     * The default minimum size of caches.
+     */
+    static final int DEFAULT_CACHE_MIN_SIZE = 20;
+    /**
+     * The default maximum size of caches.
+     */
+    static final long DEFAULT_CACHE_MAX_SIZE = 1000L;
+    /**
+     * The default timeout for cached data in seconds until they are considered invalid.
+     */
+    static final long DEFAULT_CACHE_TIMEOUT = 600L;
+
+    private String host;
+    private int port = 9090;
+    private int cacheMinSize = DEFAULT_CACHE_MIN_SIZE;
+    private long cacheMaxSize = DEFAULT_CACHE_MAX_SIZE;
+    private long cacheTimeout = DEFAULT_CACHE_TIMEOUT;
+
+    /**
+     * Gets the host of the Prometheus server to retrieve metrics from.
+     *
+     * @return host The host name or IP address.
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Sets the host of the Prometheus server to retrieve metrics from.
+     * <p>
+     * The default value of this property is {@code null}.
+     *
+     * @param host The host name or IP address.
+     */
+    public void setHost(final String host) {
+        this.host = Objects.requireNonNull(host);
+    }
+
+    /**
+     * Gets the port of the Prometheus server to retrieve metrics from.
+     *
+     * @return port The port number.
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Sets the port of the Prometheus server to retrieve metrics from.
+     * <p>
+     * The default value of this property is 9090.
+     *
+     * @param port The port number.
+     * @throws IllegalArgumentException if the port number is &lt; 0 or &gt; 2^16 - 1
+     */
+    public void setPort(final int port) {
+        if (PortConfigurationHelper.isValidPort(port)) {
+            this.port = port;
+        } else {
+            throw new IllegalArgumentException("invalid port number");
+        }
+    }
+
+    /**
+     * Gets the minimum size of the cache.
+     * <p>
+     * The cache will be initialized with this size upon creation.
+     * <p>
+     * The default value is {@link #DEFAULT_CACHE_MIN_SIZE}.
+     *
+     * @return The maximum number of results to keep in the cache.
+     */
+    public int getCacheMinSize() {
+        return cacheMinSize;
+    }
+
+    /**
+     * Sets the minimum size of the cache.
+     * <p>
+     * The cache will be initialized with this size upon creation.
+     * <p>
+     * The default value is {@link #DEFAULT_CACHE_MIN_SIZE}.
+     *
+     * @param size The maximum number of results to keep in the cache.
+     * @throws IllegalArgumentException if size is &lt; 0.
+     */
+    public void setCacheMinSize(final int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("minimum cache size must not be negative");
+        }
+        this.cacheMinSize = size;
+    }
+
+    /**
+     * Gets the maximum size of the cache.
+     * <p>
+     * Once the maximum number of entries is reached, the cache applies an implementation specific policy for handling
+     * new entries that are put to the cache.
+     * <p>
+     * The default value is {@link #DEFAULT_CACHE_MAX_SIZE}.
+     *
+     * @return The maximum number of results to keep in the cache.
+     */
+    public long getCacheMaxSize() {
+        return cacheMaxSize;
+    }
+
+    /**
+     * Sets the maximum size of the cache.
+     * <p>
+     * Once the maximum number of entries is reached, the cache applies an implementation specific policy for handling
+     * new entries that are put to the cache.
+     * <p>
+     * Setting this property to 0 disables caching.
+     * <p>
+     * The default value is {@link #DEFAULT_CACHE_MAX_SIZE}.
+     *
+     * @param size The maximum number of results to keep in the cache.
+     * @throws IllegalArgumentException if size is &lt; 0.
+     */
+    public void setCacheMaxSize(final long size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("maximum cache size must not be negative");
+        }
+        this.cacheMaxSize = size;
+    }
+
+    /**
+     * Gets the period of time after which cached data are considered invalid.
+     * <p>
+     * The default value of this property is {@link #DEFAULT_CACHE_TIMEOUT}.
+     *
+     * @return The timeout for cached values in seconds.
+     */
+    public long getCacheTimeout() {
+        return cacheTimeout;
+    }
+
+    /**
+     * Sets the period of time after which cached responses should be considered invalid.
+     * <p>
+     * The default value of this property is {@link #DEFAULT_CACHE_TIMEOUT}.
+     *
+     * @param timeout The timeout in seconds.
+     * @throws IllegalArgumentException if size is &lt;= 0.
+     */
+    public void setCacheTimeout(final long timeout) {
+        if (timeout <= 0) {
+            throw new IllegalArgumentException("default cache timeout must be greater than zero");
+        }
+        this.cacheTimeout = timeout;
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/ResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/ResourceLimitChecks.java
@@ -33,4 +33,17 @@ public interface ResourceLimitChecks {
      *         if the check could not be performed.
      */
     Future<Boolean> isConnectionLimitReached(TenantObject tenantObject);
+
+    /**
+     * Checks if the maximum limit for the messages configured for a tenant
+     * have been reached.
+     *
+     * @param tenantObject The tenant configuration to check the limit against.
+     * @param payloadSize The message payload size in bytes.
+     * @return A future indicating the outcome of the check.
+     *         <p>
+     *         The future will be failed with a {@link ServiceInvocationException}
+     *         if the check could not be performed.
+     */
+    Future<Boolean> isMessageLimitReached(TenantObject tenantObject, long payloadSize);
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecksTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecksTest.java
@@ -16,23 +16,28 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.time.LocalDate;
 
+import org.eclipse.hono.cache.CacheProvider;
+import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import io.vertx.core.AsyncResult;
@@ -57,10 +62,18 @@ public class PrometheusBasedResourceLimitChecksTest {
 
     private static final int DEFAULT_PORT = 8080;
     private static final String DEFAULT_HOST = "localhost";
+    /**
+     * Time out each test after five seconds.
+     */
+    @Rule
+    public final Timeout timeout = Timeout.seconds(5);
 
     private PrometheusBasedResourceLimitChecks limitChecksImpl;
     private WebClient webClient;
     private HttpRequest<Buffer> request;
+    private CacheProvider cacheProvider;
+    private ExpiringValueCache limitsCache;
+
 
     /**
      * Sets up the fixture.
@@ -73,11 +86,19 @@ public class PrometheusBasedResourceLimitChecksTest {
         when(request.addQueryParam(anyString(), anyString())).thenReturn(request);
         when(request.expect(any(ResponsePredicate.class))).thenReturn(request);
         when(request.as(any(BodyCodec.class))).thenReturn(request);
+
         webClient = mock(WebClient.class);
         when(webClient.get(anyInt(), anyString(), anyString())).thenReturn(request);
-        limitChecksImpl = new PrometheusBasedResourceLimitChecks(webClient);
-        limitChecksImpl.setHost(DEFAULT_HOST);
-        limitChecksImpl.setPort(DEFAULT_PORT);
+
+        limitsCache = mock(ExpiringValueCache.class);
+        cacheProvider = mock(CacheProvider.class);
+        when(cacheProvider.getCache(any())).thenReturn(limitsCache);
+
+        final PrometheusBasedResourceLimitChecksConfig config = new PrometheusBasedResourceLimitChecksConfig();
+        config.setHost(DEFAULT_HOST);
+        config.setPort(DEFAULT_PORT);
+
+        limitChecksImpl = new PrometheusBasedResourceLimitChecks(webClient, config, cacheProvider);
     }
 
     /**
@@ -196,12 +217,140 @@ public class PrometheusBasedResourceLimitChecksTest {
         assertThat(limitChecksImpl.getEffectiveSince(tenant), is(nullValue()));
     }
 
+    /**
+     *
+     * Verifies that the message limit check returns {@code false} if the limit is not exceeded.
+     * 
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testMessageLimitNotExceeded(final TestContext ctx) {
+
+        givenDataVolumeUsageInBytes(90);
+        final long incomingMessageSize = 10;
+        final JsonObject limitsConfig = new JsonObject().put(PrometheusBasedResourceLimitChecks.FIELD_DATA_VOLUME,
+                new JsonObject()
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_MAX_BYTES, 100)
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_EFFECTIVE_SINCE, "2019-01-03")
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_PERIOD_IN_DAYS, 30));
+        final TenantObject tenant = TenantObject.from("tenant", true).setResourceLimits(limitsConfig);
+
+        limitChecksImpl.isMessageLimitReached(tenant, incomingMessageSize)
+                .setHandler(ctx.asyncAssertSuccess(b -> {
+                    ctx.assertEquals(Boolean.FALSE, b);
+                    verify(webClient).get(eq(DEFAULT_PORT), eq(DEFAULT_HOST), anyString());
+                }));
+    }
+
+    /**
+     * Verifies that the message limit check returns {@code true} if the limit is exceeded.
+     * 
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testMessageLimitExceeded(final TestContext ctx) {
+
+        givenDataVolumeUsageInBytes(100);
+        final long incomingMessageSize = 20;
+        final JsonObject limitsConfig = new JsonObject().put(PrometheusBasedResourceLimitChecks.FIELD_DATA_VOLUME,
+                new JsonObject()
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_MAX_BYTES, 100)
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_EFFECTIVE_SINCE, "2019-01-03")
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_PERIOD_IN_DAYS, 30));
+        final TenantObject tenant = TenantObject.from("tenant", true).setResourceLimits(limitsConfig);
+
+        limitChecksImpl.isMessageLimitReached(tenant, incomingMessageSize)
+                .setHandler(ctx.asyncAssertSuccess(b -> {
+                    ctx.assertEquals(Boolean.TRUE, b);
+                    verify(webClient).get(eq(DEFAULT_PORT), eq(DEFAULT_HOST), anyString());
+                }));
+    }
+
+    /**
+     * Verifies that the message limit check returns {@code false} if the limit is not set and no call is made to
+     * retrieve metrics data from the prometheus server.
+     * 
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testMessageLimitNotExceededWhenNotConfigured(final TestContext ctx) {
+
+        final TenantObject tenant = TenantObject.from("tenant", true);
+        limitChecksImpl.isMessageLimitReached(tenant, 10)
+                .setHandler(ctx.asyncAssertSuccess(b -> {
+                    ctx.assertEquals(Boolean.FALSE, b);
+                    verify(webClient, never()).get(any(), any());
+                }));
+    }
+
+    /**
+     * Verifies that the consumed bytes value is taken from limitsCache.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testMessageLimitUsesValueFromCache(final TestContext ctx) {
+
+        when(limitsCache.get(any())).thenReturn(100L);
+        final long incomingMessageSize = 20;
+        final JsonObject limitsConfig = new JsonObject().put(PrometheusBasedResourceLimitChecks.FIELD_DATA_VOLUME,
+                new JsonObject()
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_MAX_BYTES, 100)
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_EFFECTIVE_SINCE, "2019-01-03")
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_PERIOD_IN_DAYS, 30));
+        final TenantObject tenant = TenantObject.from("tenant", true).setResourceLimits(limitsConfig);
+
+        limitChecksImpl.isMessageLimitReached(tenant, incomingMessageSize)
+                .setHandler(ctx.asyncAssertSuccess(b -> {
+                    ctx.assertEquals(Boolean.TRUE, b);
+                    verify(webClient, never()).get(eq(DEFAULT_PORT), eq(DEFAULT_HOST), anyString());
+                }));
+    }
+
+    /**
+     * Verifies that the metrics data retrieved from the prometheus server during message limit check
+     * is saved to the limitsCache.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testMessageLimitStoresValueToCache(final TestContext ctx){
+
+        givenDataVolumeUsageInBytes(100);
+        final long incomingMessageSize = 20;
+        final JsonObject limitsConfig = new JsonObject().put(PrometheusBasedResourceLimitChecks.FIELD_DATA_VOLUME,
+                new JsonObject()
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_MAX_BYTES, 100)
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_EFFECTIVE_SINCE, "2019-01-03")
+                        .put(PrometheusBasedResourceLimitChecks.FIELD_PERIOD_IN_DAYS, 30));
+        final TenantObject tenant = TenantObject.from("tenant", true).setResourceLimits(limitsConfig);
+
+        limitChecksImpl.isMessageLimitReached(tenant, incomingMessageSize)
+                .setHandler(ctx.asyncAssertSuccess(b -> {
+                    verify(webClient).get(eq(DEFAULT_PORT), eq(DEFAULT_HOST), anyString());
+                    verify(cacheProvider.getCache(any())).put(any(), any(), any(Duration.class));
+                }));
+    }
+
     @SuppressWarnings("unchecked")
     private void givenCurrentConnections(final int currentConnections) {
         doAnswer(invocation -> {
             final Handler<AsyncResult<HttpResponse<JsonObject>>> responseHandler = invocation.getArgument(0);
             final HttpResponse<JsonObject> response = mock(HttpResponse.class);
             when(response.body()).thenReturn(createPrometheusResponse(currentConnections));
+            responseHandler.handle(Future.succeededFuture(response));
+            return null;
+        }).when(request).send(any(Handler.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void givenDataVolumeUsageInBytes(final int consumedBytes){
+        doAnswer(invocation -> {
+            final Handler<AsyncResult<HttpResponse<JsonObject>>> responseHandler = invocation.getArgument(0);
+            final HttpResponse<JsonObject> response = mock(HttpResponse.class);
+            when(response.body()).thenReturn(createPrometheusResponse(consumedBytes));
             responseHandler.handle(Future.succeededFuture(response));
             return null;
         }).when(request).send(any(Handler.class));


### PR DESCRIPTION
`ResourceLimitChecks` API is now extended with the method `isMessageLimitExceeded(...)` to check the messages limit. This method is intended to be used by the _protocol adapters_ to verify the messages limit before accepting any telemetry or event messages. 

The _protocol adapters_ using this api to verify the messages limit will be part of the next PR. 