### PR TITLE
[#1460] Extend support to data limit in Management and Tenant APIs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,6 +68,11 @@
       <artifactId>jjwt-jackson</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>    
+    <dependency>
       <!-- required as a (missing) transient dependency for JJWT -->
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>

--- a/core/src/main/java/org/eclipse/hono/annotation/HonoTimestamp.java
+++ b/core/src/main/java/org/eclipse/hono/annotation/HonoTimestamp.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.eclipse.hono.service.annotation;
+package org.eclipse.hono.annotation;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static java.lang.annotation.ElementType.FIELD;

--- a/core/src/main/java/org/eclipse/hono/util/DataVolume.java
+++ b/core/src/main/java/org/eclipse/hono/util/DataVolume.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.util;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+/**
+ * Data volume definition of the tenant resource limits.
+ */
+@JsonInclude(Include.NON_DEFAULT)
+public class DataVolume {
+
+    @JsonProperty(value = TenantConstants.FIELD_EFFECTIVE_SINCE, required = true)
+    @HonoTimestamp
+    private Instant effectiveSince;
+
+    @JsonProperty(TenantConstants.FIELD_MAX_BYTES)
+    private long maxBytes = TenantConstants.DEFAULT_MAX_BYTES;
+
+    @JsonProperty(TenantConstants.FIELD_PERIOD)
+    private DataVolumePeriod period;
+
+    /**
+     * Gets the point in time on which the data volume limit came into effect.
+     *
+     * @return The instant on which the data volume limit came into effective or 
+     *         {@code null} if not set.
+     */
+    public final Instant getEffectiveSince() {
+        return effectiveSince;
+    }
+
+    /**
+     * Sets the point in time on which the data volume limit came into effect.
+     * 
+     * @param effectiveSince the point in time on which the data volume limit came into effect
+     *                       and it comply to the {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME}.
+     * @return  a reference to this for fluent use.
+     */
+    public final DataVolume setEffectiveSince(final Instant effectiveSince) {
+        this.effectiveSince = effectiveSince;
+        return this;
+    }
+
+    /**
+     * Gets the maximum number of bytes to be allowed for the time period defined by the
+     * {@link TenantConstants#FIELD_PERIOD_MODE} and 
+     * {@link TenantConstants#FIELD_PERIOD_NO_OF_DAYS}.
+     *
+     * @return The maximum number of bytes or {@link TenantConstants#DEFAULT_MAX_BYTES} 
+     *         if not set.
+     */
+    public final long getMaxBytes() {
+        return maxBytes;
+    }
+
+    /**
+     * Sets the maximum number of bytes to be allowed for the time period defined by the
+     * {@link TenantConstants#FIELD_PERIOD_MODE} and 
+     * {@link TenantConstants#FIELD_PERIOD_NO_OF_DAYS}.
+     *
+     * @param maxBytes The maximum number of bytes to be allowed.
+     * @return  a reference to this for fluent use.
+     * @throws IllegalArgumentException if the maximum number of bytes is set to less than -1.
+     */
+    public final DataVolume setMaxBytes(final long maxBytes) {
+        if (maxBytes < -1) {
+            throw new IllegalArgumentException("Maximum bytes allowed property must be set to value >= -1");
+        }
+        this.maxBytes = maxBytes;
+        return this;
+    }
+
+    /**
+     * Gets the period for the data usage calculation.
+     *
+     * @return The period for the data usage calculation.
+     */
+    public final DataVolumePeriod getPeriod() {
+        return period;
+    }
+
+    /**
+     * Sets the period for the data usage calculation.
+     *
+     * @param period The period for the data usage calculation.
+     * @return  a reference to this for fluent use.
+     */
+    public final DataVolume setPeriod(final DataVolumePeriod period) {
+        this.period = period;
+        return this;
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/DataVolumePeriod.java
+++ b/core/src/main/java/org/eclipse/hono/util/DataVolumePeriod.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+
+/**
+ * Data volume period definition of the tenant resource limits .
+ */
+@JsonInclude(Include.NON_DEFAULT)
+public class DataVolumePeriod {
+
+    @JsonProperty(value = TenantConstants.FIELD_PERIOD_MODE, required = true)
+    private String mode;
+
+    @JsonProperty(value = TenantConstants.FIELD_PERIOD_NO_OF_DAYS)
+    private int noOfDays;
+
+    /**
+     * Gets the mode for the data usage calculation.
+     *
+     * @return The mode for the data usage calculation.
+     */
+    public final String getMode() {
+        return mode;
+    }
+
+    /**
+     * Sets the mode for the data usage calculation.
+     *
+     * @param mode The mode for the data usage calculation.
+     * @return  a reference to this for fluent use.
+     */
+    public final DataVolumePeriod setMode(final String mode) {
+        this.mode = mode;
+        return this;
+    }
+
+    /**
+     * Gets the number of days for which the data usage is calculated.
+     * 
+     * @return The number of days for which the data usage is calculated or 0 if not set.
+     */
+    public final int getNoOfDays() {
+        return noOfDays;
+    }
+
+    /**
+     * Sets the number of days for which the data usage is calculated.
+     * 
+     * @param noOfDays The number of days for which the data usage is calculated.
+     * @return  a reference to this for fluent use.
+     * @throws IllegalArgumentException if the number of days is negative.
+     */
+    public final DataVolumePeriod setNoOfDays(final int noOfDays) {
+        if (noOfDays < 0) {
+            throw new IllegalArgumentException("Number of days property must be  set to value >= 0");
+        }
+        this.noOfDays = noOfDays;
+        return this;
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -241,10 +241,6 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_RESOURCE_LIMITS = "resource-limits";
     /**
-     * The name of the property that contains the maximum number of connected devices a tenant supports.
-     */
-    public static final String FIELD_RESOURCE_LIMITS_MAX_CONNECTIONS = "max-connections";
-    /**
      * The name of the property that defines tenant-specific tracing options.
      */
     public static final String FIELD_TRACING = "tracing";

--- a/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
@@ -11,17 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.service.management.tenant;
+package org.eclipse.hono.util;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import org.eclipse.hono.util.RegistryManagementConstants;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Resource limits definition.
@@ -29,8 +27,11 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 @JsonInclude(Include.NON_DEFAULT)
 public class ResourceLimits {
 
-    @JsonProperty(RegistryManagementConstants.FIELD_RESOURCE_LIMITS_MAX_CONNECTIONS)
-    private int maxConnections = -1;
+    @JsonProperty(TenantConstants.FIELD_MAX_CONNECTIONS)
+    private int maxConnections = TenantConstants.DEFAULT_MAX_CONNECTIONS;
+
+    @JsonProperty(TenantConstants.FIELD_DATA_VOLUME)
+    private DataVolume dataVolume;
 
     @JsonProperty(RegistryManagementConstants.FIELD_EXT)
     @JsonInclude(Include.NON_EMPTY)
@@ -41,8 +42,12 @@ public class ResourceLimits {
      * 
      * @param maxConnections The maximum number of connections to set.
      * @return A reference to this for fluent use.
+     * @throws IllegalArgumentException if the maximum connections is set to less than -1.
      */
-    public ResourceLimits setMaxConnections(final int maxConnections) {
+    public final ResourceLimits setMaxConnections(final int maxConnections) {
+        if (maxConnections < -1) {
+            throw new IllegalArgumentException("Maximum connections property must be set to value >= -1");
+        }
         this.maxConnections = maxConnections;
         return this;
     }
@@ -50,10 +55,31 @@ public class ResourceLimits {
     /**
      * Gets the maximum number of connected devices a tenant supports.
      * 
-     * @return The maximum number of connections.
+     * @return The maximum number of connections or {@link TenantConstants#DEFAULT_MAX_CONNECTIONS}
+     *         if not set.
      */
-    public int getMaxConnections() {
+    public final int getMaxConnections() {
         return this.maxConnections;
+    }
+
+    /**
+     * Gets the data volume properties which are required for the message limit verification.
+     *
+     * @return The data volume properties.
+     */
+    public final DataVolume getDataVolume() {
+        return dataVolume;
+    }
+
+    /**
+     * Sets the data volume properties which are required for the message limit verification.
+     * 
+     * @param dataVolume the data volume properties.
+     * @return a reference to this for fluent use.
+     */
+    public final ResourceLimits setDataVolume(final DataVolume dataVolume) {
+        this.dataVolume = dataVolume;
+        return this;
     }
 
     /**
@@ -62,7 +88,7 @@ public class ResourceLimits {
      * @param extensions The extensions to set.
      * @return          a reference to this for fluent use.
      */
-    public ResourceLimits setExtensions(final Map<String, Object> extensions) {
+    public final ResourceLimits setExtensions(final Map<String, Object> extensions) {
         this.extensions = extensions;
         return this;
     }
@@ -72,7 +98,7 @@ public class ResourceLimits {
      * 
      * @return The extensions.
      */
-    public Map<String, Object> getExtensions() {
+    public final Map<String, Object> getExtensions() {
         return this.extensions;
     }
 
@@ -86,7 +112,7 @@ public class ResourceLimits {
      * @return This instance, to allow chained invocations.
      * @throws NullPointerException if any of the arguments is {@code null}.
      */
-    public ResourceLimits putExtension(final String key, final Object value) {
+    public final ResourceLimits putExtension(final String key, final Object value) {
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
         if (this.extensions == null) {

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -20,11 +20,19 @@ package org.eclipse.hono.util;
 public final class TenantConstants extends RequestResponseApiConstants {
 
     /**
+     * The default value for the maximum number of bytes to be allowed for a tenant is set to -1, which implies no
+     * limit.
+     */
+    public static final long DEFAULT_MAX_BYTES = -1;
+    /**
+     * The default value for the maximum number of connections to be allowed is -1, which implies no limit.
+     */
+    public static final int DEFAULT_MAX_CONNECTIONS = -1;    
+    /**
      * The default number of seconds that a protocol adapter should wait for
      * an upstream command.
      */
     public static final int DEFAULT_MAX_TTD = 60; // seconds
-
     /**
      * The default message size is set to 0, which implies no minimum size is defined.
      */
@@ -49,6 +57,22 @@ public final class TenantConstants extends RequestResponseApiConstants {
      */
     public static final String FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED = "device-authentication-required";
     /**
+     * The name of the property that contains the configuration options for the data volume.
+     */
+    public static final String FIELD_DATA_VOLUME = "data-volume";
+    /**
+     * The name of the property that contains the date on which the data volume limit came into effect.
+     */
+    public static final String FIELD_EFFECTIVE_SINCE = "effective-since";
+    /**
+     * The name of the property that contains the maximum number of bytes to be allowed for a tenant.
+     */
+    public static final String FIELD_MAX_BYTES = "max-bytes";
+    /**
+     * The name of the property that contains the maximum number of connections to be allowed for a tenant.
+     */
+    public static final String FIELD_MAX_CONNECTIONS = "max-connections";    
+    /**
      * The name of the property that contains the maximum <em>time til disconnect</em> that protocol
      * adapters should use for a tenant.
      */
@@ -71,7 +95,19 @@ public final class TenantConstants extends RequestResponseApiConstants {
      * The name of the property that contains the trusted certificate authority configured for a tenant.
      */
     public static final String FIELD_PAYLOAD_TRUSTED_CA = "trusted-ca";
-
+    /**
+     * The name of the property that contains the period details for which the data usage is calculated.
+     */
+    public static final String FIELD_PERIOD = "period";
+    /**
+     * The name of the property that contains the number of days for which the data usage is calculated.
+     */
+    public static final String FIELD_PERIOD_NO_OF_DAYS = "no-of-days";    
+    /**
+     * The name of the property that contains the mode of the period for which the data usage
+     * is calculated.
+     */
+    public static final String FIELD_PERIOD_MODE = "mode";    
     /**
      * The name of the property that contains the minimum message size in bytes.
      */

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -36,11 +36,13 @@ import java.util.OptionalInt;
 import javax.security.auth.x500.X500Principal;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -53,6 +55,8 @@ public final class TenantObject extends JsonBackedValueObject {
 
     @JsonIgnore
     private List<Map<String, Object>> adapterConfigurations;
+    @JsonIgnore
+    private ResourceLimits resourceLimits;    
     @JsonIgnore
     private TrustAnchor trustAnchor;
 
@@ -522,9 +526,24 @@ public final class TenantObject extends JsonBackedValueObject {
      *
      * @return The resource limits or {@code null} if not set.
      */
+    @JsonGetter(TenantConstants.FIELD_RESOURCE_LIMITS)
+    public ResourceLimits getResourceLimits() {
+        return this.resourceLimits;
+    }
+
+    /**
+     * Sets the resource limits for the tenant.
+     *
+     * @param resourceLimits The resource limits configuration to add.
+     * @return This tenant for command chaining.
+     * @throws NullPointerException if resource limits to be set is {@code null}.
+     * @throws IllegalArgumentException if the resource limits object cannot be 
+     *                                  instantiated from the given jsonObject.
+     */
     @JsonIgnore
-    public JsonObject getResourceLimits() {
-        return getProperty(TenantConstants.FIELD_RESOURCE_LIMITS, JsonObject.class);
+    public TenantObject setResourceLimits(final JsonObject resourceLimits) {
+        Objects.requireNonNull(resourceLimits);
+        return setResourceLimits(resourceLimits.mapTo(ResourceLimits.class));
     }
 
     /**
@@ -534,10 +553,11 @@ public final class TenantObject extends JsonBackedValueObject {
      * @return This tenant for command chaining.
      * @throws NullPointerException if resource limits to be set is {@code null}.
      */
-    @JsonIgnore
-    public TenantObject setResourceLimits(final JsonObject resourceLimits) {
+    @JsonSetter(TenantConstants.FIELD_RESOURCE_LIMITS)
+    public TenantObject setResourceLimits(final ResourceLimits resourceLimits) {
         Objects.requireNonNull(resourceLimits);
-        return setProperty(TenantConstants.FIELD_RESOURCE_LIMITS, resourceLimits);
+        this.resourceLimits = resourceLimits;
+        return this;
     }
 
     /**

--- a/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
@@ -29,6 +29,8 @@ import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 
 import javax.security.auth.x500.X500Principal;
@@ -305,11 +307,19 @@ public class TenantObjectTest {
                 .put("max-connections", 2)
                 .put("data-volume",
                         new JsonObject().put("max-bytes", 20_000_000)
-                                .put("period-in-days", 90)
-                                .put("effective-since", "2019-04-26"));
+                                .put("effective-since", "2019-04-25T14:30:00Z")
+                                .put("period", new JsonObject()
+                                        .put("mode", "days")
+                                        .put("no-of-days", 90)));
         final TenantObject tenantObject = TenantObject.from(Constants.DEFAULT_TENANT, true);
         tenantObject.setResourceLimits(limitsConfig);
-        assertThat(tenantObject.getResourceLimits(), is(limitsConfig));
+        assertNotNull(tenantObject.getResourceLimits());
+        assertThat(tenantObject.getResourceLimits().getMaxConnections(), is(2));
+        assertThat(tenantObject.getResourceLimits().getDataVolume().getMaxBytes(), is(20_000_000L));
+        assertThat(tenantObject.getResourceLimits().getDataVolume().getEffectiveSince(), is(
+                DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse("2019-04-25T14:30:00Z", OffsetDateTime::from).toInstant()));
+        assertThat(tenantObject.getResourceLimits().getDataVolume().getPeriod().getMode(), is("days"));
+        assertThat(tenantObject.getResourceLimits().getDataVolume().getPeriod().getNoOfDays(), is(90));
     }
 
     /**

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -44,11 +44,6 @@
       <artifactId>hono-core</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
@@ -17,7 +17,7 @@ import static org.eclipse.hono.util.RegistryManagementConstants.FIELD_SECRETS_NO
 
 import java.time.Instant;
 
-import org.eclipse.hono.service.annotation.HonoTimestamp;
+import org.eclipse.hono.annotation.HonoTimestamp;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.eclipse.hono.util.RegistryManagementConstants;
+import org.eclipse.hono.util.ResourceLimits;
 import org.eclipse.hono.util.TenantTracingConfig;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/plan/PrometheusBasedResourceLimitChecks.java
@@ -16,9 +16,6 @@ import static java.time.temporal.ChronoUnit.DAYS;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -27,6 +24,9 @@ import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
+import org.eclipse.hono.util.DataVolume;
+import org.eclipse.hono.util.DataVolumePeriod;
+import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,47 +44,6 @@ import io.vertx.ext.web.codec.BodyCodec;
  * from a <em>Prometheus</em> server.
  */
 public final class PrometheusBasedResourceLimitChecks implements ResourceLimitChecks {
-
-    /**
-     * The default value for the maximum number of connections to be allowed is -1, which implies no limit.
-     */
-    static final long DEFAULT_MAX_CONNECTIONS = -1;
-
-    /**
-     * The name of the property that contains the maximum number of connections to be allowed for a tenant.
-     */
-    static final String FIELD_MAX_CONNECTIONS = "max-connections";
-
-    /**
-     * The name of the property that contains the configuration options for the data volume.
-     */
-    static final String FIELD_DATA_VOLUME = "data-volume";
-
-    /**
-     * The default value for the maximum number of bytes to be allowed for a tenant is set to -1, which implies no
-     * limit.
-     */
-    static final long DEFAULT_MAX_BYTES = -1;
-
-    /**
-     * The name of the property that contains the maximum number of bytes to be allowed for a tenant.
-     */
-    static final String FIELD_MAX_BYTES = "max-bytes";
-
-    /**
-     * The default number of days for which the data usage being calculated, is set to 30 days.
-     */
-    static final long DEFAULT_PERIOD_IN_DAYS = 30;
-
-    /**
-     * The name of the property that contains the number of days for which the data usage is calculated.
-     */
-    static final String FIELD_PERIOD_IN_DAYS = "period-in-days";
-
-    /**
-     * The name of the property that contains the date on which the data volume limit came into effect.
-     */
-    static final String FIELD_EFFECTIVE_SINCE = "effective-since";
 
     private static final String CONNECTIONS_METRIC_NAME = MicrometerBasedMetrics.METER_CONNECTIONS_AUTHENTICATED
             .replace(".", "_");
@@ -122,7 +81,12 @@ public final class PrometheusBasedResourceLimitChecks implements ResourceLimitCh
     public Future<Boolean> isConnectionLimitReached(final TenantObject tenant) {
 
         Objects.requireNonNull(tenant);
-        final long maxConnections = getConnectionsLimit(tenant);
+        if (tenant.getResourceLimits() == null) {
+            log.trace("No connection limits configured for the tenant [{}]", tenant.getTenantId());
+            return Future.succeededFuture(Boolean.FALSE);
+        }
+
+        final long maxConnections = tenant.getResourceLimits().getMaxConnections();
 
         log.trace("connection limit for tenant [{}] is [{}]", tenant.getTenantId(), maxConnections);
 
@@ -160,12 +124,22 @@ public final class PrometheusBasedResourceLimitChecks implements ResourceLimitCh
             final long payloadSize) {
 
         Objects.requireNonNull(tenant);
-        final long maxBytes = getMaximumNumberOfBytes(tenant);
-        final Instant effectiveSince = getEffectiveSince(tenant);
-        final long periodInDays = getPeriodInDays(tenant);
+        if (tenant.getResourceLimits() == null || tenant.getResourceLimits().getDataVolume() == null) {
+            log.trace("No message limits configured for the tenant [{}]", tenant.getTenantId());
+            return Future.succeededFuture(Boolean.FALSE);
+        }
+
+        final DataVolume dataVolumeConfig = tenant.getResourceLimits().getDataVolume();
+        final long maxBytes = dataVolumeConfig.getMaxBytes();
+        final Instant effectiveSince = dataVolumeConfig.getEffectiveSince();
+        final long periodInDays = Optional.ofNullable(dataVolumeConfig.getPeriod())
+                .map(DataVolumePeriod::getNoOfDays)
+                .orElse(0);
 
         log.trace("message limit config for tenant [{}] are [{}:{}, {}:{}, {}:{}]", tenant.getTenantId(),
-                FIELD_MAX_BYTES, maxBytes, FIELD_EFFECTIVE_SINCE, effectiveSince, FIELD_PERIOD_IN_DAYS, periodInDays);
+                TenantConstants.FIELD_MAX_BYTES, maxBytes,
+                TenantConstants.FIELD_EFFECTIVE_SINCE, effectiveSince,
+                TenantConstants.FIELD_PERIOD_NO_OF_DAYS, periodInDays);
 
         if (maxBytes == -1 || effectiveSince == null || periodInDays <= 0 || payloadSize <= 0) {
             return Future.succeededFuture(Boolean.FALSE);
@@ -202,70 +176,14 @@ public final class PrometheusBasedResourceLimitChecks implements ResourceLimitCh
                             return Boolean.FALSE;
                         } else {
                             log.trace("data limit exceeded for tenant. [{}] are [bytesUsed:{}, {}:{}, {}:{}, {}:{}]",
-                                    tenant.getTenantId(), bytesConsumed, FIELD_MAX_BYTES, maxBytes,
-                                    FIELD_EFFECTIVE_SINCE, effectiveSince, FIELD_PERIOD_IN_DAYS, periodInDays);
+                                    tenant.getTenantId(), bytesConsumed, TenantConstants.FIELD_MAX_BYTES,
+                                    maxBytes,
+                                    TenantConstants.FIELD_EFFECTIVE_SINCE, effectiveSince,
+                                    TenantConstants.FIELD_PERIOD_NO_OF_DAYS, periodInDays);
                             return Boolean.TRUE;
                         }
                     }).otherwise(Boolean.FALSE);
         }
-    }
-
-    /**
-     * Gets the connections limit for the tenant if configured, else returns {@link #DEFAULT_MAX_CONNECTIONS}.
-     *
-     * @param tenant The tenant configuration object.
-     * @return The connections limit.
-     */
-    long getConnectionsLimit(final TenantObject tenant) {
-        return Optional.ofNullable(tenant.getResourceLimits())
-                .map(resourceLimits -> resourceLimits.getLong(FIELD_MAX_CONNECTIONS, DEFAULT_MAX_CONNECTIONS))
-                .orElse(DEFAULT_MAX_CONNECTIONS);
-    }
-
-    /**
-     * Gets the maximum number of bytes to be allowed for the time period defined by the
-     * {@link #getPeriodInDays(TenantObject)}.
-     *
-     * @param tenant The tenant configuration object.
-     * @return The maximum number of bytes or {@link #DEFAULT_MAX_BYTES} if not set.
-     */
-    long getMaximumNumberOfBytes(final TenantObject tenant) {
-        return Optional.ofNullable(tenant.getResourceLimits())
-                .map(limits -> limits.getJsonObject(FIELD_DATA_VOLUME))
-                .map(dataVolumeLimits -> dataVolumeLimits.getLong(FIELD_MAX_BYTES, DEFAULT_MAX_BYTES))
-                .orElse(DEFAULT_MAX_BYTES);
-    }
-
-    /**
-     * Gets the number of days for which the data usage is calculated and compared against the
-     * {@link #getMaximumNumberOfBytes(TenantObject)}.
-     *
-     * @param tenant The tenant configuration object.
-     * @return The number of days for which the data usage is calculated or {@link #DEFAULT_PERIOD_IN_DAYS} if not set.
-     */
-    long getPeriodInDays(final TenantObject tenant) {
-        return Optional.ofNullable(tenant.getResourceLimits())
-                .map(limits -> limits.getJsonObject(FIELD_DATA_VOLUME))
-                .map(dataVolumeLimits -> dataVolumeLimits.getLong(FIELD_PERIOD_IN_DAYS, DEFAULT_PERIOD_IN_DAYS))
-                .orElse(DEFAULT_PERIOD_IN_DAYS);
-    }
-
-    /**
-     * Gets the instant on which the data volume limit came into effect.
-     * <p>
-     * The date string should comply to the {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME}
-     *
-     * @param tenant The tenant configuration object.
-     * @return The instant on which the data volume limit came into effective or {@code null} if not set.
-     * @throws DateTimeParseException if the date string fails to comply with the
-     *             {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME} format.
-     */
-    Instant getEffectiveSince(final TenantObject tenant) {
-        return Optional.ofNullable(tenant.getResourceLimits())
-                .map(limits -> limits.getJsonObject(FIELD_DATA_VOLUME))
-                .map(dataVolumeLimits -> dataVolumeLimits.getString(FIELD_EFFECTIVE_SINCE))
-                .map(this::getInstant)
-                .orElse(null);
     }
 
     private Future<Long> executeQuery(final String query) {
@@ -363,18 +281,5 @@ public final class PrometheusBasedResourceLimitChecks implements ResourceLimitCh
                 .ifPresent(success -> cache.put(key, result,
                         Duration.ofSeconds(config.getCacheTimeout())));
         return result;
-    }
-
-    private Instant getInstant(final String timestamp) {
-
-        if (timestamp == null) {
-            return null;
-        } else {
-            try {
-                return DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(timestamp, OffsetDateTime::from).toInstant();
-            } catch (DateTimeParseException e) {
-                return null;
-            }
-        }
     }
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/tenant/AbstractTenantServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/tenant/AbstractTenantServiceTest.java
@@ -299,10 +299,10 @@ public abstract class AbstractTenantServiceTest {
     public void testGetTenantSucceedsForExistingTenant(final VertxTestContext ctx) {
 
         final JsonObject tenantSpec = buildTenantPayload("tenant")
-            .put(RegistryManagementConstants.FIELD_EXT, new JsonObject().put("plan", "unlimited"))
-            .put(RegistryManagementConstants.FIELD_MINIMUM_MESSAGE_SIZE, 2048)
-            .put(RegistryManagementConstants.FIELD_RESOURCE_LIMITS, new JsonObject()
-                    .put(RegistryManagementConstants.FIELD_RESOURCE_LIMITS_MAX_CONNECTIONS, 1000));
+                .put(RegistryManagementConstants.FIELD_EXT, new JsonObject().put("plan", "unlimited"))
+                .put(TenantConstants.FIELD_MINIMUM_MESSAGE_SIZE, 2048)
+                .put(TenantConstants.FIELD_RESOURCE_LIMITS, new JsonObject()
+                        .put(TenantConstants.FIELD_MAX_CONNECTIONS, 1000));
 
         // GIVEN a tenant that has been added via the Management API
         addTenant("tenant", tenantSpec)

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
@@ -33,7 +33,6 @@ import javax.security.auth.x500.X500Principal;
 import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
-import org.eclipse.hono.service.management.tenant.ResourceLimits;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
 import org.eclipse.hono.service.management.tenant.TrustedCertificateAuthority;
@@ -510,7 +509,6 @@ public final class FileBasedTenantService extends AbstractVerticle implements Te
                 .ifPresent(tenant::setAdapters);
 
         Optional.ofNullable(tenantObject.getResourceLimits())
-                .map(json -> json.mapTo(ResourceLimits.class))
                 .ifPresent(tenant::setResourceLimits);
 
         Optional.ofNullable(tenantObject.getProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, JsonObject.class))

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -528,6 +528,8 @@ components:
                description: The maximum number of concurrent connections allowed
                             from devices of this tenant. The default value -1
                             indicates that no limit is set.
+            "data-volume":
+               $ref: '#/components/schemas/DataVolume'
             "ext":
                $ref: '#/components/schemas/Extensions'
 
@@ -575,6 +577,40 @@ components:
                      - all
                      - none
 
+      DataVolume:
+         type: object
+         additionalProperties: false
+         required:
+            - effective-since
+         properties:
+            "effective-since":
+               type: string
+               format: date-time
+               description: The date-time on which the data volume limit came into effect.
+            "max-bytes":
+               type: integer
+               default: -1
+               description: The maximum number of bytes to be allowed for a tenant for the
+                            defined period. The default value -1 indicates that no limit is set.
+            "period":
+               $ref: '#/components/schemas/Period'
+
+      Period:
+         type: object
+         additionalProperties: false
+         required:
+            - mode
+         properties:
+            "mode":
+               type: string
+               description: The mode of the data usage caluclation. The supported modes by
+                            the default resource limit checks implementation are `days`
+                            and `monthly`.
+            "no-of-days":
+               type: integer
+               description: The number of days for which the data usage is to be calculated
+                            provided the mode is set to `days`.
+               
 # Devices schema
 
       Device:

--- a/site/documentation/content/api/tenant/index.md
+++ b/site/documentation/content/api/tenant/index.md
@@ -135,8 +135,11 @@ The JSON structure below contains example information for tenant `TEST_TENANT`. 
     "max-connections": 100000,
     "data-volume": {
       "max-bytes": 2147483648,
-      "period-in-days": 30,
-      "effective-since": "2019-04-27"
+      "period": {
+        "mode": "days",
+        "no-of-days": 30
+      },
+      "effective-since": "2019-07-27T14:30:00Z"
     }
   },
   "adapters" : [
@@ -214,11 +217,20 @@ The table below contains the properties which are used to configure a tenant's d
 
 | Name                     | Mandatory | JSON Type     | Default Value | Description |
 | :------------------------| :-------: | :------------ | :------------ | :---------- |
+| *effective-since*        | *yes*     | *string*      | `-`           | The point in time at which the current settings became effective, i.e. the start of the first accounting period based on these settings. The value MUST be an [ISO 8601 compliant *combined date and time representation in extended format*](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations).|
 | *max-bytes*              | *no*      | *number*      | `-1`          | The maximum number of bytes allowed for the tenant for each accounting period. MUST be an integer. A negative value indicates that no limit is set. |
-| *period-in-days*         | *no*      | *number*      | `30`          | The length of an accounting period, i.e. the number of days over which the data usage is to be limited. MUST be a positive integer. |
-| *effective-since*        | *yes*     | *string*      | `-`           | The point in time at which the current settings became effective, i.e. the start of the first accounting period based on these settings. The value MUST be an [ISO 8601 compliant *combined date and time representation in extended format*](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations).
+| *period*                 | *no*      | *object*      | `-`          | The mode and length of an accounting period, i.e. the data usage can limited based on the defined number of days or on a monthly basis. |
 
 Protocol adapters SHOULD use this information to determine if a message originating from or destined to a device should be accepted for processing.
+
+### Data Volume Period Configuration Format
+
+The table below contains the properties which are used to configure a tenant's data volume period:
+
+| Name                     | Mandatory | JSON Type     | Default Value | Description |
+| :------------------------| :-------: | :------------ | :------------ | :---------- |
+| *mode*                   | *yes*     | *string*      | `-`           | The mode of the data usage calculation. The default implementation supports two modes namely `days` and `monthly`.|
+| *no-of-days*             | *no*      | *number*      | `-`           | When the mode is set as `days`, then this value represents the length of an accounting period , i.e. the number of days over which the data usage is to be limited. MUST be a positive integer.|
 
 ## Delivery States used by the Tenant API
 

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantApiTests.java
@@ -20,16 +20,19 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.service.management.tenant.Adapter;
-import org.eclipse.hono.service.management.tenant.ResourceLimits;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.Tenants;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.DataVolume;
+import org.eclipse.hono.util.DataVolumePeriod;
+import org.eclipse.hono.util.ResourceLimits;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.junit.jupiter.api.Test;
@@ -74,14 +77,14 @@ abstract class TenantApiTests extends DeviceRegistryTestBase {
                 .put("deployment", new JsonObject()
                         .put("maxInstances", 4));
 
-        final JsonObject dataVolume = new JsonObject()
-                        .put("max-bytes", 2147483648L)
-                        .put("period-in-days", 30)
-                        .put("effective-since", "2019-04-27T12:00:00+00:00");
-
-        final ResourceLimits resourceLimits = new ResourceLimits();
-        resourceLimits.setMaxConnections(100000);
-        resourceLimits.putExtension("data-volume", dataVolume.getMap());
+        final ResourceLimits resourceLimits = new ResourceLimits()
+                .setMaxConnections(100000)
+                .setDataVolume(new DataVolume()
+                        .setMaxBytes(2147483648L)
+                        .setEffectiveSince(Instant.parse("2019-07-27T14:30:00Z"))
+                        .setPeriod(new DataVolumePeriod()
+                                .setMode("days")
+                                .setNoOfDays(30)));
 
         final String tenantId = getHelper().getRandomTenantId();
         final Tenant tenant = new Tenant();
@@ -104,8 +107,12 @@ abstract class TenantApiTests extends DeviceRegistryTestBase {
                 .setDefaults(defaults)
                 .setResourceLimits(new JsonObject()
                         .put("max-connections", 100000)
-                        .put("ext", new JsonObject()
-                                .put("data-volume", dataVolume)))
+                        .put("data-volume", new JsonObject()
+                                .put("max-bytes", 2147483648L)
+                                .put("effective-since", "2019-07-27T14:30:00Z")
+                                .put("period", new JsonObject()
+                                        .put("mode", "days")
+                                        .put("no-of-days", 30))))
                 .setAdapterConfigurations(new JsonArray()
                         .add(new JsonObject()
                                 .put(TenantConstants.FIELD_ADAPTERS_TYPE, Constants.PROTOCOL_ADAPTER_TYPE_MQTT)
@@ -123,9 +130,19 @@ abstract class TenantApiTests extends DeviceRegistryTestBase {
         .compose(ok -> getAdminClient().get(tenantId))
         .setHandler(ctx.succeeding(tenantObject -> {
             ctx.verify(() -> {
-                assertThat(tenantObject.getResourceLimits()).isEqualTo(expectedTenantObject.getResourceLimits());
                 assertThat(tenantObject.getDefaults()).isEqualTo(expectedTenantObject.getDefaults());
                 assertThat(tenantObject.getAdapterConfigurations()).isEqualTo(expectedTenantObject.getAdapterConfigurations());
+                assertThat(tenantObject.getResourceLimits().getMaxConnections())
+                        .isEqualTo(expectedTenantObject.getResourceLimits().getMaxConnections());
+                assertThat(tenantObject.getResourceLimits().getDataVolume().getMaxBytes())
+                        .isEqualTo(expectedTenantObject.getResourceLimits().getDataVolume().getMaxBytes());
+                assertThat(tenantObject.getResourceLimits().getDataVolume().getEffectiveSince()).isEqualTo(
+                        expectedTenantObject.getResourceLimits().getDataVolume().getEffectiveSince());
+                assertThat(tenantObject.getResourceLimits().getDataVolume().getPeriod().getMode()).isEqualTo(
+                        expectedTenantObject.getResourceLimits().getDataVolume().getPeriod().getMode());
+                assertThat(tenantObject.getResourceLimits().getDataVolume().getPeriod().getNoOfDays())
+                        .isEqualTo(expectedTenantObject.getResourceLimits().getDataVolume().getPeriod()
+                                .getNoOfDays());
                 assertThat(tenantObject.getProperty("ext", JsonObject.class).getString("customer")).isEqualTo("ACME Inc.");
             });
             ctx.completeNow();

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantHttpIT.java
@@ -20,7 +20,7 @@ import java.net.HttpURLConnection;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.hono.service.management.tenant.ResourceLimits;
+import org.eclipse.hono.util.ResourceLimits;
 import org.eclipse.hono.service.management.tenant.Adapter;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.DeviceRegistryHttpClient;


### PR DESCRIPTION
This PR implements #1460 
- Management and Tenant API now supports data limit configuration.
- Updated default resource limit checks implementation due to changes in the Tenant API.