### PR TITLE
Migration to vert.x 3.8.3 step1

### DIFF
--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -617,6 +617,11 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
             public JsonArray bodyAsJsonArray() {
                 return null;
             }
+
+            @Override
+            public List<String> followedRedirects() {
+                return null;
+            }
         };
     }
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -51,12 +51,12 @@
     <logback.version>1.2.3</logback.version>
     <micrometer.version>1.1.6</micrometer.version>
     <mockito.version>2.24.5</mockito.version>
-    <netty.version>4.1.39.Final</netty.version>
+    <netty.version>4.1.42.Final</netty.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
     <opentracing.version>0.31.0</opentracing.version>
     <opentracing-resolver.version>0.1.5</opentracing-resolver.version>
     <opentracing-vertx-web.version>0.1.0</opentracing-vertx-web.version>
-    <proton.version>0.33.0</proton.version>
+    <proton.version>0.33.2</proton.version>
     <qpid-jms.version>0.42.0</qpid-jms.version>
     <slf4j.version>1.7.28</slf4j.version>
     <snakeyaml.version>1.23</snakeyaml.version>
@@ -64,7 +64,7 @@
     <spring-boot.version>2.1.8.RELEASE</spring-boot.version>
     <spring-security-crypto.version>5.1.6.RELEASE</spring-security-crypto.version>
     <truth.version>0.28</truth.version>
-    <vertx.version>3.7.1</vertx.version>
+    <vertx.version>3.8.3</vertx.version>
     <wiremock.version>2.24.1</wiremock.version>
 
     <!-- The port at which the Prometheus scraping endpoint is exposed -->

--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -21,6 +21,7 @@ import io.opentracing.Tracer;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.proton.ProtonClientOptions;
 import io.vertx.proton.ProtonLink;
@@ -61,7 +62,7 @@ import io.vertx.proton.ProtonSender;
  * registered on the {@code Future}s returned by these methods will be invoked from the stored Context.
  * It is the invoking code's responsibility to either ensure that the connection's methods are always invoked
  * from the same Context or to make sure that the handlers are running on the correct Context, e.g. by using
- * the {@link #executeOrRunOnContext(Handler)} method. 
+ * the {@link #executeOnContext(Handler)} method. 
  */
 public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
 
@@ -228,7 +229,6 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
      */
     boolean supportsCapability(Symbol capability);
 
-
     /**
      * Executes some code on the vert.x Context that has been used to establish the
      * connection to the peer.
@@ -240,8 +240,24 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
      *         thus indicates the outcome of executing the code. The future will
      *         be failed with a {@link ServerErrorException} if the <em>context</em>
      *         property is {@code null}.
+     * @deprecated Use {@link #executeOnContext(Handler)} instead.
      */
+    @Deprecated
     <T> Future<T> executeOrRunOnContext(Handler<Future<T>> codeToRun);
+
+    /**
+     * Executes some code on the vert.x Context that has been used to establish the
+     * connection to the peer.
+     * 
+     * @param <T> The type of the result that the code produces.
+     * @param codeToRun The code to execute. The code is required to either complete or
+     *                  fail the promise that is passed into the handler.
+     * @return The future containing the result of the promise passed in to the handler
+     *         for executing the code. The future thus indicates the outcome of executing
+     *         the code. The future will always be failed with a {@link ServerErrorException}
+     *         if this connection's <em>context</em> property is {@code null}.
+     */
+    <T> Future<T> executeOnContext(Handler<Promise<T>> codeToRun);
 
     /**
      * Creates a sender link.

--- a/client/src/main/java/org/eclipse/hono/client/impl/ApplicationClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ApplicationClientFactoryImpl.java
@@ -63,7 +63,7 @@ public class ApplicationClientFactoryImpl extends AbstractHonoClientFactory impl
             final Consumer<Message> messageConsumer,
             final Handler<Void> closeHandler) {
 
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             consumerFactory.createClient(
                     () -> TelemetryConsumerImpl.create(
                             connection,
@@ -95,7 +95,7 @@ public class ApplicationClientFactoryImpl extends AbstractHonoClientFactory impl
             final BiConsumer<ProtonDelivery, Message> messageConsumer,
             final Handler<Void> closeHandler) {
 
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             consumerFactory.createClient(
                     () -> EventConsumerImpl.create(
                             connection,
@@ -132,7 +132,7 @@ public class ApplicationClientFactoryImpl extends AbstractHonoClientFactory impl
     private Future<CommandClient> getOrCreateCommandClient(final String tenantId, final String replyId,
             final String cacheKey) {
         log.debug("get or create command client for [tenantId: {}, replyId: {}]", tenantId, replyId);
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             commandClientFactory.getOrCreateClient(
                     cacheKey,
                     () -> CommandClientImpl.create(
@@ -160,7 +160,7 @@ public class ApplicationClientFactoryImpl extends AbstractHonoClientFactory impl
 
         Objects.requireNonNull(tenantId);
 
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             final String key = String.format("%s/%s", CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId);
             asyncCommandClientFactory.getOrCreateClient(
                     key,
@@ -189,7 +189,7 @@ public class ApplicationClientFactoryImpl extends AbstractHonoClientFactory impl
             final BiConsumer<ProtonDelivery, Message> consumer,
             final Handler<Void> closeHandler) {
 
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             consumerFactory.createClient(
                     () -> AsyncCommandResponseConsumerImpl.create(
                             connection,

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
@@ -279,43 +279,6 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
                         });
             })
             .setHandler(result);
-
-//            if (!result.isComplete()) {
-//                final Promise<DestinationCommandConsumer> destinationCommandConsumerPromise = Promise.promise();
-//                // create the gateway or device specific destination consumer
-//                destinationCommandConsumerFactory.getOrCreateClient(
-//                        gatewayOrDeviceKey,
-//                        () -> newDestinationCommandConsumer(tenantId, gatewayOrDeviceId),
-//                        destinationCommandConsumerPromise);
-//
-//                // create the device specific consumer to be returned by this method
-//                final Future<MessageConsumer> deviceSpecificConsumerFuture = destinationCommandConsumerPromise.future()
-//                        .compose(consumer -> consumer.addDeviceSpecificCommandHandler(
-//                                deviceId,
-//                                gatewayId,
-//                                commandHandler,
-//                                remoteCloseHandler))
-//                        .map(ok -> new DeviceSpecificCommandConsumer(
-//                                    () -> destinationCommandConsumerFactory.getClient(gatewayOrDeviceKey),
-//                                    deviceId));
-//
-//                // create the tenant-scoped consumer that maps/delegates incoming commands to the right device-scoped handler/consumer
-//                final Future<MessageConsumer> mappingAndDelegatingCommandConsumer = getOrCreateMappingAndDelegatingCommandConsumer(tenantId);
-//
-//                CompositeFuture.all(deviceSpecificConsumerFuture, mappingAndDelegatingCommandConsumer)
-//                .map(ok -> {
-//                    if (checkInterval != null) {
-//                        final DestinationCommandConsumer destinationCommandConsumer = destinationCommandConsumerPromise.future().result();
-//                        registerLivenessCheck(
-//                                tenantId,
-//                                gatewayOrDeviceId,
-//                                () -> destinationCommandConsumer.getCommandHandlers(),
-//                                checkInterval);
-//                    }
-//                    return deviceSpecificConsumerFuture.result();
-//                })
-//                .setHandler(result);
-//            }
         });
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientFactoryImpl.java
@@ -67,7 +67,7 @@ public class CredentialsClientFactoryImpl extends AbstractHonoClientFactory impl
             final String tenantId) {
 
         Objects.requireNonNull(tenantId);
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             credentialsClientFactory.getOrCreateClient(
                     CredentialsClientImpl.getTargetAddress(tenantId),
                     () -> CredentialsClientImpl.create(

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
@@ -18,8 +18,6 @@ import java.net.HttpURLConnection;
 import java.util.Objects;
 import java.util.UUID;
 
-import io.vertx.proton.ProtonReceiver;
-import io.vertx.proton.ProtonSender;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.ClientErrorException;
@@ -42,8 +40,11 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
 
 /**
  * A Vertx-Proton based client for Hono's Credentials API.
@@ -197,7 +198,7 @@ public class CredentialsClientImpl extends AbstractRequestResponseClient<Credent
         Objects.requireNonNull(authId);
         Objects.requireNonNull(clientContext);
 
-        final Future<CredentialsResult<CredentialsObject>> responseTracker = Future.future();
+        final Promise<CredentialsResult<CredentialsObject>> responseTracker = Promise.promise();
         final JsonObject specification = CredentialsConstants
                 .getSearchCriteria(type, authId)
                 .mergeIn(clientContext);
@@ -219,8 +220,9 @@ public class CredentialsClientImpl extends AbstractRequestResponseClient<Credent
                             responseTracker,
                             key,
                             span);
-                    return responseTracker;
+                    return responseTracker.future();
                 });
+
         return mapResultAndFinishSpan(resultTracker, result -> {
             switch (result.getStatus()) {
             case HttpURLConnection.HTTP_OK:

--- a/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientFactoryImpl.java
@@ -63,7 +63,7 @@ public class DeviceConnectionClientFactoryImpl extends AbstractHonoClientFactory
 
         Objects.requireNonNull(tenantId);
 
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             deviceConnectionClientFactory.getOrCreateClient(
                     DeviceConnectionClientImpl.getTargetAddress(tenantId),
                     () -> DeviceConnectionClientImpl.create(

--- a/client/src/main/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImpl.java
@@ -58,7 +58,7 @@ public class DownstreamSenderFactoryImpl extends AbstractHonoClientFactory imple
     public final Future<DownstreamSender> getOrCreateTelemetrySender(final String tenantId) {
 
         Objects.requireNonNull(tenantId);
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             clientFactory.getOrCreateClient(
                     TelemetrySenderImpl.getTargetAddress(tenantId, null),
                     () -> TelemetrySenderImpl.create(connection, tenantId,
@@ -76,7 +76,7 @@ public class DownstreamSenderFactoryImpl extends AbstractHonoClientFactory imple
     public final Future<DownstreamSender> getOrCreateEventSender(final String tenantId) {
 
         Objects.requireNonNull(tenantId);
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             clientFactory.getOrCreateClient(
                     EventSenderImpl.getTargetAddress(tenantId, null),
                     () -> EventSenderImpl.create(connection, tenantId,

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientFactoryImpl.java
@@ -68,7 +68,7 @@ public class RegistrationClientFactoryImpl extends AbstractHonoClientFactory imp
 
         Objects.requireNonNull(tenantId);
 
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             registrationClientFactory.getOrCreateClient(
                     RegistrationClientImpl.getTargetAddress(tenantId),
                     () -> RegistrationClientImpl.create(

--- a/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
@@ -127,7 +127,7 @@ public final class TelemetrySenderImpl extends AbstractDownstreamSender {
         span.setTag(MessageHelper.APP_PROPERTY_DEVICE_ID, MessageHelper.getDeviceId(rawMessage));
         TracingHelper.injectSpanContext(connection.getTracer(), span.context(), rawMessage);
 
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             if (sender.sendQueueFull()) {
                 final ServiceInvocationException e = new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no credit available");
                 logError(span, e);

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantClientFactoryImpl.java
@@ -59,7 +59,7 @@ public class TenantClientFactoryImpl extends AbstractHonoClientFactory implement
     @Override
     public Future<TenantClient> getOrCreateTenantClient() {
 
-        return connection.executeOrRunOnContext(result -> {
+        return connection.executeOnContext(result -> {
             tenantClientFactory.getOrCreateClient(
                     TenantClientImpl.getTargetAddress(),
                     () -> TenantClientImpl.create(

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
@@ -46,6 +46,7 @@ import io.opentracing.SpanContext;
 import io.opentracing.tag.StringTag;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonReceiver;
@@ -227,7 +228,7 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
 
         final Future<TenantResult<TenantObject>> resultTracker = getResponseFromCache(key, currentSpan)
                 .recover(cacheMiss -> {
-                    final Future<TenantResult<TenantObject>> tenantResult = Future.future();
+                    final Promise<TenantResult<TenantObject>> tenantResult = Promise.promise();
                     createAndSendRequest(
                             TenantAction.get.toString(),
                             customizeRequestApplicationProperties(),
@@ -236,7 +237,7 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
                             tenantResult,
                             key,
                             currentSpan);
-                    return tenantResult;
+                    return tenantResult.future();
                 });
         return mapResultAndFinishSpan(resultTracker, tenantResult -> {
             switch (tenantResult.getStatus()) {

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
@@ -40,6 +40,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.proton.ProtonDelivery;
 import io.vertx.proton.ProtonHelper;
@@ -177,7 +178,8 @@ public class AbstractSenderTest {
             @Override
             public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message) {
                 protonSender.send(message);
-                return Future.future();
+                final Promise<ProtonDelivery> result = Promise.promise();
+                return result.future();
             }
 
             @Override

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImplTest.java
@@ -51,6 +51,7 @@ import org.mockito.ArgumentCaptor;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -267,7 +268,7 @@ public class CommandConsumerFactoryImplTest {
         .map(consumer -> {
                     verify(vertx).setPeriodic(eq(5000L), VertxMockSupport.anyHandler());
             // WHEN closing the link locally
-            final Future<Void> localCloseHandler = Future.future();
+            final Promise<Void> localCloseHandler = Promise.promise();
             consumer.close(localCloseHandler);
                     final ArgumentCaptor<Handler<Void>> closeHandler = VertxMockSupport.argumentCaptorHandler();
             verify(connection).closeAndFree(eq(deviceSpecificCommandReceiver), closeHandler.capture());
@@ -369,7 +370,7 @@ public class CommandConsumerFactoryImplTest {
                 new CommandConsumerFactoryImpl.LivenessCheckData(10L, () -> Collections.singletonList(commandHandlerWrapper)));
 
         final Handler<Long> livenessCheck = commandConsumerFactory.newLivenessCheck(tenantId, deviceId);
-        final Future<ProtonReceiver> createdReceiver = Future.future();
+        final Promise<ProtonReceiver> createdReceiver = Promise.promise();
         when(connection.isConnected()).thenReturn(Future.succeededFuture());
         when(connection.createReceiver(
                 eq(deviceSpecificCommandAddress),
@@ -377,7 +378,7 @@ public class CommandConsumerFactoryImplTest {
                 any(ProtonMessageHandler.class),
                 anyInt(),
                 anyBoolean(),
-                VertxMockSupport.anyHandler())).thenReturn(createdReceiver);
+                VertxMockSupport.anyHandler())).thenReturn(createdReceiver.future());
 
         // WHEN the liveness check fires
         livenessCheck.handle(10L);

--- a/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplTest.java
@@ -36,6 +36,7 @@ import org.mockito.ArgumentCaptor;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.ext.unit.TestContext;
@@ -82,8 +83,9 @@ public class DownstreamSenderFactoryImplTest {
     public void testGetTelemetrySenderFailsIfInvokedConcurrently(final TestContext ctx) {
 
         // GIVEN a factory that already tries to create a telemetry sender for "tenant" (and never completes doing so)
-        final Future<ProtonSender> sender = Future.future();
-        when(connection.createSender(anyString(), any(ProtonQoS.class), VertxMockSupport.anyHandler())).thenReturn(sender);
+        final Promise<ProtonSender> sender = Promise.promise();
+        when(connection.createSender(anyString(), any(ProtonQoS.class), VertxMockSupport.anyHandler()))
+        .thenReturn(sender.future());
         final Future<DownstreamSender> result = factory.getOrCreateTelemetrySender("telemetry/tenant");
         assertFalse(result.isComplete());
 
@@ -105,8 +107,9 @@ public class DownstreamSenderFactoryImplTest {
     public void testGetTelemetrySenderFailsOnConnectionFailure() {
 
         // GIVEN a factory that tries to create a telemetry sender for "tenant"
-        final Future<ProtonSender> sender = Future.future();
-        when(connection.createSender(anyString(), any(ProtonQoS.class), VertxMockSupport.anyHandler())).thenReturn(sender);
+        final Promise<ProtonSender> sender = Promise.promise();
+        when(connection.createSender(anyString(), any(ProtonQoS.class), VertxMockSupport.anyHandler()))
+        .thenReturn(sender.future());
         @SuppressWarnings("unchecked")
         final ArgumentCaptor<DisconnectListener<HonoConnection>> disconnectHandler = ArgumentCaptor.forClass(DisconnectListener.class);
         verify(connection).addDisconnectListener(disconnectHandler.capture());

--- a/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
@@ -32,6 +32,7 @@ import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.proton.ProtonQoS;
 import io.vertx.proton.ProtonReceiver;
@@ -141,11 +142,11 @@ public final class HonoClientUnitTestHelper {
         when(connection.getVertx()).thenReturn(vertx);
         when(connection.getConfig()).thenReturn(props);
         when(connection.getTracer()).thenReturn(tracer);
-        when(connection.executeOrRunOnContext(VertxMockSupport.anyHandler())).then(invocation -> {
-            final Future<?> result = Future.future();
+        when(connection.executeOnContext(VertxMockSupport.anyHandler())).then(invocation -> {
+            final Promise<?> result = Promise.promise();
             final Handler<Future<?>> handler = invocation.getArgument(0);
-            handler.handle(result);
-            return result;
+            handler.handle(result.future());
+            return result.future();
         });
         return connection;
     }

--- a/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
@@ -18,6 +18,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.proton.ProtonLink;
 import io.vertx.proton.ProtonReceiver;
@@ -161,15 +162,53 @@ public final class HonoProtonHelper {
      *                  fail the future that is passed into the handler.
      * @return The future passed into the handler for executing the code. The future
      *         thus indicates the outcome of executing the code. The future will be failed
-     *         if the required context is {@code}.
+     *         if the required context is {@code null}.
+     * @deprecated Use {@link #executeOnContext(Context, Handler)} instead.
      */
+    @Deprecated
     public static <T> Future<T> executeOrRunOnContext(
             final Context requiredContext,
             final Handler<Future<T>> codeToRun) {
 
         Objects.requireNonNull(codeToRun);
 
-        final Future<T> result = Future.future();
+        final Promise<T> result = Promise.promise();
+        if (requiredContext == null) {
+            result.fail(new IllegalStateException("no context to run on"));
+        } else {
+            final Context currentContext = Vertx.currentContext();
+            if (currentContext == requiredContext) {
+                // we are already running on the correct Context,
+                // just execute the code
+                codeToRun.handle(result.future());
+            } else {
+                // we need to run the code on the Context on which
+                // we had originally established the connection,
+                // otherwise vertx-proton will yield undefined results
+                requiredContext.runOnContext(go -> codeToRun.handle(result.future()));
+            }
+        }
+        return result.future();
+    }
+
+    /**
+     * Executes some code on a given context.
+     * 
+     * @param <T> The type of the result that the code produces.
+     * @param requiredContext The context to run the code on.
+     * @param codeToRun The code to execute. The code is required to either complete or
+     *                  fail the promise that is passed into the handler.
+     * @return The future containing the result of the promise passed in to the handler for
+     *         executing the code. The future thus indicates the outcome of executing
+     *         the code. The future will always be failed if the required context is {@code null}.
+     */
+    public static <T> Future<T> executeOnContext(
+            final Context requiredContext,
+            final Handler<Promise<T>> codeToRun) {
+
+        Objects.requireNonNull(codeToRun);
+
+        final Promise<T> result = Promise.promise();
         if (requiredContext == null) {
             result.fail(new IllegalStateException("no context to run on"));
         } else {
@@ -185,7 +224,7 @@ public final class HonoProtonHelper {
                 requiredContext.runOnContext(go -> codeToRun.handle(result));
             }
         }
-        return result;
+        return result.future();
     }
 
     /**
@@ -239,7 +278,7 @@ public final class HonoProtonHelper {
             throw new IllegalArgumentException("detach time-out must be > 0");
         }
 
-        executeOrRunOnContext(context, result -> {
+        executeOnContext(context, result -> {
 
             if (link == null) {
                 closeHandler.handle(null);

--- a/core/src/test/java/org/eclipse/hono/connection/impl/ConnectionFactoryImplTest.java
+++ b/core/src/test/java/org/eclipse/hono/connection/impl/ConnectionFactoryImplTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -135,7 +136,7 @@ public class ConnectionFactoryImplTest {
         factory.setProtonClient(protonClientMock);
 
         // WHEN trying to connect to the server
-        final Future<ProtonConnection> resultHandler = Future.future();
+        final Promise<ProtonConnection> resultHandler = Promise.promise();
 
         factory.connect(new ProtonClientOptions(), null, null, resultHandler);
 
@@ -144,7 +145,7 @@ public class ConnectionFactoryImplTest {
         verify(protonConnectionMock).disconnectHandler(disconnectHandlerCaptor.capture());
         disconnectHandlerCaptor.getValue().handle(protonConnectionMock);
         // as we call handler ourselves handling is synchronous here
-        assertTrue("Connection result handler was not failed", resultHandler.failed());
+        assertTrue("Connection result handler was not failed", resultHandler.future().failed());
     }
 
     /**

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
@@ -33,6 +33,7 @@ import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.healthchecks.Status;
@@ -216,7 +217,7 @@ public class RemoteCacheBasedDeviceConnectionService extends EventBusDeviceConne
         livenessHandler.register("remote-cache-connection", this::checkForCacheAvailability);
     }
 
-    private void checkForCacheAvailability(final Future<Status> status) {
+    private void checkForCacheAvailability(final Promise<Status> status) {
 
         if (cache == null) {
             status.complete(Status.KO());

--- a/tests/src/test/java/org/eclipse/hono/tests/GenericMessageSenderImpl.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/GenericMessageSenderImpl.java
@@ -135,15 +135,13 @@ public class GenericMessageSenderImpl extends AbstractHonoClient implements Mess
      */
     @Override
     public Future<ProtonDelivery> send(final Message message) {
-        final Future<ProtonDelivery> result = Future.future();
-        connection.executeOrRunOnContext(go -> {
+        return connection.executeOnContext(result -> {
             if (sender.isOpen() && sender.getCredit() > 0) {
                 result.complete(sender.send(message));
             } else {
                 result.fail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE));
             }
         });
-        return result;
     }
 
     /**
@@ -164,8 +162,7 @@ public class GenericMessageSenderImpl extends AbstractHonoClient implements Mess
      */
     @Override
     public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message) {
-        final Future<ProtonDelivery> result = Future.future();
-        connection.executeOrRunOnContext(go -> {
+        return connection.executeOnContext(result -> {
             if (sender.isOpen() && sender.getCredit() > 0) {
                 sender.send(message, updatedDelivery -> {
                     if (updatedDelivery.getRemoteState() instanceof Accepted) {
@@ -180,6 +177,5 @@ public class GenericMessageSenderImpl extends AbstractHonoClient implements Mess
                 result.fail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE));
             }
         });
-        return result;
     }
 }


### PR DESCRIPTION
This is the first step in a series of PRs which will migrate the existing code base to vert.x 3.8.3.
The focus is on removing all usage of API that has been deprecated in vert.x 3.8.0 around Futures.
This PR lays the foundation by focusing on the core and client modules, subsequent PRs will focus on services and adapters.