### PR TITLE
[#896] Implement trace sampling mode option in HTTP adapter

### DIFF
--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -226,6 +226,9 @@ public class VertxBasedHttpProtocolAdapterTest {
         doAnswer(invocation -> {
             return Future.succeededFuture(TenantObject.from(invocation.getArgument(0), true));
         }).when(tenantClient).get(anyString(), (SpanContext) any());
+        doAnswer(invocation -> {
+            return Future.succeededFuture(TenantObject.from(invocation.getArgument(0), true));
+        }).when(tenantClient).get(anyString());
         when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
 
         final MessageConsumer commandConsumer = mock(MessageConsumer.class);

--- a/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
@@ -19,6 +19,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.qpid.proton.message.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.opentracing.References;
 import io.opentracing.Span;
@@ -97,6 +99,8 @@ public final class TracingHelper {
     private static final String JSON_KEY_SPAN_CONTEXT = "span-context";
 
     private static final String AMQP_ANNOTATION_NAME_TRACE_CONTEXT = "x-opt-trace-context";
+
+    private static final Logger LOG = LoggerFactory.getLogger(TracingHelper.class);
 
     private TracingHelper() {
         // prevent instantiation
@@ -305,11 +309,15 @@ public final class TracingHelper {
     }
 
     /**
-     * Creates a span builder that is initialized with the given operation name and a child reference to the given span
-     * context (if set).
+     * Creates a span builder that is initialized with the given operation name and a child-of reference to the given
+     * span context (if set).
+     * <p>
+     * If the given span context contains a "sampling.priority" baggage item, it is set as a tag in the returned span
+     * builder.
      *
      * @param tracer The Tracer to use.
-     * @param spanContext The span context to set as child reference (may be null).
+     * @param spanContext The span context that shall be the parent of the Span being built and that is used to derive
+     *            the sampling priority from (may be null).
      * @param operationName The operation name to set for the span
      * @return The span builder.
      * @throws NullPointerException if tracer or operationName is {@code null}.
@@ -322,9 +330,13 @@ public final class TracingHelper {
     /**
      * Creates a span builder that is initialized with the given operation name and a follows-from reference to the
      * given span context (if set).
+     * <p>
+     * If the given span context contains a "sampling.priority" baggage item, it is set as a tag in the returned span
+     * builder.
      *
      * @param tracer The Tracer to use.
-     * @param spanContext The span context to set as follows-from reference (may be null).
+     * @param spanContext The span context that the span being build shall have a follows-from reference to and that is
+     *            used to derive the sampling priority from (may be null).
      * @param operationName The operation name to set for the span
      * @return The span builder.
      * @throws NullPointerException if tracer or operationName is {@code null}.
@@ -337,9 +349,12 @@ public final class TracingHelper {
     /**
      * Creates a span builder that is initialized with the given operation name and a reference to the given span
      * context (if set).
+     * <p>
+     * If the given span context contains a "sampling.priority" baggage item, it is set as a tag in the returned span
+     * builder.
      *
      * @param tracer The Tracer to use.
-     * @param spanContext The span context to set as reference (may be null).
+     * @param spanContext The span context to set as reference and to derive the sampling priority from (may be null).
      * @param operationName The operation name to set for the span
      * @param referenceType The type of reference towards the span context.
      * @return The span builder.
@@ -352,6 +367,40 @@ public final class TracingHelper {
         Objects.requireNonNull(referenceType);
         final Tracer.SpanBuilder spanBuilder = tracer.buildSpan(operationName)
                 .addReference(referenceType, spanContext);
+        adoptSamplingPriorityFromContext(spanContext, spanBuilder);
         return spanBuilder;
+    }
+
+    /**
+     * Sets a "sampling.priority" tag and baggage item with the given samplingPriority value in the given span.
+     *
+     * @param span The span to set the tag in.
+     * @param samplingPriority The sampling priority to set.
+     * @throws NullPointerException if the given span is null.
+     */
+    public static void setTraceSamplingPriority(final Span span, final int samplingPriority) {
+        Objects.requireNonNull(span);
+        Tags.SAMPLING_PRIORITY.set(span, samplingPriority);
+        span.setBaggageItem(Tags.SAMPLING_PRIORITY.getKey(), Integer.toString(samplingPriority));
+    }
+
+    /**
+     * Gets a "sampling.priority" baggage item from the given span context (if set) and
+     * sets a corresponding tag in the given span builder.
+     *
+     * @param spanContext The span context (may be null).
+     * @param spanBuilder The span builder to set the tag in.
+     * @throws NullPointerException if the given spanBuilder is null.
+     */
+    public static void adoptSamplingPriorityFromContext(final SpanContext spanContext, final Tracer.SpanBuilder spanBuilder) {
+        Objects.requireNonNull(spanBuilder);
+        if (spanContext != null) {
+            for (Map.Entry<String, String> baggageItem : spanContext.baggageItems()) {
+                if (Tags.SAMPLING_PRIORITY.getKey().equals(baggageItem.getKey())) {
+                    spanBuilder.withTag(Tags.SAMPLING_PRIORITY.getKey(), baggageItem.getValue());
+                    break;
+                }
+            }
+        }
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.util;
 
+import java.util.Optional;
+
 /**
  * Constants &amp; utility methods used throughout the Tenant API.
  */
@@ -79,6 +81,21 @@ public final class TenantConstants extends RequestResponseApiConstants {
     public static final String FIELD_RESOURCE_LIMITS = "resource-limits";
 
     /**
+     * The name of the field that defines in how far spans created when processing
+     * messages for a tenant shall be recorded (sampled) by the tracing system.
+     * The field contains a {@link TraceSamplingMode} value.
+     */
+    public static final String FIELD_TRACE_SAMPLING_MODE = "trace-sampling-mode";
+    /**
+     * The name of the field that defines in how far spans created when processing
+     * messages for a tenant and a particular auth-id shall be recorded (sampled)
+     * by the tracing system.
+     * The field contains a JsonObject with fields having a auth-id as name and
+     * a {@link TraceSamplingMode} value.
+     */
+    public static final String FIELD_TRACE_SAMPLING_MODE_PER_AUTH_ID = "trace-sampling-mode-per-auth-id";
+
+    /**
      * Request actions that belong to the Tenant API.
      */
     public enum TenantAction {
@@ -117,6 +134,56 @@ public final class TenantConstants extends RequestResponseApiConstants {
                 }
             }
             return custom;
+        }
+    }
+
+    /**
+     * Value that defines in how far <em>OpenTracing</em> spans created when processing
+     * messages for a tenant shall be recorded (sampled) by the tracing system.
+     */
+    public enum TraceSamplingMode {
+        DEFAULT("default"),
+        ALL("all"),
+        ;
+
+        private final String fieldValue;
+
+        TraceSamplingMode(final String fieldValue) {
+            this.fieldValue = fieldValue;
+        }
+
+        /**
+         * Gets the JSON field value for this TraceSamplingMode.
+         *
+         * @return The field value.
+         */
+        public String getFieldValue() {
+            return fieldValue;
+        }
+
+        /**
+         * Construct a TraceSamplingMode from a value.
+         *
+         * @param value The value from which the TraceSamplingMode needs to be constructed.
+         * @return The TraceSamplingMode as enum, or {@link TraceSamplingMode#DEFAULT} otherwise.
+         */
+        public static TraceSamplingMode from(final String value) {
+            for (TraceSamplingMode mode : values()) {
+                if (mode.getFieldValue().equals(value)) {
+                    return mode;
+                }
+            }
+            return DEFAULT;
+        }
+
+        /**
+         * Gets the value for the <em>sampling.priority</em> span tag.
+         *
+         * @return An <em>Optional</em> containing the value for the <em>sampling.priority</em> span tag or an empty
+         *         <em>Optional</em> if no such tag should be set.
+         */
+        public Optional<Integer> toSamplingPriority() {
+            return this.equals(ALL) ? Optional.of(1) : Optional.empty();
         }
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -562,4 +562,32 @@ public final class TenantObject extends JsonBackedValueObject {
         setProperty(TenantConstants.FIELD_PAYLOAD_DEFAULTS, Objects.requireNonNull(defaultProperties));
         return this;
     }
+
+    /**
+     * Gets the value for the <em>sampling.priority</em> span tag as encoded in the properties of this tenant.
+     *
+     * @param authId The authentication identity of a device (may be null).
+     * @return An <em>Optional</em> containing the value for the <em>sampling.priority</em> span tag or an empty
+     *         <em>Optional</em> if no priority should be set.
+     */
+    @JsonIgnore
+    public Optional<Integer> getTraceSamplingPriority(final String authId) {
+        String traceSamplingMode = null;
+        if (authId != null) {
+            // check device specific setting first
+            final JsonObject traceSamplingModePerAuthId = getProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE_PER_AUTH_ID,
+                    JsonObject.class);
+            if (traceSamplingModePerAuthId != null) {
+                traceSamplingMode = traceSamplingModePerAuthId.getString(authId);
+            }
+        }
+        if (traceSamplingMode == null) {
+            // check tenant specific setting
+            traceSamplingMode = getProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE, String.class);
+        }
+        if (traceSamplingMode == null) {
+            return Optional.empty();
+        }
+        return TenantConstants.TraceSamplingMode.from(traceSamplingMode).toSamplingPriority();
+    }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.http;
+
+import io.opentracing.SpanContext;
+import io.vertx.ext.web.RoutingContext;
+import org.eclipse.hono.util.ExecutionContext;
+
+import java.util.Objects;
+
+/**
+ * Represents the context for the handling of a Vert.x HTTP request, wrapping the Vert.x {@link RoutingContext} as well
+ * as implementing the {@link ExecutionContext} interface.
+ */
+public class HttpContext implements ExecutionContext {
+
+    private final RoutingContext routingContext;
+    private SpanContext spanContext;
+
+    /**
+     * Creates a new HttpContext.
+     * 
+     * @param routingContext The RoutingContext to wrap.
+     * @throws NullPointerException if routingContext is {@code null}.
+     */
+    public HttpContext(final RoutingContext routingContext) {
+        this.routingContext = Objects.requireNonNull(routingContext);
+    }
+
+    /**
+     * Gets the wrapped RoutingContext.
+     * 
+     * @return The RoutingContext.
+     */
+    public RoutingContext getRoutingContext() {
+        return routingContext;
+    }
+
+    @Override
+    public <T> T get(final String key) {
+        return routingContext.get(key);
+    }
+
+    @Override
+    public <T> T get(final String key, final T defaultValue) {
+        final T value = routingContext.get(key);
+        return value != null ? value : defaultValue;
+    }
+
+    @Override
+    public void put(final String key, final Object value) {
+        routingContext.put(key, value);
+    }
+
+    @Override
+    public void setTracingContext(final SpanContext spanContext) {
+        this.spanContext = spanContext;
+    }
+
+    @Override
+    public SpanContext getTracingContext() {
+        return spanContext;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpContextTenantAndAuthIdProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpContextTenantAndAuthIdProvider.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.http;
+
+import java.util.Base64;
+import java.util.Objects;
+
+import javax.net.ssl.SSLSession;
+
+import org.eclipse.hono.client.TenantClientFactory;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.service.tenant.BaseExecutionContextTenantAndAuthIdProvider;
+import org.eclipse.hono.service.tenant.ExecutionContextTenantAndAuthIdProvider;
+import org.eclipse.hono.service.tenant.TenantObjectWithAuthId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Provides a method to determine the tenant and auth-id of a HTTP request from the given HttpContext.
+ */
+public class HttpContextTenantAndAuthIdProvider extends BaseExecutionContextTenantAndAuthIdProvider
+        implements ExecutionContextTenantAndAuthIdProvider<HttpContext> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpContextTenantAndAuthIdProvider.class);
+
+    private final String tenantIdContextParamName;
+    private final String deviceIdContextParamName;
+
+    /**
+     * Creates a new HttpContextTenantAndAuthIdProvider.
+     * 
+     * @param config The configuration.
+     * @param tenantClientFactory The factory to use for creating a Tenant service client.
+     * @param tenantIdContextParamName The name of the HttpContext parameter name that provides the tenant id in case of
+     *            an unauthenticated request.
+     * @param deviceIdContextParamName The name of the HttpContext parameter name that provides the device id in case of
+     *            an unauthenticated request. The device id will be used as auth-id for the created
+     *            TenantObjectWithAuthId objects.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public HttpContextTenantAndAuthIdProvider(final ProtocolAdapterProperties config,
+            final TenantClientFactory tenantClientFactory,
+            final String tenantIdContextParamName,
+            final String deviceIdContextParamName) {
+        super(config, tenantClientFactory);
+        this.tenantIdContextParamName = Objects.requireNonNull(tenantIdContextParamName);
+        this.deviceIdContextParamName = Objects.requireNonNull(deviceIdContextParamName);
+    }
+
+    @Override
+    public Future<TenantObjectWithAuthId> get(final HttpContext context, final SpanContext spanContext) {
+        if (config.isAuthenticationRequired()) {
+            return getTenantViaCert(context.getRoutingContext(), spanContext)
+                    .recover(thr -> getTenantFromAuthHeader(context.getRoutingContext(), spanContext));
+        }
+        final String tenantId = context.get(tenantIdContextParamName);
+        if (tenantId != null) {
+            // unauthenticated request
+            final String deviceId = context.get(deviceIdContextParamName);
+            return tenantClientFactory.getOrCreateTenantClient()
+                    .compose(tenantClient -> tenantClient.get(tenantId, spanContext))
+                    .map(tenantObject -> new TenantObjectWithAuthId(tenantObject, deviceId));
+        }
+        return Future.failedFuture("tenant could not be determined");
+    }
+
+    private Future<TenantObjectWithAuthId> getTenantViaCert(final RoutingContext ctx, final SpanContext spanContext) {
+        if (!ctx.request().isSSL()) {
+            return Future.failedFuture("no cert found (not SSL/TLS encrypted)");
+        }
+        final SSLSession sslSession = ctx.request().sslSession();
+        return getFromClientCertificate(sslSession, spanContext);
+    }
+
+    private Future<TenantObjectWithAuthId> getTenantFromAuthHeader(final RoutingContext ctx,
+            final SpanContext spanContext) {
+        final String authorizationHeader = ctx.request().headers().get(HttpHeaders.AUTHORIZATION);
+        if (authorizationHeader == null) {
+            return Future.failedFuture("no auth header found");
+        }
+        String userName = null;
+        try {
+            final int idx = authorizationHeader.indexOf(' ');
+            if (idx > 0 && "Basic".equalsIgnoreCase(authorizationHeader.substring(0, idx))) {
+                final String authorization = authorizationHeader.substring(idx + 1);
+                final String decoded = new String(Base64.getDecoder().decode(authorization));
+                final int colonIdx = decoded.indexOf(":");
+                userName = colonIdx != -1 ? decoded.substring(0, colonIdx) : decoded;
+            }
+        } catch (final RuntimeException e) {
+            LOG.debug("error parsing auth header: {}", e.getMessage());
+        }
+        if (userName == null) {
+            return Future.failedFuture("unsupported auth header value");
+        }
+        return getFromUserName(userName, spanContext);
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/http/TenantTraceSamplingHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/TenantTraceSamplingHandler.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.http;
+
+import java.util.Objects;
+
+import org.eclipse.hono.service.tenant.ExecutionContextTenantAndAuthIdProvider;
+import org.eclipse.hono.service.tenant.TenantTraceSamplingHelper;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.vertx.ext.web.TracingHandler;
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A handler that determines the tenant associated with a request and applies the tenant specific trace sampling
+ * configuration (if set).
+ */
+public class TenantTraceSamplingHandler implements Handler<RoutingContext> {
+
+    private final ExecutionContextTenantAndAuthIdProvider<HttpContext> tenantObjectWithAuthIdProvider;
+
+    /**
+     * Creates a new Handler for the given config and tenantClientFactory.
+     *
+     * @param tenantObjectWithAuthIdProvider Provides the tenant from the HttpContext.
+     * @throws NullPointerException if tenantObjectWithAuthIdProvider is {@code null}.
+     */
+    public TenantTraceSamplingHandler(final ExecutionContextTenantAndAuthIdProvider<HttpContext> tenantObjectWithAuthIdProvider) {
+        this.tenantObjectWithAuthIdProvider = Objects.requireNonNull(tenantObjectWithAuthIdProvider);
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        if (ctx.failed()) {
+            ctx.next();
+            return;
+        }
+        final Span span = getTracingHandlerServerSpan(ctx);
+        tenantObjectWithAuthIdProvider.get(new HttpContext(ctx), span.context())
+                .compose(tenantObjectWithAuthId -> {
+                    TenantTraceSamplingHelper.applyTraceSamplingPriority(tenantObjectWithAuthId, span);
+                    return Future.succeededFuture(tenantObjectWithAuthId);
+                })
+                .setHandler(ar -> ctx.next());
+    }
+
+    private Span getTracingHandlerServerSpan(final RoutingContext ctx) {
+        final Object spanObject = ctx.get(TracingHandler.CURRENT_SPAN);
+        return spanObject instanceof Span ? (Span) spanObject : NoopSpan.INSTANCE;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseExecutionContextTenantAndAuthIdProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseExecutionContextTenantAndAuthIdProvider.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.tenant;
+
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.hono.client.TenantClientFactory;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+
+/**
+ * A base class for {@link ExecutionContextTenantAndAuthIdProvider} implementations.
+ */
+public class BaseExecutionContextTenantAndAuthIdProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseExecutionContextTenantAndAuthIdProvider.class);
+
+    protected final ProtocolAdapterProperties config;
+    protected final TenantClientFactory tenantClientFactory;
+
+    /**
+     * Creates a new BaseExecutionContextTenantAndAuthIdProvider for the given config and tenantClientFactory.
+     *
+     * @param config The configuration.
+     * @param tenantClientFactory The factory to use for creating a Tenant service client.
+     * @throws NullPointerException if either of the parameters is {@code null}.
+     */
+    public BaseExecutionContextTenantAndAuthIdProvider(final ProtocolAdapterProperties config,
+            final TenantClientFactory tenantClientFactory) {
+        this.config = Objects.requireNonNull(config);
+        this.tenantClientFactory = Objects.requireNonNull(tenantClientFactory);
+    }
+
+    /**
+     * Gets a {@link TenantObjectWithAuthId} from the X509 certificate of the given {@link SSLSession}.
+     *
+     * @param sslSession The SSL session.
+     * @param spanContext The OpenTracing context to use for tracking the operation (may be {@code null}).
+     * @return A future indicating the outcome of the operation.
+     * @throws NullPointerException if sslSession is {@code null}.
+     */
+    protected Future<TenantObjectWithAuthId> getFromClientCertificate(final SSLSession sslSession,
+            final SpanContext spanContext) {
+        Objects.requireNonNull(sslSession);
+        final X509Certificate deviceCert = getX509Cert(sslSession);
+        if (deviceCert == null) {
+            return Future.failedFuture("no cert found");
+        }
+        final X500Principal x500Principal = deviceCert.getIssuerX500Principal();
+        final String subjectDnAuthId = deviceCert.getSubjectX500Principal().getName();
+        return get(x500Principal, subjectDnAuthId, spanContext);
+    }
+
+    private X509Certificate getX509Cert(final SSLSession sslSession) {
+        try {
+            final Certificate[] path = sslSession.getPeerCertificates();
+            if (path.length > 0 && path[0] instanceof X509Certificate) {
+                return (X509Certificate) path[0];
+            }
+        } catch (final SSLPeerUnverifiedException e) {
+            LOG.debug("certificate chain cannot be read: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Gets a {@link TenantObjectWithAuthId} from the given username.
+     * <p>
+     * If Hono is configured for single tenant mode, the returned tenant is {@link Constants#DEFAULT_TENANT} and
+     * <em>authId</em> is set to the given username.
+     * <p>
+     * If Hono is configured for multi tenant mode, the given username is split in two around the first occurrence of
+     * the <code>&#64;</code> sign. <em>authId</em> is then set to the first part and the tenant id is derived from the
+     * second part.
+     *
+     * @param userName The user name.
+     * @param spanContext The OpenTracing context to use for tracking the operation.
+     * @return A future indicating the outcome of the operation.
+     */
+    protected Future<TenantObjectWithAuthId> getFromUserName(final String userName, final SpanContext spanContext) {
+        if (userName == null) {
+            return Future.failedFuture("user name not set");
+        }
+        final String tenantId;
+        final String authId;
+        if (config.isSingleTenant()) {
+            tenantId = Constants.DEFAULT_TENANT;
+            authId = userName;
+        } else {
+            // userName is <authId>@<tenantId>
+            final String[] userComponents = userName.split("@", 2);
+            if (userComponents.length == 2) {
+                tenantId = userComponents[1];
+                authId = userComponents[0];
+            } else {
+                tenantId = null;
+                authId = null;
+            }
+        }
+        if (tenantId == null) {
+            return Future.failedFuture("unsupported user name format");
+        }
+        return get(tenantId, authId, spanContext);
+    }
+
+    private Future<TenantObjectWithAuthId> get(final X500Principal x500Principal,
+            final String subjectDnAuthId, final SpanContext spanContext) {
+        return tenantClientFactory.getOrCreateTenantClient()
+                .compose(tenantClient -> tenantClient.get(x500Principal, spanContext))
+                .map(tenantObject -> new TenantObjectWithAuthId(tenantObject, subjectDnAuthId));
+    }
+
+    private Future<TenantObjectWithAuthId> get(final String tenantId, final String authId,
+            final SpanContext spanContext) {
+        return tenantClientFactory.getOrCreateTenantClient()
+                .compose(tenantClient -> tenantClient.get(tenantId, spanContext))
+                .map(tenantObject -> new TenantObjectWithAuthId(tenantObject, authId));
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/ExecutionContextTenantAndAuthIdProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/ExecutionContextTenantAndAuthIdProvider.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.tenant;
+
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.util.ExecutionContext;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+
+/**
+ * Provides a method to determine the tenant and auth-id of a protocol adapter request from the given ExecutionContext.
+ *
+ * @param <T> The type of ExecutionContext used.
+ */
+public interface ExecutionContextTenantAndAuthIdProvider<T extends ExecutionContext> {
+
+    /**
+     * Get the tenant and auth-id from the given ExecutionContext.
+     *
+     * @param context The execution context.
+     * @param spanContext The OpenTracing context to use for tracking the operation (may be {@code null}).
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will fail if tenant and auth-id information could not be retrieved from the ExecutionContext
+     *         or if there was an error obtaining the tenant object. In the latter case the future will be failed with a
+     *         {@link ServiceInvocationException}.
+     *         <p>
+     *         Otherwise the future will contain the created <em>TenantObjectWithAuthId</em>.
+     */
+    Future<TenantObjectWithAuthId> get(T context, SpanContext spanContext);
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantObjectWithAuthId.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantObjectWithAuthId.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.tenant;
+
+import java.util.Objects;
+
+import org.eclipse.hono.util.TenantObject;
+
+/**
+ * Class that keeps a TenantObject and an auth-id.
+ */
+public final class TenantObjectWithAuthId {
+
+    private final TenantObject tenantObject;
+    private final String authId;
+
+    /**
+     * Creates a new TenantObjectWithAuthId.
+     *
+     * @param tenantObject The tenant object.
+     * @param authId The identity a device wants to authenticate as. May also be the device id if no authentication is
+     *            used.
+     * @throws NullPointerException if tenantObject or authId is {@code null}.
+     */
+    public TenantObjectWithAuthId(final TenantObject tenantObject, final String authId) {
+        this.tenantObject = Objects.requireNonNull(tenantObject);
+        this.authId = Objects.requireNonNull(authId);
+    }
+
+    /**
+     * Gets the tenant object.
+     *
+     * @return The tenant object.
+     */
+    public TenantObject getTenantObject() {
+        return tenantObject;
+    }
+
+    /**
+     * Gets the identity that a device wants to authenticate as.
+     * <p>
+     * If no authentication is used, the device id is returned here.
+     *
+     * @return The authentication id or device id.
+     */
+    public String getAuthId() {
+        return authId;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantTraceSamplingHelper.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantTraceSamplingHelper.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.tenant;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+
+/**
+ * A helper class for applying the tenant specific trace sampling
+ * configuration.
+ */
+public final class TenantTraceSamplingHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TenantTraceSamplingHelper.class);
+
+    private TenantTraceSamplingHelper() {
+        // prevent instantiation
+    }
+
+    /**
+     * Applies the trace sampling priority configured for the given tenant to the given span.
+     *
+     * @param tenantObjectWithAuthId The tenant object combined with an auth-id.
+     * @param span The span to apply the configuration to.
+     * @return An <em>Optional</em> containing the applied sampling priority or an empty
+     *         <em>Optional</em> if no priority was applied.
+     * @throws NullPointerException if either of the parameters is {@code null}.
+     */
+    public static Optional<Integer> applyTraceSamplingPriority(
+            final TenantObjectWithAuthId tenantObjectWithAuthId, final Span span) {
+        Objects.requireNonNull(tenantObjectWithAuthId);
+        Objects.requireNonNull(span);
+        final Optional<Integer> traceSamplingPriority = tenantObjectWithAuthId.getTenantObject()
+                .getTraceSamplingPriority(tenantObjectWithAuthId.getAuthId());
+        traceSamplingPriority.ifPresent(prio -> {
+            LOG.trace("setting trace sampling prio to {} for tenant [{}], auth-id [{}]", prio,
+                    tenantObjectWithAuthId.getTenantObject().getTenantId(), tenantObjectWithAuthId.getAuthId());
+            TracingHelper.setTraceSamplingPriority(span, prio);
+        });
+        return traceSamplingPriority;
+    }
+}

--- a/service-base/src/test/java/org/eclipse/hono/service/http/TenantTraceSamplingHandlerTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/http/TenantTraceSamplingHandlerTest.java
@@ -1,0 +1,526 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.http;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.Period;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.TenantClient;
+import org.eclipse.hono.client.TenantClientFactory;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantConstants.TraceSamplingMode;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.contrib.vertx.ext.web.TracingHandler;
+import io.opentracing.tag.Tags;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Tests verifying behavior of {@link TenantTraceSamplingHandler}.
+ */
+public class TenantTraceSamplingHandlerTest {
+
+    private static final String PARAM_TENANT = "tenant";
+    private static final String PARAM_DEVICE_ID = "device_id";
+
+    private TenantClient tenantClient;
+    private ProtocolAdapterProperties config;
+    private Span span;
+    private RoutingContext ctx;
+    private Map<String, Object> ctxMap;
+    private TenantTraceSamplingHandler tenantTraceSamplingHandler;
+
+    /**
+     * Sets up the fixture.
+     */
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    public void setUp() {
+        tenantClient = mock(TenantClient.class);
+        doAnswer(invocation -> {
+            return Future.succeededFuture(TenantObject.from(invocation.getArgument(0), true));
+        }).when(tenantClient).get(anyString(), any(SpanContext.class));
+
+        final TenantClientFactory tenantClientFactory = mock(TenantClientFactory.class);
+        when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+        doAnswer(invocation -> {
+            final Handler<AsyncResult<Void>> shutdownHandler = invocation.getArgument(0);
+            shutdownHandler.handle(Future.succeededFuture());
+            return null;
+        }).when(tenantClientFactory).disconnect(any(Handler.class));
+        when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
+
+        config = new ProtocolAdapterProperties();
+        config.setSingleTenant(false);
+
+        span = mock(Span.class);
+        final SpanContext spanContext = mock(SpanContext.class);
+        when(span.context()).thenReturn(spanContext);
+
+        ctxMap = new HashMap<>();
+        ctxMap.put(TracingHandler.CURRENT_SPAN, span);
+
+        ctx = mock(RoutingContext.class);
+        when(ctx.get(anyString())).thenAnswer(invocation -> {
+            return ctxMap.get(invocation.getArgument(0));
+        });
+
+        final HttpContextTenantAndAuthIdProvider tenantAndAuthIdProvider = new HttpContextTenantAndAuthIdProvider(
+                config, tenantClientFactory, PARAM_TENANT, PARAM_DEVICE_ID);
+        tenantTraceSamplingHandler = new TenantTraceSamplingHandler(tenantAndAuthIdProvider);
+    }
+
+    /**
+     * Verifies that the handler sets the appropriate span tag for a request for a tenant with 'trace-sampling-mode' set
+     * to 'all'.
+     */
+    @Test
+    public void testHandleSetsSamplingPriorityForMatchingTenant() {
+        // GIVEN a tenant where 'trace-sampling-mode' is set to 'all'
+        final String tenantId = "testTenant";
+        final String authId = "testAuthId";
+
+        final TenantObject testTenant = TenantObject.from(tenantId, true);
+        testTenant.setProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE, TraceSamplingMode.ALL.getFieldValue());
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(testTenant));
+
+        // WHEN handling a request with basic auth for that tenant
+        setupBasicAuthHttpServerRequest(tenantId, authId);
+        tenantTraceSamplingHandler.handle(ctx);
+
+        // THEN the 'sampling.priority' priority was set on the span
+        verify(span).setTag(eq(Tags.SAMPLING_PRIORITY.getKey()), eq(1));
+        verify(ctx).next();
+    }
+
+    /**
+     * Verifies that the handler sets the appropriate span tag for a request with a device auth id for which the trace
+     * sampling mode is set to 'all'.
+     */
+    @Test
+    public void testHandleSetsSamplingPriorityForMatchingAuthId() {
+        // GIVEN a tenant and auth-id for which 'trace-sampling-mode-per-device' is set to 'all'
+        final String tenantId = "testTenant";
+        final String authId = "testAuthId";
+
+        final TenantObject testTenant = TenantObject.from(tenantId, true);
+        final JsonObject samplingModePerAuthId = new JsonObject();
+        samplingModePerAuthId.put(authId, TraceSamplingMode.ALL.getFieldValue());
+        testTenant.setProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE_PER_AUTH_ID, samplingModePerAuthId);
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(testTenant));
+
+        // WHEN handling a request with basic auth for that tenant
+        setupBasicAuthHttpServerRequest(tenantId, authId);
+        tenantTraceSamplingHandler.handle(ctx);
+
+        // THEN the 'sampling.priority' priority was set on the span
+        verify(span).setTag(eq(Tags.SAMPLING_PRIORITY.getKey()), eq(1));
+        verify(ctx).next();
+    }
+
+    /**
+     * Verifies that the handler sets the appropriate span tag for a request with a device auth id for which the trace
+     * sampling mode is set to 'all', the server being configured for single tenant use.
+     */
+    @Test
+    public void testHandleSetsSamplingPriorityForMatchingAuthIdInSingleTenantMode() {
+        // GIVEN a tenant and auth-id for which 'trace-sampling-mode-per-device' is set to 'all'
+        // and a configuration where singleTenant is true.
+        final String tenantId = Constants.DEFAULT_TENANT;
+        final String authId = "testAuthId";
+
+        final TenantObject testTenant = TenantObject.from(tenantId, true);
+        final JsonObject samplingModePerAuthId = new JsonObject();
+        samplingModePerAuthId.put(authId, TraceSamplingMode.ALL.getFieldValue());
+        testTenant.setProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE_PER_AUTH_ID, samplingModePerAuthId);
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(testTenant));
+        config.setSingleTenant(true);
+
+        // WHEN handling a request with basic auth for that tenant
+        setupBasicAuthHttpServerRequest(authId);
+        tenantTraceSamplingHandler.handle(ctx);
+
+        // THEN the 'sampling.priority' priority was set on the span
+        verify(span).setTag(eq(Tags.SAMPLING_PRIORITY.getKey()), eq(1));
+        verify(ctx).next();
+    }
+
+    /**
+     * Verifies that the handler does nothing for a request with a device auth id for which the trace sampling mode is
+     * set to 'default'.
+     */
+    @Test
+    public void testHandleRespectsOverrideForAuthId() {
+        // GIVEN a tenant and auth-id where 'trace-sampling-mode' is set to 'all'
+        // and 'trace-sampling-mode-per-device' is set to 'default'
+        final String tenantId = "testTenant";
+        final String authId = "testAuthId";
+
+        final TenantObject testTenant = TenantObject.from(tenantId, true);
+        testTenant.setProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE, TraceSamplingMode.ALL.getFieldValue());
+        final JsonObject samplingModePerAuthId = new JsonObject();
+        samplingModePerAuthId.put(authId, TraceSamplingMode.DEFAULT.getFieldValue());
+        testTenant.setProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE_PER_AUTH_ID, samplingModePerAuthId);
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(testTenant));
+
+        // WHEN handling a request with basic auth for that tenant
+        setupBasicAuthHttpServerRequest(tenantId, authId);
+        tenantTraceSamplingHandler.handle(ctx);
+
+        // THEN the 'sampling.priority' priority was set on the span
+        verify(span, never()).setTag(eq(Tags.SAMPLING_PRIORITY.getKey()), anyInt());
+        verify(ctx).next();
+    }
+
+    private void setupBasicAuthHttpServerRequest(final String tenantId, final String authId) {
+        setupBasicAuthHttpServerRequest(authId + "@" + tenantId);
+    }
+
+    private void setupBasicAuthHttpServerRequest(final String userName) {
+        final String authorization = "BASIC " +
+                Base64.getEncoder().encodeToString((userName + ":password").getBytes(StandardCharsets.UTF_8));
+        final MultiMap headers = mock(MultiMap.class);
+        when(headers.get(eq(HttpHeaders.AUTHORIZATION))).thenReturn(authorization);
+        final HttpServerRequest req = mock(HttpServerRequest.class);
+        when(req.headers()).thenReturn(headers);
+        when(ctx.request()).thenReturn(req);
+    }
+
+    /**
+     * Verifies that the handler sets the appropriate span tag for an unauthenticated request with tenant and device
+     * parameters where the tenant is configured with 'trace-sampling-mode' set to 'all'.
+     */
+    @Test
+    public void testHandleSetsSamplingPriorityForGivenTenantParam() {
+        // GIVEN a tenant where 'trace-sampling-mode' is set to 'all'
+        final String tenantId = "testTenant";
+        final String authId = "testAuthId";
+        ctxMap.put(PARAM_TENANT, tenantId);
+        ctxMap.put(PARAM_DEVICE_ID, authId);
+
+        final TenantObject testTenant = TenantObject.from(tenantId, true);
+        testTenant.setProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE, TraceSamplingMode.ALL.getFieldValue());
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(testTenant));
+
+        // WHEN handling an unauthenticated request for that tenant
+        config.setAuthenticationRequired(false);
+        setupNonSslHttpRequest();
+        tenantTraceSamplingHandler.handle(ctx);
+
+        // THEN the 'sampling.priority' priority was set on the span
+        verify(span).setTag(eq(Tags.SAMPLING_PRIORITY.getKey()), eq(1));
+        verify(ctx).next();
+    }
+
+    /**
+     * Verifies that the handler sets the appropriate span tag for an unauthenticated request with tenant and device
+     * parameters where the device auth id is configured in the tenant config with a trace sampling mode set to 'all'.
+     */
+    @Test
+    public void testHandleSetsSamplingPriorityForGivenDeviceParam() {
+        // GIVEN a tenant and device auth-id for which 'trace-sampling-mode-per-device' is set to 'all'
+        final String tenantId = "testTenant";
+        final String authId = "testAuthId";
+        ctxMap.put(PARAM_TENANT, tenantId);
+        ctxMap.put(PARAM_DEVICE_ID, authId);
+
+        final TenantObject testTenant = TenantObject.from(tenantId, true);
+        final JsonObject samplingModePerAuthId = new JsonObject();
+        samplingModePerAuthId.put(authId, TraceSamplingMode.ALL.getFieldValue());
+        testTenant.setProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE_PER_AUTH_ID, samplingModePerAuthId);
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(testTenant));
+
+        // WHEN handling an unauthenticated request for that tenant
+        config.setAuthenticationRequired(false);
+        setupNonSslHttpRequest();
+        tenantTraceSamplingHandler.handle(ctx);
+
+        // THEN the 'sampling.priority' priority was set on the span
+        verify(span).setTag(eq(Tags.SAMPLING_PRIORITY.getKey()), eq(1));
+        verify(ctx).next();
+    }
+
+    private void setupNonSslHttpRequest() {
+        final HttpServerRequest req = mock(HttpServerRequest.class);
+        when(req.isSSL()).thenReturn(false);
+        when(ctx.request()).thenReturn(req);
+    }
+
+    /**
+     * Verifies that the handler sets the appropriate span tag for a request with a certificate mapped to a tenant that
+     * has trace sampling mode set to 'all'.
+     *
+     * @throws SSLPeerUnverifiedException if the client certificate cannot be validated.
+     */
+    @Test
+    public void testHandleSetsSamplingPriorityForGivenCert() throws SSLPeerUnverifiedException {
+        // GIVEN a tenant where 'trace-sampling-mode' is set to 'all'
+        final String tenantId = "testTenant";
+        final TenantObject testTenant = TenantObject.from(tenantId, true);
+        testTenant.setProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE, TraceSamplingMode.ALL.getFieldValue());
+        doAnswer(invocation -> {
+            if (!invocation.getArgument(0).toString().equals("CN=" + tenantId)) {
+                return Future.failedFuture("tenant not found");
+            }
+            return Future.succeededFuture(testTenant);
+        }).when(tenantClient).get(any(X500Principal.class), any(SpanContext.class));
+
+        // WHEN trying to authenticate a request that contains a client certificate associated with that tenant
+        setupClientCertHttpRequest(tenantId, "CN=device");
+        tenantTraceSamplingHandler.handle(ctx);
+
+        // THEN the 'sampling.priority' priority was set on the span
+        verify(span).setTag(eq(Tags.SAMPLING_PRIORITY.getKey()), eq(1));
+        verify(ctx).next();
+    }
+
+    /**
+     * Verifies that the handler sets the appropriate span tag for a request with a certificate where the mapped tenant
+     * has a trace sampling mode 'all' configured for the cert subject-dn as auth-id.
+     *
+     * @throws SSLPeerUnverifiedException if the client certificate cannot be validated.
+     */
+    @Test
+    public void testHandleSetsSamplingPriorityForGivenCertUsingSubjectDn() throws SSLPeerUnverifiedException {
+        // GIVEN a tenant and auth-id for which 'trace-sampling-mode-per-device' is set to 'all'
+        final String tenantId = "testTenant";
+        final String subjectDnAuthId = "CN=Device 4711,OU=Hono,O=Eclipse IoT,L=Ottawa,C=CA";
+        final TenantObject testTenant = TenantObject.from(tenantId, true);
+        final JsonObject samplingModePerAuthId = new JsonObject();
+        samplingModePerAuthId.put(subjectDnAuthId, TraceSamplingMode.ALL.getFieldValue());
+        testTenant.setProperty(TenantConstants.FIELD_TRACE_SAMPLING_MODE_PER_AUTH_ID, samplingModePerAuthId);
+        doAnswer(invocation -> {
+            if (!invocation.getArgument(0).toString().equals("CN=" + tenantId)) {
+                return Future.failedFuture("tenant not found");
+            }
+            return Future.succeededFuture(testTenant);
+        }).when(tenantClient).get(any(X500Principal.class), any(SpanContext.class));
+
+        // WHEN trying to authenticate a request that contains a client certificate associated with that tenant and the auth-id
+        setupClientCertHttpRequest(tenantId, subjectDnAuthId);
+        tenantTraceSamplingHandler.handle(ctx);
+
+        // THEN the 'sampling.priority' priority was set on the span
+        verify(span).setTag(eq(Tags.SAMPLING_PRIORITY.getKey()), eq(1));
+        verify(ctx).next();
+    }
+
+    private void setupClientCertHttpRequest(final String tenantId, final String subjectDnAuthId) throws SSLPeerUnverifiedException {
+        final EmptyCertificate clientCert = new EmptyCertificate(subjectDnAuthId, "CN=" + tenantId);
+        final SSLSession sslSession = mock(SSLSession.class);
+        when(sslSession.getPeerCertificates()).thenReturn(new X509Certificate[]{clientCert});
+        final HttpServerRequest req = mock(HttpServerRequest.class);
+        when(req.isSSL()).thenReturn(true);
+        when(req.sslSession()).thenReturn(sslSession);
+        when(ctx.request()).thenReturn(req);
+    }
+
+    /**
+     * An X.509 certificate which contains a subject and issuer only.
+     */
+    private static class EmptyCertificate extends X509Certificate {
+
+        private final X500Principal subject;
+        private final X500Principal issuer;
+
+        /**
+         * Creates a new certificate.
+         *
+         * @param subject The subject.
+         * @param issuer The issuer of the certificate.
+         */
+        EmptyCertificate(final String subject, final String issuer) {
+            this.subject = new X500Principal(subject);
+            this.issuer = new X500Principal(issuer);
+        }
+
+        @Override
+        public boolean hasUnsupportedCriticalExtension() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getCriticalExtensionOIDs() {
+            return null;
+        }
+
+        @Override
+        public Set<String> getNonCriticalExtensionOIDs() {
+            return null;
+        }
+
+        @Override
+        public byte[] getExtensionValue(final String oid) {
+            return null;
+        }
+
+        @Override
+        public void checkValidity() throws java.security.cert.CertificateExpiredException,
+                java.security.cert.CertificateNotYetValidException {
+        }
+
+        @Override
+        public void checkValidity(final Date date) throws java.security.cert.CertificateExpiredException,
+                java.security.cert.CertificateNotYetValidException {
+        }
+
+        @Override
+        public int getVersion() {
+            return 0;
+        }
+
+        @Override
+        public BigInteger getSerialNumber() {
+            return null;
+        }
+
+        @Override
+        public Principal getIssuerDN() {
+            return issuer;
+        }
+
+        @Override
+        public X500Principal getIssuerX500Principal() {
+            return issuer;
+        }
+
+        @Override
+        public Principal getSubjectDN() {
+            return subject;
+        }
+
+        @Override
+        public X500Principal getSubjectX500Principal() {
+            return subject;
+        }
+
+        @Override
+        public Date getNotBefore() {
+            return Date.from(Instant.now().minus(Period.ofDays(1)));
+        }
+
+        @Override
+        public Date getNotAfter() {
+            return Date.from(Instant.now().plus(Period.ofDays(1)));
+        }
+
+        @Override
+        public byte[] getTBSCertificate() throws java.security.cert.CertificateEncodingException {
+            return null;
+        }
+
+        @Override
+        public byte[] getSignature() {
+            return null;
+        }
+
+        @Override
+        public String getSigAlgName() {
+            return null;
+        }
+
+        @Override
+        public String getSigAlgOID() {
+            return null;
+        }
+
+        @Override
+        public byte[] getSigAlgParams() {
+            return null;
+        }
+
+        @Override
+        public boolean[] getIssuerUniqueID() {
+            return null;
+        }
+
+        @Override
+        public boolean[] getSubjectUniqueID() {
+            return null;
+        }
+
+        @Override
+        public boolean[] getKeyUsage() {
+            return null;
+        }
+
+        @Override
+        public int getBasicConstraints() {
+            return 0;
+        }
+
+        @Override
+        public byte[] getEncoded() throws java.security.cert.CertificateEncodingException {
+            return null;
+        }
+
+        @Override
+        public void verify(final PublicKey key)
+                throws java.security.cert.CertificateException, NoSuchAlgorithmException,
+                InvalidKeyException, NoSuchProviderException, SignatureException {
+        }
+
+        @Override
+        public void verify(final PublicKey key, final String sigProvider)
+                throws java.security.cert.CertificateException,
+                NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
+        }
+
+        @Override
+        public String toString() {
+            return null;
+        }
+
+        @Override
+        public PublicKey getPublicKey() {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
Fix for #896. 

This introduces config options to enable forced sampling of traces (i.e. recording of traces in the tracing backend) for a specific tenant or device.

**Per tenant:**
In the Json structure returned by the Tenant API, a field `trace-sampling-mode` can be set with a value of "all" (meaning sampling of all traces is enforced) or "default".
````
  {
    "tenant-id": "DEFAULT_TENANT",
    "enabled": true,
    "trace-sampling-mode": "all"
  }
````

**Per device (auth id):**
In the Json structure returned by the Tenant API, a field `trace-sampling-mode-per-auth-id` can be set with a map value where a field with a device auth id as name and a value of "all" (meaning sampling of all traces is enforced) or "default" is set.
````
  {
    "tenant-id": "DEFAULT_TENANT",
    "enabled": true,
    "trace-sampling-mode-per-auth-id": {
      "4711": "all"
    }
  }
````