### PR TITLE
[#1073] Use "command_response" endpoint for AMQP command responses

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -828,7 +828,8 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                 return doUploadMessage(context, resource, getTelemetrySender(resource.getTenantId()), currentSpan);
             case EVENT:
                 return doUploadMessage(context, resource, getEventSender(resource.getTenantId()), currentSpan);
-            case COMMAND:
+            case COMMAND: // for backwards compatibility: support the legacy "control" endpoint (mapped to COMMAND) for command responses
+            case COMMAND_RESPONSE:
                 return doUploadCommandResponseMessage(context, resource, currentSpan);
             default:
                 return Future
@@ -991,7 +992,8 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
             result.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
         } else {
             switch (ctx.getEndpoint()) {
-            case COMMAND:
+            case COMMAND: // for backwards compatibility: support the legacy "control" endpoint (mapped to COMMAND) for command responses
+            case COMMAND_RESPONSE:
             case TELEMETRY:
                 result.complete(ctx);
                 break;

--- a/client/src/main/java/org/eclipse/hono/client/Command.java
+++ b/client/src/main/java/org/eclipse/hono/client/Command.java
@@ -148,7 +148,7 @@ public final class Command {
                         validationErrorJoiner.add("reply-to part after tenant not set: " + message.getReplyTo());
                     } else {
                         message.setReplyTo(
-                                String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT, tenantId,
+                                String.format("%s/%s/%s", CommandConstants.COMMAND_RESPONSE_ENDPOINT, tenantId,
                                         getDeviceFacingReplyToId(originalReplyToId, deviceId, replyToLegacyEndpointUsed)));
                     }
                 }

--- a/client/src/test/java/org/eclipse/hono/client/CommandTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandTest.java
@@ -64,7 +64,7 @@ public class CommandTest {
         assertThat(cmd.getCorrelationId(), is(correlationId));
         assertFalse(cmd.isOneWay());
         assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/%s%s",
-                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
+                CommandConstants.COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
     }
 
     /**
@@ -88,7 +88,7 @@ public class CommandTest {
         assertNotNull(cmd.getCommandMessage());
         assertNotNull(cmd.getCommandMessage().getReplyTo());
         assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/%s%s",
-                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
+                CommandConstants.COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
     }
 
     /**
@@ -111,7 +111,7 @@ public class CommandTest {
         assertNotNull(cmd.getCommandMessage());
         assertNotNull(cmd.getCommandMessage().getReplyTo());
         assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/%s%s",
-                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
+                CommandConstants.COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
     }
 
     /**
@@ -135,7 +135,7 @@ public class CommandTest {
         assertNotNull(cmd.getCommandMessage());
         assertNotNull(cmd.getCommandMessage().getReplyTo());
         assertThat(cmd.getCommandMessage().getReplyTo(), is(String.format("%s/%s/%s/%s%s",
-                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
+                CommandConstants.COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToOptionsBitFlag, replyToId)));
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
@@ -34,6 +34,12 @@ public class CommandConstants {
     public static final String COMMAND_ENDPOINT_SHORT = "c";
 
     /**
+     * The name of the Command and Control API endpoint provided by protocol adapters that use a separate endpoint for
+     * command responses.
+     */
+    public static final String COMMAND_RESPONSE_ENDPOINT = "command_response";
+
+    /**
      * The name of the legacy Command and Control API endpoint used by northbound applications.
      */
     public static final String NORTHBOUND_COMMAND_LEGACY_ENDPOINT = "control";

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MetricsTags.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MetricsTags.java
@@ -47,6 +47,11 @@ public final class MetricsTags {
          */
         COMMAND(CommandConstants.COMMAND_ENDPOINT),
         /**
+         * The endpoint for command &amp; control messages provided by protocol adapters that use a separate endpoint 
+         * for command responses.
+         */
+        COMMAND_RESPONSE(CommandConstants.COMMAND_RESPONSE_ENDPOINT),
+        /**
          * The unknown endpoint.
          */
         UNKNOWN("unknown");
@@ -99,6 +104,8 @@ public final class MetricsTags {
             case CommandConstants.COMMAND_ENDPOINT_SHORT:
             case CommandConstants.COMMAND_LEGACY_ENDPOINT:
                 return COMMAND;
+            case CommandConstants.COMMAND_RESPONSE_ENDPOINT:
+                return COMMAND_RESPONSE;
             default:
                 return UNKNOWN;
             }


### PR DESCRIPTION
This is for #1073:
A device, sending a command response to the AMQP adapter, should now use `command_response` instead of `command` as prefix in the response message address (as also mandated now by the `reply-to` property of the command message).
The old `control` prefix is still supported as well.