### PR TITLE
[#1302] Fix build of documentation versions.

### DIFF
--- a/jenkins/Hono-Website-Pipeline.groovy
+++ b/jenkins/Hono-Website-Pipeline.groovy
@@ -92,14 +92,14 @@ def build() {
             cd $WORKSPACE/hono/site/documentation
 
             function build_documentation_in_version {
-                VERSION="$1.$2"
-    
                 if [[ "$1" == "stable" ]]; then
                    WEIGHT="-20000"
                    VERSION="$1"
                 else
                    local pad=00
-                   WEIGHT="-$1${pad:${#2}:${#pad}}${2}"
+                   local minor="${2//[!0-9]/}" # make sure that minor only contains numbers  
+                   WEIGHT="-$1${pad:${#minor}:${#pad}}${minor}"
+                   VERSION="$1.$2"
                 fi
                 
                 echo "Going to check out version ${VERSION} from branch/tag $3"
@@ -117,6 +117,7 @@ EOS
 cat <<EOS > config_release_version.toml
 baseurl = "https://www.eclipse.org/hono/docs/${VERSION}/"
 [params]
+  urlPrefixOfVersionStable = "/hono/docs/stable/"
   honoVersion = "${VERSION}"
 EOS
 
@@ -130,10 +131,11 @@ EOS
               build_documentation_in_version "stable" "" ${TAG_STABLE}  # build stable version as "stable"  
             fi
             
+            git checkout master
             while IFS=";" read -r MAJOR MINOR BRANCH_OR_TAG
             do
               build_documentation_in_version ${MAJOR} ${MINOR} ${BRANCH_OR_TAG}
-            done < <(tail -n+4 $WORKSPACE/hono/site/homepage/versions_supported.csv)  # skip header line and comment
+            done < <(tail -n+3 $WORKSPACE/hono/site/homepage/versions_supported.csv)  # skip header line and comment
             
             git checkout master
          '''

--- a/site/documentation/config.toml
+++ b/site/documentation/config.toml
@@ -43,7 +43,7 @@ pluralizeListTitles = "false"
   ordersectionsby = "weight"
   # Change default color scheme with a variant one. Can be "red", "blue", "green".
   themeVariant = "hono"
-  urlPrefixOfVersionStable = "/hono/docs/stable/"
+  urlPrefixOfVersionStable = "/hono/docs/stable/" # might be overriden during build by value in site/documentation/config_release_version.toml
   honoVersion = "latest" # might be overriden during build by value in site/documentation/config_release_version.toml
   
   # Twitter

--- a/site/homepage/menu_main.toml
+++ b/site/homepage/menu_main.toml
@@ -3,10 +3,10 @@
 
 [[menu.main]]
     name = "Documentation"
-    weight = -30000
+    weight = 120
 
 [[menu.main]]
     parent = "Documentation"
-    name = "Development"
+    name = "latest"
     url  = "/docs/latest"
     weight = -10000


### PR DESCRIPTION
Improve calculation of the order of versions in the menu.
Make sure that the "old version hint" banner always points the current
stable version.
Display "Getting started" as first menu item on homepage.

Signed-off-by: Abel Buechner-Mihaljevic <Abel.Buechner@bosch-si.com>