### PR TITLE
[#1262] Close mqtt connection when a telemetry/event message cannot be processed.

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -713,6 +713,12 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     } else {
                         onMessageUndeliverable(context);
                     }
+                        if (context.deviceEndpoint().isConnected()) {
+                            TracingHelper.logError(span,
+                                    String.format("Closing mqtt connection to the device. [cause: %s]",
+                                            processing.cause().getMessage()));
+                            context.deviceEndpoint().close();
+                        }
                 }
                 span.finish();
             });


### PR DESCRIPTION
This PR address the issue #1262 with reference to the [MQTT 3.1.1 spec](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718042). When a _telemetry/event_ message is not able to be processed successfully then the device connection is closed.



