### PR TITLE
Add convenience methods for creating new downstream messages.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
@@ -324,6 +324,17 @@ public final class ResourceIdentifier {
         return createStringRepresentation(IDX_RESOURCE_ID);
     }
 
+    /**
+     * Checks if this resource identifier contains the event endpoint.
+     * 
+     * @return {@code true} if this resource's endpoint is either
+     *         {@link EventConstants#EVENT_ENDPOINT} or {@link EventConstants#EVENT_ENDPOINT_SHORT}.
+     */
+    public boolean hasEventEndpoint() {
+        return EventConstants.EVENT_ENDPOINT.equals(getEndpoint()) ||
+                EventConstants.EVENT_ENDPOINT_SHORT.equals(getEndpoint());
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/legal/src/main/resources/checkstyle/default.xml
+++ b/legal/src/main/resources/checkstyle/default.xml
@@ -46,6 +46,7 @@
         name="excludes"
         value="com.github.tomakehurst.wiremock.client.WireMock.*,
                org.assertj.core.api.Assertions.assertThat,
+               org.assertj.core.api.Assertions.assertThatThrownBy,
                org.hamcrest.CoreMatchers.*,
                org.hamcrest.Matchers.*,
                org.hamcrest.MatcherAssert.*,

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -27,6 +27,10 @@ title = "Release Notes"
   and [MQTT Adapter] ({{% doclink "/user-guide/mqtt-adapter/#publishing-events" %}}) for details.
 * The device registry HTTP management API now properly implements *cross-origin resource sharing (CORS)* support,
   by allowing the service to be exposed to configured domains (by default, it's exposed to all domains).
+* The `org.eclipse.hono.util.MessageHelper` now provides convenience factory methods for creating
+  new downstream messages from basic properties.
+  `org.eclipse.hono.service.AbstractProtocolAdapterbase` has been adapted to delegate to these
+  new factory methods.
 
 ### API Changes
 


### PR DESCRIPTION
The factory methods for creating new downstream messages have been moved from `AbstractProtocolAdapterBase` to `MessageHelper` so that implementors of custom adapters can profit from using these methods without requiring them to extend the abstract base class.

This addresses #1544 