### PR TITLE
Add missing properties to copy constructor of ClientConfigProperties

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/ClientConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ClientConfigProperties.java
@@ -121,6 +121,9 @@ public class ClientConfigProperties extends AbstractConfig {
         this.password = otherProperties.password;
         this.port = otherProperties.port;
         this.reconnectAttempts = otherProperties.reconnectAttempts;
+        this.reconnectMinDelayMillis = otherProperties.reconnectMinDelayMillis;
+        this.reconnectMaxDelayMillis = otherProperties.reconnectMaxDelayMillis;
+        this.reconnectDelayIncrementMillis = otherProperties.reconnectDelayIncrementMillis;
         this.requestTimeoutMillis = otherProperties.requestTimeoutMillis;
         this.sendMessageTimeoutMillis = otherProperties.sendMessageTimeoutMillis;
         this.tlsEnabled = otherProperties.tlsEnabled;


### PR DESCRIPTION
Seems to me like it had been forgotten to add the new properties to the copy constructor.