### PR TITLE
Management API : allow empty body for creating tenant or device with generated ID

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
@@ -153,6 +153,23 @@ public abstract class AbstractHttpEndpoint<T> extends AbstractEndpoint implement
     }
 
     /**
+     * Check if the payload is not null and call \
+     * {@link #extractRequiredJson(RoutingContext, Function)}} to extract it accordingly.
+     * <p>
+     *
+     * @param ctx The routing context to retrieve the JSON request body from.
+     */
+    protected final void extractOptionalJsonPayload(final RoutingContext ctx) {
+
+        if (ctx.getBody().length() != 0) {
+            extractRequiredJson(ctx, RoutingContext::getBodyAsJson);
+        } else {
+            ctx.put(KEY_REQUEST_BODY, new JsonObject());
+            ctx.next();
+        }
+    }
+
+    /**
      * Check the Content-Type of the request to be 'application/json' and extract the payload if this check was
      * successful.
      * <p>

--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementHttpEndpoint.java
@@ -67,18 +67,16 @@ public final class DeviceManagementHttpEndpoint extends AbstractHttpEndpoint<Ser
 
         // CREATE device with auto-generated deviceID
         router.post(pathWithTenant)
-                .handler(this::extractRequiredJsonPayload)
+                .handler(this::extractOptionalJsonPayload)
                 .handler(this::doCreateDevice);
 
         // CREATE device
         router.post(pathWithTenantAndDeviceId)
-                .handler(this::extractRequiredJsonPayload)
-                .handler(this::extractIfMatchVersionParam)
+                .handler(this::extractOptionalJsonPayload)
                 .handler(this::doCreateDevice);
 
         // GET device
         router.get(pathWithTenantAndDeviceId)
-                .handler(this::extractIfMatchVersionParam)
                 .handler(this::doGetDevice);
 
         // UPDATE existing device

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementHttpEndpoint.java
@@ -73,21 +73,18 @@ public final class TenantManagementHttpEndpoint extends AbstractHttpEndpoint<Ser
 
         // ADD tenant with auto-generated ID
         router.post(path).handler(bodyHandler);
-        router.post(path).handler(this::extractRequiredJsonPayload);
-        router.post(path).handler(this::extractIfMatchVersionParam);
+        router.post(path).handler(this::extractOptionalJsonPayload);
         router.post(path).handler(this::createTenant);
 
         final String pathWithTenant = String.format("/%s/:%s", getName(), PARAM_TENANT_ID);
 
         // ADD tenant
         router.post(pathWithTenant).handler(bodyHandler);
-        router.post(pathWithTenant).handler(this::extractRequiredJsonPayload);
-        router.post(pathWithTenant).handler(this::extractIfMatchVersionParam);
+        router.post(pathWithTenant).handler(this::extractOptionalJsonPayload);
         router.post(pathWithTenant).handler(this::updatePayloadWithTenantId);
         router.post(pathWithTenant).handler(this::createTenant);
 
         // GET tenant
-        router.get(pathWithTenant).handler(this::extractIfMatchVersionParam);
         router.get(pathWithTenant).handler(this::getTenant);
 
         // UPDATE tenant

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationHttpIT.java
@@ -179,15 +179,27 @@ public class DeviceRegistrationHttpIT {
     }
 
     /**
-     * Verifies that a device cannot be registered if the request
+     * Verifies that a device can be registered if the request
      * does not contain a body.
      * 
      * @param ctx The vert.x test context
      */
     @Test
-    public void testAddDeviceFailsForMissingBody(final TestContext ctx) {
+    public void testAddDeviceSucceedsForEmptyBody(final TestContext ctx) {
 
-        registry.registerDevice(TENANT, deviceId, null, HttpURLConnection.HTTP_BAD_REQUEST).setHandler(ctx.asyncAssertSuccess());
+        registry.registerDevice(TENANT, deviceId, null, HttpURLConnection.HTTP_CREATED).setHandler(ctx.asyncAssertSuccess());
+    }
+
+    /**
+     * Verifies that a device can be registered if the request
+     * does not contain a body nor a content type.
+     *
+     * @param ctx The vert.x test context
+     */
+    @Test
+    public void testAddDeviceSucceedsForEmptyBodyAndContentType(final TestContext ctx) {
+
+        registry.registerDevice(TENANT, deviceId, null, null, HttpURLConnection.HTTP_CREATED).setHandler(ctx.asyncAssertSuccess());
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantHttpIT.java
@@ -150,14 +150,14 @@ public class TenantHttpIT {
     }
 
     /**
-     * Verifies that the service returns a 400 status code for an add tenant request with an empty body.
+     * Verifies that the service successfully create a tenant from a request with an empty body.
      * 
      * @param context The vert.x test context.
      */
     @Test
-    public void testAddTenantFailsForEmptyBody(final TestContext context) {
+    public void testAddTenantSucceedsForEmptyBody(final TestContext context) {
 
-        registry.addTenant(tenantId, null, "application/json", HttpURLConnection.HTTP_BAD_REQUEST).setHandler(context.asyncAssertSuccess());
+        registry.addTenant(tenantId, null, HttpURLConnection.HTTP_CREATED).setHandler(context.asyncAssertSuccess());
     }
 
     /**


### PR DESCRIPTION
this fixes https://github.com/eclipse/hono/issues/1370