### PR TITLE
[#623] Part 1 - Multiple trusted CAs

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
@@ -294,7 +294,7 @@ public class AmqpAdapterSaslAuthenticatorFactory implements ProtonSaslAuthentica
                 tenantTracker
                         .compose(tenant -> {
                             try {
-                                final TrustAnchor trustAnchor = tenantTracker.result().getTrustAnchor();
+                                final TrustAnchor trustAnchor = tenantTracker.result().getTrustAnchors().get(0);
                                 return certValidator.validate(Collections.singletonList(deviceCert), trustAnchor);
                             } catch(final GeneralSecurityException e) {
                                 LOG.debug("cannot retrieve trust anchor of tenant [{}]", tenant.getTenantId(), e);

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -64,7 +64,7 @@ public final class TenantConstants extends RequestResponseApiConstants {
      */
     public static final String FIELD_PAYLOAD_PUBLIC_KEY = "public-key";
     /**
-     * The name of the property that contains the trusted certificate authority configured for a tenant.
+     * The name of the property that contains the list of trusted certificate authorities configured for a tenant.
      */
     public static final String FIELD_PAYLOAD_TRUSTED_CA = "trusted-ca";
 

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -697,20 +697,6 @@ public final class TenantObject extends JsonBackedValueObject {
     }
 
     /**
-     * Get the list of configured trusted CAs for this tenant.
-     * 
-     * @return The list of configured trusted CAs or {@code null} if this tenant has no configured trusted CA.
-     * 
-     */
-    @JsonIgnore
-    public List<JsonObject> getTrustedCAs() {
-        if (trustConfigurations == null) {
-            return null;
-        } else {
-            return trustConfigurations.values().stream().flatMap(List::stream).collect(Collectors.toList());
-        }
-    }
-    /**
      * Gets all the trusted certificate authorities configured for this tenant.
      * 
      * @return The list of X.509 certificates or {@code null} if no certificate authority

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -227,7 +227,7 @@ public final class TenantObject extends JsonBackedValueObject {
             return trustAnchors;
         } else {
             trustAnchors = new ArrayList<>();
-            final List<JsonObject> configs = Optional.ofNullable(getTrustConfigurationsAsList()).orElse(Collections.emptyList());
+            final List<JsonObject> configs = Optional.ofNullable(getTrustedCAs()).orElse(Collections.emptyList());
             for (JsonObject config : configs) {
                 final TrustAnchor anchor = getTrustAnchor(config);
                 if (anchor != null) {
@@ -618,13 +618,13 @@ public final class TenantObject extends JsonBackedValueObject {
     }
 
     /**
-     * Get all the trusted certificate authorities configured for this tenant.
+     * Get the list of configured trusted CAs for this tenant.
      * 
-     * @return A list of trusted CA configurations for this tenant 
-     *         or {@code null} if no trusted CA has been set for this tenant.
+     * @return The list of configured trusted CAs or {@code null} if this tenant has no configured trusted CA.
+     *
      */
     @JsonIgnore
-    private List<JsonObject> getTrustConfigurationsAsList() {
+    public List<JsonObject> getTrustedCAs() {
 
         if (trustConfigurations == null) {
             return null;
@@ -707,7 +707,7 @@ public final class TenantObject extends JsonBackedValueObject {
      */
     @JsonIgnore
     public List<X509Certificate> getTrustedCertificateAuthorities() throws CertificateException {
-        final List<JsonObject> configs = getTrustConfigurationsAsList();
+        final List<JsonObject> configs = getTrustedCAs();
         if (configs == null) {
             return null;
         } else {

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -25,13 +25,19 @@ import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -53,8 +59,12 @@ public final class TenantObject extends JsonBackedValueObject {
 
     @JsonIgnore
     private Map<String, JsonObject> adapterConfigurations;
+
     @JsonIgnore
-    private TrustAnchor trustAnchor;
+    private List<TrustAnchor> trustAnchors;
+
+    @JsonIgnore
+    private Map<String, List<JsonObject>> trustConfigurations;
 
     /**
      * Adds a property to this tenant.
@@ -113,35 +123,33 @@ public final class TenantObject extends JsonBackedValueObject {
     }
 
     /**
-     * Gets the subject DN of this tenant's configured trusted
-     * certificate authority.
+     * Get the subject DN of the configured trusted CA.
      * 
      * @return The DN or {@code null} if no CA has been set.
      */
     @JsonIgnore
+    @Deprecated
     public X500Principal getTrustedCaSubjectDn() {
 
-        final JsonObject trustedCa = getProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, JsonObject.class);
-        if (trustedCa == null) {
-            return null;
+        final Set<X500Principal> subjectNames = getTrustedCaSubjectDns();
+        if (subjectNames == null) {
+           return null;
         } else {
-            return Optional
-                    .ofNullable(getProperty(trustedCa, TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, String.class))
-                    .map(dn -> new X500Principal(dn)).orElse(null);
+            return subjectNames.stream().findFirst().orElse(null);
         }
     }
 
     /**
-     * Sets the trusted certificate authority to use for authenticating
+     * Adds the trusted certificate authority to use for authenticating
      * devices of this tenant.
+     * @param publicKey The trusted CA's public key.
+     * @param subjectDn The trusted CA's subject DN.
      * 
-     * @param publicKey The CA's public key.
-     * @param subjectDn The CA's subject DN.
      * @return This tenant for command chaining.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     @JsonIgnore
-    public TenantObject setTrustAnchor(final PublicKey publicKey, final X500Principal subjectDn) {
+    public TenantObject addTrustAnchor(final PublicKey publicKey, final X500Principal subjectDn) {
 
         Objects.requireNonNull(publicKey);
         Objects.requireNonNull(subjectDn);
@@ -150,75 +158,49 @@ public final class TenantObject extends JsonBackedValueObject {
         trustedCa.put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, subjectDn.getName(X500Principal.RFC2253));
         trustedCa.put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, publicKey.getEncoded());
         trustedCa.put(TenantConstants.FIELD_PAYLOAD_KEY_ALGORITHM, publicKey.getAlgorithm());
-        return setProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, trustedCa);
+
+        return addTrustedCA(trustedCa);
     }
 
     /**
-     * Sets the trusted certificate authority to use for authenticating
-     * devices of this tenant.
+     * Sets the trusted certificate authority to use for authenticating devices of this tenant. The certificate must
+     * contain a {@code NonNull} and non-empty subject DN value.
      * 
      * @param certificate The CA certificate.
      * @return This tenant for command chaining.
      * @throws NullPointerException if certificate is {@code null}.
-     * @throws IllegalArgumentException if the certificate cannot be (binary) encoded.
+     * @throws IllegalArgumentException if the certificate cannot be (binary) encoded or its subject DN is
+     *             missing or empty.
      */
     @JsonIgnore
-    public TenantObject setTrustAnchor(final X509Certificate certificate) {
+    public TenantObject addTrustAnchor(final X509Certificate certificate) {
 
         Objects.requireNonNull(certificate);
 
-        try {
-            final JsonObject trustedCa = new JsonObject()
-                    .put(TenantConstants.FIELD_PAYLOAD_CERT, certificate.getEncoded());
-            return setProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, trustedCa);
-        } catch (final CertificateEncodingException e) {
-            throw new IllegalArgumentException("cannot encode certificate");
-        }
-    }
-
-    /**
-     * Gets the trusted certificate authority configured for this tenant.
-     * <p>
-     * This method tries to extract the certificate from the data contained in
-     * the JSON object of the <em>trusted-ca</em> property.
-     * The value of the JSON object's <em>cert</em> property is expected to contain
-     * the Base64 encoded <em>binary</em> DER-encoding of the certificate, i.e. the same
-     * value as the <em>printable</em> form but without the leading
-     * {@code -----BEGIN CERTIFICATE-----} and trailing {@code -----END CERTIFICATE-----}.
-     * 
-     * @return The certificate or {@code null} if no certificate authority
-     *         has been set.
-     * @throws CertificateException if the value of <em>cert</em> property cannot be parsed into
-     *             an X.509 certificate.
-     */
-    @JsonIgnore
-    public X509Certificate getTrustedCertificateAuthority() throws CertificateException {
-
-        final JsonObject trustedCa = getProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, JsonObject.class);
-        if (trustedCa == null) {
-            return null;
+        final String subjectDn = certificate.getSubjectX500Principal().getName();
+        if (Strings.isNullOrEmpty(subjectDn)) {
+            throw new IllegalArgumentException("subject DN of certificate is either missing or empty");
         } else {
-            final Object obj = trustedCa.getValue(TenantConstants.FIELD_PAYLOAD_CERT);
-            if (obj instanceof String) {
-                try {
-                    final byte[] derEncodedCert = Base64.getDecoder().decode(((String) obj));
-                    final CertificateFactory factory = CertificateFactory.getInstance("X.509");
-                    return (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(derEncodedCert));
-                } catch (final IllegalArgumentException e) {
-                    // Base64 decoding failed
-                    throw new CertificateParsingException("cert property does not contain valid Base64 scheme", e);
-                }
-            } else {
-                return null;
+            try {
+                final JsonObject trustedCa = new JsonObject()
+                        .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, subjectDn)
+                        .put(TenantConstants.FIELD_PAYLOAD_CERT, certificate.getEncoded());
+                return addTrustedCA(trustedCa);
+            } catch (final CertificateEncodingException e) {
+                throw new IllegalArgumentException("cannot encode certificate");
             }
         }
     }
 
     /**
-     * Gets the trust anchor for this tenant.
+     * Gets the list of trust anchor(s) configured for this tenant.
      * <p>
-     * This method tries to create the trust anchor based on the information
-     * from the JSON object contained in the <em>trusted-ca</em> property.
+     * If the <em>trusted-ca</em> property contains a JSON object as value,
+     * then this method constructs a trust anchor based on the information contained
+     * in the JSON object.
+     * <p>If the <em>trusted-ca</em> property contains a list of JSON objects, then
+     * this method constructs a trust anchor for each JSON object contained in the list.
+     * 
      * <ol>
      * <li>If the object contains a <em>cert</em> property then its content is
      * expected to contain the Base64 encoded (binary) DER encoding of the
@@ -236,24 +218,25 @@ public final class TenantObject extends JsonBackedValueObject {
      * @return The trust anchor or {@code null} if no trusted certificate authority
      *         has been set.
      * @throws GeneralSecurityException if the value of the <em>trusted-ca</em> property
-     *             cannot be parsed into a trust anchor, e.g. because of unsupported
-     *             key type, malformed certificate or public key encoding etc. 
+     *              cannot be parsed into a trust anchor, e.g. because of unsupported
+     *              key type, malformed certificate or public key encoding etc.
      */
     @JsonIgnore
-    public TrustAnchor getTrustAnchor() throws GeneralSecurityException {
-
-        if (trustAnchor != null) {
-            return trustAnchor;
+    public List<TrustAnchor> getTrustAnchors() throws GeneralSecurityException {
+        if (trustAnchors != null) {
+            return trustAnchors;
         } else {
-            final X509Certificate cert = getTrustedCertificateAuthority();
-            if (cert != null) {
-                trustAnchor = new TrustAnchor(cert, null);
-                return trustAnchor;
-            } else {
-                return getTrustAnchorForPublicKey(
-                        getProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, JsonObject.class));
+            trustAnchors = new ArrayList<>();
+            final List<JsonObject> configs = Optional.ofNullable(getTrustConfigurationsAsList()).orElse(Collections.emptyList());
+            for (JsonObject config : configs) {
+                final TrustAnchor anchor = getTrustAnchor(config);
+                if (anchor != null) {
+                    trustAnchors.add(anchor);
+                }
             }
+            return trustAnchors;
         }
+
     }
 
     @JsonIgnore
@@ -264,6 +247,7 @@ public final class TenantObject extends JsonBackedValueObject {
         } else {
             final String subjectDn = getProperty(keyProps, TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, String.class);
             final String encodedKey = getProperty(keyProps, TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, String.class);
+
             if (subjectDn == null || encodedKey == null) {
                 return null;
             } else {
@@ -273,8 +257,7 @@ public final class TenantObject extends JsonBackedValueObject {
                     final X509EncodedKeySpec keySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(encodedKey));
                     final KeyFactory factory = KeyFactory.getInstance(type);
                     final PublicKey publicKey = factory.generatePublic(keySpec);
-                    trustAnchor = new TrustAnchor(subjectDn, publicKey, null);
-                    return trustAnchor;
+                    return new TrustAnchor(subjectDn, publicKey, null);
                 } catch (final IllegalArgumentException e) {
                     // Base64 decoding failed
                     throw new InvalidKeySpecException("cannot decode Base64 encoded public key", e);
@@ -562,4 +545,195 @@ public final class TenantObject extends JsonBackedValueObject {
         setProperty(TenantConstants.FIELD_PAYLOAD_DEFAULTS, Objects.requireNonNull(defaultProperties));
         return this;
     }
+
+    /**
+     * Sets the configuration information for this tenant's configured trusted certificate(s).
+     * 
+     * @param configuration A single JSON object property or a list of JSON objects, one set
+     *            of properties for each configured trusted CA.
+     * @return This tenant for command chaining.
+     * 
+     * @throws IllegalArgumentException if the any of the trusted CA configuration is missing the required
+     *             <em>subject-dn</em> property or either the {@code public-key} or {@code cert} property does not
+     *             contain a valid Base64 encoding.
+     */
+    @SuppressWarnings("unchecked")
+    @JsonProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA)
+    public TenantObject setTrustedCa(final Object configuration) {
+        if (configuration == null) {
+            trustConfigurations = null;
+        } else if (Map.class.isInstance(configuration)) {
+            // for backwards compatibility with the older content model.
+            final JsonObject trustedCa = new JsonObject((Map<String, Object>) configuration);
+            addTrustedCA(trustedCa);
+        } else if (List.class.isInstance(configuration)) {
+
+            final List<Map<String, Object>> configurations = (List<Map<String, Object>>) configuration;
+            configurations.stream().forEach(map -> {
+                final JsonObject trustedCa = new JsonObject(map);
+                addTrustedCA(trustedCa);
+            });
+        } else {
+            throw new IllegalArgumentException("invalid trusted-ca configuration");
+        }
+        return this;
+    }
+
+    /**
+     * Gets the configuration information for this tenant's
+     * configured trusted certificate authorities.
+     * 
+     * @return An unmodifiable list of configuration properties or
+     *         {@code null} if no trust configuration has been
+     *         set for this tenant.
+     */
+    @JsonProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA)
+    public List<Map<String, Object>> getTrustConfigurationsAsMaps() {
+        if (trustConfigurations == null) {
+            return null;
+        } else {
+            final List<Map<String, Object>> result = new LinkedList<>();
+            trustConfigurations.values().stream().flatMap(Collection::stream).forEach(config -> result.add(config.getMap()));
+            return result;
+        }
+    }
+
+    /**
+     * Get the set of subject distinguished names configure for this tenant.
+     * 
+     * @return The set of subject distinguished names or {@code null} if no CA has been configured for this tenant.
+     */
+    @JsonIgnore
+    public Set<X500Principal> getTrustedCaSubjectDns() {
+
+        if (trustConfigurations == null) {
+            return null;
+        } else {
+            final Set<X500Principal> subjectNames = new HashSet<>();
+            trustConfigurations.keySet().forEach(subjectDn -> {
+                subjectNames.add(new X500Principal(subjectDn));
+            });
+            return subjectNames;
+        }
+    }
+
+    /**
+     * Get all the trusted certificate authorities configured for this tenant.
+     * 
+     * @return A list of trusted CA configurations for this tenant 
+     *         or {@code null} if no trusted CA has been set for this tenant.
+     */
+    @JsonIgnore
+    private List<JsonObject> getTrustConfigurationsAsList() {
+
+        if (trustConfigurations == null) {
+            return null;
+        } else {
+            return trustConfigurations.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+        }
+
+    }
+
+    @JsonIgnore
+    private TrustAnchor getTrustAnchor(final JsonObject trustedCa) throws GeneralSecurityException {
+        final X509Certificate cert = getTrustedCertificateAuthority(trustedCa);
+        if (cert != null) {
+            return new TrustAnchor(cert, null);
+        } else {
+            return getTrustAnchorForPublicKey(trustedCa);
+        }
+    }
+
+    /**
+     * Get the X.509 certificate from the specified trusted CA configuration.
+     * 
+     * @param trustedCa The trusted CA configuration to construct an X.509 certificate from.
+     * 
+     * @return The certificate or {@code null} if no certificate authority
+     *          has been set.
+     * @throws CertificateException if the value of <em>cert</em> property cannot be parsed into
+     *              an X.509 certificate.
+     */
+    @JsonIgnore
+    private X509Certificate getTrustedCertificateAuthority(final JsonObject trustedCa) throws CertificateException {
+
+        final String obj = (String) trustedCa.getValue(TenantConstants.FIELD_PAYLOAD_CERT);
+        if (obj != null) {
+            try {
+                final byte[] derEncodedCert = Base64.getDecoder().decode(((String) obj));
+                final CertificateFactory factory = CertificateFactory.getInstance("X.509");
+                return (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(derEncodedCert));
+            } catch (final IllegalArgumentException e) {
+                // ignore -> should never happen
+                throw new CertificateParsingException("cert property does not contain valid Base64 encoding scheme", e);
+            }
+        } else {
+            return null;
+        }
+
+    }
+
+    /**
+     * Add a trusted CA configuration for this tenant.
+     * 
+     * @param trustedCa The trust configuration to add.
+     * 
+     * @return This tenant so the API can be used fluently.
+     */
+    public TenantObject addTrustedCA(final JsonObject trustedCa) {
+
+        if (trustConfigurations == null) {
+            trustConfigurations = new HashMap<>();
+        }
+        final String subjectDn = getProperty(trustedCa, TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, String.class);
+        if (Strings.isNullOrEmpty(subjectDn)) {
+            throw new IllegalArgumentException("missing required subject-dn property");
+        }
+        final List<JsonObject> trustedCas = trustConfigurations.getOrDefault(subjectDn, new ArrayList<>());
+
+        trustedCas.add(trustedCa);
+        trustConfigurations.put(subjectDn, trustedCas);
+        return this;
+    }
+
+    /**
+     * Get the list of configured trusted CAs for this tenant.
+     * 
+     * @return The list of configured trusted CAs or {@code null} if this tenant has no configured trusted CA.
+     * 
+     */
+    @JsonIgnore
+    public List<JsonObject> getTrustedCAs() {
+        if (trustConfigurations == null) {
+            return null;
+        } else {
+            return trustConfigurations.values().stream().flatMap(List::stream).collect(Collectors.toList());
+        }
+    }
+    /**
+     * Gets all the trusted certificate authorities configured for this tenant.
+     * 
+     * @return The list of X.509 certificates or {@code null} if no certificate authority
+     *         has been set.
+     *         
+     * @throws CertificateException CertificateException if any of the trusted CA configurations
+     *         cannot be parsed into an X.509 certificate.
+     */
+    @JsonIgnore
+    public List<X509Certificate> getTrustedCertificateAuthorities() throws CertificateException {
+        final List<JsonObject> configs = getTrustConfigurationsAsList();
+        if (configs == null) {
+            return null;
+        } else {
+            final List<X509Certificate> result = new ArrayList<>();
+            for (final JsonObject config : configs) {
+                final X509Certificate cert = getTrustedCertificateAuthority(config);
+                if (cert != null) {
+                    result.add(cert);
+                }
+            }
+            return result;
+        }
+    }
+
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
@@ -156,7 +156,7 @@ public final class TenantServiceBasedX509Authentication implements X509Authentic
             return tenantTracker
                     .compose(tenant -> {
                         try {
-                            final TrustAnchor trustAnchor = tenant.getTrustAnchor();
+                            final TrustAnchor trustAnchor = tenant.getTrustAnchors().get(0);
                             final List<X509Certificate> chainToValidate = Collections.singletonList(deviceCert);
                             return certPathValidator.validate(chainToValidate, trustAnchor)
                                     .recover(t -> Future.failedFuture(UNAUTHORIZED));

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/EventBusTenantManagementAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/EventBusTenantManagementAdapter.java
@@ -313,6 +313,9 @@ public abstract class EventBusTenantManagementAdapter<T> extends EventBusService
             return true;
         } else if (JsonObject.class.isInstance(trustConfig)) {
             return isValidTrustedCaSpec((JsonObject) trustConfig);
+        } else if (JsonArray.class.isInstance(trustConfig)) {
+            final JsonArray trustConfigs = (JsonArray) trustConfig;
+            return trustConfigs.size() > 0 && isValidTrustedCaSpec(trustConfigs);
         } else {
             return false;
         }
@@ -368,4 +371,11 @@ public abstract class EventBusTenantManagementAdapter<T> extends EventBusService
         log.debug("invalid operation in request message [{}]", request.getOperation());
         return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
     }
+
+    private boolean isValidTrustedCaSpec(final JsonArray trustConfigs) {
+        final boolean containsInvalidTrustedCa = trustConfigs.stream()
+                .anyMatch(trustedCa -> !JsonObject.class.isInstance(trustedCa) || !isValidTrustedCaSpec((JsonObject) trustedCa));
+        return !containsInvalidTrustedCa;
+    }
+
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/CompleteBaseTenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/CompleteBaseTenantService.java
@@ -254,21 +254,30 @@ public abstract class CompleteBaseTenantService<T> extends BaseTenantService<T> 
     }
 
     /**
-     * Checks if a payload contains a valid trusted CA specification.
+     * Checks if a tenant payload contains a valid trusted CA specification.
      *
-     * @param payload The payload to check.
-     * @return boolean {@code true} if the payload is valid.
+     * @param payload The tenant payload to check.
+     * @return boolean {@code true} if the tenant payload is valid.
      */
     private boolean hasValidTrustedCaSpec(final JsonObject payload) {
 
-       final Object trustConfig = payload.getValue(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA);
-       if (trustConfig == null) {
-           return true;
-       } else if (JsonObject.class.isInstance(trustConfig)) {
-           return isValidTrustedCaSpec((JsonObject) trustConfig);
-       } else {
-           return false;
-       }
+        final Object object = payload.getValue(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA);
+        if (object == null) {
+            return true;
+        } else if (JsonObject.class.isInstance(object)) {
+            return isValidTrustedCaSpec((JsonObject) object);
+        } else if (JsonArray.class.isInstance(object)){
+            final JsonArray trustConfigs = (JsonArray) object;
+            return trustConfigs.size() > 0 && isValidTrustedCaSpec(trustConfigs);
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isValidTrustedCaSpec(final JsonArray trustConfigs) {
+        final boolean containsInvalidTrustedCa = trustConfigs.stream()
+                .anyMatch(trustedCa -> !JsonObject.class.isInstance(trustedCa) || !isValidTrustedCaSpec((JsonObject) trustedCa));
+        return !containsInvalidTrustedCa;
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/tenant/AbstractCompleteTenantServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/tenant/AbstractCompleteTenantServiceTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.service.tenant;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.vertx.core.Future;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.security.auth.x500.X500Principal;
 import java.net.HttpURLConnection;
+import java.util.List;
 
 /**
  * Abstract class used as a base for verifying behavior of {@link CompleteTenantService} in device registry implementations.
@@ -149,7 +151,10 @@ public abstract class AbstractCompleteTenantServiceTest {
                 assertEquals(HttpURLConnection.HTTP_OK, s.getStatus());
                 final TenantObject obj = s.getPayload().mapTo(TenantObject.class);
                 assertEquals("tenant", obj.getTenantId());
-                final JsonObject ca = obj.getProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, JsonObject.class);
+                final List<JsonObject> trustedCAs = obj.getTrustedCAs();
+                assertNotNull(trustedCAs);
+                assertEquals(1, trustedCAs.size());
+                final JsonObject ca = trustedCAs.get(0);
                 assertEquals(trustedCa, ca);
                 ctx.completeNow();
             })));

--- a/services/device-registry-legacy/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
+++ b/services/device-registry-legacy/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
@@ -311,8 +311,7 @@ public final class FileBasedTenantService extends CompleteBaseTenantService<File
                 }
                 final TenantObject tenant = tenantSpec.mapTo(TenantObject.class);
                 tenant.setTenantId(tenantId);
-                final TenantObject conflictingTenant = getByCa(tenant.getTrustedCaSubjectDn());
-                if (conflictingTenant != null) {
+                if (hasConflict(tenantId, tenant)) {
                     // we are trying to use the same CA as an already existing tenant
                     return TenantResult.from(HttpURLConnection.HTTP_CONFLICT);
                 } else {
@@ -363,8 +362,7 @@ public final class FileBasedTenantService extends CompleteBaseTenantService<File
                 try {
                     final TenantObject tenant = tenantSpec.mapTo(TenantObject.class);
                     tenant.setTenantId(tenantId);
-                    final TenantObject conflictingTenant = getByCa(tenant.getTrustedCaSubjectDn());
-                    if (conflictingTenant != null && !tenantId.equals(conflictingTenant.getTenantId())) {
+                    if (hasConflict(tenantId, tenant)) {
                         // we are trying to use the same CA as another tenant
                         return TenantResult.from(HttpURLConnection.HTTP_CONFLICT);
                     } else {
@@ -383,13 +381,28 @@ public final class FileBasedTenantService extends CompleteBaseTenantService<File
         }
     }
 
+    private boolean hasConflict(final String tenantId, final TenantObject tenant) {
+        boolean hasConflict = false;
+        if (tenant.getTrustedCaSubjectDns() != null) {
+            hasConflict = tenant.getTrustedCaSubjectDns().stream()
+                    .anyMatch(subjectDn -> hasConflict(tenantId, subjectDn));
+        }
+        return hasConflict;
+    }
+
+    private boolean hasConflict(final String tenantId, final X500Principal subjectDn) {
+        final TenantObject conflictingTenant = getByCa(subjectDn);
+        return conflictingTenant != null && !tenantId.equals(conflictingTenant.getTenantId());
+    }
+
     private TenantObject getByCa(final X500Principal subjectDn) {
 
         if (subjectDn == null) {
             return null;
         } else {
             return tenants.values().stream()
-                    .filter(t -> subjectDn.equals(t.getTrustedCaSubjectDn()))
+                    .filter(t -> Objects.nonNull(t.getTrustedCaSubjectDns()))
+                    .filter(t -> t.getTrustedCaSubjectDns().contains(subjectDn))
                     .findFirst().orElse(null);
         }
     }

--- a/site/documentation/content/api/Tenant-API.md
+++ b/site/documentation/content/api/Tenant-API.md
@@ -109,7 +109,7 @@ The table below provides an overview of the standard members defined for the JSO
 | *enabled*                | *yes*     | *boolean*     | If set to `false` the tenant is currently disabled. Protocol adapters MUST NOT allow devices of a disabled tenant to connect and MUST NOT accept data published by such devices. |
 | *resource-limits*        | *no*      | *object*      | Any resource limits that should be enforced for the tenant, e.g. the maximum number of concurrent connections and the maximum data volume for a given period. Refer to [Resource Limits Configuration Format]({{< relref "#resource-limits-configuration-format" >}}) for details. |
 | *tenant-id*              | *yes*     | *string*      | The ID of the tenant. |
-| *trusted-ca*             | *no*      | *object*      | The trusted certificate authority to use for validating certificates presented by devices of the tenant for authentication purposes. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
+| *trusted-ca*             | *no*      | *object* or *array*     | The trusted certificate authority(ies) to use for validating certificates presented by devices of the tenant for authentication purposes. The *trusted-ca* property can contain either a single JSON object  or an array of JSON objects. See [Trusted Certificate Authority Format]({{< relref "#trusted-ca-format" >}}) for a definition of the content model of the object. |
 
 The JSON object MAY contain an arbitrary number of additional members with arbitrary names which can be of a scalar or a complex type.
 This allows for future *well-known* additions and also allows to add further information which might be relevant to a *custom* adapter only.
@@ -153,17 +153,39 @@ The JSON structure below contains example information for tenant `TEST_TENANT`. 
 
 ### Trusted CA Format
 
-The table below provides an overview of the members defined for the *trusted-ca* JSON object:
+The *trusted-ca* property of the tenant (JSON) payload can contain either a single JSON object containing the trusted CA to use for validating certificates of devices belonging to the tenant.
++The tenant can also be configured with multiple trusted certificates. In this case, the *trusted-ca* property can contain an array of JSON objects, were each JSON object represents a single trusted CA. The table below provides an overview of the members defined in a JSON object contained in the *trust-ca* property:
 
 | Name                     | Mandatory  | Type          | Default Value | Description |
 | :------------------------| :--------: | :------------ | :------------ | :---------- |
 | *subject-dn*             | *yes*      | *string*      |               | The subject DN of the trusted root certificate in the format defined by [RFC 2253](https://www.ietf.org/rfc/rfc2253.txt). |
 | *cert*                   | *no*       | *string*      |               | The Base64 encoded binary DER encoding of the trusted root X.509 certificate. |
 | *public-key*             | *no*       | *string*      |               | The Base64 encoded binary DER encoding of the trusted root certificate's public key. |
+| *not-before*             | *no*       | *string*      |               | The property indicating that the trusted root X.509 certificate is not valid before the given date. |
+| *not-after*              | *no*       | *string*      |               | The property indicating that the trusted root X.509 certificate is not valid after the given date. |
 | *algorithm*              | *no*       | *string*      | `RSA`        | The name of the public key algorithm. Supported values are `RSA` and `EC`. This property is ignored if the *cert* property is used to store a certificate. |
 
 * The *subject-dn* MUST be unique among all registered tenants.
 * Either the *cert* or the *public-key* MUST be set.
+* If the *cert* property is used to store a certificate then the *not-before*, *not-after* and *algorithm* properties are ignored.
+
+**Examples**
+
+Below is an example for a payload of the response to a *get* request for tenant `TEST_TENANT` configured with two trusted certificate authorities.
+
+~~~json
+ {
+   "tenant-id" : "TEST_TENANT",
+   "enabled" : true,
+   "trusted-ca": [ {
+           "subject-dn": "CN=ca,OU=Hono,O=Eclipse",
+           "public-key": "NOTAPUBLICKEY"
+         }, {
+           "subject-dn": "CN=ca,OU=Hono,O=Eclipse",
+           "public-key": "NOTAPUBLICKEY"
+         } ]
+ }
+~~~
 
 ### Adapter Configuration Format
 

--- a/site/documentation/content/api/Tenant-API.md
+++ b/site/documentation/content/api/Tenant-API.md
@@ -153,22 +153,19 @@ The JSON structure below contains example information for tenant `TEST_TENANT`. 
 
 ### Trusted CA Format
 
-If the *trusted-ca* property is provided, then it MUST contain a non-empty array of JSON objects, were each JSON object represents a single trusted CA. The table below provides an overview of the members defined in a JSON object contained in the *trust-ca* property:
+If the *trusted-ca* property is provided, then it MUST contain a non-empty array of JSON objects, were each JSON object represents a single trusted CA. The table below provides an overview of the members of a JSON object representing a trusted CA:
 
 | Name                     | Mandatory  | Type          | Default Value | Description |
 | :------------------------| :--------: | :------------ | :------------ | :---------- |
-| *subject-dn*             | *yes*      | *string*      |               | The subject DN of the trusted root certificate in the format defined by [RFC 2253](https://www.ietf.org/rfc/rfc2253.txt). The subject DN MUST be unique across tenants. |
-| *public-key*             | *no*       | *string*      |               | The Base64 encoded binary DER encoding of the trusted root certificate's public key. |
-| *not-before*             | *no*       | *string*      |               | The property indicating that the trusted root X.509 certificate is not valid before the given date. The date format is defined by [RFC 5280](https://www.ietf.org/rfc/rfc5280.txt). |
-| *not-after*              | *no*       | *string*      |               | The property indicating that the trusted root X.509 certificate is not valid after the given date. The date format is defined by [RFC 5280](https://www.ietf.org/rfc/rfc5280.txt).|
+| *subject-dn*             | *yes*      | *string*      |               | The subject DN of the trusted root certificate in the format defined by [RFC 2253](https://www.ietf.org/rfc/rfc2253.txt). Trusted CAs of the same tenant MAY share the same subject DN (e.g. allowing for the definition of overlapping validity periods). However, trusted CAs of different tenants MUST NOT share the same subject DN in order to allow for the look up of a tenant by the subject DN of one of its trusted CAs. |
+| *public-key*             | *yes*       | *string*     |               | The Base64 encoded binary DER encoding of the trusted root certificate's public key. |
+| *not-before*             | *no*       | *string*      |               | The property indicating that the trusted root X.509 certificate is not valid before the given date. The value MUST be an **ISO 8601 compliant** [*combined date and time representation*](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) in extended format. |
+| *not-after*              | *no*       | *string*      |               | The property indicating that the trusted root X.509 certificate is not valid after the given date. The value MUST be an **ISO 8601 compliant** [*combined date and time representation*](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) in extended format.|
 | *algorithm*              | *no*       | *string*      | `RSA`        | The name of the public key algorithm. Supported values are `RSA` and `EC`. This property is ignored if the *cert* property is used to store a certificate. |
-
-* The *subject-dn* MUST be unique among all registered tenants.
-* Either the *cert* or the *public-key* MUST be set.
 
 **Examples**
 
-Below is an example for a payload of the response to a *get* request for tenant `TEST_TENANT`. The tenant is configured with two valid trusted certificates issued by the same issuer and having overlapping validity periods.
+Below is an example for a payload of the response to a *get* request for tenant `TEST_TENANT`. The tenant is configured with two valid trusted certificate authorities having the same *public-key* and *subject-dn* but with overlapping validity periods.
 
 ~~~json
  {
@@ -176,12 +173,12 @@ Below is an example for a payload of the response to a *get* request for tenant 
    "enabled" : true,
    "trusted-ca": [ {
            "subject-dn": "CN=ca,OU=Hono,O=Eclipse",
-           "public-key": "NOTAPUBLICKEY",
+           "public-key": "NOTAPUBLICKEY==",
            "not-before": "2015-01-01T00:00:00+0000",
            "not-after": "2025-01-01T00:00:00+0000"
          }, {
            "subject-dn": "CN=ca,OU=Hono,O=Eclipse",
-           "public-key": "NOTAPUBLICKEY",
+           "public-key": "NOTAPUBLICKEY==",
            "not-before": "2024-01-01T00:00:00+0000",
            "not-after": "2034-01-01T00:00:00+0000"
          } ]
@@ -225,7 +222,7 @@ The table below contains the properties which are used to configure a tenant's d
 | :------------------------| :-------: | :------------ | :------------ | :---------- |
 | *max-bytes*              | *no*      | *number*      | `-1`          | The maximum number of bytes allowed for the tenant for each accounting period. MUST be an integer. A negative value indicates that no limit is set. |
 | *period-in-days*         | *no*      | *number*      | `30`          | The length of an accounting period, i.e. the number of days over which the data usage is to be limited. MUST be a positive integer. |
-| *effective-since*        | *yes*     | *string*      | `-`           | The point in time at which the current settings became effective, i.e. the start of the first accounting period based on these settings. The value MUST be an [ISO 8601 compliant *combined date and time representation in extended format*](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations).
+| *effective-since*        | *yes*     | *string*      | `-`           | The point in time at which the current settings became effective, i.e. the start of the first accounting period based on these settings. The value MUST be an **ISO 8601 compliant** [*combined date and time representation*](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) in extended format.
 
 Protocol adapters SHOULD use this information to determine if a message originating from or destined to a device should be accepted for processing.
 

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -343,7 +343,6 @@ public abstract class HttpTestBase {
 
                 })
                 .setHandler(ctx.asyncAssertSuccess(ok -> setup.complete()));
-
         setup.await();
 
         testUploadMessages(ctx, tenantId, count -> {

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
@@ -145,6 +145,7 @@ public class TenantAmqpIT extends TenantApiTests {
     /**
      * {@inheritDoc}
      */
+
     @Override
     protected TenantClient getRestrictedClient() {
         return defaultTenantClient;


### PR DESCRIPTION
@sophokles73 As discussed in PR #1095, this is the first part of splitting that PR. The major changes are in the `TenantObject`class, which you have almost "completely" reviewed. I also made minor changes to the `base` tenant service classes and the `file based` device registry in this PR. 

Changes to all other classes are required due to the changes in the `TenantObject` class.

In the next part, i will add the tests for the new content model in the tenant service test classes.

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>