### PR TITLE
[#930] Make getDevice() a mandatory operation

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/registration/CompleteRegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/CompleteRegistrationService.java
@@ -82,24 +82,4 @@ public interface CompleteRegistrationService extends RegistrationService {
      *      Device Registration API - Deregister Device</a>
      */
     void removeDevice(String tenantId, String deviceId, Handler<AsyncResult<RegistrationResult>> resultHandler);
-
-    /**
-     * Gets device registration data by device ID.
-     *
-     * @param tenantId The tenant the device belongs to.
-     * @param deviceId The ID of the device to get registration data for.
-     * @param resultHandler The handler to invoke with the result of the operation.
-     *             The <em>status</em> will be
-     *             <ul>
-     *             <li><em>200 OK</em> if a device with the given ID is registered
-     *             for the tenant. The <em>payload</em> will contain the properties
-     *             registered for the device.</li>
-     *             <li><em>404 Not Found</em> if no device with the given identifier
-     *             is registered for the tenant.</li>
-     *             </ul>
-     * @throws NullPointerException if any of the parameters is {@code null}.
-     * @see <a href="https://www.eclipse.org/hono/api/device-registration-api/#get-registration-information">
-     *      Device Registration API - Get Registration Information</a>
-     */
-    void getDevice(String tenantId, String deviceId, Handler<AsyncResult<RegistrationResult>> resultHandler);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
@@ -153,4 +153,24 @@ public interface RegistrationService extends Verticle {
         assertRegistration(tenantId, deviceId, gatewayId, resultHandler);
     }
 
+    /**
+     * Gets device registration data by device ID.
+     *
+     * @param tenantId The tenant the device belongs to.
+     * @param deviceId The ID of the device to get registration data for.
+     * @param resultHandler The handler to invoke with the result of the operation.
+     *             The <em>status</em> will be
+     *             <ul>
+     *             <li><em>200 OK</em> if a device with the given ID is registered
+     *             for the tenant. The <em>payload</em> will contain the properties
+     *             registered for the device.</li>
+     *             <li><em>404 Not Found</em> if no device with the given identifier
+     *             is registered for the tenant.</li>
+     *             </ul>
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @see <a href="https://www.eclipse.org/hono/api/device-registration-api/#get-registration-information">
+     *      Device Registration API - Get Registration Information</a>
+     */
+    void getDevice(String tenantId, String deviceId, Handler<AsyncResult<RegistrationResult>> resultHandler);
+
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/CompleteBaseRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/CompleteBaseRegistrationServiceTest.java
@@ -161,27 +161,6 @@ public class CompleteBaseRegistrationServiceTest {
     }
 
     /**
-    * Verifies that the getDevice method returns not implemented.
-    *
-    * @param ctx The vertx unit test context.
-    */
-    @Test
-    public void testGetDevice(final VertxTestContext ctx) {
-
-        // GIVEN an empty registry
-        final CompleteBaseRegistrationService<ServiceConfigProperties> registrationService = newCompleteRegistrationServiceWithoutImpls();
-        registrationService.setRegistrationAssertionFactory(RegistrationAssertionHelperImpl.forSigning(vertx, props));
-
-        // WHEN trying to get a device's data
-        registrationService.getDevice(Constants.DEFAULT_TENANT, "4711", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the response contain a JWT token with an empty result with status code 501.
-            assertEquals(HttpURLConnection.HTTP_NOT_IMPLEMENTED, result.getStatus());
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
-    }
-
-    /**
      * Verifies that the registry returns 400 when issuing a request with an unsupported action.
      *
      * @param ctx The vert.x test context.
@@ -216,7 +195,7 @@ public class CompleteBaseRegistrationServiceTest {
 
         // WHEN trying to assert the device's registration status
         registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4711", ctx.succeeding(result -> ctx.verify(() -> {
-            assertEquals(result.getStatus(), HttpURLConnection.HTTP_OK);
+            assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
             assertFalse(result.getCacheDirective().isCachingAllowed());
             final JsonObject payload = result.getPayload();
             assertNotNull(payload);
@@ -417,7 +396,7 @@ public class CompleteBaseRegistrationServiceTest {
 
         return new CompleteBaseRegistrationService<>() {
 
-            private final Map<String, JsonObject> updatedDevicesMap = new HashMap<>(); 
+            private final Map<String, JsonObject> updatedDevicesMap = new HashMap<>();
 
             @Override
             protected String getEventBusAddress() {

--- a/site/content/api/Device-Registration-API.md
+++ b/site/content/api/Device-Registration-API.md
@@ -8,7 +8,7 @@ It can be used by *Protocol Adapters* to register devices that are not directly 
 *Solutions* and other consumers may use the API to obtain information about a single device that is registered to Hono.
 <!--more-->
 
-Note, however, that in real world applications the registration information will probably be kept and managed by an existing *system of record*, using e.g. a database for persisting the data. The Device Registration API accounts for this fact by means of defining only the [Assert Device Registration]({{< relref "#assert-device-registration" >}}) operation as *mandatory*, i.e. this operation is strictly required by a Hono instance for it to work properly, whereas the remaining operations are defined as *optional* from a Hono perspective.
+Note, however, that in real world applications the registration information will probably be kept and managed by an existing *system of record*, using e.g. a database for persisting the data. The Device Registration API accounts for this fact by means of defining only the [Assert Device Registration]({{< relref "#assert-device-registration" >}}) operation and the [Get Registration Information]({{< relref "#get-device-registration" >}}) operation as *mandatory*, i.e. these operations are strictly required by a Hono instance for it to work properly, whereas the remaining operations are defined as *optional* from a Hono perspective.
 
 The Device Registration API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using an AMQP 1.0 client in order to invoke operations of the API as described in the following sections.
 
@@ -85,6 +85,46 @@ The response message's *status* property may contain the following codes:
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
+
+## Get Registration Information
+
+Clients use this command to *retrieve* information about a registered device.
+
+This operation is *mandatory* to implement.
+
+**Message Flow**
+
+
+The following sequence diagram illustrates the flow of messages involved in a *Client* retrieving registration information.
+
+![Get Registration Information message flow](../getDeviceInformation_Success.png)
+
+
+**Request Message Format**
+
+The following table provides an overview of the properties a client needs to set on a message to get registration information in addition to the [Standard Request Properties]({{< relref "#standard-request-properties" >}}).
+
+| Name        | Mandatory | Location                 | AMQP Type | Description |
+| :---------- | :-------: | :----------------------- | :-------- | :---------- |
+| *subject*   | yes       | *properties*             | *string*  | MUST be set to `get`. |
+
+The body of the message SHOULD be empty and will be ignored if it is not.
+
+**Response Message Format**
+
+A response to a *get registration information* request contains the [Standard Response Properties]({{< relref "#standard-response-properties" >}}).
+
+The response message includes payload as defined in the [Payload Format]({{< relref "#payload-format" >}}) section below. The `data` member contains the key/value pairs that have been registered for the device.
+
+The response message's *status* property may contain the following codes:
+
+| Code | Description |
+| :--- | :---------- |
+| *200* | OK, the payload contains the registration information for the device. |
+| *404* | Not Found, there is no device registered with the given *device_id* within the given *tenant_id*. |
+
+For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
+
 # Optional Operations
 
 The operations described in the following sections can be used by clients to manage device registration information. In real world scenarios the provisioning of devices will most likely be an orchestrated process spanning multiple components of which Hono will only be one.
@@ -134,45 +174,6 @@ The response message's *status* property may contain the following codes:
 | :---- | :---------- |
 | *201* | Created, the device has been successfully registered. |
 | *409* | Conflict, there already exists a device registration for the given *device_id* within this tenant. |
-
-For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
-
-## Get Registration Information
-
-Clients use this command to *retrieve* information about a registered device.
-
-This operation is *optional*, implementors of this API may provide other means for retrieving registration information, e.g. a RESTful API.
-
-**Message Flow**
-
-
-The following sequence diagram illustrates the flow of messages involved in a *Client* retrieving registration information.
-
-![Get Registration Information message flow](../getDeviceInformation_Success.png)
-
-
-**Request Message Format**
-
-The following table provides an overview of the properties a client needs to set on a message to get registration information in addition to the [Standard Request Properties]({{< relref "#standard-request-properties" >}}).
-
-| Name        | Mandatory | Location                 | AMQP Type | Description |
-| :---------- | :-------: | :----------------------- | :-------- | :---------- |
-| *subject*   | yes       | *properties*             | *string*  | MUST be set to `get`. |
-
-The body of the message SHOULD be empty and will be ignored if it is not.
-
-**Response Message Format**
-
-A response to a *get registration information* request contains the [Standard Response Properties]({{< relref "#standard-response-properties" >}}).
-
-The response message includes payload as defined in the [Payload Format]({{< relref "#payload-format" >}}) section below. The `data` member contains the key/value pairs that have been registered for the device.
-
-The response message's *status* property may contain the following codes:
-
-| Code | Description |
-| :--- | :---------- |
-| *200* | OK, the payload contains the registration information for the device. |
-| *404* | Not Found, there is no device registered with the given *device_id* within the given *tenant_id*. |
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -18,6 +18,10 @@ title = "Release Notes"
   `org.eclipse.hono.service.AbstractProtocolAdapterBase.addProperties` methods have
   been changed to accept an additional parameter of type `TenantObject` which may contain default
   properties defined for the tenant to be included in downstream messages.
+* The `Get Registration Information` operation of the Device Registration API is not optional anymore, 
+  it is now mandatory to implement. For device registry implementations based on the
+  `CompleteRegistrationService` interface, there is no change needed as the operation is already
+  defined there.
 
 ## 1.0-M3
 


### PR DESCRIPTION
This is for #930:
The `Get Registration Information` operation is mandatory now.