### PR TITLE
Append the site title to the page title in pages on the homepage.

### DIFF
--- a/site/homepage/layouts/partials/head.html
+++ b/site/homepage/layouts/partials/head.html
@@ -3,7 +3,7 @@
   <meta name="robots" content="all,follow">
   <meta name="googlebot" content="index,follow,snippet,archive">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ .Title }}</title>
+  <title>{{ .Title }} :: {{ .Site.Title }}</title>
   <meta name="author" content="{{ .Site.Author.name }}" />
 
   {{ if .Keywords }}


### PR DESCRIPTION
Build the page title for pages on homepage the same way it is done for the documentation. E.g. show "Getting started :: Eclipse Hono" instead of only "Getting started" (the old web site used the form "Getting started - Eclipse Hono").