### PR TITLE
[#929] Fix calculation of data usage period during message limit check.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
@@ -340,7 +340,8 @@ public final class PrometheusBasedResourceLimitChecks implements ResourceLimitCh
     private long calculateDataUsagePeriod(final LocalDate effectiveSince, final long periodInDays) {
         final long inclusiveDaysBetween = DAYS.between(effectiveSince, LocalDate.now()) + 1;
         if (inclusiveDaysBetween > 0 && periodInDays > 0) {
-            return inclusiveDaysBetween % periodInDays;
+            final long dataUsagePeriodInDays = inclusiveDaysBetween % periodInDays;
+            return dataUsagePeriodInDays == 0 ? periodInDays : dataUsagePeriodInDays;
         }
         return -1L;
     }


### PR DESCRIPTION
In `PrometheusBasedResourceLimitChecks.calculateDataUsagePeriod(...)`, when the calculated data usage period (in days) is equal to the configured `period-in-days`, then `zero` is being returned instead of the `period-in-days`.

_Example_: For the below config, the data usage period as on "2019-05-22" should be _30 days_ but currently _0 days_ is being returned. This has been fixed with this PR.
```
    "resource-limits": {
      "data-volume": {
        "max-bytes": 10000000,
        "period-in-days": 30,
        "effective-since": "2019-04-23"
      }
```