### PR TITLE
[#1255] Let CommandClient instance be scoped to a tenant

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
@@ -72,17 +72,17 @@ public class Commander extends AbstractApplicationClient {
 
         LOG.info("Command sent to device... [request will timeout in {} seconds]", requestTimeoutInSecs);
 
-        final Future<CommandClient> commandClient = clientFactory.getOrCreateCommandClient(tenantId, deviceId);
+        final Future<CommandClient> commandClient = clientFactory.getOrCreateCommandClient(tenantId);
         return commandClient
                 .map(this::setRequestTimeOut)
                 .compose(c -> {
                     if (command.isOneWay()) {
-                        return c
-                                .sendOneWayCommand(command.getName(), command.getContentType(), Buffer.buffer(command.getPayload()), null)
+                        return c.sendOneWayCommand(deviceId, command.getName(), command.getContentType(),
+                                Buffer.buffer(command.getPayload()), null)
                                 .map(ok -> c);
                     } else {
-                        return c
-                                .sendCommand(command.getName(), command.getContentType(), Buffer.buffer(command.getPayload()), null)
+                        return c.sendCommand(deviceId, command.getName(), command.getContentType(),
+                                Buffer.buffer(command.getPayload()), null)
                                 .map(this::printResponse)
                                 .map(ok -> c);
                     }

--- a/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
@@ -135,53 +135,46 @@ public interface ApplicationClientFactory extends ConnectionLifecycle<HonoConnec
             BiConsumer<ProtonDelivery, Message> consumer, Handler<Void> closeHandler);
 
     /**
-     * Gets a client for sending commands to a device.
+     * Gets a client for sending commands to devices of the given tenant.
      * <p>
      * The client returned may be either newly created or it may be an existing
-     * client for the given device.
+     * client for the given tenant.
      * <p>
      * This method will use an implementation specific mechanism (e.g. a UUID) to create
-     * a unique reply-to address to be included in commands sent to the device. The protocol
-     * adapters need to convey an encoding of the reply-to address to the device when delivering
-     * the command. Consequently, the number of bytes transferred to the device depends on the
-     * length of the reply-to address being used. In situations where this is a major concern it
-     * might be advisable to use {@link #getOrCreateCommandClient(String, String, String)} for
-     * creating a command client and provide custom (and shorter) <em>reply-to identifier</em>
+     * a unique reply-to address to be included in commands sent to devices of the tenant.
+     * The protocol adapters need to convey an encoding of the reply-to address to the device
+     * when delivering the command. Consequently, the number of bytes transferred to the device
+     * depends on the length of the reply-to address being used. In situations where this is a
+     * major concern it might be advisable to use {@link #getOrCreateCommandClient(String, String)}
+     * for creating a command client and provide custom (and shorter) <em>reply-to identifier</em>
      * to be used in the reply-to address.
      *
-     * @param tenantId The tenant that the device belongs to.
-     * @param deviceId The device to send the commands to.
+     * @param tenantId The tenant of the devices to which commands shall be sent.
      * @return A future that will complete with the command and control client (if successful) or
      *         fail if the client cannot be created, e.g. because the underlying connection
      *         is not established or if a concurrent request to create a client for the same
-     *         tenant and device is already being executed.
+     *         tenant is already being executed.
      * @throws NullPointerException if the tenantId is {@code null}.
      */
-    Future<CommandClient> getOrCreateCommandClient(String tenantId, String deviceId);
+    Future<CommandClient> getOrCreateCommandClient(String tenantId);
 
     /**
-     * Gets a client for sending commands to a device.
+     * Gets a client for sending commands to devices of the given tenant.
      * <p>
      * The client returned may be either newly created or it may be an existing
-     * client for the given device.
+     * client for the given tenant and replyId.
      *
-     * @param tenantId The tenant that the device belongs to.
-     * @param deviceId The device to send the commands to.
-     * @param replyId An arbitrary string which (in conjunction with the tenant and device ID) uniquely
-     *                identifies this command client.
-     *                This identifier will only be used for creating a <em>new</em> client for the device.
-     *                If this method returns an existing client for the device then the client will use
-     *                the reply-to address determined during its initial creation. In particular, this
-     *                means that if the (existing) client has originally been created using the
-     *                {@link #getOrCreateCommandClient(String, String)} method, then the reply-to address
-     *                used by the client will most likely not contain the given identifier.
+     * @param tenantId The tenant of the devices to which commands shall be sent.
+     * @param replyId An arbitrary string which will be used to create the reply-to address to be included in
+     *                commands sent to devices of the tenant. The combination of tenant and replyId has to be
+     *                unique among all CommandClient instances to make sure command response messages can be received.
      * @return A future that will complete with the command and control client (if successful) or
      *         fail if the client cannot be created, e.g. because the underlying connection
      *         is not established or if a concurrent request to create a client for the same
-     *         tenant and device is already being executed.
+     *         tenant and replyId is already being executed.
      * @throws NullPointerException if the tenantId is {@code null}.
      */
-    Future<CommandClient> getOrCreateCommandClient(String tenantId, String deviceId, String replyId);
+    Future<CommandClient> getOrCreateCommandClient(String tenantId, String replyId);
 
     /**
      * Gets a client for sending commands to a device asynchronously, i.e. command responses get received by a

--- a/client/src/main/java/org/eclipse/hono/client/CommandClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandClient.java
@@ -34,6 +34,7 @@ public interface CommandClient extends RequestResponseClient {
      * A device needs to be (successfully) registered before a client can upload
      * any data for it. The device also needs to be connected for a successful delivery.
      *
+     * @param deviceId The device to send the command to.
      * @param command The command name.
      * @param data The command data to send to the device or {@code null} if the command has no input data.
      * @return A future indicating the result of the operation.
@@ -46,7 +47,7 @@ public interface CommandClient extends RequestResponseClient {
      * @throws NullPointerException if command is {@code null}.
      * @see RequestResponseClient#setRequestTimeout(long)
      */
-    Future<BufferResult> sendCommand(String command, Buffer data);
+    Future<BufferResult> sendCommand(String deviceId, String command, Buffer data);
 
     /**
      * Sends a command to a device and expects a response.
@@ -54,6 +55,7 @@ public interface CommandClient extends RequestResponseClient {
      * A device needs to be (successfully) registered before a client can upload
      * any data for it. The device also needs to be connected for a successful delivery.
      *
+     * @param deviceId The device to send the command to.
      * @param command The command name.
      * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
      * @param data The command data to send to the device or {@code null} if the command has no input data.
@@ -67,7 +69,7 @@ public interface CommandClient extends RequestResponseClient {
      * @throws NullPointerException if command is {@code null}.
      * @see RequestResponseClient#setRequestTimeout(long)
      */
-    Future<BufferResult> sendCommand(String command, String contentType, Buffer data, Map<String, Object> properties);
+    Future<BufferResult> sendCommand(String deviceId, String command, String contentType, Buffer data, Map<String, Object> properties);
 
     /**
      * Sends a <em>one-way command</em> to a device, i.e. there is no response expected from the device.
@@ -75,6 +77,7 @@ public interface CommandClient extends RequestResponseClient {
      * A device needs to be (successfully) registered before a client can upload
      * any data for it. The device also needs to be connected for a successful delivery.
      *
+     * @param deviceId The device to send the command to.
      * @param command The one-way command name.
      * @param data The command data to send to the device or {@code null} if the one-way command has no input data.
      * @return A future indicating the result of the operation.
@@ -85,7 +88,7 @@ public interface CommandClient extends RequestResponseClient {
      * @throws NullPointerException if command is {@code null}.
      * @see RequestResponseClient#setRequestTimeout(long)
      */
-    Future<Void> sendOneWayCommand(String command, Buffer data);
+    Future<Void> sendOneWayCommand(String deviceId, String command, Buffer data);
 
     /**
      * Sends a <em>one-way command</em> to a device, i.e. there is no response from the device expected.
@@ -93,6 +96,7 @@ public interface CommandClient extends RequestResponseClient {
      * A device needs to be (successfully) registered before a client can upload
      * any data for it. The device also needs to be connected for a successful delivery.
      *
+     * @param deviceId The device to send the command to.
      * @param command The one-way command name.
      * @param contentType The type of the data submitted as part of the one-way command or {@code null} if unknown.
      * @param data The command data to send to the device or {@code null} if the command has no input data.
@@ -105,5 +109,5 @@ public interface CommandClient extends RequestResponseClient {
      * @throws NullPointerException if command is {@code null}.
      * @see RequestResponseClient#setRequestTimeout(long)
      */
-    Future<Void> sendOneWayCommand(String command, String contentType, Buffer data, Map<String, Object> properties);
+    Future<Void> sendOneWayCommand(String deviceId, String command, String contentType, Buffer data, Map<String, Object> properties);
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
@@ -69,7 +69,6 @@ public class CommandClientImplTest {
         client = new CommandClientImpl(
                 connection,
                 Constants.DEFAULT_TENANT,
-                DEVICE_ID,
                 REPLY_ID,
                 sender,
                 receiver);
@@ -90,14 +89,14 @@ public class CommandClientImplTest {
         final Map<String, Object> applicationProperties = new HashMap<>();
         applicationProperties.put("appKey", "appValue");
 
-        client.sendCommand("doSomething", "text/plain", Buffer.buffer("payload"), applicationProperties);
+        client.sendCommand(DEVICE_ID, "doSomething", "text/plain", Buffer.buffer("payload"), applicationProperties);
         final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
         verify(sender).send(messageCaptor.capture(), anyHandler());
         assertThat(messageCaptor.getValue().getSubject(), is("doSomething"));
         assertNotNull(messageCaptor.getValue().getMessageId());
         assertThat(messageCaptor.getValue().getContentType(), is("text/plain"));
         assertThat(messageCaptor.getValue().getReplyTo(),
-                is(String.format("%s/%s/%s/%s", client.getReplyToEndpointName(), Constants.DEFAULT_TENANT, DEVICE_ID, REPLY_ID)));
+                is(String.format("%s/%s/%s", client.getReplyToEndpointName(), Constants.DEFAULT_TENANT, REPLY_ID)));
         assertNotNull(messageCaptor.getValue().getApplicationProperties());
         assertThat(messageCaptor.getValue().getApplicationProperties().getValue().get("appKey"), is("appValue"));
     }
@@ -118,7 +117,7 @@ public class CommandClientImplTest {
         final Map<String, Object> applicationProperties = new HashMap<>();
         applicationProperties.put("appKey", "appValue");
 
-        client.sendOneWayCommand("doSomething", "text/plain", Buffer.buffer("payload"), applicationProperties);
+        client.sendOneWayCommand(DEVICE_ID, "doSomething", "text/plain", Buffer.buffer("payload"), applicationProperties);
         final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
         verify(sender).send(messageCaptor.capture(), anyHandler());
         assertThat(messageCaptor.getValue().getSubject(), is("doSomething"));

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoCommander.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoCommander.java
@@ -207,10 +207,10 @@ public class HonoCommander extends AbstractClient {
     }
 
     private void sendCommandAndReceiveResponse(final String tenantId, final String deviceId) {
-        applicationClientFactory.getOrCreateCommandClient(tenantId, deviceId)
+        applicationClientFactory.getOrCreateCommandClient(tenantId)
                 .map(this::setCommandTimeOut)
                 .compose(commandClient -> commandClient
-                        .sendCommand(sampler.getCommand(), Buffer.buffer(sampler.getCommandPayload()))
+                        .sendCommand(deviceId, sampler.getCommand(), Buffer.buffer(sampler.getCommandPayload()))
                         .map(commandResponse -> {
                             final String commandResponseText = Optional.ofNullable(commandResponse.getPayload())
                                     .orElse(Buffer.buffer()).toString();

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -675,14 +675,14 @@ public final class IntegrationTestSupport {
             final Map<String, Object> properties,
             final long requestTimeout) {
 
-        return applicationClientFactory.getOrCreateCommandClient(tenantId, deviceId).compose(commandClient -> {
+        return applicationClientFactory.getOrCreateCommandClient(tenantId).compose(commandClient -> {
 
             commandClient.setRequestTimeout(requestTimeout);
             final Future<BufferResult> result = Future.future();
             final Handler<Void> send = s -> {
                 // send the command upstream to the device
                 LOGGER.trace("sending command [name: {}, contentType: {}, payload: {}]", command, contentType, payload);
-                commandClient.sendCommand(command, contentType, payload, properties).map(responsePayload -> {
+                commandClient.sendCommand(deviceId, command, contentType, payload, properties).map(responsePayload -> {
                     LOGGER.debug("successfully sent command [name: {}, payload: {}] and received response [payload: {}]",
                             command, payload, responsePayload);
                     commandClient.close(v -> {});
@@ -752,14 +752,14 @@ public final class IntegrationTestSupport {
             final Map<String, Object> properties,
             final long requestTimeout) {
 
-        return applicationClientFactory.getOrCreateCommandClient(tenantId, deviceId).compose(commandClient -> {
+        return applicationClientFactory.getOrCreateCommandClient(tenantId).compose(commandClient -> {
 
             commandClient.setRequestTimeout(requestTimeout);
             final Future<Void> result = Future.future();
             final Handler<Void> send = s -> {
                 // send the command upstream to the device
                 LOGGER.trace("sending one-way command [name: {}, contentType: {}, payload: {}]", command, contentType, payload);
-                commandClient.sendOneWayCommand(command, contentType, payload, properties).map(ok -> {
+                commandClient.sendOneWayCommand(deviceId, command, contentType, payload, properties).map(ok -> {
                     LOGGER.debug("successfully sent one-way command [name: {}, payload: {}]", command, payload);
                     commandClient.close(v -> {});
                     return (Void) null;

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -221,7 +221,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             log.debug("received command [name: {}]", msg.getSubject());
             commandsReceived.countDown();
         }, (commandClient, payload) -> {
-            return commandClient.sendOneWayCommand("setValue", "text/plain", payload, null);
+            return commandClient.sendOneWayCommand(deviceId, "setValue", "text/plain", payload, null);
         }, commandsToSend);
 
         commandsReceived.await();
@@ -311,7 +311,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                 ctx,
                 sender -> createCommandConsumer(ctx, sender),
                 (commandClient, payload) -> {
-                    return commandClient.sendCommand("setValue", "text/plain", payload, null)
+                    return commandClient.sendCommand(deviceId, "setValue", "text/plain", payload, null)
                             .map(response -> {
                                 ctx.assertEquals(deviceId, response.getApplicationProperty(MessageHelper.APP_PROPERTY_DEVICE_ID, String.class));
                                 ctx.assertEquals(tenantId, response.getApplicationProperty(MessageHelper.APP_PROPERTY_TENANT_ID, String.class));
@@ -335,7 +335,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         final long start = System.currentTimeMillis();
 
         final Async commandClientCreation = ctx.async();
-        final Future<CommandClient> commandClient = helper.applicationClientFactory.getOrCreateCommandClient(tenantId, deviceId, "test-client")
+        final Future<CommandClient> commandClient = helper.applicationClientFactory.getOrCreateCommandClient(tenantId, "test-client")
                 .setHandler(ctx.asyncAssertSuccess(c -> {
                     c.setRequestTimeout(200);
                     commandClientCreation.complete();
@@ -455,7 +455,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         final long start = System.currentTimeMillis();
 
         final Async commandClientCreation = ctx.async();
-        final Future<CommandClient> commandClient = helper.applicationClientFactory.getOrCreateCommandClient(tenantId, deviceId, "test-client")
+        final Future<CommandClient> commandClient = helper.applicationClientFactory.getOrCreateCommandClient(tenantId, "test-client")
                 .setHandler(ctx.asyncAssertSuccess(c -> {
                     c.setRequestTimeout(300);
                     commandClientCreation.complete();
@@ -466,7 +466,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             final Async commandSent = ctx.async();
             context.runOnContext(go -> {
                 final Buffer msg = Buffer.buffer("value: " + commandsSent.getAndIncrement());
-                final Future<BufferResult> sendCmdFuture = commandClient.result().sendCommand("setValue", "text/plain",
+                final Future<BufferResult> sendCmdFuture = commandClient.result().sendCommand(deviceId, "setValue", "text/plain",
                         msg, null);
                 sendCmdFuture.setHandler(sendAttempt -> {
                     if (sendAttempt.succeeded()) {


### PR DESCRIPTION
This is for #1255.

With this PR, the `CommandClient` is scoped to a tenant, not a device anymore. The device id is given as a parameter to the individual `sendCommand` invocation.

Note: The `AsyncCommandClient` is not changed here - this will come in a follow-up commit.