### PR TITLE
[#930] Rename DelegatingCommandHandler, add tests and improve tracing.

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/CommandContext.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandContext.java
@@ -38,7 +38,7 @@ import io.vertx.proton.ProtonReceiver;
  * A context for passing around parameters relevant for processing a {@code Command}.
  *
  */
-public final class CommandContext extends MapBasedExecutionContext {
+public class CommandContext extends MapBasedExecutionContext {
 
     /**
      * The key under which the current CommandContext is stored.
@@ -62,6 +62,7 @@ public final class CommandContext extends MapBasedExecutionContext {
         this.delivery = delivery;
         this.receiver = receiver;
         this.currentSpan = currentSpan;
+        setTracingContext(currentSpan.context());
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/GatewayMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/GatewayMapper.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.client;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 
 /**
@@ -34,9 +35,10 @@ public interface GatewayMapper extends ConnectionLifecycle {
      *
      * @param tenantId The tenant identifier.
      * @param deviceId The device identifier.
+     * @param context The currently active OpenTracing span context or {@code null}.
      * @return A succeeded Future containing the mapped gateway device id or {@code null};
      *         or a failed Future if there was an error determining the mapped gateway device.
      */
-    Future<String> getMappedGatewayDevice(String tenantId, String deviceId);
+    Future<String> getMappedGatewayDevice(String tenantId, String deviceId, SpanContext context);
 
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/GatewayMapperImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/GatewayMapperImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.RegistrationConstants;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
@@ -41,9 +42,9 @@ public class GatewayMapperImpl extends ConnectionLifecycleWrapper implements Gat
     }
 
     @Override
-    public Future<String> getMappedGatewayDevice(final String tenantId, final String deviceId) {
+    public Future<String> getMappedGatewayDevice(final String tenantId, final String deviceId, final SpanContext context) {
         return registrationClientFactory.getOrCreateRegistrationClient(tenantId).compose(client -> {
-            return client.get(deviceId);
+            return client.get(deviceId, context);
         }).map(deviceData -> {
             return getDeviceLastVia(deviceId, deviceData);
         });

--- a/client/src/main/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandler.java
@@ -59,7 +59,8 @@ public class GatewayMappingCommandHandler implements Handler<CommandContext> {
         final String originalDeviceId = originalCommand.getDeviceId();
         // determine last used gateway device id
         LOG.trace("determine 'via' device to use for received command [{}]", originalCommand);
-        final Future<String> lastViaDeviceIdFuture = gatewayMapper.getMappedGatewayDevice(tenantId, originalDeviceId);
+        final Future<String> lastViaDeviceIdFuture = gatewayMapper.getMappedGatewayDevice(tenantId, originalDeviceId,
+                originalCommandContext.getTracingContext());
 
         lastViaDeviceIdFuture.setHandler(deviceIdFutureResult -> {
             if (deviceIdFutureResult.succeeded()) {

--- a/client/src/test/java/org/eclipse/hono/client/impl/DelegateViaDownstreamPeerCommandHandlerTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DelegateViaDownstreamPeerCommandHandlerTest.java
@@ -1,0 +1,241 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Modified;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.Command;
+import org.eclipse.hono.client.CommandContext;
+import org.eclipse.hono.client.DelegatedCommandSender;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.util.CommandConstants;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * Verifies behavior of {@link DelegateViaDownstreamPeerCommandHandler}.
+ */
+public class DelegateViaDownstreamPeerCommandHandlerTest {
+
+    private String tenantId;
+    private String deviceId;
+    private CommandContext commandContext;
+    private DelegateViaDownstreamPeerCommandHandler delegateViaDownstreamPeerCommandHandler;
+    private DelegatedCommandSender delegatedCommandSender;
+    private String replyTo;
+
+    /**
+     * Sets up common fixture.
+     */
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setup() {
+        tenantId = "testTenant";
+        deviceId = "testDevice";
+        replyTo = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId, "the-reply-to-id");
+
+        final Message commandMessage = mock(Message.class);
+        when(commandMessage.getSubject()).thenReturn("testSubject");
+        when(commandMessage.getCorrelationId()).thenReturn("testCorrelationId");
+        when(commandMessage.getReplyTo()).thenReturn(replyTo);
+        final Command command = Command.from(commandMessage, tenantId, deviceId);
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        final ProtonReceiver receiver = mock(ProtonReceiver.class);
+        final Span currentSpan = mock(Span.class);
+        commandContext = spy(CommandContext.from(command, delivery, receiver, currentSpan));
+
+        delegateViaDownstreamPeerCommandHandler = new DelegateViaDownstreamPeerCommandHandler(
+                tenantIdParam -> Future.succeededFuture(delegatedCommandSender));
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when sending the command message returns an
+     * <em>Accepted</em> delivery result.
+     */
+    @Test
+    public void testHandleWithAcceptedDeliveryResult() {
+
+        // GIVEN a message sender that returns an 'Accepted' delivery result
+        final ProtonDelivery protonDelivery = mock(ProtonDelivery.class);
+        when(protonDelivery.getRemoteState()).thenReturn(Accepted.getInstance());
+        // not using a DelegatedCommandSender mock here since mocking the #sendAndWaitForOutcome(Message, SpanContext) method (which has a default implementation) doesn't seem to work
+        delegatedCommandSender = new DelegatedCommandSenderImpl(mock(HonoConnection.class), mock(ProtonSender.class)) {
+            @Override
+            public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final SpanContext parent) {
+                assertThat(message.getAddress(),
+                        is(String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+                                DelegateViaDownstreamPeerCommandHandlerTest.this.tenantId,
+                                DelegateViaDownstreamPeerCommandHandlerTest.this.deviceId)));
+                assertThat(message.getReplyTo(), is(replyTo));
+                return Future.succeededFuture(protonDelivery);
+            }
+        };
+
+        // WHEN handle() is invoked
+        delegateViaDownstreamPeerCommandHandler.handle(commandContext);
+
+        // THEN the command context is accepted
+        verify(commandContext).accept();
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when sending the command message returns a
+     * <em>Rejected</em> delivery result.
+     */
+    @Test
+    public void testHandleWithRejectedDeliveryResult() {
+
+        // GIVEN a message sender that returns a 'Rejected' delivery result
+        final ProtonDelivery protonDelivery = mock(ProtonDelivery.class);
+        final Rejected rejected = new Rejected();
+        final ErrorCondition error = new ErrorCondition(Symbol.valueOf("someError"), "error message");
+        rejected.setError(error);
+        when(protonDelivery.getRemoteState()).thenReturn(rejected);
+        delegatedCommandSender = new DelegatedCommandSenderImpl(mock(HonoConnection.class), mock(ProtonSender.class)) {
+            @Override
+            public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final SpanContext parent) {
+                assertThat(message.getAddress(),
+                        is(String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+                                DelegateViaDownstreamPeerCommandHandlerTest.this.tenantId,
+                                DelegateViaDownstreamPeerCommandHandlerTest.this.deviceId)));
+                assertThat(message.getReplyTo(), is(replyTo));
+                return Future.succeededFuture(protonDelivery);
+            }
+        };
+
+        // WHEN handle() is invoked
+        delegateViaDownstreamPeerCommandHandler.handle(commandContext);
+
+        // THEN the command context is rejected
+        final ArgumentCaptor<ErrorCondition> errorConditionArgumentCaptor = ArgumentCaptor.forClass(ErrorCondition.class);
+        verify(commandContext).reject(errorConditionArgumentCaptor.capture(), anyInt());
+        assertThat(errorConditionArgumentCaptor.getValue(), is(error));
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when sending the command message returns a
+     * <em>Modified</em> delivery result.
+     */
+    @Test
+    public void testHandleWithModifiedDeliveryResult() {
+
+        // GIVEN a message sender that returns a 'Modified' delivery result
+        final ProtonDelivery protonDelivery = mock(ProtonDelivery.class);
+        final Modified modified = new Modified();
+        modified.setDeliveryFailed(true);
+        modified.setUndeliverableHere(true);
+        when(protonDelivery.getRemoteState()).thenReturn(modified);
+        delegatedCommandSender = new DelegatedCommandSenderImpl(mock(HonoConnection.class), mock(ProtonSender.class)) {
+            @Override
+            public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final SpanContext parent) {
+                assertThat(message.getAddress(),
+                        is(String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+                                DelegateViaDownstreamPeerCommandHandlerTest.this.tenantId,
+                                DelegateViaDownstreamPeerCommandHandlerTest.this.deviceId)));
+                assertThat(message.getReplyTo(), is(replyTo));
+                return Future.succeededFuture(protonDelivery);
+            }
+        };
+
+        // WHEN handle() is invoked
+        delegateViaDownstreamPeerCommandHandler.handle(commandContext);
+
+        // THEN the command context is modified
+        verify(commandContext).modify(anyBoolean(), anyBoolean(), anyInt());
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when sending the command message returns a
+     * <em>Released</em> delivery result.
+     */
+    @Test
+    public void testHandleWithReleasedDeliveryResult() {
+
+        // GIVEN a message sender that returns an 'Released' delivery result
+        final ProtonDelivery protonDelivery = mock(ProtonDelivery.class);
+        when(protonDelivery.getRemoteState()).thenReturn(Released.getInstance());
+        delegatedCommandSender = new DelegatedCommandSenderImpl(mock(HonoConnection.class), mock(ProtonSender.class)) {
+            @Override
+            public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final SpanContext parent) {
+                assertThat(message.getAddress(),
+                        is(String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+                                DelegateViaDownstreamPeerCommandHandlerTest.this.tenantId,
+                                DelegateViaDownstreamPeerCommandHandlerTest.this.deviceId)));
+                assertThat(message.getReplyTo(), is(replyTo));
+                return Future.succeededFuture(protonDelivery);
+            }
+        };
+
+        // WHEN handle() is invoked
+        delegateViaDownstreamPeerCommandHandler.handle(commandContext);
+
+        // THEN the command context is released
+        verify(commandContext).release();
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when sending the command message fails.
+     */
+    @Test
+    public void testHandleWithFailureToSend() {
+
+        // GIVEN a message sender that fails to send the message
+        delegatedCommandSender = new DelegatedCommandSenderImpl(mock(HonoConnection.class), mock(ProtonSender.class)) {
+            @Override
+            public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final SpanContext parent) {
+                return Future.failedFuture("expected send failure");
+            }
+        };
+
+        // WHEN handle() is invoked
+        delegateViaDownstreamPeerCommandHandler.handle(commandContext);
+
+        // THEN the command context is released
+        verify(commandContext).release();
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when creating the message sender fails.
+     */
+    @Test
+    public void testHandleWithFailureToCreateSender() {
+
+        // GIVEN a a scenario where sender creation fails
+        delegateViaDownstreamPeerCommandHandler = new DelegateViaDownstreamPeerCommandHandler(
+                tenantIdParam -> Future.failedFuture("expected sender creation failure"));
+
+        // WHEN handle() is invoked
+        delegateViaDownstreamPeerCommandHandler.handle(commandContext);
+
+        // THEN the command context is released
+        verify(commandContext).release();
+    }
+}

--- a/client/src/test/java/org/eclipse/hono/client/impl/GatewayMapperImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/GatewayMapperImplTest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.RegistrationClientFactory;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Verifies behavior of {@link GatewayMapperImpl}.
+ */
+public class GatewayMapperImplTest {
+
+    private GatewayMapperImpl gatewayMapper;
+    private RegistrationClient regClient;
+    private String tenantId;
+    private String deviceId;
+
+    /**
+     * Sets up common fixture.
+     */
+    @Before
+    public void setup() {
+        tenantId = "testTenant";
+        deviceId = "testDevice";
+        regClient = mock(RegistrationClient.class);
+        final RegistrationClientFactory registrationClientFactory = mock(RegistrationClientFactory.class);
+        when(registrationClientFactory.getOrCreateRegistrationClient(anyString()))
+                .thenReturn(Future.succeededFuture(regClient));
+        gatewayMapper = new GatewayMapperImpl(registrationClientFactory);
+    }
+
+    /**
+     * Verifies that the <em>getMappedGatewayDevice</em> method returns a Future with the device id as result for a
+     * device for which 'via' is not set.
+     */
+    @Test
+    public void testGetMappedGatewayDeviceUsingEmptyDeviceData() {
+        // GIVEN deviceData with no 'via'
+        final JsonObject deviceData = new JsonObject();
+        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+
+        // WHEN getMappedGatewayDevice() is invoked
+        final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, deviceId, null);
+
+        // THEN the returned Future is complete and contains the deviceId
+        assertThat(mappedGatewayDeviceFuture.isComplete(), is(true));
+        assertThat(mappedGatewayDeviceFuture.result(), is(deviceId));
+    }
+
+    /**
+     * Verifies that the <em>getMappedGatewayDevice</em> method returns the correct value for a device for which 'via'
+     * and 'last-via' is set.
+     */
+    @Test
+    public void testGetMappedGatewayDeviceUsingDeviceDataWithLastVia() {
+        final String deviceViaId = "testDeviceVia";
+
+        // GIVEN deviceData with 'via' and 'last-via'
+        final JsonObject deviceData = new JsonObject();
+        deviceData.put(RegistrationConstants.FIELD_VIA, deviceViaId);
+        final JsonObject lastViaObject = new JsonObject();
+        lastViaObject.put(Constants.JSON_FIELD_DEVICE_ID, deviceViaId);
+        deviceData.put(RegistrationConstants.FIELD_LAST_VIA, lastViaObject);
+        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+
+        // WHEN getMappedGatewayDevice() is invoked
+        final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, deviceId, null);
+
+        // THEN the returned Future is complete and contains the deviceViaId
+        assertThat(mappedGatewayDeviceFuture.isComplete(), is(true));
+        assertThat(mappedGatewayDeviceFuture.result(), is(deviceViaId));
+    }
+
+    /**
+     * Verifies that the <em>getMappedGatewayDevice</em> method returns a Future with {@code null} as result for a
+     * device for which 'via' is set but 'last-via' is not set.
+     */
+    @Test
+    public void testGetMappedGatewayDeviceUsingDeviceDataWithoutLastVia() {
+        final String deviceViaId = "testDeviceVia";
+
+        // GIVEN deviceData with 'via' but no 'last-via'
+        final JsonObject deviceData = new JsonObject();
+        deviceData.put(RegistrationConstants.FIELD_VIA, deviceViaId);
+
+        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+
+        // WHEN getMappedGatewayDevice() is invoked
+        final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, deviceId, null);
+
+        // THEN the returned Future is complete and contains null as result
+        assertThat(mappedGatewayDeviceFuture.isComplete(), is(true));
+        assertThat(mappedGatewayDeviceFuture.result(), is(nullValue()));
+    }
+
+}

--- a/client/src/test/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandlerTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandlerTest.java
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.Command;
+import org.eclipse.hono.client.CommandContext;
+import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.RegistrationClientFactory;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.Span;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonReceiver;
+
+/**
+ * Verifies behavior of {@link GatewayMappingCommandHandler}.
+ */
+public class GatewayMappingCommandHandlerTest {
+
+    private RegistrationClient regClient;
+    private String tenantId;
+    private String deviceId;
+    private Handler<CommandContext> nextCommandHandler;
+    private GatewayMappingCommandHandler gatewayMappingCommandHandler;
+    private CommandContext commandContext;
+    private Message commandMessage;
+
+    /**
+     * Sets up common fixture.
+     */
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setup() {
+        tenantId = "testTenant";
+        deviceId = "testDevice";
+        regClient = mock(RegistrationClient.class);
+        final RegistrationClientFactory registrationClientFactory = mock(RegistrationClientFactory.class);
+        when(registrationClientFactory.getOrCreateRegistrationClient(anyString()))
+                .thenReturn(Future.succeededFuture(regClient));
+        final GatewayMapperImpl gatewayMapper = new GatewayMapperImpl(registrationClientFactory);
+
+        nextCommandHandler = mock(Handler.class);
+        gatewayMappingCommandHandler = new GatewayMappingCommandHandler(gatewayMapper, nextCommandHandler);
+
+        commandMessage = mock(Message.class);
+        when(commandMessage.getSubject()).thenReturn("testSubject");
+        when(commandMessage.getCorrelationId()).thenReturn("testCorrelationId");
+        final Command command = Command.from(commandMessage, tenantId, deviceId);
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        final ProtonReceiver receiver = mock(ProtonReceiver.class);
+        final Span currentSpan = mock(Span.class);
+        commandContext = spy(CommandContext.from(command, delivery, receiver, currentSpan));
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when called in the context of a device for which 'via'
+     * is not set.
+     */
+    @Test
+    public void testHandleUsingEmptyDeviceData() {
+        // GIVEN deviceData with no 'via'
+        final JsonObject deviceData = new JsonObject();
+        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+
+        // WHEN handle() is invoked
+        gatewayMappingCommandHandler.handle(commandContext);
+
+        // THEN the nextCommandHandler is called with the original commandContext
+        final ArgumentCaptor<CommandContext> commandContextArgumentCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(nextCommandHandler).handle(commandContextArgumentCaptor.capture());
+        assertThat(commandContextArgumentCaptor.getValue(), is(commandContext));
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when called in the context of a device for which 'via'
+     * and 'last-via' is set.
+     */
+    @Test
+    public void testHandleUsingDeviceDataWithLastVia() {
+        final String deviceViaId = "testDeviceVia";
+
+        // GIVEN deviceData with 'via' and 'last-via'
+        final JsonObject deviceData = new JsonObject();
+        deviceData.put(RegistrationConstants.FIELD_VIA, deviceViaId);
+        final JsonObject lastViaObject = new JsonObject();
+        lastViaObject.put(Constants.JSON_FIELD_DEVICE_ID, deviceViaId);
+        deviceData.put(RegistrationConstants.FIELD_LAST_VIA, lastViaObject);
+        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+
+        // WHEN handle() is invoked
+        gatewayMappingCommandHandler.handle(commandContext);
+
+        // THEN the nextCommandHandler is called with an adapted commandContext (with deviceViaId)
+        final ArgumentCaptor<CommandContext> commandContextArgumentCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(nextCommandHandler).handle(commandContextArgumentCaptor.capture());
+        assertThat(commandContextArgumentCaptor.getValue().getCommand().getDeviceId(), is(deviceViaId));
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when called in the context of a device for which 'via'
+     * and 'last-via' is set and where the command has a 'reply-to' value set.
+     */
+    @Test
+    public void testHandleUsingDeviceDataWithLastViaAndCommandWithReplyTo() {
+        final String deviceViaId = "testDeviceVia";
+        final String replyToId = "the-reply-to-id";
+        final String replyTo = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId, replyToId);
+
+        // GIVEN deviceData with 'via' and 'last-via'
+        final JsonObject deviceData = new JsonObject();
+        deviceData.put(RegistrationConstants.FIELD_VIA, deviceViaId);
+        final JsonObject lastViaObject = new JsonObject();
+        lastViaObject.put(Constants.JSON_FIELD_DEVICE_ID, deviceViaId);
+        deviceData.put(RegistrationConstants.FIELD_LAST_VIA, lastViaObject);
+        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+
+        // AND a commandMessage with reply-to set
+        when(commandMessage.getReplyTo()).thenReturn(replyTo);
+        final Command command = Command.from(commandMessage, tenantId, deviceId);
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        final ProtonReceiver receiver = mock(ProtonReceiver.class);
+        final Span currentSpan = mock(Span.class);
+        commandContext = spy(CommandContext.from(command, delivery, receiver, currentSpan));
+
+        // WHEN handle() is invoked
+        gatewayMappingCommandHandler.handle(commandContext);
+
+        // THEN the nextCommandHandler is called with an adapted commandContext (with deviceViaId) and original reply-to id
+        final ArgumentCaptor<CommandContext> commandContextArgumentCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(nextCommandHandler).handle(commandContextArgumentCaptor.capture());
+        assertThat(commandContextArgumentCaptor.getValue().getCommand().getDeviceId(), is(deviceViaId));
+        assertThat(commandContextArgumentCaptor.getValue().getCommand().getCommandMessage().getReplyTo(), is(replyTo));
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when called in the context of a device for which 'via'
+     * is set but 'last-via' is not set.
+     */
+    @Test
+    public void testHandleUsingDeviceDataWithoutLastVia() {
+        final String deviceViaId = "testDeviceVia";
+
+        // GIVEN deviceData with 'via' but no 'last-via'
+        final JsonObject deviceData = new JsonObject();
+        deviceData.put(RegistrationConstants.FIELD_VIA, deviceViaId);
+        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+
+        // WHEN handle() is invoked
+        gatewayMappingCommandHandler.handle(commandContext);
+
+        // THEN the nextCommandHandler is not invoked and the commandContext is released
+        verifyZeroInteractions(nextCommandHandler);
+        verify(commandContext).release();
+    }
+
+    /**
+     * Verifies that the <em>handle</em> method behaves correctly when there is an exception retrieving device data.
+     */
+    @Test
+    public void testHandleWithRegistrationClientException() {
+        // GIVEN a registrationClient that returns a failed future
+        when(regClient.get(anyString(), any())).thenReturn(Future.failedFuture("expected exception"));
+
+        // WHEN handle() is invoked
+        gatewayMappingCommandHandler.handle(commandContext);
+
+        // THEN the nextCommandHandler is not invoked and the commandContext is released
+        verifyZeroInteractions(nextCommandHandler);
+        verify(commandContext).release();
+    }
+}


### PR DESCRIPTION
For #930:

This renames the `DelegatingCommandHandler` class to `DelegateViaDownstreamPeerCommandHandler`, making the class only responsible for one thing, namely delegating the handling of a command message (received on a tenant-scoped link) to a device-specific command consumer by sending the command message (with a modified `To` address) back to the downstream peer.

Furthermore, tests for the classes introduced in #1145 have been added. And tracing of command messages is improved by properly adding the tracing context in `CommandContext`.

The `CommandContext` class is not `final` anymore here, so that it can be mocked (configuring Mockito so that it can also mock final methods doesn't seem worth it regarding effort and the possible performance hit here, imho).
