### PR TITLE
[#1541] Allow null link address for anonymous relay in createSender()

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -245,13 +245,15 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
 
     /**
      * Creates a sender link.
-     * 
-     * @param targetAddress The target address of the link.
+     *
+     * @param targetAddress The target address of the link. If the address is {@code null}, the
+     *                      sender link will be established to the 'anonymous relay' and each
+     *                      message must specify its destination address.
      * @param qos The quality of service to use for the link.
      * @param remoteCloseHook The handler to invoke when the link is closed by the peer (may be {@code null}).
      * @return A future for the created link. The future will be completed once the link is open.
      *         The future will fail with a {@link ServiceInvocationException} if the link cannot be opened.
-     * @throws NullPointerException if any of the arguments other than close hook is {@code null}.
+     * @throws NullPointerException if qos is {@code null}.
      */
     Future<ProtonSender> createSender(
             String targetAddress,

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
@@ -598,12 +598,14 @@ public class HonoConnectionImpl implements HonoConnection {
     /**
      * Creates a sender link.
      * 
-     * @param targetAddress The target address of the link.
+     * @param targetAddress The target address of the link. If the address is {@code null}, the
+     *                      sender link will be established to the 'anonymous relay' and each
+     *                      message must specify its destination address.
      * @param qos The quality of service to use for the link.
      * @param closeHook The handler to invoke when the link is closed by the peer (may be {@code null}).
      * @return A future for the created link. The future will be completed once the link is open.
      *         The future will fail with a {@link ServiceInvocationException} if the link cannot be opened.
-     * @throws NullPointerException if any of the arguments other than close hook is {@code null}.
+     * @throws NullPointerException if qos is {@code null}.
      */
     @Override
     public final Future<ProtonSender> createSender(
@@ -611,7 +613,6 @@ public class HonoConnectionImpl implements HonoConnection {
             final ProtonQoS qos,
             final Handler<String> closeHook) {
 
-        Objects.requireNonNull(targetAddress);
         Objects.requireNonNull(qos);
 
         return executeOrRunOnContext(result -> {

--- a/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
@@ -144,10 +144,7 @@ public final class HonoProtonHelper {
      */
     public static boolean isLinkEstablished(final ProtonLink<?> link) {
         if (link instanceof ProtonSender) {
-            // check for non-null remote target address - or if it is null, for an anonymous sender link (with empty local target address)
-            return link.getRemoteTarget() != null
-                    && (link.getRemoteTarget().getAddress() != null
-                            || (link.getTarget() != null && link.getTarget().getAddress() != null && link.getTarget().getAddress().isEmpty()));
+            return link.getRemoteTarget() != null;
         } else if (link instanceof ProtonReceiver) {
             return link.getRemoteSource() != null && link.getRemoteSource().getAddress() != null;
         } else {


### PR DESCRIPTION
This fixes #1541.

Note that using an empty string as target address is still supported by means of a corresponding check in `isLinkEstablished`.