### PR TITLE
[#266] Equip HTTP Adapter to support setting TTL value for events published by devices.

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -674,7 +674,8 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                             payload,
                             tenantTracker.result(),
                             tokenTracker.result(),
-                            ttd);
+                            ttd,
+                            EndpointType.EVENT.equals(endpoint) ? HttpUtils.getTimeToLive(ctx) : null);
                     customizeDownstreamMessage(downstreamMessage, ctx);
 
                     addConnectionCloseHandler(ctx, commandConsumerTracker.result(), tenant, deviceId, currentSpan);

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.adapter.http;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -448,6 +449,39 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
                 anyInt(),
                 any(MetricsTags.TtdStatus.class),
                 any());
+    }
+
+    /**
+     * Verifies that the adapter uses the time to live value set in the down stream event message.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUploadEventWithTimeToLive() {
+        // GIVEN an adapter with a downstream event consumer attached
+        final Future<ProtonDelivery> outcome = Future.future();
+        final DownstreamSender sender = givenAnEventSenderForOutcome(outcome);
+
+        final HttpServer server = getHttpServer(false);
+        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+
+        // WHEN a device publishes an event with a time to live value as a header
+        final Buffer payload = Buffer.buffer("some payload");
+        final HttpServerResponse response = mock(HttpServerResponse.class);
+        final HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.getHeader(eq(Constants.HEADER_TIME_TO_LIVE))).thenReturn("10");
+        final RoutingContext ctx = newRoutingContext(payload, "application/text", request, response);
+        when(ctx.addBodyEndHandler(any(Handler.class))).thenAnswer(invocation -> {
+            final Handler<Void> handler = invocation.getArgument(0);
+            handler.handle(null);
+            return 0;
+        });
+
+        adapter.uploadEventMessage(ctx, "tenant", "device");
+
+        // verifies that the downstream message contains the time to live value
+        final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(sender).sendAndWaitForOutcome(messageCaptor.capture(), any());
+        assertEquals(10L * 1000, messageCaptor.getValue().getTtl());
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/util/Constants.java
+++ b/core/src/main/java/org/eclipse/hono/util/Constants.java
@@ -213,7 +213,10 @@ public final class Constants {
      * events.
      */
     public static final String HEADER_TIME_TILL_DISCONNECT = "hono-ttd";
-
+    /**
+     * The header name defined for setting the <em>time-to-live</em> for the event messages.
+     */
+    public static final String HEADER_TIME_TO_LIVE = "hono-ttl";
     /**
      * The header name defined for setting the <em>time to deliver</em> for device command readiness notification events.
      * @deprecated Use {@link #HEADER_TIME_TILL_DISCONNECT} instead

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -13,6 +13,7 @@
 package org.eclipse.hono.util;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Objects;
@@ -492,6 +493,20 @@ public final class MessageHelper {
      */
     public static String getCacheDirective(final Message msg) {
         return getApplicationProperty(msg.getApplicationProperties(), APP_PROPERTY_CACHE_CONTROL, String.class);
+    }
+
+    /**
+     * Sets the <em>time-to-live</em> of the AMQP 1.0 message.
+     * 
+     * @param message the message for that the <em>time-to-live</em> is set.
+     * @param timeToLive The <em>time-to-live</em> duration to be set in the message.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static void setTimeToLive(final Message message, final Duration timeToLive) {
+        Objects.requireNonNull(message);
+        Objects.requireNonNull(timeToLive);
+
+        message.setTtl(timeToLive.toMillis());
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/http/HttpUtilsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/http/HttpUtilsTest.java
@@ -93,4 +93,48 @@ public class HttpUtilsTest {
         assertNull(HttpUtils.getTimeTillDisconnect(routingContext));
     }
 
+    /**
+     * Verifies that the {@link Constants#HEADER_TIME_TO_LIVE} header is used by
+     * the {@link HttpUtils#getTimeToLive(RoutingContext)} method.
+     */
+    @Test
+    public void testGetTimeToLiveUsesHeader() {
+
+        // GIVEN a time to live in seconds
+        final long timeToLive = 60L;
+        // WHEN evaluating a routingContext that has this value set as a header
+        when(httpServerRequest.getHeader(Constants.HEADER_TIME_TO_LIVE))
+                .thenReturn(String.valueOf(timeToLive));
+
+        // THEN the get method returns this value
+        assertEquals(timeToLive, HttpUtils.getTimeToLive(routingContext).toSeconds());
+    }
+
+    /**
+     * Verifies that the {@link Constants#HEADER_TIME_TO_LIVE} query parameter is used by
+     * the {@link HttpUtils#getTimeToLive(RoutingContext)} method.
+     */
+    @Test
+    public void testGetTimeToLiveUsesQueryParam() {
+
+        // GIVEN a time to live in seconds
+        final long timeToLive = 60L;
+        // WHEN evaluating a routingContext that has this value set as a query param
+        when(httpServerRequest.getParam(Constants.HEADER_TIME_TO_LIVE))
+                .thenReturn(String.valueOf(timeToLive));
+
+        // THEN the get method returns this value
+        assertEquals(timeToLive, HttpUtils.getTimeToLive(routingContext).toSeconds());
+    }
+
+    /**
+     * Verifies that the {@link HttpUtils#getTimeToLive(RoutingContext)} method 
+     * returns {@code null} if {@link Constants#HEADER_TIME_TO_LIVE} is neither
+     * provided as query parameter nor as header.
+     */
+    @Test
+    public void testGetTimeToLiveReturnsNullIfNotSpecified() {
+
+        assertNull(HttpUtils.getTimeToLive(routingContext));
+    }
 }

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -274,6 +274,7 @@ content-length: 23
   * (optional) `authorization`: The device's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the device to present a client certificate as part of the TLS handshake during connection establishment.
   * (required) `content-type`: The type of payload contained in the body.
   * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
+  * (optional) `hono-ttl`: The *time-to-live* in number of seconds for event messages.  
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
@@ -316,6 +317,7 @@ content-length: 0
 * Request Headers:
   * (required) `content-type`: The type of payload contained in the body.
   * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
+  * (optional) `hono-ttl`: The *time-to-live* in number of seconds for event messages.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
@@ -359,6 +361,7 @@ content-length: 0
   * (optional) `authorization`: The gateway's *auth-id* and plain text password encoded according to the [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the gateway to present a client certificate as part of the TLS handshake during connection establishment.
   * (required) `content-type`: The type of payload contained in the body.
   * (optional) `hono-ttd`: The number of seconds the device will wait for the response.
+  * (optional) `hono-ttl`: The *time-to-live* in number of seconds for event messages.
 * Request Body:
   * (required) Arbitrary payload encoded according to the given content type.
 * Response Headers:
@@ -583,7 +586,8 @@ In most cases the AMQP Messaging Network can be configured with a maximum *time-
 from the persistent store if no consumer has attached to receive the event before the message expires.
 
 In order to support environments where the AMQP Messaging Network cannot be configured accordingly, the protocol adapter supports setting a
-downstream event message's *ttl* property based on the default *ttl* and *max-ttl* values configured for a tenant/device as described in the [Tenant API]
+downstream event message's *ttl* property based on the *hono-ttl* property set as a header or a query parameter in the event requests by the devices.
+Also the default *ttl* and *max-ttl* values can be configured for a tenant/device as described in the [Tenant API]
 ({{< relref "/api/tenant#resource-limits-configuration-format" >}}).
 
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -21,6 +21,9 @@ title = "Release Notes"
   In this case the data usage for a tenant is calculated from the beginning till the end of the 
   (Gregorian) calendar month. Refer [resource limits] ({{% doclink "/concepts/resource-limits/" %}})
   for more information.
+* The devices can now indicate a *time-to-live* duration for event messages published using 
+  the HTTP adapter by setting the *hono-ttl* property in requests explicitly - please refer to the
+  [HTTP Adapter]({{% doclink "/user-guide/http-adapter/" %}}) for details.
 
 ### API Changes
 


### PR DESCRIPTION
This  PR address the issue #266. The devices can now specify *time-to-live* for _event_ messages it publishes to Hono using the HTTP adapter by setting the *hono-ttl* property in requests explicitly.