### PR TITLE
Add 'get' method in RegistrationClient with SpanContext parameter

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/RegistrationClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/RegistrationClient.java
@@ -121,6 +121,31 @@ public interface RegistrationClient extends RequestResponseClient {
     Future<JsonObject> get(String deviceId);
 
     /**
+     * Gets registration information for a device.
+     * <p>
+     * This default implementation simply returns the result of {@link #get(String)}.
+     *
+     * @param deviceId The id of the device to check.
+     * @param context The currently active OpenTracing span. An implementation
+     *         should use this as the parent for any span it creates for tracing
+     *         the execution of this operation.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed if a response with status 200 has been received from the registration service.
+     *         The JSON object will then contain values as defined in
+     *         <a href="https://www.eclipse.org/hono/api/device-registration-api/#get-registration-information"> Get
+     *         Registration Information</a>.
+     *         <p>
+     *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing the (error) status
+     *         code returned by the service.
+     * @throws NullPointerException if device ID is {@code null}.
+     * @see RequestResponseClient#setRequestTimeout(long)
+     */
+    default Future<JsonObject> get(String deviceId, final SpanContext context) {
+        return get(deviceId);
+    }
+
+    /**
      * Registers a device with Hono.
      * <p>
      * A device needs to be (successfully) registered before a client can upload

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
@@ -252,6 +252,16 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
      */
     @Override
     public final Future<JsonObject> get(final String deviceId) {
+        return get(deviceId, null);
+    }
+
+    /**
+     * Invokes the <em>Get Registration Information</em> operation of Hono's
+     * <a href="https://www.eclipse.org/hono/api/Device-Registration-API">Device Registration API</a>
+     * on the service represented by the <em>sender</em> and <em>receiver</em> links.
+     */
+    @Override
+    public final Future<JsonObject> get(final String deviceId, final SpanContext context) {
 
         Objects.requireNonNull(deviceId);
         final Future<RegistrationResult> resultTracker = Future.future();
@@ -260,7 +270,9 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
                 RegistrationConstants.ACTION_GET,
                 createDeviceIdProperties(deviceId),
                 null,
-                resultTracker);
+                resultTracker,
+                null,
+                context);
 
         return resultTracker.map(regResult -> {
             switch (regResult.getStatus()) {


### PR DESCRIPTION
Adds an additional `RegistrationClient#get` method with a `SpanContext` parameter.

This relates to #1215 (`RegistrationClient#get` being now a mandatory operation).