### PR TITLE
[#1245] Use Device Connection API for the gateway mapping feature

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -53,6 +53,7 @@ import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoConnection;
@@ -123,6 +124,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
     private DownstreamSenderFactory downstreamSenderFactory;
     private RegistrationClientFactory registrationClientFactory;
     private CommandConsumerFactory commandConsumerFactory;
+    private DeviceConnectionClientFactory deviceConnectionClientFactory;
 
     private RegistrationClient registrationClient;
     private TenantClient tenantClient;
@@ -168,6 +170,9 @@ public class VertxBasedAmqpProtocolAdapterTest {
 
         commandConsumerFactory = mock(CommandConsumerFactory.class);
         when(commandConsumerFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
+        deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
+        when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
         resourceLimitChecks = mock(ResourceLimitChecks.class);
         when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
@@ -966,6 +971,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
         adapter.setMetrics(metrics);
         adapter.setResourceLimitChecks(resourceLimitChecks);
         return adapter;

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -46,6 +46,7 @@ import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoConnection;
@@ -99,6 +100,7 @@ public class AbstractVertxBasedCoapAdapterTest {
     private TenantClient tenantClient;
     private CoapAdapterProperties config;
     private CommandConsumerFactory commandConsumerFactory;
+    private DeviceConnectionClientFactory deviceConnectionClientFactory;
     private ResourceLimitChecks resourceLimitChecks;
 
     /**
@@ -137,6 +139,9 @@ public class AbstractVertxBasedCoapAdapterTest {
 
         commandConsumerFactory = mock(CommandConsumerFactory.class);
         when(commandConsumerFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
+        deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
+        when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
         resourceLimitChecks = mock(ResourceLimitChecks.class);
         when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
@@ -588,6 +593,7 @@ public class AbstractVertxBasedCoapAdapterTest {
             adapter.setCredentialsClientFactory(credentialsClientFactory);
         }
         adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
         adapter.setMetrics(mock(CoapAdapterMetrics.class));
         adapter.setResourceLimitChecks(resourceLimitChecks);
         adapter.init(vertx, mock(Context.class));

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -38,6 +38,7 @@ import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoConnection;
@@ -113,6 +114,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     private TenantClient                  tenantClient;
     private HttpProtocolAdapterProperties config;
     private CommandConsumerFactory        commandConsumerFactory;
+    private DeviceConnectionClientFactory deviceConnectionClientFactory;
     private MessageConsumer               commandConsumer;
     private Vertx                         vertx;
     private Context                       context;
@@ -162,6 +164,9 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         registrationClientFactory = mock(RegistrationClientFactory.class);
         when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
         when(registrationClientFactory.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(regClient));
+
+        deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
+        when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
         commandConsumer = mock(MessageConsumer.class);
         doAnswer(invocation -> {
@@ -931,6 +936,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
         adapter.setResourceLimitChecks(resourceLimitChecks);
         return adapter;
     }

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -43,6 +43,7 @@ import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoConnection;
@@ -121,6 +122,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     private MqttProtocolAdapterProperties config;
     private MqttAdapterMetrics metrics;
     private CommandConsumerFactory commandConsumerFactory;
+    private DeviceConnectionClientFactory deviceConnectionClientFactory;
     private Context context;
 
     /**
@@ -178,6 +180,9 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(commandConsumerFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
         when(commandConsumerFactory.isConnected()).thenReturn(
                 Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
+
+        deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
+        when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
         authHandler = mock(AuthHandler.class);
         resourceLimitChecks = mock(ResourceLimitChecks.class);
@@ -1150,6 +1155,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(registrationClientFactory.isConnected()).thenReturn(Future.succeededFuture());
         when(credentialsClientFactory.isConnected()).thenReturn(Future.succeededFuture());
         when(commandConsumerFactory.isConnected()).thenReturn(Future.succeededFuture());
+        when(deviceConnectionClientFactory.isConnected()).thenReturn(Future.succeededFuture());
     }
 
     @SuppressWarnings("unchecked")
@@ -1207,6 +1213,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
         adapter.setAuthHandler(authHandler);
         adapter.setResourceLimitChecks(resourceLimitChecks);
 

--- a/client/src/main/java/org/eclipse/hono/client/GatewayMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/GatewayMapper.java
@@ -27,17 +27,25 @@ public interface GatewayMapper extends ConnectionLifecycle<HonoConnection> {
      * <p>
      * The value of the returned Future can be either
      * <ul>
-     * <li>the gateway device id</li>
-     * <li>{@code null} if the device is configured to be accessed via a gateway (i.e. one or more 'via' devices are
-     * set), but no 'last-via' device is set, meaning that no message has been sent yet for this device.</li>
+     * <li>the id of the gateway that last acted on behalf of the given device</li>
+     * <li>the 'via' gateway id of the device registration information if no last known gateway is set for the device
+     * and the 'via' entry only contains a single entry</li>
      * <li>the given device id if the device is not configured to be accessed via a gateway</li>
      * </ul>
      *
      * @param tenantId The tenant identifier.
      * @param deviceId The device identifier.
      * @param context The currently active OpenTracing span context or {@code null}.
-     * @return A succeeded Future containing the mapped gateway device id or {@code null};
-     *         or a failed Future if there was an error determining the mapped gateway device.
+     * @return A succeeded Future containing the mapped gateway device id or the device id itself;
+     *         or a failed Future with:
+     *         <ul>
+     *         <li>a {@link ClientErrorException} with status <em>Not Found</em> if no last known gateway was set
+     *         for the device and the 'via' entry of the device registration contains more than one entry</li>
+     *         <li>a {@link ClientErrorException} with status <em>Not Found</em> if the last known gateway for the
+     *         device was not found in the 'via' entry of the device registration</li>
+     *         <li>a {@link ServiceInvocationException} with an error code indicating the cause of the failure
+     *         determining the device registration information or the mapped gateway device</li>
+     *         </ul>
      */
     Future<String> getMappedGatewayDevice(String tenantId, String deviceId, SpanContext context);
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/GatewayMapperImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/GatewayMapperImpl.java
@@ -13,64 +13,179 @@
 
 package org.eclipse.hono.client.impl;
 
-import java.util.Objects;
+import java.net.HttpURLConnection;
 
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ConnectionLifecycle;
+import org.eclipse.hono.client.DeviceConnectionClientFactory;
+import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.GatewayMapper;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.ReconnectListener;
 import org.eclipse.hono.client.RegistrationClientFactory;
-import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.DeviceConnectionConstants;
+import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.opentracing.References;
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 /**
  * A component that maps a given device to the gateway through which data was last published for the given device.
  */
-public class GatewayMapperImpl extends ConnectionLifecycleWrapper<HonoConnection> implements GatewayMapper {
+public class GatewayMapperImpl implements GatewayMapper, ConnectionLifecycle<HonoConnection> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GatewayMapperImpl.class);
 
     private final RegistrationClientFactory registrationClientFactory;
+    private final DeviceConnectionClientFactory deviceConnectionClientFactory;
+    private final Tracer tracer;
 
     /**
      * Creates a new GatewayMapperImpl instance.
      *
      * @param registrationClientFactory The factory to create a registration client instance.
+     * @param deviceConnectionClientFactory The factory to create a device connection client instance.
+     * @param tracer The tracer instance.
      */
-    public GatewayMapperImpl(final RegistrationClientFactory registrationClientFactory) {
-        super(registrationClientFactory);
+    public GatewayMapperImpl(final RegistrationClientFactory registrationClientFactory,
+            final DeviceConnectionClientFactory deviceConnectionClientFactory, final Tracer tracer) {
         this.registrationClientFactory = registrationClientFactory;
+        this.deviceConnectionClientFactory = deviceConnectionClientFactory;
+        this.tracer = tracer;
     }
 
     @Override
     public Future<String> getMappedGatewayDevice(final String tenantId, final String deviceId, final SpanContext context) {
+
+        final Span span = tracer.buildSpan("get mapped gateway")
+                .addReference(References.CHILD_OF, context)
+                .ignoreActiveSpan()
+                .withTag(Tags.COMPONENT.getKey(), GatewayMapper.class.getSimpleName())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER)
+                .withTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId)
+                .withTag(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId)
+                .start();
+
         return registrationClientFactory.getOrCreateRegistrationClient(tenantId).compose(client -> {
-            return client.get(deviceId, context);
-        }).map(deviceData -> {
-            return getDeviceLastVia(deviceId, deviceData);
+            return client.assertRegistration(deviceId, null, span.context());
+        }).compose(registrationAssertionJson -> {
+            final Future<String> mappedGatewayFuture = Future.future();
+            final Object viaObject = registrationAssertionJson.getValue(RegistrationConstants.FIELD_VIA);
+            final JsonArray viaArray = viaObject instanceof JsonArray ? (JsonArray) viaObject : null;
+            if (viaArray != null && !viaArray.isEmpty()) {
+                // get last-known gateway
+                deviceConnectionClientFactory.getOrCreateDeviceConnectionClient(tenantId).compose(client -> {
+                    return client.getLastKnownGatewayForDevice(deviceId, span.context());
+                }).setHandler(ar -> {
+                    if (ar.succeeded()) {
+                        final JsonObject lastKnownGatewayJson = ar.result();
+                        final String mappedGatewayId = lastKnownGatewayJson.getString(DeviceConnectionConstants.FIELD_GATEWAY_ID);
+                        // check if mappedGatewayId is in 'via' gateways
+                        if (viaArray.contains(mappedGatewayId) || deviceId.equals(mappedGatewayId)) {
+                            LOG.trace("returning mapped gateway [{}] for device [{}]", mappedGatewayId, deviceId);
+                            mappedGatewayFuture.complete(mappedGatewayId);
+                        } else {
+                            LOG.debug("mapped gateway [{}] for device [{}] is not contained in device's 'via' gateways",
+                                    mappedGatewayId, deviceId);
+                            mappedGatewayFuture.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND,
+                                    "mapped gateway not found in gateways defined for device"));
+                        }
+                    } else {
+                        // getting the last known gateway failed
+                        if (ar.cause() instanceof ServiceInvocationException
+                                && ((ServiceInvocationException) ar.cause()).getErrorCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+                            if (viaArray.size() == 1) {
+                                final String singleDefinedGateway = viaArray.getString(0);
+                                LOG.trace("no last known gateway found for device [{}]; returning single defined 'via' gateway [{}]",
+                                        deviceId, singleDefinedGateway);
+                                span.log("no last known gateway found, returning single defined 'via' gateway");
+                                mappedGatewayFuture.complete(singleDefinedGateway);
+                            } else {
+                                LOG.trace("no last known gateway found for device [{}] and device has multiple gateways defined", deviceId);
+                                mappedGatewayFuture.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND,
+                                        "no last known gateway found"));
+                            }
+                        } else {
+                            LOG.debug("error getting last known gateway for device [{}]", deviceId, ar.cause());
+                            mappedGatewayFuture.fail(ar.cause() instanceof ServiceInvocationException ? ar.cause()
+                                    : new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR));
+                        }
+                    }
+                });
+            } else {
+                // device has an empty "via" entry => return device id itself
+                LOG.trace("device [{}] has empty 'via' entry", deviceId);
+                mappedGatewayFuture.complete(deviceId);
+            }
+            return mappedGatewayFuture.map(result -> {
+                span.setTag(MessageHelper.APP_PROPERTY_GATEWAY_ID, result);
+                span.finish();
+                return result;
+            }).recover(t -> {
+                TracingHelper.logError(span, t);
+                Tags.HTTP_STATUS.set(span, ServiceInvocationException.extractStatusCode(t));
+                span.finish();
+                return Future.failedFuture(t);
+            });
         });
     }
 
-    /**
-     * Extracts the 'last-via' field content from the given device registration data JSON.
-     * <p>
-     * If the given device has no 'via' device(s) defined, the given device id is returned.
-     *
-     * @param deviceId The device identifier.
-     * @param deviceData The device registration data JSON.
-     * @return The content of the "last-via" field (or {@code null} if field doesn't exist) if a "via" is defined;
-     *         otherwise the deviceId.
-     * @throws NullPointerException if any of the parameters is {@code null}.
-     */
-    protected static String getDeviceLastVia(final String deviceId, final JsonObject deviceData) {
-        Objects.requireNonNull(deviceId);
-        Objects.requireNonNull(deviceData);
-        if (deviceData.containsKey(RegistrationConstants.FIELD_VIA)) {
-            final JsonObject lastViaObj = deviceData.getJsonObject(RegistrationConstants.FIELD_LAST_VIA);
-            return lastViaObj != null ? lastViaObj.getString(Constants.JSON_FIELD_DEVICE_ID) : null;
-        } else {
-            // device not configured to connect via gateway - return device id itself
-            return deviceId;
-        }
+    // ------------- ConnectionLifecycle methods ------------
+
+    @Override
+    public Future<HonoConnection> connect() {
+        final Future<HonoConnection> registrationFuture = registrationClientFactory.connect();
+        final Future<HonoConnection> deviceConnectionFuture = deviceConnectionClientFactory.connect();
+        return CompositeFuture.all(registrationFuture, deviceConnectionFuture).map(cf -> deviceConnectionFuture.result());
+    }
+
+    @Override
+    public void addDisconnectListener(final DisconnectListener<HonoConnection> listener) {
+        registrationClientFactory.addDisconnectListener(listener);
+        deviceConnectionClientFactory.addDisconnectListener(listener);
+    }
+
+    @Override
+    public void addReconnectListener(final ReconnectListener<HonoConnection> listener) {
+        registrationClientFactory.addReconnectListener(listener);
+        deviceConnectionClientFactory.addReconnectListener(listener);
+    }
+
+    @Override
+    public Future<Void> isConnected() {
+        final Future<Void> registrationFuture = registrationClientFactory.isConnected();
+        final Future<Void> deviceConnectionFuture = deviceConnectionClientFactory.isConnected();
+        return CompositeFuture.all(registrationFuture, deviceConnectionFuture).mapEmpty();
+    }
+
+    @Override
+    public void disconnect() {
+        registrationClientFactory.disconnect();
+        deviceConnectionClientFactory.disconnect();
+    }
+
+    @Override
+    public void disconnect(final Handler<AsyncResult<Void>> completionHandler) {
+        final Future<Void> registrationDisconnectFuture = Future.future();
+        registrationClientFactory.disconnect(registrationDisconnectFuture);
+        final Future<Void> deviceConnectionDisconnectFuture = Future.future();
+        deviceConnectionClientFactory.disconnect(deviceConnectionDisconnectFuture);
+        CompositeFuture.all(registrationDisconnectFuture, deviceConnectionDisconnectFuture)
+                .map(obj -> deviceConnectionDisconnectFuture.result()).setHandler(completionHandler);
     }
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandler.java
@@ -13,10 +13,13 @@
 
 package org.eclipse.hono.client.impl;
 
+import java.net.HttpURLConnection;
+
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.eclipse.hono.client.Command;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.GatewayMapper;
+import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
@@ -58,39 +61,40 @@ public class GatewayMappingCommandHandler implements Handler<CommandContext> {
         final String tenantId = originalCommand.getTenant();
         final String originalDeviceId = originalCommand.getDeviceId();
         // determine last used gateway device id
-        LOG.trace("determine 'via' device to use for received command [{}]", originalCommand);
-        final Future<String> lastViaDeviceIdFuture = gatewayMapper.getMappedGatewayDevice(tenantId, originalDeviceId,
+        LOG.trace("determine mapped gateway (if any) to use for received command [{}]", originalCommand);
+        final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, originalDeviceId,
                 originalCommandContext.getTracingContext());
 
-        lastViaDeviceIdFuture.setHandler(deviceIdFutureResult -> {
-            if (deviceIdFutureResult.succeeded()) {
-                final String lastViaDeviceId = deviceIdFutureResult.result();
-                if (lastViaDeviceId != null) {
-                    LOG.trace("determined 'via' device {} for device {}", lastViaDeviceId, originalDeviceId);
-                    final CommandContext commandContext;
-                    if (lastViaDeviceId.equals(originalDeviceId)) {
-                        commandContext = originalCommandContext;
-                    } else {
-                        originalCommandContext.getCurrentSpan().log("determined 'via' device " + lastViaDeviceId);
-                        if (!originalCommand.isOneWay()) {
-                            originalCommand.getCommandMessage().setReplyTo(String.format("%s/%s/%s",
-                                    CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, originalCommand.getReplyToId()));
-                        }
-                        final Command command = Command.from(originalCommand.getCommandMessage(), tenantId, lastViaDeviceId);
-                        commandContext = CommandContext.from(command, originalCommandContext.getDelivery(), originalCommandContext.getReceiver(), originalCommandContext.getCurrentSpan());
-                    }
-                    nextCommandHandler.handle(commandContext);
+        mappedGatewayDeviceFuture.setHandler(mappedGatewayResult -> {
+            if (mappedGatewayResult.succeeded()) {
+                final String mappedGatewayId = mappedGatewayResult.result();
+                final CommandContext commandContext;
+                if (mappedGatewayId.equals(originalDeviceId)) {
+                    LOG.trace("gateway mapper returned original device {}", originalDeviceId);
+                    commandContext = originalCommandContext;
                 } else {
-                    // lastViaDeviceId is null - device hasn't connected yet
-                    LOG.error("last-via for device {} is not set", originalDeviceId);
-                    TracingHelper.logError(originalCommandContext.getCurrentSpan(), "last-via for device " + originalDeviceId + " is not set");
-                    originalCommandContext.release();
+                    LOG.trace("determined mapped gateway {} for device {}", mappedGatewayId, originalDeviceId);
+                    originalCommandContext.getCurrentSpan().log("determined mapped gateway " + mappedGatewayId);
+                    if (!originalCommand.isOneWay()) {
+                        originalCommand.getCommandMessage().setReplyTo(String.format("%s/%s/%s",
+                                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, originalCommand.getReplyToId()));
+                    }
+                    final Command command = Command.from(originalCommand.getCommandMessage(), tenantId, mappedGatewayId);
+                    commandContext = CommandContext.from(command, originalCommandContext.getDelivery(),
+                            originalCommandContext.getReceiver(), originalCommandContext.getCurrentSpan());
                 }
+                nextCommandHandler.handle(commandContext);
             } else {
-                // failed to get last-via; a common cause for this is a lost connection to the device registry - automatic reconnects should resolve such a situation for subsequent requests
-                LOG.error("error getting last-via for device {}", originalDeviceId, deviceIdFutureResult.cause());
-                TracingHelper.logError(originalCommandContext.getCurrentSpan(),
-                        "error getting last-via for device: " + deviceIdFutureResult.cause());
+                if (mappedGatewayResult.cause() instanceof ServiceInvocationException
+                        && ((ServiceInvocationException) mappedGatewayResult.cause()).getErrorCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+                    LOG.debug("no mapped gateway set for device {}", originalDeviceId);
+                    TracingHelper.logError(originalCommandContext.getCurrentSpan(),
+                            "no mapped gateway set for device " + originalDeviceId);
+                } else {
+                    LOG.error("error getting mapped gateway for device {}", originalDeviceId, mappedGatewayResult.cause());
+                    TracingHelper.logError(originalCommandContext.getCurrentSpan(),
+                            "error getting mapped gateway for device: " + mappedGatewayResult.cause());
+                }
                 originalCommandContext.release();
             }
         });

--- a/client/src/test/java/org/eclipse/hono/client/impl/GatewayMapperImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/GatewayMapperImplTest.java
@@ -13,22 +13,35 @@
 
 package org.eclipse.hono.client.impl;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.HttpURLConnection;
+import java.util.Collections;
+
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.DeviceConnectionClient;
+import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.RegistrationClientFactory;
-import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -38,32 +51,46 @@ public class GatewayMapperImplTest {
 
     private GatewayMapperImpl gatewayMapper;
     private RegistrationClient regClient;
+    private DeviceConnectionClient devConClient;
     private String tenantId;
     private String deviceId;
+    private Span span;
 
     /**
      * Sets up common fixture.
      */
     @Before
     public void setup() {
+        final SpanContext spanContext = mock(SpanContext.class);
+        span = mock(Span.class);
+        when(span.context()).thenReturn(spanContext);
+        final Tracer.SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
+        final Tracer tracer = mock(Tracer.class);
+        when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
+
         tenantId = "testTenant";
         deviceId = "testDevice";
         regClient = mock(RegistrationClient.class);
         final RegistrationClientFactory registrationClientFactory = mock(RegistrationClientFactory.class);
         when(registrationClientFactory.getOrCreateRegistrationClient(anyString()))
                 .thenReturn(Future.succeededFuture(regClient));
-        gatewayMapper = new GatewayMapperImpl(registrationClientFactory);
+
+        devConClient = mock(DeviceConnectionClient.class);
+        final DeviceConnectionClientFactory deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
+        when(deviceConnectionClientFactory.getOrCreateDeviceConnectionClient(anyString()))
+                .thenReturn(Future.succeededFuture(devConClient));
+        gatewayMapper = new GatewayMapperImpl(registrationClientFactory, deviceConnectionClientFactory, tracer);
     }
 
     /**
      * Verifies that the <em>getMappedGatewayDevice</em> method returns a Future with the device id as result for a
-     * device for which 'via' is not set.
+     * device for which no 'via' entry is set.
      */
     @Test
-    public void testGetMappedGatewayDeviceUsingEmptyDeviceData() {
-        // GIVEN deviceData with no 'via'
-        final JsonObject deviceData = new JsonObject();
-        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+    public void testGetMappedGatewayDeviceUsingDeviceWithNoVia() {
+        // GIVEN assertRegistration result with no 'via'
+        final JsonObject assertRegistrationResult = new JsonObject();
+        when(regClient.assertRegistration(anyString(), any(), any())).thenReturn(Future.succeededFuture(assertRegistrationResult));
 
         // WHEN getMappedGatewayDevice() is invoked
         final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, deviceId, null);
@@ -71,52 +98,147 @@ public class GatewayMapperImplTest {
         // THEN the returned Future is complete and contains the deviceId
         assertThat(mappedGatewayDeviceFuture.isComplete(), is(true));
         assertThat(mappedGatewayDeviceFuture.result(), is(deviceId));
+        verify(span).finish();
     }
 
     /**
-     * Verifies that the <em>getMappedGatewayDevice</em> method returns the correct value for a device for which 'via'
-     * and 'last-via' is set.
+     * Verifies that the <em>getMappedGatewayDevice</em> method returns the gateway set in both the 'via' entry of
+     * the given device and the <em>getLastKnownGatewayForDevice</em> operation return value.
      */
     @Test
-    public void testGetMappedGatewayDeviceUsingDeviceDataWithLastVia() {
-        final String deviceViaId = "testDeviceVia";
+    public void testGetMappedGatewayDeviceUsingDeviceWithMappedGateway() {
+        final String gatewayId = "testDeviceVia";
 
-        // GIVEN deviceData with 'via' and 'last-via'
-        final JsonObject deviceData = new JsonObject();
-        deviceData.put(RegistrationConstants.FIELD_VIA, deviceViaId);
-        final JsonObject lastViaObject = new JsonObject();
-        lastViaObject.put(Constants.JSON_FIELD_DEVICE_ID, deviceViaId);
-        deviceData.put(RegistrationConstants.FIELD_LAST_VIA, lastViaObject);
-        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+        // GIVEN assertRegistration result with non-empty 'via'
+        final JsonObject assertRegistrationResult = new JsonObject();
+        final JsonArray viaArray = new JsonArray(Collections.singletonList(gatewayId));
+        assertRegistrationResult.put(RegistrationConstants.FIELD_VIA, viaArray);
+        when(regClient.assertRegistration(anyString(), any(), any())).thenReturn(Future.succeededFuture(assertRegistrationResult));
+        // and a non-empty getLastKnownGatewayForDevice result
+        final JsonObject lastKnownGatewayResult = new JsonObject();
+        lastKnownGatewayResult.put(DeviceConnectionConstants.FIELD_GATEWAY_ID, gatewayId);
+        when(devConClient.getLastKnownGatewayForDevice(anyString(), any())).thenReturn(Future.succeededFuture(lastKnownGatewayResult));
 
         // WHEN getMappedGatewayDevice() is invoked
         final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, deviceId, null);
 
-        // THEN the returned Future is complete and contains the deviceViaId
+        // THEN the returned Future is complete and contains the gatewayId
         assertThat(mappedGatewayDeviceFuture.isComplete(), is(true));
-        assertThat(mappedGatewayDeviceFuture.result(), is(deviceViaId));
+        assertThat(mappedGatewayDeviceFuture.result(), is(gatewayId));
+        verify(span).finish();
     }
 
     /**
-     * Verifies that the <em>getMappedGatewayDevice</em> method returns a Future with {@code null} as result for a
-     * device for which 'via' is set but 'last-via' is not set.
+     * Verifies that the <em>getMappedGatewayDevice</em> method returns the single gateway entry of a device's 'via'
+     * entry if no gateway is returned by the <em>getLastKnownGatewayForDevice</em> operation.
      */
     @Test
-    public void testGetMappedGatewayDeviceUsingDeviceDataWithoutLastVia() {
-        final String deviceViaId = "testDeviceVia";
+    public void testGetMappedGatewayDeviceReturningSingleDefinedViaGateway() {
+        final String gatewayId = "testDeviceVia";
 
-        // GIVEN deviceData with 'via' but no 'last-via'
-        final JsonObject deviceData = new JsonObject();
-        deviceData.put(RegistrationConstants.FIELD_VIA, deviceViaId);
-
-        when(regClient.get(anyString(), any())).thenReturn(Future.succeededFuture(deviceData));
+        // GIVEN assertRegistrationResult with a single 'via' array entry
+        final JsonObject assertRegistrationResult = new JsonObject();
+        final JsonArray viaArray = new JsonArray(Collections.singletonList(gatewayId));
+        assertRegistrationResult.put(RegistrationConstants.FIELD_VIA, viaArray);
+        when(regClient.assertRegistration(anyString(), any(), any())).thenReturn(Future.succeededFuture(assertRegistrationResult));
+        // and a 404 getLastKnownGatewayForDevice response
+        when(devConClient.getLastKnownGatewayForDevice(anyString(), any()))
+                .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
 
         // WHEN getMappedGatewayDevice() is invoked
         final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, deviceId, null);
 
-        // THEN the returned Future is complete and contains null as result
+        // THEN the returned Future is complete and contains the gatewayId
+        assertThat(mappedGatewayDeviceFuture.isComplete(), is(true));
+        assertThat(mappedGatewayDeviceFuture.result(), is(gatewayId));
+        verify(span).finish();
+    }
+
+    /**
+     * Verifies that the <em>getMappedGatewayDevice</em> method returns a failed Future if no gateway is returned by
+     * the <em>getLastKnownGatewayForDevice</em> operation and the device has multiple gateways defined in its 'via'
+     * entry.
+     */
+    @Test
+    public void testGetMappedGatewayDeviceFailureUsingMultiGatewayDevice() {
+        final String gatewayId = "testDeviceVia";
+
+        // GIVEN assertRegistrationResult with 'via'
+        final JsonObject assertRegistrationResult = new JsonObject();
+        final JsonArray viaArray = new JsonArray();
+        viaArray.add(gatewayId);
+        viaArray.add("otherGatewayId");
+        assertRegistrationResult.put(RegistrationConstants.FIELD_VIA, viaArray);
+        when(regClient.assertRegistration(anyString(), any(), any())).thenReturn(Future.succeededFuture(assertRegistrationResult));
+        // and a 404 getLastKnownGatewayForDevice response
+        when(devConClient.getLastKnownGatewayForDevice(anyString(), any()))
+                .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
+
+        // WHEN getMappedGatewayDevice() is invoked
+        final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, deviceId, null);
+
+        // THEN the returned Future is failed
         assertThat(mappedGatewayDeviceFuture.isComplete(), is(true));
         assertThat(mappedGatewayDeviceFuture.result(), is(nullValue()));
+        assertThat(mappedGatewayDeviceFuture.cause(), instanceOf(ClientErrorException.class));
+        assertThat(((ClientErrorException) mappedGatewayDeviceFuture.cause()).getErrorCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+        verify(span).finish();
     }
 
+    /**
+     * Verifies that the <em>getMappedGatewayDevice</em> method returns a failed Future if the gateway returned by
+     * the <em>getLastKnownGatewayForDevice</em> operation is not in the list of gateways of the device's 'via' entry.
+     */
+    @Test
+    public void testGetMappedGatewayDeviceFailureIfGatewayNotInVia() {
+        final String gatewayId = "testDeviceVia";
+
+        // GIVEN assertRegistrationResult with 'via'
+        final JsonObject assertRegistrationResult = new JsonObject();
+        final JsonArray viaArray = new JsonArray(Collections.singletonList(gatewayId));
+        assertRegistrationResult.put(RegistrationConstants.FIELD_VIA, viaArray);
+        when(regClient.assertRegistration(anyString(), any(), any())).thenReturn(Future.succeededFuture(assertRegistrationResult));
+        // and a getLastKnownGatewayForDevice response with a different gateway
+        final JsonObject lastKnownGatewayResult = new JsonObject();
+        lastKnownGatewayResult.put(DeviceConnectionConstants.FIELD_GATEWAY_ID, "otherGatewayId");
+        when(devConClient.getLastKnownGatewayForDevice(anyString(), any())).thenReturn(Future.succeededFuture(lastKnownGatewayResult));
+
+        // WHEN getMappedGatewayDevice() is invoked
+        final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, deviceId, null);
+
+        // THEN the returned Future is failed
+        assertThat(mappedGatewayDeviceFuture.isComplete(), is(true));
+        assertThat(mappedGatewayDeviceFuture.result(), is(nullValue()));
+        assertThat(mappedGatewayDeviceFuture.cause(), instanceOf(ClientErrorException.class));
+        assertThat(((ClientErrorException) mappedGatewayDeviceFuture.cause()).getErrorCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+        verify(span).finish();
+    }
+
+    /**
+     * Verifies that the <em>getMappedGatewayDevice</em> method returns a failed Future if the
+     * <em>getLastKnownGatewayForDevice</em> operation failed.
+     */
+    @Test
+    public void testGetMappedGatewayDeviceFailureIfGetLastGatewayFailed() {
+        final String gatewayId = "testDeviceVia";
+
+        // GIVEN assertRegistrationResult with 'via'
+        final JsonObject assertRegistrationResult = new JsonObject();
+        final JsonArray viaArray = new JsonArray(Collections.singletonList(gatewayId));
+        assertRegistrationResult.put(RegistrationConstants.FIELD_VIA, viaArray);
+        when(regClient.assertRegistration(anyString(), any(), any())).thenReturn(Future.succeededFuture(assertRegistrationResult));
+        // and a 500 getLastKnownGatewayForDevice response
+        when(devConClient.getLastKnownGatewayForDevice(anyString(), any()))
+                .thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR)));
+
+        // WHEN getMappedGatewayDevice() is invoked
+        final Future<String> mappedGatewayDeviceFuture = gatewayMapper.getMappedGatewayDevice(tenantId, deviceId, null);
+
+        // THEN the returned Future is failed
+        assertThat(mappedGatewayDeviceFuture.isComplete(), is(true));
+        assertThat(mappedGatewayDeviceFuture.result(), is(nullValue()));
+        assertThat(mappedGatewayDeviceFuture.cause(), instanceOf(ServerErrorException.class));
+        assertThat(((ServerErrorException) mappedGatewayDeviceFuture.cause()).getErrorCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+        verify(span).finish();
+    }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
@@ -106,6 +106,7 @@ public final class HonoClientUnitTestHelper {
         when(spanBuilder.withTag(anyString(), anyBoolean())).thenReturn(spanBuilder);
         when(spanBuilder.withTag(anyString(), anyString())).thenReturn(spanBuilder);
         when(spanBuilder.withTag(anyString(), (Number) any())).thenReturn(spanBuilder);
+        when(spanBuilder.ignoreActiveSpan()).thenReturn(spanBuilder);
         when(spanBuilder.start()).thenReturn(spanToCreate);
         return spanBuilder;
     }

--- a/deploy/src/main/deploy/example-permissions.json
+++ b/deploy/src/main/deploy/example-permissions.json
@@ -36,6 +36,14 @@
       {
         "operation": "tenant/*:*",
         "activities": [ "EXECUTE" ]
+      },
+      {
+        "resource": "device_con/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "device_con/*:*",
+        "activities": [ "EXECUTE" ]
       }
     ],
     "device-manager": [

--- a/deploy/src/main/sandbox/sandbox-permissions.json
+++ b/deploy/src/main/sandbox/sandbox-permissions.json
@@ -36,6 +36,14 @@
       {
         "operation": "tenant/*:*",
         "activities": [ "EXECUTE" ]
+      },
+      {
+        "resource": "device_con/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "device_con/*:*",
+        "activities": [ "EXECUTE" ]
       }
     ],
     "device-manager": [

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -35,6 +35,7 @@ import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoConnection;
@@ -88,6 +89,7 @@ public class AbstractProtocolAdapterBaseTest {
     private CredentialsClientFactory credentialsClientFactory;
     private DownstreamSenderFactory downstreamSenderFactory;
     private CommandConsumerFactory commandConsumerFactory;
+    private DeviceConnectionClientFactory deviceConnectionClientFactory;
 
     /**
      * Sets up the fixture.
@@ -114,6 +116,9 @@ public class AbstractProtocolAdapterBaseTest {
         commandConsumerFactory = mock(CommandConsumerFactory.class);
         when(commandConsumerFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
+        deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
+        when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
         properties = new ProtocolAdapterProperties();
         adapter = newProtocolAdapter(properties);
         adapter.setTenantClientFactory(tenantService);
@@ -121,6 +126,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setDownstreamSenderFactory(downstreamSenderFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
 
         vertx = mock(Vertx.class);
         // run timers immediately
@@ -149,6 +155,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setDownstreamSenderFactory(downstreamSenderFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
 
         // WHEN starting the adapter
         adapter.startInternal().setHandler(ctx.failing(t -> ctx.verify(() -> {
@@ -240,6 +247,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setTenantClientFactory(tenantService);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
     }
 
     /**

--- a/tests/src/test/resources/auth/permissions.json
+++ b/tests/src/test/resources/auth/permissions.json
@@ -36,6 +36,14 @@
       {
         "operation": "tenant/*:*",
         "activities": [ "EXECUTE" ]
+      },
+      {
+        "resource": "device_con/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "device_con/*:*",
+        "activities": [ "EXECUTE" ]
       }
     ],
     "DEFAULT_TENANT-manager": [


### PR DESCRIPTION
This is for #1245.

With the changes here, the protocol adapters invoke the `setLastKnownGatewayForDevice` method of the Device Connection API whenever a device (that has one or more `via` gateways defined) sends a telemetry, event, command response or ttd event.

The gateway mapping logic (that is part of processing a command message in the protocol adapter) now uses the `getLastKnownGatewayForDevice` method.

The old code for storing a `last-via` property in the device registration data is still present and will be removed later.