### PR TITLE
Replace the answers in FAQ with links to the questions on Stackoverflow.

### DIFF
--- a/site/homepage/content/faq.md
+++ b/site/homepage/content/faq.md
@@ -6,57 +6,33 @@ weight = 550
 +++
 
 
-## Technical Questions
+{{% note title="FAQ is moving to Stack Overflow" %}}
+The preferred support channel on which the Hono community would like to receive questions from users and answer them is 
+[Stackoverflow](https://stackoverflow.com/questions/tagged/eclipse-hono). There is the special tag `[eclipse-hono]`, 
+that the Hono developers keep watching. This FAQ page here will be removed soon.
+{{% /note %}}
 
 
 #### Why do I get `HTTP/1.1 503 Service Unavailable` when sending messages to the HTTP protocol adapter?
 
-Please check if you have a [consumer connected]({{< relref "getting-started#starting-a-consumer" >}}) 
-and that your consumer is for the same type of message (telemetry or event) that you are sending.  
+See the accepted answer on [Stackoverflow](https://stackoverflow.com/questions/58168705/why-do-i-get-http-1-1-503-service-unavailable-when-sending-messages-to-the-http).
 
 
 #### Why do I get the exception `io.vertx.core.VertxException: OpenSSL is not available` during startup of a protocol adapter?
 
-Please check if you have set the property `nativeTlsRequired` in the protocol adapter's configuration to `true`. The default Hono
-containers do not contain `netty-tcnative`. To enable this option, please follow the explanation in the 
-[Admin Guide]({{% doclink "/admin-guide/secure_communication/#using-openssl" %}}) or build your own container images.
+See the accepted answer on [Stackoverflow](https://stackoverflow.com/questions/58184171/protocoll-adapter-start-fails-with-openssl-is-not-available).
 
 
 #### Why do I see `ConnectionLimitManager - Connection limit (<VALUE>) exceeded` in the logs of a protocol adapter? 
 
-The configured maximum number of concurrent connections is exceeded and the protocol adapter refuses to accept more 
-connections to prevent running out of resources. This limit is either configured on the protocol adapter
-([MQTT]({{% doclink "/admin-guide/mqtt-adapter-config/#service-configuration" %}}),
-[AMQP]({{% doclink "/admin-guide/amqp-adapter-config/#service-configuration" %}})) or if not set, 
-the protocol adapter determines a reasonable value based on the available resources like memory and CPU.
+See the accepted answer on [Stackoverflow](https://stackoverflow.com/questions/58076884/no-more-devices-are-able-to-connect-to-the-mqtt-adapter).
 
 
 #### Why do I see `MemoryBasedConnectionLimitStrategy - Not enough memory` in the logs of a protocol adapter? 
 
-The protocol adapter can not allocate enough memory for handle even a small number of connections reliably. 
-Please provide more memory. To try it anyways, configure the 
-maximum number of concurrent connections, as documented in the Admin Guides of the protocol adapter
-([MQTT]({{% doclink "/admin-guide/mqtt-adapter-config/#service-configuration" %}}),
-[AMQP]({{% doclink "/admin-guide/amqp-adapter-config/#service-configuration" %}})).
-
+See the accepted answer on [Stackoverflow](https://stackoverflow.com/questions/58079988/mqtt-protocol-adapter-fails-to-start).
 
 
 #### How do I use client certificates for authentication?
 
-Make sure that you are able to connect to the respective protocol adapter with TLS 
-(see the [Admin Guide]({{% doclink "/admin-guide/secure_communication/#using-openssl" %}}) for configuration).
-[Here](https://blog.bosch-si.com/developer/x-509-based-device-authentication-in-eclipse-hono/) is an article, that 
-provides a complete walk-through guide for all required steps. 
-Additionally you can use and adapt the script for the creation of demo certificates in the Hono repository.
-More information can be found in the User Guide of the protocol adapter 
-([MQTT]({{% doclink "/user-guide/mqtt-adapter/#authentication" %}}),
-[HTTP]({{% doclink "/user-guide/http-adapter/#device-authentication" %}})).
-
-
-
-## Organizational Questions
-
-#### Will you add feature _x_ to Hono?
-
-To find out about the future development you can have a look at the [Roadmap]({{< ref "/community/road-map.md" >}}) or
-[get in touch]({{< ref "/community/get-in-touch.md" >}}) with the Hono developers.
+See the accepted answer on [Stackoverflow](https://stackoverflow.com/questions/58132846/how-do-i-use-client-certificates-for-authentication-against-hono).


### PR DESCRIPTION
As discussed in the community call, the answers were replaced by links to the corresponding questions on Stackoverflow.