### PR TITLE
Add link to hono gitter chat in homepage footer.

### DIFF
--- a/site/homepage/layouts/partials/footer.html
+++ b/site/homepage/layouts/partials/footer.html
@@ -7,6 +7,7 @@
             <ul>
                 <li><a href="https://github.com/eclipse/hono" title="View Source Code on GitHub"><i class='fab fa-github'></i> GitHub Repository</a></li>
                 <li><a href="https://twitter.com/EclipseHono" title="Follow us on Twitter"><i class='fab fa-twitter'></i> Twitter</a></li>
+                <li><a href="https://gitter.im/eclipse/hono" title="Chat with us on Gitter"><i class='fab fa-gitter'></i> Chat with us</a></li>
                 <li><a href="/hono/thankyou">Thank you</a></li>
             </ul>
 


### PR DESCRIPTION
The links to _Github_ repository and _Twitter_ already exist in homepage footer. This PR adds one more link for the _Gitter chat_ in the footer as in the below image. Right now a link to the _Gitter chat_ is only available in the _Get in touch_ page and IMHO it is also better to have it in the footer too.

![image](https://user-images.githubusercontent.com/18659982/66037978-21748580-e511-11e9-97eb-b83a7d94b3f5.png)
