### PR TITLE
[#929] Equip MQTT adapter to check the message limit

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1011,7 +1011,9 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             final Future<JsonObject> tokenTracker = getRegistrationAssertion(tenant, deviceId,
                     ctx.authenticatedDevice(), currentSpan.context());
             final Future<TenantObject> tenantEnabledTracker = getTenantConfiguration(tenant, currentSpan.context())
-                    .compose(tenantObject -> isAdapterEnabled(tenantObject));
+                    .compose(tenantObject -> CompositeFuture.all(isAdapterEnabled(tenantObject),
+                            checkMessageLimit(tenantObject, payload.length()))
+                            .map(success -> tenantObject));
 
             return CompositeFuture.all(tokenTracker, tenantEnabledTracker, senderTracker).compose(ok -> {
 


### PR DESCRIPTION
Equip _MQTT adapter_ to check the _message limit_ (if configured) before accepting any _telemetry/event_ messages.
