### PR TITLE
Share the same value object for adapter configurations between the Management and Tenant APIs

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/Adapter.java
+++ b/core/src/main/java/org/eclipse/hono/util/Adapter.java
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.service.management.tenant;
+package org.eclipse.hono.util;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -21,17 +21,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import org.eclipse.hono.util.RegistryManagementConstants;
-
 /**
  * Protocol Adapter configuration properties.
  * <p>
  * Represents the <em>Adapter</em> schema object defined in the
  * <a href="https://www.eclipse.org/hono/docs/api/management/">Device Registry Management API</a>
- * 
- * @deprecated This class will be removed in Hono 2.0.0. Use {@link org.eclipse.hono.util.Adapter} instead.
  */
-@Deprecated(forRemoval = true)
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class Adapter {
 

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
@@ -186,7 +186,11 @@ public class Tenant {
      * @param adapters The configuration properties.
      * @return This instance, to allow chained invocations.
      * @throws IllegalArgumentException if the adapters list is empty.
+     * @deprecated From Hono 2.0.0, this method will take list of objects of type
+     *             {@link org.eclipse.hono.util.Adapter} instead of
+     *             {@link org.eclipse.hono.service.management.tenant.Adapter} as argument.
      */
+    @Deprecated
     public final Tenant setAdapters(final List<Adapter> adapters) {
 
         if (adapters != null) {
@@ -213,7 +217,11 @@ public class Tenant {
      * Gets protocol adapter configuration specific to this tenant.
      *
      * @return An unmodifiable view on the adapter configuration properties.
+     * @deprecated From Hono 2.0.0, this method will return a list of objects of type
+     *             {@link org.eclipse.hono.util.Adapter} instead of
+     *             {@link org.eclipse.hono.service.management.tenant.Adapter}.
      */
+    @Deprecated
     public final List<Adapter> getAdapters() {
         return Collections.unmodifiableList(adapters);
     }
@@ -223,7 +231,11 @@ public class Tenant {
      * 
      * @param configuration The configuration properties to add.
      * @return This instance, to allow chained invocations.
+     * @deprecated From Hono 2.0.0, this method will take an argument of type
+     *             {@link org.eclipse.hono.util.Adapter} instead of
+     *             {@link org.eclipse.hono.service.management.tenant.Adapter}.
      */
+    @Deprecated
     public final Tenant addAdapterConfig(final Adapter configuration) {
 
         if (configuration == null) {

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantService.java
@@ -21,6 +21,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -538,11 +539,12 @@ public final class FileBasedTenantService extends AbstractVerticle implements Te
         .ifPresent(defaults -> target.setDefaults(defaults));
 
         Optional.ofNullable(source.getAdapters())
-        .filter(list -> !list.isEmpty())
-        .map(list -> list.stream()
-                .map(adapterConfig -> JsonObject.mapFrom(adapterConfig))
-                .collect(JsonArray::new, JsonArray::add, JsonArray::add))
-        .ifPresent(configurations -> target.setAdapterConfigurations(configurations));
+                .filter(adapters -> !adapters.isEmpty())
+                .map(adapters -> adapters.stream()
+                                .map(adapter -> JsonObject.mapFrom(adapter))
+                                .map(json -> json.mapTo(org.eclipse.hono.util.Adapter.class))
+                                .collect(Collectors.toList()))
+                .ifPresent(adapters -> target.setAdapters(adapters));
 
         Optional.ofNullable(source.getExtensions())
         .map(JsonObject::new)


### PR DESCRIPTION
In this PR, `TenantObject` is refactored to use `Adapter` as a data model instead of `List<Map<String, Object>>` to store adapter configurations. This also enables to share the same value object for Adapter configurations between the Management API and Tenant API.

In this PR,
- The `Adapter` class has been moved to the `core` module from the `service-base`.
- The below new methods are added to directly deal with objects of type `Adapter`.
```
List<Adapter> getAdapters();
TenantObject setAdapters(final List<Adapter> adapters) ;
Adapter getAdapter(final String type);
```
- The below methods are deprecated in favor of the above.

```
List<Map<String, Object>> getAdapterConfigurationsAsMaps()
JsonArray getAdapterConfigurations()
JsonObject getAdapterConfiguration(final String type)
TenantObject setAdapterConfigurations(final List<Map<String, Object>> configurations)
TenantObject setAdapterConfigurations(final JsonArray configurations)
```