### PR TITLE
[#1284] Extend message limits for command and control

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -375,7 +375,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
             }
             return null;
         }).otherwise(t -> {
-            con.setCondition(AmqpContext.getErrorCondition(t));
+            con.setCondition(getErrorCondition(t));
             con.close();
             TracingHelper.logError(span, t);
             return null;
@@ -541,7 +541,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
             return d;
         }).recover(t -> {
             if (t instanceof ClientErrorException) {
-                final ErrorCondition condition = AmqpContext.getErrorCondition(t);
+                final ErrorCondition condition = getErrorCondition(t);
                 MessageHelper.rejected(ctx.delivery(), condition);
             } else {
                 ProtonHelper.released(ctx.delivery(), true);
@@ -686,7 +686,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
 
                     if (!command.isValid()) {
                         final Exception ex = new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "malformed command message");
-                        commandContext.reject(AmqpContext.getErrorCondition(ex), 1);
+                        commandContext.reject(getErrorCondition(ex), 1);
                         metrics.reportCommand(
                                 command.isOneWay() ? Direction.ONE_WAY : Direction.REQUEST,
                                 sourceAddress.getTenantId(),
@@ -788,7 +788,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
             final Throwable t,
             final Span span) {
 
-        final ErrorCondition ec = AmqpContext.getErrorCondition(t);
+        final ErrorCondition ec = getErrorCondition(t);
         LOG.debug("closing link with error condition [symbol: {}, description: {}]", ec.getCondition(), ec.getDescription());
         link.setCondition(ec);
         link.close();

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
@@ -56,6 +56,12 @@ public final class HttpUtils {
      */
     public static final String CONTENT_TYPE_TEXT_UTF8 = "text/plain; charset=utf-8";
 
+    /**
+     * 429 Too Many Requests.
+     * Refer <a href="https://tools.ietf.org/html/rfc6585#section-4"> RFC 6585, Section 4 </a>.
+     */
+    public static final int HTTP_TOO_MANY_REQUESTS = 429;
+
     private HttpUtils() {
         // prevent instantiation
     }


### PR DESCRIPTION
With this PR, the Protocol Adapters are now equipped to check the _message limits_ before sending any _commands_ and accepting any _command responses_ as described in #1284.