### PR TITLE
[#1138] Add CORS support for device registry HTTP API

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsHttpEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,9 +14,12 @@
 package org.eclipse.hono.service.credentials;
 
 import java.net.HttpURLConnection;
+import java.util.EnumSet;
 import java.util.Objects;
 
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.http.AbstractHttpEndpoint;
@@ -29,6 +32,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.handler.CorsHandler;
 
 /**
  * An {@code HttpEndpoint} for managing device credentials.
@@ -70,6 +74,25 @@ public final class CredentialsHttpEndpoint extends AbstractHttpEndpoint<ServiceC
 
         final BodyHandler bodyHandler = BodyHandler.create();
         bodyHandler.setBodyLimit(config.getMaxPayloadSize());
+
+        // CORS handling
+        router.route(pathWithTenant)
+                .handler(CorsHandler.create(getCorsAllowedOriginPattern())
+                        .allowedMethod(HttpMethod.POST)
+                        .allowedHeader(HttpHeaders.CONTENT_TYPE.toString()));
+        router.route(pathWithTenantAndDeviceId)
+                .handler(CorsHandler.create(getCorsAllowedOriginPattern())
+                        .allowedMethods(EnumSet.of(
+                                HttpMethod.GET,
+                                HttpMethod.DELETE))
+                        .allowedHeader(HttpHeaders.CONTENT_TYPE.toString()));
+        router.route(pathWithTenantAndAuthIdAndType)
+                .handler(CorsHandler.create(getCorsAllowedOriginPattern())
+                        .allowedMethods(EnumSet.of(
+                                HttpMethod.GET,
+                                HttpMethod.PUT,
+                                HttpMethod.DELETE))
+                        .allowedHeader(HttpHeaders.CONTENT_TYPE.toString()));
 
         // add credentials
         router.post(pathWithTenant).handler(bodyHandler);

--- a/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -82,6 +82,10 @@ public abstract class AbstractHttpEndpoint<T> extends AbstractEndpoint implement
     @Autowired(required = false)
     public final void setConfiguration(final T props) {
         this.config = Objects.requireNonNull(props);
+    }
+
+    protected String getCorsAllowedOriginPattern() {
+        return "*";
     }
 
     /**


### PR DESCRIPTION
This enables CORS support for the current HTTP API of the device registry endpoint.

There is one thing still missing, which is the source of the CORS allowed origin pattern. Currently this is implemented simply allowing everything:

~~~java
protected String getCorsAllowedOriginPattern() {
   return "*";
}
~~~
See: https://github.com/eclipse/hono/pull/1189/files#diff-128d9180cb18f40e68e4d2203ae4c83aR88

This is fine for the moment, as we don't authenticate the device registry API anyway. However, I think this should be allowed to be configured, like for the HTTP adapter.

However, the endpoint currently does not have any specific configuration for HTTP endpoints. It only receives a single configuration object, which has to be of type `ServiceConfigProperties` in the case of the device registry. And that type is shared with the AMQP endpoints. There are two instances though, one marked with the qualifier `ampq`, the other with `rest`.

I don't think it makes sense to add the CORS configuration to the generic `ServiceConfigProperties` object, as CORS seems specific to HTTP for me.

My proposal would be to create a derived `HttpServiceConfigProperties` object and add the configuration there. Requiring the use of this class for all HTTP related methods and classes.
