### PR TITLE
[#1227] Remove metrics for "inactive" tenants.

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -89,6 +89,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -1037,7 +1038,9 @@ public class VertxBasedAmqpProtocolAdapterTest {
         adapter.setMetrics(metrics);
         adapter.setResourceLimitChecks(resourceLimitChecks);
 
-        adapter.init(Vertx.vertx(), mock(Context.class));
+        final Vertx vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
+        adapter.init(vertx, mock(Context.class));
         return adapter;
     }
 

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -84,8 +84,10 @@ import org.mockito.ArgumentCaptor;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
@@ -1034,6 +1036,8 @@ public class VertxBasedAmqpProtocolAdapterTest {
         adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
         adapter.setMetrics(metrics);
         adapter.setResourceLimitChecks(resourceLimitChecks);
+
+        adapter.init(Vertx.vertx(), mock(Context.class));
         return adapter;
     }
 

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -77,6 +77,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -136,6 +137,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
             task.handle(null);
             return 1L;
         });
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
 
         config = new HttpProtocolAdapterProperties();
         config.setInsecurePortEnabled(true);

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
@@ -96,6 +96,7 @@ public class CommandConsumerFactoryImplTest {
         vertx = mock(Vertx.class);
         context = HonoClientUnitTestHelper.mockContext(vertx);
         when(vertx.getOrCreateContext()).thenReturn(context);
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
         doAnswer(invocation -> {
             final Handler<Void> handler = invocation.getArgument(1);
             handler.handle(null);
@@ -219,7 +220,6 @@ public class CommandConsumerFactoryImplTest {
         when(deviceSpecificCommandReceiver.getRemoteSource()).thenReturn(source);
         when(deviceSpecificCommandReceiver.isOpen()).thenReturn(Boolean.TRUE);
         when(vertx.setPeriodic(anyLong(), anyHandler())).thenReturn(10L);
-        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
 
         // GIVEN a command consumer
         commandConsumerFactory.createCommandConsumer(tenantId, deviceId, commandHandler, null, 5000L)
@@ -266,7 +266,6 @@ public class CommandConsumerFactoryImplTest {
         when(deviceSpecificCommandReceiver.getSource()).thenReturn(source);
         when(deviceSpecificCommandReceiver.getRemoteSource()).thenReturn(source);
         when(vertx.setPeriodic(anyLong(), anyHandler())).thenReturn(10L);
-        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
         doAnswer(invocation -> {
             final Handler<Void> handler = invocation.getArgument(1);
             handler.handle(null);

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
@@ -53,6 +53,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.proton.ProtonMessageHandler;
@@ -218,6 +219,7 @@ public class CommandConsumerFactoryImplTest {
         when(deviceSpecificCommandReceiver.getRemoteSource()).thenReturn(source);
         when(deviceSpecificCommandReceiver.isOpen()).thenReturn(Boolean.TRUE);
         when(vertx.setPeriodic(anyLong(), anyHandler())).thenReturn(10L);
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
 
         // GIVEN a command consumer
         commandConsumerFactory.createCommandConsumer(tenantId, deviceId, commandHandler, null, 5000L)
@@ -264,6 +266,7 @@ public class CommandConsumerFactoryImplTest {
         when(deviceSpecificCommandReceiver.getSource()).thenReturn(source);
         when(deviceSpecificCommandReceiver.getRemoteSource()).thenReturn(source);
         when(vertx.setPeriodic(anyLong(), anyHandler())).thenReturn(10L);
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
         doAnswer(invocation -> {
             final Handler<Void> handler = invocation.getArgument(1);
             handler.handle(null);

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -133,7 +133,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @param metrics The metrics to use.
      * @throws NullPointerException if metrics is {@code null}.
      */
-    public AbstractProtocolAdapterBase(final U metrics) {
+    protected AbstractProtocolAdapterBase(final U metrics) {
         this.metrics = Objects.requireNonNull(metrics);
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -48,6 +48,7 @@ import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.auth.ValidityBasedTrustOptions;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.service.limiting.ConnectionLimitManager;
+import org.eclipse.hono.service.metric.Metrics;
 import org.eclipse.hono.service.monitoring.ConnectionEventProducer;
 import org.eclipse.hono.service.plan.NoopResourceLimitChecks;
 import org.eclipse.hono.service.plan.ResourceLimitChecks;
@@ -88,8 +89,10 @@ import io.vertx.proton.ProtonHelper;
  * Provides connections to device registration and telemetry and event service endpoints.
  *
  * @param <T> The type of configuration properties used by this service.
+ * @param <U> the type of metrics used by this service.
  */
-public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterProperties> extends AbstractServiceBase<T> {
+public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterProperties, U extends Metrics>
+        extends AbstractServiceBase<T> {
 
     /**
      * The <em>application/octet-stream</em> content type.
@@ -101,6 +104,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     protected static final String KEY_MICROMETER_SAMPLE = "micrometer.sample";
 
+    private U metrics;
     private DownstreamSenderFactory downstreamSenderFactory;
     private RegistrationClientFactory registrationClientFactory;
     private TenantClientFactory tenantClientFactory;
@@ -119,6 +123,16 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         }
 
     };
+
+    /**
+     * Creates an instance initialized with the given metrics.
+     * 
+     * @param metrics The metrics to use.
+     * @throws NullPointerException if metrics is {@code null}.
+     */
+    public AbstractProtocolAdapterBase(final U metrics) {
+        this.metrics = Objects.requireNonNull(metrics);
+    }
 
     /**
      * Adds a Micrometer sample to a command context.
@@ -379,6 +393,27 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     protected final ResourceLimitChecks getResourceLimitChecks() {
         return this.resourceLimitChecks;
+    }
+
+    /**
+     * Gets the metrics for this service.
+     *
+     * @return The metrics
+     */
+    protected final U getMetrics() {
+        return metrics;
+    }
+
+    /**
+     * Sets the metrics for this service.
+     *
+     * @param metrics The metrics
+     * @throws NullPointerException if metrics is {@code null}.
+     */
+    @Autowired
+    public final void setMetrics(final U metrics) {
+        Objects.requireNonNull(metrics);
+        this.metrics = metrics;
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -13,8 +13,10 @@
 
 package org.eclipse.hono.service.metric;
 
-import io.micrometer.core.instrument.Timer.Sample;
+import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.TenantObject;
+
+import io.micrometer.core.instrument.Timer.Sample;
 
 /**
  * A collector for metrics.
@@ -122,6 +124,21 @@ public interface Metrics {
             int payloadSize,
             MetricsTags.TtdStatus ttdStatus,
             Sample timer);
+
+    /**
+     *
+     * Removes the metrics of telemetry or event messages for the given tenant.
+     * <p>
+     * This is used to clean the metrics for tenants that are no longer active.
+     * 
+     * @see ClientConfigProperties#getInactiveLinkTimeout()
+     *
+     * @param type The type of messages to be removed, e.g. <em>telemetry</em> or <em>event</em>.
+     * @param tenantId The tenant to be removed from the metrics.
+     * @throws NullPointerException if any of the parameters except the tenant object are {@code null}.
+     * @throws IllegalArgumentException if type is neither telemetry nor event.
+     */
+    void removeTelemetryMetricsForTenant(MetricsTags.EndpointType type, String tenantId);
 
     /**
      * Reports a command &amp; control message being transferred to/from a device.

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -126,10 +126,9 @@ public interface Metrics {
             Sample timer);
 
     /**
-     *
      * Removes the metrics of telemetry or event messages for the given tenant.
      * <p>
-     * This is used to clean the metrics for tenants that are no longer active.
+     * This is done to prevent reporting of never changing meter values for inactive tenants.
      * 
      * @see ClientConfigProperties#getInactiveLinkTimeout()
      *

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
@@ -15,9 +15,9 @@ package org.eclipse.hono.service.metric;
 
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
 import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
+import org.eclipse.hono.util.TenantObject;
 
 import io.micrometer.core.instrument.Timer.Sample;
-import org.eclipse.hono.util.TenantObject;
 
 /**
  * A no-op metrics implementation.
@@ -77,6 +77,10 @@ public class NoopBasedMetrics implements Metrics {
             final int payloadSize,
             final MetricsTags.TtdStatus ttdStatus,
             final Sample timer) {
+    }
+
+    @Override
+    public void removeTelemetryMetricsForTenant(final MetricsTags.EndpointType type, final String tenantId) {
     }
 
     @Override

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -141,6 +141,7 @@ public class AbstractProtocolAdapterBaseTest {
             return 1L;
         });
         context = mock(Context.class);
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
         adapter.init(vertx, context);
     }
 
@@ -632,7 +633,8 @@ public class AbstractProtocolAdapterBaseTest {
     @Test
     public void testDoNotRegisterForNoopMetrics() {
         // GIVEN an adapter with a metrics object that is an instance of NoopBasedMetrics
-        final NoopBasedMetrics noopBasedMetrics = mock(NoopBasedMetrics.class);
+        final Metrics noopBasedMetrics = new NoopBasedMetrics() {
+        };
         adapter.setMetrics(noopBasedMetrics);
 
         // WHEN starting the adapter
@@ -669,7 +671,7 @@ public class AbstractProtocolAdapterBaseTest {
             final Handler<Void> commandConnectionLostHandler) {
 
         final AbstractProtocolAdapterBase<ProtocolAdapterProperties, Metrics> result = new AbstractProtocolAdapterBase<>(
-                mock(NoopBasedMetrics.class)) {
+                mock(Metrics.class)) {
 
             @Override
             public String getTypeName() {

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -45,6 +45,8 @@ import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.service.metric.Metrics;
+import org.eclipse.hono.service.metric.NoopBasedMetrics;
 import org.eclipse.hono.service.plan.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
@@ -83,7 +85,7 @@ public class AbstractProtocolAdapterBaseTest {
     private Vertx vertx;
     private Context context;
     private ProtocolAdapterProperties properties;
-    private AbstractProtocolAdapterBase<ProtocolAdapterProperties> adapter;
+    private AbstractProtocolAdapterBase<ProtocolAdapterProperties, Metrics> adapter;
     private RegistrationClient registrationClient;
     private TenantClientFactory tenantService;
     private RegistrationClientFactory registrationClientFactory;
@@ -589,30 +591,33 @@ public class AbstractProtocolAdapterBaseTest {
         }));
     }
 
-    private AbstractProtocolAdapterBase<ProtocolAdapterProperties> newProtocolAdapter(final ProtocolAdapterProperties props) {
+    private AbstractProtocolAdapterBase<ProtocolAdapterProperties, Metrics> newProtocolAdapter(
+            final ProtocolAdapterProperties props) {
 
         return newProtocolAdapter(props, ADAPTER_NAME);
     }
 
-    private AbstractProtocolAdapterBase<ProtocolAdapterProperties> newProtocolAdapter(final ProtocolAdapterProperties props, final String typeName) {
+    private AbstractProtocolAdapterBase<ProtocolAdapterProperties, Metrics> newProtocolAdapter(
+            final ProtocolAdapterProperties props, final String typeName) {
         return newProtocolAdapter(props, typeName, start -> {});
     }
 
-    private AbstractProtocolAdapterBase<ProtocolAdapterProperties> newProtocolAdapter(
+    private AbstractProtocolAdapterBase<ProtocolAdapterProperties, Metrics> newProtocolAdapter(
             final ProtocolAdapterProperties props,
             final String typeName,
             final Handler<Void> startupHandler) {
         return newProtocolAdapter(props, typeName, startupHandler, null, null);
     }
 
-    private AbstractProtocolAdapterBase<ProtocolAdapterProperties> newProtocolAdapter(
+    private AbstractProtocolAdapterBase<ProtocolAdapterProperties, Metrics> newProtocolAdapter(
             final ProtocolAdapterProperties props,
             final String typeName,
             final Handler<Void> startupHandler,
             final Handler<Void> commandConnectionEstablishedHandler,
             final Handler<Void> commandConnectionLostHandler) {
 
-        final AbstractProtocolAdapterBase<ProtocolAdapterProperties> result = new AbstractProtocolAdapterBase<>() {
+        final AbstractProtocolAdapterBase<ProtocolAdapterProperties, Metrics> result = new AbstractProtocolAdapterBase<>(
+                mock(NoopBasedMetrics.class)) {
 
             @Override
             public String getTypeName() {

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -633,8 +634,8 @@ public class AbstractProtocolAdapterBaseTest {
     @Test
     public void testDoNotRegisterForNoopMetrics() {
         // GIVEN an adapter with a metrics object that is an instance of NoopBasedMetrics
-        final Metrics noopBasedMetrics = new NoopBasedMetrics() {
-        };
+        final Metrics noopBasedMetrics = spy(new NoopBasedMetrics() {
+        });
         adapter.setMetrics(noopBasedMetrics);
 
         // WHEN starting the adapter

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
@@ -33,6 +33,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer.Sample;
+import io.micrometer.core.instrument.search.Search;
 import io.micrometer.graphite.GraphiteConfig;
 import io.micrometer.graphite.GraphiteMeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
@@ -218,4 +219,99 @@ public class MicrometerBasedMetricsTest {
                 registry.find(MicrometerBasedMetrics.METER_COMMANDS_PAYLOAD).summary().totalAmount());
     }
 
+    /**
+     * Verifies that the metrics for a tenant are removed when all their connections are closed.
+     *
+     * @param registry The registry that the tests should be run against.
+     */
+    @ParameterizedTest
+    @MethodSource("registries")
+    public void testAuthenticatedConnections(final MeterRegistry registry) {
+
+        final MicrometerBasedMetrics metrics = new MicrometerBasedMetrics(registry);
+
+        final String tenant1 = "tenant1";
+        final String tenant2 = "tenant2";
+
+        // GIVEN a metrics instance that has recorded one telemetry message and one event per tenant
+        metrics.incrementConnections(tenant1);
+        metrics.incrementConnections(tenant1);
+        metrics.incrementConnections(tenant2);
+        metrics.incrementConnections(tenant2);
+
+        final Search search = registry.find(MicrometerBasedMetrics.METER_CONNECTIONS_AUTHENTICATED);
+        assertEquals(2, search.meters().size());
+        assertEquals(4, metrics.getNumberOfConnections());
+
+        // WHEN closing all connections for one tenant
+        metrics.decrementConnections(tenant1);
+        assertEquals(2, search.meters().size());
+        metrics.decrementConnections(tenant1);
+
+        // THEN the metric for this tenant is removed
+        assertEquals(1, search.meters().size());
+        assertEquals(2, metrics.getNumberOfConnections());
+
+    }
+
+    /**
+     * Verifies the behavior of removeTelemetryMetricsForTenant(), i.e. checks that metrics are removed for the given
+     * event type and tenant.
+     *
+     * @param registry The registry that the tests should be run against.
+     */
+    @ParameterizedTest
+    @MethodSource("registries")
+    public void testRemoveTelemetryMetricsForTenant(final MeterRegistry registry) {
+
+        final MicrometerBasedMetrics metrics = new MicrometerBasedMetrics(registry);
+        final String tenant1 = "tenant1";
+        final Tags tenantTag1 = Tags.of(MetricsTags.getTenantTag(tenant1));
+        final String tenant2 = "tenant2";
+        final Tags tenantTag2 = Tags.of(MetricsTags.getTenantTag(tenant2));
+
+        // GIVEN a metrics instance that has recorded one telemetry message and one event per tenant
+        reportTelemetry(metrics, EndpointType.TELEMETRY, tenant1);
+        reportTelemetry(metrics, EndpointType.EVENT, tenant1);
+        reportTelemetry(metrics, EndpointType.TELEMETRY, tenant2);
+        reportTelemetry(metrics, EndpointType.EVENT, tenant2);
+
+        assertEquals(4,
+                registry.find(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED).meters().size());
+        assertEquals(4,
+                registry.find(MicrometerBasedMetrics.METER_MESSAGES_PAYLOAD).meters().size());
+
+        // WHEN removing the telemetry metrics for tenant1
+        metrics.removeTelemetryMetricsForTenant(EndpointType.TELEMETRY, tenant1);
+
+        // THEN only the metric for telemetry and this tenant is removed
+        assertEquals(1,
+                registry.find(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED).tags(tenantTag1).meters().size());
+        assertEquals(1,
+                registry.find(MicrometerBasedMetrics.METER_MESSAGES_PAYLOAD).tags(tenantTag1).meters().size());
+
+        metrics.removeTelemetryMetricsForTenant(EndpointType.EVENT, tenant1);
+        assertEquals(0,
+                registry.find(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED).tags(tenantTag1).meters().size());
+        assertEquals(0,
+                registry.find(MicrometerBasedMetrics.METER_MESSAGES_PAYLOAD).tags(tenantTag1).meters().size());
+
+        // AND the other tenant is untouched
+        assertEquals(2,
+                registry.find(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED).tags(tenantTag2).meters().size());
+        assertEquals(2,
+                registry.find(MicrometerBasedMetrics.METER_MESSAGES_PAYLOAD).tags(tenantTag2).meters().size());
+    }
+
+    private void reportTelemetry(final MicrometerBasedMetrics metrics, final EndpointType type, final String tenantId) {
+        metrics.reportTelemetry(
+                type,
+                tenantId,
+                TenantObject.from(tenantId, true),
+                MetricsTags.ProcessingOutcome.FORWARDED,
+                QoS.AT_LEAST_ONCE,
+                1024,
+                TtdStatus.NONE,
+                metrics.startTimer());
+    }
 }


### PR DESCRIPTION
The goal in this PR is to solve #1227 by removing message related metrics when corresponding downstream link times out (#1188). 
The device connection related metrics ("hono.connections.authenticated") could be removed when the connection count for a tenant drops to 0.

This logic is the same for every type of protocol adapter, so it should be implemented in the common base class `AbstractProtocolAdapterBase`. The first step for this is to pull the metrics object up to this class from the individual protocol adapter classes. This requires the base class to be parametrized with the concrete type of metrics for a protocol adapter.

Following steps are:
* expose a handler for the link close event to the protocol adapter and
* implement the removal of the metrics