### PR TITLE
[#930] Let command client use a tenant-scoped sender link address

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -80,10 +80,15 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
                             HttpURLConnection.HTTP_GONE
     };
 
+    /**
+     * Target address of the request message.
+     * Note that the target address of the sender link may be different, see {@link #getLinkTargetAddress()}.
+     */
+    protected final String targetAddress;
+
     private final Map<Object, TriTuple<Handler<AsyncResult<R>>, Object, Span>> replyMap = new HashMap<>();
     private Handler<Void> drainHandler;
     private final String replyToAddress;
-    private final String targetAddress;
     private final String tenantId;
 
     /**
@@ -305,6 +310,20 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
             ApplicationProperties applicationProperties);
 
     /**
+     * The target address of the sender link on which the request message is sent.
+     * <p>
+     * This default implementation returns the target address of the request message.
+     * <p>
+     * Subclasses may override this method in order to use a different address for creating the sender link.
+     * For example, an empty address could be returned here to create an anonymous relay link.
+     *
+     * @return The link target address.
+     */
+    protected String getLinkTargetAddress() {
+        return targetAddress;
+    }
+
+    /**
      * Creates the sender and receiver links to the peer for sending requests
      * and receiving responses.
      * 
@@ -332,7 +351,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
         return createReceiver(replyToAddress, receiverCloseHook)
                 .compose(recv -> {
                     this.receiver = recv;
-                    return createSender(targetAddress, senderCloseHook);
+                    return createSender(getLinkTargetAddress(), senderCloseHook);
                 }).compose(sender -> {
                     LOG.debug("request-response client for peer [{}] created", connection.getConfig().getHost());
                     this.sender = sender;
@@ -486,6 +505,9 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
         final Message msg = ProtonHelper.message();
         final String messageId = createMessageId();
         AbstractHonoClient.setApplicationProperties(msg, appProperties);
+        if (!targetAddress.equals(getLinkTargetAddress())) {
+            msg.setAddress(targetAddress);
+        }
         msg.setReplyTo(replyToAddress);
         msg.setMessageId(messageId);
         msg.setSubject(subject);

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
@@ -49,6 +49,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
     private static final Logger LOG = LoggerFactory.getLogger(CommandClientImpl.class);
 
     private long messageCounter;
+    private final String linkTargetAddress;
 
     /**
      * Creates a client for sending commands to devices.
@@ -69,6 +70,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
             final String replyId) {
 
         super(connection, tenantId, deviceId, replyId);
+        this.linkTargetAddress = String.format("%s/%s", getName(), tenantId);
     }
 
     /**
@@ -98,11 +100,11 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
     /**
      * Gets the AMQP <em>target</em> address to use for sending command requests
      * to Hono's Command &amp; Control API endpoint.
-     * 
+     *
      * @param tenantId The tenant that the device belongs to.
      * @param deviceId The identifier of the device.
      * @return The target address.
-     * @throws NullPointerException if tenant is {@code null}.
+     * @throws NullPointerException if tenant or device is {@code null}.
      */
     public static final String getTargetAddress(final String tenantId, final String deviceId) {
         Objects.requireNonNull(tenantId);
@@ -113,6 +115,11 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
     @Override
     protected String getName() {
         return CommandConstants.COMMAND_ENDPOINT;
+    }
+
+    @Override
+    protected String getLinkTargetAddress() {
+        return linkTargetAddress;
     }
 
     /**
@@ -206,6 +213,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
             AbstractHonoClient.setApplicationProperties(request, properties);
 
             final String messageId = createMessageId();
+            request.setAddress(targetAddress);
             request.setMessageId(messageId);
             request.setSubject(command);
 


### PR DESCRIPTION
This concludes the implementation for #930:
The command client will now create a sender link on the tenant-scoped address. The `To` property of the command message is set to the device-specific address.

Documentation changes and additions to the release notes will go in a separate PR.