### PR TITLE
[#1317] Use Minikube in Getting Started guide.

### DIFF
--- a/site/documentation/content/deployment/create-kubernetes-cluster.md
+++ b/site/documentation/content/deployment/create-kubernetes-cluster.md
@@ -1,6 +1,6 @@
 +++
 title = "Setting up a Kubernetes Cluster"
-weight = 485
+weight = 480
 +++
 
 This guide describes how to set up a Kubernetes cluster which can be used to run Eclipse Hono.
@@ -10,19 +10,35 @@ Hono can be deployed to any Kubernetes cluster running version 1.11 or newer. Th
 
 The [Kubernetes web site](https://kubernetes.io/docs/setup/) provides instructions for setting up a (local) cluster on bare metal and/or virtual infrastructure from scratch or for provisioning a managed Kubernetes cluster from one of the popular cloud providers.
 
-## Local Development
+<a name="Local Development"></a>
+## Setting up a local Development Environment
 
 The easiest option is to set up a single-node cluster running on a local VM using the [Minikube](https://github.com/kubernetes/minikube) project.
 This kind of setup is sufficient for evaluation and development purposes.
 Please refer to Kubernetes' [Minikube setup guide](https://kubernetes.io/docs/setup/minikube/) for instructions on how to set up a cluster locally.
 
-When using Minikube, the `minikube tunnel` command should be run in order to support Hono's services being deployed using the *LoadBalancer* type. Please refer to the [Minikube Networking docs](https://github.com/kubernetes/minikube/blob/master/docs/networking.md#loadbalancer-emulation-minikube-tunnel) for details.
+The recommended settings for a Minikube VM used for running Hono's example setup are as follows:
 
-## Production Environment
+* **cpus**: 2
+* **memory**: 8192 (MB)
+
+The command to start the VM will look something like this:
+```sh
+minikube start --cpus 2 --memory 8192 -p hono
+```
+
+After the Minikube VM has started successfully, the `minikube tunnel` command should be run in order to support Hono's services being deployed using the *LoadBalancer* type. Please refer to the [Minikube Networking docs](https://github.com/kubernetes/minikube/blob/master/docs/networking.md#access-to-loadbalancer-services-using-minikube-tunnel) for details.
+
+{{% note title="Supported Kubernetes Versions" %}}
+Minikube will use the most recent Kubernetes version that was available when it has been compiled by default. Hono *should* run on any version of Kubernetes starting with 1.13.6. However, it has been tested with several specific versions only so if you experience any issues with running Hono on a more recent version, please try to deploy to 1.13.6 before
+raising an issue. You can use Minikube's `--kubernetes-version` command line switch to set a particular version.
+{{% /note %}}
+
+## Setting up a Production Environment
 
 Setting up a multi-node Kubernetes cluster is a more advanced topic. Please follow the corresponding links provided in the [Kubernetes documentation](https://kubernetes.io/docs/setup/#production-environment).
 
-## Azure Kubernetes Service
+## Setting up a Cluster using Azure Kubernetes Service
 
 The following sections provide step-by-step instructions for setting up a Kubernetes cluster on Microsoft Azure that can be used to run Hono.
 

--- a/site/documentation/content/deployment/docker-swarm.md
+++ b/site/documentation/content/deployment/docker-swarm.md
@@ -1,6 +1,6 @@
 +++
 title = "Docker Swarm"
-weight = 480
+weight = 492
 +++
 
 Eclipse Hono&trade; components are distributed by means of Docker images which can be deployed to arbitrary environments where Docker is available. This section provides step-by-step instructions for deploying Hono to a cluster of Docker Engine nodes running in *Swarm mode*.

--- a/site/documentation/content/dev-guide/building_hono.md
+++ b/site/documentation/content/dev-guide/building_hono.md
@@ -1,0 +1,57 @@
++++
+title = "Building from Source"
+weight = 385
++++
+
+Hono can be deployed using the pre-built Docker images available from our [Docker Hub repositories](https://hub.docker.com/u/eclipse/). However, customizing and/or extending Hono's functionality requires building the images from source code.
+
+This page provides step by step instructions for getting the source code and building the Hono's Docker images from it.
+
+## Prerequisites for building Hono
+
+#### Docker
+
+Creating Hono's container images using the Hono build process requires a [Docker](http://www.docker.com) daemon running either locally or on another host you have access to. Please follow the instructions on the [Docker web site](http://www.docker.com) to install Docker on your platform.
+
+#### Java
+
+Hono is written in Java and therefore requires a Java Development Kit (JDK) version 11 or higher installed on your computer. Please follow the JDK vendor's instructions for installing Java on your operating system.
+
+#### Maven
+
+Hono's build process is based on [Apache Maven](https://maven.apache.org). You need at least Maven 3.5 in order to build Hono.
+Please follow the [installation instructions on the Maven home page](https://maven.apache.org/).
+
+#### Git
+
+A Git client is required if you want to contribute changes/improvements to the Hono project. It is not necessary for simply building Hono locally.
+Please refer to the [Git Downloads page](https://git-scm.com/downloads) for installation instructions.
+
+## Getting the Hono Source Code
+
+Either
+
+* download the latest [release archive](https://github.com/eclipse/hono/releases) and extract the archive to a local folder or
+* clone the Hono source code repository from GitHub:
+  ```
+  git clone https://github.com/eclipse/hono.git
+  ```
+  This will create a `hono` folder in the current working directory and clone the whole repository into that folder.
+
+
+## Starting the Hono Build Process
+
+Run the following from the source folder:
+
+```sh
+# in the "hono" folder containing the source code
+mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus
+```
+
+with `${host}` and `${port}` reflecting the name/IP address and port of the host where Docker is running on. This will build all libraries, Docker images and example code. If you are running on Linux and Docker is installed locally or you have set the `DOCKER_HOST` environment variable, you can omit the `-Ddocker.host` property definition.
+
+If you plan to build the Docker images more frequently, e.g. because you want to extend or improve the Hono code, then you should define the `docker.host` property in your Maven `settings.xml` file containing the very same value as you would use on the command line as indicated above. The file is usually located in the `.m2` folder in your user's home directory. This way you can simply do a `mvn clean install` later on and the Docker images will be built automatically as well because the `build-docker-image` profile is activated automatically if the Maven property `docker.host` is set.
+
+{{% note title="Be patient" %}}
+The first build might take several minutes because Docker will need to download all the base images that Hono is relying on. However, most of these will be cached by Docker so that subsequent builds will be running much faster.
+{{% /note %}}

--- a/site/documentation/content/dev-guide/java_client_consumer.md
+++ b/site/documentation/content/dev-guide/java_client_consumer.md
@@ -8,7 +8,7 @@ for devices belonging to the default tenant.
 
 It also includes support for Command and Control:
 
-if indicated by a received downstream message that contains a `ttd` value (refer to [Device notifications]({{< relref "/concepts/device-notifications.md" >}}) for details) it tries to send a command to the device.
+if indicated by a received downstream message that contains a `ttd` value (refer to [Device notifications]({{< relref "concepts/device-notifications.md" >}}) for details) it tries to send a command to the device.
 If the value of `ttd` indicates that the device stays connected for an unlimited time (`ttd == -1`), the application will periodically repeat to send a command until
 notified the device is disconnected again (`ttd == 0`).
 
@@ -63,7 +63,7 @@ Please note that consumers do not connect with Hono directly, but rather with an
 ### Command and Control
 
 By using a helper class provided by Hono, a callback in the application code is invoked when a downstream message was received
-that signals the device will stay connected to the protocol adapter for some time (see [Device notifications]({{< relref "/concepts/device-notifications.md" >}}) for details).
+that signals the device will stay connected to the protocol adapter for some time (see [Device notifications]({{< relref "concepts/device-notifications.md" >}}) for details).
 
 Inside this callback an arbitrary simple command is sent down to the device (once or periodically) and the response is logged to the console.
 

--- a/site/homepage/content/downloads.md
+++ b/site/homepage/content/downloads.md
@@ -1,7 +1,7 @@
 +++
 title = "Downloads"
 menu = "main"
-slug = "Download"
+linkTitle = "Download"
 weight = 150
 +++
 


### PR DESCRIPTION
The Getting Started guide is based on the Sandbox (if the user can access it) or a local Minikube instance.
In a next step I would then like to remove "official" support for Docker Swarm as well and remove the Swarm deploy scripts.
