### PR TITLE
Change URLs that produce redirects to speed up browsing.

### DIFF
--- a/site/documentation/config.toml
+++ b/site/documentation/config.toml
@@ -16,7 +16,7 @@ pluralizeListTitles = "false"
   copyright = "The Eclipse Hono Project"
 
   # used in shortcode "homelink" to create absoulte URL for links into the home page
-  homeBaseUrl = "https://www.eclipse.org/hono"
+  homeBaseUrl = "https://www.eclipse.org/hono/"
 
   # Prefix URL to edit current page. Will display an "Edit this page" button on top right hand corner of every page. 
   # Useful to give opportunity to people to create merge request for your doc.

--- a/site/documentation/content/admin-guide/device-registry-config.md
+++ b/site/documentation/content/admin-guide/device-registry-config.md
@@ -159,7 +159,7 @@ The configuration file's location is `/deploy/src/main/deploy/example-tenants.js
 
 ## Configuring Gateway Devices
 
-The Device Registry supports devices to *act on behalf of* other devices. This is particularly useful for cases where a device does not connect directly to a Hono protocol adapter but is connected to a *gateway* component that is usually specific to the device's communication protocol. It is the gateway component which then connects to a Hono protocol adapter and publishes data on behalf of the device(s). Examples of such a set up include devices using [SigFox](https://www.sigfox.com) or [LoRa](https://www.lora-alliance.org/) for communication.
+The Device Registry supports devices to *act on behalf of* other devices. This is particularly useful for cases where a device does not connect directly to a Hono protocol adapter but is connected to a *gateway* component that is usually specific to the device's communication protocol. It is the gateway component which then connects to a Hono protocol adapter and publishes data on behalf of the device(s). Examples of such a set up include devices using [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/) for communication.
 
 In these cases the protocol adapter will authenticate the gateway component instead of the device for which it wants to publish data. In order to verify that the gateway is *authorized* to publish data on behalf of the particular device, the protocol adapter should include the gateway's device identifier (as determined during the authentication process) in its invocation of the Device Registration API's *assert Device Registration* operation.
 

--- a/site/documentation/content/deployment/helm-based-deployment.md
+++ b/site/documentation/content/deployment/helm-based-deployment.md
@@ -36,12 +36,12 @@ The [installation guide](https://kubernetes.io/docs/tasks/tools/install-kubectl/
 
 #### Hono Helm Chart
 
-The Helm chart is contained in the Hono archive that is available from [Hono's download page]({{% homelink "/downloads/" %}}).
+The Helm chart is contained in the Hono archive that is available from [Hono's download page]({{% homelink "downloads/" %}}).
 After the archive has been extracted, the chart can be found in the `eclipse-hono-$VERSION/eclipse-hono` folder.
 
 #### Hono Command Line Client
 
-The Hono command line client is available from the [download page]({{% homelink "/downloads/" %}}).
+The Hono command line client is available from the [download page]({{% homelink "downloads/" %}}).
 The command line client requires a Java 11 runtime environment to run.
 
 ## Deploying Hono
@@ -501,7 +501,7 @@ Have fun with Hono on Microsoft Azure!
 
 Next steps:
 
-You can follow the steps as described in the [Getting Started]({{% homelink "/getting-started/" %}}) guide with the following differences:
+You can follow the steps as described in the [Getting Started]({{% homelink "getting-started/" %}}) guide with the following differences:
 
 Compared to a plain k8s deployment Azure provides us DNS names with static IPs for the Hono endpoints. To retrieve them:
 

--- a/site/documentation/content/dev-guide/custom_http_adapter.md
+++ b/site/documentation/content/dev-guide/custom_http_adapter.md
@@ -12,7 +12,7 @@ This section will guide you through the steps to build your own custom HTTP prot
 ## Prerequisites
 
 You should be familiar with the setup and start of Hono. Refer to the 
-[Getting Started]({{% homelink "/getting-started/" %}}) guide.
+[Getting Started]({{% homelink "getting-started/" %}}) guide.
 
 ## The standard HTTP Adapter
 
@@ -71,7 +71,7 @@ Now that you have your custom HTTP protocol adapter up and running, you can use 
 `HTTPie`, to publish data to your custom adapter.
 
 Note that before publishing data to your custom HTTP protocol adapter, you need to start a *consumer* for the tenant you intend to publish data for.
-Otherwise you will not be able to successfully send data. For this purpose, you may use the example consumer as described in the [Getting Started]({{% homelink "/getting-started/" %}}) guide.
+Otherwise you will not be able to successfully send data. For this purpose, you may use the example consumer as described in the [Getting Started]({{% homelink "getting-started/" %}}) guide.
 
 ## Further extend the custom HTTP Protocol Adapter
 

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -177,7 +177,7 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --message.addre
 
 ## Publish Telemetry Data (authenticated Gateway)
 
-A device that publishes data on behalf of another device is called a gateway device. The message address is used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://www.lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the message address is used to identify the device that the gateway publishes data for.
+A device that publishes data on behalf of another device is called a gateway device. The message address is used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the message address is used to identify the device that the gateway publishes data for.
 
 **Examples**
 

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -228,7 +228,7 @@ content-length: 23
   * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
   * 503 (Service Unavailable): The request cannot be processed because there is no consumer of telemetry data for the given tenant connected to Hono.
 
-This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://www.lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
+This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/http-adapter-config#device-registration-service-connection-configuration" >}}).
 
@@ -394,7 +394,7 @@ content-length: 0
   * 429 (Too Many Requests): The request cannot be processed because the tenant's message limit for the current period is exceeded.
   * 503 (Service Unavailable): The request cannot be processed because there is no consumer of events for the given tenant connected to Hono.
 
-This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://www.lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
+This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/http-adapter-config#device-registration-service-connection-configuration" >}}).
 
@@ -546,7 +546,7 @@ content-length: 0
          * There is no application listening for a reply to the given *commandRequestId*.
          * The application has already given up on waiting for a response.
 
-This resource can be used by *gateway* components to send the response to a command *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://www.lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
+This resource can be used by *gateway* components to send the response to a command *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
 The protocol adapter checks the gateway's authority to send responses to a command on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/http-adapter-config#device-registration-service-connection-configuration" >}}).
 

--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -108,7 +108,7 @@ mosquitto_pub -t telemetry/DEFAULT_TENANT/4711 -m '{"temp": 5}'
 * Payload:
   * (required) Arbitrary payload
 
-This topic can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://www.lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the topic name are used to identify the device that the gateway publishes data for.
+This topic can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the topic name are used to identify the device that the gateway publishes data for.
 
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/mqtt-adapter-config#device-registration-service-connection-configuration" >}}).
 
@@ -192,7 +192,7 @@ mosquitto_pub -t event/DEFAULT_TENANT/4711/?hono-ttl=15 -q 1 -m '{"alarm": 1}'
 * Payload:
   * (required) Arbitrary payload
 
-This topic can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://www.lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the topic name are used to identify the device that the gateway publishes data for.
+This topic can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the topic name are used to identify the device that the gateway publishes data for.
 
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/mqtt-adapter-config#device-registration-service-connection-configuration" >}}).
 
@@ -307,7 +307,7 @@ Note that the topic in the latter case doesn't contain a request identifier.
 
 ### Receiving Commands (authenticated Gateway)
 
-*Gateway* components can receive commands for devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://www.lora-alliance.org/). Corresponding devices have to be configured so that they can be used with a gateway. See [Configuring Gateway Devices]({{< relref "/admin-guide/device-registry-config.md#configuring-gateway-devices" >}}) for details.
+*Gateway* components can receive commands for devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). Corresponding devices have to be configured so that they can be used with a gateway. See [Configuring Gateway Devices]({{< relref "/admin-guide/device-registry-config.md#configuring-gateway-devices" >}}) for details.
 
 If a device is configured in such a way that there can be *one* gateway, acting on behalf of the device, a command sent to this device will by default be directed to that gateway.
 


### PR DESCRIPTION
Make links from the documentation to the Hono homepage to end with a slash. + The link to https://www.lora-alliance.org/ gets redirected to the one without "www".
Could/should be cherrypicked to branch "1.0.0-docfix".