### PR TITLE
Remove metrics when tenant times out.

### DIFF
--- a/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
@@ -17,13 +17,17 @@ package org.eclipse.hono.service.metric;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.eclipse.hono.config.ProtocolAdapterProperties;
@@ -44,6 +48,7 @@ import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
 
 
 /**
@@ -70,7 +75,7 @@ public class MicrometerBasedMetricsTest {
      * Verifies that arbitrary telemetry messages with or without a QoS
      * can be reported successfully.
      *
-     * @param registry : the registry that the tests should be run against.
+     * @param registry The registry that the tests should be run against.
      */
     @ParameterizedTest
     @MethodSource("registries")
@@ -119,7 +124,7 @@ public class MicrometerBasedMetricsTest {
      * Verifies that when reporting a downstream message no tags for
      * {@link QoS#UNKNOWN} nor {@link TtdStatus#NONE} are included.
      *
-     * @param registry : the registry that the tests should be run against.
+     * @param registry The registry that the tests should be run against.
      */
     @ParameterizedTest
     @MethodSource("registries")
@@ -203,7 +208,7 @@ public class MicrometerBasedMetricsTest {
     /**
      * Verifies that collecting the last message send time is disabled by default.
      * 
-     * @param registry : the registry that the tests should be run against.
+     * @param registry The registry that the tests should be run against.
      */
     @ParameterizedTest
     @MethodSource("registries")
@@ -229,7 +234,7 @@ public class MicrometerBasedMetricsTest {
      * Verifies that when sending the first message for a tenant the timestamp is recorded and a timer is started to
      * check the timeout.
      * 
-     * @param registry : the registry that the tests should be run against.
+     * @param registry The registry that the tests should be run against.
      */
     @SuppressWarnings("unchecked")
     @ParameterizedTest
@@ -256,9 +261,60 @@ public class MicrometerBasedMetricsTest {
     }
 
     /**
+     * Verifies that the metrics are removed when the tenant timeout is exceeded.
+     *
+     * @param registry The registry that the tests should be run against.
+     * @throws InterruptedException if thread sleep is interrupted.
+     */
+    @ParameterizedTest
+    @MethodSource("registries")
+    public void testTimeoutRemovesMetrics(final MeterRegistry registry) throws InterruptedException {
+
+        final Tags tenantTags = Tags.of(MetricsTags.getTenantTag(tenant));
+        final Vertx vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
+        // a mocked Vert.x timer, that can be fired deliberately later in the test
+        final AtomicReference<Handler<Long>> timerHandler = new AtomicReference<>();
+        when(vertx.setTimer(anyLong(), any())).thenAnswer(invocation -> {
+            final Handler<Long> task = invocation.getArgument(1);
+            timerHandler.set(task);
+            return 1L;
+        });
+
+        // GIVEN a metrics instance with tenantIdleTimeout configured ...
+        final MicrometerBasedMetrics metrics = new MicrometerBasedMetrics(registry, vertx);
+        metrics.setProtocolAdapterProperties(configWithTenantIdleTimeout(1L));
+
+        // ... with a device connected and a telemetry message and a command recorded
+        metrics.incrementConnections(tenant);
+        reportTelemetry(metrics);
+        reportCommand(metrics);
+
+        assertNotNull(registry.find(MicrometerBasedMetrics.METER_MESSAGES_PAYLOAD).tags(tenantTags).meter());
+        assertNotNull(registry.find(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED).tags(tenantTags).meter());
+        assertNotNull(registry.find(MicrometerBasedMetrics.METER_COMMANDS_PAYLOAD).tags(tenantTags).meter());
+        assertNotNull(registry.find(MicrometerBasedMetrics.METER_COMMANDS_RECEIVED).tags(tenantTags).meter());
+        assertNotNull(registry.find(MicrometerBasedMetrics.METER_CONNECTIONS_AUTHENTICATED).tags(tenantTags).meter());
+
+        // WHEN the device disconnects ...
+        metrics.decrementConnections(tenant);
+        // ... and the timeout timer fires
+        Thread.sleep(2L);
+        timerHandler.get().handle(null);
+
+        // THEN the metrics have been removed
+        assertNull(registry.find(MicrometerBasedMetrics.METER_MESSAGES_PAYLOAD).tags(tenantTags).meter());
+        assertNull(registry.find(MicrometerBasedMetrics.METER_MESSAGES_RECEIVED).tags(tenantTags).meter());
+        assertNull(registry.find(MicrometerBasedMetrics.METER_COMMANDS_PAYLOAD).tags(tenantTags).meter());
+        assertNull(registry.find(MicrometerBasedMetrics.METER_COMMANDS_RECEIVED).tags(tenantTags).meter());
+        assertNull(registry.find(MicrometerBasedMetrics.METER_CONNECTIONS_AUTHENTICATED).tags(tenantTags).meter());
+
+    }
+
+    /**
      * Verifies that sending messages updates the stored timestamp for the tenant.
      * 
-     * @param registry : the registry that the tests should be run against.
+     * @param registry The registry that the tests should be run against.
      * @throws InterruptedException if thread sleep is interrupted.
      */
     @ParameterizedTest
@@ -285,7 +341,7 @@ public class MicrometerBasedMetricsTest {
     /**
      * Verifies that disconnecting updates the stored timestamp for the tenant.
      * 
-     * @param registry : the registry that the tests should be run against.
+     * @param registry The registry that the tests should be run against.
      * @throws InterruptedException if thread sleep is interrupted.
      */
     @ParameterizedTest
@@ -312,7 +368,7 @@ public class MicrometerBasedMetricsTest {
     /**
      * Verifies that re-connecting updates the stored timestamp for the tenant.
      * 
-     * @param registry : the registry that the tests should be run against.
+     * @param registry The registry that the tests should be run against.
      * @throws InterruptedException if thread sleep is interrupted.
      */
     @ParameterizedTest
@@ -351,6 +407,16 @@ public class MicrometerBasedMetricsTest {
                 QoS.UNKNOWN,
                 1024,
                 TtdStatus.NONE,
+                metrics.startTimer());
+    }
+
+    private void reportCommand(final MicrometerBasedMetrics metrics) {
+        metrics.reportCommand(
+                MetricsTags.Direction.REQUEST,
+                tenant,
+                TenantObject.from(tenant, true),
+                MetricsTags.ProcessingOutcome.FORWARDED,
+                1 * 1024,
                 metrics.startTimer());
     }
 

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
@@ -264,11 +264,10 @@ public class MicrometerBasedMetricsTest {
      * Verifies that the metrics are removed when the tenant timeout is exceeded.
      *
      * @param registry The registry that the tests should be run against.
-     * @throws InterruptedException if thread sleep is interrupted.
      */
     @ParameterizedTest
     @MethodSource("registries")
-    public void testTimeoutRemovesMetrics(final MeterRegistry registry) throws InterruptedException {
+    public void testTimeoutRemovesMetrics(final MeterRegistry registry) {
 
         final Tags tenantTags = Tags.of(MetricsTags.getTenantTag(tenant));
         final Vertx vertx = mock(Vertx.class);
@@ -299,7 +298,7 @@ public class MicrometerBasedMetricsTest {
         // WHEN the device disconnects ...
         metrics.decrementConnections(tenant);
         // ... and the timeout timer fires
-        Thread.sleep(2L);
+        metrics.getLastSeenTimestampPerTenant().put(tenant, 0L); // fake timeout duration exceeded
         timerHandler.get().handle(null);
 
         // THEN the metrics have been removed
@@ -315,81 +314,72 @@ public class MicrometerBasedMetricsTest {
      * Verifies that sending messages updates the stored timestamp for the tenant.
      * 
      * @param registry The registry that the tests should be run against.
-     * @throws InterruptedException if thread sleep is interrupted.
      */
     @ParameterizedTest
     @MethodSource("registries")
-    public void testLastSeenIsUpdatedOnMessageSend(final MeterRegistry registry) throws InterruptedException {
+    public void testLastSeenIsUpdatedOnMessageSend(final MeterRegistry registry) {
 
-        // GIVEN a metrics instance with tenantIdleTimeout configured
+        // GIVEN a metrics instance with tenantIdleTimeout configured...
         final MicrometerBasedMetrics metrics = new MicrometerBasedMetrics(registry, mock(Vertx.class));
         metrics.setProtocolAdapterProperties(configWithTenantIdleTimeout(10L));
+        // ..and last seen timestamp is initialized with low value
+        final long timestampBefore = 0L;
+        metrics.getLastSeenTimestampPerTenant().put(tenant, timestampBefore);
 
-        // WHEN connecting
-        metrics.incrementConnections(tenant);
-        final long before = metrics.getLastSeenTimestampPerTenant().get(tenant);
-
-        // and later sending a message
-        Thread.sleep(1L);
+        // WHEN sending a message
         reportTelemetry(metrics);
 
         // THEN the timestamp for the tenant has been updated
         assertEquals(1, metrics.getLastSeenTimestampPerTenant().size());
-        assertNotEquals(before, metrics.getLastSeenTimestampPerTenant().get(tenant));
+        assertNotEquals(timestampBefore, metrics.getLastSeenTimestampPerTenant().get(tenant));
     }
 
     /**
      * Verifies that disconnecting updates the stored timestamp for the tenant.
      * 
      * @param registry The registry that the tests should be run against.
-     * @throws InterruptedException if thread sleep is interrupted.
      */
     @ParameterizedTest
     @MethodSource("registries")
-    public void testLastSeenIsUpdatedOnDisconnect(final MeterRegistry registry) throws InterruptedException {
+    public void testLastSeenIsUpdatedOnDisconnect(final MeterRegistry registry) {
 
-        // GIVEN a metrics instance with tenantIdleTimeout configured
+        // GIVEN a metrics instance with tenantIdleTimeout configured...
         final MicrometerBasedMetrics metrics = new MicrometerBasedMetrics(registry, mock(Vertx.class));
         metrics.setProtocolAdapterProperties(configWithTenantIdleTimeout(10L));
+        // ..and last seen timestamp is initialized with low value
+        final long timestampBefore = 0L;
+        metrics.getLastSeenTimestampPerTenant().put(tenant, timestampBefore);
 
-        // WHEN connecting
-        metrics.incrementConnections(tenant);
-        final long before = metrics.getLastSeenTimestampPerTenant().get(tenant);
-
-        // and later disconnect
-        Thread.sleep(1L);
+        // WHEN disconnecting
         metrics.decrementConnections(tenant);
 
         // THEN the timestamp for the tenant has been updated
         assertEquals(1, metrics.getLastSeenTimestampPerTenant().size());
-        assertNotEquals(before, metrics.getLastSeenTimestampPerTenant().get(tenant));
+        assertNotEquals(timestampBefore, metrics.getLastSeenTimestampPerTenant().get(tenant));
     }
 
     /**
-     * Verifies that re-connecting updates the stored timestamp for the tenant.
+     * Verifies that connecting updates the stored timestamp for the tenant.
      * 
      * @param registry The registry that the tests should be run against.
-     * @throws InterruptedException if thread sleep is interrupted.
      */
     @ParameterizedTest
     @MethodSource("registries")
-    public void testLastSeenIsUpdatedOnReconnect(final MeterRegistry registry) throws InterruptedException {
+    public void testLastSeenIsUpdatedOnConnect(final MeterRegistry registry) {
 
-        // GIVEN a metrics instance with tenantIdleTimeout configured
+        // GIVEN a metrics instance with tenantIdleTimeout configured...
         final MicrometerBasedMetrics metrics = new MicrometerBasedMetrics(registry, mock(Vertx.class));
         metrics.setProtocolAdapterProperties(configWithTenantIdleTimeout(10L));
+        // ..and last seen timestamp is initialized with low value
+        final long timestampBefore = 0L;
+        metrics.getLastSeenTimestampPerTenant().put(tenant, timestampBefore);
 
-        // WHEN disconnect
-        metrics.decrementConnections(tenant);
-        final long before = metrics.getLastSeenTimestampPerTenant().get(tenant);
-
-        // and later reconnect
-        Thread.sleep(1L);
+        // WHEN connecting
         metrics.incrementConnections(tenant);
 
         // THEN the timestamp for the tenant has been updated
         assertEquals(1, metrics.getLastSeenTimestampPerTenant().size());
-        assertNotEquals(before, metrics.getLastSeenTimestampPerTenant().get(tenant));
+        assertNotEquals(timestampBefore, metrics.getLastSeenTimestampPerTenant().get(tenant));
     }
 
     private ProtocolAdapterProperties configWithTenantIdleTimeout(final long timeoutMillis) {

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -13,9 +13,10 @@ title = "Release Notes"
   downstream event messages.
 * A protocol adapter can now be configured with a timeout for idle tenants. When there has been no 
   communication between a protocol adapter instance and the devices of a tenant, the former one releases 
-  allocated resources of the tenant. Currently this means that it closes AMQP links. The timeout is 
-  configured with the property `tenantIdleTimeout` for a protocol   adapter. Please refer to the protocol 
-  adapter [configuration guides]({{% doclink "/admin-guide/" %}}) for details.
+  allocated resources of the tenant. Currently this means that it closes AMQP links and stops reporting 
+  metrics for this tenant. The timeout is configured with the property `tenantIdleTimeout` for a protocol 
+  adapter. Please refer to the protocol adapter [configuration guides]({{% doclink "/admin-guide/" %}})
+  for details.
 * The accounting period for the *message limit* checks can now be configured as `monthly`.
   In this case the data usage for a tenant is calculated from the beginning till the end of the 
   (Gregorian) calendar month. Refer [resource limits] ({{% doclink "/concepts/resource-limits/" %}})


### PR DESCRIPTION
This is a PR to solve #1227. Since the tenant timeout is already managed by the metrics implementation (#1475), this is quite straight forward.  
This PR replaces #1456.