### PR TITLE
Support setting default TTL for downstream messages

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -874,6 +874,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                             context.getMessage(),
                             ResourceIdentifier.from(context.getEndpoint().getCanonicalName(), resource.getTenantId(), resource.getResourceId()),
                             context.getAddress().toString(),
+                            tenantEnabledFuture.result(),
                             tokenFuture.result(),
                             null); // no TTD
 

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -518,6 +518,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                             "/" + context.getExchange().getRequestOptions().getUriPathString(),
                             contentType,
                             payload,
+                            tenantEnabledTracker.result(),
                             tokenTracker.result(),
                             null);
                     customizeDownstreamMessage(downstreamMessage, context);

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -634,6 +634,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                                 ctx.request().uri(),
                                 contentType,
                                 payload,
+                                tenantTracker.result(),
                                 tokenTracker.result(),
                                 ttd);
                         customizeDownstreamMessage(downstreamMessage, ctx);

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1021,6 +1021,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                             ctx.message().topicName(),
                             ctx.contentType(),
                             payload,
+                            tenantEnabledTracker.result(),
                             tokenTracker.result(),
                             null);
 

--- a/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientImplTest.java
@@ -256,7 +256,7 @@ public class RegistrationClientImplTest {
                 .compact();
         final JsonObject result = new JsonObject().put(RegistrationConstants.FIELD_ASSERTION, token);
         if (defaultContentType != null) {
-            result.put(RegistrationConstants.FIELD_DEFAULTS, new JsonObject()
+            result.put(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS, new JsonObject()
                     .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, defaultContentType));
         }
         return result;

--- a/core/src/main/java/org/eclipse/hono/util/Constants.java
+++ b/core/src/main/java/org/eclipse/hono/util/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -42,40 +42,43 @@ public final class Constants {
     public static final Symbol AMQP_ERROR_INACTIVITY= Symbol.valueOf("hono:inactivity");
 
     /**
+     * The default separator character for target addresses.
+     */
+    public static final String DEFAULT_PATH_SEPARATOR = "/";
+    /**
+     * The default number of milliseconds to wait before trying to reconnect to a service.
+     */
+    public static final long DEFAULT_RECONNECT_INTERVAL_MILLIS = 500;
+    /**
      * The name of the default tenant.
      */
     public static final String DEFAULT_TENANT = "DEFAULT_TENANT";
 
+    /**
+     * The type of the AMQP protocol adapter.
+     */
+    public static final String PROTOCOL_ADAPTER_TYPE_AMQP= "hono-amqp";
+    /**
+     * The type of the Eclipse coap adapter.
+     */
+    public static final String PROTOCOL_ADAPTER_TYPE_COAP= "hono-coap";
+    /**
+     * The type of the http protocol adapter.
+     */
+    public static final String PROTOCOL_ADAPTER_TYPE_HTTP= "hono-http";
+    /**
+     * The type of the Eclipse Kura protocol adapter.
+     */
+    public static final String PROTOCOL_ADAPTER_TYPE_KURA= "hono-kura-mqtt";
     /**
      * The type of the mqtt protocol adapter.
      */
     public static final String PROTOCOL_ADAPTER_TYPE_MQTT= "hono-mqtt";
 
     /**
-     * The type of the http protocol adapter.
-     */
-    public static final String PROTOCOL_ADAPTER_TYPE_HTTP= "hono-http";
-
-    /**
-     * The type of the Eclipse Kura protocol adapter.
-     */
-    public static final String PROTOCOL_ADAPTER_TYPE_KURA= "hono-kura-mqtt";
-
-    /**
-     * The type of the AMQP protocol adapter.
-     */
-    public static final String PROTOCOL_ADAPTER_TYPE_AMQP= "hono-amqp";
-
-    /**
-     * The type of the Eclipse coap adapter.
-     */
-    public static final String PROTOCOL_ADAPTER_TYPE_COAP= "hono-coap";
-
-    /**
      * The (short) name of the Auth Server component.
      */
     public static final String SERVICE_NAME_AUTH = "hono-auth";
-
     /**
      * The (short) name of the Device Registry component.
      */
@@ -94,16 +97,10 @@ public final class Constants {
     public static final Symbol CAP_REG_ASSERTION_VALIDATION = Symbol.valueOf("hono-reg-assertion");
 
     /**
-     * The default number of milliseconds to wait before trying to reconnect to a service.
-     */
-    public static final long DEFAULT_RECONNECT_INTERVAL_MILLIS = 500;
-
-    /**
      * The key that an authenticated client's principal is stored under in a {@code ProtonConnection}'s
      * attachments.
      */
     public static final String KEY_CLIENT_PRINCIPAL = "CLIENT_PRINCIPAL";
-
     /**
      * The key that the (surrogate) ID of a connection is stored under in a {@code ProtonConnection}'s
      * and/or {@code ProtonLink}'s attachments.
@@ -116,20 +113,13 @@ public final class Constants {
     public static final String EVENT_BUS_ADDRESS_CONNECTION_CLOSED = "hono.connection.closed";
 
     /**
-     * The default separator character for target addresses.
+     * The AMQP 1.0 port defined by IANA for unencrypted connections.
      */
-    public static final String DEFAULT_PATH_SEPARATOR = "/";
-
+    public static final int PORT_AMQP = 5672;
     /**
      * The AMQP 1.0 port defined by IANA for TLS encrypted connections.
      */
     public static final int PORT_AMQPS = 5671;
-
-    /**
-     * The AMQP 1.0 port defined by IANA for unencrypted connections.
-     */
-    public static final int PORT_AMQP = 5672;
-
     /**
      * Default value for a port that is not explicitly configured.
      */
@@ -144,17 +134,14 @@ public final class Constants {
      * The qualifier to use for referring to AMQP based components.
      */
     public static final String QUALIFIER_AMQP = "amqp";
-
     /**
      * The qualifier to use for referring to components scoped to the AMQP 1.0 messaging network.
      */
     public static final String QUALIFIER_DOWNSTREAM = "downstream";
-
     /**
      * The qualifier to use for referring to the AMQP Messaging Network.
      */
     public static final String QUALIFIER_MESSAGING = "messaging";
-
     /**
      * The qualifier to use for referring to REST based components.
      */
@@ -166,14 +153,13 @@ public final class Constants {
     public static final String SUBJECT_ANONYMOUS = "ANONYMOUS";
 
     /**
-     * The field name of JSON payloads containing a tenant ID.
-     */
-    public static final String JSON_FIELD_TENANT_ID = "tenant-id";
-
-    /**
      * The field name of JSON payloads containing a device ID.
      */
     public static final String JSON_FIELD_DEVICE_ID = "device-id";
+    /**
+     * The field name of JSON payloads containing a tenant ID.
+     */
+    public static final String JSON_FIELD_TENANT_ID = "tenant-id";
 
     /**
      * The principal to use for anonymous clients.

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -105,6 +105,27 @@ public final class MessageHelper {
     public static final String APP_PROPERTY_TENANT_ID = "tenant_id";
 
     /**
+     * The AMQP 1.0 <em>delivery-count</em> message header property.
+     */
+    public static final String SYS_HEADER_PROPERTY_DELIVERY_COUNT = "delivery-count";
+    /**
+     * The AMQP 1.0 <em>durable</em> message header property.
+     */
+    public static final String SYS_HEADER_PROPERTY_DURABLE = "durable";
+    /**
+     * The AMQP 1.0 <em>first-acquirer</em> message header property.
+     */
+    public static final String SYS_HEADER_PROPERTY_FIRST_ACQUIRER = "first-acquirer";
+    /**
+     * The AMQP 1.0 <em>priority</em> message header property.
+     */
+    public static final String SYS_HEADER_PROPERTY_PRIORITY = "priority";
+    /**
+     * The AMQP 1.0 <em>ttl</em> message header property.
+     */
+    public static final String SYS_HEADER_PROPERTY_TTL = "ttl";
+
+    /**
      * The AMQP 1.0 <em>absolute-expiry-time</em> message property.
      */
     public static final String SYS_PROPERTY_ABSOLUTE_EXPIRY_TIME = "absolute-expiry-time";
@@ -155,7 +176,7 @@ public final class MessageHelper {
     /**
      * The AMQP 1.0 <em>to</em> message property.
      */
-    public static final String SYS_PROPERTY_TO                     = "to";
+    public static final String SYS_PROPERTY_TO = "to";
 
     /**
      * The time-til-disconnect value to use for indicating that a device will remain connected until further notice.

--- a/core/src/main/java/org/eclipse/hono/util/RegistrationConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistrationConstants.java
@@ -51,12 +51,6 @@ public final class RegistrationConstants extends RequestResponseApiConstants {
      * that contains a device's registration information.
      */
     public static final String FIELD_DATA         = "data";
-    /**
-     * The name of the field in a device's registration information that contains
-     * <em>defaults</em> to be used by protocol adapters when processing messages published
-     * by the device.
-     */
-    public static final String FIELD_DEFAULTS     = "defaults";
 
     /**
      * The name of the field in a device's registration information that contains

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RequestResponseApiConstants.java
@@ -35,7 +35,14 @@ public abstract class RequestResponseApiConstants {
      */
     public static final String CONTENT_TYPE_APPLICATION_JSON = MessageHelper.CONTENT_TYPE_APPLICATION_JSON;
 
-    /* message payload fields */
+    /**
+     * The name of the property which contains default properties that protocol adapters
+     * should add to messages published by a device.
+     */
+    public static final String FIELD_PAYLOAD_DEFAULTS  = "defaults";
+    /**
+     * The name of the property that contains the identifier of a device.
+     */
     public static final String FIELD_PAYLOAD_DEVICE_ID = Constants.JSON_FIELD_DEVICE_ID;
     /**
      * The name of the property that contains the <em>subject DN</em> of the CA certificate
@@ -43,10 +50,23 @@ public abstract class RequestResponseApiConstants {
      * <a href="https://tools.ietf.org/html/rfc2253#section-2">RFC 2253, Section 2</a>.
      */
     public static final String FIELD_PAYLOAD_SUBJECT_DN = "subject-dn";
+    /**
+     * The name of the property that contains the identifier of a tenant.
+     */
     public static final String FIELD_PAYLOAD_TENANT_ID = Constants.JSON_FIELD_TENANT_ID;
 
+    /**
+     * The name of the field that contains a boolean indicating the status of an entity.
+     */
     public static final String FIELD_ENABLED   = "enabled";
+    /**
+     * The name of the field that contains additional information about an error
+     * that has occurred while processing a request message.
+     */
     public static final String FIELD_ERROR     = "error";
+    /**
+     * The name of the field that contains the payload of a request or response message.
+     */
     public static final String FIELD_PAYLOAD   = "payload";
 
     /**

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -518,4 +518,26 @@ public final class TenantObject extends JsonBackedValueObject {
         Objects.requireNonNull(resourceLimits);
         return setProperty(TenantConstants.FIELD_RESOURCE_LIMITS, resourceLimits);
     }
+
+    /**
+     * Gets the default property values used for all devices of this tenant.
+     * 
+     * @return The default properties or an empty JSON object if no default properties
+     *         have been defined for this tenant.
+     */
+    @JsonIgnore
+    public JsonObject getDefaults() {
+        return getProperty(TenantConstants.FIELD_PAYLOAD_DEFAULTS, new JsonObject());
+    }
+
+    /**
+     * Sets the default property values to use for all devices of this tenant.
+     * 
+     * @param defaultProperties The properties or an empty JSON object if no default properties
+     *         have been defined for this tenant.
+     */
+    @JsonIgnore
+    public void setDefaults(final JsonObject defaultProperties) {
+        setProperty(TenantConstants.FIELD_PAYLOAD_DEFAULTS, Objects.requireNonNull(defaultProperties));
+    }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -838,7 +838,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * {@link RegistrationConstants#FIELD_ASSERTION}.
      * <p>
      * In addition to the assertion the returned object may include <em>default</em> values for properties to set on
-     * messages published by the device under property {@link RegistrationConstants#FIELD_DEFAULTS}.
+     * messages published by the device under property {@link RegistrationConstants#FIELD_PAYLOAD_DEFAULTS}.
      *
      * @param tenantId The tenant that the device belongs to.
      * @param deviceId The device to get the assertion for.
@@ -878,7 +878,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * <p>
      * In addition to the assertion the returned object may include <em>default</em>
      * values for properties to set on messages published by the device under
-     * property {@link RegistrationConstants#FIELD_DEFAULTS}.
+     * property {@link RegistrationConstants#FIELD_PAYLOAD_DEFAULTS}.
      * 
      * @param tenantId The tenant that the device belongs to.
      * @param deviceId The device to get the assertion for.
@@ -1075,7 +1075,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * <li>Adds {@linkplain #getTypeName() the adapter's name} to the message in application property
      * {@link MessageHelper#APP_PROPERTY_ORIG_ADAPTER}</li>
      * <li>Augments the message with missing (application) properties corresponding to the
-     * {@link RegistrationConstants#FIELD_DEFAULTS} contained in the registration information.</li>
+     * {@link RegistrationConstants#FIELD_PAYLOAD_DEFAULTS} contained in the registration information.</li>
      * <li>Adds JMS vendor properties if configuration property <em>jmsVendorPropertiesEnabled</em> is set to
      * {@code true}.</li>
      * </ul>
@@ -1090,7 +1090,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_ORIG_ADAPTER, getTypeName());
         if (getConfig().isDefaultsEnabled()) {
-            final JsonObject defaults = registrationInfo.getJsonObject(RegistrationConstants.FIELD_DEFAULTS);
+            final JsonObject defaults = registrationInfo.getJsonObject(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS);
             if (defaults != null) {
                 addDefaults(message, defaults);
             }

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/BaseRegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/BaseRegistrationService.java
@@ -446,7 +446,7 @@ public abstract class BaseRegistrationService<T> extends EventBusService<T> impl
      * Creates a registration assertion token for a device and wraps it in a JSON object.
      * <p>
      * The returned JSON object may also contain <em>default</em> values registered for the
-     * device under key {@link RegistrationConstants#FIELD_DEFAULTS}.
+     * device under key {@link RegistrationConstants#FIELD_PAYLOAD_DEFAULTS}.
      * 
      * @param tenantId The tenant the device belongs to.
      * @param deviceId The device to create the assertion token for.
@@ -458,9 +458,9 @@ public abstract class BaseRegistrationService<T> extends EventBusService<T> impl
         final JsonObject result = new JsonObject()
                 .put(RegistrationConstants.FIELD_PAYLOAD_DEVICE_ID, deviceId)
                 .put(RegistrationConstants.FIELD_ASSERTION, assertionFactory.getAssertion(tenantId, deviceId));
-        final JsonObject defaults = registrationInfo.getJsonObject(RegistrationConstants.FIELD_DEFAULTS);
+        final JsonObject defaults = registrationInfo.getJsonObject(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS);
         if (defaults != null) {
-            result.put(RegistrationConstants.FIELD_DEFAULTS, defaults);
+            result.put(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS, defaults);
         }
         return result;
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -467,7 +467,7 @@ public class AbstractProtocolAdapterBaseTest {
         final JsonObject result = new JsonObject()
                 .put(RegistrationConstants.FIELD_ASSERTION, token);
         if (defaultContentType != null) {
-            result.put(RegistrationConstants.FIELD_DEFAULTS, new JsonObject()
+            result.put(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS, new JsonObject()
                     .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, defaultContentType));
         }
         return result;

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
@@ -269,7 +269,7 @@ public class BaseRegistrationServiceTest {
                     "4711",
                     new JsonObject()
                         .put(RegistrationConstants.FIELD_ENABLED, true)
-                        .put(RegistrationConstants.FIELD_DEFAULTS, new JsonObject()
+                        .put(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS, new JsonObject()
                                 .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, "application/default"))
                         .put(RegistrationConstants.FIELD_VIA, "gw-1"));
             return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
@@ -290,7 +290,7 @@ public class BaseRegistrationServiceTest {
                     "4714",
                     new JsonObject()
                         .put(RegistrationConstants.FIELD_ENABLED, true)
-                        .put(RegistrationConstants.FIELD_DEFAULTS, new JsonObject()
+                        .put(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS, new JsonObject()
                                 .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, "application/default"))
                         .put(RegistrationConstants.FIELD_VIA, new JsonArray().add("gw-1").add("gw-4")));
             return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/CompleteBaseRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/CompleteBaseRegistrationServiceTest.java
@@ -225,7 +225,7 @@ public class CompleteBaseRegistrationServiceTest {
             final String compactJws = payload.getString(RegistrationConstants.FIELD_ASSERTION);
             assertNotNull(compactJws);
             // and contains the registered default content type
-            final JsonObject defaults = payload.getJsonObject(RegistrationConstants.FIELD_DEFAULTS);
+            final JsonObject defaults = payload.getJsonObject(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS);
             assertNotNull(defaults);
             assertEquals("application/default", defaults.getString(MessageHelper.SYS_PROPERTY_CONTENT_TYPE));
             ctx.completeNow();
@@ -455,7 +455,7 @@ public class CompleteBaseRegistrationServiceTest {
                     "4711",
                     new JsonObject()
                             .put(RegistrationConstants.FIELD_ENABLED, true)
-                            .put(RegistrationConstants.FIELD_DEFAULTS, new JsonObject()
+                            .put(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS, new JsonObject()
                                     .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, "application/default"))
                             .put(RegistrationConstants.FIELD_VIA, "gw-1"));
             return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
@@ -476,7 +476,7 @@ public class CompleteBaseRegistrationServiceTest {
                     "4714",
                     new JsonObject()
                             .put(RegistrationConstants.FIELD_ENABLED, true)
-                            .put(RegistrationConstants.FIELD_DEFAULTS, new JsonObject()
+                            .put(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS, new JsonObject()
                                     .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, "application/default"))
                             .put(RegistrationConstants.FIELD_VIA, new JsonArray().add("gw-1").add("gw-4")));
             return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));

--- a/site/content/api/Device-Registration-API.md
+++ b/site/content/api/Device-Registration-API.md
@@ -298,7 +298,15 @@ The registration data is carried in the payload as a UTF-8 encoded string repres
 
 ## Request Payload
 
-The JSON object conveyed in the payload MAY contain an arbitrary number of members with arbitrary names. Clients may register *default* values for a device which can be used by protocol adapters to augment messages with missing information that have been published by the device. Protocol adapters extract default values from the `defaults` JSON object registered for a device.
+The table below provides an overview of the standard members defined for the JSON request object:
+
+| Name                     | Mandatory | JSON Type     | Default Value | Description |
+| :------------------------| :-------: | :------------ | :------------ | :---------- |
+| *enabled*                | *no*      | *boolean*     | `true`       | If set to `false` the device is currently disabled. Protocol adapters MUST NOT allow disabled devices to connect and MUST NOT accept data published by such devices. |
+| *defaults*               | *no*      | *object*      | `-`          | Arbitrary *default* properties for the device which can be used by protocol adapters to augment downstream messages with missing information, e.g. setting a default content type or TTL. |
+
+The JSON object MAY contain an arbitrary number of additional members with arbitrary names which can be of a scalar or a complex type.
+This allows for future *well-known* additions and also allows *clients* to add further information which might be relevant to a *custom* adapter only.
 
 Below is an example for a payload of a request for registering a device with a default content type:
 ~~~json
@@ -318,8 +326,17 @@ if the payload does not contain the *enabled* property.
 
 ## Response Payload
 
+
 The JSON object conveyed in a response payload always contains a string typed member of name `device-id` whose value is the ID of the device as provided during registration.
-In addition, the object contains a member with name `data` of type `json object`. The `data` object always contains a property called `enabled` which indicates whether the device may be interacted with or not.
+In addition, the object contains a property with name `data` of type JSON *object* with the following structure:
+
+| Name                     | Mandatory | JSON Type     | Default Value | Description |
+| :------------------------| :-------: | :------------ | :------------ | :---------- |
+| *enabled*                | *no*      | *boolean*     | `true`       | If set to `false` the device is currently disabled. Protocol adapters MUST NOT allow disabled devices to connect and MUST NOT accept data published by such devices. |
+| *defaults*               | *no*      | *object*      | `-`          | Arbitrary *default* properties for the device which can be used by protocol adapters to augment downstream messages with missing information, e.g. setting a default content type or TTL. |
+
+The `data` object MAY contain an arbitrary number of additional members with arbitrary names which can be of a scalar or a complex type.
+This allows for future *well-known* additions and also allows *clients* to add further information which might be relevant to a *custom* adapter only.
 
 Below is an example for a payload of a response to a *get* request for device `4711`:
 ~~~json

--- a/site/content/api/Tenant-API.md
+++ b/site/content/api/Tenant-API.md
@@ -293,10 +293,11 @@ The table below provides an overview of the standard members defined for the JSO
 
 | Name                     | Mandatory | JSON Type     | Default Value | Description |
 | :------------------------| :-------: | :------------ | :------------ | :---------- |
-| *enabled*                | *no*      | *boolean*     | `true`       | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
-| *trusted-ca*             | *no*      | *object*      | `-`          | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
 | *adapters*               | *no*      | *array*       | `-`          | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration. |
+| *defaults*               | *no*      | *object*      | `-`          | Arbitrary *default* properties for devices belonging to the tenant. The properties can be used by protocol adapters to augment downstream messages with missing information, e.g. setting a default content type or TTL. |
+| *enabled*                | *no*      | *boolean*     | `true`       | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
 | *resource-limits*         | *no*      | *object*     | `-`          | The resource-limits such as the maximum number of connections can be set. The format of a configuration option is described here [Resource Limits Configuration Format]({{< relref "#resource-limits-configuration-format" >}}).|
+| *trusted-ca*             | *no*      | *object*      | `-`          | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
 
 If any of the mandatory members is either missing or contains invalid data, implementations MUST NOT accept the payload and return *400 Bad Request* status code.
 
@@ -306,13 +307,16 @@ This allows for future *well-known* additions and also allows *clients* to add f
 ### Examples
 
 Below is an example for a request payload defining an *enabled* tenant.
-Devices belonging to the tenant can connect to Hono via the rest-adapter only and are required to authenticate with the adapter on connection.
+Devices belonging to the tenant can connect to Hono via the HTTP adapter only and are required to authenticate with the adapter on connection.
 
 **NB** The id of the tenant is not part of the JSON as it is defined in the application properties of the AMQP 1.0 message.
 
 ~~~json
 {
   "enabled": true,
+  "defaults": {
+    "ttl": 30
+  },
   "adapters": [
     {
       "type": "hono-http",
@@ -355,22 +359,26 @@ The table below provides an overview of the standard members defined for the JSO
 
 | Name                     | Mandatory | JSON Type     | Description |
 | :------------------------| :-------: | :------------ | :---------- |
-| *tenant-id*              | *yes*     | *string*      | The ID of the tenant. |
-| *enabled*                | *yes*     | *boolean*     | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
-| *trusted-ca*             | *no*      | *object*      | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
 | *adapters*               | *no*      | *array*       | A list of configuration options valid for certain adapters only. The format of a configuration option is described here [Adapter Configuration Format]({{< relref "#adapter-configuration-format" >}}). **NB** If the element is provided then the list MUST NOT be empty. **NB** Only a single entry per *type* is allowed. If multiple entries for the same *type* are present it is handled as an error. **NB** If the element is omitted then all adapters are *enabled* in their default configuration. |
+| *defaults*               | *no*      | *object*      | `-`          | Arbitrary *default* properties for devices belonging to the tenant. The properties can be used by protocol adapters to augment downstream messages with missing information, e.g. setting a default content type or TTL. |
+| *enabled*                | *yes*     | *boolean*     | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
 | *resource-limits*        | *no*      | *object*      | Any resource limits that should be enforced for the tenant, e.g. the maximum number of concurrent connections. Refer to [Resource Limits Configuration Format]({{< relref "#resource-limits-configuration-format" >}}) for details. |
+| *tenant-id*              | *yes*     | *string*      | The ID of the tenant. |
+| *trusted-ca*             | *no*      | *object*      | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
 
-Additionally to the specified properties the JSON object MAY contain an arbitrary number of members with arbitrary names which can be of a scalar or a complex type. 
+The JSON object MAY contain an arbitrary number of additional members with arbitrary names which can be of a scalar or a complex type.
 This allows for future *well-known* additions and also allows *clients* to add further information which might be relevant to a *custom* adapter only.
 
 ### Examples
 
-Below is an example for a payload of the response to a *get* request for tenant `TEST_TENANT`. Note that the payload contains some custom properties at both the tenant (*customer*) as well as the adapter configuration level (*deployment*).
+Below is an example for a payload of the response to a *get* request for tenant `TEST_TENANT`. Note that the payload contains some custom properties at both the tenant (*customer*) as well as the adapter configuration level (*deployment*) and also defines a default TTL for downstream messages.
 
 ~~~json
 {
   "tenant-id" : "TEST_TENANT",
+  "defaults": {
+    "ttl": 30
+  },
   "enabled" : true,
   "customer": "ACME Inc.",
   "resource-limits": {

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -4,10 +4,20 @@ title = "Release Notes"
 
 ## 1.0-M4 (not released yet)
 
+### New Features
+
+* Default properties can now also be set at the tenant level, affecting all devices
+  belonging to the tenant. Please refer to the [protocol adapter user guides]({{< ref "/user-guide" >}})
+  for details.
+
 ### API Changes
 
 * The `org.eclipse.hono.util.RegistrationConstants.FIELD_DEFAULTS` constant
   has been renamed to `org.eclipse.hono.util.RegistrationConstants.FIELD_PAYLOAD_DEFAULTS`.
+* The `org.eclipse.hono.service.AbstractProtocolAdapterBase.newMessage` and
+  `org.eclipse.hono.service.AbstractProtocolAdapterBase.addProperties` methods have
+  been changed to accept an additional parameter of type `TenantObject` which may contain default
+  properties defined for the tenant to be included in downstream messages.
 
 ## 1.0-M3
 

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -2,6 +2,13 @@
 title = "Release Notes"
 +++
 
+## 1.0-M4 (not released yet)
+
+### API Changes
+
+* The `org.eclipse.hono.util.RegistrationConstants.FIELD_DEFAULTS` constant
+  has been renamed to `org.eclipse.hono.util.RegistrationConstants.FIELD_PAYLOAD_DEFAULTS`.
+
 ## 1.0-M3
 
 ### Fixes & Enhancements

--- a/site/content/user-guide/amqp-adapter.md
+++ b/site/content/user-guide/amqp-adapter.md
@@ -309,23 +309,25 @@ After sending the command, the device (i.e AMQP command client) will print out t
 
 ## Downstream Meta Data
 
-Like the MQTT and HTTP adapters, the AMQP adapter also includes the following application properties in the AMQP 1.0 message being sent downstream:
+The adapter includes the following meta data in the application properties of messages being sent downstream:
 
-| Name               | Location        | Type      | Description                                                     |
-| :----------------- | :-------------- | :-------- | :-------------------------------------------------------------- |
-| *orig_adapter*     | *application*   | *string*  | Contains the adapter's *type name* which can be used by downstream consumers to determine the protocol adapter that the message has been received over. The AMQP adapter's type name is `hono-amqp. |
-| *orig_address*     | *application*   | *string*  | Contains the name of the MQTT topic that the device has originally published the data to. |
-| *device_id*     | *application*   | *string*  | Contains the ID of the device that published the message. |
-| *reg_assertion*     | *application*   | *string*  | If the downstream peer requires assertion information to be added to the message. |
+| Name               | Type      | Description                                                     |
+| :----------------- | :-------- | :-------------------------------------------------------------- |
+| *device_id*        | *string*  | The identifier of the device that the message originates from.  |
+| *orig_adapter*     | *string*  | Contains the adapter's *type name* which can be used by downstream consumers to determine the protocol adapter that the message has been received over. The AMQP adapter's type name is `hono-amqp`. |
+| *orig_address*     | *string*  | Contains the AMQP *target address* that the device has used to send the data. |
 
+The adapter also considers *defaults* registered for the device at either the [tenant]({{< ref "/api/Tenant-API.md#payload-format" >}}) or the [device level]({{< ref "/api/Device-Registration-API.md#payload-format" >}}). The values of the default properties are determined as follows:
 
-The adapter also considers [*defaults* registered for the device]({{< relref "api/Device-Registration-API.md#payload-format" >}}). For each default value the adapter checks if a corresponding property is already set on the message and if not, sets the message's property to the registered default value or adds a corresponding application property.
+1. If the message already contains a non-empty property of the same name, the value if unchanged.
+2. Otherwise, if a default property of the same name is defined in the device's registration information, that value is used.
+3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to, that value is used.
 
-Note that of the standard AMQP 1.0 message properties only the *content-type* can be set this way to a registered default value.
+Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
 
 ## Tenant specific Configuration
 
-The adapter uses the [Tenant API]({{< relref "api/Tenant-API.md#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-amqp`.
+The adapter uses the [Tenant API]({{< ref "/api/Tenant-API.md#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-amqp`.
 The following properties are (currently) supported:
 
 | Name               | Type       | Default Value | Description                                                     |

--- a/site/content/user-guide/http-adapter.md
+++ b/site/content/user-guide/http-adapter.md
@@ -525,16 +525,23 @@ The adapter includes the following meta data in the application properties of me
 
 | Name               | Type      | Description                                                     |
 | :----------------- | :-------- | :-------------------------------------------------------------- |
+| *device_id*        | *string*  | The identifier of the device that the message originates from.  |
 | *orig_adapter*     | *string*  | Contains the adapter's *type name* which can be used by downstream consumers to determine the protocol adapter that the message has been received over. The HTTP adapter's type name is `hono-http`. |
 | *orig_address*     | *string*  | Contains the (relative) URI that the device has originally posted the data to. |
+| *ttd*              | *integer* | Contains the effective number of seconds that the device will wait for a response. This property
+is only set if the HTTP request contains the `hono-ttd` header or request parameter. |
 
-The adapter also considers [*defaults* registered for the device]({{< relref "api/Device-Registration-API.md#payload-format" >}}). For each default value the adapter checks if a corresponding property is already set on the message and if not, sets the message's property to the registered default value or adds a corresponding application property.
+The adapter also considers *defaults* registered for the device at either the [tenant]({{< ref "/api/Tenant-API.md#payload-format" >}}) or the [device level]({{< ref "/api/Device-Registration-API.md#payload-format" >}}). The values of the default properties are determined as follows:
 
-Note that of the standard AMQP 1.0 message properties only the *content-type* can be set this way to a registered default value.
+1. If the message already contains a non-empty property of the same name, the value if unchanged.
+2. Otherwise, if a default property of the same name is defined in the device's registration information, that value is used.
+3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to, that value is used.
+
+Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
 
 ## Tenant specific Configuration
 
-The adapter uses the [Tenant API]({{< relref "api/Tenant-API.md#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-http`.
+The adapter uses the [Tenant API]({{< ref "/api/Tenant-API.md#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-http`.
 The following properties are (currently) supported:
 
 | Name               | Type       | Default Value | Description                                                     |

--- a/site/content/user-guide/kura-adapter.md
+++ b/site/content/user-guide/kura-adapter.md
@@ -22,16 +22,21 @@ The adapter includes the following meta data in messages being sent downstream:
 
 | Name               | Location        | Type      | Description                                                     |
 | :----------------- | :-------------- | :-------- | :-------------------------------------------------------------- |
+| *device_id*        | *application*   | *string*  | The identifier of the device that the message originates from.  |
 | *orig_adapter*     | *application*   | *string*  | Contains the adapter's *type name* which can be used by downstream consumers to determine the protocol adapter that the message has been received over. The Kura adapter's type name is `hono-kura-mqtt`. |
 | *orig_address*     | *application*   | *string*  | Contains the name of the MQTT topic that the Kura gateway has originally published the data to. |
 
-The adapter also considers [*defaults* registered for the device]({{< relref "api/Device-Registration-API.md#payload-format" >}}). For each default value the adapter checks if a corresponding property is already set on the message and if not, sets the message's property to the registered default value or adds a corresponding application property.
+The adapter also considers *defaults* registered for the device at either the [tenant]({{< ref "/api/Tenant-API.md#payload-format" >}}) or the [device level]({{< ref "/api/Device-Registration-API.md#payload-format" >}}). The values of the default properties are determined as follows:
 
-Note that of the standard AMQP 1.0 message properties only the *content-type* can be set this way to a registered default value.
+1. If the message already contains a non-empty property of the same name, the value if unchanged.
+2. Otherwise, if a default property of the same name is defined in the device's registration information, that value is used.
+3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to, that value is used.
+
+Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
 
 ## Tenant specific Configuration
 
-The adapter uses the [Tenant API]({{< relref "api/Tenant-API.md#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-kura-mqtt`.
+The adapter uses the [Tenant API]({{< ref "/api/Tenant-API.md#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-kura-mqtt`.
 The following properties are (currently) supported:
 
 | Name               | Type       | Default Value | Description                                                     |

--- a/site/content/user-guide/mqtt-adapter.md
+++ b/site/content/user-guide/mqtt-adapter.md
@@ -278,17 +278,22 @@ The adapter includes the following meta data in messages being sent downstream:
 
 | Name               | Location                | Type      | Description                                                     |
 | :----------------- | :---------------------- | :-------- | :-------------------------------------------------------------- |
+| *device_id*        | *application*           | *string*  | The identifier of the device that the message originates from.  |
 | *orig_adapter*     | *application*           | *string*  | Contains the adapter's *type name* which can be used by downstream consumers to determine the protocol adapter that the message has been received over. The MQTT adapter's type name is `hono-mqtt`. |
 | *orig_address*     | *application*           | *string*  | Contains the name of the MQTT topic that the device has originally published the data to. |
 | *x-opt-retain*     | * *message-annotations* | *boolean* | Contains `true` if the device has published an event or telemetry message with its *retain* flag set to `1` |
 
-The adapter also considers [*defaults* registered for the device]({{< relref "api/Device-Registration-API.md#payload-format" >}}). For each default value the adapter checks if a corresponding property is already set on the message and if not, sets the message's property to the registered default value or adds a corresponding application property.
+The adapter also considers *defaults* registered for the device at either the [tenant]({{< ref "/api/Tenant-API.md#payload-format" >}}) or the [device level]({{< ref "/api/Device-Registration-API.md#payload-format" >}}). The values of the default properties are determined as follows:
 
-Note that of the standard AMQP 1.0 message properties only the *content-type* can be set this way to a registered default value.
+1. If the message already contains a non-empty property of the same name, the value if unchanged.
+2. Otherwise, if a default property of the same name is defined in the device's registration information, that value is used.
+3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to, that value is used.
+
+Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
 
 ## Tenant specific Configuration
 
-The adapter uses the [Tenant API]({{< relref "api/Tenant-API.md#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-mqtt`.
+The adapter uses the [Tenant API]({{< ref "/api/Tenant-API.md#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-mqtt`.
 The following properties are (currently) supported:
 
 | Name               | Type       | Default Value | Description                                                     |


### PR DESCRIPTION
This PR extends the concept of *default properties* to the tenant level and then uses this concept to support setting a default *time-to-live* on downstream messages.