### PR TITLE
POC of junit5/jupiter test migration

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -217,6 +217,11 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-junit5</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
         <version>${junit.jupiter.version}</version>
@@ -225,6 +230,12 @@
       <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
+        <version>${junit.jupiter.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
         <version>${junit.jupiter.version}</version>
         <scope>test</scope>
       </dependency>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -48,8 +48,21 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractServiceBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractServiceBaseTest.java
@@ -19,8 +19,8 @@ import io.vertx.core.net.NetServerOptions;
 
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.util.Constants;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -46,7 +46,7 @@ public class AbstractServiceBaseTest {
     /**
      * Sets up common mock objects used by the test cases.
      */
-    @Before
+    @BeforeEach
     public void initMocks() {
         eventBus = mock(EventBus.class);
         vertx = mock(Vertx.class);

--- a/service-base/src/test/java/org/eclipse/hono/service/EventBusServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/EventBusServiceTest.java
@@ -14,12 +14,13 @@
 package org.eclipse.hono.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.hono.util.EventBusMessage;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
@@ -36,7 +37,7 @@ public class EventBusServiceTest {
     /**
      * Sets up the fixture.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         service = new EventBusService<Object>() {
 
@@ -90,13 +91,13 @@ public class EventBusServiceTest {
                 .put("intValue", 42);
 
         final String stringValue = EventBusService.getTypesafeValueForField(String.class, payload, "stringValue");
-        Assert.assertEquals("foo", stringValue);
+        assertEquals("foo", stringValue);
 
         final Integer intValue = EventBusService.getTypesafeValueForField(Integer.class, payload, "intValue");
-        Assert.assertEquals(Integer.valueOf(42), intValue);
+       assertEquals(Integer.valueOf(42), intValue);
 
         final Boolean booleanValue = EventBusService.getTypesafeValueForField(Boolean.class, payload, "booleanValue");
-        Assert.assertEquals(Boolean.TRUE, booleanValue);
+        assertEquals(Boolean.TRUE, booleanValue);
     }
 
     /**
@@ -107,10 +108,10 @@ public class EventBusServiceTest {
         final JsonObject device = new JsonObject().put("device-id", "someValue");
 
         final String stringValue = EventBusService.getTypesafeValueForField(String.class, device, "device-id");
-        Assert.assertEquals("someValue", stringValue);
+        assertEquals("someValue", stringValue);
 
         final Integer intValue = EventBusService.getTypesafeValueForField(Integer.class, device, "device-id");
-        Assert.assertNull(intValue);
+        assertNull(intValue);
     }
 
     /**
@@ -121,7 +122,6 @@ public class EventBusServiceTest {
         final JsonObject device = new JsonObject().put("device-id", (String) null);
 
         final String value = EventBusService.getTypesafeValueForField(String.class, device, "device-id");
-        Assert.assertNull(value);
+        assertNull(value);
     }
-
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.hono.service.credentials;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.net.HttpURLConnection;
 
 import org.eclipse.hono.client.ServiceInvocationException;
@@ -20,22 +22,22 @@ import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsObject;
 import org.eclipse.hono.util.CredentialsResult;
 import org.eclipse.hono.util.EventBusMessage;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
 
 import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 
 /**
  * Tests verifying behavior of {@link BaseCredentialsService}.
  */
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class BaseCredentialsServiceTest {
 
     private static BaseCredentialsService<ServiceConfigProperties> service;
@@ -50,7 +52,7 @@ public class BaseCredentialsServiceTest {
     /**
      * Sets up the fixture.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         service = createBaseCredentialsService();
     }
@@ -62,7 +64,7 @@ public class BaseCredentialsServiceTest {
      * @param ctx The vert.x test context.
      */
     @Test
-    public void testGetFailsForMissingType(final TestContext ctx) {
+    public void testGetFailsForMissingType(final VertxTestContext ctx) {
 
         // GIVEN a request for getting credentials that does not specify a type
         final CredentialsObject malformedPayload = new CredentialsObject()
@@ -73,10 +75,11 @@ public class BaseCredentialsServiceTest {
                 JsonObject.mapFrom(malformedPayload));
 
         // WHEN processing the request
-        service.processRequest(request).setHandler(ctx.asyncAssertFailure(t -> {
+        service.processRequest(request).setHandler(ctx.failing(t -> ctx.verify(() -> {
             // THEN the response contains a 400 error code
-            ctx.assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, ((ServiceInvocationException) t).getErrorCode());
-        }));
+            assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, ((ServiceInvocationException) t).getErrorCode());
+            ctx.completeNow();
+        })));
     }
 
     /**
@@ -86,7 +89,7 @@ public class BaseCredentialsServiceTest {
      * @param ctx The vert.x test context.
      */
     @Test
-    public void testGetFailsForMissingAuthId(final TestContext ctx) {
+    public void testGetFailsForMissingAuthId(final VertxTestContext ctx) {
 
         // GIVEN a request for getting credentials that does not specify an auth ID
         final CredentialsObject malformedPayload = new CredentialsObject()
@@ -97,10 +100,11 @@ public class BaseCredentialsServiceTest {
                 JsonObject.mapFrom(malformedPayload));
 
         // WHEN processing the request
-        service.processRequest(request).setHandler(ctx.asyncAssertFailure(t -> {
+        service.processRequest(request).setHandler(ctx.failing(t -> ctx.verify(() -> {
             // THEN the response contains a 400 error code
-            ctx.assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, ((ServiceInvocationException) t).getErrorCode());
-        }));
+            assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, ((ServiceInvocationException) t).getErrorCode());
+            ctx.completeNow();
+        })));
     }
 
     private static EventBusMessage createRequestForPayload(final CredentialsConstants.CredentialsAction operation, final JsonObject payload) {

--- a/service-base/src/test/java/org/eclipse/hono/service/credentials/CredentialsMessageFilterTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/credentials/CredentialsMessageFilterTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.hono.service.credentials;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
@@ -22,8 +22,8 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonHelper;
@@ -42,7 +42,7 @@ public class CredentialsMessageFilterTest {
     /**
      * Sets up the fixture.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         target = ResourceIdentifier.from(CredentialsConstants.CREDENTIALS_ENDPOINT, Constants.DEFAULT_TENANT, null);
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/limiting/DefaultConnectionLimitManagerTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/limiting/DefaultConnectionLimitManagerTest.java
@@ -13,15 +13,15 @@
 
 package org.eclipse.hono.service.limiting;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.function.Supplier;
 
 import org.eclipse.hono.config.ProtocolAdapterProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Verifies the behavior of {@link DefaultConnectionLimitManager}.

--- a/service-base/src/test/java/org/eclipse/hono/service/limiting/MemoryBasedConnectionLimitStrategyTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/limiting/MemoryBasedConnectionLimitStrategyTest.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.hono.service.limiting;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Verifies the behavior of {@link MemoryBasedConnectionLimitStrategy}.

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/LegacyMetricsConfigTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/LegacyMetricsConfigTest.java
@@ -14,14 +14,13 @@
 
 package org.eclipse.hono.service.metric;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.TelemetryConstants;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.Meter.Type;
@@ -50,7 +49,7 @@ public class LegacyMetricsConfigTest {
     /**
      * Sets up the fixture.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
 
         config = new LegacyMetricsConfig();
@@ -162,6 +161,6 @@ public class LegacyMetricsConfigTest {
     private void assertMapping(final Id orig, final String expectedMapping) {
 
         final String metricName = mapper.toHierarchicalName(filter(orig), NamingConvention.dot);
-        assertThat(metricName, is(expectedMapping));
+        assertEquals(expectedMapping, metricName);
     }
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
@@ -14,23 +14,18 @@
 
 package org.eclipse.hono.service.metric;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.eclipse.hono.service.metric.MetricsTags.EndpointType;
 import org.eclipse.hono.service.metric.MetricsTags.QoS;
 import org.eclipse.hono.service.metric.MetricsTags.TtdStatus;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -46,43 +41,31 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
  * Verifies behavior of {@link MicrometerBasedMetrics}.
  *
  */
-@RunWith(Parameterized.class)
 public class MicrometerBasedMetricsTest {
-
-    /**
-     * The Micrometer registry to run the tests against.
-     */
-    @Parameter
-    public MeterRegistry registry;
-    private MicrometerBasedMetrics metrics;
 
     /**
      * Gets the Micrometer registries that the tests should be run against.
      * 
      * @return The registries.
      */
-    @Parameters(name = "{0}")
-    public static Collection<MeterRegistry> registries() {
-        return Arrays.asList(new MeterRegistry[] {
+    public static Stream<MeterRegistry> registries() {
+        return Stream.of(new MeterRegistry[] {
                                 new PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
                                 new GraphiteMeterRegistry(GraphiteConfig.DEFAULT, Clock.SYSTEM)
                                 });
     }
 
     /**
-     * Sets up the fixture.
-     */
-    @Before
-    public void setUp() {
-        metrics = new MicrometerBasedMetrics(registry);
-    }
-
-    /**
      * Verifies that arbitrary telemetry messages with or without a QoS
      * can be reported successfully.
+     *
+     * @param registry : the registry that the tests should be run against.
      */
-    @Test
-    public void testReportTelemetryWithOptionalQos() {
+    @ParameterizedTest
+    @MethodSource("registries")
+    public void testReportTelemetryWithOptionalQos(final MeterRegistry registry) {
+
+        final MicrometerBasedMetrics metrics = new MicrometerBasedMetrics(registry);
 
         // GIVEN a sample
         final Sample sample = metrics.startTimer();
@@ -122,9 +105,14 @@ public class MicrometerBasedMetricsTest {
     /**
      * Verifies that when reporting a downstream message no tags for
      * {@link QoS#UNKNOWN} nor {@link TtdStatus#NONE} are included.
+     *
+     * @param registry : the registry that the tests should be run against.
      */
-    @Test
-    public void testReportTelemetryWithUnknownTagValues() {
+    @ParameterizedTest
+    @MethodSource("registries")
+    public void testReportTelemetryWithUnknownTagValues(final MeterRegistry registry) {
+
+        final MicrometerBasedMetrics metrics = new MicrometerBasedMetrics(registry);
 
         metrics.reportTelemetry(
                 MetricsTags.EndpointType.TELEMETRY,
@@ -147,9 +135,14 @@ public class MicrometerBasedMetricsTest {
     /**
      * Verifies that when reporting a downstream message the legacy metrics
      * are also reported, if set.
+     *
+     * @param registry : the registry that the tests should be run against.
      */
-    @Test
-    public void testReportTelemetryInvokesLegacyMetrics() {
+    @ParameterizedTest
+    @MethodSource("registries")
+    public void testReportTelemetryInvokesLegacyMetrics(final MeterRegistry registry) {
+
+        final MicrometerBasedMetrics metrics = new MicrometerBasedMetrics(registry);
 
         final LegacyMetrics legacyMetrics = mock(LegacyMetrics.class);
         metrics.setLegacyMetrics(legacyMetrics);

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImplTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImplTest.java
@@ -13,10 +13,12 @@
 
 package org.eclipse.hono.service.registration;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.hono.config.SignatureSupportingConfigProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.Vertx;
 
@@ -32,11 +34,12 @@ public class RegistrationAssertionHelperImplTest {
     /**
      * Verifies that the helper asserts a minimum length of 32 bytes for shared secrets.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testForSigningRejectsShortSecret() {
 
         final String shortSecret = "01234567890123456"; // not 32 bytes long
-        RegistrationAssertionHelperImpl.forSharedSecret(shortSecret, 10);
+        assertThrows(IllegalArgumentException.class, () ->
+                RegistrationAssertionHelperImpl.forSharedSecret(shortSecret, 10));
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationMessageFilterTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationMessageFilterTest.java
@@ -13,14 +13,14 @@
 package org.eclipse.hono.service.registration;
 
 import static org.eclipse.hono.util.RegistrationConstants.ACTION_GET;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.proton.ProtonHelper;
 

--- a/services/device-registry/pom.xml
+++ b/services/device-registry/pom.xml
@@ -25,7 +25,7 @@
   <dependencies>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
+      <artifactId>vertx-junit5</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is a POC on the tests to experiment the junit 5 tests, as discussed in a recent community call. 
As expected, it's needed to rewrite a bunch of things, but nothing really complicated.

Also, there is currently no support for class-wide `@Rule` timeout, as we currently use in hono. Each test must have a Timeout specified. However, this feature should be introduced back in the next jupiter release, as this is a popular demand ( https://github.com/junit-team/junit5/issues/80).

On the plus side there are some nice features such as nested tests that would allow to improve the maintainability of the tests ( see  `FileBasedCredentialsServiceTest.testLoadCredentialsCanReadOutputOfSaveToFile` where I needed `countdownLatch` to replace the vertx `Async`. This could be factored the `@BeforeEach` method of a nested test class)
I also removed all the vertx assertions to use only the assertions provided by Junit. 
It is also nice that both Junit4 and jupiter can coexist without disrupting anything, so the migration can happen over time.

I also completely removed the junit4 dependency : all the tests can run through the vintage engine. I had to add hamcrest as i think it was pulled through junit4. Keeping both dependencies made the codecov bot miss out on the test coverage.

For more details on `VertxTestContext` see https://vertx.io/docs/vertx-junit5/java/

Signed-off-by: Trystram Jean-Baptiste <jbtrystram@redhat.com>