### PR TITLE
Align image tags with helm deployment and registry deployment improvements.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -42,7 +42,7 @@
     <jaeger.version>0.34.0</jaeger.version>
     <jaeger-agent.image.name>jaegertracing/jaeger-agent:1.13.1</jaeger-agent.image.name>
     <jaeger-all-in-one.image.name>jaegertracing/all-in-one:1.13.1</jaeger-all-in-one.image.name>
-    <java-base-image.name>openjdk:11-jre-slim</java-base-image.name>
+    <java-base-image.name>docker.io/openjdk:11-jre-slim</java-base-image.name>
     <jaxb.api.version>2.2.12</jaxb.api.version>
     <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
     <jjwt.version>0.10.6</jjwt.version>

--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -71,13 +71,13 @@
 
     <plugins>
       <plugin>
-        <!-- Copy legal documents from "legal" module to "target/classes" folder so that we make sure to include 
+        <!-- Copy legal documents from "legal" module to "target/classes" folder so that we make sure to include
           legal docs in all modules. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <!-- Execution and configuration for copying certificates from related module to "target/classes" folder 
+            <!-- Execution and configuration for copying certificates from related module to "target/classes" folder
               so that we can include them in the image. -->
             <id>copy_demo_certs</id>
             <phase>generate-resources</phase>
@@ -139,7 +139,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/deploy/helm</outputDirectory>
+              <outputDirectory>${project.build.directory}/deploy/helm/eclipse-hono</outputDirectory>
               <resources>
                 <resource>
                   <directory>${project.build.directory}/config/hono-demo-certs-jar</directory>

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.honoContainerRegistry }}/eclipse/hono-adapter-amqp-vertx:{{ .Values.honoImageTag }}
+      - image: {{ .Values.adapters.amqp.imageName }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-amqp-vertx
         ports:

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.honoContainerRegistry }}/eclipse/hono-adapter-coap-vertx:{{ .Values.honoImageTag }}
+      - image: {{ .Values.adapters.coap.imageName }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-coap-vertx
         ports:

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.honoContainerRegistry }}/eclipse/hono-adapter-http-vertx:{{ .Values.honoImageTag }}
+      - image: {{ .Values.adapters.http.imageName }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-http-vertx
         ports:

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.honoContainerRegistry }}/eclipse/hono-adapter-kura:{{ .Values.honoImageTag }}
+      - image: {{ .Values.adapters.kura.imageName }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-kura
         ports:

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.honoContainerRegistry }}/eclipse/hono-adapter-mqtt-vertx:{{ .Values.honoImageTag }}
+      - image: {{ .Values.adapters.mqtt.imageName }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-adapter-mqtt-vertx
         ports:

--- a/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       {{- include "hono.metadata" $args | nindent 6 }}
     spec:
       containers:
-      - image: {{ .Values.honoContainerRegistry }}/eclipse/hono-service-auth:{{ .Values.honoImageTag }}
+      - image: {{ .Values.authServer.imageName }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-auth
         ports:

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.honoContainerRegistry }}/eclipse/hono-service-device-connection:{{ .Values.honoImageTag }}
+      - image: {{ .Values.deviceConnectionService.imageName }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-connection
         ports:

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1beta1
-kind: Deployment
+kind: StatefulSet
 metadata:
   {{- $args := dict "dot" . "component" "service-device-registry" "name" "service-device-registry" }}
   {{- include "hono.metadata" $args | nindent 2 }}
@@ -12,6 +12,7 @@ spec:
     metadata:
       {{- include "hono.metadata" $args | nindent 6 }}
     spec:
+{{- if .Values.deviceRegistry.resetFiles }}
       initContainers:
       - name: copy-example-data
         image: busybox
@@ -26,9 +27,10 @@ spec:
           name: conf
         - mountPath: /var/lib/hono/device-registry
           name: registry
+{{- end }}
       containers:
       {{- include "hono.jaeger.agent" . | indent 6 }}
-      - image: {{ .Values.honoContainerRegistry }}/eclipse/hono-service-device-registry:{{ .Values.honoImageTag }}
+      - image: {{ .Values.deviceRegistry.imageName }}
         imagePullPolicy: IfNotPresent
         name: eclipse-hono-service-device-registry
         ports:

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-pvc.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-pvc.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
+  storageClassName: {{ .Values.deviceRegistry.storageClass }}
   resources:
     requests:
       storage: 1Mi

--- a/deploy/src/main/deploy/helm/values.yaml
+++ b/deploy/src/main/deploy/helm/values.yaml
@@ -17,6 +17,12 @@ artemisImageName: ${artemis.image.name}
 # deviceRegistryDeployExample indicates whether the example Device Registry
 # should be deployed and used.
 deviceRegistryDeployExample: true
+deviceRegistry:
+  # Persistent volume claim storage class
+  storageClass: default
+  # Set to false to not override registry files with example content
+  resetFiles: true
+  imageName: ${docker.repository}/hono-service-device-registry:${project.version}
 
 
 # dataGridDeployExample indicates whether the example data grid
@@ -58,19 +64,6 @@ jaegerAgentConf:
 #  REPORTER_TCHANNEL_HOST_PORT: my-jaeger-collector:14267
 #  REPORTER_TCHANNEL_DISCOVERY_MIN_PEERS: 1
 
-
-# honoContainerRegistry contains the host name of the container registry
-# to pull Hono images from.
-# This can be set to e.g. a private container registry where
-# snapshot images have been pushed to.
-# By default we pull from Docker Hub.
-honoContainerRegistry: index.docker.io
-
-# honoImageTag contains the image tag to use when pulling Hono container images.
-# The default value is the chart's app version. It may be overridden in
-# order to pull custom built images from a (private) container registry.
-honoImageTag: ${project.version}
-
 # defaultJavaOptions contains options to pass to the JVM when starting
 # up Hono's containers
 defaultJavaOptions: ${default-java-options}
@@ -102,10 +95,14 @@ authServer:
     # tokenExpiration contains the number of seconds after which tokens issued
     # by the Auth server will expire.
     tokenExpiration: 3600
+  # Docker image repository
+  imageName: ${docker.repository}/hono-service-auth:${project.version}
 
 # Configuration options for adapters.
 adapters:
-
+  amqp:
+    # Docker image repository
+    imageName: ${docker.repository}/hono-adapter-amqp-vertx:${project.version}
   #amqpMessagingNetworkSpec:
   #commandAndControlSpec:
   #credentialsSpec:
@@ -118,15 +115,27 @@ adapters:
     # Note that this requires building the corresponding container image manually because
     # there is no official image available from Docker Hub (yet).
     enabled: false
+    # Docker image repository
+    imageName: ${docker.repository}/hono-adapter-coap-vertx:${project.version}
+  http:
+    # Docker image repository
+    imageName: ${docker.repository}/hono-adapter-http-vertx:${project.version}
+  mqtt:
+    # Docker image repository
+    imageName: ${docker.repository}/hono-adapter-mqtt-vertx:${project.version}
   kura:
     # enabled indicates if Hono's (deprecated) Kura adapter should be deployed.
     enabled: false
+    # Docker image repository
+    imageName: ${docker.repository}/hono-adapter-kura:${project.version}
   # Configures a timeout for inactive sender links.
   # Please refer to the Spring Boot documentation for the supported syntax:
   # https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-conversion-duration
   inactiveLinkTimeout: 1h
 
 deviceConnectionService:
+  # Docker image repository
+  imageName: ${docker.repository}/hono-service-device-connection:${project.version}
 
   # enabled indicates if the data grid based Device Connection service implementation
   # should be deployed and used. If set to false (the default), the example implementation

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
-   
+
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
-   
+
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License 2.0 which is available at
     http://www.eclipse.org/legal/epl-2.0
-   
+
     SPDX-License-Identifier: EPL-2.0
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -174,21 +174,32 @@
      -->
     <snapshotDependencyAllowed>true</snapshotDependencyAllowed>
 
-    <!-- 
+    <!--
       Build images defined in modules with packaging type "pom".
      -->
     <docker.skip.build.pom>false</docker.skip.build.pom>
 
-    <!-- 
+    <!--
       The organization name to use for our Docker image names.
      -->
-     <docker.image.org-name>eclipse</docker.image.org-name>
+    <docker.image.org-name>eclipse</docker.image.org-name>
+
+    <!--
+      The Docker registry to use for our Docker image names.
+    -->
+    <docker.registry>index.docker.io</docker.registry>
+
+    <!--
+      The Docker repository to use for our Docker image names.
+    -->
+    <docker.repository>${docker.registry}/${docker.image.org-name}</docker.repository>
 
     <!--
       Additional tag which can be defined for custom builds
      -->
     <docker.image.additional.tag></docker.image.additional.tag>
-     <jacoco.version>0.8.2</jacoco.version>
+
+    <jacoco.version>0.8.2</jacoco.version>
   </properties>
 
   <modules>
@@ -228,7 +239,7 @@
           <configuration>
             <images>
               <image>
-                <name>${docker.image.org-name}/%a:%v</name>
+                <name>${docker.repository}/%a:%v</name>
                 <build>
                   <maintainer>The Eclipse Hono project</maintainer>
                   <labels>
@@ -299,7 +310,7 @@
           <version>2.22.1</version>
         </plugin>
         <plugin>
-          <!-- 
+          <!--
             Copy legal documents from "legal" module to "target/classes" folder
             so that we make sure to include legal docs in all modules.
            -->
@@ -367,7 +378,7 @@
             <configLocation>checkstyle/default.xml</configLocation>
             <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
-            
+
             <!--
               The next two lines are required due to an issue in M2E support
               for Checkstyle.
@@ -425,7 +436,7 @@
         <version>3.0.0-M2</version>
         <executions>
           <execution>
-            <!-- Make sure that only non-snapshot versions are used for the dependencies. 
+            <!-- Make sure that only non-snapshot versions are used for the dependencies.
               Only active when property 'snapshotDependencyAllowed' is false. -->
             <id>enforce-no-snapshots</id>
             <goals>
@@ -520,7 +531,7 @@
       <build>
         <plugins>
           <plugin>
-            <!-- 
+            <!--
               Use the Nexus Staging plugin as a full replacement for the standard
               Maven Deploy plugin.
               See https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin
@@ -547,7 +558,7 @@
       </build>
     </profile>
     <profile>
-      <!-- 
+      <!--
         This profile is activated by Eclipse IDE automatically.
        -->
       <id>eclipse-only</id>

--- a/site/documentation/content/deployment/create-kubernetes-cluster.md
+++ b/site/documentation/content/deployment/create-kubernetes-cluster.md
@@ -124,6 +124,7 @@ Now it's time to create the AKS cluster.
 ```sh
 az ad sp create-for-rbac --skip-assignment
 ```
+
 If successful, *appId* and *password* will be displayed.
 
 #### Create Cluster
@@ -171,6 +172,32 @@ ACR_ID=$(az acr show --name $ACR_NAME --resource-group $AKS_RESOURCE_GROUP --que
 # Create role assignment
 az role assignment create --assignee $CLIENT_ID --role acrpull --scope $ACR_ID
 ```
+
+#### (Optional) Create retain StorageClass for the Device Registry
+
+With the [reclaim policy retain](https://docs.microsoft.com/en-us/azure/aks/concepts-storage) AKS ensures that your storage persists even through Hono redeployments.
+
+Create a file `managed-premium-retain.yaml` with the following content.
+
+```yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: managed-premium-retain
+provisioner: kubernetes.io/azure-disk
+reclaimPolicy: Retain
+parameters:
+  storageaccounttype: Premium_LRS
+  kind: Managed
+```
+
+Now apply to your AKS cluster:
+
+```shell
+kubectl apply -f managed-premium-retain.yaml
+```
+
+Note: in your helm deployment later you have to set the value `deviceRegistry.storageClass=managed-premium-retain`.
 
 ### Monitoring
 

--- a/site/documentation/content/deployment/helm-based-deployment.md
+++ b/site/documentation/content/deployment/helm-based-deployment.md
@@ -31,7 +31,7 @@ The [installation guide](https://kubernetes.io/docs/tasks/tools/install-kubectl/
 #### Hono Helm Chart
 
 The Helm chart is contained in the Hono archive that is available from [Hono's download page]({{% homelink "/downloads/" %}}).
-After the archive has been extracted, the chart can be found in the `eclipse-hono-$VERSION/deploy/helm` folder.
+After the archive has been extracted, the chart can be found in the `eclipse-hono-$VERSION/deploy/helm/eclipse-hono` folder.
 
 #### Hono Command Line Client
 
@@ -43,8 +43,8 @@ The command line client requires a Java 11 runtime environment to run.
 The recommended way of deploying Hono is by means of using Helm's *Tiller* service running on the Kubernetes cluster:
 
 ~~~sh
-# in directory: eclipse-hono-$VERSION/deploy/
-helm install --dep-up --name hono --namespace hono helm/
+# in directory: eclipse-hono-$VERSION/deploy/helm
+helm install --dep-up --name hono --namespace hono eclipse-hono/
 ~~~
 
 This will create namespace `hono` in the cluster and install all the components to that namespace. The name of the Helm release will be `hono`.
@@ -186,7 +186,7 @@ Once the images have been pushed, the deployment can be done using Helm:
 
 ~~~sh
 # in Hono working tree directory: hono/deploy
-helm install --dep-up --name hono --namespace hono --set honoContainerRegistry=my.registry.io target/deploy/helm/
+helm install --dep-up --name hono --namespace hono --set deviceRegistry.imageName=my.registry.io/eclipse/hono-service-device-registry:1.0-CUSTOM,authServer.imageName=my.registry.io/eclipse/hono-service-auth:1.0-CUSTOM,deviceConnectionService.imageName=my.registry.io/eclipse/hono-service-device-connection:1.0-CUSTOM,adapters.amqp.imageName=my.registry.io/eclipse/hono-adapter-amqp-vertx:1.0-CUSTOM,adapters.mqtt.imageName=my.registry.io/eclipse/hono-adapter-mqtt-vertx:1.0-CUSTOM,adapters.http.imageName=my.registry.io/eclipse/hono-adapter-http-vertx:1.0-CUSTOM target/deploy/helm/eclipse-hono/
 ~~~
 
 ### Deploying to Minikube
@@ -210,7 +210,7 @@ The newly built images can then be deployed using Helm:
 
 ~~~sh
 # in Hono working tree directory: hono/deploy
-helm install --dep-up --name hono --namespace hono target/deploy/helm/
+helm install --dep-up --name hono --namespace hono target/deploy/helm/eclipse-hono/
 ~~~
 
 ## Using the Device Connection Service
@@ -224,7 +224,7 @@ running Helm:
 
 ~~~sh
 # in directory: eclipse-hono-$VERSION/deploy/
-helm install --dep-up --name hono --namespace hono --set deviceConnectionService.enabled=true helm/
+helm install --dep-up --name hono --namespace hono --set deviceConnectionService.enabled=true helm/eclipse-hono/
 ~~~
 
 This will deploy the Device Connection service and configure all protocol adapters to use it instead of the example Device Registry implementation.
@@ -234,7 +234,7 @@ The Helm chart supports deployment of a simple data grid which can be used for e
 
 ~~~sh
 # in directory: eclipse-hono-$VERSION/deploy/
-helm install --dep-up --name hono --namespace hono --set deviceConnectionService.enabled=true --set dataGridDeployExample=true helm/
+helm install --dep-up --name hono --namespace hono --set deviceConnectionService.enabled=true --set dataGridDeployExample=true helm/eclipse-hono/
 ~~~
 
 This will deploy the data grid and configure the Device Connection service to use it for storing the connection data.
@@ -257,7 +257,7 @@ to `true` when running Helm:
 
 ~~~sh
 # in Hono working tree directory: hono/deploy
-helm install --dep-up --name hono --namespace hono --set jaegerBackendDeployExample=true target/deploy/helm/
+helm install --dep-up --name hono --namespace hono --set jaegerBackendDeployExample=true target/deploy/helm/eclipse-hono/
 ~~~
 
 This will create a Jaeger back end instance suitable for testing purposes and will configure all deployed Hono components to use the
@@ -274,7 +274,7 @@ the Jaeger Agent that is deployed with each of Hono's components.
 
 ~~~sh
 # in Hono working tree directory: hono/deploy
-helm install --dep-up --name hono --namespace hono --set jaegerAgentConf.REPORTER_TYPE=tchannel --set jaegerAgentConf.REPORTER_TCHANNEL_HOST_PORT=my-jaeger-collector:14267 target/deploy/helm/
+helm install --dep-up --name hono --namespace hono --set jaegerAgentConf.REPORTER_TYPE=tchannel --set jaegerAgentConf.REPORTER_TCHANNEL_HOST_PORT=my-jaeger-collector:14267 target/deploy/helm/eclipse-hono/
 ~~~
 
 ## Deploying optional Adapters
@@ -290,5 +290,5 @@ The following command will deploy the Kura adapter along with Hono's standard ad
 
 ~~~sh
 # in directory: eclipse-hono-$VERSION/deploy/
-helm install --dep-up --name hono --namespace hono --set adapters.kura.enabled=true helm/
+helm install --dep-up --name hono --namespace hono --set adapters.kura.enabled=true helm/eclipse-hono/
 ~~~


### PR DESCRIPTION
I added a few improvements for AKS or k8s deployments in general.

* Aligned image tagging between build and (helm) deployment, i.e.
  * Align to set a custom registry (which was possible to deploy in with Helm but not to tag in the build).
  * Align to set a custom org (which was possible tag in build but not to deploy with Helm)
* Registry deployment improvements:
  * Add Azure AKS docs how to set storage class with retain policy.
  * Switch from k8s `deployment` to `StatefulSet` in order to avoid deadlock situations at update/redeployment time due to the `ReadWriteOnce` access.
  * Allow for registry to configure a custom storage class and disable the example storage override at container startup.
* Fix helm folder according to helm spec (i.e. needs to be identical to chart name for instance to allow `helm package`).

I apologise that my editor removed a few whitespaces.

Kai

Signed-off-by: Kai Zimmermann <kai.zimmermann@microsoft.com>