### PR TITLE
Consider SSLException terminal for connection attempt.

### DIFF
--- a/core/src/test/java/org/eclipse/hono/connection/impl/ConnectionFactoryImplTest.java
+++ b/core/src/test/java/org/eclipse/hono/connection/impl/ConnectionFactoryImplTest.java
@@ -12,8 +12,15 @@
  *******************************************************************************/
 package org.eclipse.hono.connection.impl;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.connection.ConnectTimeoutException;

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -37,6 +37,7 @@
   <logger name="org.eclipse.hono" level="INFO"/>
   <logger name="org.eclipse.hono.client" level="INFO"/>
   <logger name="org.eclipse.hono.client.impl" level="INFO"/>
+  <logger name="org.eclipse.hono.connection" level="INFO"/>
   <logger name="org.eclipse.hono.tests" level="INFO"/>
   <logger name="org.eclipse.hono.tests.CrudHttpClient" level="INFO"/>
   <logger name="org.eclipse.hono.tests.amqp" level="INFO"/>


### PR DESCRIPTION
The HonoClient now stops a connection attempt if it runs into an
SSLException which indicates a permanent problem with the TLS handshake.

Fixes #1424