### PR TITLE
[#1508] Add links to "Getting Started" and "Home" to documentation menu.

### DIFF
--- a/site/documentation/config.toml
+++ b/site/documentation/config.toml
@@ -56,3 +56,16 @@ pluralizeListTitles = "false"
 
 [outputs]
   home = [ "HTML", "RSS", "JSON"]
+
+# Menu Shortcuts
+[[menu.shortcuts]]
+name = "<i class='fas fa-home'></i> Hono Home"
+url = "https://www.eclipse.org/hono"
+title = "Hono's Homepage"
+weight = 10
+
+[[menu.shortcuts]] 
+name = "<i class='fas fa-plane-departure'></i> Getting Started"
+url = "https://www.eclipse.org/hono/getting-started"
+weight = 20
+

--- a/site/documentation/layouts/partials/menu.html
+++ b/site/documentation/layouts/partials/menu.html
@@ -32,7 +32,7 @@
         <ul>
           {{ range sort . "Weight"}}
               <li> 
-                  {{.Pre}}<a class="padding" href="{{.URL | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
+                  {{.Pre}}<a class="padding" href="{{.URL | absLangURL }}" title="{{.Title }}">{{safeHTML .Name}}</a>{{.Post}}
               </li>
           {{end}}
         </ul>


### PR DESCRIPTION
Adds static links to the "Getting Started" and the homepage to the "shortcuts" menu of the documentation.