### PR TITLE
[#1484] CLI: Allow TLS for basic auth.

### DIFF
--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -38,12 +38,16 @@ message:
 
 ---
 
+# For use with the demo certificates.
+# Do not use this profile for certificates that the JVM trusts, e.g. for the Hono sandbox. Simply set hono.client.tlsEnabled 
+# to true. 
 spring:
   profiles: ssl
 hono:
   client:
     hostnameVerificationRequired: false
     trustStorePath: target/config/hono-demo-certs-jar/trusted-certs.pem
+    tlsEnabled: true
 
 ---
 


### PR DESCRIPTION
The AmqpCliClient did not set TLS options when username and password
where used for configuration.

Signed-off-by: Abel Buechner-Mihaljevic <Abel.Buechner@bosch-si.com>