### PR TITLE
Introduce retries in CachingClientFactory#getOrCreateClient()

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/ApplicationClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ApplicationClientFactoryImpl.java
@@ -49,8 +49,8 @@ public class ApplicationClientFactoryImpl extends AbstractHonoClientFactory impl
     public ApplicationClientFactoryImpl(final HonoConnection connection) {
         super(connection);
         consumerFactory = new ClientFactory<>();
-        commandClientFactory = new CachingClientFactory<>(c -> c.isOpen());
-        asyncCommandClientFactory = new CachingClientFactory<>(c -> c.isOpen());
+        commandClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
+        asyncCommandClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
@@ -96,9 +96,9 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
     public CommandConsumerFactoryImpl(final HonoConnection connection, final GatewayMapper gatewayMapper) {
         super(connection);
         this.gatewayMapper = Objects.requireNonNull(gatewayMapper);
-        deviceSpecificCommandConsumerFactory = new CachingClientFactory<>(c -> true);
-        tenantScopedCommandConsumerFactory = new CachingClientFactory<>(c -> true);
-        delegatedCommandSenderFactory = new CachingClientFactory<>(s -> s.isOpen());
+        deviceSpecificCommandConsumerFactory = new CachingClientFactory<>(connection.getVertx(), c -> true);
+        tenantScopedCommandConsumerFactory = new CachingClientFactory<>(connection.getVertx(), c -> true);
+        delegatedCommandSenderFactory = new CachingClientFactory<>(connection.getVertx(), s -> s.isOpen());
     }
 
     @Override

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientFactoryImpl.java
@@ -43,7 +43,7 @@ public class CredentialsClientFactoryImpl extends AbstractHonoClientFactory impl
      */
     public CredentialsClientFactoryImpl(final HonoConnection connection, final CacheProvider cacheProvider) {
         super(connection);
-        credentialsClientFactory = new CachingClientFactory<>(c -> c.isOpen());
+        credentialsClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
         this.cacheProvider = cacheProvider;
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImpl.java
@@ -36,7 +36,7 @@ public class DownstreamSenderFactoryImpl extends AbstractHonoClientFactory imple
      */
     public DownstreamSenderFactoryImpl(final HonoConnection connection) {
         super(connection);
-        clientFactory = new CachingClientFactory<>(s -> s.isOpen());
+        clientFactory = new CachingClientFactory<>(connection.getVertx(), s -> s.isOpen());
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientFactoryImpl.java
@@ -44,7 +44,7 @@ public class RegistrationClientFactoryImpl extends AbstractHonoClientFactory imp
      */
     public RegistrationClientFactoryImpl(final HonoConnection connection, final CacheProvider cacheProvider) {
         super(connection);
-        this.registrationClientFactory = new CachingClientFactory<>(c -> c.isOpen());
+        this.registrationClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
         this.cacheProvider = cacheProvider;
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantClientFactoryImpl.java
@@ -41,7 +41,7 @@ public class TenantClientFactoryImpl extends AbstractHonoClientFactory implement
      */
     public TenantClientFactoryImpl(final HonoConnection connection, final CacheProvider cacheProvider) {
         super(connection);
-        this.tenantClientFactory = new CachingClientFactory<>(c -> c.isOpen());
+        this.tenantClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
         this.cacheProvider = cacheProvider;
     }
 

--- a/client/src/test/java/org/eclipse/hono/client/impl/CachingClientFactoryTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CachingClientFactoryTest.java
@@ -14,14 +14,21 @@
 
 package org.eclipse.hono.client.impl;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
 import java.net.HttpURLConnection;
 
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -34,6 +41,23 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class CachingClientFactoryTest {
 
+    private Vertx vertx;
+
+    /**
+     * Sets up common fixture.
+     */
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setup() {
+        vertx = mock(Vertx.class);
+        // run timers immediately
+        when(vertx.setTimer(anyLong(), any(Handler.class))).thenAnswer(invocation -> {
+            final Handler<Void> task = invocation.getArgument(1);
+            task.handle(null);
+            return 1L;
+        });
+    }
+
     /**
      * Verifies that a request to create a client fails if the given
      * supplier fails.
@@ -44,7 +68,7 @@ public class CachingClientFactoryTest {
     public void testGetOrCreateClientFailsIfSupplierFails(final TestContext ctx) {
 
         // GIVEN a factory
-        final CachingClientFactory<Object> factory = new CachingClientFactory<>(o -> true);
+        final CachingClientFactory<Object> factory = new CachingClientFactory<>(vertx, o -> true);
         // WHEN creating a client instance and the supplier returns a failed future
         factory.getOrCreateClient(
                 "bumlux",
@@ -59,15 +83,15 @@ public class CachingClientFactoryTest {
 
     /**
      * Verifies that a concurrent request to create a client fails the given
-     * future for tracking the attempt.
+     * future for tracking the attempt if the initial request doesn't complete.
      * 
      * @param ctx The helper to use for running async tests.
      */
     @Test
     public void testGetOrCreateClientFailsIfInvokedConcurrently(final TestContext ctx) {
 
-        // GIVEN a factory that already creates a client for key "bumlux"
-        final CachingClientFactory<Object> factory = new CachingClientFactory<>(o -> true);
+        // GIVEN a factory that already creates a client for key "bumlux" (and never completes doing so)
+        final CachingClientFactory<Object> factory = new CachingClientFactory<>(vertx, o -> true);
         final Future<Object> creationResult = Future.future();
         factory.getOrCreateClient(
                 "bumlux",
@@ -81,12 +105,51 @@ public class CachingClientFactoryTest {
                     ctx.fail("should not create client concurrently");
                     return Future.succeededFuture();
                 }, ctx.asyncAssertFailure(t -> {
-                    // THEN the concurrent attempt fails without any attempt being made to create another client
+                    // THEN the concurrent attempt fails after having done the default number of retries.
                     ctx.assertTrue(t instanceof ServerErrorException);
                     ctx.assertEquals(
                             HttpURLConnection.HTTP_UNAVAILABLE,
                             ServiceInvocationException.extractStatusCode(t));
+                    verify(vertx, times(CachingClientFactory.MAX_CREATION_RETRIES)).setTimer(anyLong(), notNull());
                 }));
+    }
+
+    /**
+     * Verifies that a concurrent request to create a client succeeds
+     * if the initial request completes before the first retry of the
+     * concurrent request.
+     *
+     * @param ctx The helper to use for running async tests.
+     */
+    @Test
+    public void testGetOrCreateClientSucceedsOnRetry(final TestContext ctx) {
+
+        // GIVEN a factory that already creates a client for key "bumlux"
+        final CachingClientFactory<Object> factory = new CachingClientFactory<>(vertx, o -> true);
+        final Future<Object> creationResult = Future.future();
+        final Future<Object> clientInstanceFuture = Future.future();
+        factory.getOrCreateClient(
+                "bumlux",
+                () -> clientInstanceFuture,
+                creationResult);
+
+        // WHEN an additional, concurrent attempt is made to create a client for the same key
+        // and the first 'setTimer' invocation finishes the first creation attempt.
+        when(vertx.setTimer(anyLong(), any(Handler.class))).thenAnswer(invocation -> {
+            clientInstanceFuture.tryComplete(new Object());
+            final Handler<Void> task = invocation.getArgument(1);
+            task.handle(null);
+            return 1L;
+        });
+        // THEN the additional attempt finishes after one retry
+        factory.getOrCreateClient(
+                "bumlux",
+                () -> {
+                    ctx.fail("should not create new client (cached one shall be used)");
+                    return Future.succeededFuture();
+                },
+                ctx.asyncAssertSuccess());
+        verify(vertx).setTimer(anyLong(), notNull());
     }
 
     /**
@@ -99,7 +162,7 @@ public class CachingClientFactoryTest {
     public void testGetOrCreateClientFailsWhenStateIsCleared(final TestContext ctx) {
 
         // GIVEN a factory that tries to create a client for key "tenant"
-        final CachingClientFactory<Object> factory = new CachingClientFactory<>(o -> true);
+        final CachingClientFactory<Object> factory = new CachingClientFactory<>(vertx, o -> true);
         final Async supplierInvocation = ctx.async();
 
         final Future<Object> creationAttempt = Future.future();


### PR DESCRIPTION
This will perform a retry in `CachingClientFactory#getOrCreateClient()` in case there is a concurrent attempt with the same key.

Needed for C&C integration tests after changes for #930. Frequent error there (e.g. in AMQP adapter):
````
14:59:25.305 [vert.x-eventloop-thread-0] ERROR o.e.h.c.i.GatewayMappingCommandHandler - error getting last-via for device f9647e8d-ce54-4585-aa2a-9496bd5de194
org.eclipse.hono.client.ServerErrorException: already creating client for key
	at org.eclipse.hono.client.impl.CachingClientFactory.getOrCreateClient(CachingClientFactory.java:167)
	at org.eclipse.hono.client.impl.RegistrationClientFactoryImpl.lambda$getOrCreateRegistrationClient$2(RegistrationClientFactoryImpl.java:68)
	at org.eclipse.hono.util.HonoProtonHelper.executeOrRunOnContext(HonoProtonHelper.java:183)
	at org.eclipse.hono.client.impl.HonoConnectionImpl.executeOrRunOnContext(HonoConnectionImpl.java:225)
	at org.eclipse.hono.client.impl.RegistrationClientFactoryImpl.getOrCreateRegistrationClient(RegistrationClientFactoryImpl.java:67)
	at org.eclipse.hono.client.impl.GatewayMapperImpl.getMappedGatewayDevice(GatewayMapperImpl.java:46)
	at org.eclipse.hono.client.impl.GatewayMappingCommandHandler.handle(GatewayMappingCommandHandler.java:62)
	at org.eclipse.hono.client.impl.CommandConsumerFactoryImpl.lambda$newTenantScopedCommandConsumer$10(CommandConsumerFactoryImpl.java:198)
	at org.eclipse.hono.client.impl.HonoConnectionImpl.lambda$createReceiver$14(HonoConnectionImpl.java:690)
````
