### PR TITLE
Drop the unnecessary type argument to event bus classes

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/ConfigurationSupportingVerticle.java
+++ b/core/src/main/java/org/eclipse/hono/util/ConfigurationSupportingVerticle.java
@@ -44,7 +44,7 @@ public abstract class ConfigurationSupportingVerticle<T> extends AbstractVerticl
      * object.
      * <p>
      * This method mainly exists so that subclasses can annotate its concrete implementation
-     * with Spring annotations like @c{@code Autowired} and/or {@code Qualifier} to get injected
+     * with Spring annotations like {@code Autowired} and/or {@code Qualifier} to get injected
      * a particular bean instance.
      * 
      * @param configuration The configuration properties.

--- a/service-base/src/main/java/org/eclipse/hono/service/EventBusService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/EventBusService.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.tracing.TracingHelper;
-import org.eclipse.hono.util.ConfigurationSupportingVerticle;
 import org.eclipse.hono.util.EventBusMessage;
 import org.eclipse.hono.util.RequestResponseApiConstants;
 import org.slf4j.Logger;
@@ -30,6 +29,7 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.opentracing.tag.Tags;
+import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
@@ -40,10 +40,8 @@ import io.vertx.core.json.JsonObject;
  * <p>
  * In particular, this base class provides support for receiving request messages via vert.x' event bus
  * and route them to specific methods corresponding to the operation indicated in the message.
- *
- * @param <C> The type of configuration this service supports.
  */
-public abstract class EventBusService<C> extends ConfigurationSupportingVerticle<C> {
+public abstract class EventBusService extends AbstractVerticle {
 
     /**
      * A logger to be shared by subclasses.

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/BaseCredentialsService.java
@@ -35,8 +35,10 @@ import io.vertx.core.json.JsonObject;
  * @deprecated - Use {@link CredentialsService} and {@link org.eclipse.hono.service.management.credentials.CredentialsManagementService} instead.
  */
 @Deprecated
-public abstract class BaseCredentialsService<T> extends EventBusCredentialsAdapter<T>
+public abstract class BaseCredentialsService<T> extends EventBusCredentialsAdapter
         implements CredentialsService {
+
+    private T config;
 
     @Override
     protected CredentialsService getService() {
@@ -94,5 +96,36 @@ public abstract class BaseCredentialsService<T> extends EventBusCredentialsAdapt
      */
     protected void handleUnimplementedOperation(final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
         resultHandler.handle(Future.succeededFuture(CredentialsResult.from(HttpURLConnection.HTTP_NOT_IMPLEMENTED)));
+    }
+
+    /**
+     * Sets the specific object instance to use for configuring this <em>Verticle</em>.
+     * 
+     * @param props The properties.
+     */
+    protected final void setSpecificConfig(final T props) {
+        this.config = props;
+    }
+
+    /**
+     * Sets the properties to use for configuring this <em>Verticle</em>.
+     * <p>
+     * Subclasses <em>must</em> invoke {@link #setSpecificConfig(Object)} with the configuration object.
+     * <p>
+     * This method mainly exists so that subclasses can annotate its concrete implementation with Spring annotations
+     * like {@code Autowired} and/or {@code Qualifier} to get injected a particular bean instance.
+     * 
+     * @param configuration The configuration properties.
+     * @throws NullPointerException if configuration is {@code null}.
+     */
+    public abstract void setConfig(T configuration);
+
+    /**
+     * Gets the properties that this <em>Verticle</em> has been configured with.
+     * 
+     * @return The properties or {@code null} if not set.
+     */
+    public final T getConfig() {
+        return this.config;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CompleteBaseCredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CompleteBaseCredentialsService.java
@@ -39,6 +39,8 @@ public abstract class CompleteBaseCredentialsService<T> extends EventBusComplete
 
     private final HonoPasswordEncoder pwdEncoder;
 
+    private T config;
+
     /**
      * Creates a new service instance for a password encoder.
      * 
@@ -118,5 +120,36 @@ public abstract class CompleteBaseCredentialsService<T> extends EventBusComplete
     protected void handleUnimplementedOperation(
             final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
         resultHandler.handle(Future.succeededFuture(CredentialsResult.from(HttpURLConnection.HTTP_NOT_IMPLEMENTED)));
+    }
+
+    /**
+     * Sets the specific object instance to use for configuring this <em>Verticle</em>.
+     * 
+     * @param props The properties.
+     */
+    protected final void setSpecificConfig(final T props) {
+        this.config = props;
+    }
+
+    /**
+     * Sets the properties to use for configuring this <em>Verticle</em>.
+     * <p>
+     * Subclasses <em>must</em> invoke {@link #setSpecificConfig(Object)} with the configuration object.
+     * <p>
+     * This method mainly exists so that subclasses can annotate its concrete implementation with Spring annotations
+     * like {@code Autowired} and/or {@code Qualifier} to get injected a particular bean instance.
+     * 
+     * @param configuration The configuration properties.
+     * @throws NullPointerException if configuration is {@code null}.
+     */
+    public abstract void setConfig(T configuration);
+
+    /**
+     * Gets the properties that this <em>Verticle</em> has been configured with.
+     * 
+     * @return The properties or {@code null} if not set.
+     */
+    public final T getConfig() {
+        return this.config;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/EventBusCompleteCredentialsAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/EventBusCompleteCredentialsAdapter.java
@@ -41,7 +41,7 @@ import io.vertx.core.json.JsonObject;
  * @deprecated - Use {@link org.eclipse.hono.service.management.credentials.EventBusCredentialsManagementAdapter} instead.
  */
 @Deprecated
-public abstract class EventBusCompleteCredentialsAdapter<T> extends EventBusCredentialsAdapter<T> {
+public abstract class EventBusCompleteCredentialsAdapter<T> extends EventBusCredentialsAdapter {
 
     private static final int DEFAULT_MAX_BCRYPT_ITERATIONS = 10;
 

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/EventBusCredentialsAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/EventBusCredentialsAdapter.java
@@ -38,10 +38,8 @@ import io.vertx.core.json.JsonObject;
  * <p>
  * This base class provides support for receiving <em>Get</em> request messages via vert.x' event bus and routing them
  * to specific methods accepting the query parameters contained in the request message.
- *
- * @param <T> The type of configuration class this service supports.
  */
-public abstract class EventBusCredentialsAdapter<T> extends EventBusService<T> implements Verticle {
+public abstract class EventBusCredentialsAdapter extends EventBusService implements Verticle {
 
     private static final String SPAN_NAME_GET_CREDENTIALS = "get Credentials";
 

--- a/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/BaseDeviceConnectionService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/BaseDeviceConnectionService.java
@@ -36,8 +36,10 @@ import io.vertx.core.Handler;
  * @deprecated - Use {@link DeviceConnectionService} instead.
  */
 @Deprecated
-public abstract class BaseDeviceConnectionService<T> extends EventBusDeviceConnectionAdapter<T>
+public abstract class BaseDeviceConnectionService<T> extends EventBusDeviceConnectionAdapter
         implements DeviceConnectionService {
+
+    private T config;
 
     @Override
     protected DeviceConnectionService getService() {
@@ -83,5 +85,36 @@ public abstract class BaseDeviceConnectionService<T> extends EventBusDeviceConne
      */
     protected void handleUnimplementedOperation(final Handler<AsyncResult<DeviceConnectionResult>> resultHandler) {
         resultHandler.handle(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_NOT_IMPLEMENTED)));
+    }
+
+    /**
+     * Sets the specific object instance to use for configuring this <em>Verticle</em>.
+     * 
+     * @param props The properties.
+     */
+    protected final void setSpecificConfig(final T props) {
+        this.config = props;
+    }
+
+    /**
+     * Sets the properties to use for configuring this <em>Verticle</em>.
+     * <p>
+     * Subclasses <em>must</em> invoke {@link #setSpecificConfig(Object)} with the configuration object.
+     * <p>
+     * This method mainly exists so that subclasses can annotate its concrete implementation with Spring annotations
+     * like {@code Autowired} and/or {@code Qualifier} to get injected a particular bean instance.
+     * 
+     * @param configuration The configuration properties.
+     * @throws NullPointerException if configuration is {@code null}.
+     */
+    public abstract void setConfig(T configuration);
+
+    /**
+     * Gets the properties that this <em>Verticle</em> has been configured with.
+     * 
+     * @return The properties or {@code null} if not set.
+     */
+    public final T getConfig() {
+        return this.config;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/EventBusDeviceConnectionAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/EventBusDeviceConnectionAdapter.java
@@ -37,10 +37,8 @@ import io.vertx.core.Verticle;
  * This base class provides support for receiving service invocation request messages
  * via vert.x' event bus and routing them to specific methods accepting the
  * query parameters contained in the request message.
- *
- * @param <T> The type of configuration class this service supports.
  */
-public abstract class EventBusDeviceConnectionAdapter<T> extends EventBusService<T> implements Verticle {
+public abstract class EventBusDeviceConnectionAdapter extends EventBusService implements Verticle {
 
     private static final String SPAN_NAME_GET_LAST_GATEWAY = "get last known gateway";
     private static final String SPAN_NAME_SET_LAST_GATEWAY = "set last known gateway";

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/EventBusCredentialsManagementAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/EventBusCredentialsManagementAdapter.java
@@ -36,10 +36,8 @@ import io.vertx.core.json.JsonObject;
 
 /**
  * Adapter to bind {@link CredentialsManagementService} to the vertx event bus.
- *
- * @param <T> The type of configuration properties this service requires.
  */
-public abstract class EventBusCredentialsManagementAdapter<T> extends EventBusService<T>
+public abstract class EventBusCredentialsManagementAdapter extends EventBusService
         implements Verticle {
 
     private static final String SPAN_NAME_GET_CREDENTIAL = "get Credential from management API";

--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/EventBusDeviceManagementAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/EventBusDeviceManagementAdapter.java
@@ -38,10 +38,8 @@ import io.vertx.core.json.JsonObject;
  * <p>
  * In particular, this base class provides support for receiving service invocation request messages via vert.x' event
  * bus and route them to specific methods corresponding to the operation indicated in the message.
- *
- * @param <T> The type of configuration properties this service requires.
  */
-public abstract class EventBusDeviceManagementAdapter<T> extends EventBusService<T>
+public abstract class EventBusDeviceManagementAdapter extends EventBusService
         implements Verticle {
 
     private static final String SPAN_NAME_CREATE_DEVICE = "create Device from management API";

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/EventBusTenantManagementAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/EventBusTenantManagementAdapter.java
@@ -50,7 +50,7 @@ import io.vertx.core.json.JsonObject;
  *
  * @param <T> The type of configuration properties this service requires.
  */
-public abstract class EventBusTenantManagementAdapter<T> extends EventBusService<T> {
+public abstract class EventBusTenantManagementAdapter<T> extends EventBusService {
 
     private static final String SPAN_NAME_GET_TENANT = "get Tenant from management API";
     private static final String SPAN_NAME_CREATE_TENANT = "create Tenant from management API";

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/BaseRegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/BaseRegistrationService.java
@@ -40,13 +40,15 @@ import io.vertx.core.json.JsonObject;
  * @deprecated - Use {@link RegistrationService} and {@link org.eclipse.hono.service.management.device.DeviceManagementService} instead.
  */
 @Deprecated
-public abstract class BaseRegistrationService<T> extends EventBusRegistrationAdapter<T> implements RegistrationService {
+public abstract class BaseRegistrationService<T> extends EventBusRegistrationAdapter implements RegistrationService {
 
     /**
      * The default number of seconds that information returned by this service's
      * operations may be cached for.
      */
     public static final int DEFAULT_MAX_AGE_SECONDS = 300;
+
+    private T config;
 
     private final AbstractRegistrationService service = new AbstractRegistrationService() {
 
@@ -123,5 +125,36 @@ public abstract class BaseRegistrationService<T> extends EventBusRegistrationAda
             final JsonObject registrationInfo) {
 
         return service.getAssertionPayload(tenantId, deviceId, registrationInfo);
+    }
+
+    /**
+     * Sets the specific object instance to use for configuring this <em>Verticle</em>.
+     * 
+     * @param props The properties.
+     */
+    protected final void setSpecificConfig(final T props) {
+        this.config = props;
+    }
+
+    /**
+     * Sets the properties to use for configuring this <em>Verticle</em>.
+     * <p>
+     * Subclasses <em>must</em> invoke {@link #setSpecificConfig(Object)} with the configuration object.
+     * <p>
+     * This method mainly exists so that subclasses can annotate its concrete implementation with Spring annotations
+     * like {@code Autowired} and/or {@code Qualifier} to get injected a particular bean instance.
+     * 
+     * @param configuration The configuration properties.
+     * @throws NullPointerException if configuration is {@code null}.
+     */
+    public abstract void setConfig(T configuration);
+
+    /**
+     * Gets the properties that this <em>Verticle</em> has been configured with.
+     * 
+     * @return The properties or {@code null} if not set.
+     */
+    public final T getConfig() {
+        return this.config;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/EventBusRegistrationAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/EventBusRegistrationAdapter.java
@@ -40,10 +40,8 @@ import io.vertx.core.json.JsonObject;
  * <p>
  * This base class provides support for receiving <em>assert Registration</em> request messages via vert.x' event bus
  * and routing them to specific methods accepting the query parameters contained in the request message.
- * 
- * @param <T> The type of configuration properties this service requires.
  */
-public abstract class EventBusRegistrationAdapter<T> extends EventBusService<T> implements Verticle {
+public abstract class EventBusRegistrationAdapter extends EventBusService implements Verticle {
 
     /**
      * The default number of seconds that information returned by this service's

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseTenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/BaseTenantService.java
@@ -38,7 +38,9 @@ import org.eclipse.hono.util.TenantResult;
  * @deprecated - Use {@link TenantService} and {@link org.eclipse.hono.service.management.tenant.TenantManagementService} instead.
  */
 @Deprecated
-public abstract class BaseTenantService<T> extends EventBusTenantAdapter<T> implements TenantService {
+public abstract class BaseTenantService<T> extends EventBusTenantAdapter implements TenantService {
+
+    private T config;
 
     @Override
     protected TenantService getService() {
@@ -88,5 +90,36 @@ public abstract class BaseTenantService<T> extends EventBusTenantAdapter<T> impl
      */
     protected void handleUnimplementedOperation(final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
         resultHandler.handle(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_NOT_IMPLEMENTED)));
+    }
+
+    /**
+     * Sets the specific object instance to use for configuring this <em>Verticle</em>.
+     * 
+     * @param props The properties.
+     */
+    protected final void setSpecificConfig(final T props) {
+        this.config = props;
+    }
+
+    /**
+     * Sets the properties to use for configuring this <em>Verticle</em>.
+     * <p>
+     * Subclasses <em>must</em> invoke {@link #setSpecificConfig(Object)} with the configuration object.
+     * <p>
+     * This method mainly exists so that subclasses can annotate its concrete implementation with Spring annotations
+     * like {@code Autowired} and/or {@code Qualifier} to get injected a particular bean instance.
+     * 
+     * @param configuration The configuration properties.
+     * @throws NullPointerException if configuration is {@code null}.
+     */
+    public abstract void setConfig(T configuration);
+
+    /**
+     * Gets the properties that this <em>Verticle</em> has been configured with.
+     * 
+     * @return The properties or {@code null} if not set.
+     */
+    public final T getConfig() {
+        return this.config;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/EventBusTenantAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/EventBusTenantAdapter.java
@@ -42,10 +42,8 @@ import io.vertx.core.json.JsonObject;
  * In particular, this base class provides support for receiving service invocation request messages
  * via vert.x' event bus and routing them to specific methods accepting the
  * query parameters contained in the request message.
- *
- * @param <T> The type of configuration properties this service requires.
  */
-public abstract class EventBusTenantAdapter<T> extends EventBusService<T> implements Verticle {
+public abstract class EventBusTenantAdapter extends EventBusService implements Verticle {
 
     private static final String SPAN_NAME_GET_TENANT = "get Tenant";
 

--- a/service-base/src/test/java/org/eclipse/hono/service/EventBusServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/EventBusServiceTest.java
@@ -32,18 +32,14 @@ import io.vertx.core.json.JsonObject;
  */
 public class EventBusServiceTest {
 
-    private static EventBusService<Object> service;
+    private static EventBusService service;
 
     /**
      * Sets up the fixture.
      */
     @BeforeAll
     public static void setUp() {
-        service = new EventBusService<>() {
-
-            @Override
-            public void setConfig(final Object configuration) {
-            }
+        service = new EventBusService() {
 
             @Override
             protected String getEventBusAddress() {

--- a/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
@@ -38,7 +38,7 @@ import io.vertx.junit5.VertxTestContext;
 @ExtendWith(VertxExtension.class)
 public class BaseCredentialsServiceTest {
 
-    private static EventBusCredentialsAdapter<?> service;
+    private static EventBusCredentialsAdapter service;
 
     private static final String TEST_TENANT = "dummy";
 
@@ -107,7 +107,7 @@ public class BaseCredentialsServiceTest {
                 .setJsonPayload(payload);
     }
 
-    private static EventBusCredentialsAdapter<?> createCredentialsService() {
+    private static EventBusCredentialsAdapter createCredentialsService() {
 
         final var service = new CredentialsService() {
 
@@ -122,17 +122,11 @@ public class BaseCredentialsServiceTest {
             }
         };
 
-        return new EventBusCredentialsAdapter<>() {
+        return new EventBusCredentialsAdapter() {
 
             @Override
             protected CredentialsService getService() {
                 return service;
-            }
-
-            @Override
-            public void setConfig(final Object configuration) {
-                // TODO Auto-generated method stub
-
             }
         };
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/deviceconnection/BaseDeviceConnectionServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/deviceconnection/BaseDeviceConnectionServiceTest.java
@@ -37,6 +37,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
  * Tests verifying behavior of {@link BaseDeviceConnectionService}.
  *
  */
+@Deprecated
 @RunWith(VertxUnitRunner.class)
 public class BaseDeviceConnectionServiceTest {
 
@@ -164,6 +165,7 @@ public class BaseDeviceConnectionServiceTest {
 
             @Override
             public void setConfig(final Object configuration) {
+                setSpecificConfig(configuration);
             }
         };
     }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredCredentialsAdapter.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredCredentialsAdapter.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
  * in a Spring Boot environment.
  */
 @Component
-public final class AutowiredCredentialsAdapter extends EventBusCredentialsAdapter<Void> {
+public final class AutowiredCredentialsAdapter extends EventBusCredentialsAdapter {
 
     private CredentialsService service;
 
@@ -39,10 +39,6 @@ public final class AutowiredCredentialsAdapter extends EventBusCredentialsAdapte
     @Override
     protected CredentialsService getService() {
         return this.service;
-    }
-
-    @Override
-    public void setConfig(final Void configuration) {
     }
 
 }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredCredentialsManagementAdapter.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredCredentialsManagementAdapter.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConditionalOnBean(CredentialsManagementService.class)
-public final class AutowiredCredentialsManagementAdapter extends EventBusCredentialsManagementAdapter<Void> {
+public final class AutowiredCredentialsManagementAdapter extends EventBusCredentialsManagementAdapter {
 
     private CredentialsManagementService service;
 
@@ -41,10 +41,6 @@ public final class AutowiredCredentialsManagementAdapter extends EventBusCredent
     @Override
     protected CredentialsManagementService getService() {
         return this.service;
-    }
-
-    @Override
-    public void setConfig(final Void configuration) {
     }
 
 }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredDeviceConnectionAdapter.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredDeviceConnectionAdapter.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
  * in a Spring Boot environment.
  */
 @Component
-public final class AutowiredDeviceConnectionAdapter extends EventBusDeviceConnectionAdapter<Void> {
+public final class AutowiredDeviceConnectionAdapter extends EventBusDeviceConnectionAdapter {
 
     private DeviceConnectionService service;
 
@@ -39,10 +39,6 @@ public final class AutowiredDeviceConnectionAdapter extends EventBusDeviceConnec
     @Override
     protected DeviceConnectionService getService() {
         return this.service;
-    }
-
-    @Override
-    public void setConfig(final Void configuration) {
     }
 
 }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredDeviceManagementAdapter.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredDeviceManagementAdapter.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConditionalOnBean(DeviceManagementService.class)
-public final class AutowiredDeviceManagementAdapter extends EventBusDeviceManagementAdapter<Void> {
+public final class AutowiredDeviceManagementAdapter extends EventBusDeviceManagementAdapter {
 
     private DeviceManagementService service;
 
@@ -41,10 +41,6 @@ public final class AutowiredDeviceManagementAdapter extends EventBusDeviceManage
     @Override
     protected DeviceManagementService getService() {
         return this.service;
-    }
-
-    @Override
-    public void setConfig(final Void configuration) {
     }
 
 }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredRegistrationAdapter.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredRegistrationAdapter.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
  * in a Spring Boot environment.
  */
 @Component
-public final class AutowiredRegistrationAdapter extends EventBusRegistrationAdapter<Void> {
+public final class AutowiredRegistrationAdapter extends EventBusRegistrationAdapter {
 
     private RegistrationService service;
 
@@ -40,10 +40,6 @@ public final class AutowiredRegistrationAdapter extends EventBusRegistrationAdap
     @Override
     protected RegistrationService getService() {
         return this.service;
-    }
-
-    @Override
-    public void setConfig(final Void configuration) {
     }
 
 }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredTenantAdapter.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredTenantAdapter.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
  * in a Spring Boot environment.
  */
 @Component
-public final class AutowiredTenantAdapter extends EventBusTenantAdapter<Void> {
+public final class AutowiredTenantAdapter extends EventBusTenantAdapter {
 
     private TenantService service;
 
@@ -40,10 +40,6 @@ public final class AutowiredTenantAdapter extends EventBusTenantAdapter<Void> {
     @Override
     protected TenantService getService() {
         return this.service;
-    }
-
-    @Override
-    public void setConfig(final Void configuration) {
     }
 
 }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredTenantManagementAdapter.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/AutowiredTenantManagementAdapter.java
@@ -43,8 +43,4 @@ public final class AutowiredTenantManagementAdapter extends EventBusTenantManage
         return this.service;
     }
 
-    @Override
-    public void setConfig(final Void configuration) {
-    }
-
 }


### PR DESCRIPTION
This change drops inheritance on `ConfigurationSupportingVerticle` as most classes implement this now with `<Void>`.