### PR TITLE
Fix: Do not start protocol adapter if not enough memory.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/limiting/ConnectionLimitAutoConfigException.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/limiting/ConnectionLimitAutoConfigException.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.limiting;
+
+/**
+ * Indicates that the auto-configuration of the connection limit failed.
+ *
+ */
+public class ConnectionLimitAutoConfigException extends RuntimeException {
+
+    /**
+     * Creates a new exception for a detail message.
+     *
+     * @param msg The detail message.
+     */
+    public ConnectionLimitAutoConfigException(final String msg) {
+        super(msg);
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/limiting/DefaultConnectionLimitManager.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/limiting/DefaultConnectionLimitManager.java
@@ -44,6 +44,8 @@ public class DefaultConnectionLimitManager implements ConnectionLimitManager {
      * @param currentConnections The supplier to invoke for getting the current number of connections.
      * @param config The configuration of the adapter or {@code null}.
      * @throws NullPointerException if strategy or currentConnections are {@code null}.
+     * @throws ConnectionLimitAutoConfigException if no connection limit is configured and the auto-configuration
+     *             calculates a limit of 0.
      */
     public DefaultConnectionLimitManager(final ConnectionLimitStrategy strategy, final Supplier<Integer> currentConnections,
             final ProtocolAdapterProperties config) {
@@ -62,7 +64,8 @@ public class DefaultConnectionLimitManager implements ConnectionLimitManager {
         final int recommendedLimit = strategy.getRecommendedLimit();
 
         if (recommendedLimit == 0) {
-            throw new RuntimeException("Not enough memory to handle connections. To override this check, configure a connection limit.");
+            throw new ConnectionLimitAutoConfigException("The connection limit would be auto-configured to 0 (based on "
+                    + strategy.getResourcesDescription() + "). To override this check, configure a connection limit.");
         }
 
         LOG.info("Setting connection limit to {} (based on {})", recommendedLimit, strategy.getResourcesDescription());

--- a/service-base/src/main/java/org/eclipse/hono/service/limiting/DefaultConnectionLimitManager.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/limiting/DefaultConnectionLimitManager.java
@@ -61,6 +61,10 @@ public class DefaultConnectionLimitManager implements ConnectionLimitManager {
 
         final int recommendedLimit = strategy.getRecommendedLimit();
 
+        if (recommendedLimit == 0) {
+            throw new RuntimeException("Not enough memory to handle connections. To override this check, configure a connection limit.");
+        }
+
         LOG.info("Setting connection limit to {} (based on {})", recommendedLimit, strategy.getResourcesDescription());
 
         return recommendedLimit;


### PR DESCRIPTION
Throw a exception if the connection limit is auto-configured to 0. 
Currently the protocol adapter only prints a warning to the logs, but then completes the startup. So, possibly nobody would notice that it would not accept any connections.