### PR TITLE
Add Span parameter to getDevice method

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/registration/BaseRegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/BaseRegistrationService.java
@@ -51,7 +51,7 @@ public abstract class BaseRegistrationService<T> extends EventBusRegistrationAda
     private final AbstractRegistrationService service = new AbstractRegistrationService() {
 
         @Override
-        protected void getDevice(final String tenantId, final String deviceId,
+        protected void getDevice(final String tenantId, final String deviceId, final Span span,
                 final Handler<AsyncResult<RegistrationResult>> resultHandler) {
             BaseRegistrationService.this.getDevice(tenantId, deviceId, resultHandler);
         }

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
@@ -28,6 +28,8 @@ import org.eclipse.hono.util.RegistrationResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import io.opentracing.Span;
+import io.opentracing.noop.NoopSpan;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -157,7 +159,7 @@ public class BaseRegistrationServiceTest {
 
     /**
      * Verifies that the getDevice method returns "not implemented" if the base
-     * {@link AbstractRegistrationService#getDevice(String, String, Handler)} implementation is used.
+     * {@link AbstractRegistrationService#getDevice(String, String, Span, Handler)} implementation is used.
      *
      * @param ctx The vert.x unit test context.
      */
@@ -168,7 +170,8 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationServiceWithoutImpls();
 
         // WHEN trying to get a device's data
-        registrationService.getDevice(Constants.DEFAULT_TENANT, "4711", ctx.succeeding(result -> ctx.verify(() -> {
+        registrationService.getDevice(Constants.DEFAULT_TENANT, "4711", NoopSpan.INSTANCE,
+                ctx.succeeding(result -> ctx.verify(() -> {
             // THEN the assertion fails with a status code 501
             assertEquals(HttpURLConnection.HTTP_NOT_IMPLEMENTED, result.getStatus());
             // and the response payload is empty
@@ -252,7 +255,8 @@ public class BaseRegistrationServiceTest {
         return new AbstractRegistrationService() {
 
             @Override
-            public void getDevice(final String tenantId, final String deviceId, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+            public void getDevice(final String tenantId, final String deviceId, final Span span,
+                    final Handler<AsyncResult<RegistrationResult>> resultHandler) {
                 devices.apply(deviceId).setHandler(resultHandler);
             }
 
@@ -269,7 +273,7 @@ public class BaseRegistrationServiceTest {
         return new AbstractRegistrationService() {
 
             @Override
-            protected void getDevice(final String tenantId, final String deviceId,
+            protected void getDevice(final String tenantId, final String deviceId, final Span span,
                     final Handler<AsyncResult<RegistrationResult>> resultHandler) {
                 resultHandler.handle(
                         Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_NOT_IMPLEMENTED)));

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyRegistrationService.java
@@ -52,7 +52,8 @@ public class DummyRegistrationService extends AbstractRegistrationService {
     }
 
     @Override
-    protected void getDevice(final String tenantId, final String deviceId, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+    protected void getDevice(final String tenantId, final String deviceId, final Span span,
+            final Handler<AsyncResult<RegistrationResult>> resultHandler) {
         resultHandler.handle(Future.failedFuture("Not implemented"));
     }
 

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedRegistrationService.java
@@ -98,7 +98,7 @@ public class FileBasedRegistrationService extends AbstractVerticle
     private final AbstractRegistrationService registrationService = new AbstractRegistrationService() {
 
         @Override
-        public void getDevice(final String tenantId, final String deviceId,
+        public void getDevice(final String tenantId, final String deviceId, final Span span,
                 final Handler<AsyncResult<RegistrationResult>> resultHandler) {
             FileBasedRegistrationService.this.getDevice(tenantId, deviceId, resultHandler);
         }


### PR DESCRIPTION
This change adds the Span parameter to the `getDevice` method of the `AbstractRegistrationService`.

It already is present in the "assert" methods, but doesn't get passed on to the `getDevice` method.

As all touched classes are part of the new API, which wasn't released yet, no wrapper method with the existing signature is provided.

The change does not make any changes in the old class hierarchy, and thus the old `getDevice` method in the old "base" class is left untouched, and the parameter was not added there. This allows makes the "legacy" class hierarchy compatible with the previous version.