### PR TITLE
Update actual link in deployment guide.

### DIFF
--- a/site/documentation/content/deployment/helm-based-deployment.md
+++ b/site/documentation/content/deployment/helm-based-deployment.md
@@ -106,7 +106,7 @@ hono-service-device-registry-ext        LoadBalancer   10.101.42.99     10.101.4
 hono-service-device-registry-headless   ClusterIP      None             <none>           <none>
 ~~~
 
-The listing above has been retrieved from a Minikube cluster that emulates a load balancer via the `minikube tunnel` command (refer to the [Minikube Networking docs](https://github.com/kubernetes/minikube/blob/master/docs/networking.md#loadbalancer-emulation-minikube-tunnel) for details).
+The listing above has been retrieved from a Minikube cluster that emulates a load balancer via the `minikube tunnel` command (refer to the [Minikube docs](https://minikube.sigs.k8s.io/docs/tasks/loadbalancer/) for details).
 The service endpoints can be accessed at the *EXTERNAL-IP* addresses and corresponding *PORT(S)*, e.g. 8080 for the HTTP adapter (*hono-adapter-http-vertx*) and 28080 for the device registry (*hono-service-device-registry*).
 
 The following command assigns the IP address of the device registry service to the `REGISTRY_IP` environment variable so that they can easily be used from the command line:


### PR DESCRIPTION
The _Minikube_ networking guide has been moved to a new location under https://minikube.sigs.k8s.io/docs/tasks/loadbalancer/. This has been updated in the deployment guide.