### PR TITLE
[#1245] Add indication of GW usage to assertRegistration response JSON

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RegistrationConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistrationConstants.java
@@ -64,6 +64,12 @@ public final class RegistrationConstants extends RequestResponseApiConstants {
     public static final String FIELD_LAST_VIA_UPDATE_DATE = "update-date";
 
     /**
+     * The name of the field in a response payload that contains the boolean value
+     * defining whether one or more gateways may act on behalf of the device.
+     */
+    public static final String FIELD_PAYLOAD_GATEWAY_SUPPORTED = "gw-supported";
+
+    /**
      * The name of the Device Registration API endpoint.
      */
     public static final String REGISTRATION_ENDPOINT = "registration";

--- a/site/content/api/Device-Registration-API.md
+++ b/site/content/api/Device-Registration-API.md
@@ -61,12 +61,14 @@ The body of the response message consists of a single *Data* section containing 
 | Name             | Mandatory | JSON Type     | Description |
 | :--------------- | :-------: | :------------ | :---------- |
 | *device-id*      | *yes*     | *string*      | The ID of the device that is subject of the assertion. |
+| *gw-supported*   | *no*      | *boolean*     | If set to `true`, the device allows one or more gateways to act on its behalf. These gateways are configured in the device registration data by means of the `via` property. |
 | *defaults*       | *no*      | *object*      | Default values to be used by protocol adapters for augmenting messages from devices with missing information like a *content type*. It is up to the discretion of a protocol adapter if and how to use the given default values when processing messages published by the device. |
 
 Below is an example for a payload of a response to an *assert* request for device `4711` which also includes a default *content-type*:
 ~~~json
 {
   "device-id" : "4711",
+  "gw-supported": true,
   "defaults": {
     "content-type": "application/vnd.acme+json"
   }

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -41,6 +41,9 @@ title = "Release Notes"
   has been adapted accordingly.
 * The already deprecated `org.eclipse.hono.client.CommandConsumerFactory.closeCommandConsumer`
   method has been removed.
+* The response message format of the *assert Device Registration* operation of the Device Registration API
+  has been changed to include an optional `gw-supported` boolean field. The value of this field refers to 
+  whether the device on which the operation is invoked allows one or more gateways to act on its behalf.
 
 ## 1.0-M3
 


### PR DESCRIPTION
This is for #1245.

The intention of #1245 is that the update of the `last_via` property shall be done in a separate request. In order to decide whether we actually need to do that request, this PR changes the `assertRegistration` return JSON to include the `via` property value.