### PR TITLE
Pass through original message in LoRaWAN adapter

### DIFF
--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraCommandProperties.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraCommandProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraConstants.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -35,6 +35,19 @@ public class LoraConstants {
     public static final String FIELD_LORA_DEVICE_PORT = "lora-port";
     public static final String FIELD_LORA_DOWNLINK_PAYLOAD = "payload";
     public static final String EMPTY = "";
+    public static final String CONTENT_TYPE_LORA_POST_FIX = "+json";
+    public static final String CONTENT_TYPE_LORA_BASE = "application/vnd.eclipse-hono.lora.";
+    public static final String NORMALIZED_PROPERTIES = "normalized_properties";
+    public static final String ADDITIONAL_DATA = "additional_data";
+    public static final String APP_PROPERTY_RSS = "rss";
+    public static final String APP_PROPERTY_TX_POWER = "tx_power";
+    public static final String APP_PROPERTY_CHANNEL = "channel";
+    public static final String APP_PROPERTY_SUB_BAND = "sub_band";
+    public static final String APP_PROPERTY_SPREADING_FACTOR = "spreading_factor";
+    public static final String APP_PROPERTY_SNR = "snr";
+    public static final String APP_PROPERTY_FUNCTION_PORT = "function_port";
+    public static final String APP_PROPERTY_FUNCTION_LATITUDE = "latitude";
+    public static final String APP_PROPERTY_FUNCTION_LONGITUDE = "longitude";
 
     private LoraConstants() {
         // prevent instantiation

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraMessageType.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraMessageType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Application.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ActilityProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ActilityProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,10 +13,14 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
+import org.eclipse.hono.adapter.lora.LoraConstants;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.springframework.stereotype.Component;
 
 import io.vertx.core.json.JsonObject;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A LoRaWAN provider with API for Actility.
@@ -27,6 +31,15 @@ public class ActilityProvider implements LoraProvider {
     private static final String FIELD_ACTILITY_ROOT_OBJECT = "DevEUI_uplink";
     private static final String FIELD_ACTILITY_DEVICE_EUI = "DevEUI";
     private static final String FIELD_ACTILITY_PAYLOAD = "payload_hex";
+    private static final String FIELD_ACTILITY_LRR_RSSI = "LrrRSSI";
+    private static final String FIELD_ACTILITY_TX_POWER = "TxPower";
+    private static final String FIELD_ACTILITY_CHANNEL = "Channel";
+    private static final String FIELD_ACTILITY_SUB_BAND = "SubBand";
+    private static final String FIELD_ACTILITY_SPREADING_FACTOR = "SpFact";
+    private static final String FIELD_ACTILITY_LRR_SNR = "LrrRSSI";
+    private static final String FIELD_ACTILITY_FPORT = "FPort";
+    private static final String FIELD_ACTILITY_LATITUTDE = "LrrLAT";
+    private static final String FIELD_ACTILITY_LONGITUDE = "LrrLON";
 
     @Override
     public String getProviderName() {
@@ -45,11 +58,9 @@ public class ActilityProvider implements LoraProvider {
     }
 
     @Override
-    public String extractPayloadEncodedInBase64(final JsonObject loraMessage) {
-        final String hexPayload = loraMessage.getJsonObject(FIELD_ACTILITY_ROOT_OBJECT, new JsonObject())
+    public String extractPayload(final JsonObject loraMessage) {
+        return loraMessage.getJsonObject(FIELD_ACTILITY_ROOT_OBJECT, new JsonObject())
                 .getString(FIELD_ACTILITY_PAYLOAD);
-
-        return LoraUtils.convertFromHexToBase64(hexPayload);
     }
 
     @Override
@@ -59,5 +70,71 @@ public class ActilityProvider implements LoraProvider {
             return LoraMessageType.UPLINK;
         }
         return LoraMessageType.UNKNOWN;
+    }
+
+    @Override
+    public Map<String, Object> extractNormalizedData(final JsonObject loraMessage) {
+        final Map<String, Object> returnMap = new HashMap<>();
+        if (loraMessage.containsKey(FIELD_ACTILITY_LRR_RSSI)) {
+            returnMap.put(LoraConstants.APP_PROPERTY_RSS, Math.abs(loraMessage.getDouble(FIELD_ACTILITY_LRR_RSSI)));
+        }
+        if (loraMessage.containsKey(FIELD_ACTILITY_TX_POWER)) {
+            returnMap.put(LoraConstants.APP_PROPERTY_TX_POWER, loraMessage.getDouble(FIELD_ACTILITY_TX_POWER));
+        }
+        if (loraMessage.containsKey(FIELD_ACTILITY_CHANNEL)) {
+            returnMap.put(LoraConstants.APP_PROPERTY_CHANNEL, loraMessage.getString(FIELD_ACTILITY_CHANNEL));
+        }
+        if (loraMessage.containsKey(FIELD_ACTILITY_SUB_BAND)) {
+            returnMap.put(LoraConstants.APP_PROPERTY_SUB_BAND, loraMessage.getString(FIELD_ACTILITY_SUB_BAND));
+        }
+        if (loraMessage.containsKey(FIELD_ACTILITY_SPREADING_FACTOR)) {
+            returnMap.put(LoraConstants.APP_PROPERTY_SPREADING_FACTOR, loraMessage.getInteger(FIELD_ACTILITY_SPREADING_FACTOR));
+        }
+        if (loraMessage.containsKey(FIELD_ACTILITY_LRR_SNR)) {
+            returnMap.put(LoraConstants.APP_PROPERTY_SNR, Math.abs(loraMessage.getDouble(FIELD_ACTILITY_LRR_SNR)));
+        }
+        if (loraMessage.containsKey(FIELD_ACTILITY_FPORT)) {
+            returnMap.put(LoraConstants.APP_PROPERTY_FUNCTION_PORT, loraMessage.getInteger(FIELD_ACTILITY_FPORT));
+        }
+        if (loraMessage.containsKey(FIELD_ACTILITY_LATITUTDE)) {
+            returnMap.put(LoraConstants.APP_PROPERTY_FUNCTION_LATITUDE, loraMessage.getDouble(FIELD_ACTILITY_LATITUTDE));
+        }
+        if (loraMessage.containsKey(FIELD_ACTILITY_LONGITUDE)) {
+            returnMap.put(LoraConstants.APP_PROPERTY_FUNCTION_LONGITUDE, loraMessage.getDouble(FIELD_ACTILITY_LONGITUDE));
+        }
+        return returnMap;
+    }
+
+    @Override
+    public JsonObject extractAdditionalData(final JsonObject loraMessage) {
+        final JsonObject returnMessage = loraMessage.copy();
+        if (returnMessage.containsKey(FIELD_ACTILITY_LRR_RSSI)) {
+            returnMessage.remove(LoraConstants.APP_PROPERTY_RSS);
+        }
+        if (returnMessage.containsKey(FIELD_ACTILITY_TX_POWER)) {
+            returnMessage.remove(LoraConstants.APP_PROPERTY_TX_POWER);
+        }
+        if (returnMessage.containsKey(FIELD_ACTILITY_CHANNEL)) {
+            returnMessage.remove(LoraConstants.APP_PROPERTY_CHANNEL);
+        }
+        if (returnMessage.containsKey(FIELD_ACTILITY_SUB_BAND)) {
+            returnMessage.remove(LoraConstants.APP_PROPERTY_SUB_BAND);
+        }
+        if (returnMessage.containsKey(FIELD_ACTILITY_SPREADING_FACTOR)) {
+            returnMessage.remove(LoraConstants.APP_PROPERTY_SPREADING_FACTOR);
+        }
+        if (returnMessage.containsKey(FIELD_ACTILITY_LRR_SNR)) {
+            returnMessage.remove(LoraConstants.APP_PROPERTY_SNR);
+        }
+        if (returnMessage.containsKey(FIELD_ACTILITY_FPORT)) {
+            returnMessage.remove(LoraConstants.APP_PROPERTY_FUNCTION_PORT);
+        }
+        if (returnMessage.containsKey(FIELD_ACTILITY_LATITUTDE)) {
+            returnMessage.remove(LoraConstants.APP_PROPERTY_FUNCTION_LATITUDE);
+        }
+        if (returnMessage.containsKey(FIELD_ACTILITY_LONGITUDE)) {
+            returnMessage.remove(LoraConstants.APP_PROPERTY_FUNCTION_LONGITUDE);
+        }
+        return null;
     }
 }

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/EverynetProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/EverynetProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -60,7 +60,7 @@ public class EverynetProvider implements LoraProvider {
     }
 
     @Override
-    public String extractPayloadEncodedInBase64(final JsonObject loraMessage) {
+    public String extractPayload(final JsonObject loraMessage) {
         return loraMessage.getJsonObject(FIELD_EVERYNET_ROOT_PARAMS_OBJECT, new JsonObject())
                 .getString(FIELD_EVERYNET_PAYLOAD);
     }

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/KerlinkProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/KerlinkProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -130,7 +130,7 @@ public class KerlinkProvider implements LoraProvider {
     }
 
     @Override
-    public String extractPayloadEncodedInBase64(final JsonObject loraMessage) {
+    public String extractPayload(final JsonObject loraMessage) {
         return loraMessage.getJsonObject(FIELD_UPLINK_USER_DATA, new JsonObject()).getString(FIELD_UPLINK_PAYLOAD);
     }
 

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,6 +22,8 @@ import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 
+import java.util.Map;
+
 /**
  * A LoraWAN provider which can send and receive messages from and to LoRa devices.
  */
@@ -37,7 +39,7 @@ public interface LoraProvider {
 
     /**
      * The url path prefix which is used for this provider. E.g. "/myloraprovider".
-     * 
+     *
      * @return The url path prefix with leading slash. E.g. "/myloraprovider".
      */
     String pathPrefix();
@@ -83,10 +85,30 @@ public interface LoraProvider {
      * Extracts the payload from an incoming message of the LoRa Provider.
      * 
      * @param loraMessage from which the payload should be extracted.
-     * @return Payload Encoded in Base64 format.
+     * @return Payload
      * @throws LoraProviderMalformedPayloadException if payload cannot be extracted.
      */
-    String extractPayloadEncodedInBase64(JsonObject loraMessage);
+    String extractPayload(JsonObject loraMessage);
+
+    /**
+     * Extracts the normalizable data from an incoming message of the LoRa Provider.
+     *
+     * @param loraMessage from which the payload should be extracted.
+     * @return Normalized data map.
+     */
+    default Map<String, Object> extractNormalizedData(JsonObject loraMessage){
+        return null;
+    }
+
+    /**
+     * Extracts the payload from an incoming message of the LoRa Provider.
+     *
+     * @param loraMessage from which the payload should be extracted.
+     * @return Data which could not be normalized as a JsonObject.
+     */
+    default JsonObject extractAdditionalData(JsonObject loraMessage){
+        return null;
+    }
 
     /**
      * Sends the given payload using this lora provider.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProviderDownlinkException.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProviderDownlinkException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProviderMalformedPayloadException.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProviderMalformedPayloadException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraUtils.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ObjeniousProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ObjeniousProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -46,10 +46,8 @@ public class ObjeniousProvider implements LoraProvider {
     }
 
     @Override
-    public String extractPayloadEncodedInBase64(final JsonObject loraMessage) {
-        final String hexPayload = loraMessage.getString(FIELD_PAYLOAD);
-
-        return LoraUtils.convertFromHexToBase64(hexPayload);
+    public String extractPayload(final JsonObject loraMessage) {
+        return loraMessage.getString(FIELD_PAYLOAD);
     }
 
     @Override

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ProximusProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ProximusProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -42,7 +42,7 @@ public class ProximusProvider implements LoraProvider {
     }
 
     @Override
-    public String extractPayloadEncodedInBase64(final JsonObject loraMessage) {
+    public String extractPayload(final JsonObject loraMessage) {
         return loraMessage.getString(FIELD_PROXIMUS_PAYLOAD);
     }
 }

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -42,7 +42,7 @@ public class ThingsNetworkProvider implements LoraProvider {
     }
 
     @Override
-    public String extractPayloadEncodedInBase64(final JsonObject loraMessage) {
+    public String extractPayload(final JsonObject loraMessage) {
         return loraMessage.getString(FIELD_TTN_PAYLOAD_RAW);
     }
 

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/LoraUtilsTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/LoraUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ActilityProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ActilityProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,9 +43,9 @@ public class ActilityProviderTest {
     @Test
     public void extractPayloadFromLoraMessage() {
         final JsonObject loraMessage = LoraTestUtil.loadTestFile("actility.uplink");
-        final String payload = provider.extractPayloadEncodedInBase64(loraMessage);
+        final String payload = provider.extractPayload(loraMessage);
 
-        Assert.assertEquals("AA==", payload);
+        Assert.assertEquals("00", payload);
     }
 
     /**

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/EverynetProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/EverynetProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,7 +43,7 @@ public class EverynetProviderTest {
     @Test
     public void extractPayloadFromLoraMessage() {
         final JsonObject loraMessage = LoraTestUtil.loadTestFile("everynet.uplink");
-        final String payload = this.providerPost.extractPayloadEncodedInBase64(loraMessage);
+        final String payload = this.providerPost.extractPayload(loraMessage);
 
         Assert.assertEquals("YnVtbHV4", payload);
     }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -93,7 +93,7 @@ public class KerlinkProviderTest {
     @Test
     public void extractPayloadFromLoraMessage() {
         final JsonObject loraMessage = LoraTestUtil.loadTestFile("kerlink.uplink");
-        final String payload = provider.extractPayloadEncodedInBase64(loraMessage);
+        final String payload = provider.extractPayload(loraMessage);
 
         Assert.assertEquals("YnVtbHV4", payload);
     }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraTestUtil.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraTestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ObjeniousProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ObjeniousProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,9 +43,9 @@ public class ObjeniousProviderTest {
     @Test
     public void extractPayloadFromLoraMessage() {
         final JsonObject loraMessage = LoraTestUtil.loadTestFile("objenious.uplink");
-        final String payload = provider.extractPayloadEncodedInBase64(loraMessage);
+        final String payload = provider.extractPayload(loraMessage);
 
-        Assert.assertEquals("AAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", payload);
+        Assert.assertEquals("00000000004000000000000000000000000000000000000000000000000000000000", payload);
     }
 
     /**

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ProximusProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ProximusProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,7 +43,7 @@ public class ProximusProviderTest {
     @Test
     public void extractPayloadFromLoraMessage() {
         final JsonObject loraMessage = LoraTestUtil.loadTestFile("proximus.uplink");
-        final String payload = this.provider.extractPayloadEncodedInBase64(loraMessage);
+        final String payload = this.provider.extractPayload(loraMessage);
 
         Assert.assertEquals("2205630000328c", payload);
     }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,7 +43,7 @@ public class ThingsNetworkProviderTest {
     @Test
     public void extractPayloadFromLoraMessage() {
         final JsonObject loraMessage = LoraTestUtil.loadTestFile("ttn.uplink");
-        final String payload = provider.extractPayloadEncodedInBase64(loraMessage);
+        final String payload = provider.extractPayload(loraMessage);
 
         Assert.assertEquals("YnVtbHV4", payload);
     }


### PR DESCRIPTION
Fixes #1190: LoRaWAN adapter does not pass through the metadata