### PR TITLE
Fix getPathWithoutBase(), extend javadocs and tests

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
@@ -117,7 +117,9 @@ public final class ResourceIdentifier {
 
         final StringBuilder b = new StringBuilder();
         for (int i = startIdx; i < resourcePath.length; i++) {
-            b.append(resourcePath[i]);
+            if (resourcePath[i] != null) {
+                b.append(resourcePath[i]);
+            }
             if (i < resourcePath.length - 1) {
                 b.append("/");
             }
@@ -241,6 +243,10 @@ public final class ResourceIdentifier {
     }
 
     /**
+     * Gets the resourceId part of this identifier.
+     * <p>
+     * E.g. for a resource <em>telemetry/DEFAULT_TENANT/4711</em>, the return value will be <em>4711</em>.
+     *
      * @return the resourceId or {@code null} if not set.
      */
     public String getResourceId() {
@@ -275,8 +281,10 @@ public final class ResourceIdentifier {
     }
 
     /**
-     * Gets a string representation of this resource identifier's
-     * <em>endpoint</em> and <em>tenantId</em>.
+     * Gets a string representation of this resource identifier's <em>endpoint</em> and <em>tenantId</em>.
+     * <p>
+     * E.g. for a resource <em>telemetry/DEFAULT_TENANT/4711</em>, the return value will be
+     * <em>telemetry/DEFAULT_TENANT</em>.
      *
      * @return A string consisting of the properties separated by a forward slash.
      */
@@ -286,6 +294,12 @@ public final class ResourceIdentifier {
 
     /**
      * Gets a string representation of the resource identifiers' parts without the base path.
+     * <p>
+     * E.g. for a resource <em>control/myTenant/deviceId/some/path</em>, the return value will be
+     * <em>deviceId/some/path</em>.
+     * <p>
+     * If this resource identifier doesn't contain any additional path segments after the base path, an empty string is
+     * returned.
      *
      * @return A string with all parts after the base bath.
      * @see ResourceIdentifier#getBasePath()

--- a/core/src/test/java/org/eclipse/hono/util/ResourceIdentifierTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/ResourceIdentifierTest.java
@@ -34,6 +34,8 @@ public class ResourceIdentifierTest {
         assertThat(resourceId.getEndpoint(), is("telemetry"));
         assertThat(resourceId.getTenantId(), is("myTenant"));
         assertNull(resourceId.getResourceId());
+        assertThat(resourceId.getBasePath(), is("telemetry/myTenant"));
+        assertThat(resourceId.getPathWithoutBase(), is(""));
         assertThat(resourceId.toString(), is("telemetry/myTenant"));
     }
 
@@ -48,6 +50,8 @@ public class ResourceIdentifierTest {
         assertThat(resourceId.getEndpoint(), is("control"));
         assertNull(resourceId.getTenantId());
         assertNull(resourceId.getResourceId());
+        assertThat(resourceId.getBasePath(), is("control"));
+        assertThat(resourceId.getPathWithoutBase(), is("/req/cmd-req-id"));
         assertThat(resourceId.getResourcePath()[4], is("cmd-req-id"));
     }
 
@@ -62,6 +66,8 @@ public class ResourceIdentifierTest {
         assertThat(resourceId.getEndpoint(), is("telemetry"));
         assertThat(resourceId.getTenantId(), is(Constants.DEFAULT_TENANT));
         assertNull(resourceId.getResourceId());
+        assertThat(resourceId.getBasePath(), is("telemetry/" + Constants.DEFAULT_TENANT));
+        assertThat(resourceId.getPathWithoutBase(), is(""));
         assertThat(resourceId.toString(), is("telemetry/" + Constants.DEFAULT_TENANT));
     }
 
@@ -76,6 +82,8 @@ public class ResourceIdentifierTest {
         assertThat(resourceId.getEndpoint(), is("telemetry"));
         assertThat(resourceId.getTenantId(), is("myTenant"));
         assertThat(resourceId.getResourceId(), is("deviceId"));
+        assertThat(resourceId.getBasePath(), is("telemetry/myTenant"));
+        assertThat(resourceId.getPathWithoutBase(), is("deviceId/what/ever"));
         assertThat(resourceId.toString(), is("telemetry/myTenant/deviceId/what/ever"));
         assertThat(resourceId.getResourcePath()[3], is("what"));
         assertThat(resourceId.getResourcePath()[4], is("ever"));
@@ -91,6 +99,8 @@ public class ResourceIdentifierTest {
         assertThat(resourceId.getEndpoint(), is("cbs"));
         assertNull(resourceId.getTenantId());
         assertNull(resourceId.getResourceId());
+        assertThat(resourceId.getBasePath(), is("cbs"));
+        assertThat(resourceId.getPathWithoutBase(), is(""));
     }
 
     /**
@@ -102,6 +112,8 @@ public class ResourceIdentifierTest {
         assertThat(resourceId.getEndpoint(), is("cbs"));
         assertNull(resourceId.getTenantId());
         assertNull(resourceId.getResourceId());
+        assertThat(resourceId.getBasePath(), is("cbs"));
+        assertThat(resourceId.getPathWithoutBase(), is(""));
     }
 
     /**
@@ -113,6 +125,8 @@ public class ResourceIdentifierTest {
         assertThat(resourceId.getEndpoint(), is("cbs"));
         assertNull(resourceId.getTenantId());
         assertNull(resourceId.getResourceId());
+        assertThat(resourceId.getBasePath(), is("cbs"));
+        assertThat(resourceId.getPathWithoutBase(), is(""));
     }
 
     /**
@@ -125,6 +139,8 @@ public class ResourceIdentifierTest {
         assertThat(resourceId.getEndpoint(), is("telemetry"));
         assertThat(resourceId.getTenantId(), is("myTenant"));
         assertThat(resourceId.getResourceId(), is("myDevice"));
+        assertThat(resourceId.getBasePath(), is("telemetry/myTenant"));
+        assertThat(resourceId.getPathWithoutBase(), is("myDevice"));
         assertThat(resourceId.toString(), is("telemetry/myTenant/myDevice"));
     }
 
@@ -139,6 +155,8 @@ public class ResourceIdentifierTest {
         assertThat(resourceId.getEndpoint(), is("telemetry"));
         assertThat(resourceId.getTenantId(), is("myTenant"));
         assertNull(resourceId.getResourceId());
+        assertThat(resourceId.getBasePath(), is("telemetry/myTenant"));
+        assertThat(resourceId.getPathWithoutBase(), is(""));
         assertThat(resourceId.toString(), is("telemetry/myTenant"));
     }
 


### PR DESCRIPTION
`ResourceIdentifier.fromString("control///req/cmd-req-id").getPathWithoutBase()` 
was returning `null/req/cmd-req-id`.

With this fix it will return `/req/cmd-req-id`.
