### PR TITLE
Change credentials model and drop "delete" operation

### DIFF
--- a/site/documentation/static/api/device-registry-v1.yaml
+++ b/site/documentation/static/api/device-registry-v1.yaml
@@ -390,30 +390,6 @@ paths:
             412:
                $ref: '#/components/responses/ResourceVersionMismatch'
 
-      delete:
-         tags:
-            - credentials
-         summary: Delete all credentials of a device
-         description: |
-             Deletes all credentials from a device registration. The device is
-             still registered, and a following call to *get* credentials must
-             not return `404`, as the device is still registered. Instead an
-             empty result must be returned.
-         operationId: deleteAllCredentials
-         parameters:
-            - $ref: '#/components/parameters/resourceVersion'
-         responses:
-            204:
-               $ref: '#/components/responses/Deleted'
-            401:
-               $ref: '#/components/responses/Unauthorized'
-            403:
-               $ref: '#/components/responses/NotAllowed'
-            404:
-               $ref: '#/components/responses/NotFound'
-            412:
-               $ref: '#/components/responses/ResourceVersionMismatch'
-
 components:
 
    schemas:

--- a/site/documentation/static/api/device-registry-v1.yaml
+++ b/site/documentation/static/api/device-registry-v1.yaml
@@ -527,23 +527,25 @@ components:
 
       CredentialsSet:
          type: array
+         description: A set of credentials. The entries in this list must be
+                      unique by the composite key of `auth-id` and `type`.
          items:
-            $ref: '#/components/schemas/TypedSecret'
+            $ref: '#/components/schemas/TypedCredentials'
 
-      TypedSecret:
+      TypedCredentials:
          additionalProperties: false
          oneOf:
-            - $ref: '#/components/schemas/PasswordSecret'
-            - $ref: '#/components/schemas/PSKSecret'
-            - $ref: '#/components/schemas/X509CertificateSecret'
+            - $ref: '#/components/schemas/PasswordCredentials'
+            - $ref: '#/components/schemas/PSKCredentials'
+            - $ref: '#/components/schemas/X509CertificateCredentials'
          discriminator:
             propertyName: type
             mapping:
-               "hashed-password": '#/components/schemas/PasswordSecret'
-               "psk": '#/components/schemas/PSKSecret'
-               "x509-cert": '#/components/schemas/X509CertificateSecret'
+               "hashed-password": '#/components/schemas/PasswordCredentials'
+               "psk": '#/components/schemas/PSKCredentials'
+               "x509-cert": '#/components/schemas/X509CertificateCredentials'
 
-      CommonSecret:
+      CommonCredentials:
          type: object
          additionalProperties: false
          required:
@@ -554,6 +556,52 @@ components:
                type: string
             "auth-id":
                type: string
+            "enabled":
+               type: boolean
+               default: true
+            "ext":
+               $ref: '#/components/schemas/Extensions'
+
+      PasswordCredentials:
+         additionalProperties: false
+         allOf:
+            - $ref: '#/components/schemas/CommonCredentials'
+            - type: object
+              additionalProperties: false
+              properties:
+                 "secrets":
+                    type: array
+                    items:
+                       $ref: '#/components/schemas/PasswordSecret'
+
+      PSKCredentials:
+         additionalProperties: false
+         allOf:
+            - $ref: '#/components/schemas/CommonCredentials'
+            - type: object
+              additionalProperties: false
+              properties:
+                 "secrets":
+                    type: array
+                    items:
+                       $ref: '#/components/schemas/PSKSecret'
+
+      X509CertificateCredentials:
+         additionalProperties: false
+         allOf:
+            - $ref: '#/components/schemas/CommonCredentials'
+            - type: object
+              additionalProperties: false
+              properties:
+                 "secrets":
+                    type: array
+                    items:
+                       $ref: '#/components/schemas/X509CertificateSecret'
+
+      CommonSecret:
+         type: object
+         additionalProperties: false
+         properties:
             "enabled":
                type: boolean
                default: true


### PR DESCRIPTION
This change alters the model of the device registry HTTP API in way
that redundant parts of the secrets (type, auth-id, enabled) get pulled
up one level. And that new level gets the "ext" extensions as well.

The "enabled" flag is still present on the "secrets" level, as it might
be beneficial to e.g. disable a single secret temporarily.