### PR TITLE
[#1558] refuse already hashed password and add fields to secrets

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -108,6 +108,10 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
 
     /* secrets fields */
     /**
+     * The name of the field that contains the secret id.
+     */
+    public static final String FIELD_SECRETS_ID                 = "id";
+    /**
      * The name of the field that contains the password hash.
      */
     public static final String FIELD_SECRETS_PWD_HASH            = "pwd-hash";

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
@@ -31,6 +31,9 @@ public abstract class CommonSecret {
     @JsonProperty
     private Boolean enabled;
 
+    @JsonProperty
+    private String id;
+
     @JsonProperty(RegistryManagementConstants.FIELD_SECRETS_NOT_BEFORE)
     @HonoTimestamp
     private Instant notBefore;
@@ -52,6 +55,21 @@ public abstract class CommonSecret {
      */
     public CommonSecret setEnabled(final Boolean enabled) {
         this.enabled = enabled;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the ID of the secret. This id may be assigned by the device registry.
+     *
+     * @param id The string to set as the id.
+     * @return   a reference to this for fluent use.
+     */
+    public CommonSecret setId(final String id) {
+        this.id = id;
         return this;
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/EventBusCredentialsManagementAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/EventBusCredentialsManagementAdapter.java
@@ -152,7 +152,9 @@ public abstract class EventBusCredentialsManagementAdapter extends EventBusServi
     protected CommonCredential decodeCredential(final String type, final JsonObject object) {
         switch (type) {
             case RegistryManagementConstants.SECRETS_TYPE_HASHED_PASSWORD:
-                return object.mapTo(PasswordCredential.class);
+                final PasswordCredential passwordCredential = object.mapTo(PasswordCredential.class);
+                passwordCredential.getSecrets().forEach(s -> s.checkIsPlainText());
+                return passwordCredential;
             case RegistryManagementConstants.SECRETS_TYPE_PRESHARED_KEY:
                 return object.mapTo(PskCredential.class);
             case RegistryManagementConstants.SECRETS_TYPE_X509_CERT:

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericSecret.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericSecret.java
@@ -35,5 +35,4 @@ public class GenericSecret extends CommonSecret {
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
-
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
@@ -138,6 +138,9 @@ public class PasswordSecret extends CommonSecret {
         if (!Strings.isNullOrEmpty(passwordHash)) {
             throw new IllegalStateException(String.format("'%s' must be empty", RegistryManagementConstants.FIELD_SECRETS_PWD_HASH));
         }
+        if (!Strings.isNullOrEmpty(salt)) {
+            throw new IllegalStateException(String.format("'%s' must be empty", RegistryManagementConstants.FIELD_SECRETS_SALT));
+        }
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
@@ -124,6 +124,23 @@ public class PasswordSecret extends CommonSecret {
     }
 
     /**
+     * Verifies that only the "password-plain" field is set in the Password Secret, i.e. the password is not hashed.
+     *
+     * @throws IllegalStateException if this is not the case.
+     */
+    public void checkIsPlainText() {
+        if (Strings.isNullOrEmpty(passwordPlain)) {
+            throw new IllegalStateException(String.format("'%s' must be provided", RegistryManagementConstants.FIELD_SECRETS_PWD_PLAIN));
+        }
+        if (!Strings.isNullOrEmpty(hashFunction)) {
+            throw new IllegalStateException(String.format("'%s' must be empty", RegistryManagementConstants.FIELD_SECRETS_HASH_FUNCTION));
+        }
+        if (!Strings.isNullOrEmpty(passwordHash)) {
+            throw new IllegalStateException(String.format("'%s' must be empty", RegistryManagementConstants.FIELD_SECRETS_PWD_HASH));
+        }
+    }
+
+    /**
      * Encodes the clear text password contained in the <em>pwd-plain</em> field.
      * 
      * @param encoder The password encoder to use.

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -387,8 +387,6 @@ paths:
                   schema:
                      $ref: '#/components/schemas/CredentialsSet'
                   examples:
-                     Hashed Password:
-                        $ref: '#/components/examples/HashedPasswordExample'
                      Plain Password:
                         $ref: '#/components/examples/PlainPasswordExample'
             required: true
@@ -661,7 +659,7 @@ components:
          discriminator:
             propertyName: type
             mapping:
-               "hashed-password": '#/components/schemas/PasswordCredentials'
+               "password": '#/components/schemas/PasswordCredentials'
                "psk": '#/components/schemas/PSKCredentials'
                "x509-cert": '#/components/schemas/X509CertificateCredentials'
 
@@ -750,34 +748,12 @@ components:
             - type: object
               additionalProperties: false
               properties:
-                 "hash-function":
-                    type: string
-                    example: bcrypt
-                    description: The name of the hash function used to create the password hash (defined in `pwd-hash` property).
-                                 If the password is defined using a `pwd-plain` property, this value will be ignored by the device registry.
-                                 This property should be empty when returning passwords from the device registry using only secret metadata.
-                                 In this case the id field must be set instead.
-                 "pwd-hash":
-                    type: string
-                    format: byte
-                    description: The password hash created using the `hash-function` and optional `salt` values.
-                                 If the password is defined using a `pwd-plain` property, this value will be ignored by the device registry.
-                                 This property should be empty when returning passwords from the device registry using only secret metadata.
-                                 In this case the id field must be set instead.
-                 "salt":
-                    type: string
-                    format: byte
-                    description: The Base64 encoding of the salt used in the password hash (defined in the `pwd-hash` property).
-                                 If the password is defined using a `pwd-plain` property, this value will be ignored by the device registry.
-                                 This property should be empty when returning passwords from the device registry using only secret metadata.
-                                 In this case the id field must be set instead.
                  "pwd-plain":
                     type: string
                     format: byte
                     description: The clear text value of the password to be hashed by the device registry.
-                                 If this property is specified, the device registry will ignore user-provided hash properties (`hash-function`, `pwd-hash` and `salt`).
-                                 This property should never be stored by the device registry.
-                                 This property should be empty when returning passwords from the device registry.
+                                 This property must never be stored by the device registry.
+                                 This property must be empty when returning passwords from the device registry.
 
       PSKSecret:
          additionalProperties: false
@@ -937,16 +913,6 @@ components:
          scheme: basic
 
    examples:
-      HashedPasswordExample:
-         value:
-            auth-id: sensor1
-            type: hashed-password
-            secrets: [{
-               "not-after": "2027-12-24T19:00:00Z",
-               "pwd-hash": "AQIDBAUGBwg=",
-               "salt": "Mq7wFw==",
-               "hash-function": "sha-512"
-            }]
       PlainPasswordExample:
          value:
             auth-id: sensor1
@@ -963,8 +929,5 @@ components:
             secrets: [{
                "id": "349556ea-4902-47c7-beb0-1009ab693fb4",
                "not-after": "2027-12-24T19:00:00Z",
-               "pwd-plain": "",
-               "pwd-hash": "",
-               "salt": "",
-               "hash-function": ""
+               "pwd-plain": ""
             }]

--- a/site/documentation/content/user-guide/device-registry.md
+++ b/site/documentation/content/user-guide/device-registry.md
@@ -277,7 +277,7 @@ The following command adds some `hashed-password` credentials from a given plain
     HTTP/1.1 204 No Content
     ETag: becc93d7-ab0f-48ec-ad26-debdf339cbf4x
     
-This uses a convenient option which lets the Device Registry do the hashing of the password. The following command retrieves the credentials that are stored by the Device Registry as a result of the command above: 
+This lets the Device Registry do the hashing of the password. The following command retrieves some metadata credentials that are stored by the Device Registry as a result of the command above: 
     
     
     curl -i http://localhost:28080/v1/credentials/DEFAULT_TENANT/4710
@@ -292,21 +292,18 @@ This uses a convenient option which lets the Device Registry do the hashing of t
       "enabled": true,
       "secrets": [
         {
-          "pwd-hash": "$2a$10$uc.qVDwXeDRE1DWa1sM9iOaY9wuevjfALGMtXmHKP.SJDEqg0q7M6",
-          "hash-function": "bcrypt"
+          "id": "349556ea-4902-47c7-beb0-1009ab693fb4"
         }
       ]
     }]
     
 The following commands add some `hashed-password` credentials for device `4720` using authentication identifier `sensor20`:
 
-    PWD_HASH=$(echo -n "mylittlesecret" | openssl dgst -binary -sha512 | base64 -w 0)
     curl -i -X PUT -H 'Content-Type: application/json' --data-binary '[{
         "type": "hashed-password",
         "auth-id": "sensor20",
         "secrets": [{
-            "hash-function" : "sha-512",
-            "pwd-hash": "'$PWD_HASH'"
+            "pwd-plain": "mylittlesecret"
         }]
       }]' http://localhost:28080/v1/credentials/DEFAULT_TENANT/4720
     
@@ -315,14 +312,12 @@ The following commands add some `hashed-password` credentials for device `4720` 
 
 The following command adds an expiration date to the `hashed-password` credentials for authentication identifier `sensor20`:
 
-    PWD_HASH=$(echo -n "mylittlesecret" | openssl dgst -binary -sha512 | base64 -w 0)
     curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{
         "device-id": "4720",
         "type": "hashed-password",
         "auth-id": "sensor20",
         "secrets": [{
-            "hash-function" : "sha-512",
-            "pwd-hash": "'$PWD_HASH'",
+            "pwd-plain": "mylittlesecret",
             "not-after": "2018-01-01T00:00:00+01:00"
         }]
     }' http://localhost:28080/v1/credentials/DEFAULT_TENANT/4720
@@ -339,8 +334,7 @@ The following commands add `psk` credentials for the same device `4720` using au
         "type": "hashed-password",
         "auth-id": "sensor20",
         "secrets": [{
-            "hash-function" : "bcrypt",
-            "pwd-hash": "$2a$10$uc.qVDwXeDRE1DWa1sM9iOaY9wuevjfALGMtXmHKP.SJDEqg0q7M6"
+            "pwd-plain": "mylittlesecret"
         }]
     },
     {
@@ -387,8 +381,7 @@ The following command retrieves credentials for device `4720`:
             "enabled": true,
             "secrets": [
                 {
-                    "hash-function": "sha-512",
-                    "pwd-hash": "tnxz0zDFs+pJGdCVSuoPE4TnamXsfIjBEOb0rg3e9WFD9KfbCkoRuwVZKgRWInfqp87kCLsoV/HEwdJwgw793Q=="
+                    "id": "d383ba4d-1853-4d03-b322-b7ff5af05ae2"
                 }
             ],
             "type": "hashed-password"

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -47,6 +47,9 @@ title = "Release Notes"
   Also the configuration parameters for the resource limits were renamed from `hono.plan`
   to `hono.resourceLimits`. Please refer to the protocol adapter [configuration guides]
   ({{% doclink "/admin-guide/" %}}) for more information.
+ * The device registry credentials endpoint will not accept secrets containing already 
+   hashed password anymore. The passwords MUST be sent as plain-text values and hashed 
+   by the device registry. 
 
 ### Deprecations
 

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -30,7 +30,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -1253,8 +1252,7 @@ public final class IntegrationTestSupport {
      * @return The new instance.
      */
     public static PasswordCredential createPasswordCredential(final String authId, final String password) {
-        return AbstractCredentialsServiceTest.createPasswordCredential(authId, password,
-                OptionalInt.of(IntegrationTestSupport.MAX_BCRYPT_ITERATIONS));
+        return AbstractCredentialsServiceTest.createPlainPasswordCredential(authId, password);
     }
 
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
@@ -23,7 +23,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -31,7 +30,6 @@ import org.eclipse.hono.client.CredentialsClient;
 import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
-import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsObject;
@@ -86,7 +84,7 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
 
         final String deviceId = getHelper().getRandomDeviceId(Constants.DEFAULT_TENANT);
         final String authId = UUID.randomUUID().toString();
-        final Collection<CommonCredential> credentials = getRandomHashedPasswordCredentials(authId);
+        final Collection<CommonCredential> credentials = getRandomPlainTextPasswordCredentials(authId);
 
         getHelper().registry
                 .registerDevice(Constants.DEFAULT_TENANT, deviceId)
@@ -119,7 +117,7 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
         final String deviceId = getHelper().getRandomDeviceId(Constants.DEFAULT_TENANT);
         final String authId = UUID.randomUUID().toString();
 
-        final CommonCredential credential = getRandomHashedPasswordCredential(authId);
+        final CommonCredential credential = getRandomPlainTextPasswordCredential(authId);
         credential.setEnabled(false);
 
         getHelper().registry
@@ -148,7 +146,7 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
 
         final String deviceId = getHelper().getRandomDeviceId(Constants.DEFAULT_TENANT);
         final String authId = UUID.randomUUID().toString();
-        final Collection<CommonCredential> credentials = getRandomHashedPasswordCredentials(authId);
+        final Collection<CommonCredential> credentials = getRandomPlainTextPasswordCredentials(authId);
 
         // FIXME: credentials.setProperty("client-id", "gateway-one");
 
@@ -186,7 +184,7 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
 
         final String deviceId = getHelper().getRandomDeviceId(Constants.DEFAULT_TENANT);
         final String authId = UUID.randomUUID().toString();
-        final Collection<CommonCredential> credentials = getRandomHashedPasswordCredentials(authId);
+        final Collection<CommonCredential> credentials = getRandomPlainTextPasswordCredentials(authId);
         // FIXME: credentials.setProperty("client-id", "gateway-one");
 
         final JsonObject clientContext = new JsonObject()
@@ -214,7 +212,7 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
 
         final String deviceId = getHelper().getRandomDeviceId(Constants.DEFAULT_TENANT);
         final String authId = UUID.randomUUID().toString();
-        final Collection<CommonCredential> credentials = getRandomHashedPasswordCredentials(authId);
+        final Collection<CommonCredential> credentials = getRandomPlainTextPasswordCredentials(authId);
 
         final JsonObject clientContext = new JsonObject()
                 .put("client-id", "gateway-one");
@@ -229,20 +227,17 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
         }));
     }
 
-    private Collection<CommonCredential> getRandomHashedPasswordCredentials(final String authId) {
-        return Collections.singleton(getRandomHashedPasswordCredential(authId));
+    private Collection<CommonCredential> getRandomPlainTextPasswordCredentials(final String authId) {
+        return Collections.singleton(getRandomPlainTextPasswordCredential(authId));
     }
 
-    private CommonCredential getRandomHashedPasswordCredential(final String authId) {
+    private CommonCredential getRandomPlainTextPasswordCredential(final String authId) {
 
-        final var secret1 = AbstractCredentialsServiceTest.createPasswordSecret("ClearTextPWD",
-                OptionalInt.of(IntegrationTestSupport.MAX_BCRYPT_ITERATIONS));
+        final var secret1 = AbstractCredentialsServiceTest.createPlainTextPasswordSecret("ClearTextPWD");
         secret1.setNotBefore(Instant.parse("2017-05-01T14:00:00Z"));
         secret1.setNotAfter(Instant.parse("2037-06-01T14:00:00Z"));
 
-        final var secret2 = AbstractCredentialsServiceTest.createPasswordSecret("hono-password",
-                OptionalInt.of(IntegrationTestSupport.MAX_BCRYPT_ITERATIONS));
-
+        final var secret2 = AbstractCredentialsServiceTest.createPlainTextPasswordSecret("hono-password");
         final var credential = new PasswordCredential();
         credential.setAuthId(authId);
         credential.setSecrets(Arrays.asList(secret1, secret2));


### PR DESCRIPTION
Follow up to #1377 : 
- HTTP Management API now refuses PUT credentials request containing hashed passwords. (400 Bad request)
- An `id` field is attached to each secret.
- Reponses to GET on credentials from the managment API do not contain hashed-password details anymore.
- updated integration tests to now use plain text passwords and verify each secret contains an ID.

The second part of this work is to filter `PUT` requests to the device registry credentials resources to allow the update of a single password using the `id` field.

Signed-off-by: Jean-Baptiste Trystram <jbtrystram@redhat.com>