### PR TITLE
[#1055] Add support for Jaeger in the Helm-based K8s deployment

### DIFF
--- a/deploy/src/main/deploy/helm/requirements.yaml
+++ b/deploy/src/main/deploy/helm/requirements.yaml
@@ -2,3 +2,7 @@ dependencies:
   - name: prometheus-operator
     version: 1.4.1
     repository: "@stable"
+  - name: jaeger-operator
+    version: 2.4.1
+    repository: "@stable"
+    condition: jaeger.enabled

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -20,6 +20,12 @@ spec:
         version: "{{ .Chart.AppVersion }}"
         group: {{ .Values.project.groupId }}
     spec:
+      {{- if eq .Values.jaeger.enabled true}}
+      initContainers:
+        - name: wait-for-jaeger-agent
+          image: busybox:1.28
+          command: ['sh', '-c', 'until nslookup {{ .Values.jaeger.agentHost }}; do echo waiting for {{ .Values.jaeger.agentHost }}; sleep 2; done;']
+      {{- end}}
       containers:
       - image: {{ .Values.hono.image.repoPrefix }}/hono-adapter-amqp-vertx:{{ .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
@@ -40,6 +46,14 @@ spec:
           value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
+        {{- if eq .Values.jaeger.enabled true}}
+        - name: JAEGER_SERVICE_NAME
+          value: hono-adapter-amqp
+        {{- range $key, $value := .Values.jaeger.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end}}
         - name: _JAVA_OPTIONS
           value: "{{ .Values.defaultJavaOptions }}"
         - name: KUBERNETES_NAMESPACE

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yml
@@ -20,6 +20,12 @@ spec:
         version: "{{ .Chart.AppVersion }}"
         group: {{ .Values.project.groupId }}
     spec:
+      {{- if eq .Values.jaeger.enabled true}}
+      initContainers:
+        - name: wait-for-jaeger-agent
+          image: busybox:1.28
+          command: ['sh', '-c', 'until nslookup {{ .Values.jaeger.agentHost }}; do echo waiting for {{ .Values.jaeger.agentHost }}; sleep 2; done;']
+      {{- end}}
       containers:
       - image: {{ .Values.hono.image.repoPrefix }}/hono-adapter-http-vertx:{{ .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
@@ -40,6 +46,14 @@ spec:
           value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
+        {{- if eq .Values.jaeger.enabled true}}
+        - name: JAEGER_SERVICE_NAME
+          value: hono-adapter-http
+        {{- range $key, $value := .Values.jaeger.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end}}
         - name: _JAVA_OPTIONS
           value: "{{ .Values.defaultJavaOptions }}"
         - name: KUBERNETES_NAMESPACE

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -20,6 +20,12 @@ spec:
         version: "{{ .Chart.AppVersion }}"
         group: {{ .Values.project.groupId }}
     spec:
+      {{- if eq .Values.jaeger.enabled true}}
+      initContainers:
+        - name: wait-for-jaeger-agent
+          image: busybox:1.28
+          command: ['sh', '-c', 'until nslookup {{ .Values.jaeger.agentHost }}; do echo waiting for {{ .Values.jaeger.agentHost }}; sleep 2; done;']
+      {{- end}}
       containers:
       - image: {{ .Values.hono.image.repoPrefix }}/hono-adapter-kura:{{ .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
@@ -40,6 +46,14 @@ spec:
           value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
+        {{- if eq .Values.jaeger.enabled true}}
+        - name: JAEGER_SERVICE_NAME
+          value: hono-adapter-kura
+        {{- range $key, $value := .Values.jaeger.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end}}
         - name: _JAVA_OPTIONS
           value: "{{ .Values.defaultJavaOptions }}"
         - name: KUBERNETES_NAMESPACE

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -20,6 +20,12 @@ spec:
         version: "{{ .Chart.AppVersion }}"
         group: {{ .Values.project.groupId }}
     spec:
+      {{- if eq .Values.jaeger.enabled true}}
+      initContainers:
+        - name: wait-for-jaeger-agent
+          image: busybox:1.28
+          command: ['sh', '-c', 'until nslookup {{ .Values.jaeger.agentHost }}; do echo waiting for {{ .Values.jaeger.agentHost }}; sleep 2; done;']
+      {{- end}}
       containers:
       - image: {{ .Values.hono.image.repoPrefix }}/hono-adapter-mqtt-vertx:{{ .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
@@ -40,6 +46,14 @@ spec:
           value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
+        {{- if eq .Values.jaeger.enabled true}}
+        - name: JAEGER_SERVICE_NAME
+          value: hono-adapter-mqtt
+        {{- range $key, $value := .Values.jaeger.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end}}
         - name: _JAVA_OPTIONS
           value: "{{ .Values.defaultJavaOptions }}"
         - name: KUBERNETES_NAMESPACE

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
@@ -20,6 +20,12 @@ spec:
         version: "{{ .Chart.AppVersion }}"
         group: {{ .Values.project.groupId }}
     spec:
+      {{- if eq .Values.jaeger.enabled true}}
+      initContainers:
+        - name: wait-for-jaeger-agent
+          image: busybox:1.28
+          command: ['sh', '-c', 'until nslookup {{ .Values.jaeger.agentHost }}; do echo waiting for {{ .Values.jaeger.agentHost }}; sleep 2; done;']
+      {{- end}}
       containers:
       - image: {{ .Values.hono.image.repoPrefix }}/hono-service-device-registry:{{ .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
@@ -42,6 +48,14 @@ spec:
           value: dev
         - name: LOGGING_CONFIG
           value: classpath:logback-spring.xml
+        {{- if eq .Values.jaeger.enabled true}}
+        - name: JAEGER_SERVICE_NAME
+          value: hono-service-device-registry
+        {{- range $key, $value := .Values.jaeger.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end}}
         - name: _JAVA_OPTIONS
           value: "{{ .Values.defaultJavaOptions }}"
         - name: KUBERNETES_NAMESPACE

--- a/deploy/src/main/deploy/helm/templates/jaeger/jaeger.yaml
+++ b/deploy/src/main/deploy/helm/templates/jaeger/jaeger.yaml
@@ -1,0 +1,14 @@
+{{if eq .Values.jaeger.enabled true}}
+apiVersion: jaegertracing.io/v1
+kind: "Jaeger"
+metadata:
+  labels:
+    app: jaeger
+    version: "{{ .Chart.AppVersion }}"
+    group: {{ .Values.project.groupId }}
+  name: "jaeger"
+spec:
+{{- if .Values.jaeger.deploy.spec }}
+{{ toYaml .Values.jaeger.deploy.spec | indent 2 }}
+{{- end }}
+{{end}}

--- a/deploy/src/main/deploy/helm/values.yaml
+++ b/deploy/src/main/deploy/helm/values.yaml
@@ -35,6 +35,27 @@ platform: kubernetes
 # do not use with "platform: openshift".
 useLoadBalancer: false
 
+jaeger:
+  # whether the Jaeger tracing component should be deployed
+  enabled: false
+  agentHost: jaeger-agent.hono
+  # environment variables for containers that provide tracing data
+  env:
+    JAEGER_AGENT_HOST: jaeger-agent.hono
+    JAEGER_AGENT_PORT: "6831"
+    JAEGER_SAMPLER_TYPE: const
+    JAEGER_SAMPLER_PARAM: 1
+  deploy:
+    # configuration of Jaeger deployment
+    # see examples of spec definitions here: https://github.com/jaegertracing/jaeger-operator/tree/master/deploy/examples
+    spec:
+      strategy: allInOne
+      storage:
+        options:
+          memory:
+            max-traces: 100000
+
+
 # Default values for prometheus-operator.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/site/content/admin-guide/monitoring-tracing-config.md
+++ b/site/content/admin-guide/monitoring-tracing-config.md
@@ -120,7 +120,7 @@ All jar files can then be found in the directory `target/dependency`.
 ## Configuring usage of Jaeger tracing (included in Docker images)
 
 In case [Jaeger tracing](https://www.jaegertracing.io/) shall be used, there is an alternative to putting the jar files in the container's `/opt/hono/extensions` folder as described above.
-This is to have the Jaeger tracing jar files be included in the Hono Docker images by using the `jaeger` maven profile when building Hono.
+This is to have the Jaeger tracing jar files be included in the Hono Docker images by using the `jaeger` Maven profile when building Hono.
 
 For example, building the HTTP adapter image with the Jaeger client included:
 

--- a/site/content/deployment/kubernetes.md
+++ b/site/content/deployment/kubernetes.md
@@ -45,6 +45,20 @@ helm install --dep-up --name eclipse-hono --namespace hono target/deploy/helm/
 
 This will create a new `hono` namespace in the cluster and install all the components to that namespace. The name of the Helm release will be `eclipse-hono`.
 
+#### Adding Jaeger support
+
+In order to deploy the Jaeger tracing component along with Hono, first make sure that the Hono Docker images have been built with the Jaeger client included. That is done using the `jaeger` Maven profile, see [Monitoring & Tracing]({{< relref "monitoring-tracing-config.md#configuring-usage-of-jaeger-tracing-included-in-docker-images" >}}).
+The deployment can then be done using the `jaeger.enabled=true` option:
+ 
+~~~sh
+# in directory: hono/deploy/
+helm install --dep-up --name eclipse-hono --set jaeger.enabled=true --namespace hono target/deploy/helm/
+~~~
+
+For information on how to access the Jaeger UI, see the [Jaeger Operator documentation](https://github.com/jaegertracing/jaeger-operator#accessing-the-ui).
+
+#### View deployment status
+
 You can check the status of the deployment with one of the following commands:
 
 ~~~sh
@@ -89,6 +103,12 @@ kubectl delete crd prometheuses.monitoring.coreos.com prometheusrules.monitoring
 ~~~
 
 The additional `kubectl delete` command is necessary to remove [Prometheus operator CRDs](https://github.com/helm/charts/tree/master/stable/prometheus-operator#uninstalling-the-chart).
+
+If the Jaeger tracing component has been deployed, additional resources have to be deleted manually:
+~~~sh
+kubectl delete crd jaegers.jaegertracing.io
+kubectl delete svc -n hono eclipse-hono-jaeger-operator 
+~~~sh
 
 To undeploy a Hono instance that has been deployed manually from the resource files, run:
 


### PR DESCRIPTION
This is for #1055.

An option to deploy Hono along with the Jaeger tracing component has been added (`deployJaeger`).
This uses the [Jaeger Operator](https://github.com/jaegertracing/jaeger-operator) as a Helm dependency.