### PR TITLE
[#1297] Upgrade to Spring Boot 2

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapPreSharedKeyHandler.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapPreSharedKeyHandler.java
@@ -39,8 +39,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -87,12 +87,11 @@ public class CoapPreSharedKeyHandler implements PskStore, CoapAuthenticationHand
         this.context = Objects.requireNonNull(context);
         this.config = Objects.requireNonNull(config);
         this.credentialsClientFactory = Objects.requireNonNull(credentialsClientFactory);
-        final CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder()
-                .concurrencyLevel(1)
+        this.devices = Caffeine.newBuilder()
                 .softValues()
                 .initialCapacity(config.getDeviceCacheMinSize())
-                .maximumSize(config.getDeviceCacheMaxSize());
-        this.devices = builder.build();
+                .maximumSize(config.getDeviceCacheMaxSize())
+                .build();
     }
 
     /**

--- a/adapters/lora-vertx/pom.xml
+++ b/adapters/lora-vertx/pom.xml
@@ -48,6 +48,10 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
@@ -125,7 +125,7 @@ public class Config extends AbstractAdapterConfig {
      * @return The connection event producer based on {@link LoggingConnectionEventProducer}.
      */
     @Bean
-    @ConditionalOnProperty(value = "hono.connectionEvents.producer", havingValue = "logging", matchIfMissing = true)
+    @ConditionalOnProperty(value = "hono.connection-events.producer", havingValue = "logging", matchIfMissing = true)
     public ConnectionEventProducer connectionEventProducerLogging() {
         return new LoggingConnectionEventProducer();
     }
@@ -136,7 +136,7 @@ public class Config extends AbstractAdapterConfig {
      * @return The connection event producer based on {@link HonoEventConnectionEventProducer}.
      */
     @Bean
-    @ConditionalOnProperty(value = "hono.connectionEvents.producer", havingValue = "events")
+    @ConditionalOnProperty(value = "hono.connection-events.producer", havingValue = "events")
     public ConnectionEventProducer connectionEventProducerEvents() {
         return new HonoEventConnectionEventProducer();
     }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -34,6 +34,7 @@
     <dispatch-router.image.name>quay.io/enmasse/qdrouterd-base:1.7.0</dispatch-router.image.name>
     <grafana.version>5.3.2</grafana.version>
     <guava.version>25.0-jre</guava.version>
+    <caffeine.version>2.6.2</caffeine.version>
     <hamcrest-core.version>2.1</hamcrest-core.version>
     <jackson.version>2.9.8</jackson.version>
     <jaeger.version>0.32.0</jaeger.version>
@@ -56,9 +57,9 @@
     <qpid-jms.version>0.42.0</qpid-jms.version>
     <slf4j.version>1.7.26</slf4j.version>
     <snakeyaml.version>1.17</snakeyaml.version>
-    <spring.version>4.3.23.RELEASE</spring.version>
-    <spring-boot.version>1.5.20.RELEASE</spring-boot.version>
-    <spring-security-crypto.version>4.2.12.RELEASE</spring-security-crypto.version>
+    <spring.version>5.1.8.RELEASE</spring.version>
+    <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
+    <spring-security-crypto.version>5.1.5.RELEASE</spring-security-crypto.version>
     <truth.version>0.28</truth.version>
     <vertx.version>3.7.0</vertx.version>
     <wiremock.version>2.22.0</wiremock.version>
@@ -402,6 +403,11 @@
             <artifactId>animal-sniffer-annotations</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeine.version}</version>
       </dependency>
       <dependency>
         <groupId>io.opentracing</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -56,7 +56,7 @@
     <proton.version>0.31.0</proton.version>
     <qpid-jms.version>0.42.0</qpid-jms.version>
     <slf4j.version>1.7.26</slf4j.version>
-    <snakeyaml.version>1.17</snakeyaml.version>
+    <snakeyaml.version>1.23</snakeyaml.version>
     <spring.version>5.1.8.RELEASE</spring.version>
     <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
     <spring-security-crypto.version>5.1.5.RELEASE</spring-security-crypto.version>

--- a/legal/legal/LICENSE.Spring.txt
+++ b/legal/legal/LICENSE.Spring.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
@@ -202,9 +202,9 @@
 
 =======================================================================
 
-SPRING FRAMEWORK 4.3.18.RELEASE SUBCOMPONENTS:
+SPRING FRAMEWORK 5.1.8.RELEASE SUBCOMPONENTS:
 
-Spring Framework 4.3.18.RELEASE includes a number of subcomponents
+Spring Framework 5.1.8.RELEASE includes a number of subcomponents
 with separate copyright notices and license terms. The product that
 includes this file does not necessarily use all the open source
 subcomponents referred to below. Your use of the source
@@ -244,36 +244,32 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
-Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
 
 
 >>> CGLIB 3.0 (cglib:cglib:3.0):
 
 Per the LICENSE file in the CGLIB JAR distribution downloaded from
-http://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download,
+https://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download,
 CGLIB 3.0 is licensed under the Apache License, version 2.0, the text of which
 is included above.
 
 
-=======================================================================
+===============================================================================
 
-To the extent any open source subcomponents are licensed under the EPL and/or
+To the extent any open source components are licensed under the EPL and/or
 other similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a
 copy of the source code corresponding to the binaries for such open source
 components and modifications thereto, if any, (the "Source Files"), by
-downloading the Source Files from http://www.springsource.org/download, or by
-sending a request, with your name and address to:
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
 
-    Pivotal, Inc., 875 Howard St,
-    San Francisco, CA 94103
-    United States of America
-
-or email info@pivotal.io.  All such requests should clearly specify:
-
-    OPEN SOURCE FILES REQUEST
-    Attention General Counsel
-
-Pivotal shall mail a copy of the Source Files to you on a CD or equivalent
-physical medium. This offer to obtain a copy of the Source Files is valid for
-three years from the date you acquired this Software product.
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/legal/legal/NOTICE.Spring.txt
+++ b/legal/legal/NOTICE.Spring.txt
@@ -1,5 +1,5 @@
-Spring Framework 4.3.18.RELEASE
-Copyright (c) 2002-2018 Pivotal, Inc.
+Spring Framework 5.1.8.RELEASE
+Copyright (c) 2002-2019 Pivotal, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0
 (the "License"). You may not use this product except in compliance with

--- a/legal/legal/NOTICE.md
+++ b/legal/legal/NOTICE.md
@@ -49,6 +49,16 @@ http://www.apache.org/licenses/LICENSE-2.0.html.
 
 The source code is available from [Maven Central](http://search.maven.org/remotecontent?filepath=com/google/guava/guava/${guava.version}/guava-${guava.version}-sources.jar).
 
+### Caffeine ${caffeine.version}
+
+This product includes software developed by the [Caffeine project](https://github.com/ben-manes/caffeine).
+
+Your use of *Caffeine* is subject to the terms and conditions of the Apache Software License 2.0.
+A copy of the license is contained in the file [LICENSE-2.0.txt](LICENSE-2.0.txt) and is also available at
+http://www.apache.org/licenses/LICENSE-2.0.html.
+
+The source code is available from [Maven Central](http://search.maven.org/remotecontent?filepath=com/github/ben-manes/caffeine/caffeine/${caffeine.version}/caffeine-${caffeine.version}-sources.jar).
+
 ### Jackson ${jackson.version}
 
 This product includes software developed by [FasterXML, LLC](http://fasterxml.com/).

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
-          <version>1.5.20.RELEASE</version>
+          <version>2.1.5.RELEASE</version>
           <executions>
             <execution>
               <goals>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -107,8 +107,8 @@
       <artifactId>vertx-micrometer-metrics</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -508,8 +508,8 @@ public abstract class AbstractAdapterConfig {
      * @return The properties.
      */
     @Bean
-    @ConfigurationProperties(prefix = "hono.plan.prometheusBased")
-    @ConditionalOnProperty(name = "hono.plan.prometheusBased.host")
+    @ConfigurationProperties(prefix = "hono.plan.prometheus-based")
+    @ConditionalOnProperty(name = "hono.plan.prometheus-based.host")
     public PrometheusBasedResourceLimitChecksConfig resourceLimitChecksConfig() {
         return new PrometheusBasedResourceLimitChecksConfig();
     }
@@ -520,7 +520,7 @@ public abstract class AbstractAdapterConfig {
      * @return A ResourceLimitChecks instance.
      */
     @Bean
-    @ConditionalOnProperty(name = "hono.plan.prometheusBased.host")
+    @ConditionalOnProperty(name = "hono.plan.prometheus-based.host")
     public ResourceLimitChecks resourceLimitChecks() {
         final PrometheusBasedResourceLimitChecksConfig config = resourceLimitChecksConfig();
         return new PrometheusBasedResourceLimitChecks(WebClient.create(vertx()), config,

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -304,7 +304,7 @@ public class ApplicationConfig {
      * @return The properties.
      */
     @Bean
-    @ConfigurationProperties(prefix = "hono.deviceConnection.svc")
+    @ConfigurationProperties(prefix = "hono.device-connection.svc")
     public MapBasedDeviceConnectionsConfigProperties deviceConnectionsProperties() {
         return new MapBasedDeviceConnectionsConfigProperties();
     }

--- a/site/documentation/content/deployment/openshift.md
+++ b/site/documentation/content/deployment/openshift.md
@@ -725,7 +725,7 @@ guide, data produced by devices is usually consumed by downstream applications
 which connect directly to the router network service. You can start the client
 from the `cli` folder as follows:
 
-    mvn spring-boot:run -Drun.arguments=--hono.client.host=$(oc -n hono get addressspace default -o jsonpath={.status.endpointStatuses[?(@.name==\'messaging\')].externalHost}),--hono.client.port=443,--hono.client.username=consumer,--hono.client.password=verysecret,--hono.client.trustStorePath=target/config/hono-demo-certs-jar/tls.crt
+    mvn spring-boot:run -Dspring-boot.run.arguments=--hono.client.host=$(oc -n hono get addressspace default -o jsonpath={.status.endpointStatuses[?(@.name==\'messaging\')].externalHost}),--hono.client.port=443,--hono.client.username=consumer,--hono.client.password=verysecret,--hono.client.trustStorePath=target/config/hono-demo-certs-jar/tls.crt
 
 ### Register device
 

--- a/site/homepage/content/getting-started/index.md
+++ b/site/homepage/content/getting-started/index.md
@@ -370,7 +370,7 @@ In order to do so, the client needs to be run with the `command` profile as foll
  
 ~~~sh
 # in directory: hono/cli/
-mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret -Drun.profiles=command,ssl
+mvn spring-boot:run -Dspring-boot.run.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret -Dspring-boot.run.profiles=command,ssl
 ~~~
 
 The client will prompt the user to enter the command's name, the payload to send and the payload's content type. For more information about command and payload refer to [Command and Control Concepts](https://www.eclipse.org/hono/docs/latest/concepts/command-and-control/).
@@ -403,7 +403,7 @@ a response from the device but will consider the sending of the command successf
 
 ~~~sh
 # in directory: hono/cli/
-mvn spring-boot:run -Drun.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,--command.timeoutInSeconds=10,--device.id=4711,--tenant.id=DEFAULT_TENANT -Drun.profiles=command,ssl
+mvn spring-boot:run -Dspring-boot.run.arguments=--hono.client.host=localhost,--hono.client.username=consumer@HONO,--hono.client.password=verysecret,--command.timeoutInSeconds=10,--device.id=4711,--tenant.id=DEFAULT_TENANT -Dspring-boot.run.profiles=command,ssl
 ~~~
 
 ### Summary


### PR DESCRIPTION
**Not to merge until necessary CQs are created and approved.**

1. The spring artifacts are upgraded as below.

| **Artifact** | **Version** |
| ------------- | ------------- |
| Spring Boot | 2.1.5.RELEASE |
| Spring  | 5.1.8.RELEASE |
| Spring  Security | 5.1.5.RELEASE |

2. The below dependencies/plug-ins are updated to be in compatible with the above spring version.

| **Artifact** | **Version** |
| ------------- | ------------- |
| snakeyaml | 1.23 |
| maven-deploy-plugin  | 2.8.2 |
| maven-assembly-plugin |3.1.0 |

3. Support for Guava has been [dropped](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#guavacachemanager) in Spring Framework 5. Instead of `GuavaCacheManager`,  `CaffeineCacheManager` is being used and the corresponding dependency ([com.github.ben-manes.caffeine:caffeine:2.7.0](https://github.com/ben-manes/caffeine/tree/v2.7.0)) is added. It uses Apache 2.0 license.

4. [Changed](https://docs.spring.io/spring-boot/docs/2.1.5.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config-relaxed-binding) the prefix value in annotations to be in kebab case (lowercase and separated by -)

5. Spring Boot Maven plug-in configuration attributes are to [start](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#spring-boot-maven-plugin) with `spring-boot` as in the below example. It has been updated in the documentation.
```
mvn spring-boot:run -Dspring-boot.run.arguments=--hono.client.username=consumer@HONO,--hono.client.password=verysecret -Dspring-boot.run.profiles=command,ssl
```
