### PR TITLE
[#1289] Disable auto-accept for command receiver links

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -381,6 +381,33 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
             Handler<String> remoteCloseHook);
 
     /**
+     * Creates a receiver link.
+     *
+     * @param sourceAddress The address to receive messages from.
+     * @param qos The quality of service to use for the link.
+     * @param messageHandler The handler to invoke with every message received.
+     * @param preFetchSize The number of credits to flow to the peer as soon as the link
+     *                     has been established. A value of 0 prevents pre-fetching and
+     *                     allows for manual flow control using the returned receiver's
+     *                     <em>flow</em> method.
+     * @param autoAccept {@code true} if received deliveries should be automatically accepted (and settled)
+     *                   after the message handler runs for them, if no other disposition has been applied
+     *                   during handling.
+     * @param remoteCloseHook The handler to invoke when the link is closed at the peer's request (may be {@code null}).
+     * @return A future for the created link. The future will be completed once the link is open.
+     *         The future will fail with a {@link ServiceInvocationException} if the link cannot be opened.
+     * @throws NullPointerException if any of the arguments other than close hook is {@code null}.
+     * @throws IllegalArgumentException if the pre-fetch size is &lt; 0.
+     */
+    Future<ProtonReceiver> createReceiver(
+            String sourceAddress,
+            ProtonQoS qos,
+            ProtonMessageHandler messageHandler,
+            int preFetchSize,
+            boolean autoAccept,
+            Handler<String> remoteCloseHook);
+
+    /**
      * Closes an AMQP link and frees up its allocated resources.
      * <p>
      * This method is equivalent to {@link #closeAndFree(ProtonLink, long, Handler)}

--- a/client/src/main/java/org/eclipse/hono/client/impl/DeviceSpecificCommandConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DeviceSpecificCommandConsumer.java
@@ -104,6 +104,7 @@ public class DeviceSpecificCommandConsumer extends CommandConsumer {
                     commandHandler.handle(CommandContext.from(command, delivery, receiverRef.get(), currentSpan));
                 },
                 0, // no pre-fetching
+                false, // no auto-accept
                 sourceAddress -> {
                     LOG.debug("command receiver link [tenant-id: {}, device-id: {}] closed remotely",
                             tenantId, deviceId);

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
@@ -693,6 +693,17 @@ public class HonoConnectionImpl implements HonoConnection {
             final ProtonMessageHandler messageHandler,
             final int preFetchSize,
             final Handler<String> remoteCloseHook) {
+        return createReceiver(sourceAddress, qos, messageHandler, preFetchSize, true, remoteCloseHook);
+    }
+
+    @Override
+    public Future<ProtonReceiver> createReceiver(
+            final String sourceAddress,
+            final ProtonQoS qos,
+            final ProtonMessageHandler messageHandler,
+            final int preFetchSize,
+            final boolean autoAccept,
+            final Handler<String> remoteCloseHook) {
 
         Objects.requireNonNull(sourceAddress);
         Objects.requireNonNull(qos);
@@ -705,7 +716,7 @@ public class HonoConnectionImpl implements HonoConnection {
             checkConnected().compose(v -> {
                 final Future<ProtonReceiver> receiverFuture = Future.future();
                 final ProtonReceiver receiver = connection.createReceiver(sourceAddress);
-                receiver.setAutoAccept(true);
+                receiver.setAutoAccept(autoAccept);
                 receiver.setQoS(qos);
                 receiver.setPrefetch(preFetchSize);
                 receiver.handler((delivery, message) -> {

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantScopedCommandConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantScopedCommandConsumer.java
@@ -84,6 +84,8 @@ public class TenantScopedCommandConsumer extends CommandConsumer {
                 address,
                 ProtonQoS.AT_LEAST_ONCE,
                 messageHandler,
+                con.getConfig().getInitialCredits(),
+                false, // no auto-accept
                 sourceAddress -> {
                     LOG.debug("command receiver link [tenant-id: {}] closed remotely", tenantId);
                     remoteCloseHandler.handle(sourceAddress);

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.hono.client.impl.VertxMockSupport.argumentCaptorHandle
 import static org.eclipse.hono.client.impl.VertxMockSupport.mockHandler;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -113,6 +114,7 @@ public class CommandConsumerFactoryImplTest {
                 any(ProtonQoS.class),
                 any(ProtonMessageHandler.class),
                 anyInt(),
+                anyBoolean(),
                 anyHandler())).thenReturn(Future.succeededFuture(deviceSpecificCommandReceiver));
         tenantScopedCommandReceiver = mock(ProtonReceiver.class);
         tenantCommandAddress = ResourceIdentifier.from(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, null).toString();
@@ -120,6 +122,8 @@ public class CommandConsumerFactoryImplTest {
                 eq(tenantCommandAddress),
                 any(ProtonQoS.class),
                 any(ProtonMessageHandler.class),
+                anyInt(),
+                anyBoolean(),
                 anyHandler())).thenReturn(Future.succeededFuture(tenantScopedCommandReceiver));
         gatewayMapper = mock(GatewayMapper.class);
         commandConsumerFactory = new CommandConsumerFactoryImpl(connection, gatewayMapper);
@@ -142,6 +146,7 @@ public class CommandConsumerFactoryImplTest {
                 any(ProtonQoS.class),
                 any(ProtonMessageHandler.class),
                 anyInt(),
+                anyBoolean(),
                 anyHandler()))
         .thenReturn(Future.failedFuture(ex));
 
@@ -186,6 +191,7 @@ public class CommandConsumerFactoryImplTest {
                 eq(ProtonQoS.AT_LEAST_ONCE),
                 any(ProtonMessageHandler.class),
                 eq(0),
+                eq(false),
                 captor.capture());
         captor.getValue().handle(deviceSpecificCommandAddress);
         verify(closeHandler).handle(null);
@@ -236,6 +242,7 @@ public class CommandConsumerFactoryImplTest {
                     eq(ProtonQoS.AT_LEAST_ONCE),
                     any(ProtonMessageHandler.class),
                     eq(0),
+                    eq(false),
                     anyHandler());
             return newConsumer;
         }).setHandler(ctx.asyncAssertSuccess());
@@ -290,6 +297,7 @@ public class CommandConsumerFactoryImplTest {
                 eq(ProtonQoS.AT_LEAST_ONCE),
                 any(ProtonMessageHandler.class),
                 eq(0),
+                eq(false),
                 anyHandler());
 
         // and when the consumer is finally closed locally
@@ -319,6 +327,7 @@ public class CommandConsumerFactoryImplTest {
                 eq(ProtonQoS.AT_LEAST_ONCE),
                 any(ProtonMessageHandler.class),
                 anyInt(),
+                anyBoolean(),
                 anyHandler())).thenReturn(createdReceiver);
 
         // WHEN the liveness check fires
@@ -332,6 +341,7 @@ public class CommandConsumerFactoryImplTest {
                 eq(ProtonQoS.AT_LEAST_ONCE),
                 any(ProtonMessageHandler.class),
                 eq(0),
+                eq(false),
                 anyHandler());
 
         // and when the first attempt has finally timed out
@@ -345,6 +355,7 @@ public class CommandConsumerFactoryImplTest {
                 eq(ProtonQoS.AT_LEAST_ONCE),
                 any(ProtonMessageHandler.class),
                 eq(0),
+                eq(false),
                 anyHandler());
     }
 }


### PR DESCRIPTION
This fixes #1289.

Adds a new `createReceiver` method in `HonoConnection` with an `autoAccept` param.
CommandConsumer classes use this to disable `autoAccept`.

(An alternative solution would have been to just set `receiver.setAutoAccept(false)` on the returned receiver, but letting the flag be set inside the `createReceiver` method *before* `receiver.open()` is called is the cleaner solution IMHO.)