### PR TITLE
Improve log output of parameterized tests

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -249,7 +249,7 @@ public final class IntegrationTestSupport {
      * The name of the system property to use for setting the maximum number of BCrypt iterations supported
      * by Hono.
      */
-    public static final String PROPTERY_MAX_BCRYPT_ITERATIONS = "max.bcrypt.iterations";
+    public static final String PROPERTY_MAX_BCRYPT_ITERATIONS = "max.bcrypt.iterations";
 
 
     /**
@@ -376,12 +376,17 @@ public final class IntegrationTestSupport {
     /**
      * The maximum number of BCrypt iterations supported by Hono.
      */
-    public static final int    MAX_BCRYPT_ITERATIONS = Integer.getInteger(PROPTERY_MAX_BCRYPT_ITERATIONS, DEFAULT_MAX_BCRYPT_ITERATIONS);
+    public static final int    MAX_BCRYPT_ITERATIONS = Integer.getInteger(PROPERTY_MAX_BCRYPT_ITERATIONS, DEFAULT_MAX_BCRYPT_ITERATIONS);
 
     /**
      * The absolute path to the trust store to use for establishing secure connections with Hono.
      */
     public static final String TRUST_STORE_PATH = System.getProperty("trust-store.path");
+
+    /**
+     * Pattern used for the <em>name</em> field of the {@code @ParameterizedTest} annotation.
+     */
+    public static final String PARAMETERIZED_TEST_NAME_PATTERN = "{displayName} [{index}]; parameters: {arguments}";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IntegrationTestSupport.class);
     private static final BCryptPasswordEncoder bcryptPwdEncoder = new BCryptPasswordEncoder(4);

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
@@ -61,7 +61,7 @@ public class AmqpConnectionIT extends AmqpAdapterTestBase {
      * Closes the connection to the adapter.
      */
     @AfterEach
-    public void disconnnect() {
+    public void disconnect() {
         if (connection != null) {
             connection.closeHandler(null);
             connection.close();

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
@@ -199,7 +199,7 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
      * @param ctx The Vert.x test context.
      * @throws InterruptedException if test is interrupted while running.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("senderQoSTypes")
     public void testUploadMessagesUsingSaslPlain(final ProtonQoS senderQos, final VertxTestContext ctx) throws InterruptedException {
 
@@ -229,7 +229,7 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
      * @param ctx The test context.
      * @throws InterruptedException if test execution is interrupted.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("senderQoSTypes")
     public void testUploadMessagesUsingSaslExternal(final ProtonQoS senderQos, final VertxTestContext ctx) throws InterruptedException {
 

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -208,7 +208,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
      * @param ctx The vert.x test context.
      * @throws InterruptedException if not all commands and responses are exchanged in time.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("allCombinations")
     public void testSendOneWayCommandSucceeds(
             final AmqpCommandEndpointConfiguration endpointConfig,
@@ -261,7 +261,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
      * @param ctx The vert.x test context.
      * @throws InterruptedException if not all commands and responses are exchanged in time.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource
     public void testSendAsyncCommandsSucceeds(
             final AmqpCommandEndpointConfiguration endpointConfig,
@@ -272,8 +272,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         connectAndSubscribe(ctx, endpointConfig, sender -> createCommandConsumer(ctx, sender));
 
         final String replyId = "reply-id";
-        final int totalNoOfcommandsToSend = 60;
-        final CountDownLatch commandsSucceeded = new CountDownLatch(totalNoOfcommandsToSend);
+        final int totalNoOfCommandsToSend = 60;
+        final CountDownLatch commandsSucceeded = new CountDownLatch(totalNoOfCommandsToSend);
         final AtomicInteger commandsSent = new AtomicInteger(0);
         final AtomicLong lastReceivedTimestamp = new AtomicLong();
 
@@ -286,7 +286,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                     lastReceivedTimestamp.set(System.currentTimeMillis());
                     commandsSucceeded.countDown();
                     if (commandsSucceeded.getCount() % 20 == 0) {
-                        log.info("command responses received: {}", totalNoOfcommandsToSend - commandsSucceeded.getCount());
+                        log.info("command responses received: {}", totalNoOfCommandsToSend - commandsSucceeded.getCount());
                     }
                 },
                 null);
@@ -301,7 +301,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
 
         final long start = System.currentTimeMillis();
 
-        while (commandsSent.get() < totalNoOfcommandsToSend) {
+        while (commandsSent.get() < totalNoOfCommandsToSend) {
             final CountDownLatch commandSent = new CountDownLatch(1);
             context.runOnContext(go -> {
                 final String correlationId = String.valueOf(commandsSent.getAndIncrement());
@@ -328,11 +328,11 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             commandSent.await();
         }
 
-        final long timeToWait = totalNoOfcommandsToSend * 200;
+        final long timeToWait = totalNoOfCommandsToSend * 200;
         if (!commandsSucceeded.await(timeToWait, TimeUnit.MILLISECONDS)) {
             log.info("Timeout of {} milliseconds reached, stop waiting for command responses", timeToWait);
         }
-        final long commandsCompleted = totalNoOfcommandsToSend - commandsSucceeded.getCount();
+        final long commandsCompleted = totalNoOfCommandsToSend - commandsSucceeded.getCount();
         log.info("commands sent: {}, responses received: {} after {} milliseconds",
                 commandsSent.get(), commandsCompleted, lastReceivedTimestamp.get() - start);
         if (commandsCompleted == commandsSent.get()) {
@@ -350,7 +350,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
      * @param ctx The vert.x test context.
      * @throws InterruptedException if not all commands and responses are exchanged in time.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("allCombinations")
     public void testSendCommandSucceeds(
             final AmqpCommandEndpointConfiguration endpointConfig,
@@ -388,16 +388,16 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             final AmqpCommandEndpointConfiguration endpointConfig,
             final Function<ProtonSender, ProtonMessageHandler> commandConsumerFactory,
             final Function<Buffer, Future<?>> commandSender,
-            final int totalNoOfcommandsToSend) throws InterruptedException {
+            final int totalNoOfCommandsToSend) throws InterruptedException {
 
         connectAndSubscribe(ctx, endpointConfig, commandConsumerFactory);
 
-        final CountDownLatch commandsSucceeded = new CountDownLatch(totalNoOfcommandsToSend);
+        final CountDownLatch commandsSucceeded = new CountDownLatch(totalNoOfCommandsToSend);
         final AtomicInteger commandsSent = new AtomicInteger(0);
         final AtomicLong lastReceivedTimestamp = new AtomicLong();
         final long start = System.currentTimeMillis();
 
-        while (commandsSent.get() < totalNoOfcommandsToSend) {
+        while (commandsSent.get() < totalNoOfCommandsToSend) {
             final CountDownLatch commandSent = new CountDownLatch(1);
             context.runOnContext(go -> {
                 final Buffer payload = Buffer.buffer("value: " + commandsSent.getAndIncrement());
@@ -408,7 +408,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                         lastReceivedTimestamp.set(System.currentTimeMillis());
                         commandsSucceeded.countDown();
                         if (commandsSucceeded.getCount() % 20 == 0) {
-                            log.info("commands succeeded: {}", totalNoOfcommandsToSend - commandsSucceeded.getCount());
+                            log.info("commands succeeded: {}", totalNoOfCommandsToSend - commandsSucceeded.getCount());
                         }
                     }
                     if (commandsSent.get() % 20 == 0) {
@@ -421,11 +421,11 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             commandSent.await();
         }
 
-        final long timeToWait = totalNoOfcommandsToSend * 200;
+        final long timeToWait = totalNoOfCommandsToSend * 200;
         if (!commandsSucceeded.await(timeToWait, TimeUnit.MILLISECONDS)) {
             log.info("Timeout of {} milliseconds reached, stop waiting for commands to succeed", timeToWait);
         }
-        final long commandsCompleted = totalNoOfcommandsToSend - commandsSucceeded.getCount();
+        final long commandsCompleted = totalNoOfCommandsToSend - commandsSucceeded.getCount();
         log.info("commands sent: {}, commands succeeded: {} after {} milliseconds",
                 commandsSent.get(), commandsCompleted, lastReceivedTimestamp.get() - start);
         if (commandsCompleted == commandsSent.get()) {
@@ -442,7 +442,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
      * @param ctx The vert.x test context.
      * @throws InterruptedException if not all commands and responses are exchanged in time.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("allCombinations")
     @Timeout(timeUnit = TimeUnit.SECONDS, value = 10)
     public void testSendCommandFailsForMalformedMessage(
@@ -513,7 +513,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
      * @param ctx The vert.x test context.
      * @throws InterruptedException if not all commands and responses are exchanged in time.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("allCombinations")
     @Timeout(timeUnit = TimeUnit.SECONDS, value = 10)
     public void testSendCommandFailsForCommandRejectedByDevice(

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -887,7 +887,7 @@ public abstract class HttpTestBase {
      * @param ctx The test context.
      * @throws InterruptedException if the test fails.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("commandAndControlVariants")
     public void testUploadMessagesWithTtdThatReplyWithCommand(
             final HttpCommandEndpointConfiguration endpointConfig,
@@ -992,7 +992,7 @@ public abstract class HttpTestBase {
      * @param ctx The test context.
      * @throws InterruptedException if the test fails.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("commandAndControlVariants")
     public void testUploadMessagesWithTtdThatReplyWithOneWayCommand(
             final HttpCommandEndpointConfiguration endpointConfig,
@@ -1133,8 +1133,7 @@ public abstract class HttpTestBase {
 
         final StringBuilder result = new StringBuilder("Basic ");
         final String username = IntegrationTestSupport.getUsername(deviceId, tenant);
-        result.append(Base64.getEncoder().encodeToString(new StringBuilder(username).append(":").append(password)
-                .toString().getBytes(StandardCharsets.UTF_8)));
+        result.append(Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8)));
         return result.toString();
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -127,7 +127,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
      * @param ctx The vert.x test context.
      * @throws InterruptedException if not all commands and responses are exchanged in time.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("allCombinations")
     @Timeout(timeUnit = TimeUnit.SECONDS, value = 10)
     public void testSendOneWayCommandSucceeds(
@@ -166,7 +166,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
      * @param ctx The vert.x test context.
      * @throws InterruptedException if not all commands and responses are exchanged in time.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("allCombinations")
     public void testSendCommandSucceedsWithQos0(
             final MqttCommandEndpointConfiguration endpointConfig,
@@ -183,7 +183,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
      * @param ctx The vert.x test context.
      * @throws InterruptedException if not all commands and responses are exchanged in time.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("allCombinations")
     public void testSendCommandSucceedsWithQos1(
             final MqttCommandEndpointConfiguration endpointConfig,
@@ -322,7 +322,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
      * @param ctx The vert.x test context.
      * @throws InterruptedException if not all commands and responses are exchanged in time.
      */
-    @ParameterizedTest
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("allCombinations")
     @Timeout(timeUnit = TimeUnit.SECONDS, value = 20)
     public void testSendCommandFailsForMalformedMessage(


### PR DESCRIPTION
Improve log output of parameterized tests; fix typos.

Before, the log output for parameterized tests was just:
````
o.e.h.t.mqtt.CommandAndControlMqttIT - running [6] gateway device: true, southbound endpoint: control, northbound endpoint: command, topic filter: control/+/+/req/#
````
With this commit, it will be:
````
o.e.h.t.mqtt.CommandAndControlMqttIT - running testSendCommandFailsForMalformedMessage(MqttCommandEndpointConfiguration, VertxTestContext) [6]; parameters: gateway device: true, southbound endpoint: control, northbound endpoint: command, topic filter: control/+/+/req/#
````
