### PR TITLE
Azure: Fix ARM template and provide option to define k8s version for AKS

### DIFF
--- a/deploy/src/main/deploy/azure/arm/honoInfrastructureDeployment.json
+++ b/deploy/src/main/deploy/azure/arm/honoInfrastructureDeployment.json
@@ -16,6 +16,13 @@
                 "description": "Optional AKS cluster name. Otherwise calculated from uniqueSolutionPrefix."
             }
         },
+        "kubernetesVersion": {
+            "type": "string",
+            "defaultValue": "1.14.7",
+            "metadata": {
+                "description": "Kubernetes version."
+            }
+        },
         "vnetName": {
             "type": "string",
             "defaultValue": "",
@@ -176,7 +183,8 @@
         "vnetName": "[if(empty(parameters('vnetName')),concat(parameters('uniqueSolutionPrefix'), 'honovnet'),parameters('vnetName'))]",
         "aksSubnetName": "[if(empty(parameters('aksSubnetName')),concat(parameters('uniqueSolutionPrefix'), 'honoakssubnet'),parameters('aksSubnetName'))]"
     },
-    "resources": [{
+    "resources": [
+        {
             "condition": "[parameters('aks')]",
             "name": "honoKubernetesDeployment",
             "type": "Microsoft.Resources/deployments",
@@ -192,6 +200,9 @@
                 "parameters": {
                     "clusterName": {
                         "value": "[variables('aksClusterName')]"
+                    },
+                    "kubernetesVersion": {
+                        "value": "[parameters('kubernetesVersion')]"
                     },
                     "location": {
                         "value": "[parameters('location')]"
@@ -249,7 +260,8 @@
                     }
                 }
             }
-        }, {
+        },
+        {
             "condition": "[parameters('serviceBus')]",
             "name": "honoServiceBusDeployment",
             "type": "Microsoft.Resources/deployments",
@@ -318,51 +330,51 @@
         },
         "mqttPublicIPAddress": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.mqttIpAddress.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.mqttIpAddress.value]"
         },
         "mqttPublicIPFQDN": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.mqttIpFQDN.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.mqttIpFQDN.value]"
         },
         "httpPublicIPAddress": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.httpIpAddress.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.httpIpAddress.value]"
         },
         "httpPublicIPFQDN": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.httpIpFQDN.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.httpIpFQDN.value]"
         },
         "amqpPublicIPAddress": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.amqpIpAddress.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.amqpIpAddress.value]"
         },
         "amqpPublicIPFQDN": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.amqpIpFQDN.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.amqpIpFQDN.value]"
         },
         "registryPublicIPAddress": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.registryIpAddress.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.registryIpAddress.value]"
         },
         "registryPublicIPFQDN": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.registryIpFQDN.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.registryIpFQDN.value]"
         },
         "networkPublicIPAddress": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.networkIpAddress.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.networkIpAddress.value]"
         },
         "networkPublicIPFQDN": {
             "type": "string",
-            "value": "[reference('honoKubernetesDeployment').outputs.networkIpFQDN.value]"
+            "value": "[reference('honoKubernetesDeployment', '2019-06-01').outputs.networkIpFQDN.value]"
         },
         "serviceBusKey": {
             "type": "string",
-            "value": "[reference('honoServiceBusDeployment').outputs.DefaultSharedAccessPolicyPrimaryKey.value]"
+            "value": "[reference('honoServiceBusDeployment', '2019-06-01').outputs.DefaultSharedAccessPolicyPrimaryKey.value]"
         },
         "serviceBusKeyName": {
             "type": "string",
-            "value": "[reference('honoServiceBusDeployment').outputs.DefaultSharedAccessPolicyKeyName.value]"
+            "value": "[reference('honoServiceBusDeployment', '2019-06-01').outputs.DefaultSharedAccessPolicyKeyName.value]"
         },
         "serviceBusNamespaceName": {
             "type": "string",

--- a/deploy/src/main/deploy/azure/arm/templates/kubernetesDeploy.json
+++ b/deploy/src/main/deploy/azure/arm/templates/kubernetesDeploy.json
@@ -4,7 +4,6 @@
   "parameters": {
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.14.5",
       "metadata": {
         "description": "Kubernetes version."
       }
@@ -105,7 +104,9 @@
     "osType": {
       "type": "string",
       "defaultValue": "Linux",
-      "allowedValues": ["Linux"],
+      "allowedValues": [
+        "Linux"
+      ],
       "metadata": {
         "description": "The type of operating system."
       }
@@ -236,12 +237,14 @@
     "networkPublicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('networkPublicIPAddressName'))]",
     "vnetSubnetId": "[resourceId(parameters('virtualNetworkResourceGroup'),'Microsoft.Network/virtualNetworks/subnets',parameters('virtualNetworkName'),parameters('subnetName'))]"
   },
-  "resources": [{
+  "resources": [
+    {
       "apiVersion": "2019-06-01",
       "type": "Microsoft.ContainerService/managedClusters",
       "location": "[parameters('location')]",
       "name": "[parameters('clusterName')]",
-      "tags": {},
+      "tags": {
+      },
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'ClusterResourceGroupRoleAssignmentDeployment')]",
         "[variables('mqttPublicIPRef')]",
@@ -259,16 +262,18 @@
             "enabled": "[parameters('enableHttpApplicationRouting')]"
           }
         },
-        "agentPoolProfiles": [{
-          "name": "agentpool",
-          "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
-          "count": "[parameters('agentCount')]",
-          "vmSize": "[parameters('agentVMSize')]",
-          "osType": "[parameters('osType')]",
-          "storageProfile": "ManagedDisks",
-          "vnetSubnetID": "[variables('vnetSubnetID')]",
-          "maxPods": "[parameters('maxPods')]"
-        }],
+        "agentPoolProfiles": [
+          {
+            "name": "agentpool",
+            "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+            "count": "[parameters('agentCount')]",
+            "vmSize": "[parameters('agentVMSize')]",
+            "osType": "[parameters('osType')]",
+            "storageProfile": "ManagedDisks",
+            "vnetSubnetID": "[variables('vnetSubnetID')]",
+            "maxPods": "[parameters('maxPods')]"
+          }
+        ],
         "servicePrincipalProfile": {
           "clientId": "[parameters('servicePrincipalClientId')]",
           "Secret": "[parameters('servicePrincipalClientSecret')]"
@@ -293,18 +298,22 @@
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
           "contentVersion": "1.0.0.0",
-          "parameters": {},
-          "variables": {},
-          "resources": [{
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2017-05-01",
-            "name": "[guid(resourceGroup().id, deployment().name)]",
-            "properties": {
-              "scope": "[resourceGroup().id]",
-              "principalId": "[parameters('servicePrincipalObjectId')]",
-              "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '4d97b98b-1d4f-4787-a291-c67834d212e7')]"
+          "parameters": {
+          },
+          "variables": {
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2017-05-01",
+              "name": "[guid(resourceGroup().id, deployment().name)]",
+              "properties": {
+                "scope": "[resourceGroup().id]",
+                "principalId": "[parameters('servicePrincipalObjectId')]",
+                "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '4d97b98b-1d4f-4787-a291-c67834d212e7')]"
+              }
             }
-          }]
+          ]
         }
       }
     },

--- a/site/documentation/content/deployment/create-kubernetes-cluster.md
+++ b/site/documentation/content/deployment/create-kubernetes-cluster.md
@@ -80,8 +80,8 @@ acr_login_server=$acr_registry_name.azurecr.io
 
 # Create service principal
 service_principal=`az ad sp create-for-rbac --name http://honoServicePrincipal --skip-assignment --output tsv`
-app_id_principal=`echo $service_principal|cut -f1 -d ' '`
-password_principal=`echo $service_principal|cut -f4 -d ' '`
+app_id_principal=`echo $service_principal|cut -f1`
+password_principal=`echo $service_principal|cut -f4`
 object_id_principal=`az ad sp show --id $app_id_principal --query objectId --output tsv`
 acr_id_access_registry=`az acr show --resource-group $acr_resourcegroupname --name $acr_registry_name --query "id" --output tsv`
 ```
@@ -103,7 +103,10 @@ cd deploy/src/main/deploy/azure/
 az group deployment create --name HonoBasicInfrastructure --resource-group $resourcegroup_name --template-file arm/honoInfrastructureDeployment.json --parameters uniqueSolutionPrefix=$unique_solution_prefix servicePrincipalObjectId=$object_id_principal servicePrincipalClientId=$app_id_principal servicePrincipalClientSecret=$password_principal
 ```
 
-Note: add the following parameter in case you want to opt for the Azure Service Bus as broker in the [Hono AMQP 1.0 Messaging Network]({{< relref "/architecture/component-view#amqp-1-0-messaging-network" >}}) instead of deploying a (self-hosted) ActiveMQ Artemis into AKS: _serviceBus=true_
+Notes:
+
+- add the following parameter in case you want to opt for the Azure Service Bus as broker in the [Hono AMQP 1.0 Messaging Network]({{< relref "/architecture/component-view#amqp-1-0-messaging-network" >}}) instead of deploying a (self-hosted) ActiveMQ Artemis into AKS: _serviceBus=true_
+- add the following parameter to define the k8s version of the AKS cluster. The default as defined in the template [might not be supported](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions) in your target Azure region, e.g. _kubernetesVersion=1.14.6_
 
 After the deployment is complete you can set your cluster in _kubectl_.
 


### PR DESCRIPTION
- Fixed an issue where the templates where not valid.
- Added option to define k8s version of AKS (especially necessary when the default in the template is no longer supported by Azure).
- Small fix on shell command as provided in Azure deployment guidance.

Kai

Signed-off-by: Kai Zimmermann <kai.zimmermann@microsoft.com>