### PR TITLE
Fix: look up files in page bundle in same directory for index files.

### DIFF
--- a/site/documentation/content/api/credentials/index.md
+++ b/site/documentation/content/api/credentials/index.md
@@ -30,7 +30,7 @@ Protocol adapters use this command to *look up* credentials of a particular type
 
 **Message Flow**
 
-{{< figure src="../getCredentials_Success.svg" title="Client looking up credentials for a device" alt="A client sends a request message for looking up device credentials and receives a response containing the credentials" >}}
+{{< figure src="getCredentials_Success.svg" title="Client looking up credentials for a device" alt="A client sends a request message for looking up device credentials and receives a response containing the credentials" >}}
 
 
 **Request Message Format**

--- a/site/documentation/content/architecture/auth/index.md
+++ b/site/documentation/content/architecture/auth/index.md
@@ -17,7 +17,7 @@ This page describes how authentication and authorization of devices, consumers (
 
 The following diagram provides an overview of the components involved in use cases requiring authentication and authorization.
 
-{{< figure src="../Hono-Auth-Overview-Today.jpg">}}
+{{< figure src="Hono-Auth-Overview-Today.jpg">}}
 
 ### Device Auth
 
@@ -29,7 +29,7 @@ Client components opening an AMQP connection to a server component are authentic
 
 Based on the components shown above, the following sequence diagram shows how the *MQTT Adapter* connects to the *Device Registry* and gets authenticated transparently using the *Auth Server*.
 
-{{< figure src="../MQTT-Adapter-authentication-today.png" width="80%" >}}
+{{< figure src="MQTT-Adapter-authentication-today.png" width="80%" >}}
 
 Client components are authorized whenever they open a new AMQP link on an existing connection to the server. When a client tries to open a receiver link, the server checks if the client is authorized to *read* from the source address the client has specified in its AMQP *attach* frame. Analogously, when a client tries to open a sender link, the server checks if the client is authorized to *write* to the target address from the client's *attach* frame.
 

--- a/site/documentation/content/architecture/component-view/index.md
+++ b/site/documentation/content/architecture/component-view/index.md
@@ -10,7 +10,7 @@ This page describes the high level components constituting an Eclipse Hono&trade
 
 The diagram below provides an overview of the top level *logical* components.
 
-{{< figure src="../top-level.png" >}}
+{{< figure src="top-level.png" >}}
 
 The *MQTT* and *HTTP Adapters* use the *Device Registry* to authenticate *Devices* connecting to the adapters and asserting their
 registration status. The adapters then forward the telemetry data and events received from the devices to the *AMQP 1.0 Messaging Network*
@@ -31,7 +31,7 @@ All interactions between the components are based on AMQP 1.0 message exchanges 
 
 The diagram below provides an overview of the *Device Registry* component's internal structure.
 
-{{< figure src="../device-registry.png" width="100%" >}}
+{{< figure src="device-registry.png" width="100%" >}}
 
 The *Device Registry* component implements the [Credentials API]({{< relref "/api/credentials" >}}), [Tenant API]({{< relref "/api/tenant" >}}) and [Device Registration API]({{< relref "/api/device-registration" >}}). Clients opening a connection to *SimpleDeviceRegistryServer* are authenticated by means of an external service accessed via the *Auth* port. The *FileBasedCredentialsService*, *FileBasedTenantService* and *FileBasedRegistrationService* store all data in the local file system. The *Device Registry* is therefore not recommended to be used in production environments because the component cannot easily scale out horizontally. It is mainly intended to be used for demonstration purposes and PoCs. In real world scenarios, a more sophisticated implementation should be used that is designed to scale out, e.g. using a persistent store for keeping device registration information that can be shared by multiple instances.
 
@@ -41,6 +41,6 @@ The *AMQP 1.0 Messaging Network* is not *per se* a component being developed as 
 
 The diagram below provides an overview of the default implementation of the Messaging Network component used with Hono.
 
-{{< figure src="../hono-messaging.png"  >}}
+{{< figure src="hono-messaging.png"  >}}
 
 Scaling out messaging infrastructure is a not a trivial task. Hono **does not** provide an out-of-the-box solution to this problem but instead integrates with the [EnMasse](http://enmasse.io) project which aims at providing *Messaging as a Service* infrastructure.


### PR DESCRIPTION
File names of markdown files are generated to a directory with that name
by Hugo, except for index files. Therefore relative links to images in
 the same source directory (page bundle) need to point to the same dir
 in case of index files and to the parent dir in case of files with
 other names.

Signed-off-by: Abel Buechner-Mihaljevic <Abel.Buechner@bosch-si.com>