### PR TITLE
Add namespace to the templates

### DIFF
--- a/deploy/src/main/deploy/helm/templates/_helpers.tpl
+++ b/deploy/src/main/deploy/helm/templates/_helpers.tpl
@@ -51,6 +51,7 @@ The scope passed in is expected to be a dict with keys
 */}}
 {{- define "hono.metadata" -}}
 name: {{ .dot.Release.Name }}-{{ .name }}
+namespace: {{ .dot.Release.Namespace }}
 labels:
   app.kubernetes.io/name: {{ template "hono.name" .dot }}
   helm.sh/chart: {{ template "hono.chart" .dot }}


### PR DESCRIPTION
I have no real experience with Helm, but to me it looks like we are missing the namespace in the metadata section. Otherwise using `helm template --namespace foo` will not work.