### PR TITLE
[#1109] Delete old files when building web site.

### DIFF
--- a/jenkins/Hono-Website-Pipeline.groovy
+++ b/jenkins/Hono-Website-Pipeline.groovy
@@ -74,7 +74,7 @@ def build() {
                echo "cloning Hono web site repository..."
                git clone ssh://genie.hono@git.eclipse.org:29418/www.eclipse.org/hono $WORKSPACE/hono-web-site
                echo "scrubbing web site target directory..."
-               rm -rf "$WORKSPACE/hono-web-site/!(copyrighted-logos)"
+               rm -rf $WORKSPACE/hono-web-site/* # TODO replace by `rm -rf "$WORKSPACE/hono-web-site/!(copyrighted-logos)"`
                '''
         }
     }


### PR DESCRIPTION
Removed the exclusion of directory `copyrighted-logos` when deleting
the directory to which the web site is build. The command seemingly
did not work on Jenkins. Todo: add the exception later in a way that
works on the Jenkins machine.

Signed-off-by: Abel Buechner-Mihaljevic <Abel.Buechner@bosch-si.com>