### PR TITLE
[#1450] Upgrade to Netty 4.1.39.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -51,8 +51,8 @@
     <logback.version>1.2.3</logback.version>
     <micrometer.version>1.1.4</micrometer.version>
     <mockito.version>2.24.5</mockito.version>
-    <netty.version>4.1.34.Final</netty.version>
-    <netty.tcnative.version>2.0.23.Final</netty.tcnative.version>
+    <netty.version>4.1.39.Final</netty.version>
+    <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <opentracing.version>0.31.0</opentracing.version>
     <opentracing-resolver.version>0.1.5</opentracing-resolver.version>
     <opentracing-vertx-web.version>0.1.0</opentracing-vertx-web.version>
@@ -437,6 +437,61 @@
         <artifactId>netty-tcnative</artifactId>
         <version>${netty.tcnative.version}</version>
         <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-mqtt</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.version}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
This fixes several CVEs around HTTP/2.
Also upgrades tcnative to 2.0.25.
