### PR TITLE
Update Openapi Definition for tenant and device

### DIFF
--- a/site/documentation/static/latest/api/device-registry-v1.yaml
+++ b/site/documentation/static/latest/api/device-registry-v1.yaml
@@ -440,7 +440,12 @@ components:
       Tenant:
          type: object
          additionalProperties: false
+         required:
+            - tenant-id
+            - enabled
          properties:
+            "tenant-id":
+               type: string
             "enabled":
                type: boolean
                default: true
@@ -534,7 +539,11 @@ components:
       Device:
          type: object
          additionalProperties: false
+         required:
+            - device-id 
          properties:
+            "device-id":
+               type: string
             "enabled":
                type: boolean
                default: true


### PR DESCRIPTION
I updated the tenant and device objects in the openapi definition, to include their respective id's. I also added "required" according to https://www.eclipse.org/hono/docs/api/tenant-api/.

Signed-off-by: wistefan <wistefan@googlemail.com>
