### PR TITLE
Use common disposition method; improve logging/tracing

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/CommandContext.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandContext.java
@@ -297,16 +297,19 @@ public class CommandContext extends MapBasedExecutionContext {
             currentSpan.log("accepted command for device");
 
         } else if (Released.class.isInstance(deliveryState)) {
+            LOG.debug("released command message [{}]", getCommand());
             TracingHelper.logError(currentSpan, "released command for device");
 
         } else if (Modified.class.isInstance(deliveryState)) {
             final Modified modified = (Modified) deliveryState;
+            LOG.debug("modified command message [{}]", getCommand());
             TracingHelper.logError(currentSpan, "modified command for device"
                     + (Boolean.TRUE.equals(modified.getDeliveryFailed()) ? "; delivery failed" : "")
                     + (Boolean.TRUE.equals(modified.getUndeliverableHere()) ? "; undeliverable here" : ""));
 
         } else if (Rejected.class.isInstance(deliveryState)) {
             final ErrorCondition errorCondition = ((Rejected) deliveryState).getError();
+            LOG.debug("rejected command message [error: {}, command: {}]", errorCondition, getCommand());
             TracingHelper.logError(currentSpan, "rejected command for device"
                     + ((errorCondition != null && errorCondition.getDescription() != null) ? "; error: " + errorCondition.getDescription() : ""));
         } else {

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -545,7 +545,10 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                 result.complete(address);
             }
         }
-        return result;
+        return result.recover(t -> {
+            LOG.debug("validation failed for address [{}], device [{}]: {}", address, authenticatedDevice, t.getMessage());
+            return Future.failedFuture(t);
+        });
     }
 
     /**


### PR DESCRIPTION
Use the recently introduced `CommandContext#disposition` method in the `onCommandReceived` method of the AMQP adapter.

Some further logging/tracing improvements.