### PR TITLE
Prevent that anchors are positioned behind menu bar in documentation.

### DIFF
--- a/site/documentation/static/css/hono.css
+++ b/site/documentation/static/css/hono.css
@@ -89,3 +89,11 @@
 .swagger-ui table, .swagger-ui thead, .swagger-ui td {
 	border: none;
 }
+
+/* prevents that the anchor is positioned behind the menu bar */
+:target:before {
+  content: "";
+  display: block;
+  height: 60px;
+  margin: -60px 0 0;
+}


### PR DESCRIPTION
This adds CSS to prevent that anchors are positioned behind the (sticky) menu bar in the documentation (similar to the solution for the homepage).