### PR TITLE
Add preview card to be used by twitter.

### DIFF
--- a/site/documentation/config.toml
+++ b/site/documentation/config.toml
@@ -42,6 +42,10 @@ pluralizeListTitles = "false"
   themeVariant = "hono"
   urlPrefixOfVersionStable = "/hono/docs/latest/"
   honoVersion = "latest" # might be overriden during build by value in site/documentation/config_release_version.toml
+  
+  # Twitter
+  twitter = "EclipseHono"
+  twitterImage = "images/HONO-Logo_Bild-Wort_quer-w-310x120px.svg"
 
 [blackfriday]
   smartypants = true

--- a/site/documentation/layouts/partials/custom-header.html
+++ b/site/documentation/layouts/partials/custom-header.html
@@ -5,3 +5,11 @@ Don’t forget to include style HTML tag directive in your file
 
 <link rel="stylesheet" href="https://www.eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/vendor/cookieconsent/cookieconsent.min.css">
 <link rel="stylesheet" href='{{ "css/hono.css" | relURL }}'>
+
+<!-- Twitter Card meta tags -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@{{ .Site.Params.twitter }}">
+<meta name="twitter:title" content="{{ if .Title }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }}">
+{{ if .Params.banner }}<meta name="twitter:image" content="{{ .Params.banner | absURL }}">
+{{ else }}<meta name="twitter:image" content="{{ .Site.Params.twitterImage | absURL }}">
+{{ end }}<meta name="twitter:description" content="{{ if .Params.description }}{{ .Params.description }}{{ else }}{{ .Site.Params.defaultDescription }}{{ end }}">

--- a/site/homepage/config.toml
+++ b/site/homepage/config.toml
@@ -11,16 +11,16 @@ pluralizeListTitles = "false"
 # The menu is defined in the file menu_main.toml
 
 [params]
-  author = "The Eclipse Hono Project"
-  description = "A set of micro-services for connecting millions of devices."
-  copyright = "&copy; 2019 The Eclipse Hono Project"
+    author = "The Eclipse Hono Project"
+    description = "A set of micro-services for connecting millions of devices."
+    copyright = "&copy; 2019 The Eclipse Hono Project"
     viewMorePostLink = "/blog/"
     defaultKeywords = []
     defaultDescription = "A set of micro-services for connecting millions of devices."
 
     # Twitter
-#    twitter = "EclipseHono"
-#    twitterImage = "img/twitter-default.png"
+    twitter = "EclipseHono"
+    twitterImage = "img/HONO-Logo_Bild-Wort_quer-s-310x120px.svg"
 
     # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet
     style = "hono"


### PR DESCRIPTION
Added configuration that causes Twitter to generate a "card" with
logo, title and a reference to the Hono Twitter account, when a link
to the Hono site appears in a Twitter message.

Signed-off-by: Abel Buechner-Mihaljevic <Abel.Buechner@bosch-si.com>