### PR TITLE
[#1229] Remove usage of deprecated Vertx method.

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
@@ -227,9 +227,9 @@ public class AmqpAdapterSaslAuthenticatorFactory implements ProtonSaslAuthentica
             sasl.recv(saslResponse, 0, saslResponse.length);
 
             if (AuthenticationConstants.MECHANISM_PLAIN.equals(remoteMechanism)) {
-                verifyPlain(saslResponse, deviceAuthTracker.completer());
+                verifyPlain(saslResponse, deviceAuthTracker);
             } else if (AuthenticationConstants.MECHANISM_EXTERNAL.equals(remoteMechanism)) {
-                verifyExternal(deviceAuthTracker.completer());
+                verifyExternal(deviceAuthTracker);
             }
 
         }

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -193,7 +193,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
         final Future<Void> result = Future.future();
         if (insecureServer != null) {
             LOG.info("Shutting down insecure server");
-            insecureServer.close(result.completer());
+            insecureServer.close(result);
         } else {
             result.complete();
         }
@@ -205,7 +205,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
         if (secureServer != null) {
 
             LOG.info("Shutting down secure server");
-            secureServer.close(result.completer());
+            secureServer.close(result);
 
         } else {
             result.complete();

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -435,14 +435,14 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
 
         final Future<Void> serverStopTracker = Future.future();
         if (server != null) {
-            server.close(serverStopTracker.completer());
+            server.close(serverStopTracker);
         } else {
             serverStopTracker.complete();
         }
 
         final Future<Void> insecureServerStopTracker = Future.future();
         if (insecureServer != null) {
-            insecureServer.close(insecureServerStopTracker.completer());
+            insecureServer.close(insecureServerStopTracker);
         } else {
             insecureServerStopTracker.complete();
         }

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -306,14 +306,14 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
 
         final Future<Void> serverTracker = Future.future();
         if (this.server != null) {
-            this.server.close(serverTracker.completer());
+            this.server.close(serverTracker);
         } else {
             serverTracker.complete();
         }
 
         final Future<Void> insecureServerTracker = Future.future();
         if (this.insecureServer != null) {
-            this.insecureServer.close(insecureServerTracker.completer());
+            this.insecureServer.close(insecureServerTracker);
         } else {
             insecureServerTracker.complete();
         }

--- a/client/src/main/java/org/eclipse/hono/client/AuthenticationServerClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/AuthenticationServerClient.java
@@ -183,7 +183,7 @@ public final class AuthenticationServerClient {
 
     private static Future<ProtonReceiver> openReceiver(final ProtonConnection openConnection, final ProtonMessageHandler messageHandler) {
         final Future<ProtonReceiver> result = Future.future();
-        openConnection.createReceiver(AuthenticationConstants.ENDPOINT_NAME_AUTHENTICATION).openHandler(result.completer()).handler(messageHandler).open();
+        openConnection.createReceiver(AuthenticationConstants.ENDPOINT_NAME_AUTHENTICATION).openHandler(result).handler(messageHandler).open();
         return result;
     }
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
@@ -164,7 +164,7 @@ public abstract class AbstractSender extends AbstractHonoClient implements Messa
                 span.finish();
                 result.fail(e);
             } else {
-                sendMessage(rawMessage, span).setHandler(result.completer());
+                sendMessage(rawMessage, span).setHandler(result);
             }
         });
     }

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
@@ -210,7 +210,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
             request.setSubject(command);
 
             MessageHelper.setPayload(request, contentType, data);
-            sendRequest(request, responseTracker.completer(), null, currentSpan);
+            sendRequest(request, responseTracker, null, currentSpan);
 
             return responseTracker.recover(t -> {
                 TracingHelper.logError(currentSpan, t);

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
@@ -354,7 +354,7 @@ public class HonoConnectionImpl implements HonoConnection {
         if (shuttingDown.get()) {
             result.fail(new ClientErrorException(HttpURLConnection.HTTP_CONFLICT, "client is already shut down"));
         } else {
-            connect(options, result.completer(), disconnectHandler);
+            connect(options, result, disconnectHandler);
         }
         return result;
     }

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
@@ -181,7 +181,7 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
                 RegistrationConstants.ACTION_REGISTER,
                 createDeviceIdProperties(deviceId),
                 data != null ? data.toBuffer() : null,
-                regResultTracker.completer());
+                regResultTracker);
         return regResultTracker.map(response -> {
             switch(response.getStatus()) {
             case HttpURLConnection.HTTP_CREATED:
@@ -207,7 +207,7 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
                 RegistrationConstants.ACTION_UPDATE,
                 createDeviceIdProperties(deviceId),
                 data != null ? data.toBuffer() : null,
-                regResultTracker.completer());
+                regResultTracker);
         return regResultTracker.map(response -> {
             switch(response.getStatus()) {
             case HttpURLConnection.HTTP_NO_CONTENT:
@@ -233,7 +233,7 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
                 RegistrationConstants.ACTION_DEREGISTER,
                 createDeviceIdProperties(deviceId),
                 null,
-                regResultTracker.completer());
+                regResultTracker);
         return regResultTracker.map(response -> {
             switch(response.getStatus()) {
             case HttpURLConnection.HTTP_NO_CONTENT:
@@ -343,7 +343,7 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
                     properties,
                     null,
                     RegistrationConstants.CONTENT_TYPE_APPLICATION_JSON,
-                    regResult.completer(),
+                    regResult,
                     key,
                     span);
             return regResult;

--- a/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
@@ -134,7 +134,7 @@ public final class TelemetrySenderImpl extends AbstractDownstreamSender {
                 span.finish();
                 result.fail(e);
             } else {
-                sendMessageAndWaitForOutcome(rawMessage, span).setHandler(result.completer());
+                sendMessageAndWaitForOutcome(rawMessage, span).setHandler(result);
             }
         });
     }

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
@@ -239,7 +239,7 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
                             customizeRequestApplicationProperties(),
                             payloadSupplier.get().toBuffer(),
                             RegistrationConstants.CONTENT_TYPE_APPLICATION_JSON,
-                            tenantResult.completer(),
+                            tenantResult,
                             key,
                             currentSpan);
                     return tenantResult;

--- a/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
+++ b/example/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
@@ -124,7 +124,7 @@ public class HonoExampleApplicationBase {
             });
             return createConsumer();
         })
-        .setHandler(consumerFuture.completer());
+        .setHandler(consumerFuture);
 
         latch.await();
 

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/AbstractClient.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/AbstractClient.java
@@ -56,7 +56,7 @@ public abstract class AbstractClient {
      */
     protected final Future<Void> closeVertx() {
         final Future<Void> result = Future.future();
-        vertx.close(result.completer());
+        vertx.close(result);
         return result;
     }
 }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoCommander.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoCommander.java
@@ -147,7 +147,7 @@ public class HonoCommander extends AbstractClient {
         final CompletableFuture<Void> shutdownTracker = new CompletableFuture<>();
         final Future<Void> clientTracker = Future.future();
         LOG.debug("Clean resources...");
-        applicationClientFactory.disconnect(clientTracker.completer());
+        applicationClientFactory.disconnect(clientTracker);
         clientTracker
                 .compose(ok -> closeVertx())
                 .recover(error -> closeVertx())

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoReceiver.java
@@ -283,7 +283,7 @@ public class HonoReceiver extends AbstractClient {
 
         final CompletableFuture<Void> result = new CompletableFuture<>();
         final Future<Void> clientTracker = Future.future();
-        applicationClientFactory.disconnect(clientTracker.completer());
+        applicationClientFactory.disconnect(clientTracker);
         clientTracker.otherwiseEmpty().compose(ok -> closeVertx()).setHandler(attempt -> result.complete(null));
         return result;
     }

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
@@ -305,7 +305,7 @@ public class HonoSender extends AbstractClient {
 
             final Future<Void> honoTracker = Future.future();
             if (downstreamSenderFactory != null) {
-                downstreamSenderFactory.disconnect(honoTracker.completer());
+                downstreamSenderFactory.disconnect(honoTracker);
             } else {
                 honoTracker.complete();
             }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractApplication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -189,7 +189,7 @@ public class AbstractApplication implements ApplicationRunner {
         for (final ObjectFactory<? extends AbstractServiceBase<?>> serviceFactory : serviceFactories) {
 
             final Future<String> deployTracker = Future.future();
-            vertx.deployVerticle(serviceFactory::getObject, deploymentOptions, deployTracker.completer());
+            vertx.deployVerticle(serviceFactory::getObject, deploymentOptions, deployTracker);
             deploymentTracker.add(deployTracker);
         }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -89,7 +89,7 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
     @Override
     public final void start(final Future<Void> startFuture) {
         healthCheckServer.registerHealthCheckResources(this);
-        startInternal().setHandler(startFuture.completer());
+        startInternal().setHandler(startFuture);
     }
 
     /**
@@ -114,7 +114,7 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
      */
     @Override
     public final void stop(final Future<Void> stopFuture) {
-        stopInternal().setHandler(stopFuture.completer());
+        stopInternal().setHandler(stopFuture);
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/VertxBasedHealthCheckServer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/VertxBasedHealthCheckServer.java
@@ -164,7 +164,7 @@ public final class VertxBasedHealthCheckServer implements HealthCheckServer {
         final Future<Void> result = Future.future();
         if (server != null) {
             LOG.info("closing health check HTTP server [{}:{}]", config.getHealthCheckBindAddress(), server.actualPort());
-            server.close(result.completer());
+            server.close(result);
         } else {
             result.complete();
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -395,7 +395,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
 
         if (server != null) {
             LOG.info("stopping secure AMQP server [{}:{}]", getBindAddress(), getActualPort());
-            server.close(secureTracker.completer());
+            server.close(secureTracker);
         } else {
             secureTracker.complete();
         }
@@ -408,7 +408,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
 
         if (insecureServer != null) {
             LOG.info("stopping insecure AMQP server [{}:{}]", getInsecurePortBindAddress(), getActualInsecurePort());
-            insecureServer.close(insecureTracker.completer());
+            insecureServer.close(insecureTracker);
         } else {
             insecureTracker.complete();
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/HonoSaslAuthenticator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/HonoSaslAuthenticator.java
@@ -142,7 +142,7 @@ public final class HonoSaslAuthenticator implements ProtonSaslAuthenticator {
             final byte[] saslResponse = new byte[sasl.pending()];
             sasl.recv(saslResponse, 0, saslResponse.length);
 
-            verify(chosenMechanism, saslResponse, authTracker.completer());
+            verify(chosenMechanism, saslResponse, authTracker);
         }
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
@@ -126,7 +126,7 @@ public abstract class BaseCredentialsService<T> extends EventBusService<T> imple
         TracingHelper.TAG_CREDENTIALS_TYPE.set(span, type);
         TracingHelper.TAG_AUTH_ID.set(span, authId);
         final Future<CredentialsResult<JsonObject>> result = Future.future();
-        get(tenantId, type, authId, payload, span, result.completer());
+        get(tenantId, type, authId, payload, span, result);
         return result.map(res -> {
             final String deviceIdFromPayload = Optional.ofNullable(res.getPayload())
                     .map(p -> getTypesafeValueForField(String.class, p,
@@ -148,7 +148,7 @@ public abstract class BaseCredentialsService<T> extends EventBusService<T> imple
         TracingHelper.TAG_CREDENTIALS_TYPE.set(span, type);
         span.setTag(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId);
         final Future<CredentialsResult<JsonObject>> result = Future.future();
-        getAll(tenantId, deviceId, span, result.completer());
+        getAll(tenantId, deviceId, span, result);
         return result.map(res -> {
             return request.getResponse(res.getStatus())
                     .setDeviceId(deviceId)

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CompleteBaseCredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CompleteBaseCredentialsService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -111,7 +111,7 @@ public abstract class CompleteBaseCredentialsService<T> extends BaseCredentialsS
         try {
             payload.checkValidity(this::checkSecret);
             final Future<CredentialsResult<JsonObject>> result = Future.future();
-            add(tenantId, JsonObject.mapFrom(payload), result.completer());
+            add(tenantId, JsonObject.mapFrom(payload), result);
             return result.map(res -> {
                 return request.getResponse(res.getStatus())
                         .setDeviceId(payload.getDeviceId())
@@ -148,7 +148,7 @@ public abstract class CompleteBaseCredentialsService<T> extends BaseCredentialsS
         try {
             payload.checkValidity(this::checkSecret);
             final Future<CredentialsResult<JsonObject>> result = Future.future();
-            update(tenantId, JsonObject.mapFrom(payload), result.completer());
+            update(tenantId, JsonObject.mapFrom(payload), result);
             return result.map(res -> {
                 return request.getResponse(res.getStatus())
                         .setDeviceId(payload.getDeviceId())
@@ -183,7 +183,7 @@ public abstract class CompleteBaseCredentialsService<T> extends BaseCredentialsS
                 // delete a single credentials instance
                 log.debug("removing specific credentials [tenant: {}, type: {}, auth-id: {}]", tenantId, type, authId);
                 final Future<CredentialsResult<JsonObject>> result = Future.future();
-                remove(tenantId, type, authId, result.completer());
+                remove(tenantId, type, authId, result);
                 return result.map(res -> {
                     return request.getResponse(res.getStatus())
                             .setCacheDirective(res.getCacheDirective());
@@ -192,7 +192,7 @@ public abstract class CompleteBaseCredentialsService<T> extends BaseCredentialsS
                 // delete all credentials for device
                 log.debug("removing all credentials for device [tenant: {}, device-id: {}]", tenantId, deviceId);
                 final Future<CredentialsResult<JsonObject>> result = Future.future();
-                removeAll(tenantId, deviceId, result.completer());
+                removeAll(tenantId, deviceId, result);
                 return result.map(res -> {
                     return request.getResponse(res.getStatus())
                             .setDeviceId(deviceId)

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -386,7 +386,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
         final Future<Void> serverStopTracker = Future.future();
         if (server != null) {
             LOG.info("stopping secure HTTP server [{}:{}]", getBindAddress(), getActualPort());
-            server.close(serverStopTracker.completer());
+            server.close(serverStopTracker);
         } else {
             serverStopTracker.complete();
         }
@@ -397,7 +397,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
         final Future<Void> insecureServerStopTracker = Future.future();
         if (insecureServer != null) {
             LOG.info("stopping insecure HTTP server [{}:{}]", getInsecurePortBindAddress(), getActualInsecurePort());
-            insecureServer.close(insecureServerStopTracker.completer());
+            insecureServer.close(insecureServerStopTracker);
         } else {
             insecureServerStopTracker.complete();
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/BaseRegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/BaseRegistrationService.java
@@ -138,11 +138,11 @@ public abstract class BaseRegistrationService<T> extends EventBusService<T> impl
             final Future<RegistrationResult> result = Future.future();
             if (gatewayId == null) {
                 log.debug("asserting registration of device [{}] with tenant [{}]", deviceId, tenantId);
-                assertRegistration(tenantId, deviceId, span, result.completer());
+                assertRegistration(tenantId, deviceId, span, result);
             } else {
                 log.debug("asserting registration of device [{}] with tenant [{}] for gateway [{}]",
                         deviceId, tenantId, gatewayId);
-                assertRegistration(tenantId, deviceId, gatewayId, span, result.completer());
+                assertRegistration(tenantId, deviceId, gatewayId, span, result);
             }
             resultFuture = result.map(res -> {
                 return request.getResponse(res.getStatus())
@@ -219,7 +219,7 @@ public abstract class BaseRegistrationService<T> extends EventBusService<T> impl
         Objects.requireNonNull(resultHandler);
 
         final Future<RegistrationResult> getResultTracker = Future.future();
-        getDevice(tenantId, deviceId, getResultTracker.completer());
+        getDevice(tenantId, deviceId, getResultTracker);
 
         getResultTracker.compose(result -> {
             if (isDeviceEnabled(result)) {
@@ -269,8 +269,8 @@ public abstract class BaseRegistrationService<T> extends EventBusService<T> impl
         final Future<RegistrationResult> deviceInfoTracker = Future.future();
         final Future<RegistrationResult> gatewayInfoTracker = Future.future();
 
-        getDevice(tenantId, deviceId, deviceInfoTracker.completer());
-        getDevice(tenantId, gatewayId, gatewayInfoTracker.completer());
+        getDevice(tenantId, deviceId, deviceInfoTracker);
+        getDevice(tenantId, gatewayId, gatewayInfoTracker);
 
         CompositeFuture.all(deviceInfoTracker, gatewayInfoTracker).compose(ok -> {
 

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/CompleteBaseRegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/CompleteBaseRegistrationService.java
@@ -84,7 +84,7 @@ public abstract class CompleteBaseRegistrationService<T> extends BaseRegistratio
         } else {
             log.debug("registering device [{}] for tenant [{}]", deviceId, tenantId);
             final Future<RegistrationResult> result = Future.future();
-            addDevice(tenantId, deviceId, payload, result.completer());
+            addDevice(tenantId, deviceId, payload, result);
             return result.map(res -> {
                 return request.getResponse(res.getStatus())
                         .setDeviceId(deviceId)
@@ -103,7 +103,7 @@ public abstract class CompleteBaseRegistrationService<T> extends BaseRegistratio
         } else {
             log.debug("retrieving device [{}] of tenant [{}]", deviceId, tenantId);
             final Future<RegistrationResult> result = Future.future();
-            getDevice(tenantId, deviceId, result.completer());
+            getDevice(tenantId, deviceId, result);
             return result.map(res -> {
                 return request.getResponse(res.getStatus())
                         .setDeviceId(deviceId)
@@ -124,7 +124,7 @@ public abstract class CompleteBaseRegistrationService<T> extends BaseRegistratio
         } else {
             log.debug("updating registration information for device [{}] of tenant [{}]", deviceId, tenantId);
             final Future<RegistrationResult> result = Future.future();
-            updateDevice(tenantId, deviceId, payload, result.completer());
+            updateDevice(tenantId, deviceId, payload, result);
             return result.map(res -> {
                 return request.getResponse(res.getStatus())
                         .setDeviceId(deviceId)
@@ -143,7 +143,7 @@ public abstract class CompleteBaseRegistrationService<T> extends BaseRegistratio
         } else {
             log.debug("deregistering device [{}] of tenant [{}]", deviceId, tenantId);
             final Future<RegistrationResult> result = Future.future();
-            removeDevice(tenantId, deviceId, result.completer());
+            removeDevice(tenantId, deviceId, result);
             return result.map(res -> {
                 return request.getResponse(res.getStatus())
                         .setDeviceId(deviceId)

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseTenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseTenantService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -128,7 +128,7 @@ public abstract class BaseTenantService<T> extends EventBusService<T> implements
             final Span span) {
 
         final Future<TenantResult<JsonObject>> getResult = Future.future();
-        get(tenantId, span, getResult.completer());
+        get(tenantId, span, getResult);
         return getResult.map(tr -> {
             return request.getResponse(tr.getStatus())
                     .setJsonPayload(tr.getPayload())
@@ -144,7 +144,7 @@ public abstract class BaseTenantService<T> extends EventBusService<T> implements
             final X500Principal dn = new X500Principal(subjectDn);
             log.debug("retrieving tenant [subject DN: {}]", subjectDn);
             final Future<TenantResult<JsonObject>> getResult = Future.future();
-            get(dn, span, getResult.completer());
+            get(dn, span, getResult);
             return getResult.map(tr -> {
                 final EventBusMessage response = request.getResponse(tr.getStatus())
                         .setJsonPayload(tr.getPayload())

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/CompleteBaseTenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/CompleteBaseTenantService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -90,7 +90,7 @@ public abstract class CompleteBaseTenantService<T> extends BaseTenantService<T> 
             log.debug("creating tenant [{}]", tenantId);
             final Future<TenantResult<JsonObject>> addResult = Future.future();
             addNotPresentFieldsWithDefaultValuesForTenant(payload);
-            add(tenantId, payload, addResult.completer());
+            add(tenantId, payload, addResult);
             return addResult.map(tr -> {
                 return request.getResponse(tr.getStatus())
                         .setJsonPayload(tr.getPayload())
@@ -115,7 +115,7 @@ public abstract class CompleteBaseTenantService<T> extends BaseTenantService<T> 
             log.debug("updating tenant [{}]", tenantId);
             final Future<TenantResult<JsonObject>> updateResult = Future.future();
             addNotPresentFieldsWithDefaultValuesForTenant(payload);
-            update(tenantId, payload, updateResult.completer());
+            update(tenantId, payload, updateResult);
             return updateResult.map(tr -> {
                 return request.getResponse(tr.getStatus())
                         .setJsonPayload(tr.getPayload())
@@ -138,7 +138,7 @@ public abstract class CompleteBaseTenantService<T> extends BaseTenantService<T> 
         } else {
             log.debug("deleting tenant [{}]", tenantId);
             final Future<TenantResult<JsonObject>> removeResult = Future.future();
-            remove(tenantId, removeResult.completer());
+            remove(tenantId, removeResult);
             return removeResult.map(tr -> {
                 return request.getResponse(tr.getStatus())
                         .setJsonPayload(tr.getPayload())

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/AbstractCompleteRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/AbstractCompleteRegistrationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -93,14 +93,14 @@ public abstract class AbstractCompleteRegistrationServiceTest {
         final Future<RegistrationResult> result = Future.future();
         final Checkpoint register = ctx.checkpoint(2);
 
-        getCompleteRegistrationService().addDevice(TENANT, DEVICE, new JsonObject(), result.completer());
+        getCompleteRegistrationService().addDevice(TENANT, DEVICE, new JsonObject(), result);
         result.map(response -> {
             assertEquals(HttpURLConnection.HTTP_CREATED, response.getStatus());
             register.flag();
             return response;
         }).compose(ok -> {
             final Future<RegistrationResult> addResult = Future.future();
-            getCompleteRegistrationService().addDevice(TENANT, DEVICE, new JsonObject(), addResult.completer());
+            getCompleteRegistrationService().addDevice(TENANT, DEVICE, new JsonObject(), addResult);
             return addResult;
         }).setHandler(
                 ctx.succeeding(response -> ctx.verify(() -> {
@@ -120,12 +120,12 @@ public abstract class AbstractCompleteRegistrationServiceTest {
         final Future<RegistrationResult> result = Future.future();
         final Checkpoint get = ctx.checkpoint(2);
 
-        getCompleteRegistrationService().addDevice(TENANT, DEVICE, new JsonObject(), result.completer());
+        getCompleteRegistrationService().addDevice(TENANT, DEVICE, new JsonObject(), result);
         result.compose(response -> {
             assertEquals(HttpURLConnection.HTTP_CREATED, response.getStatus());
             get.flag();
             final Future<RegistrationResult> addResult = Future.future();
-            getCompleteRegistrationService().getDevice(TENANT, DEVICE, addResult.completer());
+            getCompleteRegistrationService().getDevice(TENANT, DEVICE, addResult);
             return addResult;
         }).setHandler(
                 ctx.succeeding(s -> ctx.verify(() -> {
@@ -147,18 +147,18 @@ public abstract class AbstractCompleteRegistrationServiceTest {
         final Future<RegistrationResult> result = Future.future();
         final Checkpoint get = ctx.checkpoint(3);
 
-        getCompleteRegistrationService().addDevice(TENANT, DEVICE, new JsonObject(), result.completer());
+        getCompleteRegistrationService().addDevice(TENANT, DEVICE, new JsonObject(), result);
         result.compose(response -> {
             assertEquals(HttpURLConnection.HTTP_CREATED, response.getStatus());
             get.flag();
             final Future<RegistrationResult> deregisterResult = Future.future();
-            getCompleteRegistrationService().removeDevice(TENANT, DEVICE, deregisterResult.completer());
+            getCompleteRegistrationService().removeDevice(TENANT, DEVICE, deregisterResult);
             return deregisterResult;
         }).compose(response -> {
             assertEquals(HttpURLConnection.HTTP_NO_CONTENT, response.getStatus());
             get.flag();
             final Future<RegistrationResult> getResult = Future.future();
-            getCompleteRegistrationService().getDevice(TENANT, DEVICE, getResult.completer());
+            getCompleteRegistrationService().getDevice(TENANT, DEVICE, getResult);
             return getResult;
         }).setHandler(ctx.succeeding(response -> ctx.verify(() -> {
             assertEquals(HttpURLConnection.HTTP_NOT_FOUND, response.getStatus());

--- a/service-base/src/test/java/org/eclipse/hono/service/tenant/AbstractCompleteTenantServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/tenant/AbstractCompleteTenantServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -221,13 +221,13 @@ public abstract class AbstractCompleteTenantServiceTest {
 
         addTenant("tenant").compose(ok -> {
             final Future<TenantResult<JsonObject>> updateResult = Future.future();
-            getCompleteTenantService().update("tenant", updatedPayload.copy(), updateResult.completer());
+            getCompleteTenantService().update("tenant", updatedPayload.copy(), updateResult);
             return updateResult;
         }).compose(updateResult -> {
             assertEquals(HttpURLConnection.HTTP_NO_CONTENT, updateResult.getStatus());
             update.flag();
             final Future<TenantResult<JsonObject>> getResult = Future.future();
-            getCompleteTenantService().get("tenant", null, getResult.completer());
+            getCompleteTenantService().get("tenant", null, getResult);
             return getResult;
         }).setHandler(ctx.succeeding(getResult -> ctx.verify(() -> {
             assertEquals(HttpURLConnection.HTTP_OK, getResult.getStatus());
@@ -331,7 +331,7 @@ public abstract class AbstractCompleteTenantServiceTest {
     protected Future<Void> addTenant(final String tenantId, final JsonObject payload) {
 
         final Future<TenantResult<JsonObject>> result = Future.future();
-        getCompleteTenantService().add(tenantId, payload, result.completer());
+        getCompleteTenantService().add(tenantId, payload, result);
         return result.map(response -> {
             if (response.getStatus() == HttpURLConnection.HTTP_CREATED) {
                 return null;

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -114,7 +114,7 @@ public class Application extends AbstractApplication {
     private Future<String> deployCredentialsService() {
         final Future<String> result = Future.future();
         log.info("Starting credentials service {}", credentialsService);
-        getVertx().deployVerticle(credentialsService, result.completer());
+        getVertx().deployVerticle(credentialsService, result);
         return result;
     }
 
@@ -124,7 +124,7 @@ public class Application extends AbstractApplication {
             result.fail("authentication service is not a verticle");
         } else {
             log.info("Starting authentication service {}", authenticationService);
-            getVertx().deployVerticle((Verticle) authenticationService, result.completer());
+            getVertx().deployVerticle((Verticle) authenticationService, result);
         }
         return result;
     }
@@ -132,14 +132,14 @@ public class Application extends AbstractApplication {
     private Future<String> deployRegistrationService() {
         final Future<String> result = Future.future();
         log.info("Starting registration service {}", registrationService);
-        getVertx().deployVerticle(registrationService, result.completer());
+        getVertx().deployVerticle(registrationService, result);
         return result;
     }
 
     private Future<String> deployTenantService() {
         final Future<String> result = Future.future();
         log.info("Starting tenant service {}", tenantService);
-        getVertx().deployVerticle(tenantService, result.completer());
+        getVertx().deployVerticle(tenantService, result);
         return result;
     }
 

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
@@ -93,7 +93,7 @@ public final class FileBasedCredentialsService extends CompleteBaseCredentialsSe
         } else if (vertx.fileSystem().existsBlocking(getConfig().getFilename())) {
             result.complete();
         } else if (createIfMissing) {
-            vertx.fileSystem().createFile(getConfig().getFilename(), result.completer());
+            vertx.fileSystem().createFile(getConfig().getFilename(), result);
         } else {
             log.debug("no such file [{}]", getConfig().getFilename());
             result.complete();
@@ -144,7 +144,7 @@ public final class FileBasedCredentialsService extends CompleteBaseCredentialsSe
         } else {
             final Future<Buffer> readResult = Future.future();
             log.debug("trying to load credentials from file {}", getConfig().getFilename());
-            vertx.fileSystem().readFile(getConfig().getFilename(), readResult.completer());
+            vertx.fileSystem().readFile(getConfig().getFilename(), readResult);
             return readResult.compose(buffer -> {
                 return addAll(buffer);
             }).recover(t -> {
@@ -230,7 +230,7 @@ public final class FileBasedCredentialsService extends CompleteBaseCredentialsSe
                 vertx.fileSystem().writeFile(
                         getConfig().getFilename(),
                         Buffer.buffer(tenants.encodePrettily(), StandardCharsets.UTF_8.name()),
-                        writeHandler.completer());
+                        writeHandler);
                 return writeHandler.map(ok -> {
                     dirty = false;
                     log.trace("successfully wrote {} credentials to file {}", idCount.get(), getConfig().getFilename());

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
@@ -111,7 +111,7 @@ public final class FileBasedRegistrationService extends CompleteBaseRegistration
             return Future.succeededFuture();
         } else {
             final Future<Buffer> readResult = Future.future();
-            vertx.fileSystem().readFile(getConfig().getFilename(), readResult.completer());
+            vertx.fileSystem().readFile(getConfig().getFilename(), readResult);
             return readResult.compose(buffer -> {
                 return addAll(buffer);
             }).recover(t -> {
@@ -129,7 +129,7 @@ public final class FileBasedRegistrationService extends CompleteBaseRegistration
         } else if (vertx.fileSystem().existsBlocking(getConfig().getFilename())) {
             result.complete();
         } else if (createIfMissing) {
-            vertx.fileSystem().createFile(getConfig().getFilename(), result.completer());
+            vertx.fileSystem().createFile(getConfig().getFilename(), result);
         } else {
             log.debug("no such file [{}]", getConfig().getFilename());
             result.complete();
@@ -219,7 +219,7 @@ public final class FileBasedRegistrationService extends CompleteBaseRegistration
                 }
 
                 final Future<Void> writeHandler = Future.future();
-                vertx.fileSystem().writeFile(getConfig().getFilename(), Buffer.factory.buffer(tenants.encodePrettily()), writeHandler.completer());
+                vertx.fileSystem().writeFile(getConfig().getFilename(), Buffer.factory.buffer(tenants.encodePrettily()), writeHandler);
                 return writeHandler.map(ok -> {
                     dirty = false;
                     log.trace("successfully wrote {} device identities to file {}", idCount.get(), getConfig().getFilename());

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
@@ -100,7 +100,7 @@ public final class FileBasedTenantService extends CompleteBaseTenantService<File
             return Future.succeededFuture();
         } else {
             final Future<Buffer> readResult = Future.future();
-            vertx.fileSystem().readFile(getConfig().getFilename(), readResult.completer());
+            vertx.fileSystem().readFile(getConfig().getFilename(), readResult);
             return readResult.compose(buffer -> {
                 return addAll(buffer);
             }).recover(t -> {
@@ -118,7 +118,7 @@ public final class FileBasedTenantService extends CompleteBaseTenantService<File
         } else if (vertx.fileSystem().existsBlocking(getConfig().getFilename())) {
             result.complete();
         } else if (createIfMissing) {
-            vertx.fileSystem().createFile(getConfig().getFilename(), result.completer());
+            vertx.fileSystem().createFile(getConfig().getFilename(), result);
         } else {
             log.debug("no such file [{}]", getConfig().getFilename());
             result.complete();
@@ -187,7 +187,7 @@ public final class FileBasedTenantService extends CompleteBaseTenantService<File
 
                 final Future<Void> writeHandler = Future.future();
                 vertx.fileSystem().writeFile(getConfig().getFilename(),
-                        Buffer.factory.buffer(tenantsJson.encodePrettily()), writeHandler.completer());
+                        Buffer.factory.buffer(tenantsJson.encodePrettily()), writeHandler);
                 return writeHandler.map(ok -> {
                     dirty = false;
                     log.trace("successfully wrote {} tenants to file {}", tenantsJson.size(),

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -19,6 +19,11 @@ title = "Release Notes"
   [Device Registry Admin Guide]({{< ref "/admin-guide/device-registry-config.md" >}}) for details
   regarding the configuration properties to use.
 
+### Fixes & Enhancements
+
+* vert.x has been updated to version 3.7.0.
+* The already deprecated method `io.vertx.core.Future.completer` is not used anymore.
+
 ### API Changes
 
 * The `org.eclipse.hono.util.RegistrationConstants.FIELD_DEFAULTS` constant

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -630,7 +630,7 @@ public final class IntegrationTestSupport {
     private Future<Buffer> loadFile(final String path) {
 
         final Future<Buffer> result = Future.future();
-        vertx.fileSystem().readFile(path, result.completer());
+        vertx.fileSystem().readFile(path, result);
         return result;
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttTestBase.java
@@ -112,7 +112,7 @@ public abstract class MqttTestBase {
             disconnectHandler.complete();
         } else {
             context.runOnContext(go -> {
-                mqttClient.disconnect(disconnectHandler.completer());
+                mqttClient.disconnect(disconnectHandler);
             });
         }
         disconnectHandler.setHandler(tidyUp -> {
@@ -187,7 +187,7 @@ public abstract class MqttTestBase {
                     .setUsername(username)
                     .setPassword(password);
             mqttClient = MqttClient.create(VERTX, options);
-            mqttClient.connect(IntegrationTestSupport.MQTT_PORT, IntegrationTestSupport.MQTT_HOST, result.completer());
+            mqttClient.connect(IntegrationTestSupport.MQTT_PORT, IntegrationTestSupport.MQTT_HOST, result);
         });
         return result.map(conAck -> {
             LOGGER.debug(
@@ -217,7 +217,7 @@ public abstract class MqttTestBase {
                     .setSsl(true);
             options.setHostnameVerificationAlgorithm("");
             mqttClient = MqttClient.create(VERTX, options);
-            mqttClient.connect(IntegrationTestSupport.MQTTS_PORT, IntegrationTestSupport.MQTT_HOST, result.completer());
+            mqttClient.connect(IntegrationTestSupport.MQTTS_PORT, IntegrationTestSupport.MQTT_HOST, result);
         });
         return result.map(conAck -> {
             LOGGER.debug(

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistryAmqpTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistryAmqpTestSupport.java
@@ -98,7 +98,7 @@ public final class DeviceRegistryAmqpTestSupport {
 
         final Future<Void> clientTracker = Future.future();
         if (factory != null) {
-            factory.disconnect(clientTracker.completer());
+            factory.disconnect(clientTracker);
         } else {
             clientTracker.complete();
         }


### PR DESCRIPTION
The method `io.vertx.core.Future.completer()` has been _deprecated_ and will be removed in the next _Vertx_ version (4.0.0). In this PR, the usage of `Future.completer()` has been removed and the release notes has been updated.

https://github.com/vert-x3/wiki/wiki/3.7.0-Deprecations-and-breaking-changes