### PR TITLE
[#1337] Message limit checks now also supports monthly calculation.

### DIFF
--- a/service-base/src/test/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecksTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecksTest.java
@@ -275,7 +275,12 @@ public class PrometheusBasedResourceLimitChecksTest {
                 .setHandler(ctx.succeeding(response -> {
                     ctx.verify(() -> {
                         verify(webClient).get(eq(DEFAULT_PORT), eq(DEFAULT_HOST), anyString());
-                        verify(cacheProvider.getCache(any())).put(any(), any(), any(Duration.class));
+                        verify(cacheProvider.getCache(any())).put(eq("tenant_bytes_consumed"), any(),
+                                any(Duration.class));
+                        verify(cacheProvider.getCache(any())).put(eq("tenant_allowed_max_bytes"), any(),
+                                any(Duration.class));
+                        verify(cacheProvider.getCache(any())).put(eq("tenant_data_usage_period"), any(),
+                                any(Duration.class));
                     });
                     ctx.completeNow();
                 }));


### PR DESCRIPTION
This PR implements #1337. 

With this PR,  Hono now also supports _monthly_ mode of calculation. In the _monthly_ mode, the data usage is calculated from the beginning till the end of the current calendar month and compared with the limits already set using the `max-bytes` parameter. There is an exception to this calculation in the first month on which this limit becomes effective. In this case, the `max-bytes` value is recalculated based on the remaining days in the month from the `effective-since` date. The data usage for these remaining days is compared with the above recalculated value.

Below configurations illustrate how the `mode` can be set to _monthly_ or _days_.

```
"data-volume": {
        "max-bytes": 2147483648,
        "period": {
          "mode": "monthly",
        },
        "effective-since": "2019-07-27T14:30Z"
      }
```

```
"data-volume": {
        "max-bytes": 2147483648,
        "period": {
          "mode": "days",
          "no-of-days": 30
        },
        "effective-since": "2019-07-27T14:30Z"
      }
```