### PR TITLE
Add a basic Sigfox protocol adapter

### DIFF
--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -35,6 +35,7 @@
     <module>lora-vertx</module>
     <module>mqtt-vertx</module>
     <module>mqtt-vertx-base</module>
+    <module>sigfox-vertx</module>
   </modules>
 
   <name>Hono Protocol Adapters</name>

--- a/adapters/sigfox-vertx/pom.xml
+++ b/adapters/sigfox-vertx/pom.xml
@@ -1,0 +1,115 @@
+<!--
+    Copyright (c) 2019 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-adapters</artifactId>
+        <version>1.0-M4-SNAPSHOT</version>
+    </parent>
+    <artifactId>hono-adapter-sigfox-vertx</artifactId>
+    <name>Hono Sigfox Adapter</name>
+
+    <description>A protocol adapter for connecting to the Sigfox backend.</description>
+    <url>https://www.eclipse.org/hono</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-adapter-http-vertx-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+        <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+        </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>build-docker-image</id>
+            <activation>
+                <property>
+                <name>docker.host</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <configuration>
+                    <images>
+                        <image>
+                        <build>
+                            <from>${java-base-image.name}</from>
+                            <ports>
+                                <port>8080</port>
+                                <port>8443</port>
+                                <port>${vertx.health.port}</port>
+                            </ports>
+                            <cmd>
+                            <exec>
+                                <arg>java</arg>
+                                <arg>--illegal-access=permit</arg>
+                                <arg>-Dvertx.cacheDirBase=/tmp</arg>
+                                <arg>-Dloader.home=/opt/hono</arg>
+                                <arg>-Dloader.path=extensions</arg>
+                                <arg>-cp</arg>
+                                <arg>/opt/hono/${project.artifactId}-${project.version}-${classifier.spring.boot.artifact}.jar</arg>
+                                <arg>org.springframework.boot.loader.PropertiesLauncher</arg>
+                            </exec>
+                            </cmd>
+                            <assembly>
+                            <mode>dir</mode>
+                            <basedir>/</basedir>
+                            <inline>
+                                <fileSets>
+                                <fileSet>
+                                    <directory>${project.build.directory}</directory>
+                                    <outputDirectory>opt/hono</outputDirectory>
+                                    <includes>
+                                    <include>${project.artifactId}-${project.version}-${classifier.spring.boot.artifact}.jar</include>
+                                    </includes>
+                                </fileSet>
+                                </fileSets>
+                            </inline>
+                            </assembly>
+                        </build>
+                        </image>
+                    </images>
+                    </configuration>
+                </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Application.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Application.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.sigfox.impl;
+
+import org.eclipse.hono.service.AbstractApplication;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+/**
+ * The Hono Sigfox adapter main application class.
+ */
+@ComponentScan("org.eclipse.hono.adapter.sigfox")
+@ComponentScan("org.eclipse.hono.adapter.http")
+@ComponentScan("org.eclipse.hono.service.metric")
+@SpringBootApplication
+public class Application extends AbstractApplication {
+
+    /**
+     * Starts the Sigfox Adapter application.
+     * 
+     * @param args Command line args passed to the application.
+     */
+    public static void main(final String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
@@ -20,6 +20,7 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -37,7 +38,6 @@ public class Config extends AbstractAdapterConfig {
 
     private static final String CONTAINER_ID_HONO_SIGFOX_ADAPTER = "Hono Sigfox Adapter";
     private static final String BEAN_NAME_SIGFOX_PROTOCOL_ADAPTER = "sigfoxProtocolAdapter";
-    private static final String METRICS_PROTOCOL_TAG = "sigfox";
 
     @PostConstruct
     void validateConfiguration() {
@@ -130,7 +130,7 @@ public class Config extends AbstractAdapterConfig {
     @Bean
     public MeterRegistryCustomizer<MeterRegistry> commonTags() {
         return r -> r.config().commonTags(
-                MetricsTags.forProtocolAdapter(METRICS_PROTOCOL_TAG));
+                MetricsTags.forProtocolAdapter(Constants.PROTOCOL_ADAPTER_TYPE_SIGFOX));
     }
 
 }

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.sigfox.impl;
+
+import javax.annotation.PostConstruct;
+
+import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.service.AbstractAdapterConfig;
+import org.eclipse.hono.service.metric.MetricsTags;
+import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
+
+/**
+ * Spring Boot configuration for the Sigfox adapter.
+ */
+@Configuration
+@EnableCaching
+public class Config extends AbstractAdapterConfig {
+
+    private static final String CONTAINER_ID_HONO_SIGFOX_ADAPTER = "Hono Sigfox Adapter";
+    private static final String BEAN_NAME_SIGFOX_PROTOCOL_ADAPTER = "sigfoxProtocolAdapter";
+    private static final String METRICS_PROTOCOL_TAG = "sigfox";
+
+    @PostConstruct
+    void validateConfiguration() {
+        final HttpProtocolAdapterProperties httpProtocolAdapterProperties = adapterProperties();
+        if (!httpProtocolAdapterProperties.isAuthenticationRequired()) {
+            throw new IllegalStateException(
+                    "LoRa Protocol Adapter does not support unauthenticated mode. Please change your configuration accordingly.");
+        }
+    }
+
+    /**
+     * Creates a new LoRa adapter instance.
+     * 
+     * @return The new instance.
+     */
+    @Bean(name = BEAN_NAME_SIGFOX_PROTOCOL_ADAPTER)
+    @Scope("prototype")
+    public SigfoxProtocolAdapter sigfoxProtocolAdapter() {
+        return new SigfoxProtocolAdapter();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
+        if (props.getName() == null) {
+            props.setName(CONTAINER_ID_HONO_SIGFOX_ADAPTER);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
+        if (props.getName() == null) {
+            props.setName(CONTAINER_ID_HONO_SIGFOX_ADAPTER);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
+        if (props.getName() == null) {
+            props.setName(CONTAINER_ID_HONO_SIGFOX_ADAPTER);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void customizeTenantClientFactoryConfig(final RequestResponseClientConfigProperties props) {
+        if (props.getName() == null) {
+            props.setName(CONTAINER_ID_HONO_SIGFOX_ADAPTER);
+        }
+    }
+
+    /**
+     * Exposes the LoRa adapter's configuration properties as a Spring bean.
+     *
+     * @return The configuration properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.http")
+    public HttpProtocolAdapterProperties adapterProperties() {
+        return new HttpProtocolAdapterProperties();
+    }
+
+    /**
+     * Exposes a factory for creating LoRa adapter instances.
+     *
+     * @return The factory bean.
+     */
+    @Bean
+    public ObjectFactoryCreatingFactoryBean serviceFactory() {
+        final ObjectFactoryCreatingFactoryBean factory = new ObjectFactoryCreatingFactoryBean();
+        factory.setTargetBeanName(BEAN_NAME_SIGFOX_PROTOCOL_ADAPTER);
+        return factory;
+    }
+
+    /**
+     * Gets the cache manager.
+     *
+     * @return the cache manager
+     */
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager();
+    }
+
+    /**
+     * Customizer for meter registry.
+     *
+     * @return The new meter registry customizer.
+     */
+    @Bean
+    public MeterRegistryCustomizer<MeterRegistry> commonTags() {
+        return r -> r.config().commonTags(
+                MetricsTags.forProtocolAdapter(METRICS_PROTOCOL_TAG));
+    }
+
+}

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
@@ -22,9 +22,6 @@ import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -36,7 +33,6 @@ import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
  * Spring Boot configuration for the Sigfox adapter.
  */
 @Configuration
-@EnableCaching
 public class Config extends AbstractAdapterConfig {
 
     private static final String CONTAINER_ID_HONO_SIGFOX_ADAPTER = "Hono Sigfox Adapter";
@@ -124,16 +120,6 @@ public class Config extends AbstractAdapterConfig {
         final ObjectFactoryCreatingFactoryBean factory = new ObjectFactoryCreatingFactoryBean();
         factory.setTargetBeanName(BEAN_NAME_SIGFOX_PROTOCOL_ADAPTER);
         return factory;
-    }
-
-    /**
-     * Gets the cache manager.
-     *
-     * @return the cache manager
-     */
-    @Bean
-    public CacheManager cacheManager() {
-        return new ConcurrentMapCacheManager();
     }
 
     /**

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
@@ -48,12 +48,12 @@ public class Config extends AbstractAdapterConfig {
         final HttpProtocolAdapterProperties httpProtocolAdapterProperties = adapterProperties();
         if (!httpProtocolAdapterProperties.isAuthenticationRequired()) {
             throw new IllegalStateException(
-                    "LoRa Protocol Adapter does not support unauthenticated mode. Please change your configuration accordingly.");
+                    "SigFox Protocol Adapter does not support unauthenticated mode. Please change your configuration accordingly.");
         }
     }
 
     /**
-     * Creates a new LoRa adapter instance.
+     * Creates a new SigFox adapter instance.
      * 
      * @return The new instance.
      */
@@ -104,7 +104,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     /**
-     * Exposes the LoRa adapter's configuration properties as a Spring bean.
+     * Exposes the SigFox adapter's configuration properties as a Spring bean.
      *
      * @return The configuration properties.
      */
@@ -115,7 +115,7 @@ public class Config extends AbstractAdapterConfig {
     }
 
     /**
-     * Exposes a factory for creating LoRa adapter instances.
+     * Exposes a factory for creating SigFox adapter instances.
      *
      * @return The factory bean.
      */

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.sigfox.impl;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
+import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
+import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
+import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
+import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
+import org.eclipse.hono.service.http.HonoBasicAuthHandler;
+import org.eclipse.hono.service.http.HonoChainAuthHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.BaseEncoding;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.ChainAuthHandler;
+
+/**
+ * A Vert.x based Hono protocol adapter for receiving HTTP push messages from and sending commands to the Sigfox
+ * backend.
+ */
+public final class SigfoxProtocolAdapter extends AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SigfoxProtocolAdapter.class);
+
+    private HonoClientBasedAuthProvider<UsernamePasswordCredentials> usernamePasswordAuthProvider;
+
+    /**
+     * Sets the provider to use for authenticating devices based on a username and password.
+     * <p>
+     * If not set explicitly using this method, a {@code UsernamePasswordAuthProvider} will be created during startup.
+     *
+     * @param provider The provider to use.
+     * @throws NullPointerException if provider is {@code null}.
+     */
+    public void setUsernamePasswordAuthProvider(
+            final HonoClientBasedAuthProvider<UsernamePasswordCredentials> provider) {
+        this.usernamePasswordAuthProvider = Objects.requireNonNull(provider);
+    }
+
+
+    @Override
+    protected String getTypeName() {
+        return "hono-sigfox";
+    }
+
+    private void setupAuthorization(final Router router) {
+        final ChainAuthHandler authHandler = new HonoChainAuthHandler();
+
+        authHandler.append(new HonoBasicAuthHandler(
+                Optional.ofNullable(usernamePasswordAuthProvider).orElse(
+                        new UsernamePasswordAuthProvider(getCredentialsClientFactory(), getConfig(), tracer)),
+                getConfig().getRealm(), tracer));
+
+        router.route().handler(authHandler);
+    }
+
+    @Override
+    protected void addRoutes(final Router router) {
+
+        setupAuthorization(router);
+
+        router.get("/data/telemetry")
+                .handler(ctx -> dataGetHandler(ctx));
+        router.errorHandler(500, t -> {
+            LOG.warn("Unhandled exception", t);
+        });
+    }
+
+    protected void dataGetHandler(final RoutingContext ctx) {
+
+        if (!(ctx.user() instanceof Device)) {
+            LOG.warn("Not a device");
+            return;
+        }
+
+        final Device gatewayDevice = (Device) ctx.user();
+
+        final String tenant = gatewayDevice.getTenantId();
+
+        final String deviceId = ctx.queryParams().get("device");
+        final String data = ctx.queryParams().get("data");
+
+        LOG.debug("GET handler - deviceId: {}, data: {}", deviceId, data);
+
+        uploadTelemetryMessage(ctx, tenant, deviceId, decode(data), CONTENT_TYPE_OCTET_STREAM);
+    }
+
+    @Override
+    protected void customizeDownstreamMessage(final Message downstreamMessage, final RoutingContext ctx) {
+        super.customizeDownstreamMessage(downstreamMessage, ctx);
+
+        // pass along all properties that start with 'sigfox.'
+        // If a key has multiple values, then only one of them will be mapped.
+
+        for (final Map.Entry<String, String> entry : ctx.queryParams()) {
+            if (entry.getKey() == null || !entry.getKey().startsWith("sigfox.")) {
+                continue;
+            }
+            downstreamMessage.getApplicationProperties().getValue().put(entry.getKey(), entry.getValue());
+        }
+
+    }
+
+    private static Buffer decode(final String data) {
+        if (data == null) {
+            return Buffer.buffer();
+        }
+        return Buffer.buffer(BaseEncoding.base16().decode(data.toUpperCase()));
+    }
+
+}

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -53,7 +53,7 @@ public final class SigfoxProtocolAdapter extends AbstractVertxBasedHttpProtocolA
 
     private static final String SIGFOX_PROPERTY_PREFIX = "sigfox.";
 
-    private static final String SIGFOX_PARAM_DEVICE_ID = "deviceId";
+    private static final String SIGFOX_PARAM_DEVICE_ID = "device";
 
     private static final String SIGFOX_PARAM_DATA = "data";
 

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -26,12 +26,14 @@ import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
 import org.eclipse.hono.service.http.HonoBasicAuthHandler;
 import org.eclipse.hono.service.http.HonoChainAuthHandler;
+import org.eclipse.hono.util.EventConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.io.BaseEncoding;
 
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.ChainAuthHandler;
@@ -42,9 +44,21 @@ import io.vertx.ext.web.handler.ChainAuthHandler;
  */
 public final class SigfoxProtocolAdapter extends AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> {
 
+    private static final String SIGFOX_HEADER_PREFIX = "sigfox-";
+
+    private static final String SIGFOX_PROPERTY_PREFIX = "sigfox.";
+
     private static final Logger LOG = LoggerFactory.getLogger(SigfoxProtocolAdapter.class);
 
     private HonoClientBasedAuthProvider<UsernamePasswordCredentials> usernamePasswordAuthProvider;
+
+    /**
+     * Handle message upload.
+     */
+    @FunctionalInterface
+    private interface UploadHandler {
+        void upload(RoutingContext ctx, String tenant, String deviceId, Buffer payload, String contentType);
+    }
 
     /**
      * Sets the provider to use for authenticating devices based on a username and password.
@@ -81,14 +95,24 @@ public final class SigfoxProtocolAdapter extends AbstractVertxBasedHttpProtocolA
 
         setupAuthorization(router);
 
-        router.get("/data/telemetry")
-                .handler(ctx -> dataGetHandler(ctx));
+        router.route("/data/telemetry")
+                .method(HttpMethod.GET)
+                .method(HttpMethod.POST)
+                .method(HttpMethod.PUT)
+                .handler(ctx -> dataHandler(ctx, this::uploadTelemetryMessage));
+
+        router.route("/data/event")
+                .method(HttpMethod.GET)
+                .method(HttpMethod.POST)
+                .method(HttpMethod.PUT)
+                .handler(ctx -> dataHandler(ctx, this::uploadEventMessage));
+
         router.errorHandler(500, t -> {
             LOG.warn("Unhandled exception", t);
         });
     }
 
-    protected void dataGetHandler(final RoutingContext ctx) {
+    protected void dataHandler(final RoutingContext ctx, final UploadHandler uploadHandler) {
 
         if (!(ctx.user() instanceof Device)) {
             LOG.warn("Not a device");
@@ -100,25 +124,44 @@ public final class SigfoxProtocolAdapter extends AbstractVertxBasedHttpProtocolA
         final String tenant = gatewayDevice.getTenantId();
 
         final String deviceId = ctx.queryParams().get("device");
-        final String data = ctx.queryParams().get("data");
+        final Buffer data = decode(ctx.queryParams().get("data"));
 
-        LOG.debug("GET handler - deviceId: {}, data: {}", deviceId, data);
+        LOG.debug("{} handler - deviceId: {}, data: {}", ctx.request().method(), deviceId, data);
 
-        uploadTelemetryMessage(ctx, tenant, deviceId, decode(data), CONTENT_TYPE_OCTET_STREAM);
+        final String contentType = (data != null) ? CONTENT_TYPE_OCTET_STREAM
+                : EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION;
+
+        uploadHandler.upload(ctx, tenant, deviceId, data, contentType);
     }
 
     @Override
     protected void customizeDownstreamMessage(final Message downstreamMessage, final RoutingContext ctx) {
         super.customizeDownstreamMessage(downstreamMessage, ctx);
 
-        // pass along all properties that start with 'sigfox.'
+        // pass along all query parameters that start with 'sigfox.'
         // If a key has multiple values, then only one of them will be mapped.
 
         for (final Map.Entry<String, String> entry : ctx.queryParams()) {
-            if (entry.getKey() == null || !entry.getKey().startsWith("sigfox.")) {
+            if (entry.getKey() == null || !entry.getKey().startsWith(SIGFOX_PROPERTY_PREFIX)) {
                 continue;
             }
             downstreamMessage.getApplicationProperties().getValue().put(entry.getKey(), entry.getValue());
+        }
+
+        // pass along all headers that start with 'sigfox-' and map the prefix to "sigfox."
+        // If a key has multiple values, then only one of them will be mapped.
+
+        for (final Map.Entry<String, String> entry : ctx.request().headers()) {
+            String key = entry.getKey();
+            if (key == null) {
+                continue;
+            }
+            key = key.toLowerCase();
+            if (!key.startsWith(SIGFOX_HEADER_PREFIX)) {
+                continue;
+            }
+            key = key.substring(SIGFOX_HEADER_PREFIX.length());
+            downstreamMessage.getApplicationProperties().getValue().put(SIGFOX_PROPERTY_PREFIX + key, entry.getValue());
         }
 
     }

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -44,7 +44,7 @@ import io.vertx.ext.web.handler.ChainAuthHandler;
 import io.vertx.ext.web.handler.CorsHandler;
 
 /**
- * A Vert.x based Hono protocol adapter for receiving HTTP push messages from and sending commands to the Sigfox
+ * A Vert.x based Hono protocol adapter for receiving HTTP push messages from and sending commands to the SigFox
  * backend.
  */
 public final class SigfoxProtocolAdapter extends AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> {

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -49,8 +49,6 @@ import io.vertx.ext.web.handler.CorsHandler;
  */
 public final class SigfoxProtocolAdapter extends AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> {
 
-    private static final String TYPE_NAME = "hono-sigfox";
-
     private static final String SIGFOX_PROPERTY_PREFIX = "sigfox.";
 
     private static final String SIGFOX_PARAM_DEVICE_ID = "device";
@@ -84,10 +82,9 @@ public final class SigfoxProtocolAdapter extends AbstractVertxBasedHttpProtocolA
         this.usernamePasswordAuthProvider = Objects.requireNonNull(provider);
     }
 
-
     @Override
     protected String getTypeName() {
-        return TYPE_NAME;
+        return Constants.PROTOCOL_ADAPTER_TYPE_MQTT;
     }
 
     private void setupAuthorization(final Router router) {

--- a/core/src/main/java/org/eclipse/hono/util/Constants.java
+++ b/core/src/main/java/org/eclipse/hono/util/Constants.java
@@ -74,6 +74,10 @@ public final class Constants {
      * The type of the mqtt protocol adapter.
      */
     public static final String PROTOCOL_ADAPTER_TYPE_MQTT= "hono-mqtt";
+    /**
+     * The type of the sigfox protocol adapter.
+     */
+    public static final String PROTOCOL_ADAPTER_TYPE_SIGFOX = "hono-sigfox";
 
     /**
      * The (short) name of the Auth Server component.

--- a/service-base/src/main/java/org/eclipse/hono/service/http/DefaultFailureHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/DefaultFailureHandler.java
@@ -67,6 +67,7 @@ public class DefaultFailureHandler implements Handler<RoutingContext> {
                         final HttpStatusException e = (HttpStatusException) ctx.failure();
                         sendError(ctx.response(), e.getStatusCode(), e.getMessage());
                     } else {
+                        LOG.debug("unexpected internal failure", ctx.failure());
                         sendError(ctx.response(), HttpURLConnection.HTTP_INTERNAL_ERROR, ctx.failure().getMessage());
                     }
                 } else if (ctx.statusCode() != -1) {

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -27,6 +27,9 @@ title = "Release Notes"
 * The concept and implementation of *message limit* have been added. The protocol adapters can be now 
   enabled to verify this *message limit* for each tenant before accepting any telemetry/event messages.
   Please refer to the [resource limits]({{< ref "/concepts/resource-limits.md" >}}) for details.  
+* A basic Sigfox protocol adapter, for use with the Sigfox backend. Please read
+  the [Sigfox protocol adapter]({{< ref "/user-guide/sigfox-adapter" >}})
+  documentation to learn more about pre-requisites and limitations.
 
 ### Fixes & Enhancements
 

--- a/site/content/user-guide/sigfox-adapter.md
+++ b/site/content/user-guide/sigfox-adapter.md
@@ -76,11 +76,12 @@ Create a new *device*, referencing the previous *gateway device*. The
 Log in to the Sigfox backend at https://backend.sigfox.com and then open up
 the view `Device Type` -> `Callbacks`.
 
-Create a new "Custom" callback, with the following settings:
+Create a new "Custom" callback, with the following settings
+(replacing `<TENANT>` with the name of the tenant):
 
 * **Type**: `DATA` – `UPLINK`
 * **Channel**: `URL`
-* **Url pattern**: `https://iot-sigfox-adapter.my.hono/data/telemetry?device={device}&data={data}`
+* **Url pattern**: `https://iot-sigfox-adapter.my.hono/data/telemetry/<TENANT>?device={device}&data={data}`
 * **Use HTTP Method**: `GET`
 * **Headers**
   * `Authorization` – `Basic …` (see note below)

--- a/site/content/user-guide/sigfox-adapter.md
+++ b/site/content/user-guide/sigfox-adapter.md
@@ -1,0 +1,98 @@
++++
+title = "Sigfox Adapter"
+weight = 260
++++
+
+The Sigfox protocol adapter exposes an HTTP endpoint for connecting up with
+the Sigfox backend for publishing telemetry, events and use command & control.
+<!--more-->
+
+{{% note title="Tech preview" %}}
+This protocol adapter is not considered production ready. Its APIs might still
+be subject to change without warning.
+{{% /note %}}
+
+## Pre-requisites
+
+This Sigfox adapter only connects to the Sigfox backend system
+(`backend.sigfox.com`). It does not allow direct access to Sigfox devices.
+
+So you need to set up your Sigfox devices on `backend.sigfox.com` and then
+configure the callbacks connect to your installation of Hono.
+
+## Devices and credentials
+
+In a nutshell, the Sigfox adapter requires a single *device* identity, acting
+as a gateway device. This identity will be used to connect to Hono. All devices
+registered with Sigfox (the actual Sigfox devices), will be registered in Hono
+to allow this first identity as their gateway device.
+
+## Setup example
+
+The following sub-sections walk you through an example setup.
+
+### Registering devices
+
+This example assumes that the Sigfox protocol adapter is available as
+`https://iot-sigfox-adapter.my.hono`.
+
+Create a new *gateway device* with the following registration:
+
+~~~json
+{
+  "device-id": "sigfox-backend"
+}
+~~~
+
+Create new credentials for the *gateway device*. For example, using
+a username of `sigfox` and a password of `test12`:
+
+~~~json
+{
+  "auth-id": "sigfox",
+  "device-id": "sigfox-backend",
+  "enabled": true,
+  "secrets": [
+    {
+      "hash-function": "sha-512",
+      "pwd-hash": "yHRiqBGqGlGBctRvzX98JpeTTk0ao9BfzR714G7737y8oOuRsFzJYGC0846lFy96FWev8sSb7MGeSqoJi3I6mw==",
+      "salt": "j9PyA6Y9obw="
+    }
+  ],
+  "type": "hashed-password"
+}
+~~~
+
+Create a new *device*, referencing the previous *gateway device*. The
+*device id* must be your Sigfox device ID (e.g. `1AB2C3`):
+
+~~~json
+{
+  "device-id": "1AB2C3",
+  "via": "sigfox-backend"
+}
+~~~
+
+### Setting up callbacks
+
+Log in to the Sigfox backend at https://backend.sigfox.com and then open up
+the view `Device Type` -> `Callbacks`.
+
+Create a new "Custom" callback, with the following settings:
+
+* **Type**: `DATA` - `UPLINK`
+* **Channel**: `URL`
+* **Url pattern**: `https://sigfox%40DEFAULT_TENANT:test12@iot-sigfox-adapter.my.hono/data/telemetry?device={device}&data={data}`
+* **Use HTTP Method**: `GET`
+* **Send SNI**: ☑ (Enabled)
+
+## Consuming data
+
+Use the standard way of consuming Hono messages.
+
+## Known bugs and limitations
+
+* Command and control is currently not supported
+* Events are currently not supported
+* Only the simple `URL` and only *data* (no *service* or *device events* are
+  currently supported.

--- a/site/content/user-guide/sigfox-adapter.md
+++ b/site/content/user-guide/sigfox-adapter.md
@@ -54,9 +54,7 @@ a username of `sigfox` and a password of `test12`:
   "enabled": true,
   "secrets": [
     {
-      "hash-function": "sha-512",
-      "pwd-hash": "yHRiqBGqGlGBctRvzX98JpeTTk0ao9BfzR714G7737y8oOuRsFzJYGC0846lFy96FWev8sSb7MGeSqoJi3I6mw==",
-      "salt": "j9PyA6Y9obw="
+      "pwd-plain": "test12",
     }
   ],
   "type": "hashed-password"
@@ -80,11 +78,40 @@ the view `Device Type` -> `Callbacks`.
 
 Create a new "Custom" callback, with the following settings:
 
-* **Type**: `DATA` - `UPLINK`
+* **Type**: `DATA` – `UPLINK`
 * **Channel**: `URL`
-* **Url pattern**: `https://sigfox%40DEFAULT_TENANT:test12@iot-sigfox-adapter.my.hono/data/telemetry?device={device}&data={data}`
+* **Url pattern**: `https://iot-sigfox-adapter.my.hono/data/telemetry?device={device}&data={data}`
 * **Use HTTP Method**: `GET`
+* **Headers**
+  * `Authorization` – `Basic …` (see note below)
 * **Send SNI**: ☑ (Enabled)
+
+{{% note title="Credentials" %}}
+At the moment you need to manually put in the `Authorization` header,
+you cannot put the credentials into the URL, as there is a bug in the
+Sigfox backend, which cannot be fixed by Hono. The backend does not
+properly escape the `@` character, and thus sends `foo%40tenant`
+instead of `foo@tenant` to the Hono protocol adapter.
+
+As a workaround, you can explicitly set the `Authorization` header to a
+value of `Basic <base64 encoded credentials>`. You can encode the
+credentials using:
+
+~~~sh
+echo -n "sigfox@tenant:password" | base64
+~~~
+
+To get the full value, including the `Basic` you may use:
+
+~~~sh
+echo "Basic $(echo -n "sigfox@tenant:password" | base64)"
+~~~
+
+{{% /note %}}
+
+## Events
+
+You can send events by using the path `/data/event` on the URL.
 
 ## Consuming data
 
@@ -93,6 +120,5 @@ Use the standard way of consuming Hono messages.
 ## Known bugs and limitations
 
 * Command and control is currently not supported
-* Events are currently not supported
 * Only the simple `URL` and only *data* (no *service* or *device events* are
   currently supported.


### PR DESCRIPTION
This adds a first version of a Sigfox protocol adapter. The current limitations are:

* ~~Telemetry only~~
* Supports only `DATA` callbacks
* Does not yet support command and control

I would consider this "tech preview" for the moment.