### PR TITLE
[#1245] Extract methods for handling the bit flag used in the Command class

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -556,7 +556,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
         // WHEN an unauthenticated device publishes a command response
         final String replyToAddress = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, TEST_TENANT_ID,
-                TEST_DEVICE);
+                Command.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE));
 
         final Map<String, Object> propertyMap = new HashMap<>();
         propertyMap.put(MessageHelper.APP_PROPERTY_STATUS, 200);

--- a/client/src/test/java/org/eclipse/hono/client/CommandResponseTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandResponseTest.java
@@ -17,8 +17,6 @@ import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
 
 import java.net.HttpURLConnection;
-import java.util.HashMap;
-import java.util.Map;
 
 import io.vertx.proton.ProtonHelper;
 import org.apache.qpid.proton.message.Message;
@@ -60,10 +58,10 @@ public class CommandResponseTest {
 
     /**
      * Verifies that creating a response from a request ID which does not contain a hex encoded byte
-     * at the start position fails.
+     * at the second position fails.
      */
     @Test
-    public void testFromFailsForMalformedRequestId() {
+    public void testFromFailsForRequestIdWithMalformedLengthPart() {
 
         // make sure we succeed with a valid length string
         final CommandResponse resp = CommandResponse.from(
@@ -78,6 +76,28 @@ public class CommandResponseTest {
         assertThat(resp.getReplyToId(), is("String"));
 
         assertNull(CommandResponse.from("0ZZanyString", TENANT_ID, DEVICE_ID, null, null, HttpURLConnection.HTTP_OK));
+    }
+
+    /**
+     * Verifies that creating a response from a request ID which does not contain a single digit
+     * at the start position fails.
+     */
+    @Test
+    public void testFromFailsForRequestIdWithMalformedReplyIdOptionBitsPart() {
+
+        // make sure we succeed with a valid length string
+        final CommandResponse resp = CommandResponse.from(
+                "003anyString",
+                TENANT_ID,
+                DEVICE_ID,
+                null,
+                null,
+                HttpURLConnection.HTTP_OK);
+        assertNotNull(resp.toMessage());
+        assertThat(resp.toMessage().getCorrelationId(), is("any"));
+        assertThat(resp.getReplyToId(), is("String"));
+
+        assertNull(CommandResponse.from("Z03anyString", TENANT_ID, DEVICE_ID, null, null, HttpURLConnection.HTTP_OK));
     }
 
     /**
@@ -108,7 +128,7 @@ public class CommandResponseTest {
      * by the hex encoded byte at the start position fails.
      */
     @Test
-    public void testFailsForIncorrectCorrelationIdLength() {
+    public void testFromFailsForIncorrectCorrelationIdLength() {
 
         final String id = "thisIsLessThan255Characters";
         // make sure we succeed with valid length
@@ -164,9 +184,11 @@ public class CommandResponseTest {
      */
     @Test
     public void testForDeviceIdInReplyToId() {
+        final boolean replyToContainedDeviceId = true;
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId);
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from("control", TENANT_ID, String.format("%s/0rid-1", DEVICE_ID)).toString());
+                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
         message.setCorrelationId(CORRELATION_ID);
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
         final CommandResponse response = CommandResponse.from(message);
@@ -175,13 +197,120 @@ public class CommandResponseTest {
     }
 
     /**
+     * Verifies that creating a response fails for a message with no correlation id.
+     */
+    @Test
+    public void testFromMessageFailsForMissingCorrelationId() {
+        final boolean replyToContainedDeviceId = true;
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId);
+        final Message message = ProtonHelper.message();
+        message.setAddress(ResourceIdentifier
+                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+        MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        final CommandResponse response = CommandResponse.from(message);
+        assertThat(response, nullValue());
+    }
+
+    /**
+     * Verifies that creating a response fails for a message with no address set.
+     */
+    @Test
+    public void testFromMessageFailsForMissingAddress() {
+        final Message message = ProtonHelper.message();
+        message.setCorrelationId(CORRELATION_ID);
+        MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        final CommandResponse response = CommandResponse.from(message);
+        assertThat(response, nullValue());
+    }
+
+    /**
+     * Verifies that creating a response fails for a message with no status property.
+     */
+    @Test
+    public void testFromMessageFailsForMissingStatus() {
+        final boolean replyToContainedDeviceId = true;
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId);
+        final Message message = ProtonHelper.message();
+        message.setAddress(ResourceIdentifier
+                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+        message.setCorrelationId(CORRELATION_ID);
+        final CommandResponse response = CommandResponse.from(message);
+        assertThat(response, nullValue());
+    }
+
+    /**
+     * Verifies that creating a response fails for a message with status property containing an invalid value.
+     */
+    @Test
+    public void testFromMessageFailsForInvalidStatus() {
+        final boolean replyToContainedDeviceId = true;
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId);
+        final Message message = ProtonHelper.message();
+        message.setAddress(ResourceIdentifier
+                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+        message.setCorrelationId(CORRELATION_ID);
+        MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, 777);
+        final CommandResponse response = CommandResponse.from(message);
+        assertThat(response, nullValue());
+    }
+
+    /**
+     * Verifies that creating a response fails for a message with an invalid address, containing nothing behind the
+     * device id part.
+     */
+    @Test
+    public void testFromMessageFailsForInvalidAddressWithNothingBehindDeviceId() {
+        final Message message = ProtonHelper.message();
+        // use address with an invalid resource id part (nothing behind the device id)
+        message.setAddress(ResourceIdentifier.from("control", TENANT_ID, DEVICE_ID).toString());
+        message.setCorrelationId(CORRELATION_ID);
+        MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        final CommandResponse response = CommandResponse.from(message);
+        assertThat(response, nullValue());
+    }
+
+    /**
+     * Verifies that creating a response fails for a message with an invalid address, ending with the replyToOptions bit.
+     */
+    @Test
+    public void testFromMessageFailsForInvalidAddressWithOnlyReplyToOptionsBit() {
+        final boolean replyToContainedDeviceId = true;
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId);
+        final Message message = ProtonHelper.message();
+        message.setAddress(ResourceIdentifier
+                .from("control", TENANT_ID, String.format("%s/%s", DEVICE_ID, replyToOptionsBitFlag)).toString());
+        message.setCorrelationId(CORRELATION_ID);
+        MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        final CommandResponse response = CommandResponse.from(message);
+        assertThat(response, nullValue());
+    }
+
+    /**
+     * Verifies that creating a response fails for a message with an invalid address, containing an invalid
+     * replyToOptions bit.
+     */
+    @Test
+    public void testFromMessageFailsForInvalidAddressWithWrongReplyToOptionsBit() {
+        final String replyToOptionsBitFlag = "X"; // invalid value to test with
+        final Message message = ProtonHelper.message();
+        message.setAddress(ResourceIdentifier
+                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+        message.setCorrelationId(CORRELATION_ID);
+        MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        final CommandResponse response = CommandResponse.from(message);
+        assertThat(response, nullValue());
+    }
+
+    /**
      * Verifies that the device-id is not part of the reply-to-id.
      */
     @Test
     public void testForNoDeviceIdInReplyToId() {
+        final boolean replyToContainedDeviceId = false;
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId);
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from("control", TENANT_ID, String.format("%s/1rid-1", DEVICE_ID)).toString());
+                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
         message.setCorrelationId(CORRELATION_ID);
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
         final CommandResponse response = CommandResponse.from(message);
@@ -190,13 +319,10 @@ public class CommandResponseTest {
     }
 
     /**
-     * Verifies that the tenant and device ids are present in the properties.
+     * Verifies that the tenant and device ids are present in the response message.
      */
     @Test
     public void testForDeviceAndTenantIds() {
-        final Map<String, Object> properties = new HashMap<>();
-        properties.put("testKey1", "testValue1");
-        properties.put("testKey2", "testValue2");
         final CommandResponse response = CommandResponse.from(
                 Command.getRequestId(CORRELATION_ID, REPLY_TO_ID, DEVICE_ID),
                 TENANT_ID,

--- a/client/src/test/java/org/eclipse/hono/client/CommandTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandTest.java
@@ -54,14 +54,15 @@ public class CommandTest {
         message.setCorrelationId(correlationId);
         message.setReplyTo(String.format("%s/%s/%s/%s",
                 CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(true);
         final Command cmd = Command.from(message, Constants.DEFAULT_TENANT, "4711");
         assertTrue(cmd.isValid());
         assertThat(cmd.getName(), is("doThis"));
         assertThat(cmd.getReplyToId(), is(String.format("4711/%s", replyToId)));
         assertThat(cmd.getCorrelationId(), is(correlationId));
         assertFalse(cmd.isOneWay());
-        assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/0%s",
-                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId)));
+        assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/%s%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
     }
 
     /**
@@ -77,13 +78,14 @@ public class CommandTest {
         message.setCorrelationId(correlationId);
         message.setReplyTo(String.format("%s/%s/%s",
                 CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, replyToId));
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(false);
         final Command cmd = Command.from(message, Constants.DEFAULT_TENANT, "4711");
         assertTrue(cmd.isValid());
         assertThat(cmd.getReplyToId(), is(replyToId));
         assertNotNull(cmd.getCommandMessage());
         assertNotNull(cmd.getCommandMessage().getReplyTo());
-        assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/1%s",
-                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId)));
+        assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/%s%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
     }
 
     /**
@@ -99,13 +101,14 @@ public class CommandTest {
         message.setCorrelationId(correlationId);
         message.setReplyTo(String.format("%s/%s/%s/%s",
                 CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(true);
         final Command cmd = Command.from(message, Constants.DEFAULT_TENANT, "4711");
         assertTrue(cmd.isValid());
         assertThat(cmd.getReplyToId(), is(String.format("4711/%s", replyToId)));
         assertNotNull(cmd.getCommandMessage());
         assertNotNull(cmd.getCommandMessage().getReplyTo());
-        assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/0%s",
-                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId)));
+        assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/%s%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
     }
 
     /**
@@ -227,5 +230,19 @@ public class CommandTest {
         assertThat(command.getInvalidCommandReason(), containsString("subject"));
         assertThat(command.getInvalidCommandReason(), containsString("message/correlation-id"));
         assertThat(command.getInvalidCommandReason(), containsString("reply-to"));
+    }
+
+    /**
+     * Verifies the correct encoding and decoding of the bit flag with options relating to the reply-to address.
+     */
+    @Test
+    public void testEncodeDecodeReplyToOptions() {
+        final boolean replyToContainedDeviceId = false;
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId);
+        assertThat(Command.isReplyToContainedDeviceIdOptionSet(replyToOptionsBitFlag), is(replyToContainedDeviceId));
+
+        final boolean replyToContainedDeviceId2 = true;
+        final String replyToOptions2 = Command.encodeReplyToOptions(replyToContainedDeviceId2);
+        assertThat(Command.isReplyToContainedDeviceIdOptionSet(replyToOptions2), is(replyToContainedDeviceId2));
     }
 }


### PR DESCRIPTION
For #1245:
Extract methods for the bit flag used in the Command request id (denoting whether the original reply-to address contained the device id).

Encoding and decoding of the bit flag used in `Command.getDeviceFacingReplyToId`
and `CommandResponse.getReplyToId` has been refactored to use the new
methods as well. Note that for this, the bit flag value in these methods has been switched, making it identical to the flag value used for the Command request id.

This is a preparation for storing an additional option in the bit flag,
denoting whether the old or new command response address pattern was
used.
