### PR TITLE
[#1073] Change northbound control endpoint names

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -556,7 +556,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
         // WHEN an unauthenticated device publishes a command response
         final String replyToAddress = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, TEST_TENANT_ID,
-                Command.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE));
+                Command.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE, false));
 
         final Map<String, Object> propertyMap = new HashMap<>();
         propertyMap.put(MessageHelper.APP_PROPERTY_STATUS, 200);

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -620,7 +620,7 @@ public class VertxBasedHttpProtocolAdapterTest {
         final Message msg = mock(Message.class);
         when(msg.getSubject()).thenReturn(name);
         when(msg.getCorrelationId()).thenReturn("the-correlation-id");
-        when(msg.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+        when(msg.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT,
                 tenantId, deviceId, "the-reply-to-id"));
         return msg;
     }

--- a/client/src/main/java/org/eclipse/hono/client/AsyncCommandClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/AsyncCommandClient.java
@@ -34,11 +34,12 @@ public interface AsyncCommandClient extends MessageSender {
      *
      * @param command The command name.
      * @param data The command data to send to the device or {@code null} if the command has no input data.
-     * @param correlationId The identifier to use for correlating the response with the request. Note: This parameter
-     * is security sensitive. To ensure secure request response mapping choose correlationId carefully, e.g.
-     * {@link java.util.UUID#randomUUID()}.
-     * @param replyId An arbitrary string which gets used for response link address in the form of <em>control/${
-     * tenantId}/${replyId}</em> Must match the {@code replyId} passed to the command response receiver, see also below.
+     * @param correlationId The identifier to use for correlating the response with the request. Note: This parameter is
+     *            security sensitive. To ensure secure request response mapping choose correlationId carefully, e.g.
+     *            {@link java.util.UUID#randomUUID()}.
+     * @param replyId An arbitrary string which gets used for the response link address in the form of
+     *            <em>command_response/${tenantId}/${replyId}</em>. Must match the {@code replyId} passed to the
+     *            command response receiver, see also below.
      * @return A future indicating the result of the operation.
      *         <p>
      *         If the command was accepted, the future will succeed.
@@ -63,11 +64,12 @@ public interface AsyncCommandClient extends MessageSender {
      * @param command The command name.
      * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
      * @param data The command data to send to the device or {@code null} if the command has no input data.
-     * @param correlationId The identifier to use for correlating the response with the request. Note: This parameter
-     * is security sensitive. To ensure secure request response mapping choose correlationId carefully, e.g.
-     * {@link java.util.UUID#randomUUID()}.
-     * @param replyId An arbitrary string which gets used for response link address in the form of <em>control/${
-     * tenantId}/${replyId}</em>. Must match the {@code replyId} passed to the command response receiver, see also below.
+     * @param correlationId The identifier to use for correlating the response with the request. Note: This parameter is
+     *            security sensitive. To ensure secure request response mapping choose correlationId carefully, e.g.
+     *            {@link java.util.UUID#randomUUID()}.
+     * @param replyId An arbitrary string which gets used for response link address in the form of
+     *            <em>command_response/${tenantId}/${replyId}</em>. Must match the {@code replyId} passed to the command
+     *            response receiver, see also below.
      * @param properties The headers to include in the command message as AMQP application properties
      * @return A future indicating the result of the operation.
      *         <p>

--- a/client/src/main/java/org/eclipse/hono/client/CommandConsumerFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandConsumerFactory.java
@@ -123,11 +123,31 @@ public interface CommandConsumerFactory extends ConnectionLifecycle {
      * once the sender is no longer needed anymore.
      * 
      * @param tenantId The ID of the tenant to send the command responses for.
-     * @param replyId The ID used to build the reply address as {@code control/tenantId/replyId}.
+     * @param replyId The ID used to build the reply address as {@code command_response/tenantId/replyId}.
      * @return A future that will complete with the sender once the link has been established.
      *         The future will be failed with a {@link ServiceInvocationException} if
      *         the link cannot be established, e.g. because this client is not connected.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     Future<CommandResponseSender> getCommandResponseSender(String tenantId, String replyId);
+
+    /**
+     * Gets a sender for sending command responses to a business application.
+     * <p>
+     * This implementation uses the legacy command response address pattern with the <em>control</em> prefix.
+     * <p>
+     * It is the responsibility of the calling code to properly close the
+     * link by invoking {@link CommandResponseSender#close(Handler)}
+     * once the sender is no longer needed anymore.
+     *
+     * @param tenantId The ID of the tenant to send the command responses for.
+     * @param replyId The ID used to build the reply address as {@code control/tenantId/replyId}.
+     * @return A future that will complete with the sender once the link has been established.
+     *         The future will be failed with a {@link ServiceInvocationException} if
+     *         the link cannot be established, e.g. because this client is not connected.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @deprecated Use {@link #getCommandResponseSender(String, String)} instead.
+     */
+    @Deprecated
+    Future<CommandResponseSender> getLegacyCommandResponseSender(String tenantId, String replyId);
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -126,10 +126,10 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
         this.requestTimeoutMillis = connection.getConfig().getRequestTimeout();
         if (tenantId == null) {
             this.targetAddress = getName();
-            this.replyToAddress = String.format("%s/%s", getName(), UUID.randomUUID());
+            this.replyToAddress = String.format("%s/%s", getReplyToEndpointName(), UUID.randomUUID());
         } else {
             this.targetAddress = String.format("%s/%s", getName(), tenantId);
-            this.replyToAddress = String.format("%s/%s/%s", getName(), tenantId, UUID.randomUUID());
+            this.replyToAddress = String.format("%s/%s/%s", getReplyToEndpointName(), tenantId, UUID.randomUUID());
         }
         this.tenantId = tenantId;
     }
@@ -168,7 +168,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
 
         this.requestTimeoutMillis = connection.getConfig().getRequestTimeout();
         this.targetAddress = String.format("%s/%s/%s", getName(), tenantId, deviceId);
-        this.replyToAddress = String.format("%s/%s/%s/%s", getName(), tenantId, deviceId, replyId);
+        this.replyToAddress = String.format("%s/%s/%s/%s", getReplyToEndpointName(), tenantId, deviceId, replyId);
         this.tenantId = tenantId;
     }
 
@@ -278,11 +278,24 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
     }
 
     /**
-     * Get the name of the endpoint that this client targets at.
+     * Gets the name of the endpoint that this client targets at.
      *
      * @return The name of the endpoint for this client.
      */
     protected abstract String getName();
+
+    /**
+     * Gets the name of the endpoint that will be used for the reply-to address.
+     * <p>
+     * This default implementation returns the endpoint returned by {@link #getName()}.
+     * <p>
+     * Subclasses may override this method in order to use a different endpoint name.
+     *
+     * @return The name of the endpoint for the reply-to address.
+     */
+    protected String getReplyToEndpointName() {
+        return getName();
+    }
 
     /**
      * Build a unique messageId for a request that serves as an identifier for a new message.

--- a/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandClientImpl.java
@@ -69,7 +69,7 @@ public class AsyncCommandClientImpl extends AbstractSender implements AsyncComma
 
     @Override
     public String getEndpoint() {
-        return CommandConstants.COMMAND_ENDPOINT;
+        return CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT;
     }
 
     /**
@@ -80,7 +80,7 @@ public class AsyncCommandClientImpl extends AbstractSender implements AsyncComma
      * @return The target address of the command message.
      */
     static String getTargetAddress(final String tenantId, final String deviceId) {
-        return String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId);
+        return String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, deviceId);
     }
 
     /**
@@ -90,7 +90,7 @@ public class AsyncCommandClientImpl extends AbstractSender implements AsyncComma
      * @return The link target address.
      */
     static String getLinkTargetAddress(final String tenantId) {
-        return String.format("%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId);
+        return String.format("%s/%s", CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId);
     }
 
     @Override
@@ -117,7 +117,7 @@ public class AsyncCommandClientImpl extends AbstractSender implements AsyncComma
         MessageHelper.setPayload(message, contentType, data);
         message.setSubject(command);
         message.setAddress(targetAddress);
-        final String replyToAddress = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId, replyId);
+        final String replyToAddress = String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, replyId);
         message.setReplyTo(replyToAddress);
 
         return sendAndWaitForOutcome(message).compose(ignore -> Future.succeededFuture());
@@ -126,8 +126,9 @@ public class AsyncCommandClientImpl extends AbstractSender implements AsyncComma
     /**
      * Creates a new asynchronous command client for a tenant and device.
      * <p>
-     * The instance created is scoped to the given device. In particular, the sender link's target address is set to
-     * <em>control/${tenantId}/${deviceId}</em>.
+     * The instance created is scoped to the given device. In particular, the target address of messages is set to
+     * <em>command/${tenantId}/${deviceId}</em>, whereas the sender link's target address is set to
+     * <em>command/${tenantId}</em>.
      *
      * @param con The connection to the Hono server.
      * @param tenantId The tenant that the device belongs to.

--- a/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandResponseConsumerImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandResponseConsumerImpl.java
@@ -32,7 +32,7 @@ import io.vertx.proton.ProtonReceiver;
  */
 public class AsyncCommandResponseConsumerImpl extends AbstractConsumer implements MessageConsumer {
 
-    private static final String ASYNC_COMMAND_RESPONSE_ADDRESS_TEMPLATE = CommandConstants.COMMAND_ENDPOINT
+    private static final String ASYNC_COMMAND_RESPONSE_ADDRESS_TEMPLATE = CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT
             + "/%s/%s";
 
     private AsyncCommandResponseConsumerImpl(

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
@@ -109,12 +109,17 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
     public static final String getTargetAddress(final String tenantId, final String deviceId) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
-        return String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId);
+        return String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, deviceId);
     }
 
     @Override
     protected String getName() {
-        return CommandConstants.COMMAND_ENDPOINT;
+        return CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT;
+    }
+
+    @Override
+    protected String getReplyToEndpointName() {
+        return CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT;
     }
 
     @Override
@@ -240,10 +245,11 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
     /**
      * Creates a new command client for a tenant and device.
      * <p>
-     * The instance created is scoped to the given device.
-     * In particular, the sender link's target address is set to
-     * <em>control/${tenantId}/${deviceId}</em> and the receiver link's source
-     * address is set to <em>control/${tenantId}/${deviceId}/${replyId}</em>.
+     * The instance created is scoped to the given device. In particular, the target address of messages is set to
+     * <em>command/${tenantId}/${deviceId}</em>, whereas the sender link's target address is set to
+     * <em>command/${tenantId}</em>. The receiver link's source address is set to
+     * <em>command_response/${tenantId}/${deviceId}/${replyId}</em>.
+     *
      * This address is also used as the value of the <em>reply-to</em>
      * property of all command request messages sent by this client.
      *

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
@@ -380,6 +380,29 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
         });
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * This implementation always creates a new sender link.
+     */
+    @Override
+    public Future<CommandResponseSender> getLegacyCommandResponseSender(
+            final String tenantId,
+            final String replyId) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(replyId);
+
+        return connection.executeOrRunOnContext(result -> {
+            LegacyCommandResponseSenderImpl.create(
+                    connection,
+                    tenantId,
+                    replyId,
+                    onRemoteClose -> {})
+                    .setHandler(result);
+        });
+    }
+
     // ------------- Override AbstractHonoClientFactory methods to also connect/disconnect the gatewayMapper ------------
 
     @Override

--- a/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
@@ -57,7 +57,7 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
 
     @Override
     public String getEndpoint() {
-        return CommandConstants.COMMAND_ENDPOINT;
+        return CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT;
     }
 
     @Override
@@ -182,8 +182,7 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
         final String deviceId = command.getDeviceId();
         final String targetAddress = getTargetAddress(tenantId, deviceId);
         final String replyToAddress = command.isOneWay() ? null
-                : String.format("%s/%s/%s",
-                CommandConstants.COMMAND_ENDPOINT, tenantId, command.getReplyToId());
+                : String.format("%s/%s/%s", command.getReplyToEndpoint(), tenantId, command.getReplyToId());
         return sendAndWaitForOutcome(
                 createDelegatedCommandMessage(command.getCommandMessage(), targetAddress, replyToAddress),
                 spanContext);
@@ -198,7 +197,7 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
      * @throws NullPointerException if tenant or device id is {@code null}.
      */
     static String getTargetAddress(final String tenantId, final String deviceId) {
-        return String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, Objects.requireNonNull(tenantId),
+        return String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT, Objects.requireNonNull(tenantId),
                 Objects.requireNonNull(deviceId));
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/DeviceSpecificCommandConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DeviceSpecificCommandConsumer.java
@@ -85,7 +85,7 @@ public class DeviceSpecificCommandConsumer extends CommandConsumer {
 
         LOG.trace("creating new command consumer [tenant-id: {}, device-id: {}]", tenantId, deviceId);
 
-        final String address = ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId).toString();
+        final String address = ResourceIdentifier.from(CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT, tenantId, deviceId).toString();
 
         final AtomicReference<ProtonReceiver> receiverRef = new AtomicReference<>();
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandler.java
@@ -74,7 +74,7 @@ public class GatewayMappingCommandHandler implements Handler<CommandContext> {
                         originalCommandContext.getCurrentSpan().log("determined 'via' device " + lastViaDeviceId);
                         if (!originalCommand.isOneWay()) {
                             originalCommand.getCommandMessage().setReplyTo(String.format("%s/%s/%s",
-                                    CommandConstants.COMMAND_ENDPOINT, tenantId, originalCommand.getReplyToId()));
+                                    CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, originalCommand.getReplyToId()));
                         }
                         final Command command = Command.from(originalCommand.getCommandMessage(), tenantId, lastViaDeviceId);
                         commandContext = CommandContext.from(command, originalCommandContext.getDelivery(), originalCommandContext.getReceiver(), originalCommandContext.getCurrentSpan());

--- a/client/src/main/java/org/eclipse/hono/client/impl/LegacyCommandResponseSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/LegacyCommandResponseSenderImpl.java
@@ -34,7 +34,7 @@ import io.vertx.proton.ProtonSender;
  * A wrapper around an AMQP link for sending response messages to
  * commands downstream.
  */
-public class CommandResponseSenderImpl extends AbstractSender implements CommandResponseSender {
+public class LegacyCommandResponseSenderImpl extends AbstractSender implements CommandResponseSender {
 
     /**
      * The default amount of time to wait for credits after link creation. This is higher as in the client defaults,
@@ -42,7 +42,7 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
      */
     public static final long DEFAULT_COMMAND_FLOW_LATENCY = 200L; // ms
 
-    CommandResponseSenderImpl(
+    LegacyCommandResponseSenderImpl(
             final HonoConnection connection,
             final ProtonSender sender,
             final String tenantId,
@@ -63,7 +63,7 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
 
     @Override
     public String getEndpoint() {
-        return CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT;
+        return CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT;
     }
 
     @Override
@@ -77,7 +77,7 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
     }
 
     static final String getTargetAddress(final String tenantId, final String replyId) {
-        return String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, replyId);
+        return String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT, tenantId, replyId);
     }
 
     /**
@@ -120,14 +120,14 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(replyId);
 
-        final String targetAddress = CommandResponseSenderImpl.getTargetAddress(tenantId, replyId);
+        final String targetAddress = LegacyCommandResponseSenderImpl.getTargetAddress(tenantId, replyId);
         final ClientConfigProperties props = new ClientConfigProperties(con.getConfig());
         if (props.getFlowLatency() < DEFAULT_COMMAND_FLOW_LATENCY) {
             props.setFlowLatency(DEFAULT_COMMAND_FLOW_LATENCY);
         }
 
         return con.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, closeHook)
-                .map(sender -> (CommandResponseSender) new CommandResponseSenderImpl(con, sender, tenantId,
+                .map(sender -> (CommandResponseSender) new LegacyCommandResponseSenderImpl(con, sender, tenantId,
                         targetAddress));
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantScopedCommandConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantScopedCommandConsumer.java
@@ -78,7 +78,7 @@ public class TenantScopedCommandConsumer extends CommandConsumer {
 
         LOG.trace("creating new tenant scoped command consumer [tenant-id: {}]", tenantId);
 
-        final String address = ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, null).toString();
+        final String address = ResourceIdentifier.from(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, null).toString();
 
         return con.createReceiver(
                 address,

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
@@ -109,7 +109,7 @@ public class CommandClientImplTest {
         assertNotNull(messageCaptor.getValue().getMessageId());
         assertThat(messageCaptor.getValue().getContentType(), is("text/plain"));
         assertThat(messageCaptor.getValue().getReplyTo(),
-                is(String.format("%s/%s/%s/%s", client.getName(), Constants.DEFAULT_TENANT, DEVICE_ID, REPLY_ID)));
+                is(String.format("%s/%s/%s/%s", client.getReplyToEndpointName(), Constants.DEFAULT_TENANT, DEVICE_ID, REPLY_ID)));
         assertNotNull(messageCaptor.getValue().getApplicationProperties());
         assertThat(messageCaptor.getValue().getApplicationProperties().getValue().get("appKey"), is("appValue"));
     }

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
@@ -105,7 +105,7 @@ public class CommandConsumerFactoryImplTest {
 
         connection = HonoClientUnitTestHelper.mockHonoConnection(vertx, props);
         deviceSpecificCommandReceiver = mock(ProtonReceiver.class);
-        deviceSpecificCommandAddress = ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId).toString();
+        deviceSpecificCommandAddress = ResourceIdentifier.from(CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT, tenantId, deviceId).toString();
         when(connection.createReceiver(
                 eq(deviceSpecificCommandAddress),
                 any(ProtonQoS.class),
@@ -113,7 +113,7 @@ public class CommandConsumerFactoryImplTest {
                 anyInt(),
                 any(Handler.class))).thenReturn(Future.succeededFuture(deviceSpecificCommandReceiver));
         tenantScopedCommandReceiver = mock(ProtonReceiver.class);
-        tenantCommandAddress = ResourceIdentifier.from(CommandConstants.COMMAND_ENDPOINT, tenantId, null).toString();
+        tenantCommandAddress = ResourceIdentifier.from(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, null).toString();
         when(connection.createReceiver(
                 eq(tenantCommandAddress),
                 any(ProtonQoS.class),

--- a/client/src/test/java/org/eclipse/hono/client/impl/DelegateViaDownstreamPeerCommandHandlerTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DelegateViaDownstreamPeerCommandHandlerTest.java
@@ -63,7 +63,7 @@ public class DelegateViaDownstreamPeerCommandHandlerTest {
     public void setup() {
         tenantId = "testTenant";
         deviceId = "testDevice";
-        replyTo = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId, "the-reply-to-id");
+        replyTo = String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, "the-reply-to-id");
 
         final Message commandMessage = mock(Message.class);
         when(commandMessage.getSubject()).thenReturn("testSubject");
@@ -94,7 +94,7 @@ public class DelegateViaDownstreamPeerCommandHandlerTest {
             @Override
             public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final SpanContext parent) {
                 assertThat(message.getAddress(),
-                        is(String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+                        is(String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT,
                                 DelegateViaDownstreamPeerCommandHandlerTest.this.tenantId,
                                 DelegateViaDownstreamPeerCommandHandlerTest.this.deviceId)));
                 assertThat(message.getReplyTo(), is(replyTo));
@@ -128,7 +128,7 @@ public class DelegateViaDownstreamPeerCommandHandlerTest {
             @Override
             public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final SpanContext parent) {
                 assertThat(message.getAddress(),
-                        is(String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+                        is(String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT,
                                 DelegateViaDownstreamPeerCommandHandlerTest.this.tenantId,
                                 DelegateViaDownstreamPeerCommandHandlerTest.this.deviceId)));
                 assertThat(message.getReplyTo(), is(replyTo));
@@ -163,7 +163,7 @@ public class DelegateViaDownstreamPeerCommandHandlerTest {
             @Override
             public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final SpanContext parent) {
                 assertThat(message.getAddress(),
-                        is(String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+                        is(String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT,
                                 DelegateViaDownstreamPeerCommandHandlerTest.this.tenantId,
                                 DelegateViaDownstreamPeerCommandHandlerTest.this.deviceId)));
                 assertThat(message.getReplyTo(), is(replyTo));
@@ -194,7 +194,7 @@ public class DelegateViaDownstreamPeerCommandHandlerTest {
             @Override
             public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final SpanContext parent) {
                 assertThat(message.getAddress(),
-                        is(String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+                        is(String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT,
                                 DelegateViaDownstreamPeerCommandHandlerTest.this.tenantId,
                                 DelegateViaDownstreamPeerCommandHandlerTest.this.deviceId)));
                 assertThat(message.getReplyTo(), is(replyTo));

--- a/client/src/test/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandlerTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandlerTest.java
@@ -129,7 +129,7 @@ public class GatewayMappingCommandHandlerTest {
     public void testHandleUsingDeviceDataWithLastViaAndCommandWithReplyTo() {
         final String deviceViaId = "testDeviceVia";
         final String replyToId = "the-reply-to-id";
-        final String replyTo = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId, replyToId);
+        final String replyTo = String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, replyToId);
 
         // GIVEN deviceData with 'via' and 'last-via'
         final JsonObject deviceData = new JsonObject();

--- a/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
@@ -29,6 +29,21 @@ public class CommandConstants {
     public static final String COMMAND_ENDPOINT_SHORT = "c";
 
     /**
+     * The name of the Command and Control API legacy endpoint used by northbound applications.
+     */
+    public static final String NORTHBOUND_COMMAND_LEGACY_ENDPOINT = "control";
+
+    /**
+     * The name of the northbound Command and Control API request endpoint used by northbound applications.
+     */
+    public static final String NORTHBOUND_COMMAND_REQUEST_ENDPOINT = "command";
+
+    /**
+     * The name of the northbound Command and Control API response endpoint used by northbound applications.
+     */
+    public static final String NORTHBOUND_COMMAND_RESPONSE_ENDPOINT = "command_response";
+
+    /**
      * The part of the address for a command response between a device and an adapter, which identifies the request.
      */
     public static final String COMMAND_RESPONSE_REQUEST_PART = "req";
@@ -65,12 +80,33 @@ public class CommandConstants {
     }
 
     /**
-     * Returns true if the passed endpoint denotes a command endpoint (full or short version).
+     * Returns {@code true} if the passed endpoint denotes a command endpoint (full or short version).
      *
      * @param endpoint The endpoint as a string.
      * @return {@code true} if the endpoint is a command endpoint.
      */
     public static final boolean isCommandEndpoint(final String endpoint) {
         return COMMAND_ENDPOINT.equals(endpoint) || COMMAND_ENDPOINT_SHORT.equals(endpoint);
+    }
+
+    /**
+     * Returns {@code true} if the passed endpoint denotes a command response endpoint as used by northbound applications.
+     *
+     * @param endpoint The endpoint as a string.
+     * @return {@code true} if the endpoint is a command response endpoint.
+     */
+    public static boolean isNorthboundCommandResponseEndpoint(final String endpoint) {
+        return CommandConstants.NORTHBOUND_COMMAND_LEGACY_ENDPOINT.equals(endpoint)
+                || CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT.equals(endpoint);
+    }
+
+    /**
+     * Checks whether the given endpoint is the command legacy endpoint.
+     * 
+     * @param endpoint The endpoint as a string.
+     * @return {@code true} if the endpoint is the command legacy endpoint.
+     */
+    public static boolean isNorthboundCommandLegacyEndpoint(final String endpoint) {
+        return NORTHBOUND_COMMAND_LEGACY_ENDPOINT.equals(endpoint);
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
@@ -295,7 +295,7 @@ public final class ResourceIdentifier {
     /**
      * Gets a string representation of the resource identifiers' parts without the base path.
      * <p>
-     * E.g. for a resource <em>control/myTenant/deviceId/some/path</em>, the return value will be
+     * E.g. for a resource <em>command_response/myTenant/deviceId/some/path</em>, the return value will be
      * <em>deviceId/some/path</em>.
      * <p>
      * If this resource identifier doesn't contain any additional path segments after the base path, an empty string is

--- a/deploy/src/main/config/qpid/qdrouterd-with-broker.json
+++ b/deploy/src/main/config/qpid/qdrouterd-with-broker.json
@@ -120,8 +120,8 @@
           "maxMessageSize": 131072,
           "allowUserIdProxy": true,
           "allowAnonymousSender": true,
-          "sources": "control/*",
-          "targets": "telemetry/*, event/*, control/*"
+          "sources": "control/*, command/*",
+          "targets": "telemetry/*, event/*, control/*, command_response/*"
         }
       }
   }],

--- a/deploy/src/main/deploy/example-permissions.json
+++ b/deploy/src/main/deploy/example-permissions.json
@@ -60,6 +60,14 @@
       {
         "resource": "control/*",
         "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "resource": "command/*",
+        "activities": [ "WRITE" ]
+      },
+      {
+        "resource": "command_response/*",
+        "activities": [ "READ" ]
       }
     ]
   },

--- a/deploy/src/main/deploy/openshift/hono-tenant-template.yml
+++ b/deploy/src/main/deploy/openshift/hono-tenant-template.yml
@@ -54,6 +54,24 @@ objects:
 - kind: Address
   apiVersion: enmasse.io/v1alpha1
   metadata:
+    name: ${ENMASSE_ADDRESS_SPACE}.${RESOURCE_NAME}.command
+  spec:
+    address: command/${HONO_TENANT_NAME}
+    type: anycast
+    plan: standard-small-anycast
+
+- kind: Address
+  apiVersion: enmasse.io/v1alpha1
+  metadata:
+    name: ${ENMASSE_ADDRESS_SPACE}.${RESOURCE_NAME}.command_response
+  spec:
+    address: command_response/${HONO_TENANT_NAME}
+    type: anycast
+    plan: standard-small-anycast
+
+- kind: Address
+  apiVersion: enmasse.io/v1alpha1
+  metadata:
     name: ${ENMASSE_ADDRESS_SPACE}.${RESOURCE_NAME}.event
   spec:
     address: event/${HONO_TENANT_NAME}

--- a/deploy/src/main/sandbox/qpid/sandbox-qdrouterd.json
+++ b/deploy/src/main/sandbox/qpid/sandbox-qdrouterd.json
@@ -110,8 +110,8 @@
           "remoteHosts": "*",
           "allowUserIdProxy": true,
           "allowAnonymousSender": true,
-          "targets": "telemetry/*, event/*, control/*",
-          "sources": "control/*"
+          "sources": "control/*, command/*",
+          "targets": "telemetry/*, event/*, control/*, command_response/*"
         }
       }
   }],

--- a/deploy/src/main/sandbox/sandbox-permissions.json
+++ b/deploy/src/main/sandbox/sandbox-permissions.json
@@ -60,6 +60,14 @@
       {
         "resource": "control/*",
         "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "resource": "command/*",
+        "activities": [ "WRITE" ]
+      },
+      {
+        "resource": "command_response/*",
+        "activities": [ "READ" ]
       }
     ]
   },

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -744,7 +744,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     protected final Future<CommandResponseSender> createCommandResponseSender(
             final String tenantId,
-            final String replyId) {
+            final String replyId,
+            final boolean isReplyToLegacyEndpointUsed) {
+        if (isReplyToLegacyEndpointUsed) {
+            return commandConsumerFactory.getLegacyCommandResponseSender(tenantId, replyId);
+        }
         return commandConsumerFactory.getCommandResponseSender(tenantId, replyId);
     }
 
@@ -772,7 +776,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(response);
 
-        final Future<CommandResponseSender> senderTracker = createCommandResponseSender(tenantId, response.getReplyToId());
+        final Future<CommandResponseSender> senderTracker = createCommandResponseSender(tenantId,
+                response.getReplyToId(), response.isReplyToLegacyEndpointUsed());
         return senderTracker
                 .compose(sender -> sender.sendCommandResponse(response, context))
                 .map(delivery -> {

--- a/tests/src/test/resources/auth/permissions.json
+++ b/tests/src/test/resources/auth/permissions.json
@@ -104,6 +104,14 @@
       {
         "resource": "control/*",
         "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "resource": "command/*",
+        "activities": [ "WRITE" ]
+      },
+      {
+        "resource": "command_response/*",
+        "activities": [ "READ" ]
       }
     ],
     "DEFAULT_TENANT-application": [
@@ -117,6 +125,14 @@
       {
         "resource": "control/DEFAULT_TENANT",
         "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "resource": "command/DEFAULT_TENANT",
+        "activities": [ "WRITE" ]
+      },
+      {
+        "resource": "command_response/DEFAULT_TENANT",
+        "activities": [ "READ" ]
       }
     ]
   },

--- a/tests/src/test/resources/qpid/qdrouterd-with-broker.json
+++ b/tests/src/test/resources/qpid/qdrouterd-with-broker.json
@@ -116,8 +116,8 @@
           "maxMessageSize": 131072,
           "allowUserIdProxy": true,
           "allowAnonymousSender": true,
-          "targets": "telemetry/*, event/*, control/*",
-          "sources": "control/*"
+          "sources": "control/*, command/*",
+          "targets": "telemetry/*, event/*, control/*, command_response/*"
         }
       }
   }],


### PR DESCRIPTION
This is for #1073:
The recently introduced `control/${tenant_id}` endpoint (providing the gateway mapping feature) is renamed to `control_request/${tenant_id}`.
For the command reply address, the pattern `control_response/${tenant_id}/${reply_id}` is now used by default. The old pattern `control/${tenant_id}/${reply_id}` is still supported as legacy control endpoint.