### PR TITLE
Configure nexus plugin in a dedicated profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -454,31 +454,6 @@
         </executions>
       </plugin>
       <plugin>
-        <!-- 
-          Use the Nexus Staging plugin as a full replacement for the standard
-          Maven Deploy plugin.
-          See https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin
-          why this makes sense :-)
-          We can control whether we want to deploy to the Eclipse repo or Maven Central
-          by a combination of the version being a SNAPHOT or release version and property
-          skipStaging=true/false.
-          In any case we can take advantage of the plugin's "deferred deploy" feature which
-          makes sure that all artifacts of a multi-module project are deployed as a whole
-          at the end of the build process instead of deploying each module's artifacts
-          individually as part of building the module.
-         -->
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${jacoco.version}</version>
@@ -515,6 +490,43 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>nexus</id>
+      <activation>
+        <property>
+          <name>disableNexus</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <!-- 
+              Use the Nexus Staging plugin as a full replacement for the standard
+              Maven Deploy plugin.
+              See https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin
+              why this makes sense :-)
+              We can control whether we want to deploy to the Eclipse repo or Maven Central
+              by a combination of the version being a SNAPHOT or release version and property
+              skipStaging=true/false.
+              In any case we can take advantage of the plugin's "deferred deploy" feature which
+              makes sure that all artifacts of a multi-module project are deployed as a whole
+              at the end of the build process instead of deploying each module's artifacts
+              individually as part of building the module.
+             -->
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <!-- 
         This profile is activated by Eclipse IDE automatically.

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,10 @@
           </configuration>
         </plugin>
         <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.7</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.0.2</version>


### PR DESCRIPTION
I would like to put the nexus plugin into a dedicated profile. I know this, most likely has an impact in the Eclipse CI infrastructure as well.

The reason behind that is that the plugin completely takes control of the deployment. And causes some problems in our internal build. And currently there is no other way to remove this plugin, than to manually patch the main POM file.