### PR TITLE
Update and docker-wrap JMeter tests.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -46,7 +46,7 @@
     <jaxb.api.version>2.2.12</jaxb.api.version>
     <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
     <jjwt.version>0.10.6</jjwt.version>
-    <jmeter.version>3.3</jmeter.version>
+    <jmeter.version>5.1.1</jmeter.version>
     <junit.jupiter.version>5.5.1</junit.jupiter.version>
     <logback.version>1.2.3</logback.version>
     <micrometer.version>1.1.6</micrometer.version>

--- a/jmeter/Dockerfile
+++ b/jmeter/Dockerfile
@@ -1,0 +1,63 @@
+#!/bin/bash
+#*******************************************************************************
+# Copyright (c) 2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+# Stage image (for downloading files etc)
+FROM index.docker.io/busybox as stage
+
+# Set workdir to Container root
+WORKDIR /
+
+# Download and extract/install apache-jmeter 5.1.1
+RUN [ "wget", "https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-5.1.1.tgz" ]
+RUN tar -xvzf apache-jmeter-5.1.1.tgz
+RUN rm apache-jmeter-5.1.1.tgz
+# Download and install mqtt-xmeter-1.0.1 into apache-jmeter
+RUN [ "wget", "https://github.com/emqx/mqtt-jmeter/releases/download/1.0.1/mqtt-xmeter-1.0.1-jar-with-dependencies.jar" ]
+RUN mv mqtt-xmeter-1.0.1-jar-with-dependencies.jar apache-jmeter-5.1.1/lib/ext/.
+
+# Install Hono Plugin into apache-jmeter
+COPY target/plugin/hono-jmeter-*.jar apache-jmeter-5.1.1/lib/ext/.
+
+# Runtime image
+FROM openjdk:11-jre-slim
+
+# Set workdir to Container root
+WORKDIR /
+
+# Download and extract/install apache-jmeter 5.1.1
+COPY --from=stage apache-jmeter-5.1.1/ apache-jmeter-5.1.1/
+
+# Check if it is executable
+RUN /apache-jmeter-5.1.1/bin/jmeter --version
+
+# Place Load Test scripts into work dir
+COPY src/jmeter/load-test-http-router-docker.sh load-test-http-router.sh
+COPY src/jmeter/load-test-messaging-router-docker.sh load-test-messaging-router.sh
+COPY src/jmeter/load-test-mqtt-router-docker.sh load-test-mqtt-router.sh
+# Place all jmeter load test files into work dir
+COPY src/jmeter/*.jmx /jmx/
+
+# Environment Variables used by the scripts
+ENV JMETER_HOME=/apache-jmeter-5.1.1 \
+REGISTRATION_HOST=host \
+REGISTRATION_PORT=28080 \
+ROUTER_HOST=host \
+ROUTER_PORT=15672 \
+MQTT_ADAPTER_HOST=host \
+MQTT_ADAPTER_PORT=1883 \
+HTTP_ADAPTER_HOST=host \
+HTTP_ADAPTER_PORT=8080 \
+SAMPLE_LOG=load-test-router.jtl \
+TEST_LOG=load-test-router.log \
+DEVICE_COUNT=10 \
+CONSUMER_COUNT=2

--- a/jmeter/pom.xml
+++ b/jmeter/pom.xml
@@ -78,4 +78,52 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>build-docker-image</id>
+      <activation>
+        <property>
+          <name>docker.host</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <build>
+                    <dockerFileDir>${project.basedir}</dockerFileDir>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>docker-push-image</id>
+      <build>
+          <plugins>
+              <plugin>
+                  <groupId>io.fabric8</groupId>
+                  <artifactId>docker-maven-plugin</artifactId>
+                  <executions>
+                      <execution>
+                          <id>docker-push-image</id>
+                          <phase>install</phase>
+                          <goals>
+                              <goal>push</goal>
+                          </goals>
+                      </execution>
+                  </executions>
+              </plugin>
+          </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/jmeter/readme.md
+++ b/jmeter/readme.md
@@ -1,0 +1,77 @@
+# Hono Load Tests
+
+This module contains load tests for Hono. The load tests can be executed against any Hono installation.
+
+The load tests can be executed as:
+
+* local bash script with local installation of Apache JMeter 5.1.1 with MQTT XMeter 1.0.1 and Hono JMeter Plugin [Load Tests with JMeter on the project web site](https://www.eclipse.org/hono/docs/user-guide/jmeter_load_tests/)
+* within a docker container created with maven build flag `-Pbuild-docker-image`. See the [Getting Started guide on the project web site](https://www.eclipse.org/hono/getting-started/) for instructions on building the Docker images.
+
+## Load test scenarios
+
+The following load test scenarios are currently supported:
+
+* `load-test-http-router.sh` -> Sending Telemetry Messages against HTTP Adapter and receiving them from the dispatch router
+* `load-test-mqtt-router.sh` -> Sending Telemetry Messages against MQTT Adapter and receiving them from the dispatch router
+* `load-test-messaging-router.sh` -> Sending Telemetry Messages against dispatch router and receiving them from the dispatch router
+
+## Local bash script execution
+
+In order to run the load tests you will need the following:
+
+* a working *Apache JMeter 5.1.1* installation
+* added the plugin *MQTT XMeter 1.0.1* to JMeter /lib/ext folder
+* a successful maven build of Eclipse/Hono
+
+Execute load test:
+
+    # in directory: hono/jmeter/src/jmeter
+
+    ./load-test-http-router.sh <apache jmeter install dir> <dns/ip of Hono Device Registry> <dns/ip of Hono Dispatch Router> <dns/ip of Hono HTTP Adapter> <#Devices to simulate> <#Consumers to simulate>
+    # e.g. 
+    # ./load-test-http-router.sh /home/hono/apache-jmeter-5.1.1 registry.hono.yourdomain.com router.hono.yourdomain.com http.hono.yourdomain.com 10 2
+
+    ./load-test-mqtt-router.sh <apache jmeter install dir> <dns/ip of Hono Device Registry> <dns/ip of Hono Dispatch Router> <dns/ip of Hono MQTT Adapter> <#Devices to simulate> <#Consumers to simulate>
+    # e.g.
+    # ./load-test-mqtt-router.sh /home/hono/apache-jmeter-5.1.1 registry.hono.yourdomain.com router.hono.yourdomain.com mqtt.hono.yourdomain.com 10 2
+
+    ./load-test-messaging-router.sh <apache jmeter install dir> <dns/ip of Hono Device Registry> <#Sender/Consumers to simulate>
+    # e.g.
+    # ./load-test-messaging-router.sh /home/hono/apache-jmeter-5.1.1 router.hono.yourdomain.com 4
+
+## Container based execution
+
+In order to run the load tests you will need the following:
+
+* a successful maven build of Eclipse/Hono
+
+Execute load test:
+
+    docker run -it -e REGISTRATION_HOST=<dns/ip of Hono Device Registry> -e ROUTER_HOST=<dns/ip of Hono Dispatch Router> -e HTTP_ADAPTER_HOST=<dns/ip of Hono HTTP Adapter> -e DEVICE_COUNT=<#Devices to simulate> <jmeter container image name> /bin/bash load-test-http-router.sh
+    # e.g.
+    # docker run -it -e REGISTRATION_HOST=registry.hono.yourdomain.com -e ROUTER_HOST=router.hono.yourdomain.com -e HTTP_ADAPTER_HOST=http.hono.yourdomain.com -e DEVICE_COUNT=5 yourregistry.io/eclipse/hono-jmeter /bin/bash load-test-messaging-router.sh
+
+    docker run -it -e REGISTRATION_HOST=<dns/ip of Hono Device Registry> -e ROUTER_HOST=<dns/ip of Hono Dispatch Router> -e MQTT_ADAPTER_HOST=<dns/ip of Hono MQTT Adapter> -e DEVICE_COUNT=<#Devices to simulate> <jmeter container image name> /bin/bash load-test-mqtt-router.sh
+    # e.g.
+    # docker run -it -e REGISTRATION_HOST=registry.hono.yourdomain.com -e ROUTER_HOST=router.hono.yourdomain.com -e MQTT_ADAPTER_HOST=mqtt.hono.yourdomain.com -e DEVICE_COUNT=5 yourregistry.io/eclipse/hono-jmeter /bin/bash load-test-messaging-router.sh
+
+    docker run -it -e REGISTRATION_HOST=<dns/ip of Hono Device Registry> -e ROUTER_HOST=<dns/ip of Hono Dispatch Router> -e MQTT_ADAPTER_HOST=<dns/ip of Hono MQTT Adapter> -e HTTP_ADAPTER_HOST=<dns/ip of Hono HTTP Adapter> -e DEVICE_COUNT=<#Devices to simulate> <jmeter container image name> /bin/bash load-test-messaging-router.sh
+    # e.g.
+    # docker run -it -e REGISTRATION_HOST=registry.hono.yourdomain.com -e ROUTER_HOST=router.hono.yourdomain.com -e MQTT_ADAPTER_HOST=mqtt.hono.yourdomain.com -e HTTP_ADAPTER_HOST=http.hono.yourdomain.com -e DEVICE_COUNT=5 yourregistry.io/eclipse/hono-jmeter /bin/bash load-test-messaging-router.sh
+
+It is possible to modify following parameters via docker env variables:
+
+| Parameter | Type | Default |
+|-----------|------|---------|
+|REGISTRATION_HOST|mandatory||
+|REGISTRATION_PORT|optional|28080|
+|ROUTER_HOST|mandatory||
+|ROUTER_PORT|optional|15672|
+|MQTT_ADAPTER_HOST|mandatory||
+|MQTT_ADAPTER_PORT|optional|1883|
+|HTTP_ADAPTER_HOST|mandatory||
+|HTTP_ADAPTER_PORT|optional|8080|
+|SAMPLE_LOG|optional|load-test-<mqtt/http/messaging>-router.jtl|
+|TEST_LOG|optional|load-test-<mqtt/http/messaging>-router.log|
+|DEVICE_COUNT|optional|10|
+|CONSUMER_COUNT|optional|2|

--- a/jmeter/src/jmeter/http_messaging_throughput_test.jmx
+++ b/jmeter/src/jmeter/http_messaging_throughput_test.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.3 r1808647">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="HTTP throughput test" enabled="true">
       <boolProp name="TestPlan.functional_mode">false</boolProp>
@@ -201,6 +201,10 @@
             <stringProp name="Assertion.custom_message"></stringProp>
           </ResponseAssertion>
           <hashTree/>
+          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Delay between Device creation and Connection" enabled="true">
+            <stringProp name="ConstantTimer.delay">3000</stringProp>
+          </ConstantTimer>
+          <hashTree/>
         </hashTree>
         <RunTime guiclass="RunTimeGui" testclass="RunTime" testname="Run n seconds" enabled="true">
           <stringProp name="RunTime.seconds">${honoTestRuntime}</stringProp>
@@ -272,40 +276,7 @@
           <stringProp name="HTTPSampler.port">${__P(registration.http.port, 28080)}</stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/registration/${honoTenant}/device_${__threadNum}</stringProp>
-          <stringProp name="HTTPSampler.method">DELETE</stringProp>
-          <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
-          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-          <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="TestPlan.comments">Unregisters the device that has been registered during startup of the thread group.</stringProp>
-        </HTTPSamplerProxy>
-        <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assert success" enabled="true">
-            <collectionProp name="Asserion.test_strings">
-              <stringProp name="49590">204</stringProp>
-              <stringProp name="51512">404</stringProp>
-            </collectionProp>
-            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-            <boolProp name="Assertion.assume_success">true</boolProp>
-            <intProp name="Assertion.test_type">40</intProp>
-            <stringProp name="Assertion.custom_message"></stringProp>
-          </ResponseAssertion>
-          <hashTree/>
-        </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Remove Credentials" enabled="true">
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
-            <collectionProp name="Arguments.arguments"/>
-          </elementProp>
-          <stringProp name="HTTPSampler.domain">${__P(registration.host, 127.0.0.1)}</stringProp>
-          <stringProp name="HTTPSampler.port">${__P(registration.http.port, 28080)}</stringProp>
-          <stringProp name="HTTPSampler.protocol"></stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/credentials/${honoTenant}/device_${__threadNum}</stringProp>
+          <stringProp name="HTTPSampler.path">/v1/devices/${honoTenant}/device_${__threadNum}</stringProp>
           <stringProp name="HTTPSampler.method">DELETE</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/jmeter/src/jmeter/load-test-http-router-docker.sh
+++ b/jmeter/src/jmeter/load-test-http-router-docker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#*******************************************************************************
+# Copyright (c) 2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+JMX_FILE="/jmx/http_messaging_throughput_test.jmx"
+$JMETER_HOME/bin/jmeter -n -f \
+-l $SAMPLE_LOG -j $TEST_LOG -t $JMX_FILE \
+-Jplugin_dependency_paths=$HONO_HOME/jmeter/target/plugin \
+-Jjmeterengine.stopfail.system.exit=true \
+-Jrouter.host=$ROUTER_HOST -Jrouter.port=$ROUTER_PORT \
+-Jregistration.host=$REGISTRATION_HOST -Jregistration.http.port=$REGISTRATION_PORT \
+-Jhttp.host=$HTTP_ADAPTER_HOST -Jhttp.port=$HTTP_ADAPTER_PORT \
+-Lorg.eclipse.hono.client.impl=INFO -Lorg.eclipse.hono.jmeter=INFO \
+-JdeviceCount=$DEVICE_COUNT -JconsumerCount=$CONSUMER_COUNT

--- a/jmeter/src/jmeter/load-test-http-router.sh
+++ b/jmeter/src/jmeter/load-test-http-router.sh
@@ -11,17 +11,20 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
+# Execution Example
+# ./load-test-http-router.sh /home/hono/apache-jmeter-5.1.1 registry.hono.yourdomain.com router.hono.yourdomain.com http.hono.yourdomain.com 10 2
+#*******************************************************************************
 SCRIPTPATH="$(cd "$(dirname "$0")" && pwd -P)"
-JMETER_HOME=${JMETER_HOME:=~/apache-jmeter-3.3}
-HONO_HOST=$1
-HONO_HOST=${HONO_HOST:=127.0.0.1}
-OUT=$SCRIPTPATH/results
+JMETER_HOME=${1:-~/apache-jmeter-5.1.1}
+REGISTRATION_HOST=${2:-127.0.0.1}
+ROUTER_HOST=${3:-127.0.0.1}
+HTTP_ADAPTER_HOST=${4:-127.0.0.1}
 HONO_HOME=${HONO_HOME:=$SCRIPTPATH/../../..}
-TRUST_STORE_PATH=$HONO_HOME/demo-certs/certs/trusted-certs.pem
 SAMPLE_LOG=load-test-http-router.jtl
 TEST_LOG=load-test-http-router.log
+DEVICE_COUNT=${5:-10}
+CONSUMER_COUNT=${6:-2}
 
-rm -rf $OUT
 rm $SAMPLE_LOG
 
 $JMETER_HOME/bin/jmeter -n -f \
@@ -29,9 +32,8 @@ $JMETER_HOME/bin/jmeter -n -f \
 -t $SCRIPTPATH/http_messaging_throughput_test.jmx \
 -Jplugin_dependency_paths=$HONO_HOME/jmeter/target/plugin \
 -Jjmeterengine.stopfail.system.exit=true \
--Jrouter.host=$HONO_HOST -Jrouter.port=15672 \
--Jregistration.host=$HONO_HOST -Jregistration.http.port=28080 \
--Jhttp.host=$HONO_HOST -Jhttp.port=8080 \
--Lorg.eclipse.hono.client.impl=WARN -Lorg.eclipse.hono.jmeter=INFO \
--JdeviceCount=15
-
+-Jrouter.host=$ROUTER_HOST -Jrouter.port=15672 \
+-Jregistration.host=$REGISTRATION_HOST -Jregistration.http.port=28080 \
+-Jhttp.host=$HTTP_ADAPTER_HOST -Jhttp.port=8080 \
+-Lorg.eclipse.hono.client.impl=INFO -Lorg.eclipse.hono.jmeter=INFO \
+-JdeviceCount=$DEVICE_COUNT -JconsumerCount=$CONSUMER_COUNT

--- a/jmeter/src/jmeter/load-test-messaging-router-docker.sh
+++ b/jmeter/src/jmeter/load-test-messaging-router-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #*******************************************************************************
-# Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+# Copyright (c) 2019 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,26 +11,12 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
-# Execution Example
-# ./load-test-messaging-router.sh /home/hono/apache-jmeter-5.1.1 router.hono.yourdomain.com 4
-#*******************************************************************************
-SCRIPTPATH="$(cd "$(dirname "$0")" && pwd -P)"
-JMETER_HOME=${1:-~/apache-jmeter-5.1.1}
-ROUTER_HOST=${2:-127.0.0.1}
-HONO_HOME=${HONO_HOME:=$SCRIPTPATH/../../..}
-SAMPLE_LOG=load-test-messaging-router.jtl
-TEST_LOG=load-test-messaging-router.log
-DEVICE_COUNT=${3:-4}
-
-rm $SAMPLE_LOG
-
+JMX_FILE="/jmx/amqp_messaging_throughput_test.jmx"
 $JMETER_HOME/bin/jmeter -n -f \
--l $SAMPLE_LOG -j $TEST_LOG \
--t $SCRIPTPATH/amqp_messaging_throughput_test.jmx \
+-l $SAMPLE_LOG -j $TEST_LOG -t $JMX_FILE \
 -Jplugin_dependency_paths=$HONO_HOME/jmeter/target/plugin \
 -Jjmeterengine.stopfail.system.exit=true \
--Jrouter.host=$ROUTER_HOST -Jrouter.port=15672 \
--Jmessaging.host=$ROUTER_HOST -Jmessaging.port=15672 \
+-Jrouter.host=$ROUTER_HOST -Jrouter.port=$ROUTER_PORT \
+-Jmessaging.host=$ROUTER_HOST -Jmessaging.port=$ROUTER_PORT \
 -Lorg.eclipse.hono.client.impl=INFO -Lorg.eclipse.hono.jmeter=INFO \
 -JdeviceCount=$DEVICE_COUNT
-

--- a/jmeter/src/jmeter/load-test-mqtt-router-docker.sh
+++ b/jmeter/src/jmeter/load-test-mqtt-router-docker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#*******************************************************************************
+# Copyright (c) 2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+JMX_FILE="/jmx/mqtt_messaging_throughput_test.jmx"
+$JMETER_HOME/bin/jmeter -n -f -l $SAMPLE_LOG -j $TEST_LOG -t $JMX_FILE \
+-Jplugin_dependency_paths=$JMETER_HOME/lib/ext \
+-Jjmeterengine.stopfail.system.exit=true \
+-Jrouter.host=$ROUTER_HOST -Jrouter.port=$ROUTER_PORT \
+-Jregistration.host=$REGISTRATION_HOST -Jregistration.port=$REGISTRATION_PORT \
+-Jmqtt.host=$MQTT_ADAPTER_HOST -Jmqtt.port=$MQTT_ADAPTER_PORT \
+-Lorg.eclipse.hono.client.impl=INFO -Lorg.eclipse.hono.jmeter=INFO \
+-JdeviceCount=$DEVICE_COUNT -JconsumerCount=$CONSUMER_COUNT 

--- a/jmeter/src/jmeter/load-test-mqtt-router.sh
+++ b/jmeter/src/jmeter/load-test-mqtt-router.sh
@@ -11,27 +11,28 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
+# Execution Example
+# ./load-test-mqtt-router.sh /home/hono/apache-jmeter-5.1.1 registry.hono.yourdomain.com router.hono.yourdomain.com mqtt.hono.yourdomain.com 10 2
+#*******************************************************************************
 SCRIPTPATH="$(cd "$(dirname "$0")" && pwd -P)"
-JMETER_HOME=${JMETER_HOME:=~/apache-jmeter-3.3}
-HONO_HOST=$1
-HONO_HOST=${HONO_HOST:=127.0.0.1}
-OUT=$SCRIPTPATH/results
+JMETER_HOME=${1:-~/apache-jmeter-5.1.1}
+REGISTRATION_HOST=${2:-127.0.0.1}
+ROUTER_HOST=${3:-127.0.0.1}
+MQTT_ADAPTER_HOST=${4:-127.0.0.1}
 HONO_HOME=${HONO_HOME:=$SCRIPTPATH/../../..}
-TRUST_STORE_PATH=$HONO_HOME/demo-certs/certs/trusted-certs.pem
 SAMPLE_LOG=load-test-mqtt-router.jtl
 TEST_LOG=load-test-mqtt-router.log
+DEVICE_COUNT=${5:-10}
+CONSUMER_COUNT=${6:-2}
 
-rm -rf $OUT
-rm $SAMPLE_LOG
+rm -f $SAMPLE_LOG
 
-$JMETER_HOME/bin/jmeter -n -f \
--l $SAMPLE_LOG -j $TEST_LOG \
+$JMETER_HOME/bin/jmeter -n -f -l $SAMPLE_LOG -j $TEST_LOG \
 -t $SCRIPTPATH/mqtt_messaging_throughput_test.jmx \
 -Jplugin_dependency_paths=$HONO_HOME/jmeter/target/plugin \
 -Jjmeterengine.stopfail.system.exit=true \
--Jrouter.host=$HONO_HOST -Jrouter.port=15672 \
--Jregistration.host=$HONO_HOST -Jregistration.http.port=28080 \
--Jmqtt.host=$HONO_HOST -Jmqtt.port=1883 \
+-Jrouter.host=$ROUTER_HOST -Jrouter.port=15672 \
+-Jregistration.host=$REGISTRATION_HOST -Jregistration.port=28080 \
+-Jmqtt.host=$MQTT_ADAPTER_HOST -Jmqtt.port=1883 \
 -Lorg.eclipse.hono.client.impl=INFO -Lorg.eclipse.hono.jmeter=INFO \
--JdeviceCount=10 -JconsumerCount=2
-
+-JdeviceCount=$DEVICE_COUNT -JconsumerCount=$CONSUMER_COUNT

--- a/jmeter/src/jmeter/mqtt_messaging_throughput_test.jmx
+++ b/jmeter/src/jmeter/mqtt_messaging_throughput_test.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.3 r1808647">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="MQTT throughput test" enabled="true">
       <boolProp name="TestPlan.functional_mode">false</boolProp>
@@ -126,21 +126,14 @@
         </HeaderManager>
         <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Register Device" enabled="true">
-          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="" elementType="HTTPArgument">
-                <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{&quot;device-id&quot;: &quot;device_${__threadNum}&quot;}</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
           </elementProp>
           <stringProp name="HTTPSampler.domain">${__P(registration.host, 127.0.0.1)}</stringProp>
-          <stringProp name="HTTPSampler.port">${__P(registration.http.port, 28080)}</stringProp>
+          <stringProp name="HTTPSampler.port">${__P(registration.port, 28080)}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/registration/${honoTenant}</stringProp>
+          <stringProp name="HTTPSampler.path">/v1/devices/${honoTenant}/device_${__threadNum}</stringProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -161,6 +154,7 @@
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
             <boolProp name="Assertion.assume_success">true</boolProp>
             <intProp name="Assertion.test_type">40</intProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
@@ -170,15 +164,14 @@
             <collectionProp name="Arguments.arguments">
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{&#xd;
-	&quot;device-id&quot;: &quot;device_${__threadNum}&quot;,&#xd;
+                <stringProp name="Argument.value">[{&#xd;
 	&quot;type&quot;: &quot;hashed-password&quot;,&#xd;
 	&quot;auth-id&quot;: &quot;device_${__threadNum}&quot;,&#xd;
  	&quot;secrets&quot;: [{&#xd;
 		&quot;hash-function&quot; : &quot;sha-512&quot;,&#xd;
 		&quot;pwd-hash&quot;: &quot;vSsar3708Jvp9Szi2NWZZ02Bqp1qRCFpbcTZPdBhnWgs5WtNZKnvCXdhztmeD2cmW192CF5bDufKRpayrW/isg==&quot;&#xd;
 	}]	&#xd;
-}</stringProp>
+}]</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
             </collectionProp>
@@ -187,8 +180,8 @@
           <stringProp name="HTTPSampler.port">${__P(registration.http.port, 28080)}</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/credentials/${honoTenant}</stringProp>
-          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <stringProp name="HTTPSampler.path">/v1/credentials/${honoTenant}/device_${__threadNum}</stringProp>
+          <stringProp name="HTTPSampler.method">PUT</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
@@ -200,42 +193,58 @@
           <stringProp name="TestPlan.comments">Registers a device with the configured tenant using a device identifier based on the thread number.</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="Set content type" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">content-type</stringProp>
+                <stringProp name="Header.value">application/json</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assert success" enabled="true">
             <collectionProp name="Asserion.test_strings">
-              <stringProp name="49587">201</stringProp>
+              <stringProp name="49590">204</stringProp>
               <stringProp name="51517">409</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
             <boolProp name="Assertion.assume_success">true</boolProp>
             <intProp name="Assertion.test_type">40</intProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
           </ResponseAssertion>
           <hashTree/>
+          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Delay between Device creation and Connection" enabled="true">
+            <stringProp name="ConstantTimer.delay">3000</stringProp>
+          </ConstantTimer>
+          <hashTree/>
         </hashTree>
+        <net.xmeter.samplers.ConnectSampler guiclass="net.xmeter.gui.ConnectSamplerUI" testclass="net.xmeter.samplers.ConnectSampler" testname="Connect" enabled="true">
+          <stringProp name="mqtt.keystore_file_path"></stringProp>
+          <stringProp name="mqtt.clientcert_file_path"></stringProp>
+          <stringProp name="mqtt.conn_keep_alive">300</stringProp>
+          <stringProp name="mqtt.conn_attampt_max">5</stringProp>
+          <stringProp name="mqtt.keep_time">1800</stringProp>
+          <stringProp name="mqtt.client_id_prefix">device_${__threadNum}</stringProp>
+          <boolProp name="mqtt.conn_share">false</boolProp>
+          <boolProp name="mqtt.client_id_suffix">true</boolProp>
+          <stringProp name="mqtt.reconn_attampt_max">3</stringProp>
+          <stringProp name="mqtt.conn_timeout">5</stringProp>
+          <boolProp name="mqtt.dual_ssl_authentication">false</boolProp>
+          <stringProp name="mqtt.keystore_password"></stringProp>
+          <stringProp name="mqtt.clientcert_password"></stringProp>
+          <stringProp name="mqtt.port">${__P(mqtt.port, 1883)}</stringProp>
+          <stringProp name="mqtt.protocol">TCP</stringProp>
+          <stringProp name="mqtt.server">${__P(mqtt.host, 127.0.0.1)}</stringProp>
+          <stringProp name="mqtt.version">3.1.1</stringProp>
+          <stringProp name="mqtt.user_name">device_${__threadNum}@${honoTenant}</stringProp>
+          <stringProp name="mqtt.password">secret</stringProp>
+        </net.xmeter.samplers.ConnectSampler>
+        <hashTree/>
         <RunTime guiclass="RunTimeGui" testclass="RunTime" testname="Run n seconds" enabled="true">
           <stringProp name="RunTime.seconds">${honoTestRuntime}</stringProp>
         </RunTime>
         <hashTree>
           <net.xmeter.samplers.PubSampler guiclass="net.xmeter.gui.PubSamplerUI" testclass="net.xmeter.samplers.PubSampler" testname="publish data" enabled="true">
-            <stringProp name="TestPlan.comments">	</stringProp>
-            <stringProp name="mqtt.keystore_file_path"></stringProp>
-            <stringProp name="mqtt.clientcert_file_path"></stringProp>
-            <stringProp name="mqtt.conn_keep_alive">300</stringProp>
-            <stringProp name="mqtt.conn_attampt_max">5</stringProp>
-            <stringProp name="mqtt.keep_time">1800</stringProp>
-            <stringProp name="mqtt.client_id_prefix">device_${__threadNum}</stringProp>
-            <boolProp name="mqtt.conn_share">false</boolProp>
-            <boolProp name="mqtt.client_id_suffix">true</boolProp>
-            <stringProp name="mqtt.reconn_attampt_max">3</stringProp>
-            <stringProp name="mqtt.conn_timeout">5</stringProp>
-            <boolProp name="mqtt.dual_ssl_authentication">false</boolProp>
-            <stringProp name="mqtt.keystore_password"></stringProp>
-            <stringProp name="mqtt.clientcert_password"></stringProp>
-            <stringProp name="mqtt.port">${__P(mqtt.port, 1883)}</stringProp>
-            <stringProp name="mqtt.protocol">TCP</stringProp>
-            <stringProp name="mqtt.server">${__P(mqtt.host, 127.0.0.1)}</stringProp>
-            <stringProp name="mqtt.version">3.1.1</stringProp>
-            <stringProp name="mqtt.user_name">device_${__threadNum}@${honoTenant}</stringProp>
-            <stringProp name="mqtt.password">secret</stringProp>
             <stringProp name="mqtt.topic_name">${honoEndpoint}</stringProp>
             <stringProp name="mqtt.qos_level">0</stringProp>
             <boolProp name="mqtt.add_timestamp">false</boolProp>
@@ -252,6 +261,8 @@
           </ConstantTimer>
           <hashTree/>
         </hashTree>
+        <net.xmeter.samplers.DisConnectSampler guiclass="net.xmeter.gui.DisConnectSamplerUI" testclass="net.xmeter.samplers.DisConnectSampler" testname="Disconnect" enabled="true"/>
+        <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Unregister Device" enabled="true">
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
@@ -260,7 +271,7 @@
           <stringProp name="HTTPSampler.port">${__P(registration.http.port, 28080)}</stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/registration/${honoTenant}/device_${__threadNum}</stringProp>
+          <stringProp name="HTTPSampler.path">/v1/devices/${honoTenant}/device_${__threadNum}</stringProp>
           <stringProp name="HTTPSampler.method">DELETE</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -281,43 +292,12 @@
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
             <boolProp name="Assertion.assume_success">true</boolProp>
             <intProp name="Assertion.test_type">40</intProp>
-          </ResponseAssertion>
-          <hashTree/>
-        </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Remove Credentials" enabled="true">
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
-            <collectionProp name="Arguments.arguments"/>
-          </elementProp>
-          <stringProp name="HTTPSampler.domain">${__P(registration.host, 127.0.0.1)}</stringProp>
-          <stringProp name="HTTPSampler.port">${__P(registration.http.port, 28080)}</stringProp>
-          <stringProp name="HTTPSampler.protocol"></stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/credentials/${honoTenant}/device_${__threadNum}</stringProp>
-          <stringProp name="HTTPSampler.method">DELETE</stringProp>
-          <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
-          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-          <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="TestPlan.comments">Unregisters the device that has been registered during startup of the thread group.</stringProp>
-        </HTTPSamplerProxy>
-        <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assert success" enabled="true">
-            <collectionProp name="Asserion.test_strings">
-              <stringProp name="49590">204</stringProp>
-              <stringProp name="51512">404</stringProp>
-            </collectionProp>
-            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-            <boolProp name="Assertion.assume_success">true</boolProp>
-            <intProp name="Assertion.test_type">40</intProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
       </hashTree>
-      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="false">
+      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>
@@ -354,9 +334,5 @@
       </ResultCollector>
       <hashTree/>
     </hashTree>
-    <WorkBench guiclass="WorkBenchGui" testclass="WorkBench" testname="WorkBench" enabled="true">
-      <boolProp name="WorkBench.save">true</boolProp>
-    </WorkBench>
-    <hashTree/>
   </hashTree>
 </jmeterTestPlan>

--- a/legal/src/main/resources/legal/NOTICE.md
+++ b/legal/src/main/resources/legal/NOTICE.md
@@ -19,6 +19,7 @@ of the Eclipse Public License 2.0 which is available at https://www.eclipse.org/
 * Copyright 2018 Alfusainey Jallow
 * Copyright 2019 Aloxy NV
 * Copyright 2019 Thiyagarajan B
+* Copyright 2019 Microsoft Corporation
 
 # Third-party Content
 


### PR DESCRIPTION
Hi,

as I tried to execute the JMeter tests against my sample Hono installation on an AKS cluster they did not work as expected.

I mainly edited the RESTful calls to the device registry (JMeter scripts used outdated API) and upgraded the JMeter scripts that they are runnable with Apache JMeter 5.1.1 and MQTT XMeter 1.0.1. In addition to that I wrapped everything in a container that the current three load test bash scripts can be run from directly without having to worry about installation of JMeter and the plugins (XMeter and Hono). 

I used a dockerfile instead of the build style of fabric8io in pom, but included a link to this dockerfile so that fabric8io plugin will generate the load test image within a full Hono build as well.

Waiting for your questions, remarks and update requests!
Thanks,
Florian