### PR TITLE
[#1073] Change southbound control endpoint names

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -828,7 +828,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                 return doUploadMessage(context, resource, getTelemetrySender(resource.getTenantId()), currentSpan);
             case EVENT:
                 return doUploadMessage(context, resource, getEventSender(resource.getTenantId()), currentSpan);
-            case CONTROL:
+            case COMMAND:
                 return doUploadCommandResponseMessage(context, resource, currentSpan);
             default:
                 return Future
@@ -991,7 +991,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
             result.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
         } else {
             switch (ctx.getEndpoint()) {
-            case CONTROL:
+            case COMMAND:
             case TELEMETRY:
                 result.complete(ctx);
                 break;

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterLegacyEndpointTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterLegacyEndpointTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.adapter.amqp.impl;
+
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+/**
+ * Verifies the behavior of {@link VertxBasedAmqpProtocolAdapter} using the legacy Command & Control endpoint.
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxBasedAmqpProtocolAdapterLegacyEndpointTest extends VertxBasedAmqpProtocolAdapterTest {
+
+    @Override
+    protected boolean useLegacyCommandEndpoint() {
+        return true;
+    }
+}

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -400,7 +400,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         when(deviceConnection.attachments()).thenReturn(mock(Record.class));
         when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class), anyLong()))
             .thenReturn(Future.succeededFuture(mock(MessageConsumer.class)));
-        final String sourceAddress = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, TEST_TENANT_ID, TEST_DEVICE);
+        final String sourceAddress = String.format("%s/%s/%s", getCommandEndpoint(), TEST_TENANT_ID, TEST_DEVICE);
         final ProtonSender sender = getSender(sourceAddress);
 
         adapter.handleRemoteSenderOpenForCommands(deviceConnection, sender);
@@ -433,7 +433,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         final MessageConsumer commandConsumer = mock(MessageConsumer.class);
         when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class), anyLong()))
             .thenReturn(Future.succeededFuture(commandConsumer));
-        final String sourceAddress = String.format("%s", CommandConstants.COMMAND_ENDPOINT);
+        final String sourceAddress = String.format("%s", getCommandEndpoint());
         final ProtonSender sender = getSender(sourceAddress);
         final Device authenticatedDevice = new Device(TEST_TENANT_ID, TEST_DEVICE);
         final ProtonConnection deviceConnection = mock(ProtonConnection.class);
@@ -460,7 +460,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
     /**
      * Verifies that the adapter closes a corresponding command consumer if
      * the device closes the connection to the adapter.
-     * 
+     *
      * @param ctx The vert.x test context.
      */
     @Test
@@ -478,7 +478,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
     /**
      * Verifies that the adapter closes a corresponding command consumer if
      * the connection to a device fails unexpectedly.
-     * 
+     *
      * @param ctx The vert.x test context.
      */
     @Test
@@ -496,7 +496,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
     /**
      * Verifies that the adapter closes a corresponding command consumer if
      * the connection to a device fails unexpectedly.
-     * 
+     *
      * @param ctx The vert.x test context.
      */
     @SuppressWarnings("unchecked")
@@ -529,7 +529,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         final MessageConsumer commandConsumer = mock(MessageConsumer.class);
         when(commandConsumerFactory.createCommandConsumer(eq(TEST_TENANT_ID), eq(TEST_DEVICE), any(Handler.class), any(Handler.class), anyLong()))
             .thenReturn(Future.succeededFuture(commandConsumer));
-        final String sourceAddress = CommandConstants.COMMAND_ENDPOINT;
+        final String sourceAddress = getCommandEndpoint();
         final ProtonSender sender = getSender(sourceAddress);
 
         adapter.handleRemoteSenderOpenForCommands(deviceConnection, sender);
@@ -548,7 +548,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
     /**
      * Verify that the AMQP adapter forwards command responses downstream.
-     * 
+     *
      * @param ctx The vert.x test context.
      */
     @Test
@@ -563,7 +563,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         givenAConfiguredTenant(TEST_TENANT_ID, true);
 
         // WHEN an unauthenticated device publishes a command response
-        final String replyToAddress = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, TEST_TENANT_ID,
+        final String replyToAddress = String.format("%s/%s/%s", getCommandEndpoint(), TEST_TENANT_ID,
                 Command.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE, false));
 
         final Map<String, Object> propertyMap = new HashMap<>();
@@ -658,7 +658,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
         // WHEN an application sends a one-way command to the device
         final ProtonDelivery commandDelivery = mock(ProtonDelivery.class);
-        final String commandAddress = String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, TEST_TENANT_ID, TEST_DEVICE);
+        final String commandAddress = String.format("%s/%s/%s", getCommandEndpoint(), TEST_TENANT_ID, TEST_DEVICE);
         final Buffer payload = Buffer.buffer("payload");
         final Message message = getFakeMessage(commandAddress, payload, "commandToEecute");
         final Command command = Command.from(message, TEST_TENANT_ID, TEST_DEVICE);
@@ -849,6 +849,22 @@ public class VertxBasedAmqpProtocolAdapterTest {
                             eq(payload.length()),
                             any());
                 }));
+    }
+
+    private String getCommandEndpoint() {
+        return useLegacyCommandEndpoint() ? CommandConstants.COMMAND_LEGACY_ENDPOINT : CommandConstants.COMMAND_ENDPOINT;
+    }
+
+    /**
+     * Checks whether the legacy Command & Control endpoint shall be used.
+     * <p>
+     * Returns {@code false} by default. Subclasses may return {@code true} here to perform tests using the legacy
+     * command endpoint.
+     *
+     * @return {@code true} if the legacy command endpoint shall be used.
+     */
+    protected boolean useLegacyCommandEndpoint() {
+        return false;
     }
 
     private Target getTarget(final ResourceIdentifier resource) {

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterLegacyEndpointTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterLegacyEndpointTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.http.impl;
+
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+/**
+ * Verifies behavior of {@link VertxBasedHttpProtocolAdapter} using the legacy Command & Control endpoint.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxBasedHttpProtocolAdapterLegacyEndpointTest extends VertxBasedHttpProtocolAdapterTest {
+
+    @Override
+    protected boolean useLegacyCommandEndpoint() {
+        return true;
+    }
+}

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -519,7 +519,7 @@ public class VertxBasedHttpProtocolAdapterTest {
 
         mockSuccessfulAuthentication("DEFAULT_TENANT", "device_1");
 
-        httpClient.post(String.format("/control/res/%s", "wrongCommandRequestId"))
+        httpClient.post(getCommandResponsePath("wrongCommandRequestId"))
                 .addQueryParam(Constants.HEADER_COMMAND_RESPONSE_STATUS, "200")
                 .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpUtils.CONTENT_TYPE_JSON)
                 .basicAuthentication("testuser@DEFAULT_TENANT", "password123")
@@ -539,7 +539,7 @@ public class VertxBasedHttpProtocolAdapterTest {
 
         mockSuccessfulAuthentication("DEFAULT_TENANT", "device_1");
 
-        httpClient.post(String.format("/control/res/%s", CMD_REQ_ID))
+        httpClient.post(getCommandResponsePath(CMD_REQ_ID))
                 .addQueryParam(Constants.HEADER_COMMAND_RESPONSE_STATUS, "600")
                 .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpUtils.CONTENT_TYPE_JSON)
                 .basicAuthentication("testuser@DEFAULT_TENANT", "password123")
@@ -559,7 +559,7 @@ public class VertxBasedHttpProtocolAdapterTest {
 
         mockSuccessfulAuthentication("DEFAULT_TENANT", "device_1");
 
-        httpClient.post(String.format("/control/res/%s", CMD_REQ_ID))
+        httpClient.post(getCommandResponsePath(CMD_REQ_ID))
                 .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpUtils.CONTENT_TYPE_JSON)
                 .basicAuthentication("testuser@DEFAULT_TENANT", "password123")
                 .putHeader(HttpHeaders.ORIGIN.toString(), "hono.eclipse.org")
@@ -581,7 +581,7 @@ public class VertxBasedHttpProtocolAdapterTest {
         when(commandResponseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(
                 Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
 
-        httpClient.post(String.format("/control/res/%s", CMD_REQ_ID))
+        httpClient.post(getCommandResponsePath(CMD_REQ_ID))
                 .addQueryParam(Constants.HEADER_COMMAND_RESPONSE_STATUS, "200")
                 .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpUtils.CONTENT_TYPE_JSON)
                 .basicAuthentication("testuser@DEFAULT_TENANT", "password123")
@@ -607,13 +607,33 @@ public class VertxBasedHttpProtocolAdapterTest {
         when(commandResponseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(
                 Future.succeededFuture(remotelySettledDelivery));
 
-        httpClient.post(String.format("/control/res/%s", CMD_REQ_ID))
+        httpClient.post(getCommandResponsePath(CMD_REQ_ID))
                 .addQueryParam(Constants.HEADER_COMMAND_RESPONSE_STATUS, "200")
                 .putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpUtils.CONTENT_TYPE_JSON)
                 .basicAuthentication("testuser@DEFAULT_TENANT", "password123")
                 .putHeader(HttpHeaders.ORIGIN.toString(), "hono.eclipse.org")
                 .expect(ResponsePredicate.SC_ACCEPTED)
                 .sendJsonObject(new JsonObject(), ctx.asyncAssertSuccess());
+    }
+
+    private String getCommandResponsePath(final String wrongCommandRequestId) {
+        return String.format("/%s/res/%s", getCommandEndpoint(), wrongCommandRequestId);
+    }
+
+    private String getCommandEndpoint() {
+        return useLegacyCommandEndpoint() ? CommandConstants.COMMAND_LEGACY_ENDPOINT : CommandConstants.COMMAND_ENDPOINT;
+    }
+
+    /**
+     * Checks whether the legacy Command & Control endpoint shall be used.
+     * <p>
+     * Returns {@code false} by default. Subclasses may return {@code true} here to perform tests using the legacy
+     * command endpoint.
+     *
+     * @return {@code true} if the legacy command endpoint shall be used.
+     */
+    protected boolean useLegacyCommandEndpoint() {
+        return false;
     }
 
     private static Message newMockMessage(final String tenantId, final String deviceId, final String name) {

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderTest.java
@@ -25,6 +25,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.adapter.lora.LoraConstants;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.client.Command;
+import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.CredentialsObject;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.junit.Assert;
@@ -439,7 +440,7 @@ public class KerlinkProviderTest {
         final Message message = Message.Factory.create();
         message.setSubject("subject");
         message.setCorrelationId("correlation_id");
-        message.setReplyTo("control/bumlux");
+        message.setReplyTo(CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT + "/bumlux");
 
         final JsonObject payload = new JsonObject();
         payload.put(LoraConstants.FIELD_LORA_DOWNLINK_PAYLOAD, "bumlux".getBytes(Charsets.UTF_8));

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -761,7 +761,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     resource.getTenantId(),
                     resource.getResourceId(),
                     message.payload());
-        case CONTROL:
+        case COMMAND:
             return uploadCommandResponseMessage(ctx, resource);
         default:
             return Future

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -52,12 +52,16 @@ public class CommandSubscription {
         this.topic = topic;
         final String[] parts = topic.split("\\/");
         if (parts.length != 5 || !"#".equals(parts[4])) {
-            throw new IllegalArgumentException("topic filter does not match pattern: control|c/+/+/req|q/#");
+            throw new IllegalArgumentException(
+                    "topic filter does not match pattern: " + CommandConstants.COMMAND_ENDPOINT + "|"
+                            + CommandConstants.COMMAND_LEGACY_ENDPOINT + "|"
+                            + CommandConstants.COMMAND_ENDPOINT_SHORT + "/+/+/req|q/#");
         }
         endpoint = parts[0];
         if (!CommandConstants.isCommandEndpoint(endpoint)) {
             throw new IllegalArgumentException(
                     "the endpoint needs to be '" + CommandConstants.COMMAND_ENDPOINT + "' or '"
+                            + CommandConstants.COMMAND_LEGACY_ENDPOINT + "' or '"
                             + CommandConstants.COMMAND_ENDPOINT_SHORT + "'");
         }
         req = parts[3];

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterLegacyEndpointTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterLegacyEndpointTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.mqtt;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.runner.RunWith;
+
+/**
+ * Verifies behavior of {@link AbstractVertxBasedMqttProtocolAdapter} using the legacy Command & Control endpoint.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class AbstractVertxBasedMqttProtocolAdapterLegacyEndpointTest extends AbstractVertxBasedMqttProtocolAdapterTest {
+
+    @Override
+    protected boolean useLegacyCommandEndpoint() {
+        return true;
+    }
+}

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/CommandSubscriptionLegacyEndpointTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/CommandSubscriptionLegacyEndpointTest.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.mqtt;
+
+/**
+ * Verifies behavior of {@link CommandSubscription} using the legacy Command & Control endpoint.
+ *
+ */
+public class CommandSubscriptionLegacyEndpointTest extends CommandSubscriptionTest {
+
+    @Override
+    protected boolean useLegacyCommandEndpoint() {
+        return true;
+    }
+}

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/MqttContextTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/MqttContextTest.java
@@ -73,7 +73,7 @@ public class MqttContextTest {
                 MetricsTags.EndpointType.EVENT);
         assertEndpoint(
                 newMessage(CommandConstants.COMMAND_ENDPOINT_SHORT, "tenant", "device"),
-                MetricsTags.EndpointType.CONTROL);
+                MetricsTags.EndpointType.COMMAND);
     }
 
     private static void assertEndpoint(final MqttPublishMessage msg, final MetricsTags.EndpointType expectedEndpoint) {

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
@@ -79,7 +79,7 @@ public final class VertxBasedMqttProtocolAdapter extends AbstractVertxBasedMqttP
                     result.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "Only QoS 1 supported for event messages"));
                 }
                 break;
-            case CONTROL:
+            case COMMAND:
                 if (MqttQoS.EXACTLY_ONCE.equals(qos)) {
                     // client tries to send control message using QoS 2
                     result.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "QoS 2 not supported for command response messages"));

--- a/client/src/test/java/org/eclipse/hono/client/CommandResponseTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandResponseTest.java
@@ -13,17 +13,18 @@
 
 package org.eclipse.hono.client;
 
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 import java.net.HttpURLConnection;
 
-import io.vertx.proton.ProtonHelper;
 import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.junit.Test;
 
+import io.vertx.proton.ProtonHelper;
 
 /**
  * Verifies behavior of {@link CommandResponse}.
@@ -207,7 +208,7 @@ public class CommandResponseTest {
         final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId, false);
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
         final CommandResponse response = CommandResponse.from(message);
         assertThat(response, nullValue());
@@ -234,7 +235,7 @@ public class CommandResponseTest {
         final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId, false);
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
         message.setCorrelationId(CORRELATION_ID);
         final CommandResponse response = CommandResponse.from(message);
         assertThat(response, nullValue());
@@ -249,7 +250,7 @@ public class CommandResponseTest {
         final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId, false);
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
         message.setCorrelationId(CORRELATION_ID);
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, 777);
         final CommandResponse response = CommandResponse.from(message);
@@ -264,7 +265,7 @@ public class CommandResponseTest {
     public void testFromMessageFailsForInvalidAddressWithNothingBehindDeviceId() {
         final Message message = ProtonHelper.message();
         // use address with an invalid resource id part (nothing behind the device id)
-        message.setAddress(ResourceIdentifier.from("control", TENANT_ID, DEVICE_ID).toString());
+        message.setAddress(ResourceIdentifier.from(getCommandResponseEndpoint(), TENANT_ID, DEVICE_ID).toString());
         message.setCorrelationId(CORRELATION_ID);
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
         final CommandResponse response = CommandResponse.from(message);
@@ -280,7 +281,7 @@ public class CommandResponseTest {
         final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId, false);
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from("control", TENANT_ID, String.format("%s/%s", DEVICE_ID, replyToOptionsBitFlag)).toString());
+                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%s", DEVICE_ID, replyToOptionsBitFlag)).toString());
         message.setCorrelationId(CORRELATION_ID);
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
         final CommandResponse response = CommandResponse.from(message);
@@ -296,7 +297,7 @@ public class CommandResponseTest {
         final String replyToOptionsBitFlag = "X"; // invalid value to test with
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
         message.setCorrelationId(CORRELATION_ID);
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
         final CommandResponse response = CommandResponse.from(message);
@@ -312,7 +313,7 @@ public class CommandResponseTest {
         final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId, false);
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
         message.setCorrelationId(CORRELATION_ID);
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
         final CommandResponse response = CommandResponse.from(message);
@@ -368,12 +369,16 @@ public class CommandResponseTest {
         final String replyToOptionsBitFlag = Command.encodeReplyToOptions(true, replyToLegacyEndpointUsed);
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from("control", TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
         message.setCorrelationId(CORRELATION_ID);
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
         final CommandResponse response = CommandResponse.from(message);
         assertThat(response, notNullValue());
         assertThat(response.getReplyToId(), is("4711/rid-1"));
         assertThat(response.isReplyToLegacyEndpointUsed(), is(replyToLegacyEndpointUsed));
+    }
+
+    private String getCommandResponseEndpoint() {
+        return CommandConstants.COMMAND_ENDPOINT;
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,7 +21,12 @@ public class CommandConstants {
     /**
      * The name of the Command and Control API endpoint.
      */
-    public static final String COMMAND_ENDPOINT = "control";
+    public static final String COMMAND_ENDPOINT = "command";
+
+    /**
+     * The name of the legacy Command and Control API endpoint.
+     */
+    public static final String COMMAND_LEGACY_ENDPOINT = "control";
 
     /**
      * The short name of the control endpoint.
@@ -29,7 +34,7 @@ public class CommandConstants {
     public static final String COMMAND_ENDPOINT_SHORT = "c";
 
     /**
-     * The name of the Command and Control API legacy endpoint used by northbound applications.
+     * The name of the legacy Command and Control API endpoint used by northbound applications.
      */
     public static final String NORTHBOUND_COMMAND_LEGACY_ENDPOINT = "control";
 
@@ -86,7 +91,8 @@ public class CommandConstants {
      * @return {@code true} if the endpoint is a command endpoint.
      */
     public static final boolean isCommandEndpoint(final String endpoint) {
-        return COMMAND_ENDPOINT.equals(endpoint) || COMMAND_ENDPOINT_SHORT.equals(endpoint);
+        return COMMAND_ENDPOINT.equals(endpoint) || COMMAND_LEGACY_ENDPOINT.equals(endpoint)
+                || COMMAND_ENDPOINT_SHORT.equals(endpoint);
     }
 
     /**

--- a/core/src/test/java/org/eclipse/hono/util/ResourceIdentifierTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/ResourceIdentifierTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -45,12 +45,12 @@ public class ResourceIdentifierTest {
      */
     @Test
     public void testFromStringAllowsEmptyPathSegments() {
-        final ResourceIdentifier resourceId = ResourceIdentifier.fromString("control///req/cmd-req-id");
+        final ResourceIdentifier resourceId = ResourceIdentifier.fromString("endpoint///req/cmd-req-id");
         assertNotNull(resourceId);
-        assertThat(resourceId.getEndpoint(), is("control"));
+        assertThat(resourceId.getEndpoint(), is("endpoint"));
         assertNull(resourceId.getTenantId());
         assertNull(resourceId.getResourceId());
-        assertThat(resourceId.getBasePath(), is("control"));
+        assertThat(resourceId.getBasePath(), is("endpoint"));
         assertThat(resourceId.getPathWithoutBase(), is("/req/cmd-req-id"));
         assertThat(resourceId.getResourcePath()[4], is("cmd-req-id"));
     }

--- a/example/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
+++ b/example/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletionException;
 import java.util.function.Predicate;
 
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 
@@ -223,7 +224,7 @@ public class HonoHttpDevice {
     private Future<Integer> sendCommandResponse(final String contentType, final Buffer payload, final String commandReqId, final int status) {
 
         final Future<Integer> result = Future.future();
-        final HttpClientRequest req = httpClient.post(String.format("/control/res/%s", commandReqId))
+        final HttpClientRequest req = httpClient.post(String.format("/%s/res/%s", CommandConstants.COMMAND_ENDPOINT, commandReqId))
                 .handler(response -> {
                     result.complete(response.statusCode());
                 });

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MetricsTags.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MetricsTags.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -45,7 +45,7 @@ public final class MetricsTags {
         /**
          * The endpoint for command &amp; control messages.
          */
-        CONTROL(CommandConstants.COMMAND_ENDPOINT),
+        COMMAND(CommandConstants.COMMAND_ENDPOINT),
         /**
          * The unknown endpoint.
          */
@@ -97,7 +97,8 @@ public final class MetricsTags {
                 return EVENT;
             case CommandConstants.COMMAND_ENDPOINT:
             case CommandConstants.COMMAND_ENDPOINT_SHORT:
-                return CONTROL;
+            case CommandConstants.COMMAND_LEGACY_ENDPOINT:
+                return COMMAND;
             default:
                 return UNKNOWN;
             }

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlLegacyEndpointAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlLegacyEndpointAmqpIT.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tests.amqp;
+
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+
+/**
+ * Integration tests for sending commands to a device connected to the AMQP adapter using the legacy Command & Control
+ * endpoint.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class CommandAndControlLegacyEndpointAmqpIT extends CommandAndControlAmqpIT {
+
+    @Override
+    protected boolean useLegacyCommandEndpoint() {
+        return true;
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventLegacyCommandEndpointHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventLegacyCommandEndpointHttpIT.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tests.http;
+
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+
+/**
+ * Integration tests for uploading events to the HTTP adapter using the legacy Command & Control endpoint.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class EventLegacyCommandEndpointHttpIT extends EventHttpIT {
+
+    @Override
+    protected boolean useLegacyCommandEndpoint() {
+        return true;
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -32,6 +32,7 @@ import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.tests.CrudHttpClient;
 import org.eclipse.hono.tests.IntegrationTestSupport;
+import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
@@ -86,7 +87,6 @@ public abstract class HttpTestBase {
 
     private static final String COMMAND_TO_SEND = "setBrightness";
     private static final String COMMAND_JSON_KEY = "brightness";
-    private static final String COMMAND_RESPONSE_URI_TEMPLATE = "/control/res/%s";
 
     private static final String ORIGIN_WILDCARD = "*";
     private static final Vertx VERTX = Vertx.vertx();
@@ -947,8 +947,24 @@ public abstract class HttpTestBase {
                 });
     }
 
-    private static String getCommandResponseUri(final String commandRequestId) {
-        return String.format(COMMAND_RESPONSE_URI_TEMPLATE, commandRequestId);
+    private String getCommandResponseUri(final String commandRequestId) {
+        return String.format("/%s/res/%s", getCommandEndpoint(), commandRequestId);
+    }
+
+    /**
+     * Checks whether the legacy Command & Control endpoint shall be used.
+     * <p>
+     * Returns {@code false} by default. Subclasses may return {@code true} here to perform tests using the legacy
+     * command endpoint.
+     *
+     * @return {@code true} if the legacy command endpoint shall be used.
+     */
+    protected boolean useLegacyCommandEndpoint() {
+        return false;
+    }
+
+    private String getCommandEndpoint() {
+        return useLegacyCommandEndpoint() ? CommandConstants.COMMAND_LEGACY_ENDPOINT : CommandConstants.COMMAND_ENDPOINT;
     }
 
     private void assertMessageProperties(final TestContext ctx, final Message msg) {

--- a/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryLegacyCommandEndpointHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryLegacyCommandEndpointHttpIT.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tests.http;
+
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+
+/**
+ * Integration tests for uploading telemetry data to the HTTP adapter using the legacy Command & Control endpoint.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class TelemetryLegacyCommandEndpointHttpIT extends TelemetryHttpIT {
+
+    @Override
+    protected boolean useLegacyCommandEndpoint() {
+        return true;
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlLegacyEndpointMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlLegacyEndpointMqttIT.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tests.mqtt;
+
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+
+/**
+ * Integration tests for sending commands to device connected to the MQTT adapter using the legacy Command & Control
+ * endpoint.
+ *
+ */
+@RunWith(VertxUnitRunner.class)
+public class CommandAndControlLegacyEndpointMqttIT extends CommandAndControlMqttIT {
+
+    @Override
+    protected boolean useLegacyCommandEndpoint() {
+        return true;
+    }
+}


### PR DESCRIPTION
This is for #1073:

The default prefix for the southbound command & control endpoints has been renamed from `control` to `command`. The old `control` endpoints are still exposed and working.

(For the AMQP adapter, there is still one "command" endpoint used both for receiving commands and sending back the command response. Usage of a "command_response" endpoint for the responses shall be introduced following this commit.)