### PR TITLE
Fix grafana dashboard for JVM details

### DIFF
--- a/deploy/src/main/config/grafana/dashboard-definitions/jvm-details.json
+++ b/deploy/src/main/config/grafana/dashboard-definitions/jvm-details.json
@@ -539,7 +539,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "process_files_open{host=~\"$instance\"}",
+          "expr": "process_files_open_files{host=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "open files - {{host}}",
@@ -647,7 +647,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(jvm_threads_live{host=~\"$instance\"})",
+          "expr": "sum(jvm_threads_live_threads{host=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",


### PR DESCRIPTION
In Grafana dashboard for JVM details, the values corresponding to the `Threads` and `Open Files` are always empty. In this PR, this has been addressed by fixing the query expressions with appropriate time series.