### PR TITLE
Increase request timeout in integration tests

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -36,6 +36,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <service.startup.timeout>120000</service.startup.timeout>
     <link.establishment.timeout>5000</link.establishment.timeout>
     <flow.latency>1000</flow.latency>
+    <request.timeout>500</request.timeout>
     <!-- use minimum number of iterations in order to speed up test execution --> 
     <max.bcrypt.iterations>4</max.bcrypt.iterations>
     <max.event-loop.execute-time>5000</max.event-loop.execute-time>

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -21,6 +21,7 @@ hono:
     trustStorePath: /etc/hono/certs/trusted-certs.pem
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   registration:
     name: 'Hono MQTT Adapter'
     host: ${hono.registration.host}
@@ -29,6 +30,7 @@ hono:
     password: amqp-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   credentials:
     name: 'Hono AMQP Adapter'
     host: ${hono.registration.host}
@@ -37,6 +39,7 @@ hono:
     password: amqp-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   tenant:
     name: 'Hono AMQP Adapter'
     host: ${hono.registration.host}
@@ -45,6 +48,7 @@ hono:
     password: amqp-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   deviceConnection:
     name: 'Hono AMQP Adapter'
     host: ${hono.registration.host}
@@ -53,6 +57,7 @@ hono:
     password: amqp-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   command:
     name: 'Hono AMQP Adapter'
     host: ${hono.amqp-network.host}
@@ -63,6 +68,7 @@ hono:
     trustStorePath: /etc/hono/certs/trusted-certs.pem
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
 

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -20,6 +20,7 @@ hono:
     trustStorePath: /etc/hono/certs/trusted-certs.pem
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   registration:
     name: 'Hono CoAP Adapter'
     host: ${hono.registration.host}
@@ -28,6 +29,7 @@ hono:
     password: coap-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   credentials:
     name: 'Hono CoAP Adapter'
     host: ${hono.registration.host}
@@ -36,6 +38,7 @@ hono:
     password: coap-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   tenant:
     name: 'Hono CoAP Adapter'
     host: ${hono.registration.host}
@@ -44,6 +47,7 @@ hono:
     password: coap-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   deviceConnection:
     name: 'Hono CoAP Adapter'
     host: ${hono.registration.host}
@@ -52,6 +56,7 @@ hono:
     password: coap-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   command:
     name: 'Hono CoAP Adapter'
     host: ${hono.amqp-network.host}
@@ -62,6 +67,7 @@ hono:
     trustStorePath: /etc/hono/certs/trusted-certs.pem
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
 

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -22,6 +22,7 @@ hono:
     trustStorePath: /etc/hono/certs/trusted-certs.pem
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   registration:
     name: 'Hono HTTP Adapter'
     host: ${hono.registration.host}
@@ -30,6 +31,7 @@ hono:
     password: http-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   credentials:
     name: 'Hono HTTP Adapter'
     host: ${hono.registration.host}
@@ -38,6 +40,7 @@ hono:
     password: http-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   tenant:
     name: 'Hono HTTP Adapter'
     host: ${hono.registration.host}
@@ -46,6 +49,7 @@ hono:
     password: http-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   deviceConnection:
     name: 'Hono HTTP Adapter'
     host: ${hono.registration.host}
@@ -54,6 +58,7 @@ hono:
     password: http-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   command:
     name: 'Hono HTTP Adapter'
     host: ${hono.amqp-network.host}
@@ -64,6 +69,7 @@ hono:
     trustStorePath: /etc/hono/certs/trusted-certs.pem
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
 

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -22,6 +22,7 @@ hono:
     trustStorePath: /etc/hono/certs/trusted-certs.pem
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   registration:
     name: 'Hono MQTT Adapter'
     host: ${hono.registration.host}
@@ -30,6 +31,7 @@ hono:
     password: mqtt-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   credentials:
     name: 'Hono MQTT Adapter'
     host: ${hono.registration.host}
@@ -38,6 +40,7 @@ hono:
     password: mqtt-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   tenant:
     name: 'Hono MQTT Adapter'
     host: ${hono.registration.host}
@@ -46,6 +49,7 @@ hono:
     password: mqtt-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   deviceConnection:
     name: 'Hono MQTT Adapter'
     host: ${hono.registration.host}
@@ -54,6 +58,7 @@ hono:
     password: mqtt-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   command:
     name: 'Hono MQTT Adapter'
     host: ${hono.amqp-network.host}
@@ -64,6 +69,7 @@ hono:
     trustStorePath: /etc/hono/certs/trusted-certs.pem
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
 


### PR DESCRIPTION
This is to prevent 
`org.eclipse.hono.client.ServerErrorException: request timed out after 200ms`
errors in the integration tests with regards to slower machines running them.

The `requestTimeout` setting of the `HonoConnection` `ClientConfigProperties`, used for request/response operations, is increased here to 500ms.