### PR TITLE
[#896] Implement config option to force sampling of traces

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
@@ -22,6 +22,8 @@ import org.eclipse.hono.util.ResourceIdentifier;
 
 import io.micrometer.core.instrument.Timer.Sample;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 
@@ -39,6 +41,7 @@ public final class MqttContext extends MapBasedExecutionContext {
     private String contentType;
     private Sample timer;
     private MetricsTags.EndpointType endpoint;
+    private Span span;
 
     private MqttContext() {
     }
@@ -236,5 +239,31 @@ public final class MqttContext extends MapBasedExecutionContext {
      */
     public Sample getTimer() {
         return timer;
+    }
+
+    /**
+     * Gets the <em>OpenTracing</em> span used for tracking
+     * the processing of this context.
+     *
+     * @return The span or {@code null} if no tracing span is set.
+     */
+    public Span getTracingSpan() {
+        return span;
+    }
+
+    /**
+     * Sets the <em>OpenTracing</em> span used for tracking
+     * the processing of this context.
+     * <p>
+     * Also invokes {@link #setTracingContext(SpanContext)}
+     * with the context of the given span.
+     *
+     * @param span The span.
+     */
+    public void setTracingSpan(final Span span) {
+        this.span = span;
+        if (span != null) {
+            setTracingContext(span.context());
+        }
     }
 }

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -77,6 +77,7 @@ import org.mockito.ArgumentCaptor;
 
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -206,7 +207,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
     private static MqttContext newMqttContext(final MqttPublishMessage message, final MqttEndpoint endpoint) {
         final MqttContext result = MqttContext.fromPublishPacket(message, endpoint);
-        result.setTracingContext(mock(SpanContext.class));
+        result.setTracingSpan(mock(Span.class));
         return result;
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.util;
 
+import java.util.Optional;
+
 /**
  * Constants &amp; utility methods used throughout the Tenant API.
  */
@@ -79,6 +81,21 @@ public final class TenantConstants extends RequestResponseApiConstants {
     public static final String FIELD_RESOURCE_LIMITS = "resource-limits";
 
     /**
+     * The name of the field that defines in how far spans created when processing
+     * messages for a tenant shall be recorded (sampled) by the tracing system.
+     * The field contains a {@link TraceSamplingMode} value.
+     */
+    public static final String FIELD_TRACE_SAMPLING_MODE = "trace-sampling-mode";
+    /**
+     * The name of the field that defines in how far spans created when processing
+     * messages for a tenant and a particular tenant shall be recorded (sampled)
+     * by the tracing system.
+     * The field contains a JsonObject with fields having a device id as name and
+     * a {@link TraceSamplingMode} value.
+     */
+    public static final String FIELD_TRACE_SAMPLING_MODE_PER_DEVICE = "trace-sampling-mode-per-device";
+
+    /**
      * Request actions that belong to the Tenant API.
      */
     public enum TenantAction {
@@ -117,6 +134,47 @@ public final class TenantConstants extends RequestResponseApiConstants {
                 }
             }
             return custom;
+        }
+    }
+
+    /**
+     * Value that defines in how far <em>OpenTracing</em> spans created when processing
+     * messages for a tenant shall be recorded (sampled) by the tracing system.
+     */
+    public enum TraceSamplingMode {
+        DEFAULT("default"),
+        ALL("all"),
+        ;
+
+        private final String fieldValue;
+
+        TraceSamplingMode(String fieldValue) {
+            this.fieldValue = fieldValue;
+        }
+
+        /**
+         * Construct a TraceSamplingMode from a value.
+         *
+         * @param value The value from which the TraceSamplingMode needs to be constructed.
+         * @return The TraceSamplingMode as enum, or {@link TraceSamplingMode#DEFAULT} otherwise.
+         */
+        public static TraceSamplingMode from(final String value) {
+            for (TraceSamplingMode mode : values()) {
+                if (mode.fieldValue.equals(value)) {
+                    return mode;
+                }
+            }
+            return DEFAULT;
+        }
+
+        /**
+         * Gets the value for the <em>sampling.priority</em> span tag.
+         *
+         * @return An <em>Optional</em> containing the value for the <em>sampling.priority</em> span tag or an empty
+         *         <em>Optional</em> if no such tag should be set.
+         */
+        public Optional<Integer> toSamplingPriority() {
+            return this.equals(ALL) ? Optional.of(1) : Optional.empty();
         }
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -562,4 +562,32 @@ public final class TenantObject extends JsonBackedValueObject {
         setProperty(TenantConstants.FIELD_PAYLOAD_DEFAULTS, Objects.requireNonNull(defaultProperties));
         return this;
     }
+
+    /**
+     * Gets the value for the <em>sampling.priority</em> span tag as encoded in the properties of this tenant.
+     *
+     * @param deviceId The device id (may be null).
+     * @return An <em>Optional</em> containing the value for the <em>sampling.priority</em> span tag or an empty
+     *         <em>Optional</em> if no priority should be set.
+     */
+    @JsonIgnore
+    public Optional<Integer> getTraceSamplingPriority(final String deviceId) {
+        String traceSamplingMode = null;
+        if (deviceId != null) {
+            // check device specific setting first
+            final JsonObject traceSamplingModePerDevice = getProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE_PER_DEVICE,
+                    JsonObject.class);
+            if (traceSamplingModePerDevice != null) {
+                traceSamplingMode = traceSamplingModePerDevice.getString(deviceId);
+            }
+        }
+        if (traceSamplingMode == null) {
+            // check tenant specific setting
+            traceSamplingMode = getProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE, String.class);
+        }
+        if (traceSamplingMode == null) {
+            return Optional.empty();
+        }
+        return TenantConstants.TraceSamplingMode.from(traceSamplingMode).toSamplingPriority();
+    }
 }


### PR DESCRIPTION
Fix for #896. 

This introduces config options to enable forced sampling of traces (i.e. recording of traces in the tracing backend) for a specific tenant or device.

**Per tenant:**
In the Json structure returned by the Tenant API, a field `trace-sampling-mode` can be set with a value of "all" (meaning sampling of all traces is enforced) or "default".
````
  {
    "tenant-id": "DEFAULT_TENANT",
    "enabled": true,
    "trace-sampling-mode": "all"
  }
````

**Per device:**
In the Json structure returned by the Tenant API, a field `trace-sampling-mode-per-device` can be set with a map value where a field with the device id as name and a value of "all" (meaning sampling of all traces is enforced) or "default" is set.
````
  {
    "tenant-id": "DEFAULT_TENANT",
    "enabled": true,
    "trace-sampling-mode-per-device": {
      "4711": "all"
    }
  }
````

**Limitations:**
The sampling of traces can only be enforced by setting a "sampling-priority" tag on all spans that shall be sampled. That means that all spans created and finished *before* getting the tenant Json can not be taken into account here. For example, from all the spans created as part of uploading telemetry data in the HTTP protocol adapter:
````
hono-adapter-http: POST
  hono-adapter-http: authenticate device
    hono-adapter-http: get Credentials
      hono-service-device-registry: process request message
        hono-service-device-registry: get Credentials
    hono-adapter-http: validate Credentials
  hono-adapter-http: upload telemetry
    hono-adapter-http: get Tenant by ID
      hono-service-device-registry: process request message
        hono-service-device-registry: get Tenant
    hono-adapter-http: assert Device Registration
      hono-service-device-registry: process request message
        hono-service-device-registry: assert Device Registration
hono-adapter-http: forward Telemetry data
````
only these get forcefully sampled for now:
````
hono-adapter-http: POST
  hono-adapter-http: upload telemetry
    hono-adapter-http: assert Device Registration
      hono-service-device-registry: process request message
        hono-service-device-registry: assert Device Registration
hono-adapter-http: forward Telemetry data
````

**Scope:**
As part of this PR, the feature has been implemented for the HTTP, MQTT and AMQP adapters.