### PR TITLE
[#1566] No two adapters can have same type during tenant registration.

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
@@ -19,6 +19,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.hono.util.RegistryManagementConstants;
 import org.eclipse.hono.util.ResourceLimits;
@@ -170,8 +172,17 @@ public class Tenant {
      */
     public final Tenant setAdapters(final List<Adapter> adapters) {
 
-        if (adapters != null && adapters.isEmpty()) {
-            throw new IllegalArgumentException("Atleast one adapter must be configured");
+        if (adapters != null) {
+            if (adapters.isEmpty()) {
+                throw new IllegalArgumentException("Atleast one adapter must be configured");
+            }
+
+            final Set<String> uniqueAdapterTypes = adapters.stream()
+                    .map(Adapter::getType)
+                    .collect(Collectors.toSet());
+            if (adapters.size() != uniqueAdapterTypes.size()) {
+                throw new IllegalArgumentException("Each adapter must have a unique type");
+            }
         }
 
         this.adapters.clear();
@@ -202,6 +213,12 @@ public class Tenant {
             return this;
         }
 
+        final boolean hasAdapterOfSameType = adapters.stream()
+                .anyMatch(adapter -> configuration.getType().equals(adapter.getType()));
+        if (hasAdapterOfSameType) {
+            throw new IllegalArgumentException(
+                    String.format("Already an adapter of the type [%s] exists", configuration.getType()));
+        }
         adapters.add(configuration);
         return this;
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/management/tenant/EventBusTenantManagementAdapterTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/management/tenant/EventBusTenantManagementAdapterTest.java
@@ -132,7 +132,7 @@ public class EventBusTenantManagementAdapterTest {
     private static JsonObject buildTenantPayload() {
 
         final JsonObject adapterDetailsHttp = new JsonObject()
-                .put(RegistryManagementConstants.FIELD_ADAPTERS_TYPE, Constants.PROTOCOL_ADAPTER_TYPE_MQTT)
+                .put(RegistryManagementConstants.FIELD_ADAPTERS_TYPE, Constants.PROTOCOL_ADAPTER_TYPE_HTTP)
                 .put(RegistryManagementConstants.FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED, Boolean.TRUE)
                 .put(RegistryManagementConstants.FIELD_ENABLED, Boolean.TRUE);
         final JsonObject adapterDetailsMqtt = new JsonObject()

--- a/service-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
@@ -133,6 +133,41 @@ class TenantTest {
     }
 
     /**
+     * Verifies that decoding of a tenant object having more than one adapter of the same type fails.
+     */
+    @Test
+    public void testWithMultipleAdapterEntriesOfSameType() {
+        final JsonObject httpAdapterConfig = new JsonObject()
+                .put(RegistryManagementConstants.FIELD_ADAPTERS_TYPE, "http")
+                .put(RegistryManagementConstants.FIELD_ENABLED, false)
+                .put(RegistryManagementConstants.FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED, true);
+        final JsonArray adaptersConfig = new JsonArray()
+                .add(httpAdapterConfig)
+                .add(httpAdapterConfig);
+        final var tenant = new JsonObject()
+                .put(RegistryManagementConstants.FIELD_ADAPTERS, adaptersConfig);
+
+        assertThrows(IllegalArgumentException.class, () -> tenant.mapTo(Tenant.class));
+    }
+
+    /**
+     * Verifies that adding an adapter fails, if the adapter's type is same as that of any
+     * already existing adapters.
+     */
+    @Test
+    public void testAddAdapterOfAlreadyExistingType() {
+        final Tenant tenant = new Tenant();
+        tenant.setEnabled(true);
+        tenant.addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_HTTP)
+                .setEnabled(false)
+                .setDeviceAuthenticationRequired(true));
+        assertThrows(IllegalArgumentException.class, () -> tenant
+                .addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_HTTP)
+                        .setEnabled(false)
+                        .setDeviceAuthenticationRequired(true)));
+    }
+
+    /**
      * Decode tenant with "minimum-message-size=4096".
      */
     @Test


### PR DESCRIPTION
This fixes the issue #1566.
