### PR TITLE
Update OpenAPI definition of Tenant and Device

### DIFF
--- a/site/documentation/static/latest/api/device-registry-v1.yaml
+++ b/site/documentation/static/latest/api/device-registry-v1.yaml
@@ -440,10 +440,15 @@ components:
       Tenant:
          type: object
          additionalProperties: false
+         required:
+            - tenant-id
+            - enabled
          properties:
             "enabled":
                type: boolean
                default: true
+            "tenant-id":
+               type: string
             "ext":
                $ref: '#/components/schemas/Extensions'
             "adapters":
@@ -534,7 +539,11 @@ components:
       Device:
          type: object
          additionalProperties: false
+         required:
+            - device-id 
          properties:
+            "device-id":
+               type: string
             "enabled":
                type: boolean
                default: true


### PR DESCRIPTION
Since the definition at https://www.eclipse.org/hono/docs/api/tenant-api/ defines tenant-id and device-id as parts of the respective devices, I added them. I also made properties required, as defined there.