### PR TITLE
Minor cosmetic changes

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -205,10 +205,10 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                         bindInsecureEndpoint(startingServer, insecureConfig.result());
                         startingServer.start();
                         if (secureEndpoint != null) {
-                            LOG.info("coaps/udp endpoint running on {}", secureEndpoint.getAddress());
+                            log.info("coaps/udp endpoint running on {}", secureEndpoint.getAddress());
                         }
                         if (insecureEndpoint != null) {
-                            LOG.info("coap/udp endpoint running on {}", insecureEndpoint.getAddress());
+                            log.info("coap/udp endpoint running on {}", insecureEndpoint.getAddress());
                         }
                         return ok;
                     });
@@ -217,7 +217,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                 onStartupSuccess();
                 startFuture.complete();
             } catch (final Exception e) {
-                LOG.error("error in onStartupSuccess", e);
+                log.error("error in onStartupSuccess", e);
                 startFuture.fail(e);
             }
         }, startFuture);
@@ -258,7 +258,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                 // Californium's cipher suites support ECC based keys only
                 dtlsConfig.setIdentity(keyLoader.getPrivateKey(), keyLoader.getCertificateChain());
             } else {
-                LOG.warn("configured key is not ECC based, certificate based cipher suites will be disabled");
+                log.warn("configured key is not ECC based, certificate based cipher suites will be disabled");
             }
         }
 
@@ -270,7 +270,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
             startingServer.addEndpoint(this.secureEndpoint);
 
         } catch (final IllegalStateException ex) {
-            LOG.warn("failed to create secure endpoint", ex);
+            log.warn("failed to create secure endpoint", ex);
         }
     }
 
@@ -278,7 +278,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
 
         if (getConfig().isInsecurePortEnabled()) {
             if (getConfig().isAuthenticationRequired()) {
-                LOG.warn("skipping start up of insecure endpoint, configuration requires authentication of devices");
+                log.warn("skipping start up of insecure endpoint, configuration requires authentication of devices");
             } else {
                 final CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
                 builder.setNetworkConfig(config);
@@ -376,10 +376,10 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                     try (InputStream is = new ByteArrayInputStream(readAttempt.result().getBytes())) {
                         networkConfig.load(is);
                     } catch (final IOException e) {
-                        LOG.warn("skipping malformed NetworkConfig properties [{}]", fileName);
+                        log.warn("skipping malformed NetworkConfig properties [{}]", fileName);
                     }
                 } else {
-                    LOG.warn("error reading NetworkConfig file [{}]", fileName, readAttempt.cause());
+                    log.warn("error reading NetworkConfig file [{}]", fileName, readAttempt.cause());
                 }
             });
         }
@@ -406,7 +406,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
         try {
             preShutdown();
         } catch (final Exception e) {
-            LOG.error("error in preShutdown", e);
+            log.error("error in preShutdown", e);
         }
 
         final Future<Void> serverStopTracker = Future.future();
@@ -591,7 +591,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                         return sender.send(downstreamMessage);
                     }
             }).map(delivery -> {
-                LOG.trace("successfully processed message for device [tenantId: {}, deviceId: {}, endpoint: {}]",
+                log.trace("successfully processed message for device [tenantId: {}, deviceId: {}, endpoint: {}]",
                         device.getTenantId(), device.getDeviceId(), endpoint.getCanonicalName());
                 metrics.reportTelemetry(
                         endpoint,
@@ -604,7 +604,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                 context.respondWithCode(ResponseCode.CHANGED);
                 return delivery;
             }).recover(t -> {
-                LOG.debug("cannot process message for device [tenantId: {}, deviceId: {}, endpoint: {}]",
+                log.debug("cannot process message for device [tenantId: {}, deviceId: {}, endpoint: {}]",
                         device.getTenantId(), device.getDeviceId(), endpoint.getCanonicalName(), t);
                 metrics.reportTelemetry(
                         endpoint,

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapErrorResponse.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapErrorResponse.java
@@ -109,6 +109,7 @@ public class CoapErrorResponse {
                 try {
                     return ResponseCode.valueOf(codeClass << 5 | codeDetail);
                 } catch (MessageFormatException e) {
+                    // ignore
                 }
             }
         }

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
@@ -138,8 +138,8 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
             addCommandResponseRoutes(CommandConstants.COMMAND_LEGACY_ENDPOINT, router, authHandler);
         } else {
 
-            LOG.warn("device authentication has been disabled");
-            LOG.warn("any device may publish data on behalf of all other devices");
+            log.warn("device authentication has been disabled");
+            log.warn("any device may publish data on behalf of all other devices");
             addTelemetryApiRoutes(router, null);
             addEventApiRoutes(router, null);
             addCommandResponseRoutes(CommandConstants.COMMAND_ENDPOINT, router, null);

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/KuraProtocolAdapter.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/KuraProtocolAdapter.java
@@ -51,7 +51,7 @@ public final class KuraProtocolAdapter extends AbstractVertxBasedMqttProtocolAda
 
         return mapTopic(ctx)
                 .recover(t -> {
-                    LOG.debug("discarding message [topic: {}] from device: {}", ctx.message().topicName(), t.getMessage());
+                    log.debug("discarding message [topic: {}] from device: {}", ctx.message().topicName(), t.getMessage());
                     return Future.failedFuture(t);
                 }).compose(targetAddress -> uploadMessage(ctx, targetAddress, ctx.message()));
     }
@@ -84,7 +84,7 @@ public final class KuraProtocolAdapter extends AbstractVertxBasedMqttProtocolAda
             // topic does not contain account_name and client_id
             result.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "topic does not comply with Kura format"));
         } else {
-            LOG.debug("mapped Kura message [topic: {}, QoS: {}] to Hono message [to: {}, device_id: {}, content-type: {}]",
+            log.debug("mapped Kura message [topic: {}, QoS: {}] to Hono message [to: {}, device_id: {}, content-type: {}]",
                     topic, ctx.message().qosLevel(), mappedTopic.getBasePath(), mappedTopic.getResourceId(), ctx.contentType());
             result.complete(mappedTopic);
         }

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -101,7 +101,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
 
     private static final int IANA_MQTT_PORT = 1883;
     private static final int IANA_SECURE_MQTT_PORT = 8883;
-    private static final String KEY_TOPIC_NAME_FILTER = "filter";
+    private static final String KEY_TOPIC_FILTER = "filter";
 
     private MqttAdapterMetrics metrics = MqttAdapterMetrics.NOOP;
 
@@ -589,7 +589,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     result = createCommandConsumer(endpoint, cmdSub, cmdHandler).map(consumer -> {
                         final Map<String, Object> items = new HashMap<>(4);
                         items.put(Fields.EVENT, "accepting subscription");
-                        items.put(KEY_TOPIC_NAME_FILTER, subscription.topicName());
+                        items.put(KEY_TOPIC_FILTER, subscription.topicName());
                         items.put("requested QoS", subscription.qualityOfService());
                         items.put("granted QoS", subscription.qualityOfService());
                         span.log(items);
@@ -601,7 +601,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     }).recover(t -> {
                         final Map<String, Object> items = new HashMap<>(4);
                         items.put(Fields.EVENT, Tags.ERROR.getKey());
-                        items.put(KEY_TOPIC_NAME_FILTER, subscription.topicName());
+                        items.put(KEY_TOPIC_FILTER, subscription.topicName());
                         items.put("requested QoS", subscription.qualityOfService());
                         items.put(Fields.MESSAGE, "rejecting subscription: " + t.getMessage());
                         TracingHelper.logError(span, items);
@@ -698,7 +698,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             if (cmdSub == null) {
                 final Map<String, Object> items = new HashMap<>(2);
                 items.put(Fields.EVENT, "ignoring unsupported topic filter");
-                items.put(KEY_TOPIC_NAME_FILTER, topic);
+                items.put(KEY_TOPIC_FILTER, topic);
                 span.log(items);
                 log.debug("ignoring unsubscribe request for unsupported topic filter [{}]", topic);
             } else {
@@ -706,7 +706,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                 final String deviceId = cmdSub.getDeviceId();
                 final Map<String, Object> items = new HashMap<>(2);
                 items.put(Fields.EVENT, "unsubscribing device from topic");
-                items.put(KEY_TOPIC_NAME_FILTER, topic);
+                items.put(KEY_TOPIC_FILTER, topic);
                 span.log(items);
                 log.debug("unsubscribing device [tenant-id: {}, device-id: {}] from topic [{}]",
                         tenantId, deviceId, topic);

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
@@ -51,7 +51,7 @@ public final class VertxBasedMqttProtocolAdapter extends AbstractVertxBasedMqttP
         .compose(address -> validateAddress(address, ctx.authenticatedDevice()))
         .compose(targetAddress -> uploadMessage(ctx, targetAddress, ctx.message()))
         .recover(t -> {
-            LOG.debug("discarding message [topic: {}] from device: {}",
+            log.debug("discarding message [topic: {}] from device: {}",
                     ctx.message().topicName(), ctx.authenticatedDevice(), t);
             return Future.failedFuture(t);
         });
@@ -90,7 +90,7 @@ public final class VertxBasedMqttProtocolAdapter extends AbstractVertxBasedMqttP
                 break;
             default:
                 // MQTT client is trying to publish on a not supported endpoint
-                LOG.debug("no such endpoint [{}]", topic.getEndpoint());
+                log.debug("no such endpoint [{}]", topic.getEndpoint());
                 result.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND, "no such endpoint"));
         }
         return result;

--- a/cli/src/main/java/org/eclipse/hono/cli/AbstractCliClient.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/AbstractCliClient.java
@@ -33,7 +33,7 @@ public abstract class AbstractCliClient {
     /**
      * A logger to be shared with subclasses.
      */
-    protected final Logger LOG = LoggerFactory.getLogger(getClass());
+    protected final Logger log = LoggerFactory.getLogger(getClass());
 
     /**
      * The vert.x instance to run on.

--- a/cli/src/main/java/org/eclipse/hono/cli/Application.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/Application.java
@@ -32,7 +32,7 @@ public class Application {
     private String profiles;
 
     @PostConstruct
-    private void start() throws Exception {
+    private void start() {
         LOG.info("running command line client in role(s): {}", profiles);
     }
 

--- a/cli/src/main/java/org/eclipse/hono/cli/adapter/AmqpCliClient.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/adapter/AmqpCliClient.java
@@ -101,7 +101,7 @@ public abstract class AmqpCliClient extends AbstractCliClient {
             options.addEnabledSaslMechanism(ProtonSaslPlainImpl.MECH_NAME);
 
 
-            LOG.info("connecting to AMQP org.eclipse.hono.cli.app.adapter using SASL PLAIN [host: {}, port: {}, username: {}]",
+            log.info("connecting to AMQP org.eclipse.hono.cli.app.adapter using SASL PLAIN [host: {}, port: {}, username: {}]",
                     properties.getHost(), properties.getPort(), properties.getUsername());
 
             client.connect(
@@ -118,7 +118,7 @@ public abstract class AmqpCliClient extends AbstractCliClient {
             } else {
                 // SASL ANONYMOUS auth
             }
-            LOG.info("connecting to AMQP org.eclipse.hono.cli.app.adapter [host: {}, port: {}]", properties.getHost(), properties.getPort());
+            log.info("connecting to AMQP org.eclipse.hono.cli.app.adapter [host: {}, port: {}]", properties.getHost(), properties.getPort());
             client.connect(options, properties.getHost(), properties.getPort(), connectAttempt);
         }
 

--- a/cli/src/main/java/org/eclipse/hono/cli/adapter/CommandAndControlClient.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/adapter/CommandAndControlClient.java
@@ -82,7 +82,7 @@ public class CommandAndControlClient extends AmqpCliClient {
     private Future<ProtonReceiver> startCommandReceiver(final ProtonMessageHandler msgHandler) {
         return connectToAdapter()
         .compose(con -> {
-            LOG.info("connection to AMQP adapter established");
+            log.info("connection to AMQP adapter established");
             adapterConnection = con;
             return createSender();
         }).compose(s -> {

--- a/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
@@ -72,18 +72,17 @@ public class Commander extends AbstractApplicationClient {
 
     private Future<Void> processCommand(final Command command) {
 
-
         final Future<CommandClient> commandClient = clientFactory.getOrCreateCommandClient(tenantId);
         return commandClient
                 .map(this::setRequestTimeOut)
                 .compose(c -> {
                     if (command.isOneWay()) {
-                        LOG.info("Command sent to device");
+                        log.info("Command sent to device");
                         return c.sendOneWayCommand(deviceId, command.getName(), command.getContentType(),
                                 Buffer.buffer(command.getPayload()), null)
                                 .map(ok -> c);
                     } else {
-                        LOG.info("Command sent to device... [waiting for response for max. {} seconds]",
+                        log.info("Command sent to device... [waiting for response for max. {} seconds]",
                                 requestTimeoutInSecs);
                         return c.sendCommand(deviceId, command.getName(), command.getContentType(),
                                 Buffer.buffer(command.getPayload()), null)
@@ -94,11 +93,11 @@ public class Commander extends AbstractApplicationClient {
                 .map(this::closeCommandClient)
                 .otherwise(error -> {
                     if (ServerErrorException.extractStatusCode(error) == HttpURLConnection.HTTP_UNAVAILABLE) {
-                        LOG.error(
+                        log.error(
                                 "Error sending command (error code 503). Is the device really waiting for a command? (device [{}] in tenant [{}])",
                                 deviceId, tenantId);
                     } else {
-                        LOG.error("Error sending command: {}", error.getMessage());
+                        log.error("Error sending command: {}", error.getMessage());
                     }
                     if (commandClient.succeeded()) {
                         return closeCommandClient(commandClient.result());
@@ -114,15 +113,15 @@ public class Commander extends AbstractApplicationClient {
     }
 
     private Void closeCommandClient(final CommandClient commandClient) {
-        LOG.trace("Close command connection to device [{}:{}]", tenantId, deviceId);
+        log.trace("Close command connection to device [{}:{}]", tenantId, deviceId);
         commandClient.close(closeHandler -> {
         });
         return null;
     }
 
     private Void printResponse(final BufferResult result) {
-        LOG.info("Received Command response: {}",
-                Optional.ofNullable(result.getPayload()).orElse(Buffer.buffer()).toString());
+        log.info("Received Command response : {}",
+                Optional.ofNullable(result.getPayload()).orElse(Buffer.buffer()));
         return null;
     }
 
@@ -149,7 +148,7 @@ public class Commander extends AbstractApplicationClient {
     private void close(final Throwable t) {
         workerExecutor.close();
         vertx.close();
-        LOG.error("Error: {}", t.getMessage());
+        log.error("Error: {}", t.getMessage());
     }
 
     /**

--- a/cli/src/main/java/org/eclipse/hono/cli/app/Receiver.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/Receiver.java
@@ -71,9 +71,9 @@ public class Receiver extends AbstractApplicationClient {
     private CompositeFuture createConsumer(final HonoConnection connection) {
 
         final Handler<Void> closeHandler = closeHook -> {
-            LOG.info("close handler of consumer is called");
+            log.info("close handler of consumer is called");
             vertx.setTimer(connectionRetryInterval, reconnect -> {
-                LOG.info("attempting to re-open the consumer link ...");
+                log.info("attempting to re-open the consumer link ...");
                 createConsumer(connection);
             });
         };
@@ -104,20 +104,20 @@ public class Receiver extends AbstractApplicationClient {
 
         final Buffer payload = MessageHelper.getPayload(msg);
 
-        LOG.info("received {} message [device: {}, content-type: {}]: {}", endpoint, deviceId, msg.getContentType(),
+        log.info("received {} message [device: {}, content-type: {}]: {}", endpoint, deviceId, msg.getContentType(),
                 payload);
 
         if (msg.getApplicationProperties() != null) {
-            LOG.info("... with application properties: {}", msg.getApplicationProperties().getValue());
+            log.info("... with application properties: {}", msg.getApplicationProperties().getValue());
         }
     }
 
     private void handleCreateConsumerStatus(final AsyncResult<CompositeFuture> startup) {
         if (startup.succeeded()) {
-            LOG.info("Receiver [tenant: {}, mode: {}] created successfully, hit ctrl-c to exit", tenantId,
+            log.info("Receiver [tenant: {}, mode: {}] created successfully, hit ctrl-c to exit", tenantId,
                     messageType);
         } else {
-            LOG.error("Error occurred during initialization of receiver: {}", startup.cause().getMessage());
+            log.error("Error occurred during initialization of receiver: {}", startup.cause().getMessage());
             vertx.close();
         }
     }

--- a/client/src/main/java/org/eclipse/hono/client/CommandContext.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandContext.java
@@ -46,7 +46,7 @@ public class CommandContext extends MapBasedExecutionContext {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommandContext.class);
 
-    private static final String ERROR_MSG_INVALID_CREDIT_VALUE = "";
+    private static final String ERROR_MSG_INVALID_CREDIT_VALUE = "credit must be >= 0";
 
     private final Command command;
     private final ProtonDelivery delivery;
@@ -247,7 +247,7 @@ public class CommandContext extends MapBasedExecutionContext {
     public void reject(final ErrorCondition errorCondition, final int credit) {
 
         if (credit < 0) {
-            throw new IllegalArgumentException("credit must be >= 0");
+            throw new IllegalArgumentException(ERROR_MSG_INVALID_CREDIT_VALUE);
         }
         final Rejected rejected = new Rejected();
         if (errorCondition != null) {

--- a/client/src/main/java/org/eclipse/hono/client/CommandContext.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandContext.java
@@ -46,6 +46,8 @@ public class CommandContext extends MapBasedExecutionContext {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommandContext.class);
 
+    private static final String ERROR_MSG_INVALID_CREDIT_VALUE = "";
+
     private final Command command;
     private final ProtonDelivery delivery;
     private final ProtonReceiver receiver;
@@ -147,7 +149,7 @@ public class CommandContext extends MapBasedExecutionContext {
     public void accept(final int credit) {
 
         if (credit < 0) {
-            throw new IllegalArgumentException("credit must be >= 0");
+            throw new IllegalArgumentException(ERROR_MSG_INVALID_CREDIT_VALUE);
         }
         LOG.trace("accepting command message [{}]", getCommand());
         ProtonHelper.accepted(delivery, true);
@@ -181,7 +183,7 @@ public class CommandContext extends MapBasedExecutionContext {
     public void release(final int credit) {
 
         if (credit < 0) {
-            throw new IllegalArgumentException("credit must be >= 0");
+            throw new IllegalArgumentException(ERROR_MSG_INVALID_CREDIT_VALUE);
         }
         ProtonHelper.released(delivery, true);
         TracingHelper.logError(currentSpan, "released command for device");
@@ -206,7 +208,7 @@ public class CommandContext extends MapBasedExecutionContext {
     public void modify(final boolean deliveryFailed, final boolean undeliverableHere, final int credit) {
 
         if (credit < 0) {
-            throw new IllegalArgumentException("credit must be >= 0");
+            throw new IllegalArgumentException(ERROR_MSG_INVALID_CREDIT_VALUE);
         }
         ProtonHelper.modified(delivery, true, deliveryFailed, undeliverableHere);
         TracingHelper.logError(currentSpan, "modified command for device"
@@ -289,7 +291,7 @@ public class CommandContext extends MapBasedExecutionContext {
 
         Objects.requireNonNull(deliveryState);
         if (credit < 0) {
-            throw new IllegalArgumentException("credit must be >= 0");
+            throw new IllegalArgumentException(ERROR_MSG_INVALID_CREDIT_VALUE);
         }
         delivery.disposition(deliveryState, true);
         if (Accepted.class.isInstance(deliveryState)) {

--- a/client/src/main/java/org/eclipse/hono/client/CommandResponse.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandResponse.java
@@ -14,7 +14,7 @@
 package org.eclipse.hono.client;
 
 import java.util.Objects;
-import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.MessageHelper;
@@ -34,8 +34,8 @@ public final class CommandResponse {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommandResponse.class);
 
-    private static final IntPredicate INVALID_STATUS_CODE = code ->
-        code < 200 || (code >= 300 && code < 400) || code >= 600;
+    private static final Predicate<Integer> INVALID_STATUS_CODE = code ->
+        code == null || code < 200 || (code >= 300 && code < 400) || code >= 600;
 
     private final Message message;
     private final String replyToId;
@@ -84,7 +84,7 @@ public final class CommandResponse {
         if (requestId == null) {
             LOG.debug("cannot create CommandResponse: request id is null");
             return null;
-        } else if (status == null || INVALID_STATUS_CODE.test(status)) {
+        } else if (INVALID_STATUS_CODE.test(status)) {
             LOG.debug("cannot create CommandResponse: status is invalid: {}", status);
             return null;
         } else if (requestId.length() < 3) {
@@ -130,7 +130,7 @@ public final class CommandResponse {
             LOG.debug("cannot create CommandResponse: invalid message (correlationId: {}, address: {}, status: {})",
                     correlationId, message.getAddress(), status);
             return null;
-        } else if (status == null || INVALID_STATUS_CODE.test(status)) {
+        } else if (INVALID_STATUS_CODE.test(status)) {
             LOG.debug("cannot create CommandResponse: status is invalid: {}", status);
             return null;
         } else {

--- a/client/src/main/java/org/eclipse/hono/client/CommandResponse.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandResponse.java
@@ -14,7 +14,7 @@
 package org.eclipse.hono.client;
 
 import java.util.Objects;
-import java.util.function.Predicate;
+import java.util.function.IntPredicate;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.MessageHelper;
@@ -34,8 +34,8 @@ public final class CommandResponse {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommandResponse.class);
 
-    private static final Predicate<Integer> INVALID_STATUS_CODE = code ->
-        code == null || code < 200 || (code >= 300 && code < 400) || code >= 600;
+    private static final IntPredicate INVALID_STATUS_CODE = code ->
+        code < 200 || (code >= 300 && code < 400) || code >= 600;
 
     private final Message message;
     private final String replyToId;
@@ -84,7 +84,7 @@ public final class CommandResponse {
         if (requestId == null) {
             LOG.debug("cannot create CommandResponse: request id is null");
             return null;
-        } else if (INVALID_STATUS_CODE.test(status)) {
+        } else if (status == null || INVALID_STATUS_CODE.test(status)) {
             LOG.debug("cannot create CommandResponse: status is invalid: {}", status);
             return null;
         } else if (requestId.length() < 3) {
@@ -130,7 +130,7 @@ public final class CommandResponse {
             LOG.debug("cannot create CommandResponse: invalid message (correlationId: {}, address: {}, status: {})",
                     correlationId, message.getAddress(), status);
             return null;
-        } else if (INVALID_STATUS_CODE.test(status)) {
+        } else if (status == null || INVALID_STATUS_CODE.test(status)) {
             LOG.debug("cannot create CommandResponse: status is invalid: {}", status);
             return null;
         } else {

--- a/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
@@ -134,7 +134,7 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
                                 HttpURLConnection.HTTP_UNAVAILABLE,
                                 "waiting for delivery update timed out after "
                                         + connection.getConfig().getSendMessageTimeout() + "ms");
-                        LOG.debug("waiting for delivery update timed out for message [message ID: {}] after {}ms",
+                        log.debug("waiting for delivery update timed out for message [message ID: {}] after {}ms",
                                 messageId, connection.getConfig().getSendMessageTimeout());
                         result.fail(exception);
                     }
@@ -147,12 +147,12 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
             }
             final DeliveryState remoteState = deliveryUpdated.getRemoteState();
             if (result.isComplete()) {
-                LOG.debug("ignoring received delivery update for message [message ID: {}]: waiting for the update has already timed out", messageId);
+                log.debug("ignoring received delivery update for message [message ID: {}]: waiting for the update has already timed out", messageId);
             } else if (deliveryUpdated.remotelySettled()) {
                 logUpdatedDeliveryState(currentSpan, messageId, deliveryUpdated);
                 result.complete(deliveryUpdated);
             } else {
-                LOG.debug("peer did not settle message [message ID: {}, remote state: {}], failing delivery",
+                log.debug("peer did not settle message [message ID: {}, remote state: {}], failing delivery",
                         messageId, remoteState);
                 final ServiceInvocationException e = new ServerErrorException(
                         HttpURLConnection.HTTP_INTERNAL_ERROR,
@@ -160,10 +160,10 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
                 result.fail(e);
             }
         });
-        LOG.trace("sent message [ID: {}], remaining credit: {}, queued messages: {}", messageId, sender.getCredit(), sender.getQueued());
+        log.trace("sent message [ID: {}], remaining credit: {}, queued messages: {}", messageId, sender.getCredit(), sender.getQueued());
 
         return result.map(delivery -> {
-            LOG.trace("message [ID: {}] accepted by peer", messageId);
+            log.trace("message [ID: {}] accepted by peer", messageId);
             Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_ACCEPTED);
             currentSpan.finish();
             return delivery;

--- a/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
@@ -175,7 +175,7 @@ public final class TelemetrySenderImpl extends AbstractDownstreamSender {
                         final ServerErrorException exception = new ServerErrorException(
                                 HttpURLConnection.HTTP_UNAVAILABLE,
                                 "waiting for delivery update timed out after " + config.getSendMessageTimeout() + "ms");
-                        LOG.debug("waiting for delivery update timed out for message [message ID: {}] after {}ms",
+                        log.debug("waiting for delivery update timed out for message [message ID: {}] after {}ms",
                                 messageId, config.getSendMessageTimeout());
                         TracingHelper.logError(currentSpan, exception.getMessage());
                         Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_UNAVAILABLE);
@@ -190,11 +190,11 @@ public final class TelemetrySenderImpl extends AbstractDownstreamSender {
             }
             final DeliveryState remoteState = deliveryUpdated.getRemoteState();
             if (timeoutReached.get()) {
-                LOG.debug("ignoring received delivery update for message [message ID: {}]: waiting for the update has already timed out", messageId);
+                log.debug("ignoring received delivery update for message [message ID: {}]: waiting for the update has already timed out", messageId);
             } else if (deliveryUpdated.remotelySettled()) {
                 logUpdatedDeliveryState(currentSpan, messageId, deliveryUpdated);
             } else {
-                LOG.warn("peer did not settle message [message ID: {}, remote state: {}]",
+                log.warn("peer did not settle message [message ID: {}, remote state: {}]",
                         messageId, remoteState);
                 TracingHelper.logError(currentSpan, new ServerErrorException(
                         HttpURLConnection.HTTP_INTERNAL_ERROR,
@@ -202,7 +202,7 @@ public final class TelemetrySenderImpl extends AbstractDownstreamSender {
             }
             currentSpan.finish();
         });
-        LOG.trace("sent message [ID: {}], remaining credit: {}, queued messages: {}", messageId, sender.getCredit(), sender.getQueued());
+        log.trace("sent message [ID: {}], remaining credit: {}, queued messages: {}", messageId, sender.getCredit(), sender.getQueued());
 
         return Future.succeededFuture(result);
     }

--- a/core/src/main/java/org/eclipse/hono/auth/AuthoritiesImpl.java
+++ b/core/src/main/java/org/eclipse/hono/auth/AuthoritiesImpl.java
@@ -39,8 +39,8 @@ public final class AuthoritiesImpl implements Authorities {
     public static final String PREFIX_OPERATION = "o:";
 
     private static final Logger LOG = LoggerFactory.getLogger(AuthoritiesImpl.class);
-    private static final String opTemplate = PREFIX_OPERATION + "%s:%s";
-    private static final String resTemplate = PREFIX_RESOURCE + "%s";
+    private static final String TEMPLATE_OP = PREFIX_OPERATION + "%s:%s";
+    private static final String TEMPLATE_RESOURCE = PREFIX_RESOURCE + "%s";
     // holds mapping resources -> activities
     private final Map<String, String> authorities = new HashMap<>();
 
@@ -73,17 +73,17 @@ public final class AuthoritiesImpl implements Authorities {
 
     private static String getOperationKey(final String endpoint, final String tenant, final String operation) {
         if (tenant == null) {
-            return String.format(opTemplate, endpoint, operation);
+            return String.format(TEMPLATE_OP, endpoint, operation);
         } else {
-            return String.format(opTemplate, endpoint + "/" + tenant, operation);
+            return String.format(TEMPLATE_OP, endpoint + "/" + tenant, operation);
         }
     }
 
     private static String getResourceKey(final String endpoint, final String tenant) {
         if (tenant == null) {
-            return String.format(resTemplate, endpoint);
+            return String.format(TEMPLATE_RESOURCE, endpoint);
         } else {
-            return String.format(resTemplate, endpoint + "/" + tenant);
+            return String.format(TEMPLATE_RESOURCE, endpoint + "/" + tenant);
         }
     }
 
@@ -161,15 +161,15 @@ public final class AuthoritiesImpl implements Authorities {
 
         boolean allowed = false;
         if (resource.getResourceId() != null) {
-            allowed = isAuthorized(String.format(resTemplate, resource.toString()), intent);
+            allowed = isAuthorized(String.format(TEMPLATE_RESOURCE, resource.toString()), intent);
         }
         if (!allowed && resource.getTenantId() != null) {
-            allowed = isAuthorized(String.format(resTemplate, resource.getEndpoint() + "/" + resource.getTenantId()), intent) ||
-                    isAuthorized(String.format(resTemplate, resource.getEndpoint() + "/*"), intent);
+            allowed = isAuthorized(String.format(TEMPLATE_RESOURCE, resource.getEndpoint() + "/" + resource.getTenantId()), intent) ||
+                    isAuthorized(String.format(TEMPLATE_RESOURCE, resource.getEndpoint() + "/*"), intent);
         }
         if (!allowed) {
-            allowed = isAuthorized(String.format(resTemplate, resource.getEndpoint()), intent) ||
-                    isAuthorized(String.format(resTemplate, "*"), intent);
+            allowed = isAuthorized(String.format(TEMPLATE_RESOURCE, resource.getEndpoint()), intent) ||
+                    isAuthorized(String.format(TEMPLATE_RESOURCE, "*"), intent);
         }
         return allowed;
     }
@@ -179,20 +179,20 @@ public final class AuthoritiesImpl implements Authorities {
 
         boolean allowed = false;
         if (resource.getResourceId() != null) {
-            allowed = isAuthorized(String.format(opTemplate, resource.toString(), operation), Activity.EXECUTE) ||
-                    isAuthorized(String.format(opTemplate, resource.toString(), "*"), Activity.EXECUTE);
+            allowed = isAuthorized(String.format(TEMPLATE_OP, resource.toString(), operation), Activity.EXECUTE) ||
+                    isAuthorized(String.format(TEMPLATE_OP, resource.toString(), "*"), Activity.EXECUTE);
         }
         if (!allowed && resource.getTenantId() != null) {
-            allowed = isAuthorized(String.format(opTemplate, resource.getEndpoint() + "/" + resource.getTenantId(), operation), Activity.EXECUTE) ||
-                    isAuthorized(String.format(opTemplate, resource.getEndpoint() + "/" + resource.getTenantId(), "*"), Activity.EXECUTE) ||
-                    isAuthorized(String.format(opTemplate, resource.getEndpoint() + "/*", operation), Activity.EXECUTE) ||
-                    isAuthorized(String.format(opTemplate, resource.getEndpoint() + "/*", "*"), Activity.EXECUTE);
+            allowed = isAuthorized(String.format(TEMPLATE_OP, resource.getEndpoint() + "/" + resource.getTenantId(), operation), Activity.EXECUTE) ||
+                    isAuthorized(String.format(TEMPLATE_OP, resource.getEndpoint() + "/" + resource.getTenantId(), "*"), Activity.EXECUTE) ||
+                    isAuthorized(String.format(TEMPLATE_OP, resource.getEndpoint() + "/*", operation), Activity.EXECUTE) ||
+                    isAuthorized(String.format(TEMPLATE_OP, resource.getEndpoint() + "/*", "*"), Activity.EXECUTE);
         }
         if (!allowed) {
-            allowed = isAuthorized(String.format(opTemplate, resource.getEndpoint(), operation), Activity.EXECUTE) ||
-                    isAuthorized(String.format(opTemplate, resource.getEndpoint(), "*"), Activity.EXECUTE) ||
-                    isAuthorized(String.format(opTemplate, "*", operation), Activity.EXECUTE) ||
-                    isAuthorized(String.format(opTemplate, "*", "*"), Activity.EXECUTE);
+            allowed = isAuthorized(String.format(TEMPLATE_OP, resource.getEndpoint(), operation), Activity.EXECUTE) ||
+                    isAuthorized(String.format(TEMPLATE_OP, resource.getEndpoint(), "*"), Activity.EXECUTE) ||
+                    isAuthorized(String.format(TEMPLATE_OP, "*", operation), Activity.EXECUTE) ||
+                    isAuthorized(String.format(TEMPLATE_OP, "*", "*"), Activity.EXECUTE);
         }
         return allowed;
     }

--- a/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
@@ -19,8 +19,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.qpid.proton.message.Message;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.opentracing.References;
 import io.opentracing.Span;
@@ -99,8 +97,6 @@ public final class TracingHelper {
     private static final String JSON_KEY_SPAN_CONTEXT = "span-context";
 
     private static final String AMQP_ANNOTATION_NAME_TRACE_CONTEXT = "x-opt-trace-context";
-
-    private static final Logger LOG = LoggerFactory.getLogger(TracingHelper.class);
 
     private TracingHelper() {
         // prevent instantiation

--- a/example/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
+++ b/example/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
@@ -20,7 +20,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.function.Predicate;
+import java.util.function.IntPredicate;
 
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.CommandConstants;
@@ -175,7 +175,7 @@ public class HonoHttpDevice {
 
         final CompletableFuture<Void> result = new CompletableFuture<>();
 
-        final Predicate<Integer> successfulStatus = statusCode -> statusCode >= 200 && statusCode < 300;
+        final IntPredicate successfulStatus = statusCode -> statusCode >= 200 && statusCode < 300;
 
         final HttpClientRequest req = httpClient
                 .post(request.isEvent ? "/event" : "/telemetry")

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -450,18 +450,18 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     @Override
     protected final Future<Void> stopInternal() {
 
-        LOG.info("stopping protocol adapter");
+        log.info("stopping protocol adapter");
         final Future<Void> result = Future.future();
         final Future<Void> doStopResult = Future.future();
         doStop(doStopResult);
         doStopResult
                 .compose(s -> closeServiceClients())
                 .recover(t -> {
-                    LOG.info("error while stopping protocol adapter", t);
+                    log.info("error while stopping protocol adapter", t);
                     return Future.failedFuture(t);
                 }).compose(s -> {
                     result.complete();
-                    LOG.info("successfully stopped protocol adapter");
+                    log.info("successfully stopped protocol adapter");
                 }, result);
         return result;
     }
@@ -510,11 +510,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         Objects.requireNonNull(tenantConfig);
 
         if (tenantConfig.isAdapterEnabled(getTypeName())) {
-            LOG.debug("protocol adapter [{}] is enabled for tenant [{}]",
+            log.debug("protocol adapter [{}] is enabled for tenant [{}]",
                     getTypeName(), tenantConfig.getTenantId());
             return Future.succeededFuture(tenantConfig);
         } else {
-            LOG.debug("protocol adapter [{}] is disabled for tenant [{}]",
+            log.debug("protocol adapter [{}] is disabled for tenant [{}]",
                     getTypeName(), tenantConfig.getTenantId());
             return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN,
                     "adapter disabled for tenant"));
@@ -631,7 +631,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             }
         }
         return result.recover(t -> {
-            LOG.debug("validation failed for address [{}], device [{}]: {}", address, authenticatedDevice, t.getMessage());
+            log.debug("validation failed for address [{}], device [{}]: {}", address, authenticatedDevice, t.getMessage());
             return Future.failedFuture(t);
         });
     }
@@ -695,22 +695,22 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
         Objects.requireNonNull(factory);
         factory.addDisconnectListener(c -> {
-            LOG.info("lost connection to {}", serviceName);
+            log.info("lost connection to {}", serviceName);
             if (disconnectListener != null) {
                 disconnectListener.onDisconnect(c);
             }
         });
         factory.addReconnectListener(c -> {
-            LOG.info("connection to {} re-established", serviceName);
+            log.info("connection to {} re-established", serviceName);
             if (reconnectListener != null) {
                 reconnectListener.onReconnect(c);
             }
         });
         return factory.connect().map(c -> {
-            LOG.info("connected to {}", serviceName);
+            log.info("connected to {}", serviceName);
             return c;
         }).recover(t -> {
-            LOG.warn("failed to connect to {}", serviceName, t);
+            log.warn("failed to connect to {}", serviceName, t);
             return Future.failedFuture(t);
         });
     }
@@ -954,7 +954,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                     // so don't wait for the outcome here
                     updateLastGateway(registrationAssertion, tenantId, deviceId, authenticatedDevice, context)
                             .otherwise(t -> {
-                                LOG.warn("failed to update last gateway [tenantId: {}, deviceId: {}]", tenantId, deviceId, t);
+                                log.warn("failed to update last gateway [tenantId: {}, deviceId: {}]", tenantId, deviceId, t);
                                 return null;
                             });
                     return Future.succeededFuture(registrationAssertion);
@@ -1448,7 +1448,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             final String deviceId,
             final BiConsumer<ProtonDelivery, Message> commandMessageConsumer) {
 
-        LOG.debug("command consumer closed [tenantId: {}, deviceId: {}] - no command will be received for this device anymore",
+        log.debug("command consumer closed [tenantId: {}, deviceId: {}] - no command will be received for this device anymore",
                 tenant, deviceId);
     }
 
@@ -1468,7 +1468,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                     procedure.complete(Status.OK());
                 });
             } else {
-                LOG.info("Protocol Adapter - HealthCheck Server context match. Assume protocol adapter is alive.");
+                log.info("Protocol Adapter - HealthCheck Server context match. Assume protocol adapter is alive.");
                 procedure.complete(Status.OK());
             }
         });

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
@@ -43,7 +43,7 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
     /**
      * A logger to be shared with subclasses.
      */
-    protected final Logger LOG = LoggerFactory.getLogger(getClass());
+    protected final Logger log = LoggerFactory.getLogger(getClass());
 
     /**
      * The OpenTracing {@code Tracer} for tracking processing of requests.
@@ -63,7 +63,7 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
      */
     @Autowired(required = false)
     public final void setTracer(final Tracer opentracingTracer) {
-        LOG.info("using OpenTracing Tracer implementation [{}]", opentracingTracer.getClass().getName());
+        log.info("using OpenTracing Tracer implementation [{}]", opentracingTracer.getClass().getName());
         this.tracer = Objects.requireNonNull(opentracingTracer);
     }
 
@@ -239,24 +239,24 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
     protected final Future<Void> checkPortConfiguration() {
 
         if (vertx != null) {
-            LOG.info("Vertx native support: {}", vertx.isNativeTransportEnabled());
+            log.info("Vertx native support: {}", vertx.isNativeTransportEnabled());
         }
 
         final Future<Void> result = Future.future();
 
         if (getConfig().getKeyCertOptions() == null) {
             if (getConfig().getPort() >= 0) {
-                LOG.warn("Secure port number configured, but the certificate setup is not correct. No secure port will be opened - please check your configuration!");
+                log.warn("Secure port number configured, but the certificate setup is not correct. No secure port will be opened - please check your configuration!");
             }
             if (!getConfig().isInsecurePortEnabled()) {
-                LOG.error("configuration must have at least one of key & certificate or insecure port set to start up");
+                log.error("configuration must have at least one of key & certificate or insecure port set to start up");
                 result.fail("no ports configured");
             } else {
                 result.complete();
             }
         } else if (getConfig().isInsecurePortEnabled()) {
             if (getConfig().getPort(getPortDefaultValue()) == getConfig().getInsecurePort(getInsecurePortDefaultValue())) {
-                LOG.error("secure and insecure ports must be configured to bind to different port numbers");
+                log.error("secure and insecure ports must be configured to bind to different port numbers");
                 result.fail("secure and insecure ports configured to bind to same port number");
             } else {
                 result.complete();
@@ -281,9 +281,9 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
         final int port = getConfig().getPort(getPortDefaultValue());
 
         if (port == getPortDefaultValue()) {
-            LOG.info("Server uses secure standard port {}", port);
+            log.info("Server uses secure standard port {}", port);
         } else if (port == 0) {
-            LOG.info("Server found secure port number configured for ephemeral port selection (port chosen automatically).");
+            log.info("Server found secure port number configured for ephemeral port selection (port chosen automatically).");
         }
         return port;
     }
@@ -301,12 +301,12 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
         final int insecurePort = getConfig().getInsecurePort(getInsecurePortDefaultValue());
 
         if (insecurePort == 0) {
-            LOG.info("Server found insecure port number configured for ephemeral port selection (port chosen automatically).");
+            log.info("Server found insecure port number configured for ephemeral port selection (port chosen automatically).");
         } else if (insecurePort == getInsecurePortDefaultValue()) {
-            LOG.info("Server uses standard insecure port {}", insecurePort);
+            log.info("Server uses standard insecure port {}", insecurePort);
         } else if (insecurePort == getPortDefaultValue()) {
-            LOG.warn("Server found insecure port number configured to standard port for secure connections {}", getConfig().getInsecurePort());
-            LOG.warn("Possibly misconfigured?");
+            log.warn("Server found insecure port number configured to standard port for secure connections {}", getConfig().getInsecurePort());
+            log.warn("Possibly misconfigured?");
         }
         return insecurePort;
     }
@@ -369,7 +369,7 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
             final TrustOptions trustOptions = getServerTrustOptions();
             if (trustOptions != null) {
                 serverOptions.setTrustOptions(trustOptions).setClientAuth(ClientAuth.REQUEST);
-                LOG.info("enabling client authentication using certificates [{}]", trustOptions.getClass().getName());
+                log.info("enabling client authentication using certificates [{}]", trustOptions.getClass().getName());
             }
         }
     }
@@ -419,21 +419,21 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
             final boolean useOpenSsl =
                     getConfig().isNativeTlsRequired() || (isOpenSslAvailable && supportsKeyManagerFactory);
 
-            LOG.debug("OpenSSL [available: {}, supports KeyManagerFactory: {}]",
+            log.debug("OpenSSL [available: {}, supports KeyManagerFactory: {}]",
                     isOpenSslAvailable, supportsKeyManagerFactory);
 
             if (useOpenSsl) {
-                LOG.info("using OpenSSL [version: {}] instead of JDK's default SSL engine",
+                log.info("using OpenSSL [version: {}] instead of JDK's default SSL engine",
                         OpenSsl.versionString());
                 serverOptions.setSslEngineOptions(new OpenSSLEngineOptions());
             } else {
-                LOG.info("using JDK's default SSL engine");
+                log.info("using JDK's default SSL engine");
             }
 
             serverOptions.getEnabledSecureTransportProtocols()
                 .forEach(protocol -> serverOptions.removeEnabledSecureTransportProtocol(protocol));
             getConfig().getSecureProtocols().forEach(protocol -> {
-                LOG.info("enabling secure protocol [{}]", protocol);
+                log.info("enabling secure protocol [{}]", protocol);
                 serverOptions.addEnabledSecureTransportProtocol(protocol);
             });
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
@@ -126,9 +126,9 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
      */
     public final void addEndpoint(final AmqpEndpoint ep) {
         if (endpoints.putIfAbsent(ep.getName(), ep) != null) {
-            LOG.warn("multiple endpoints defined with name [{}]", ep.getName());
+            log.warn("multiple endpoints defined with name [{}]", ep.getName());
         } else {
-            LOG.debug("registering endpoint [{}]", ep.getName());
+            log.debug("registering endpoint [{}]", ep.getName());
         }
     }
 
@@ -219,7 +219,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
         if (!con.isDisconnected()) {
             final HonoUser clientPrincipal = Constants.getClientPrincipal(con);
             if (clientPrincipal != null) {
-                LOG.debug("client's [{}] access token has expired, closing connection", clientPrincipal.getName());
+                log.debug("client's [{}] access token has expired, closing connection", clientPrincipal.getName());
                 con.disconnectHandler(null);
                 con.closeHandler(null);
                 con.setCondition(ProtonHelper.condition(AmqpError.UNAUTHORIZED_ACCESS, "access token expired"));
@@ -248,7 +248,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
         final
         List<Future> endpointFutures = new ArrayList<>(endpoints.size());
         for (final AmqpEndpoint ep : endpoints.values()) {
-            LOG.info("starting endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
+            log.info("starting endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
             endpointFutures.add(ep.start());
         }
         final Future<Void> startFuture = Future.future();
@@ -268,7 +268,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
         final
         List<Future> endpointFutures = new ArrayList<>(endpoints.size());
         for (final AmqpEndpoint ep : endpoints.values()) {
-            LOG.info("stopping endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
+            log.info("stopping endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
             endpointFutures.add(ep.stop());
         }
         final Future<Void> stopFuture = Future.future();
@@ -293,20 +293,20 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
                     .listen(insecurePort, getConfig().getInsecurePortBindAddress(), bindAttempt -> {
                         if (bindAttempt.succeeded()) {
                             if (getInsecurePort() == getInsecurePortDefaultValue()) {
-                                LOG.info("server listens on standard insecure port [{}:{}]", getInsecurePortBindAddress(), getInsecurePort());
+                                log.info("server listens on standard insecure port [{}:{}]", getInsecurePortBindAddress(), getInsecurePort());
                             } else {
-                                LOG.warn("server listens on non-standard insecure port [{}:{}], default is {}", getInsecurePortBindAddress(),
+                                log.warn("server listens on non-standard insecure port [{}:{}], default is {}", getInsecurePortBindAddress(),
                                         getInsecurePort(), getInsecurePortDefaultValue());
                             }
                             result.complete();
                         } else {
-                            LOG.error("cannot bind to insecure port", bindAttempt.cause());
+                            log.error("cannot bind to insecure port", bindAttempt.cause());
                             result.fail(bindAttempt.cause());
                         }
                     });
             return result;
         } else {
-            LOG.info("insecure port is not enabled");
+            log.info("insecure port is not enabled");
             return Future.succeededFuture();
         }
     }
@@ -322,20 +322,20 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
                     .listen(securePort, getConfig().getBindAddress(), bindAttempt -> {
                         if (bindAttempt.succeeded()) {
                             if (getPort() == getPortDefaultValue()) {
-                                LOG.info("server listens on standard secure port [{}:{}]", getBindAddress(), getPort());
+                                log.info("server listens on standard secure port [{}:{}]", getBindAddress(), getPort());
                             } else {
-                                LOG.warn("server listens on non-standard secure port [{}:{}], default is {}", getBindAddress(),
+                                log.warn("server listens on non-standard secure port [{}:{}], default is {}", getBindAddress(),
                                         getPort(), getPortDefaultValue());
                             }
                             result.complete();
                         } else {
-                            LOG.error("cannot bind to secure port", bindAttempt.cause());
+                            log.error("cannot bind to secure port", bindAttempt.cause());
                             result.fail(bindAttempt.cause());
                         }
                     });
             return result;
         } else {
-            LOG.info("secure port is not enabled");
+            log.info("secure port is not enabled");
             return Future.succeededFuture();
         }
     }
@@ -397,7 +397,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
         final Future<Void> secureTracker = Future.future();
 
         if (server != null) {
-            LOG.info("stopping secure AMQP server [{}:{}]", getBindAddress(), getActualPort());
+            log.info("stopping secure AMQP server [{}:{}]", getBindAddress(), getActualPort());
             server.close(secureTracker);
         } else {
             secureTracker.complete();
@@ -410,7 +410,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
         final Future<Void> insecureTracker = Future.future();
 
         if (insecureServer != null) {
-            LOG.info("stopping insecure AMQP server [{}:{}]", getInsecurePortBindAddress(), getActualInsecurePort());
+            log.info("stopping insecure AMQP server [{}:{}]", getInsecurePortBindAddress(), getActualInsecurePort());
             insecureServer.close(insecureTracker);
         } else {
             insecureTracker.complete();
@@ -475,7 +475,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
      * @param address The unknown target address.
      */
     protected final void handleUnknownEndpoint(final ProtonConnection con, final ProtonLink<?> link, final ResourceIdentifier address) {
-        LOG.info("client [container: {}] wants to establish link for unknown endpoint [address: {}]",
+        log.info("client [container: {}] wants to establish link for unknown endpoint [address: {}]",
                 con.getRemoteContainer(), address);
         link.setCondition(
                 ProtonHelper.condition(
@@ -510,12 +510,12 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
      */
     protected void handleReceiverOpen(final ProtonConnection con, final ProtonReceiver receiver) {
         if (receiver.getRemoteTarget().getAddress() == null) {
-            LOG.debug("client [container: {}] wants to open an anonymous link for sending messages to arbitrary addresses, closing link ...",
+            log.debug("client [container: {}] wants to open an anonymous link for sending messages to arbitrary addresses, closing link ...",
                     con.getRemoteContainer());
             receiver.setCondition(ProtonHelper.condition(AmqpError.NOT_ALLOWED, "anonymous relay not supported"));
             receiver.close();
         } else {
-            LOG.debug("client [container: {}] wants to open a link [address: {}] for sending messages",
+            log.debug("client [container: {}] wants to open a link [address: {}] for sending messages",
                     con.getRemoteContainer(), receiver.getRemoteTarget());
             try {
                 final ResourceIdentifier targetResource = getResourceIdentifier(receiver.getRemoteTarget().getAddress());
@@ -531,14 +531,14 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
                             receiver.setTarget(receiver.getRemoteTarget());
                             endpoint.onLinkAttach(con, receiver, targetResource);
                         } else {
-                            LOG.debug("subject [{}] is not authorized to WRITE to [{}]", user.getName(), targetResource);
+                            log.debug("subject [{}] is not authorized to WRITE to [{}]", user.getName(), targetResource);
                             receiver.setCondition(ProtonHelper.condition(AmqpError.UNAUTHORIZED_ACCESS.toString(), "unauthorized"));
                             receiver.close();
                         }
                     });
                 }
             } catch (final IllegalArgumentException e) {
-                LOG.debug("client has provided invalid resource identifier as target address", e);
+                log.debug("client has provided invalid resource identifier as target address", e);
                 receiver.setCondition(ProtonHelper.condition(AmqpError.NOT_FOUND, "no such address"));
                 receiver.close();
             }
@@ -553,7 +553,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
      */
     protected void handleSenderOpen(final ProtonConnection con, final ProtonSender sender) {
         final Source remoteSource = sender.getRemoteSource();
-        LOG.debug("client [container: {}] wants to open a link [address: {}] for receiving messages",
+        log.debug("client [container: {}] wants to open a link [address: {}] for receiving messages",
                 con.getRemoteContainer(), remoteSource);
         try {
             final ResourceIdentifier targetResource = getResourceIdentifier(remoteSource.getAddress());
@@ -569,14 +569,14 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
                         sender.setTarget(sender.getRemoteTarget());
                         endpoint.onLinkAttach(con, sender, targetResource);
                     } else {
-                        LOG.debug("subject [{}] is not authorized to READ from [{}]", user.getName(), targetResource);
+                        log.debug("subject [{}] is not authorized to READ from [{}]", user.getName(), targetResource);
                         sender.setCondition(ProtonHelper.condition(AmqpError.UNAUTHORIZED_ACCESS.toString(), "unauthorized"));
                         sender.close();
                     }
                 });
             }
         } catch (final IllegalArgumentException e) {
-            LOG.debug("client has provided invalid resource identifier as target address", e);
+            log.debug("client has provided invalid resource identifier as target address", e);
             sender.setCondition(ProtonHelper.condition(AmqpError.NOT_FOUND, "no such address"));
             sender.close();
         }
@@ -603,7 +603,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
      */
     protected void setRemoteConnectionOpenHandler(final ProtonConnection connection) {
 
-        LOG.debug("received connection request from client");
+        log.debug("received connection request from client");
         connection.sessionOpenHandler(session -> {
             HonoProtonHelper.setDefaultCloseHandler(session);
             handleSessionOpen(connection, session);
@@ -620,7 +620,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
         connection.closeHandler(remoteClose -> handleRemoteConnectionClose(connection, remoteClose));
         connection.openHandler(remoteOpen -> {
             if (remoteOpen.failed()) {
-                LOG.debug("ignoring peer's open frame containing error", remoteOpen.cause());
+                log.debug("ignoring peer's open frame containing error", remoteOpen.cause());
             } else {
                 processRemoteOpen(remoteOpen.result());
             }
@@ -644,7 +644,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
      */
     protected void processRemoteOpen(final ProtonConnection connection) {
 
-        LOG.debug("processing open frame from client container [{}]", connection.getRemoteContainer());
+        log.debug("processing open frame from client container [{}]", connection.getRemoteContainer());
         final HonoUser clientPrincipal = Constants.getClientPrincipal(connection);
         // attach an ID so that we can later inform downstream components when connection is closed
         connection.attachments().set(Constants.KEY_CONNECTION_ID, String.class, UUID.randomUUID().toString());
@@ -657,7 +657,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
             }
         });
         connection.open();
-        LOG.info("client connected [container: {}, user: {}, token valid until: {}]",
+        log.info("client connected [container: {}, user: {}, token valid until: {}]",
                 connection.getRemoteContainer(), clientPrincipal.getName(), clientPrincipal.getExpirationTime().toString());
     }
 
@@ -684,7 +684,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
      * @param session The session that is initiated.
      */
     protected void handleSessionOpen(final ProtonConnection con, final ProtonSession session) {
-        LOG.debug("opening new session with client [container: {}]", con.getRemoteContainer());
+        log.debug("opening new session with client [container: {}]", con.getRemoteContainer());
         session.open();
     }
 
@@ -711,9 +711,9 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
      */
     protected void handleRemoteConnectionClose(final ProtonConnection con, final AsyncResult<ProtonConnection> res) {
         if (res.succeeded()) {
-            LOG.debug("client [container: {}] closed connection", con.getRemoteContainer());
+            log.debug("client [container: {}] closed connection", con.getRemoteContainer());
         } else {
-            LOG.debug("client [container: {}] closed connection with error", con.getRemoteContainer(), res.cause());
+            log.debug("client [container: {}] closed connection with error", con.getRemoteContainer(), res.cause());
         }
         con.close();
         con.disconnect();
@@ -726,7 +726,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
      * @param con The connection that was disconnected.
      */
     protected void handleRemoteDisconnect(final ProtonConnection con) {
-        LOG.debug("client [container: {}] disconnected", con.getRemoteContainer());
+        log.debug("client [container: {}] disconnected", con.getRemoteContainer());
         con.disconnect();
         publishConnectionClosedEvent(con);
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.function.IntPredicate;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.AbstractEndpoint;
@@ -227,7 +227,7 @@ public abstract class AbstractHttpEndpoint<T> extends AbstractEndpoint implement
      */
     protected final BiConsumer<Integer, EventBusMessage> getDefaultResponseHandler(
             final RoutingContext ctx,
-            final Predicate<Integer> successfulOutcomeFilter,
+            final IntPredicate successfulOutcomeFilter,
             final Handler<HttpServerResponse> customHandler) {
 
         Objects.requireNonNull(successfulOutcomeFilter);
@@ -270,7 +270,7 @@ public abstract class AbstractHttpEndpoint<T> extends AbstractEndpoint implement
      */
     protected final BiConsumer<Integer, EventBusMessage> getDefaultResponseHandler(
             final RoutingContext ctx,
-            final Predicate<Integer> successfulOutcomeFilter,
+            final IntPredicate successfulOutcomeFilter,
             final BiConsumer<HttpServerResponse, EventBusMessage> customHandler) {
 
         Objects.requireNonNull(successfulOutcomeFilter);

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -79,7 +79,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
      * @param ep The endpoint.
      */
     public final void addEndpoint(final HttpEndpoint ep) {
-        LOG.debug("registering endpoint [{}]", ep.getName());
+        log.debug("registering endpoint [{}]", ep.getName());
         endpoints.add(Objects.requireNonNull(ep));
     }
 
@@ -197,7 +197,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
         // 2. default handler for failed routes
         matchAllRoute.failureHandler(new DefaultFailureHandler());
         // 3. BodyHandler with request size limit
-        LOG.info("limiting size of inbound request body to {} bytes", getConfig().getMaxPayloadSize());
+        log.info("limiting size of inbound request body to {} bytes", getConfig().getMaxPayloadSize());
         matchAllRoute.handler(BodyHandler.create().setUploadsDirectory(DEFAULT_UPLOADS_DIRECTORY)
                 .setBodyLimit(getConfig().getMaxPayloadSize()));
         //4. AuthHandler
@@ -308,14 +308,14 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
             server.requestHandler(router).listen(bindAttempt -> {
                 if (bindAttempt.succeeded()) {
                     if (getPort() == getPortDefaultValue()) {
-                        LOG.info("server listens on standard secure port [{}:{}]", bindAddress, server.actualPort());
+                        log.info("server listens on standard secure port [{}:{}]", bindAddress, server.actualPort());
                     } else {
-                        LOG.warn("server listens on non-standard secure port [{}:{}], default is {}", bindAddress,
+                        log.warn("server listens on non-standard secure port [{}:{}], default is {}", bindAddress,
                                 server.actualPort(), getPortDefaultValue());
                     }
                     result.complete(bindAttempt.result());
                 } else {
-                    LOG.error("cannot bind to secure port", bindAttempt.cause());
+                    log.error("cannot bind to secure port", bindAttempt.cause());
                     result.fail(bindAttempt.cause());
                 }
             });
@@ -336,14 +336,14 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
             insecureServer.requestHandler(router).listen(bindAttempt -> {
                 if (bindAttempt.succeeded()) {
                     if (getInsecurePort() == getInsecurePortDefaultValue()) {
-                        LOG.info("server listens on standard insecure port [{}:{}]", bindAddress, insecureServer.actualPort());
+                        log.info("server listens on standard insecure port [{}:{}]", bindAddress, insecureServer.actualPort());
                     } else {
-                        LOG.warn("server listens on non-standard insecure port [{}:{}], default is {}", bindAddress,
+                        log.warn("server listens on non-standard insecure port [{}:{}], default is {}", bindAddress,
                                 insecureServer.actualPort(), getInsecurePortDefaultValue());
                     }
                     result.complete(bindAttempt.result());
                 } else {
-                    LOG.error("cannot bind to insecure port", bindAttempt.cause());
+                    log.error("cannot bind to insecure port", bindAttempt.cause());
                     result.fail(bindAttempt.cause());
                 }
             });
@@ -366,7 +366,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
             final
             List<Future> endpointFutures = new ArrayList<>(endpoints.size());
             for (final HttpEndpoint ep : endpoints) {
-                LOG.info("starting endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
+                log.info("starting endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
                 endpointFutures.add(ep.start());
             }
             CompositeFuture.all(endpointFutures).setHandler(startup -> {
@@ -387,7 +387,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
         final
         List<Future> endpointFutures = new ArrayList<>(endpoints.size());
         for (final HttpEndpoint ep : endpoints) {
-            LOG.info("stopping endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
+            log.info("stopping endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
             endpointFutures.add(ep.stop());
         }
         CompositeFuture.all(endpointFutures).setHandler(shutdown -> {
@@ -415,7 +415,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
     private Future<Void> stopServer() {
         final Future<Void> serverStopTracker = Future.future();
         if (server != null) {
-            LOG.info("stopping secure HTTP server [{}:{}]", getBindAddress(), getActualPort());
+            log.info("stopping secure HTTP server [{}:{}]", getBindAddress(), getActualPort());
             server.close(serverStopTracker);
         } else {
             serverStopTracker.complete();
@@ -426,7 +426,7 @@ public abstract class HttpServiceBase<T extends ServiceConfigProperties> extends
     private Future<Void> stopInsecureServer() {
         final Future<Void> insecureServerStopTracker = Future.future();
         if (insecureServer != null) {
-            LOG.info("stopping insecure HTTP server [{}:{}]", getInsecurePortBindAddress(), getActualInsecurePort());
+            log.info("stopping insecure HTTP server [{}:{}]", getInsecurePortBindAddress(), getActualInsecurePort());
             insecureServer.close(insecureServerStopTracker);
         } else {
             insecureServerStopTracker.complete();

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementHttpEndpoint.java
@@ -19,7 +19,7 @@ import java.net.HttpURLConnection;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
+import java.util.function.IntPredicate;
 
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.http.AbstractHttpEndpoint;
@@ -152,7 +152,7 @@ public final class CredentialsManagementHttpEndpoint extends AbstractHttpEndpoin
      */
     protected BiConsumer<Integer, EventBusMessage> getCredentialsResponseHandler(
             final RoutingContext ctx,
-            final Predicate<Integer> successfulOutcomeFilter) {
+            final IntPredicate successfulOutcomeFilter) {
 
         Objects.requireNonNull(successfulOutcomeFilter);
         final HttpServerResponse response = ctx.response();

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementHttpEndpoint.java
@@ -27,7 +27,7 @@ import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
+import java.util.function.IntPredicate;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.http.AbstractHttpEndpoint;
@@ -175,7 +175,7 @@ public final class TenantManagementHttpEndpoint extends AbstractHttpEndpoint<Ser
             final RoutingContext ctx,
             final String tenantId,
             final String action,
-            final Predicate<Integer> successfulOutcomeFilter,
+            final IntPredicate successfulOutcomeFilter,
             final BiConsumer<HttpServerResponse, EventBusMessage> httpServerResponseHandler) {
 
         logger.debug("http request [{}] for tenant [tenant: {}]", action, tenantId);

--- a/tests/src/test/java/org/eclipse/hono/tests/CrudHttpClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/CrudHttpClient.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.tests;
 import java.net.HttpURLConnection;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
 import io.vertx.core.http.HttpClientResponse;
@@ -100,7 +101,7 @@ public final class CrudHttpClient {
     public Future<MultiMap> options(
             final String uri,
             final MultiMap requestHeaders,
-            final Predicate<Integer> successPredicate) {
+            final IntPredicate successPredicate) {
 
         Objects.requireNonNull(uri);
         return options(createRequestOptions().setURI(uri), requestHeaders, successPredicate);
@@ -119,7 +120,7 @@ public final class CrudHttpClient {
     public Future<MultiMap> options(
             final RequestOptions requestOptions,
             final MultiMap requestHeaders,
-            final Predicate<Integer> successPredicate) {
+            final IntPredicate successPredicate) {
 
         Objects.requireNonNull(requestOptions);
         Objects.requireNonNull(successPredicate);
@@ -299,7 +300,7 @@ public final class CrudHttpClient {
      * @return A future that will succeed if the predicate evaluates to {@code true}.
      * @throws NullPointerException if URI or predicate are {@code null}.
      */
-    public Future<MultiMap> update(final String uri, final JsonObject body, final Predicate<Integer> successPredicate) {
+    public Future<MultiMap> update(final String uri, final JsonObject body, final IntPredicate successPredicate) {
         return update(uri, body, CONTENT_TYPE_JSON, successPredicate);
     }
 
@@ -314,7 +315,7 @@ public final class CrudHttpClient {
      * @return A future that will succeed if the predicate evaluates to {@code true}.
      * @throws NullPointerException if URI or predicate are {@code null}.
      */
-    public Future<MultiMap> update(final String uri, final JsonArray body, final Predicate<Integer> successPredicate) {
+    public Future<MultiMap> update(final String uri, final JsonArray body, final IntPredicate successPredicate) {
         return update(uri, body, CONTENT_TYPE_JSON, successPredicate);
     }
 
@@ -329,8 +330,9 @@ public final class CrudHttpClient {
      * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<MultiMap> update(final String uri, final JsonObject body, final String contentType,
-            final Predicate<Integer> successPredicate) {
+            final IntPredicate successPredicate) {
         return update(uri, Optional.ofNullable(body).map(json -> json.toBuffer()).orElse(null), contentType, successPredicate, true);
+
     }
 
     /**
@@ -344,8 +346,9 @@ public final class CrudHttpClient {
      * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<MultiMap> update(final String uri, final JsonArray body, final String contentType,
-            final Predicate<Integer> successPredicate) {
+            final IntPredicate successPredicate) {
         return update(uri, Optional.ofNullable(body).map(json -> json.toBuffer()).orElse(null), contentType, successPredicate, true);
+
     }
 
     /**
@@ -360,7 +363,7 @@ public final class CrudHttpClient {
      * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<MultiMap> update(final String uri, final Buffer body, final String contentType,
-            final Predicate<Integer> successPredicate, final boolean checkCorsHeaders) {
+            final IntPredicate successPredicate, final boolean checkCorsHeaders) {
 
         final MultiMap headers = Optional.ofNullable(contentType)
                 .map(ct -> MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.CONTENT_TYPE, ct))
@@ -383,7 +386,7 @@ public final class CrudHttpClient {
             final String uri,
             final Buffer body,
             final MultiMap requestHeaders,
-            final Predicate<Integer> successPredicate) {
+            final IntPredicate successPredicate) {
 
         Objects.requireNonNull(uri);
         Objects.requireNonNull(successPredicate);
@@ -411,7 +414,7 @@ public final class CrudHttpClient {
             final String uri,
             final Buffer body,
             final MultiMap requestHeaders,
-            final Predicate<Integer> successPredicate,
+            final IntPredicate successPredicate,
             final boolean checkCorsHeaders) {
 
         Objects.requireNonNull(uri);
@@ -440,7 +443,7 @@ public final class CrudHttpClient {
             final RequestOptions requestOptions,
             final Buffer body,
             final MultiMap requestHeaders,
-            final Predicate<Integer> successPredicate,
+            final IntPredicate successPredicate,
             final boolean checkCorsHeaders) {
 
         Objects.requireNonNull(requestOptions);
@@ -486,7 +489,7 @@ public final class CrudHttpClient {
      *         future will contain the response body.
      * @throws NullPointerException if URI or predicate are {@code null}.
      */
-    public Future<Buffer> get(final String uri, final Predicate<Integer> successPredicate) {
+    public Future<Buffer> get(final String uri, final IntPredicate successPredicate) {
 
         Objects.requireNonNull(uri);
         Objects.requireNonNull(successPredicate);
@@ -502,7 +505,7 @@ public final class CrudHttpClient {
      *         future will contain the response body.
      * @throws NullPointerException if options or predicate are {@code null}.
      */
-    public Future<Buffer> get(final RequestOptions requestOptions, final Predicate<Integer> successPredicate) {
+    public Future<Buffer> get(final RequestOptions requestOptions, final IntPredicate successPredicate) {
 
         Objects.requireNonNull(requestOptions);
         Objects.requireNonNull(successPredicate);
@@ -537,7 +540,7 @@ public final class CrudHttpClient {
      * @return A future that will succeed if the predicate evaluates to {@code true}.
      * @throws NullPointerException if URI or predicate are {@code null}.
      */
-    public Future<Void> delete(final String uri, final Predicate<Integer> successPredicate) {
+    public Future<Void> delete(final String uri, final IntPredicate successPredicate) {
 
         Objects.requireNonNull(uri);
         Objects.requireNonNull(successPredicate);
@@ -553,7 +556,7 @@ public final class CrudHttpClient {
      * @return A future that will succeed if the predicate evaluates to {@code true}.
      * @throws NullPointerException if options or predicate are {@code null}.
      */
-    public Future<Void> delete(final RequestOptions requestOptions, final Predicate<Integer> successPredicate) {
+    public Future<Void> delete(final RequestOptions requestOptions, final IntPredicate successPredicate) {
 
         Objects.requireNonNull(requestOptions);
         Objects.requireNonNull(successPredicate);


### PR DESCRIPTION
Change Summary:

* Use the specialized IntPredicate instead of Predicate<Integer> for HTTP status codes
* Replace occurrences of non-constant "LOG" variable to "log"

plus other minor fixes

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>