### PR TITLE
[#929] Equip HTTP, AMQP and COAP protocol adapters to check message limit

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -510,7 +510,9 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                     authenticatedDevice,
                     null);
             final Future<TenantObject> tenantEnabledTracker = getTenantConfiguration(device.getTenantId(), null)
-                    .compose(tenantObject -> isAdapterEnabled(tenantObject));
+                    .compose(tenantObject -> CompositeFuture
+                            .all(isAdapterEnabled(tenantObject), checkMessageLimit(tenantObject, payload.length()))
+                            .map(success -> tenantObject));
             CompositeFuture.all(tokenTracker, senderTracker, tenantEnabledTracker).compose(ok -> {
                     final DownstreamSender sender = senderTracker.result();
                     final Message downstreamMessage = newMessage(

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1011,7 +1011,9 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             final Future<JsonObject> tokenTracker = getRegistrationAssertion(tenant, deviceId,
                     ctx.authenticatedDevice(), currentSpan.context());
             final Future<TenantObject> tenantEnabledTracker = getTenantConfiguration(tenant, currentSpan.context())
-                    .compose(tenantObject -> isAdapterEnabled(tenantObject));
+                    .compose(tenantObject -> CompositeFuture.all(isAdapterEnabled(tenantObject),
+                            checkMessageLimit(tenantObject, payload.length()))
+                            .map(success -> tenantObject));
 
             return CompositeFuture.all(tokenTracker, tenantEnabledTracker, senderTracker).compose(ok -> {
 


### PR DESCRIPTION
This has dependency to the PR #1249 and that need to be merged first. 

This PR equips _HTTP_, _AMQP_ and _COAP_ protocol adapters to check the _message limit_ before accepting any _telemetry/event_ messages. The commit corresponding to this PR is [[#929] Equip HTTP, AMQP and COAP adapters to check message limit.](https://github.com/eclipse/hono/commit/f0fb971751ec4ff2a612339590a7bb09bfd8186b)
