### PR TITLE
Ensure code compiles with JDK 8

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -207,7 +207,7 @@ public interface HonoConnection extends ConnectionLifecycle {
      * @deprecated Use one of the other connect methods instead and use {@link #addDisconnectListener(DisconnectListener)}
      *             to be notified when the underlying AMQP connection fails unexpectedly.
      */
-    @Deprecated(forRemoval = true, since = "1.0-M2")
+    @Deprecated
     Future<HonoConnection> connect(Handler<ProtonConnection> disconnectHandler);
 
     /**
@@ -246,7 +246,7 @@ public interface HonoConnection extends ConnectionLifecycle {
      * @deprecated Use one of the other connect methods instead and use {@link #addDisconnectListener(DisconnectListener)}
      *             to be notified when the underlying AMQP connection fails unexpectedly.
      */
-    @Deprecated(forRemoval = true, since = "1.0-M2")
+    @Deprecated
     Future<HonoConnection> connect(
             ProtonClientOptions options,
             Handler<ProtonConnection> disconnectHandler);

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
@@ -183,6 +183,7 @@ public class HonoConnectionImpl implements HonoConnection {
      * 
      * @return The tracer.
      */
+    @Override
     public final Tracer getTracer() {
         return tracer;
     }
@@ -333,7 +334,7 @@ public class HonoConnectionImpl implements HonoConnection {
     /**
      * {@inheritDoc}
      */
-    @Deprecated(forRemoval = true, since = "1.0-M2")
+    @Deprecated
     @Override
     public final Future<HonoConnection> connect(final Handler<ProtonConnection> disconnectHandler) {
         return connect(null, Objects.requireNonNull(disconnectHandler));
@@ -342,7 +343,7 @@ public class HonoConnectionImpl implements HonoConnection {
     /**
      * {@inheritDoc}
      */
-    @Deprecated(forRemoval = true, since = "1.0-M2")
+    @Deprecated
     @Override
     public final Future<HonoConnection> connect(
             final ProtonClientOptions options,


### PR DESCRIPTION
Using the (in JDK 8) unsupported attributes cause a compile error in my IDE, which is correct btw. The reason for that is, that we are using Java X (X being the Java version available to the Maven compiler plugin) to compile against JDK X for JVM 8.

The animal sniffer plugin will detect when methods of a newer version than JDK 8 are used during runtime, but it seems to ignore the additional field in the annotation. That should not cause any issues during runtine, btw.

However if the available Java version is 8, then the compilation will fail, as those fields are only available after Java 8.