### PR TITLE
[#1448] Use max-ttl to limit downstream event TTL.

### DIFF
--- a/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
@@ -295,7 +295,7 @@ public class TenantClientImplTest {
         verify(sender).send(messageCaptor.capture(), anyHandler());
         final Message sentMessage = messageCaptor.getValue();
         assertNull(MessageHelper.getTenantId(sentMessage));
-        assertThat(sentMessage.getMessageId().toString(), is(notNullValue()));
+        assertThat(sentMessage.getMessageId(), is(notNullValue()));
         assertThat(sentMessage.getSubject(), is(TenantConstants.TenantAction.get.toString()));
         assertThat(MessageHelper.getJsonPayload(sentMessage).getString(TenantConstants.FIELD_PAYLOAD_TENANT_ID), is("tenant"));
     }

--- a/core/src/main/java/org/eclipse/hono/util/DataVolume.java
+++ b/core/src/main/java/org/eclipse/hono/util/DataVolume.java
@@ -31,7 +31,7 @@ public class DataVolume {
     private Instant effectiveSince;
 
     @JsonProperty(TenantConstants.FIELD_MAX_BYTES)
-    private long maxBytes = TenantConstants.DEFAULT_MAX_BYTES;
+    private long maxBytes = TenantConstants.UNLIMITED_BYTES;
 
     @JsonProperty(TenantConstants.FIELD_PERIOD)
     private DataVolumePeriod period;
@@ -63,7 +63,7 @@ public class DataVolume {
      * {@link TenantConstants#FIELD_PERIOD_MODE} and 
      * {@link TenantConstants#FIELD_PERIOD_NO_OF_DAYS}.
      *
-     * @return The maximum number of bytes or {@link TenantConstants#DEFAULT_MAX_BYTES} 
+     * @return The maximum number of bytes or {@link TenantConstants#UNLIMITED_BYTES} 
      *         if not set.
      */
     public final long getMaxBytes() {

--- a/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
@@ -28,7 +28,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ResourceLimits {
 
     @JsonProperty(TenantConstants.FIELD_MAX_CONNECTIONS)
-    private int maxConnections = TenantConstants.DEFAULT_MAX_CONNECTIONS;
+    private int maxConnections = TenantConstants.UNLIMITED_CONNECTIONS;
+    @JsonProperty(TenantConstants.FIELD_MAX_TTL)
+    private long maxTtl = TenantConstants.UNLIMITED_TTL;
 
     @JsonProperty(TenantConstants.FIELD_DATA_VOLUME)
     private DataVolume dataVolume;
@@ -55,11 +57,33 @@ public class ResourceLimits {
     /**
      * Gets the maximum number of connected devices a tenant supports.
      * 
-     * @return The maximum number of connections or {@link TenantConstants#DEFAULT_MAX_CONNECTIONS}
+     * @return The maximum number of connections or {@link TenantConstants#UNLIMITED_CONNECTIONS}
      *         if not set.
      */
     public final int getMaxConnections() {
         return this.maxConnections;
+    }
+
+    /**
+     * Sets the maximum time-to-live to use for events published by
+     * devices of a tenant.
+     * 
+     * @param maxTtl The time-to-live in seconds.
+     * @return A reference to this for fluent use.
+     */
+    public ResourceLimits setMaxTtl(final long maxTtl) {
+        this.maxTtl = maxTtl;
+        return this;
+    }
+
+    /**
+     * Gets the maximum time-to-live to use for events published by
+     * devices of a tenant.
+     * 
+     * @return The time-to-live in seconds.
+     */
+    public long getMaxTtl() {
+        return this.maxTtl;
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
@@ -70,8 +70,12 @@ public class ResourceLimits {
      * 
      * @param maxTtl The time-to-live in seconds.
      * @return A reference to this for fluent use.
+     * @throws IllegalArgumentException if the time-to-live is set to less than -1.
      */
     public ResourceLimits setMaxTtl(final long maxTtl) {
+        if (maxTtl < -1) {
+            throw new IllegalArgumentException("Maximum time-to-live property must be set to value >= -1");
+        }
         this.maxTtl = maxTtl;
         return this;
     }

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -20,15 +20,6 @@ package org.eclipse.hono.util;
 public final class TenantConstants extends RequestResponseApiConstants {
 
     /**
-     * The default value for the maximum number of bytes to be allowed for a tenant is set to -1, which implies no
-     * limit.
-     */
-    public static final long DEFAULT_MAX_BYTES = -1;
-    /**
-     * The default value for the maximum number of connections to be allowed is -1, which implies no limit.
-     */
-    public static final int DEFAULT_MAX_CONNECTIONS = -1;    
-    /**
      * The default number of seconds that a protocol adapter should wait for
      * an upstream command.
      */
@@ -37,6 +28,19 @@ public final class TenantConstants extends RequestResponseApiConstants {
      * The default message size is set to 0, which implies no minimum size is defined.
      */
     public static final int DEFAULT_MINIMUM_MESSAGE_SIZE = 0;
+
+    /**
+     * The value indicating an <em>unlimited</em> number of bytes to be allowed for a tenant.
+     */
+    public static final long UNLIMITED_BYTES = -1;
+    /**
+     * The value indicating an <em>unlimited</em> number of connections to be allowed for a tenant.
+     */
+    public static final int UNLIMITED_CONNECTIONS = -1;
+    /**
+     * The value indicating <em>unlimited</em> time-to-live for downstream events.
+     */
+    public static final long UNLIMITED_TTL = -1;
 
     /**
      * The name of the property that contains configuration options for specific
@@ -69,10 +73,15 @@ public final class TenantConstants extends RequestResponseApiConstants {
      */
     public static final String FIELD_MAX_CONNECTIONS = "max-connections";    
     /**
-     * The name of the property that contains the maximum <em>time til disconnect</em> that protocol
+     * The name of the property that contains the maximum <em>time til disconnect</em> (seconds) that protocol
      * adapters should use for a tenant.
      */
     public static final String FIELD_MAX_TTD = "max-ttd";
+    /**
+     * The name of the property that contains the maximum <em>time to live</em> (seconds) for
+     * downstream events that protocol adapters should use for a tenant.
+     */
+    public static final String FIELD_MAX_TTL = "max-ttl";
     /**
      * The name of the property that contains the algorithm used for a public key.
      */

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -56,7 +56,7 @@ public final class TenantObject extends JsonBackedValueObject {
     @JsonIgnore
     private List<Map<String, Object>> adapterConfigurations;
     @JsonIgnore
-    private ResourceLimits resourceLimits;    
+    private ResourceLimits resourceLimits;
     @JsonIgnore
     private TrustAnchor trustAnchor;
 

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -1222,8 +1222,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                 final boolean isEvent = target.getEndpoint().equals(EventConstants.EVENT_ENDPOINT);
                 if (isEvent && message.getTtl() == 0 && Number.class.isInstance(prop.getValue())) {
                     final long defaultTtl = ((Number) prop.getValue()).longValue();
-                    if (maxTtl > -1 && defaultTtl > maxTtl) {
-                            message.setTtl(maxTtl);
+                    if (maxTtl != TenantConstants.UNLIMITED_TTL && defaultTtl > maxTtl) {
+                        message.setTtl(maxTtl);
                     } else {
                         message.setTtl(defaultTtl);
                     }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -1178,9 +1178,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                 .orElse(TenantConstants.UNLIMITED_TTL);
 
         final boolean isEvent = target.getEndpoint().equals(EventConstants.EVENT_ENDPOINT);
-        if (isEvent && maxTtl != TenantConstants.UNLIMITED_TTL && message.getTtl() > maxTtl) {
-            LOG.debug("adjusting device provided TTL [{}] to max TTL [{}]", message.getTtl(), maxTtl);
-            message.setTtl(maxTtl);
+        // AMQP spec defines TTL as milliseconds
+        final long maxTtlMillis = maxTtl * 1000L;
+        if (isEvent && maxTtl != TenantConstants.UNLIMITED_TTL && message.getTtl() > maxTtlMillis) {
+            LOG.debug("adjusting device provided TTL [{}ms] to max TTL [{}ms]", message.getTtl(), maxTtlMillis);
+            message.setTtl(maxTtlMillis);
         }
 
         if (getConfig().isDefaultsEnabled()) {
@@ -1223,9 +1225,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                 if (isEvent && message.getTtl() == 0 && Number.class.isInstance(prop.getValue())) {
                     final long defaultTtl = ((Number) prop.getValue()).longValue();
                     if (maxTtl != TenantConstants.UNLIMITED_TTL && defaultTtl > maxTtl) {
-                        message.setTtl(maxTtl);
+                        // AMQP spec defines TTL as milliseconds
+                        message.setTtl(maxTtl * 1000L);
                     } else {
-                        message.setTtl(defaultTtl);
+                     // AMQP spec defines TTL as milliseconds
+                        message.setTtl(defaultTtl * 1000L);
                     }
                 }
                 break;

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -355,7 +355,7 @@ public class AbstractProtocolAdapterBaseTest {
         assertThat(
                 MessageHelper.getApplicationProperty(message.getApplicationProperties(), "custom-device", Boolean.class),
                 is(Boolean.TRUE));
-        assertThat(message.getTtl(), is(30L));
+        assertThat(message.getTtl(), is(30000L));
     }
 
     /**
@@ -376,7 +376,7 @@ public class AbstractProtocolAdapterBaseTest {
 
         adapter.addProperties(message, target, null, tenant, assertion, null);
 
-        assertThat(message.getTtl(), is(15L));
+        assertThat(message.getTtl(), is(15000L));
     }
 
     /**
@@ -394,7 +394,7 @@ public class AbstractProtocolAdapterBaseTest {
 
         adapter.addProperties(message, target, null, tenant, assertion, null);
 
-        assertThat(message.getTtl(), is(15L));
+        assertThat(message.getTtl(), is(15000L));
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
@@ -142,6 +142,7 @@ class TenantTest {
         final JsonObject tenantSpec = new JsonObject()
                 .put(RegistryManagementConstants.FIELD_RESOURCE_LIMITS, new JsonObject()
                         .put(TenantConstants.FIELD_MAX_CONNECTIONS, 100)
+                        .put(TenantConstants.FIELD_MAX_TTL, 30)
                         .put(TenantConstants.FIELD_DATA_VOLUME, new JsonObject()
                                 .put(TenantConstants.FIELD_MAX_BYTES, 20_000_000)
                                 .put(TenantConstants.FIELD_EFFECTIVE_SINCE, "2019-04-25T14:30:00Z")
@@ -153,9 +154,10 @@ class TenantTest {
         assertNotNull(tenant);
         assertNull(tenant.getEnabled());
 
-        final var limits = tenant.getResourceLimits();
+        final ResourceLimits limits = tenant.getResourceLimits();
         assertNotNull(limits);
         assertEquals(100, limits.getMaxConnections());
+        assertEquals(30, limits.getMaxTtl());
         assertNotNull(limits.getDataVolume());
         assertEquals(
                 DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse("2019-04-25T14:30:00Z", OffsetDateTime::from).toInstant(),

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -535,7 +535,7 @@ components:
                             devices of this tenant. Any default TTL value specified
                             at either the tenant or device level will be limited to
                             the max value specified here.
-                            If this property is set to a value other than -1 and no
+                            If this property is set to a value greater than -1 and no
                             default TTL is specified for a device, the max value will
                             be used for events published by the device.
                             A value of -1 (the default) indicates that no limit is set.

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -539,6 +539,9 @@ components:
                             default TTL is specified for a device, the max value will
                             be used for events published by the device.
                             A value of -1 (the default) indicates that no limit is set.
+                            Note that this property contains the TTL in seconds whereas
+                            the AMQP 1.0 specification defines a message's ttl header
+                            to use milliseconds.
             "data-volume":
                $ref: '#/components/schemas/DataVolume'
             "ext":

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -526,8 +526,19 @@ components:
                type: integer
                default: -1
                description: The maximum number of concurrent connections allowed
-                            from devices of this tenant. The default value -1
-                            indicates that no limit is set.
+                            from devices of this tenant.
+                            A value of -1 (the default) indicates that no limit is set.
+            "max-ttl":
+               type: integer
+               default: -1
+               description: The maximum time-to-live (in seconds) to use for events published by
+                            devices of this tenant. Any default TTL value specified
+                            at either the tenant or device level will be limited to
+                            the max value specified here.
+                            If this property is set to a value other than -1 and no
+                            default TTL is specified for a device, the max value will
+                            be used for events published by the device.
+                            A value of -1 (the default) indicates that no limit is set.
             "data-volume":
                $ref: '#/components/schemas/DataVolume'
             "ext":
@@ -591,7 +602,8 @@ components:
                type: integer
                default: -1
                description: The maximum number of bytes to be allowed for a tenant for the
-                            defined period. The default value -1 indicates that no limit is set.
+                            defined period.
+                            A value of -1 (the default) indicates that no limit is set.
             "period":
                $ref: '#/components/schemas/Period'
 
@@ -604,12 +616,12 @@ components:
             "mode":
                type: string
                description: The mode of the data usage caluclation. The supported modes by
-                            the default resource limit checks implementation are `days`
-                            and `monthly`.
+                            the default resource limit checks implementation are "days"
+                            and "monthly".
             "no-of-days":
                type: integer
                description: The number of days for which the data usage is to be calculated
-                            provided the mode is set to `days`.
+                            if mode is set to "days". Otherwise, this property is ignored.
                
 # Devices schema
 
@@ -739,7 +751,7 @@ components:
               properties:
                  "hash-function":
                     type: string
-                    example: sha-512
+                    example: bcrypt
                     description: The name of the hash function used to create the password hash (defined in `pwd-hash` property).
                                  If the password is defined using a `pwd-plain` property, this value will be ignored by the device registry.
                                  This property should be empty when returning passwords from the device registry using only secret metadata.

--- a/site/documentation/content/api/tenant/index.md
+++ b/site/documentation/content/api/tenant/index.md
@@ -204,7 +204,7 @@ The table below contains the properties which are used to configure a tenant's r
 | Name                | Mandatory | JSON Type     | Default Value | Description |
 | :------------------ | :-------: | :------------ | :------------ | :---------- |
 | *max-connections*   | *no*      | *number*      | `-1`          | The maximum number of concurrent connections allowed from devices of this tenant. The default value `-1` indicates that no limit is set. |
-| *max-ttl*           | *no*      | *number*      | `-1`          | The maximum time-to-live (in seconds) to use for events published by  devices of this tenant. Any default TTL value specified at either the tenant or device level will be limited to the max value specified here. If this property is set to a value greater than `-1` and no default TTL is specified for a device, the max value will be used for events published by the device. A value of `-1` (the default) indicates that no limit is set. |
+| *max-ttl*           | *no*      | *number*      | `-1`          | The maximum time-to-live (in seconds) to use for events published by devices of this tenant. Any default TTL value specified at either the tenant or device level will be limited to the max value specified here. If this property is set to a value greater than `-1` and no default TTL is specified for a device, the max value will be used for events published by the device. A value of `-1` (the default) indicates that no limit is set. **Note** that this property contains the TTL in *seconds* whereas the AMQP 1.0 specification defines a message's *ttl* header to use milliseconds. |
 | *data-volume*       | *no*      | *object*      | `-`           | The maximum data volume allowed for the given tenant. Refer to  [Data Volume Configuration Format]({{< relref "#data-volume-configuration-format" >}}) for details.|
 
 Protocol adapters SHOULD use the *max-connections* property to determine if a device's connection request should be accepted or rejected.
@@ -213,12 +213,12 @@ Protocol adapters SHOULD use the *max-ttl* property to determine the *effective 
 
 1. If a non-default *max-ttl* is set for the tenant, use that value as the *effective ttl*, otherwise set *effective ttl* to `-1`.
 1. If the event published by the device
-   1. contains a *ttl* property and *effective ttl* is not `-1` and the *ttl* value provided by the device is smaller than the
+   1. contains a *ttl* header and *effective ttl* is not `-1` and the *ttl* value (in seconds) provided by the device is smaller than the
       *effective ttl*, use the device provided *ttl* value as the new *effective ttl*.
-   1. does not contain a *ttl* property but a default *ttl* value is configured for the device (with the device level taking precedence
+   1. does not contain a *ttl* header but a default *ttl* value is configured for the device (with the device level taking precedence
       over the tenant level) and *effective ttl* is not `-1` and the default value is smaller than the *effective ttl*,
       use the default *ttl* value as the new *effective ttl*.
-1. If *effective ttl* is not `-1`, set the downstream event message's *ttl* property to its value.
+1. If *effective ttl* is not `-1`, set the downstream event message's *ttl* header to its value (in milliseconds).
 
 The JSON object MAY contain an arbitrary number of additional members with arbitrary names of either scalar or complex type.
 This allows for future *well-known* additions and also allows to add further information which might be relevant to a *custom* adapter only.

--- a/site/documentation/content/api/tenant/index.md
+++ b/site/documentation/content/api/tenant/index.md
@@ -201,12 +201,24 @@ This allows for future *well-known* additions and also allows to add further inf
 
 The table below contains the properties which are used to configure a tenant's resource limits:
 
-| Name                     | Mandatory | JSON Type     | Default Value | Description |
-| :------------------------| :-------: | :------------ | :------------ | :---------- |
-| *max-connections*        | *no*      | *number*      | `-1`          | The maximum number of concurrent connections allowed from devices of this tenant. The default value `-1` indicates that no limit is set. |
-| *data-volume*            | *no*      | *object*      | `-`           | The maximum data volume allowed for the given tenant. Refer to  [Data Volume Configuration Format]({{< relref "#data-volume-configuration-format" >}}) for details.|
+| Name                | Mandatory | JSON Type     | Default Value | Description |
+| :------------------ | :-------: | :------------ | :------------ | :---------- |
+| *max-connections*   | *no*      | *number*      | `-1`          | The maximum number of concurrent connections allowed from devices of this tenant. The default value `-1` indicates that no limit is set. |
+| *max-ttl*           | *no*      | *number*      | `-1`          | The maximum time-to-live (in seconds) to use for events published by  devices of this tenant. Any default TTL value specified at either the tenant or device level will be limited to the max value specified here. If this property is set to a value other than `-1` and no default TTL is specified for a device, the max value will be used for events published by the device. A value of `-1` (the default) indicates that no limit is set. |
+| *data-volume*       | *no*      | *object*      | `-`           | The maximum data volume allowed for the given tenant. Refer to  [Data Volume Configuration Format]({{< relref "#data-volume-configuration-format" >}}) for details.|
 
 Protocol adapters SHOULD use the *max-connections* property to determine if a device's connection request should be accepted or rejected.
+
+Protocol adapters SHOULD use the *max-ttl* property to determine the *effective time-to-live* for events published by devices as follows:
+
+1. If a non-default *max-ttl* is set for the tenant, use that value as the *effective ttl*, otherwise set *effective ttl* to `-1`.
+1. If the event published by the device
+   1. contains a *ttl* property and *effective ttl* is not `-1` and the *ttl* value provided by the device is smaller than the
+      *effective ttl*, use the device provided *ttl* value as the new *effective ttl*.
+   1. does not contain a *ttl* property but a default *ttl* value is configured for the device (either at the tenant or the device level)
+      and *effective ttl* is not `-1` and the default value is smaller than the *effective ttl*,
+      use the default *ttl* value as the new *effective ttl*.
+1. If *effective ttl* is not `-1`, set the downstream event message's *ttl* property to its value.
 
 The JSON object MAY contain an arbitrary number of additional members with arbitrary names of either scalar or complex type.
 This allows for future *well-known* additions and also allows to add further information which might be relevant to a *custom* adapter only.

--- a/site/documentation/content/api/tenant/index.md
+++ b/site/documentation/content/api/tenant/index.md
@@ -204,7 +204,7 @@ The table below contains the properties which are used to configure a tenant's r
 | Name                | Mandatory | JSON Type     | Default Value | Description |
 | :------------------ | :-------: | :------------ | :------------ | :---------- |
 | *max-connections*   | *no*      | *number*      | `-1`          | The maximum number of concurrent connections allowed from devices of this tenant. The default value `-1` indicates that no limit is set. |
-| *max-ttl*           | *no*      | *number*      | `-1`          | The maximum time-to-live (in seconds) to use for events published by  devices of this tenant. Any default TTL value specified at either the tenant or device level will be limited to the max value specified here. If this property is set to a value other than `-1` and no default TTL is specified for a device, the max value will be used for events published by the device. A value of `-1` (the default) indicates that no limit is set. |
+| *max-ttl*           | *no*      | *number*      | `-1`          | The maximum time-to-live (in seconds) to use for events published by  devices of this tenant. Any default TTL value specified at either the tenant or device level will be limited to the max value specified here. If this property is set to a value greater than `-1` and no default TTL is specified for a device, the max value will be used for events published by the device. A value of `-1` (the default) indicates that no limit is set. |
 | *data-volume*       | *no*      | *object*      | `-`           | The maximum data volume allowed for the given tenant. Refer to  [Data Volume Configuration Format]({{< relref "#data-volume-configuration-format" >}}) for details.|
 
 Protocol adapters SHOULD use the *max-connections* property to determine if a device's connection request should be accepted or rejected.
@@ -215,8 +215,8 @@ Protocol adapters SHOULD use the *max-ttl* property to determine the *effective 
 1. If the event published by the device
    1. contains a *ttl* property and *effective ttl* is not `-1` and the *ttl* value provided by the device is smaller than the
       *effective ttl*, use the device provided *ttl* value as the new *effective ttl*.
-   1. does not contain a *ttl* property but a default *ttl* value is configured for the device (either at the tenant or the device level)
-      and *effective ttl* is not `-1` and the default value is smaller than the *effective ttl*,
+   1. does not contain a *ttl* property but a default *ttl* value is configured for the device (with the device level taking precedence
+      over the tenant level) and *effective ttl* is not `-1` and the default value is smaller than the *effective ttl*,
       use the default *ttl* value as the new *effective ttl*.
 1. If *effective ttl* is not `-1`, set the downstream event message's *ttl* property to its value.
 

--- a/site/documentation/content/concepts/resource-limits.md
+++ b/site/documentation/content/concepts/resource-limits.md
@@ -19,3 +19,4 @@ The MQTT and AMQP protocol adapters keep the connections longer opened than thei
 Hono supports limiting the number of messages that devices and north bound applications of a tenant can publish to Hono during a given time interval. Before accepting any telemetry or event or command messages from devices or north bound applications, it is checked by the protocol adapters that if the message limit is exceeded or not. The incoming message is discarded if the limit is exceeded. 
 
 The default prometheus based implementation uses data volume as the factor to limit the messages. The data volume already consumed by a tenant over the given time interval is compared with the configured message limit before accepting any messages.
+

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -337,6 +337,17 @@ The adapter also considers *defaults* registered for the device at either the [t
 
 Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
 
+### Event Message Time-to-live
+
+Events published by devices will usually be persisted by the AMQP Messaging Network in order to support deferred delivery to downstream consumers.
+In most cases the AMQP Messaging Network can be configured with a maximum *time-to-live* to apply to the events so that the events will be removed
+from the persistent store if no consumer has attached to receive the event before the message expires.
+
+In order to support environments where the AMQP Messaging Network cannot be configured accordingly, the protocol adapter supports setting a
+downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values configured for a tenant/device as described in the [Tenant API]
+({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
+
+
 ## Tenant specific Configuration
 
 The adapter uses the [Tenant API]({{< ref "/api/tenant#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-amqp`.

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -576,6 +576,17 @@ The adapter also considers *defaults* registered for the device at either the [t
 
 Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
 
+### Event Message Time-to-live
+
+Events published by devices will usually be persisted by the AMQP Messaging Network in order to support deferred delivery to downstream consumers.
+In most cases the AMQP Messaging Network can be configured with a maximum *time-to-live* to apply to the events so that the events will be removed
+from the persistent store if no consumer has attached to receive the event before the message expires.
+
+In order to support environments where the AMQP Messaging Network cannot be configured accordingly, the protocol adapter supports setting a
+downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values configured for a tenant/device as described in the [Tenant API]
+({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
+
+
 ## Tenant specific Configuration
 
 The adapter uses the [Tenant API]({{< ref "/api/tenant#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-http`.

--- a/site/documentation/content/user-guide/kura-adapter.md
+++ b/site/documentation/content/user-guide/kura-adapter.md
@@ -38,6 +38,17 @@ The adapter also considers *defaults* registered for the device at either the [t
 
 Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
 
+### Event Message Time-to-live
+
+Events published by devices will usually be persisted by the AMQP Messaging Network in order to support deferred delivery to downstream consumers.
+In most cases the AMQP Messaging Network can be configured with a maximum *time-to-live* to apply to the events so that the events will be removed
+from the persistent store if no consumer has attached to receive the event before the message expires.
+
+In order to support environments where the AMQP Messaging Network cannot be configured accordingly, the protocol adapter supports setting a
+downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values configured for a tenant/device as described in the [Tenant API]
+({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
+
+
 ## Tenant specific Configuration
 
 The adapter uses the [Tenant API]({{< ref "/api/tenant#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-kura-mqtt`.

--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -302,6 +302,17 @@ The adapter also considers *defaults* registered for the device at either the [t
 
 Note that of the standard AMQP 1.0 message properties only the *content-type* and *ttl* can be set this way to a default value.
 
+### Event Message Time-to-live
+
+Events published by devices will usually be persisted by the AMQP Messaging Network in order to support deferred delivery to downstream consumers.
+In most cases the AMQP Messaging Network can be configured with a maximum *time-to-live* to apply to the events so that the events will be removed
+from the persistent store if no consumer has attached to receive the event before the message expires.
+
+In order to support environments where the AMQP Messaging Network cannot be configured accordingly, the protocol adapter supports setting a
+downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values configured for a tenant/device as described in the [Tenant API]
+({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
+
+
 ## Tenant specific Configuration
 
 The adapter uses the [Tenant API]({{< ref "/api/tenant#get-tenant-information" >}}) to retrieve *tenant specific configuration* for adapter type `hono-mqtt`.

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -2,6 +2,16 @@
 title = "Release Notes"
 +++
 
+## 1.0.0 (not yet released)
+
+### New Features
+
+* A tenant can now be configured with a *max-ttl* which is used as a upper boundary for default
+  TTL values configured for devices/tenants. Please refer to the [Tenant API]
+  ({{< relref "/api/tenant#resource-limits-configuration-format" >}}) for details.
+  The AMQP, HTTP, MQTT and Kura protocol adapters consider this property when setting a TTL on
+  downstream event messages.
+
 ## 1.0-M7
 
 ### New Features

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -89,7 +89,7 @@ public class EventMqttIT extends MqttPublishTestBase {
     }
 
     /**
-     * Verifies that an event frmo a device for which a default TTL has been
+     * Verifies that an event from a device for which a default TTL has been
      * specified cannot be consumed after the TTL has expired.
      * 
      * @param ctx The vert.x test context.
@@ -101,7 +101,7 @@ public class EventMqttIT extends MqttPublishTestBase {
         final String tenantId = helper.getRandomTenantId();
         final String deviceId = helper.getRandomDeviceId(tenantId);
         final Tenant tenant = new Tenant();
-        tenant.getDefaults().put(MessageHelper.SYS_HEADER_PROPERTY_TTL, 500);
+        tenant.getDefaults().put(MessageHelper.SYS_HEADER_PROPERTY_TTL, 3); // seconds
         final Async setup = ctx.async();
 
         helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, "secret")
@@ -120,7 +120,7 @@ public class EventMqttIT extends MqttPublishTestBase {
             }
         })).compose(ok -> {
             final Future<MessageConsumer> consumerCreated = Future.future();
-            VERTX.setTimer(1000, tid -> {
+            VERTX.setTimer(4000, tid -> {
                 LOGGER.info("opening event consumer for tenant [{}]", tenantId);
                 // THEN no messages can be consumed after the TTL has expired
                 createConsumer(tenantId, msg -> receivedMessageCount.incrementAndGet())
@@ -129,7 +129,7 @@ public class EventMqttIT extends MqttPublishTestBase {
             return consumerCreated;
         }).compose(c -> {
             final Future<Void> done = Future.future();
-            VERTX.setTimer(500, tid -> {
+            VERTX.setTimer(1000, tid -> {
                 if (receivedMessageCount.get() > 0) {
                     done.fail(new IllegalStateException("should not have received any events after TTL has expired"));
                 } else {

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantApiTests.java
@@ -79,6 +79,7 @@ abstract class TenantApiTests extends DeviceRegistryTestBase {
 
         final ResourceLimits resourceLimits = new ResourceLimits()
                 .setMaxConnections(100000)
+                .setMaxTtl(30L)
                 .setDataVolume(new DataVolume()
                         .setMaxBytes(2147483648L)
                         .setEffectiveSince(Instant.parse("2019-07-27T14:30:00Z"))
@@ -107,6 +108,7 @@ abstract class TenantApiTests extends DeviceRegistryTestBase {
                 .setDefaults(defaults)
                 .setResourceLimits(new JsonObject()
                         .put("max-connections", 100000)
+                        .put("max-ttl", 300L)
                         .put("data-volume", new JsonObject()
                                 .put("max-bytes", 2147483648L)
                                 .put("effective-since", "2019-07-27T14:30:00Z")


### PR DESCRIPTION
Support definition of a maximum TTL per tenant to limit the default TTL applied to downstream events from devices.