### PR TITLE
Adjust heading levels to start with h2 per page.

### DIFF
--- a/site/content/admin-guide/secure_communication.md
+++ b/site/content/admin-guide/secure_communication.md
@@ -6,7 +6,7 @@ weight = 350
 The individual components of an Eclipse Hono&trade; installation, e.g. the protocol adapters, *AMQP Messaging Network*, *Hono Auth* etc., and the clients attaching to Hono in order to send and receive data all communicate with each other using AMQP 1.0 over TCP. The Hono components and the clients will usually not be located on the same local network but will probably communicate over public networking infrastructure. For most use cases it is therefore desirable, if not necessary, to provide for confidentiality of the data being transferred between these components. This section describes how Hono supports confidentiality by means of *Transport Layer Security* (TLS) and how to configure it.
 <!--more-->
 
-# Enabling TLS
+## Enabling TLS
 
 All of Hono's components can be configured to use TLS for establishing an encrypted communication channel with peers. When a client initiates a connection with a server, the TLS handshake protocol is used to negotiate parameters of a secure channel to be used for exchanging data. The most important of those parameters is a secret (symmetric) encryption key that is only known to the client and the server and which is used to transparently encrypt all data being sent over the connection as long as the connection exists. With each new connection, a new secret key is negotiated.
 
@@ -20,7 +20,7 @@ Within a Hono installation the following communication channels can be secured w
 1. *Protocol Adapter* connecting to *AMQP Messaging Network* - A protocol adapter connects to the messaging network in order to forward telemetry data and commands hence and forth between downstream components (client applications) and devices. This (internal) connection can be secured by configuring the Dispatch Router and the protocol adapters for TLS.
 1. *Devices* connecting to a *Protocol Adapter* - Devices use TLS to both authenticate the protocol adapter and to establish an encrypted channel that provides integrity and privacy when transmitting data. Note that the specifics of if and how TLS can be used with a particular protocol adapter is specific to the transport protocol the adapter uses for communicating with the devices.
 
-## Auth Server
+### Auth Server
 
 The Auth Server supports the use of TLS for connections to clients. Please refer to the [Auth Server admin guide]({{< relref "auth-server-config.md" >}}) for details regarding the required configuration steps.
 
@@ -33,7 +33,7 @@ The `demo-certs/certs` folder includes the following demo keys and certificates 
 | `trusted-certs.pem`    | Trusted CA certificates to use for verifying signatures. |
 
 
-## Dispatch Router
+### Dispatch Router
 
 The Dispatch Router reads its configuration from a file on startup (the default location is `/etc/qpid-dispatch/qdrouterd.conf`). Please refer to the [Dispatch Router documentation](https://qpid.apache.org/components/dispatch-router/index.html) for details regarding the configuration of TLS/SSL.
 
@@ -45,7 +45,7 @@ The `demo-certs/certs` folder includes the following demo keys and certificates 
 | `qdrouter-cert.pem`   | The example certificate asserting the server's identity. |
 | `trusted-certs.pem`   | Trusted CA certificates to use for verifying signatures. |
 
-## Device Registry
+### Device Registry
 
 The Device Registry supports the use of TLS for connections to protocol adapters and the Auth Server.
 Please refer to the [Device Registry admin guide]({{< relref "device-registry-config.md" >}}) for details regarding the required configuration steps.
@@ -60,7 +60,7 @@ The `demo-certs/certs` folder contains the following demo keys and certificates 
 | `trusted-certs.pem`         | Trusted CA certificates to use for verifying signatures. |
 
 
-## HTTP Adapter
+### HTTP Adapter
 
 The HTTP adapter supports the use of TLS for its connections to the Tenant service, the Device Registration service, the Credentials service and the AMQP Messaging Network. The adapter also supports the use of TLS for connections with devices. For this purpose, the adapter can be configured with a server certificate and private key.
 Please refer to the [HTTP adapter admin guide]({{< relref "http-adapter-config.md" >}}) for details regarding the required configuration steps.
@@ -74,7 +74,7 @@ The `demo-certs/certs` folder contains the following demo keys and certificates 
 | `trusted-certs.pem`     | Trusted CA certificates to use for verifying signatures. |
 
 
-## MQTT Adapter
+### MQTT Adapter
 
 The MQTT adapter supports the use of TLS for its connections to the Tenant service, the Device Registration service, the Credentials service and the AMQP Messaging Network. The adapter also supports the use of TLS for connections with devices. For this purpose, the adapter can be configured with a server certificate and private key.
 Please refer to the [MQTT adapter admin guide]({{< relref "mqtt-adapter-config.md" >}}) for details regarding the required configuration steps.
@@ -87,7 +87,7 @@ The `demo-certs/certs` folder contains the following demo keys and certificates 
 | `mqtt-adapter-cert.pem` | The example certificate asserting the adapter's identity. |
 | `trusted-certs.pem`     | Trusted CA certificates to use for verifying signatures. |
 
-## Kura Adapter
+### Kura Adapter
 
 The Kura adapter supports the use of TLS for its connections to the Tenant service, the Device Registration service, the Credentials service and the AMQP Messaging Network. The adapter also supports the use of TLS for connections with devices. For this purpose, the adapter can be configured with a server certificate and private key.
 Please refer to the [Kura adapter admin guide]({{< relref "kura-adapter-config.md" >}}) for details regarding the required configuration steps.
@@ -102,7 +102,7 @@ The `demo-certs/certs` folder contains the following demo keys and certificates 
 
 
 
-## Client Application
+### Client Application
 
 When the connection between an application client and Hono (i.e. the Dispatch Router) is supposed to be secured by TLS (which is a good idea), then the client application needs to be configured to trust the CA that signed the Dispatch Router's certificate chain. When the application uses the `org.eclipse.hono.client.HonoClientImpl` class from the `client` module, then this can be done by means of configuring the `org.eclipse.hono.connection.ConnectionFactoryImpl` with a trust store containing the CA's certificate. Please refer to the [Hono Client configuration guide]({{< relref "hono-client-configuration.md" >}}) for details regarding the configuration properties that need to be set.
 
@@ -112,7 +112,7 @@ The `demo-certs/certs` folder contains the following demo keys to be used with c
 | :------------------------ | :--------------------------------------------------------------- |
 | `trusted-certs.pem`     | Trusted CA certificates to use for verifying signatures. |
 
-# Using OpenSSL
+## Using OpenSSL
 
 Hono's individual services are implemented in Java and therefore, by default, use the SSL/TLS engine that comes with the Java Virtual Machine that the services are running on. In case of the Docker images provided by Hono this is the SSL engine of OpenJDK. While the standard SSL engine has the advantage of being a part of the JVM itself and thus being available on every operating system that the JVM is running on without further installation, it provides only limited performance and throughput when compared to native TLS implementations like [OpenSSL](https://www.openssl.org/).
 
@@ -120,7 +120,7 @@ In order to address this problem, the Netty networking library that is used in H
 
 The tcnative module comes in several flavors, corresponding to the way that the OpenSSL library has been linked in. The statically linked versions include a specific version of OpenSSL (or [BoringSSL](https://boringssl.googlesource.com/) for that matter) and is therefore most easy to use on supported platforms, regardless of whether another version of OpenSSL is already installed or not. In contrast, the dynamically linked variants depend on a particular version of OpenSSL being already installed on the operating system. Both approaches have their pros and cons and Hono therefore does not include tcnative in its Docker images by default, i.e. Hono's services will use the JVM's default SSL engine by default.
 
-## Configuring Containers
+### Configuring Containers
 
 When starting up any of Hono's Docker images as a container, the JVM will look for additional jar files to include in its classpath in the container's `/opt/hono/extensions` folder. Thus, using a specific variant of tcnative is just a matter of configuring the container to mount a volume or binding a host folder at that location and putting the desired variant of tcnative into the corresponding volume or host folder.r
 Assuming that the Auth Server should be run with the statically linked, BoringSSL based tcnative variant, the following steps are necessary:

--- a/site/content/api/Authentication-API.md
+++ b/site/content/api/Authentication-API.md
@@ -12,17 +12,17 @@ Note that a component implementing this API will most likely need to also provid
 
 In a real world environment there will often already be an *identity management system* in place. In such cases it can make sense to just implement a *facade* exposing the Authentication API operations and mapping them to the underlying existing system's functionality.
 
-# Preconditions
+## Preconditions
 
 The preconditions for performing any of the operations are as follows:
 
 1. Client is in possession of credentials for the subject to get a token for.
 
-# Operations
+## Operations
 
 The Authentication API only defines a single operation which is mandatory to implement.
 
-## Get Token
+### Get Token
 
 Clients use this operation to
 
@@ -55,7 +55,7 @@ The following table provides an overview of the properties of the message sent t
 
 The message's body consists of a single AMQP 1.0 *AmqpValue* section which contains the UTF-8 representation of a JSON Web Token as defined in [Token Format]({{< relref "#token-format" >}}).
 
-# Token Format
+## Token Format
 
 The token returned by the *get Token* operation is a cryptographically signed JSON Web Token as defined by [RFC 7519](https://tools.ietf.org/html/rfc7519).
 
@@ -76,7 +76,7 @@ The allowed activities are encoded in a claim's value by means of simply concate
 
 The token may contain any number of additional claims which may be ignored by clients that do not understand their meaning.
 
-## Resource Authorities
+### Resource Authorities
 
 A client's authority on a resource is represented by a JWT *claim* with a name containing the resource node address prefixed with `r:` and a value containing the activities the client is allowed to perform on the resource. The node address MAY contain one or more wildcard (`*`) characters to represent *any* string.
 
@@ -98,7 +98,7 @@ the corresponding claims (in the token's JSON representation) would look like th
 }
 ~~~
 
-## Operation Authorities
+### Operation Authorities
 
 A client's authority to invoke an endpoint's operation(s) is represented by a JWT *claim* with a name containing the endpoint's node address and operation identifier prefixed with `o:` and a value of `E` (for `EXECUTE`). The endpoint node address MAY contain one or more wildcard (`*`) characters to represent *any* string. The operation identifier is the *subject* value defined by the corresponding API for the operation. The operation identifier MAY be set to `*` to represent *any* operation of the endpoint.
 

--- a/site/content/api/Command-And-Control-API.md
+++ b/site/content/api/Command-And-Control-API.md
@@ -17,11 +17,11 @@ The Command & Control API is defined by means of AMQP 1.0 message exchanges, i.e
 There is also a description of Command & Control [at the conceptual level]({{< ref "/concepts/command-and-control.md" >}}) 
 and the [Getting Started]({{< ref "/getting-started.md" >}}) guide contains a walk through example.
 
-# Operations
+## Operations
 
 The following API defines operations that can be used by *Business Applications* to send commands to devices over an AMQP 1.0 Network.
 
-## Send a One-Way Command
+### Send a One-Way Command
 
 Business Applications use this operation to send a command to a device for which they do not expect to receive a response from the device.
 
@@ -78,7 +78,7 @@ The following sequence diagram illustrates how a malformed command sent by a *Bu
 
 
 
-## Send a (Request/Response) Command
+### Send a (Request/Response) Command
 
 *Business Applications* use this operation to send a command to a device for which they expect the device to send back a response.
 
@@ -168,7 +168,7 @@ The sending of a command may fail for the same reasons as those illustrated for 
 ![Command times out](../command_control_response_time_out.png)
 
 
-## Strategies for Building the Receiver Link Address
+### Strategies for Building the Receiver Link Address
 
 While the `${reply_id}` may be chosen arbitrarily by the client, the specific use case for sending commands should be considered when doing so.
 The following hints might help with creating an appropriate `${reply_id}`:

--- a/site/content/api/Credentials-API.md
+++ b/site/content/api/Credentials-API.md
@@ -12,7 +12,7 @@ Note, however, that in real world applications the device credentials will proba
 
 The Credentials API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using an AMQP 1.0 client in order to invoke operations of the API as described in the following sections.
 
-# Preconditions
+## Preconditions
 
 The preconditions for invoking any of the Credential API's operations are as follows:
 
@@ -24,11 +24,11 @@ The flow of messages for creating the links is illustrated by the following sequ
 
 ![Credentials message flow preconditions](../connectToCredentials.png)
 
-# Mandatory Operations 
+## Mandatory Operations 
 
 The operations described in the following sections are invoked by Hono's components during run time and are therefore mandatory to implement.
 
-## Get Credentials
+### Get Credentials
 
 Protocol adapters use this command to *look up* credentials of a particular type for a device identity.
 
@@ -83,7 +83,7 @@ The response message's *status* property may contain the following codes:
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
 
-# Optional Operations
+## Optional Operations
 
 The operations described in the following sections can be used by clients to manage credentials for authenticating devices connected to protocol adapters.
 
@@ -97,7 +97,7 @@ Functionality for *managing* the content of a device registry will be defined by
 API that will be specified as part of Hono 1.0.
 {{% /warning %}}
 
-## Add Credentials
+### Add Credentials
 
 Clients may use this command to initially *add* credentials for a device. The credentials to be added may be of arbitrary type. However, [Standard Credential Types]({{< relref "#standard-credential-types" >}}) contains an overview of some common types that are used by Hono's protocol adapters and which may be useful to others as well.
 
@@ -138,7 +138,7 @@ The response message's *status* property may contain the following codes:
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
-## Update Credentials
+### Update Credentials
 
 Clients use this command to *update* existing credentials registered for a device. All of the information that has been previously registered for the device gets *replaced* with the information contained in the request message.
 
@@ -176,7 +176,7 @@ The response message's *status* property may contain the following codes:
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
-## Remove Credentials
+### Remove Credentials
 
 Clients use this command to *remove* credentials registered for a device. Once the credentials are removed, the device may no longer be able to authenticate with protocol adapters using the authentication mechanism that the removed credentials corresponded to.
 
@@ -228,11 +228,11 @@ The response message's *status* property may contain the following codes:
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
-# Standard Message Properties
+## Standard Message Properties
 
 Due to the nature of the request/response message pattern of the operations of the Credentials API, there are some standard properties shared by all of the request and response messages exchanged as part of the operations.
 
-### Standard Request Properties
+#### Standard Request Properties
 
 The following table provides an overview of the properties shared by all request messages regardless of the particular operation being invoked.
 
@@ -244,7 +244,7 @@ The following table provides an overview of the properties shared by all request
 | *reply-to*       | yes       | *properties*             | *string*    | MUST contain the source address that the client wants to received response messages from. This address MUST be the same as the source address used for establishing the client's receive link (see [Preconditions]({{< relref "#Preconditions" >}})). |
 | *content-type*   | yes       | *properties*             | *string*     | MUST be set to `application/json`. |
 
-### Standard Response Properties
+#### Standard Response Properties
 
 The following table provides an overview of the properties shared by all response messages regardless of the particular operation being invoked.
 
@@ -257,7 +257,7 @@ The following table provides an overview of the properties shared by all respons
 | *status*         | yes       | *application-properties* | *int*        | Contains the status code indicating the outcome of the operation. Concrete values and their semantics are defined for each particular operation. |
 | *cache_control*  | no        | *application-properties* | *string*     | Contains an [RFC 2616](https://tools.ietf.org/html/rfc2616#section-14.9) compliant <em>cache directive</em>. The directive contained in the property MUST be obeyed by clients that are caching responses. |
 
-# Delivery States
+## Delivery States
 
 Hono uses the following AMQP message delivery states when receiving request messages from clients:
 
@@ -266,7 +266,7 @@ Hono uses the following AMQP message delivery states when receiving request mess
 | *ACCEPTED*     | Indicates that Hono has successfully received and accepted the request for processing. |
 | *REJECTED*     | Indicates that Hono has received the request but was not able to process it. The *error* field contains information regarding the reason why. Clients should not try to re-send the request using the same message properties in this case. |
 
-# Credentials Format
+## Credentials Format
 
 Most of the operations of the Credentials API allow or require the inclusion of credential data in the payload of the
 request or response messages of the operation. Such payload is carried in the body of the corresponding AMQP 
@@ -288,7 +288,7 @@ For each set of credentials the combination of *auth-id* and *type* MUST be uniq
 
 **NB** Care needs to be taken that the value for the *authentication identifier* is compliant with the authentication mechanism(s) it is supposed to be used with. For example, when using standard HTTP Basic authentication, the *username* part of the Basic Authorization header value (which corresponds to the *auth-id*) MUST not contain any *colon* (`:`) characters, because the colon character is used as the separator between username and password. Similar constraints may exist for other authentication mechanisms, so the *authentication identifier* needs to be chosen with the anticipated mechanism(s) being used in mind. Otherwise, devices may fail to authenticate with protocol adapters, even if the credentials provided by the device match the credentials registered for the device. In general, using only characters from the `[a-zA-Z0-9_-]` range for the authentication identifier should be compatible with most mechanisms.
 
-## Secrets Format
+### Secrets Format
 
 Each set of credentials may contain arbitrary *secrets* scoped to a particular *validity period* during which the secrets may be used for authenticating a device. The validity periods MAY overlap in order to support the process of changing a secret on a device that itself doesn't support the definition of multiple secrets for gapless authentication across adjacent validity periods.
 
@@ -299,7 +299,7 @@ The table below contains the properties used to define the validity period of a 
 | *not-before*     | *no*      | *string*   | `null`        | The point in time from which on the secret may be used to authenticate devices. If not *null*, the value MUST be an [ISO 8601 compliant *combined date and time representation in extended format*](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations). **NB** It is up to the discretion of the protocol adapter to make use of this information. |
 | *not-after*      | *no*      | *string*   | `null`        | The point in time until which the secret may be used to authenticate devices. If not *null*, the value MUST be an [ISO 8601 compliant *combined date and time representation in extended format*](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations). **NB** It is up to the discretion of the protocol adapter to make use of this information. |
 
-## Examples
+### Examples
 
 Below is an example for a payload containing [a hashed password]({{< relref "#hashed-password" >}}) for device `4711` with auth-id `sensor1` using SHA512 as the hashing function with a 4 byte salt (Base64 encoding of `0x32AEF017`). Note that the payload does not contain a `not-before` property, thus it may be used immediately up until X-mas eve 2017.
 
@@ -336,7 +336,7 @@ The next example contains two [pre-shared secrets]({{< relref "#pre-shared-key" 
 }
 ~~~
 
-# Credential Verification
+## Credential Verification
 
 Protocol Adapters are responsible for authenticating devices when they connect. The Credentials API provides the [Get Credentials]({{< relref "#get-credentials" >}}) operation to support Protocol Adapters in doing so as illustrated below:
 
@@ -354,15 +354,15 @@ Retrieved credentials have to be verified by the *Protocol Adapter*:
    * their `not-before` property set to either `null` or the current or a past point in time **and**
    * their `not-after` property set to either `null` or the current or a future point in time.
 
-# Standard Credential Types
+## Standard Credential Types
 
 The following sections define some standard credential types and their properties. Applications are encouraged to make use of these types. However, the types are not enforced anywhere in Hono and clients may of course add application specific properties to the credential types.
 
-## Common Properties
+### Common Properties
 
 All credential types used with Hono MUST contain `device-id`, `type`, `auth-id`, `enabled` and `secrets` properties as defined in [Credentials Format]({{< relref "#credentials-format" >}}).
 
-## Hashed Password
+### Hashed Password
 
 A credential type for storing a (hashed) password for a device.
 
@@ -402,7 +402,7 @@ The table below describes the hash functions supported by Hono and how they map 
 | *sha-512*    | optional     | *salt* field     | The Base64 encoding of the bytes resulting from applying the *sha-512* hash function to the byte array consisting of the salt bytes (if a salt is used) and the UTF-8 encoding of the clear text password. |
 | *bcrypt*     | mandatory    | *pwd-hash* value | The output of applying the *Bcrypt* hash function to the clear text password. The salt is contained in the password hash.<br>**NB** Hono (currently) uses [Spring Security](https://docs.spring.io/spring-security/site/docs/4.2.7.RELEASE/reference/htmlsingle/#core-services-password-encoding) for matching clear text passwords against Bcrypt hashes. However, this library only supports hashes containing the `$2a$` prefix (see https://github.com/fpirsch/twin-bcrypt#about-prefixes) so Hono will fail to verify any passwords for which the corresponding Bcrypt hashes returned by the Credentials service contain e.g. the `$2y$` prefix. ||
 
-## Pre-Shared Key
+### Pre-Shared Key
 
 A credential type for storing a *Pre-shared Key* as used in TLS handshakes.
 
@@ -427,7 +427,7 @@ Example:
 
 **NB** The example above does not contain any of the `not-before`, `not-after` and `enabled` properties, thus the credentials can be used at any time according to the rules defined in [Credential Verification]({{< relref "#credential-verification" >}}).
 
-## X.509 Certificate
+### X.509 Certificate
 
 A credential type for storing the [RFC 2253](https://www.ietf.org/rfc/rfc2253.txt) formatted *subject DN* of a client certificate that is used to authenticate the device as part of a TLS handshake.
 

--- a/site/content/api/Device-Registration-API.md
+++ b/site/content/api/Device-Registration-API.md
@@ -12,7 +12,7 @@ Note, however, that in real world applications the registration information will
 
 The Device Registration API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using an AMQP 1.0 client in order to invoke operations of the API as described in the following sections.
 
-# Preconditions
+## Preconditions
 
 The preconditions for performing any of the operations are as follows:
 
@@ -24,11 +24,11 @@ This flow of messages is illustrated by the following sequence diagram (showing 
 
 ![Device Registration message flow preconditions](../connectToDeviceRegistration.png)
 
-# Mandatory Operations
+## Mandatory Operations
 
 The operations described in the following sections are invoked by Hono's components during run time and are therefore mandatory to implement.
 
-## Assert Device Registration
+### Assert Device Registration
 
 Clients use this command to verify that a device is registered for a particular tenant and is enabled.
 
@@ -86,7 +86,7 @@ The response message's *status* property may contain the following codes:
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
 
-## Get Registration Information
+### Get Registration Information
 
 Clients use this command to *retrieve* information about a registered device.
 
@@ -125,7 +125,7 @@ The response message's *status* property may contain the following codes:
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
-# Optional Operations
+## Optional Operations
 
 The operations described in the following sections can be used by clients to manage device registration information. In real world scenarios the provisioning of devices will most likely be an orchestrated process spanning multiple components of which Hono will only be one.
 
@@ -139,7 +139,7 @@ Functionality for *managing* the content of a device registry will be defined by
 API that will be specified as part of Hono 1.0.
 {{% /warning %}}
 
-## Register Device
+### Register Device
 
 Clients use this command to initially *add* information about a new device to Hono. Each device is registered within a *tenant*, providing the scope of the device's identifier.
 
@@ -177,7 +177,7 @@ The response message's *status* property may contain the following codes:
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
-## Update Device Registration
+### Update Device Registration
 
 Clients use this command to *update* information about an already registered device. All of the information that has been previously registered for the device gets *replaced* with the information contained in the request message.
 
@@ -213,7 +213,7 @@ The response message's *status* property may contain the following codes:
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
-## Deregister Device
+### Deregister Device
 
 Clients use this command to *remove* all information about a device from Hono. Once a device is deregistered, clients can no longer use Hono to interact with the device nor can they consume any more data produced by the device.
 
@@ -250,11 +250,11 @@ The response may contain the following status codes:
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 
-# Standard Message Properties
+## Standard Message Properties
 
 Due to the nature of the request/response message pattern of the operations of the Device Registration API, there are some standard properties shared by all of the request and response messages exchanged as part of the operations.
 
-## Standard Request Properties
+### Standard Request Properties
 
 The following table provides an overview of the properties shared by all request messages regardless of the particular operation being invoked.
 
@@ -267,7 +267,7 @@ The following table provides an overview of the properties shared by all request
 | *content-type*   | yes       | *properties*             | *string*     | MUST be set to `application/json`. |
 | *device_id*      | yes       | *application-properties* | *string*     | MUST contain the ID of the device that is subject to the operation. |
 
-## Standard Response Properties
+### Standard Response Properties
 
 The following table provides an overview of the properties shared by all response messages regardless of the particular operation being invoked.
 
@@ -280,7 +280,7 @@ The following table provides an overview of the properties shared by all respons
 | *status*         | yes       | *application-properties* | *int*        | Contains the status code indicating the outcome of the operation. Concrete values and their semantics are defined for each particular operation. |
 | *cache_control*  | no        | *application-properties* | *string*     | Contains an [RFC 2616](https://tools.ietf.org/html/rfc2616#section-14.9) compliant <em>cache directive</em>. The directive contained in the property MUST be obeyed by clients that are caching responses. |
 
-# Delivery States
+## Delivery States
 
 Hono uses the following AMQP message delivery states when receiving request messages from clients:
 
@@ -289,7 +289,7 @@ Hono uses the following AMQP message delivery states when receiving request mess
 | *ACCEPTED*     | Indicates that Hono has successfully received and accepted the request for processing. |
 | *REJECTED*     | Indicates that Hono has received the request but was not able to process it. The *error* field contains information regarding the reason why. Clients should not try to re-send the request using the same message properties in this case. |
 
-# Payload Format
+## Payload Format
 
 Most of the operations of the Device Registration API allow or require the inclusion of registration data in the payload of the
 request or response messages of the operation. Such payload is carried in the body of the corresponding AMQP 
@@ -297,7 +297,7 @@ messages as part of a single *Data* section. The content type must be set to `ap
 
 The registration data is carried in the payload as a UTF-8 encoded string representation of a single JSON object. It is an error to include payload that is not of this type.
 
-## Request Payload
+### Request Payload
 
 The table below provides an overview of the standard members defined for the JSON request object:
 
@@ -325,7 +325,7 @@ The device's *enabled* property will be set to *true* by default if the request 
 if the payload does not contain the *enabled* property.
 {{% /note %}}
 
-## Response Payload
+### Response Payload
 
 
 The JSON object conveyed in a response payload always contains a string typed member of name `device-id` whose value is the ID of the device as provided during registration.

--- a/site/content/api/Event-API.md
+++ b/site/content/api/Event-API.md
@@ -10,11 +10,11 @@ The *Event* API is used by *Protocol Adapters* to send event messages downstream
 The Event API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using AMQP 1.0 in order to invoke operations of the API as described in the following sections. Throughout the remainder of this page we will simply use *AMQP* when referring to AMQP 1.0.
 
 
-# Southbound Operations
+## Southbound Operations
 
 The following operations can be used by *Protocol Adapters* to forward event messages received from devices to downstream consumers like *Business Applications*.
 
-## Forward Event
+### Forward Event
 
 **Preconditions**
 
@@ -44,9 +44,9 @@ When the AMQP Messaging Network fails to settle the transfer of an event message
 
 See [Telemetry API]({{< relref "Telemetry-API.md#upload-telemetry-data" >}}) for definition of message format.
 
-# Northbound Operations
+## Northbound Operations
 
-## Receive Events
+### Receive Events
 
 Hono delivers messages containing events reported by a particular device in the same order that they have been received in (using the *Forward Event* operation defined above).
 
@@ -74,11 +74,11 @@ The following sequence diagram illustrates the flow of messages involved in a *B
 See [*Telemetry API*]({{< relref "Telemetry-API.md" >}}) for definition of message format. 
 
 
-# Well-known Event Message Types
+## Well-known Event Message Types
 
 Hono defines several *well-known* event types which have specific semantics. Events of these types are identified by means of the AMQP message's *content-type*.
 
-## Empty Notification
+### Empty Notification
 
 An AMQP message containing this type of event does not have any payload so the body of the message MUST be empty.
 
@@ -93,7 +93,7 @@ The relevant properties are listed again in the following table:
 
 NB: An empty notification can be used to indicate to a *Business Application* that a device is currently ready to receive an upstream message by setting the *ttd* property. *Backend Applications* may use this information to determine the time window during which the device will be able to receive a command.
 
-## Connection Event
+### Connection Event
 
 Protocol Adapters may send this type of event to indicate that a connection with a device has
 been established or has ended. Note that such events can only be sent for authenticated devices,

--- a/site/content/api/Telemetry-API.md
+++ b/site/content/api/Telemetry-API.md
@@ -9,11 +9,11 @@ The *Telemetry* API is used by *Protocol Adapters* to send telemetry data downst
 
 The Telemetry API is defined by means of AMQP 1.0 message exchanges, i.e. a client needs to connect to Hono using AMQP 1.0 in order to invoke operations of the API as described in the following sections. Throughout the remainder of this page we will simply use *AMQP* when referring to AMQP 1.0.
 
-# Southbound Operations
+## Southbound Operations
 
 The following operations can be used by *Protocol Adapters* to forward telemetry data received from devices to downstream consumers like *Business Applications*.
 
-## Forward Telemetry Data
+### Forward Telemetry Data
 
 **Preconditions**
 
@@ -78,9 +78,9 @@ The body of the message MUST consist of a single AMQP *Data* section containing 
 
 Any additional properties set by the client in either the *properties* or *application-properties* sections are preserved by Hono, i.e. these properties will also be contained in the message delivered to consumers.
 
-# Northbound Operations
+## Northbound Operations
 
-## Receive Telemetry Data
+### Receive Telemetry Data
 
 Hono delivers messages containing telemetry data reported by a particular device in the same order that they have been received in (using the *Upload Telemetry Data* operation defined above). Hono MAY drop telemetry messages that it cannot deliver to any consumers. Reasons for this include that there are no consumers connected to Hono or the existing consumers are not able to process the messages from Hono fast enough.
 


### PR DESCRIPTION
The page title is always h1. The content should not contain further headings on level h1, because this is punished by search engines. So on all pages containing h1 headings I just pushed every heading one level down.