### PR TITLE
Remove usage of TenantObject in code performing tenant API client requests

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Adapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Adapter.java
@@ -15,7 +15,11 @@ package org.eclipse.hono.service.management.tenant;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 /**
@@ -35,6 +39,18 @@ public class Adapter {
     @JsonProperty(RegistryManagementConstants.FIELD_EXT)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Object> extensions;
+
+    /**
+     * Creates a new adapter instance for the given type.
+     *
+     * @param type The adapter type.
+     * @throws NullPointerException if the type is null.
+     */
+    public Adapter(@JsonProperty("type") final String type) {
+        Objects.requireNonNull(type);
+
+        this.type = type;
+    }
 
     /**
      * Set the enabled property.
@@ -95,4 +111,25 @@ public class Adapter {
     public Map<String, Object> getExtensions() {
         return this.extensions;
     }
+
+    /**
+     * Adds an extension property to this adapter.
+     * <p>
+     * If an extension property already exist for the specified key, the old value is replaced by the specified value.
+     *
+     * @param key The key of the entry.
+     * @param value The value of the entry.
+     * @return This instance, to allow chained invocations.
+     * @throws NullPointerException if any of the arguments is {@code null}.
+     */
+    public Adapter putExtension(final String key, final Object value) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        if (this.extensions == null) {
+            this.extensions = new HashMap<>();
+        }
+        this.extensions.put(key, value);
+        return this;
+    }
+
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/ResourceLimits.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/ResourceLimits.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.hono.service.management.tenant;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.hono.util.RegistryManagementConstants;
 
@@ -48,4 +50,25 @@ public class ResourceLimits {
     public Map<String, Object> getExtensions() {
         return this.extensions;
     }
+
+    /**
+     * Adds an extension property to this resource limit.
+     * <p>
+     * If an extension property already exist for the specified key, the old value is replaced by the specified value.
+     *
+     * @param key The key of the entry.
+     * @param value The value of the entry.
+     * @return This instance, to allow chained invocations.
+     * @throws NullPointerException if any of the arguments is {@code null}.
+     */
+    public ResourceLimits putExtension(final String key, final Object value) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        if (this.extensions == null) {
+            this.extensions = new HashMap<>();
+        }
+        this.extensions.put(key, value);
+        return this;
+    }
+
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 /**
@@ -125,17 +127,41 @@ public class Tenant {
     }
 
     /**
-     * Add a new extension entry to the Tenant.
+     * Adds an extension property to this tenant.
+     * <p>
+     * If an extension property already exist for the specified key, the old value is replaced by the specified value.
      *
      * @param key The key of the entry.
      * @param value The value of the entry.
-     * @return This instance, to allowed chained invocations.
+     * @return This instance, to allow chained invocations.
+     * @throws NullPointerException if any of the arguments is {@code null}.
      */
     public Tenant putExtension(final String key, final Object value) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
         if (this.extensions == null) {
             this.extensions = new HashMap<>();
         }
         this.extensions.put(key, value);
         return this;
     }
+
+    /**
+     * Adds the specified adapter to the list of adapters for this Tenant.
+     * 
+     * @param adapter The adapter to add for the tenant.
+     * @return        This instance, to allow chained invocations.
+     * @throws        NullPointerException if the specified adapter is {@code null}.
+     */
+    public Tenant addAdapterConfig(final Adapter adapter) {
+
+        Objects.requireNonNull(adapter);
+
+        if (adapters == null) {
+            adapters = new LinkedList<>();
+        }
+        adapters.add(adapter);
+        return this;
+    }
+
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
@@ -23,10 +23,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import io.vertx.core.json.JsonArray;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+
+import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.RegistryManagementConstants;
 import org.hamcrest.collection.IsEmptyIterable;
 import org.junit.jupiter.api.Test;
@@ -219,27 +220,20 @@ class TenantTest {
     @Test
     public void testSerializeAdapters() {
 
-        final Adapter httpAdapter = new Adapter()
-                .setType("http")
-                .setEnabled(false)
-                .setDeviceAuthenticationRequired(true);
-        final Adapter mqttAdapter = new Adapter()
-                .setType("mqtt")
-                .setEnabled(true)
-                .setDeviceAuthenticationRequired(true);
-
-        final ArrayList<Adapter> adapters = new ArrayList<>();
-        adapters.add(httpAdapter);
-        adapters.add(mqttAdapter);
-
         final Tenant tenant = new Tenant();
         tenant.setEnabled(true);
-        tenant.setAdapters(adapters);
+        tenant
+            .addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_HTTP)
+                    .setEnabled(false)
+                    .setDeviceAuthenticationRequired(true))
+            .addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_MQTT)
+                    .setEnabled(true)
+                    .setDeviceAuthenticationRequired(true));
 
         final JsonArray result = JsonObject.mapFrom(tenant).getJsonArray(FIELD_ADAPTERS);
         assertNotNull(result);
-        assertEquals("http", result.getJsonObject(0).getString(FIELD_ADAPTERS_TYPE));
-        assertEquals("mqtt", result.getJsonObject(1).getString(FIELD_ADAPTERS_TYPE));
+        assertEquals(Constants.PROTOCOL_ADAPTER_TYPE_HTTP, result.getJsonObject(0).getString(FIELD_ADAPTERS_TYPE));
+        assertEquals(Constants.PROTOCOL_ADAPTER_TYPE_MQTT, result.getJsonObject(1).getString(FIELD_ADAPTERS_TYPE));
         assertEquals(false, result.getJsonObject(0).getBoolean(FIELD_ENABLED));
         assertEquals(true, result.getJsonObject(0).getBoolean(FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED));
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/Tenants.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/Tenants.java
@@ -15,11 +15,9 @@ package org.eclipse.hono.tests;
 
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
-import java.util.LinkedList;
 
 import javax.security.auth.x500.X500Principal;
 
-import org.eclipse.hono.service.management.tenant.Adapter;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.service.management.tenant.TrustedCertificateAuthority;
 
@@ -31,6 +29,7 @@ public final class Tenants {
     private Tenants() {
     }
 
+
     /**
      * Create a new tenant, based on a trust anchor.
      *
@@ -38,42 +37,36 @@ public final class Tenants {
      * @return The new tenant. Never returns {@code null}.
      */
     public static Tenant createTenantForTrustAnchor(final X509Certificate cert) {
-        return createTenantForTrustAnchor(cert, cert.getPublicKey());
+        return createTenantForTrustAnchor(cert.getSubjectX500Principal(), cert.getPublicKey());
     }
 
     /**
      * Create a new tenant, based on a trust anchor.
      *
-     * @param cert The trust anchor.
+     * @param subjectDn The subject DN of the trust anchor.
      * @param publicKey The public key for the anchor.
      * @return The new tenant. Never returns {@code null}.
      */
-    public static Tenant createTenantForTrustAnchor(final X509Certificate cert, final PublicKey publicKey) {
-        final var tenant = new Tenant();
-        final var trustedCa = new TrustedCertificateAuthority();
-        trustedCa.setSubjectDn(cert.getSubjectX500Principal().getName(X500Principal.RFC2253));
-        trustedCa.setPublicKey(publicKey.getEncoded());
-        trustedCa.setKeyAlgorithm(publicKey.getAlgorithm());
-        tenant.setTrustedCertificateAuthority(trustedCa);
-        return tenant;
+    public static Tenant createTenantForTrustAnchor(final X500Principal subjectDn, final PublicKey publicKey) {
+        return createTenantForTrustAnchor(subjectDn.getName(X500Principal.RFC2253), publicKey.getEncoded(), publicKey.getAlgorithm());
     }
 
     /**
-     * Create a new adapter section and set the enabled state.
+     * Create a new tenant, based on a trust anchor.
      * 
-     * @param tenant The tenant to process.
-     * @param type The adapter type to configure.
-     * @param state The enabled state.
+     * @param subjectDn  The subject DN of the trust anchor.
+     * @param publicKey  The public key for the anchor.
+     * @param algorithmn The public key algorithm.
+     * 
+     * @return The new tenant. Never returns {@code null}.
      */
-    public static void setAdapterEnabled(final Tenant tenant, final String type, final Boolean state) {
-        final Adapter adapter = new Adapter();
-        adapter.setType(type);
-        adapter.setEnabled(state);
-        if (tenant.getAdapters() == null) {
-            tenant.setAdapters(new LinkedList<>());
-        }
-        tenant.getAdapters().add(adapter);
-
+    public static Tenant createTenantForTrustAnchor(final String subjectDn, final byte[] publicKey, final String algorithmn) {
+        final var tenant = new Tenant();
+        final var trustedCa = new TrustedCertificateAuthority();
+        trustedCa.setSubjectDn(subjectDn);
+        trustedCa.setPublicKey(publicKey);
+        trustedCa.setKeyAlgorithm(algorithmn);
+        tenant.setTrustedCertificateAuthority(trustedCa);
+        return tenant;
     }
-
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
@@ -23,6 +23,7 @@ import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.service.management.tenant.Adapter;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.Tenants;
@@ -343,7 +344,7 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
 
         final Tenant tenant = new Tenant();
         if (disableTenant) {
-            Tenants.setAdapterEnabled(tenant, Constants.PROTOCOL_ADAPTER_TYPE_AMQP, false);
+            tenant.addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_AMQP).setEnabled(false));
         }
 
         return helper.registry

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -54,9 +54,9 @@ import org.eclipse.hono.client.MessageConsumer;
 
 import org.eclipse.hono.service.management.credentials.GenericCredential;
 import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.tenant.Adapter;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
-import org.eclipse.hono.tests.Tenants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.MessageHelper;
@@ -76,7 +76,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 
@@ -537,7 +536,7 @@ public abstract class CoapTestBase {
         credential.setType(CredentialsConstants.SECRETS_TYPE_PRESHARED_KEY);
         credential.getAdditionalProperties().put(CredentialsConstants.FIELD_SECRETS_KEY, "notBase64");
 
-        helper.registry.addTenant(tenantId, JsonObject.mapFrom(tenant))
+        helper.registry.addTenant(tenantId, tenant)
         .compose(ok -> helper.registry.registerDevice(tenantId, deviceId))
                 .compose(ok -> helper.registry.addCredentials(tenantId, deviceId, Collections.singleton(credential)))
         .setHandler(ctx.asyncAssertSuccess(ok -> setup.complete()));
@@ -591,7 +590,7 @@ public abstract class CoapTestBase {
 
         // GIVEN a tenant for which the CoAP adapter is disabled
         final Tenant tenant = new Tenant();
-        Tenants.setAdapterEnabled(tenant, Constants.PROTOCOL_ADAPTER_TYPE_COAP, false);
+        tenant.addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_COAP).setEnabled(false));
 
         helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, SECRET)
                 .compose(ok -> {

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -36,6 +36,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.tenant.Adapter;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.service.management.tenant.TrustedCertificateAuthority;
 import org.eclipse.hono.tests.CrudHttpClient;
@@ -524,7 +525,7 @@ public abstract class HttpTestBase {
 
         // GIVEN a tenant for which the HTTP adapter is disabled
         final Tenant tenant = new Tenant();
-        Tenants.setAdapterEnabled(tenant, Constants.PROTOCOL_ADAPTER_TYPE_HTTP, false);
+        tenant.addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_HTTP).setEnabled(false));
 
         helper.registry
                 .addDeviceForTenant(tenantId, tenant, deviceId, PWD)

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
@@ -22,6 +22,7 @@ import org.eclipse.hono.service.management.credentials.PasswordCredential;
 import org.eclipse.hono.service.management.credentials.X509CertificateCredential;
 import org.eclipse.hono.service.management.credentials.X509CertificateSecret;
 import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.tenant.Adapter;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.Tenants;
@@ -35,7 +36,6 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -190,7 +190,7 @@ public class MqttConnectionIT extends MqttTestBase {
         helper.getCertificate(deviceCert.certificatePath())
                 .compose(cert -> {
                     final var tenant = Tenants.createTenantForTrustAnchor(cert);
-                    return helper.registry.addTenant(tenantId, JsonObject.mapFrom(tenant));
+                    return helper.registry.addTenant(tenantId, tenant);
                 }).compose(ok -> helper.registry.registerDevice(tenantId, deviceId))
                 .compose(ok -> {
                     final X509CertificateCredential credential = new X509CertificateCredential();
@@ -220,7 +220,7 @@ public class MqttConnectionIT extends MqttTestBase {
     public void testConnectFailsForDisabledAdapter(final TestContext ctx) {
 
         final Tenant tenant = new Tenant();
-        Tenants.setAdapterEnabled(tenant, Constants.PROTOCOL_ADAPTER_TYPE_MQTT, false);
+        tenant.addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_MQTT).setEnabled(false));
 
         helper.registry
                 .addDeviceForTenant(tenantId, tenant, deviceId, password)
@@ -248,7 +248,7 @@ public class MqttConnectionIT extends MqttTestBase {
         helper.getCertificate(deviceCert.certificatePath())
         .compose(cert -> {
                     final var tenant = Tenants.createTenantForTrustAnchor(cert);
-                    Tenants.setAdapterEnabled(tenant, Constants.PROTOCOL_ADAPTER_TYPE_MQTT, false);
+                    tenant.addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_MQTT).setEnabled(false));
                     return helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, cert);
         })
         // WHEN a device that belongs to the tenant tries to connect to the adapter
@@ -274,7 +274,7 @@ public class MqttConnectionIT extends MqttTestBase {
         final Tenant tenant = new Tenant();
 
         helper.registry
-                .addTenant(tenantId, JsonObject.mapFrom(tenant))
+                .addTenant(tenantId, tenant)
                 .compose(ok -> {
                     return helper.registry.registerDevice(tenantId, deviceId);
                 })
@@ -308,7 +308,7 @@ public class MqttConnectionIT extends MqttTestBase {
         final Tenant tenant = new Tenant();
 
         helper.registry
-                .addTenant(tenantId, JsonObject.mapFrom(tenant))
+                .addTenant(tenantId, tenant)
                 .compose(ok -> {
                     final var device = new Device();
                     device.setEnabled(false);


### PR DESCRIPTION
This patch attempts to restrict the usage of the `TenantObject` value to what it is created for: encapsulating the tenant payload retrieved through the get operation of the tenant API.

This restriction avoids the unnecessary/costly mapping from a `TenantObject` to a `JsonObject`, as we currently do in test cases performing tenant API client requests

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>