### PR TITLE
Fix an issue encoding the timestamp.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/annotation/HonoTimestamp.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/annotation/HonoTimestamp.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.annotation;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
+
+/**
+ * An annotation to indicate that a value should be serialized/de-serialized in the format expected by Hono.
+ */
+@Retention(RUNTIME)
+@JacksonAnnotationsInside
+@JsonInclude(NON_NULL)
+@Target(FIELD)
+@Documented
+@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss[XXX]", timezone = "UTC")
+@JsonSerialize(using = InstantSerializer.class)
+@JsonDeserialize(using = HonoInstantDeserializer.class)
+public @interface HonoTimestamp {
+}
+
+/**
+ * A deserializer for Hono's format of {@link Instant}s.
+ */
+class HonoInstantDeserializer extends InstantDeserializer<Instant> {
+
+    private static final long serialVersionUID = 1L;
+
+    HonoInstantDeserializer() {
+        super(Instant.class, DateTimeFormatter.ISO_INSTANT,
+                Instant::from,
+                a -> Instant.ofEpochMilli(a.value),
+                a -> Instant.ofEpochSecond(a.integer, a.fraction),
+                null,
+                true);
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
@@ -17,7 +17,8 @@ import static org.eclipse.hono.util.RegistryManagementConstants.FIELD_SECRETS_NO
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import org.eclipse.hono.service.annotation.HonoTimestamp;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -33,10 +34,10 @@ public abstract class CommonSecret {
     private Boolean enabled;
 
     @JsonProperty(FIELD_SECRETS_NOT_BEFORE)
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss[XXX]", timezone = "UTC")
+    @HonoTimestamp
     private Instant notBefore;
     @JsonProperty(FIELD_SECRETS_NOT_AFTER)
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss[XXX]", timezone = "UTC")
+    @HonoTimestamp
     private Instant notAfter;
     @JsonProperty
     private String comment;

--- a/service-base/src/test/java/org/eclipse/hono/service/management/credentials/SecretsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/management/credentials/SecretsTest.java
@@ -13,7 +13,6 @@
 package org.eclipse.hono.service.management.credentials;
 
 
-import io.vertx.core.json.Json;
 import static org.eclipse.hono.util.CredentialsConstants.FIELD_SECRETS;
 import static org.eclipse.hono.util.CredentialsConstants.FIELD_SECRETS_NOT_BEFORE;
 import static org.eclipse.hono.util.RegistryManagementConstants.FIELD_AUTH_ID;
@@ -48,8 +47,6 @@ import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * Verifies {@link CommonSecret} and others.
@@ -172,8 +169,6 @@ public class SecretsTest {
      */
     @Test
     public void testDateFormats() {
-
-        Json.mapper.registerModule(new JavaTimeModule());
 
         final JsonObject json = new JsonObject()
                 .put(FIELD_SECRETS_COMMENT, "test")

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
@@ -55,19 +55,14 @@ import io.opentracing.Span;
 import io.opentracing.noop.NoopSpan;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
-
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 
 /**
@@ -134,17 +129,10 @@ public final class FileBasedCredentialsService extends AbstractVerticle
     }
 
     @Override
-    public void init(final Vertx vertx, final Context context) {
-        super.init(vertx, context);
-        Json.mapper.registerModule(new JavaTimeModule());
-    }
-
-    @Override
     public void start(final Future<Void> startFuture) {
         if (running) {
             startFuture.complete();
         } else {
-            Json.mapper.registerModule(new JavaTimeModule());
             if (!getConfig().isModificationEnabled()) {
                 log.info("modification of credentials has been disabled");
             }
@@ -589,16 +577,6 @@ public final class FileBasedCredentialsService extends AbstractVerticle
         Objects.requireNonNull(pwdHash);
         if (BCryptHelper.getIterations(pwdHash) > getMaxBcryptIterations()) {
             throw new IllegalStateException("password hash uses too many iterations, max is " + getMaxBcryptIterations());
-        }
-    }
-
-    private void checkHashedPassword(final PasswordSecret secret) {
-        if (secret.getHashFunction() == null) {
-            throw new IllegalStateException("missing/invalid hash function");
-        }
-
-        if (secret.getPasswordHash() == null) {
-            throw new IllegalStateException("missing/invalid password hash");
         }
     }
 


### PR DESCRIPTION
This change sets up explicit encoding of the timestamp, and also enforces this when encoding.

Instead of expecting the user of the classes to register an additional data type module, the fields explicitly declare their serializer now.