### PR TITLE
Remove deprecated variant of getRegistrationAssertion.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -904,42 +904,6 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     /**
      * Gets an assertion for a device's registration status.
      * <p>
-     * The returned JSON object may include <em>default</em> values for properties to set on
-     * messages published by the device under property {@link RegistrationConstants#FIELD_PAYLOAD_DEFAULTS}.
-     *
-     * @param tenantId The tenant that the device belongs to.
-     * @param deviceId The device to get the assertion for.
-     * @param authenticatedDevice The device that has authenticated to this protocol adapter.
-     *            <p>
-     *            If not {@code null} then the authenticated device is compared to the given tenant and device ID. If
-     *            they differ in the device identifier, then the authenticated device is considered to be a gateway
-     *            acting on behalf of the device.
-     * @return A future indicating the outcome of the operation.
-     *         <p>
-     *         The future will fail if the assertion cannot be retrieved. The cause will be a
-     *         {@link ServiceInvocationException} containing a corresponding error code.
-     *         <p>
-     *         Otherwise the future will contain the assertion.
-     * @throws NullPointerException if tenant ID or device ID are {@code null}.
-     * @deprecated Use {@link #getRegistrationAssertion(String, String, Device, SpanContext)} instead.
-     */
-    @Deprecated
-    protected final Future<JsonObject> getRegistrationAssertion(final String tenantId, final String deviceId,
-            final Device authenticatedDevice) {
-
-        Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(deviceId);
-
-        final Future<String> gatewayId = getGatewayId(tenantId, deviceId, authenticatedDevice);
-
-        return gatewayId
-                .compose(gwId -> getRegistrationClient(tenantId))
-                .compose(client -> client.assertRegistration(deviceId, gatewayId.result()));
-    }
-
-    /**
-     * Gets an assertion for a device's registration status.
-     * <p>
      * The returned JSON object may include <em>default</em>
      * values for properties to set on messages published by the device under
      * property {@link RegistrationConstants#FIELD_PAYLOAD_DEFAULTS}.

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -370,7 +370,7 @@ public class AbstractProtocolAdapterBaseTest {
 
         final Checkpoint assertion = ctx.checkpoint();
         // WHEN an assertion for the device is retrieved
-        adapter.getRegistrationAssertion("tenant", "device", null)
+        adapter.getRegistrationAssertion("tenant", "device", null, mock(SpanContext.class))
                 .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
             // THEN the result contains the registration assertion
             assertEquals(assertionResult, result);
@@ -401,7 +401,7 @@ public class AbstractProtocolAdapterBaseTest {
 
         final Checkpoint assertion = ctx.checkpoint();
         // WHEN an assertion for a non-existing device is retrieved
-        adapter.getRegistrationAssertion("tenant", "non-existent", null)
+        adapter.getRegistrationAssertion("tenant", "non-existent", null, mock(SpanContext.class))
                 .setHandler(ctx.failing(t -> ctx.verify(() -> {
             // THEN the request fails with a 404
             assertEquals(HttpURLConnection.HTTP_NOT_FOUND, ((ServiceInvocationException) t).getErrorCode());

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -7,6 +7,9 @@ title = "Release Notes"
 ### API Changes
 * The obsolete method variants of `reportTelemetry` in `org.eclipse.hono.service.metric.Metrics` 
   have been removed. The new variants of this method accept an additional parameter of type `TenantObject`.
+* The already deprecated `org.eclipse.hono.service.AbstractProtocolAdapterBase.getRegistrationAssertion`
+  method has been removed. The alternate variant of the `getRegistrationAssertion` method which accepts an 
+  additional OpenTracing span parameter should be used.
 
 ## 1.0-M6
 


### PR DESCRIPTION
Remove deprecated variant of `AbstractProtocolAdapterBase.getRegistrationAssertion` method and its usage.