### PR TITLE
[#267] Equip MQTT Adapter to support setting TTL for events published by devices. 

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/PropertyBag.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/PropertyBag.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.adapter.mqtt;
+
+import io.netty.handler.codec.http.QueryStringDecoder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A collection of methods for processing <em>property-bag</em> set at the end of a topic.
+ *
+ */
+public final class PropertyBag {
+
+    private final Map<String, List<String>> properties;
+    private final String topicWithoutPropertyBag;
+
+    private PropertyBag(final String topicWithoutPropertyBag, final Map<String, List<String>> properties) {
+        this.topicWithoutPropertyBag = topicWithoutPropertyBag;
+        this.properties = properties;
+    }
+
+    /**
+     * Creates a property bag object from the given topic by retrieving 
+     * all the properties from the <em>property-bag</em>.
+     * 
+     * @param topic The topic that the message has been published to.
+     * @return The property bag object or {@code null} if no 
+     *         <em>property-bag</em> is set in the topic.
+     * @throws NullPointerException if topic is {@code null}.
+     */
+    public static PropertyBag fromTopic(final String topic) {
+
+        Objects.requireNonNull(topic);
+
+        final int index = topic.lastIndexOf("/?");
+        if (index > 0) {
+            return new PropertyBag(
+                    topic.substring(0, index),
+                    new QueryStringDecoder(topic.substring(index)).parameters());
+        }
+        return null;
+    }
+
+    /**
+     * Gets a property value from the <em>property-bag</em>.
+     *
+     * @param name The property name.
+     * @return The property value or {@code null} if the property is not set.
+     */
+    public String getProperty(final String name) {
+        return Optional.ofNullable(properties)
+                .map(props -> props.get(name))
+                .map(values -> values.get(0))
+                .orElse(null);
+    }    
+
+    /**
+     * Returns the topic without the <em>property-bag</em>.
+     *
+     * @return The topic without the <em>property-bag</em>.
+     */
+    public String topicWithoutPropertyBag() {
+        return topicWithoutPropertyBag;
+    }
+}

--- a/adapters/mqtt-vertx-base/src/test/java/PropertyBagTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/PropertyBagTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import org.eclipse.hono.adapter.mqtt.PropertyBag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Verifies behavior of {@link PropertyBag}.
+ *
+ */
+public class PropertyBagTest {
+
+    /**
+     * Verifies the value of properties set in the <em>property-bag</em> of the message's topic.
+     */
+    @Test
+    public void verifyPropertiesInPropertyBag() {
+        final PropertyBag propertyBag = PropertyBag.fromTopic("event/tenant/device/?param1=30&param2=value2");
+        assertEquals("30", propertyBag.getProperty("param1"));
+        assertEquals("value2", propertyBag.getProperty("param2"));
+    }
+
+    /**
+     * Verifies that the property bag object is null when no <em>property-bag</em> is set.
+     */
+    @Test
+    public void VerifyWhenNoPropertyBagIsSet() {
+        assertNull(PropertyBag.fromTopic("event/tenant/device"));
+    }
+
+    /**
+     * Verifies that no <em>property-bag</em> is set in the given topic with special characters.
+     */
+    @Test
+    public void verifyTopicWithSpecialCharacters() {
+        assertNull(PropertyBag.fromTopic("event/tenant/device/segment1?param=value/segment2/"));
+    }
+
+    /**
+     * Verifies that the <em>property-bag</em> is trimmed from a topic string and the rest is returned.
+     */
+    @Test
+    public void verifyTopicWithoutPropertyBag() {
+        assertEquals("event/tenant/device",
+                PropertyBag.fromTopic("event/tenant/device/?hono-ttl=30")
+                        .topicWithoutPropertyBag());
+    }
+}

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -22,8 +22,9 @@ title = "Release Notes"
   (Gregorian) calendar month. Refer [resource limits] ({{% doclink "/concepts/resource-limits/" %}})
   for more information.
 * The devices can now indicate a *time-to-live* duration for event messages published using 
-  the HTTP adapter by setting the *hono-ttl* property in requests explicitly - please refer to the
-  [HTTP Adapter]({{% doclink "/user-guide/http-adapter/" %}}) for details.
+  the HTTP and MQTT adapters by setting the *hono-ttl* property in requests explicitly. Please refer to the
+  [HTTP Adapter]({{% doclink "/user-guide/http-adapter/#publish-an-event-authenticated-device" %}})
+  and [MQTT Adapter] ({{% doclink "/user-guide/mqtt-adapter/#publishing-events" %}}) for details.
 
 ### API Changes
 


### PR DESCRIPTION
The devices can now specify *time-to-live* for _event_ messages it publishes to Hono using the MQTT adapter. This can be done by setting the *hono-ttl* property in the *property-bag* explicitly. This  PR address the issue #267. 