### PR TITLE
[#1462] Fix usage of deprecated API in service-base module

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractApplication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractApplication.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * A base class for implementing Spring Boot applications.
@@ -87,12 +88,12 @@ public class AbstractApplication extends AbstractBaseApplication {
         for (final ObjectFactory<? extends AbstractServiceBase<?>> serviceFactory : serviceFactories) {
 
             for (int i = 1; i <= maxInstances; i++) {
-                final Future<String> deployTracker = Future.future();
+                final Promise<String> deployPromise = Promise.promise();
                 final AbstractServiceBase<?> serviceInstance = serviceFactory.getObject();
                 preDeploy(serviceInstance);
                 log.debug("deploying service instance #{} [type: {}]", i, serviceInstance.getClass().getName());
-                getVertx().deployVerticle(serviceInstance, deployTracker);
-                deploymentTracker.add(deployTracker.map(id -> {
+                getVertx().deployVerticle(serviceInstance, deployPromise);
+                deploymentTracker.add(deployPromise.future().map(id -> {
                     postDeploy(serviceInstance);
                     return id;
                 }));

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractEndpoint.java
@@ -23,6 +23,7 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
@@ -73,13 +74,25 @@ public abstract class AbstractEndpoint implements Endpoint {
 
     @Override
     public final Future<Void> start() {
-        final Future<Void> result = Future.future();
+        final Promise<Void> result = Promise.promise();
         if (vertx == null) {
             result.fail(new IllegalStateException("Vert.x instance must be set"));
         } else {
             doStart(result);
         }
-        return result;
+        return result.future();
+    }
+
+    /**
+     * Subclasses should override this method to create required resources
+     * during startup.
+     * <p>
+     * This default implementation delegates to {@link #doStart(Future)}.
+     * 
+     * @param startPromise Completes if startup succeeded.
+     */
+    protected void doStart(final Promise<Void> startPromise) {
+        doStart(startPromise.future());
     }
 
     /**
@@ -89,16 +102,30 @@ public abstract class AbstractEndpoint implements Endpoint {
      * This implementation always completes the start future.
      * 
      * @param startFuture Completes if startup succeeded.
+     * @deprecated Override {@link #doStart(Promise)} instead.
      */
+    @Deprecated
     protected void doStart(final Future<Void> startFuture) {
         startFuture.complete();
     }
 
     @Override
     public final Future<Void> stop() {
-        final Future<Void> result = Future.future();
+        final Promise<Void> result = Promise.promise();
         doStop(result);
-        return result;
+        return result.future();
+    }
+
+    /**
+     * Subclasses should override this method to release resources
+     * during shutdown.
+     * <p>
+     * This default implementation delegates to {@link #doStop(Future)}.
+     * 
+     * @param stopPromise Completes if shutdown succeeded.
+     */
+    protected void doStop(final Promise<Void> stopPromise) {
+        doStop(stopPromise.future());
     }
 
     /**
@@ -108,7 +135,9 @@ public abstract class AbstractEndpoint implements Endpoint {
      * This implementation always completes the stop future.
      * 
      * @param stopFuture Completes if shutdown succeeded.
+     * @deprecated Override {@link #doStop(Promise)} instead.
      */
+    @Deprecated
     protected void doStop(final Future<Void> stopFuture) {
         stopFuture.complete();
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceBase.java
@@ -26,6 +26,7 @@ import io.netty.handler.ssl.OpenSsl;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.NetServerOptions;
@@ -242,7 +243,7 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
             log.info("Vertx native support: {}", vertx.isNativeTransportEnabled());
         }
 
-        final Future<Void> result = Future.future();
+        final Promise<Void> result = Promise.promise();
 
         if (getConfig().getKeyCertOptions() == null) {
             if (getConfig().getPort() >= 0) {
@@ -265,7 +266,7 @@ public abstract class AbstractServiceBase<T extends ServiceConfigProperties> ext
             result.complete();
         }
 
-        return result;
+        return result.future();
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/BaseAuthenticationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/BaseAuthenticationService.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
@@ -45,10 +46,23 @@ public abstract class BaseAuthenticationService<T> extends ConfigurationSupporti
     private MessageConsumer<JsonObject> authRequestConsumer;
 
     @Override
-    public final void start(final Future<Void> startFuture) {
+    public final void start(final Promise<Void> startPromise) {
         authRequestConsumer = vertx.eventBus().consumer(AuthenticationConstants.EVENT_BUS_ADDRESS_AUTHENTICATION_IN, this::processMessage);
         LOG.info("listening on event bus [address: {}] for authentication requests", AuthenticationConstants.EVENT_BUS_ADDRESS_AUTHENTICATION_IN);
-        doStart(startFuture);
+        doStart(startPromise);
+    }
+
+    /**
+     * Subclasses should override this method to create required resources
+     * during startup.
+     * <p>
+     * This default implementation delegates to {@link #doStart(Future)}.
+     * 
+     * @param startPromise Completes if startup succeeded.
+     */
+    protected void doStart(final Promise<Void> startPromise) {
+        // should be overridden by subclasses
+        doStart(startPromise.future());
     }
 
     /**
@@ -58,17 +72,33 @@ public abstract class BaseAuthenticationService<T> extends ConfigurationSupporti
      * This implementation always completes the start future.
      * 
      * @param startFuture Completes if startup succeeded.
+     * @deprecated Override {@link #doStart(Promise)} instead.
      */
+    @Deprecated
     protected void doStart(final Future<Void> startFuture) {
         // should be overridden by subclasses
         startFuture.complete();
     }
 
     @Override
-    public final void stop(final Future<Void> stopFuture) {
+    public final void stop(final Promise<Void> stopPromise) {
         LOG.info("unregistering event bus listener [address: {}]", AuthenticationConstants.EVENT_BUS_ADDRESS_AUTHENTICATION_IN);
         authRequestConsumer.unregister();
-        doStop(stopFuture);
+        doStop(stopPromise);
+    }
+
+    /**
+     * Subclasses should override this method to release resources
+     * during shutdown.
+     * <p>
+     * This default implementation delegates to {@link #doStop(Future)}.
+     * 
+     * @param stopPromise Completes if shutdown succeeded.
+     */
+    protected void doStop(final Promise<Void> stopPromise) {
+
+        // to be overridden by subclasses
+        doStop(stopPromise.future());
     }
 
     /**
@@ -78,7 +108,9 @@ public abstract class BaseAuthenticationService<T> extends ConfigurationSupporti
      * This implementation always completes the stop future.
      * 
      * @param stopFuture Completes if shutdown succeeded.
+     * @deprecated Override {@link #doStop(Promise)} instead.
      */
+    @Deprecated
     protected void doStop(final Future<Void> stopFuture) {
 
         // to be overridden by subclasses

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/EventBusAuthenticationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/EventBusAuthenticationService.java
@@ -69,7 +69,7 @@ public final class EventBusAuthenticationService implements AuthenticationServic
     public void authenticate(final JsonObject authRequest, final Handler<AsyncResult<HonoUser>> authenticationResultHandler) {
 
         final DeliveryOptions options = new DeliveryOptions().setSendTimeout(AUTH_REQUEST_TIMEOUT_MILLIS);
-        vertx.eventBus().send(AuthenticationConstants.EVENT_BUS_ADDRESS_AUTHENTICATION_IN, authRequest, options, reply -> {
+        vertx.eventBus().request(AuthenticationConstants.EVENT_BUS_ADDRESS_AUTHENTICATION_IN, authRequest, options, reply -> {
             if (reply.succeeded()) {
                 final JsonObject result = (JsonObject) reply.result().body();
                 final String token = result.getString(AuthenticationConstants.FIELD_TOKEN);

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/HonoSaslAuthenticator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/HonoSaslAuthenticator.java
@@ -31,8 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetSocket;
 import io.vertx.proton.ProtonConnection;
@@ -109,8 +109,8 @@ public final class HonoSaslAuthenticator implements ProtonSaslAuthenticator {
             LOG.debug("client wants to authenticate using SASL [mechanism: {}, host: {}, state: {}]",
                     chosenMechanism, sasl.getHostname(), sasl.getState().name());
 
-            final Future<HonoUser> authTracker = Future.future();
-            authTracker.setHandler(s -> {
+            final Promise<HonoUser> authTracker = Promise.promise();
+            authTracker.future().setHandler(s -> {
                 final SaslOutcome saslOutcome;
                 if (s.succeeded()) {
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/delegating/DelegatingAuthenticationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/delegating/DelegatingAuthenticationService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.dns.DnsClient;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
@@ -132,11 +133,15 @@ public class DelegatingAuthenticationService extends AbstractHonoAuthenticationS
 
     @Override
     protected void doStart(final Future<Void> startFuture) {
+
+        final Promise<Void> result = Promise.promise();
+        result.future().setHandler(startFuture);
+
         if (factory == null) {
-            startFuture.fail("no connection factory for Authentication service set");
+            result.fail(new IllegalStateException("no connection factory for Authentication service set"));
         } else {
             client = new AuthenticationServerClient(vertx, factory);
-            startFuture.complete();
+            result.complete();
         }
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/ChainAuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/ChainAuthHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.hono.util.ExecutionContext;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 
 
@@ -63,9 +64,9 @@ public class ChainAuthHandler<T extends ExecutionContext> extends ExecutionConte
      */
     @Override
     public Future<JsonObject> parseCredentials(final T context) {
-        final Future<JsonObject> result = Future.future();
+        final Promise<JsonObject> result = Promise.promise();
         parseCredentials(0, context, null, result);
-        return result;
+        return result.future();
     }
 
     private void parseCredentials(

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/DeviceCertificateValidator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/DeviceCertificateValidator.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 
 /**
@@ -67,7 +68,7 @@ public class DeviceCertificateValidator implements X509CertificateChainValidator
             throw new IllegalArgumentException("trust anchor list must not be empty");
         }
 
-        final Future<Void> result = Future.future();
+        final Promise<Void> result = Promise.promise();
 
         try {
             final PKIXParameters params = new PKIXParameters(trustAnchors);
@@ -89,6 +90,6 @@ public class DeviceCertificateValidator implements X509CertificateChainValidator
                 result.fail(new CertificateException("validation of device certificate failed", e));
             }
         }
-        return result;
+        return result.future();
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/ExecutionContextAuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/ExecutionContextAuthHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.User;
 
@@ -60,12 +61,12 @@ public abstract class ExecutionContextAuthHandler<T extends ExecutionContext> im
     @Override
     public Future<DeviceUser> authenticateDevice(final T context) {
 
-        final Future<DeviceUser> result = Future.future();
+        final Promise<DeviceUser> result = Promise.promise();
         parseCredentials(context)
                 .compose(authInfo -> {
-                    final Future<User> authResult = Future.future();
+                    final Promise<User> authResult = Promise.promise();
                     getAuthProvider(context).authenticate(authInfo, authResult);
-                    return authResult;
+                    return authResult.future();
                 }).setHandler(authAttempt -> {
                     if (authAttempt.succeeded()) {
                         if (authAttempt.result() instanceof DeviceUser) {
@@ -79,7 +80,7 @@ public abstract class ExecutionContextAuthHandler<T extends ExecutionContext> im
                         result.fail(authAttempt.cause());
                     }
                 });
-        return result;
+        return result.future();
     }
 
     private AuthProvider getAuthProvider(final T ctx) {

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import io.opentracing.Tracer;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
@@ -112,7 +113,7 @@ public final class UsernamePasswordAuthProvider extends CredentialsApiAuthProvid
         if (currentContext == null) {
             return Future.failedFuture(new IllegalStateException("not running on vert.x Context"));
         } else {
-            final Future<Device> result = Future.future();
+            final Promise<Device> result = Promise.promise();
             currentContext.executeBlocking(blockingCodeHandler -> {
                 log.debug("validating password hash on vert.x worker thread [{}]", Thread.currentThread().getName());
                 final boolean isValid = credentialsOnRecord.getCandidateSecrets().stream()
@@ -123,7 +124,7 @@ public final class UsernamePasswordAuthProvider extends CredentialsApiAuthProvid
                     blockingCodeHandler.fail(new ClientErrorException(HttpURLConnection.HTTP_UNAUTHORIZED, "bad credentials"));
                 }
             }, false, result);
-            return result;
+            return result.future();
         }
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
@@ -308,7 +308,7 @@ public abstract class AbstractHttpEndpoint<T> extends AbstractEndpoint implement
             final BiConsumer<Integer, EventBusMessage> responseHandler) {
 
         final DeliveryOptions options = createEventBusMessageDeliveryOptions(TracingHandler.serverSpanContext(ctx));
-        vertx.eventBus().send(getEventBusAddress(), requestMsg, options, invocation -> {
+        vertx.eventBus().request(getEventBusAddress(), requestMsg, options, invocation -> {
             if (invocation.failed()) {
                 HttpUtils.serviceUnavailable(ctx, 2);
             } else {

--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/Device.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/Device.java
@@ -82,6 +82,11 @@ public class Device {
         return this;
     }
 
+    /**
+     * Checks if this device is enabled.
+     * 
+     * @return {@code true} if this device is enabled.
+     */
     public Boolean getEnabled() {
         return enabled;
     }
@@ -112,6 +117,11 @@ public class Device {
         return this;
     }
 
+    /**
+     * Gets the extension properties for this device.
+     * 
+     * @return The extension properties.
+     */
     public Map<String, Object> getExtensions() {
         return this.extensions;
     }
@@ -127,16 +137,26 @@ public class Device {
         return this;
     }
 
+    /**
+     * Gets the default properties for this device.
+     *
+     * @return The default properties.
+     */
     public Map<String, Object> getDefaults() {
         return defaults;
     }
 
+    /**
+     * Gets the identifiers of the gateway devices that this device may connect via.
+     * 
+     * @return The identifiers.
+     */
     public List<String> getVia() {
         return via;
     }
 
     /**
-     * Sets the via property for this device.
+     * Sets the identifiers of the gateway devices that this device may connect via.
      * 
      * @param via The via property to set.
      * @return    a reference to this for fluent use.

--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/EventBusDeviceManagementAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/EventBusDeviceManagementAdapter.java
@@ -23,12 +23,13 @@ import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
 import org.eclipse.hono.service.management.Util;
-import org.eclipse.hono.util.RegistryManagementConstants;
 import org.eclipse.hono.util.EventBusMessage;
+import org.eclipse.hono.util.RegistryManagementConstants;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.core.json.JsonObject;
 
@@ -129,9 +130,9 @@ public abstract class EventBusDeviceManagementAdapter extends EventBusService
 
         return deviceFuture.compose(device -> {
             log.debug("registering device [{}] for tenant [{}]", deviceId.orElse("<auto>"), tenantId);
-            final Future<OperationResult<Id>> result = Future.future();
+            final Promise<OperationResult<Id>> result = Promise.promise();
             getService().createDevice(tenantId, deviceId, device, span, result);
-            return result.map(res -> {
+            return result.future().map(res -> {
                 final String createdDeviceId = Optional.ofNullable(res.getPayload()).map(Id::getId).orElse(null);
                 return res.createResponse(request, JsonObject::mapFrom).setDeviceId(createdDeviceId);
             });
@@ -152,9 +153,9 @@ public abstract class EventBusDeviceManagementAdapter extends EventBusService
         }
 
         log.debug("retrieving device [{}] of tenant [{}]", deviceId, tenantId);
-        final Future<OperationResult<Device>> result = Future.future();
+        final Promise<OperationResult<Device>> result = Promise.promise();
         getService().readDevice(tenantId, deviceId, span, result);
-        return result.map(res -> {
+        return result.future().map(res -> {
             return res.createResponse(request, JsonObject::mapFrom).setDeviceId(deviceId);
         });
 
@@ -178,9 +179,9 @@ public abstract class EventBusDeviceManagementAdapter extends EventBusService
         return deviceFuture.compose(device -> {
 
             log.debug("updating registration information for device [{}] of tenant [{}]", deviceId, tenantId);
-            final Future<OperationResult<Id>> result = Future.future();
+            final Promise<OperationResult<Id>> result = Promise.promise();
             getService().updateDevice(tenantId, deviceId, device, resourceVersion, span, result);
-            return result.map(res -> {
+            return result.future().map(res -> {
                 return res.createResponse(request, JsonObject::mapFrom).setDeviceId(deviceId);
             });
 
@@ -201,9 +202,9 @@ public abstract class EventBusDeviceManagementAdapter extends EventBusService
         }
 
         log.debug("deleting device [{}] of tenant [{}]", deviceId, tenantId);
-        final Future<Result<Void>> result = Future.future();
+        final Promise<Result<Void>> result = Promise.promise();
         getService().deleteDevice(tenantId, deviceId, resourceVersion, span, result);
-        return result.map(res -> {
+        return result.future().map(res -> {
             return res.createResponse(request, id -> null).setDeviceId(deviceId);
         });
 

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/EventBusRegistrationAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/EventBusRegistrationAdapter.java
@@ -31,6 +31,7 @@ import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -99,7 +100,7 @@ public abstract class EventBusRegistrationAdapter extends EventBusService implem
             TracingHelper.logError(span, "missing tenant and/or device");
             resultFuture = Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
         } else {
-            final Future<RegistrationResult> result = Future.future();
+            final Promise<RegistrationResult> result = Promise.promise();
             if (gatewayId == null) {
                 log.debug("asserting registration of device [{}] with tenant [{}]", deviceId, tenantId);
                 getService().assertRegistration(tenantId, deviceId, span, result);
@@ -108,7 +109,7 @@ public abstract class EventBusRegistrationAdapter extends EventBusService implem
                         deviceId, tenantId, gatewayId);
                 getService().assertRegistration(tenantId, deviceId, gatewayId, span, result);
             }
-            resultFuture = result.map(res -> {
+            resultFuture = result.future().map(res -> {
                 return request.getResponse(res.getStatus())
                         .setDeviceId(deviceId)
                         .setJsonPayload(res.getPayload())

--- a/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/PrometheusBasedResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/PrometheusBasedResourceLimitChecks.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
@@ -270,7 +271,7 @@ public final class PrometheusBasedResourceLimitChecks implements ResourceLimitCh
 
     private Future<Long> executeQuery(final String query) {
 
-        final Future<Long> result = Future.future();
+        final Promise<Long> result = Promise.promise();
         log.trace("running query [{}] against Prometheus backend [http://{}:{}{}]",
                 query, config.getHost(), config.getPort(), QUERY_URI);
         client.get(config.getPort(), config.getHost(), QUERY_URI)
@@ -286,7 +287,7 @@ public final class PrometheusBasedResourceLimitChecks implements ResourceLimitCh
                 result.fail(sendAttempt.cause());
             }
         });
-        return result;
+        return result.future();
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/EventBusTenantAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/EventBusTenantAdapter.java
@@ -32,6 +32,7 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.core.json.JsonObject;
 
@@ -130,9 +131,9 @@ public abstract class EventBusTenantAdapter extends EventBusService implements V
     private Future<EventBusMessage> processGetByIdRequest(final EventBusMessage request, final String tenantId,
             final Span span) {
 
-        final Future<TenantResult<JsonObject>> getResult = Future.future();
+        final Promise<TenantResult<JsonObject>> getResult = Promise.promise();
         getService().get(tenantId, span, getResult);
-        return getResult.map(tr -> {
+        return getResult.future().map(tr -> {
             return request.getResponse(tr.getStatus())
                     .setJsonPayload(tr.getPayload())
                     .setTenant(tenantId)
@@ -146,9 +147,9 @@ public abstract class EventBusTenantAdapter extends EventBusService implements V
         try {
             final X500Principal dn = new X500Principal(subjectDn);
             log.debug("retrieving tenant [subject DN: {}]", subjectDn);
-            final Future<TenantResult<JsonObject>> getResult = Future.future();
+            final Promise<TenantResult<JsonObject>> getResult = Promise.promise();
             getService().get(dn, span, getResult);
-            return getResult.map(tr -> {
+            return getResult.future().map(tr -> {
                 final EventBusMessage response = request.getResponse(tr.getStatus())
                         .setJsonPayload(tr.getPayload())
                         .setCacheDirective(tr.getCacheDirective());

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -64,6 +64,7 @@ import io.opentracing.SpanContext;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
@@ -609,9 +610,9 @@ public class AbstractProtocolAdapterBaseTest {
             }
 
             @Override
-            protected void doStart(final Future<Void> startFuture) {
+            protected void doStart(final Promise<Void> startPromise) {
                 startupHandler.handle(null);
-                startFuture.complete();
+                startPromise.complete();
             }
 
             @Override

--- a/service-base/src/test/java/org/eclipse/hono/service/VertxBasedHealthCheckServerTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/VertxBasedHealthCheckServerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.web.client.WebClient;
@@ -167,7 +168,7 @@ class VertxBasedHealthCheckServerTest {
 
     private Future<WebClient> checkHealth(final VertxTestContext ctx, final WebClient httpClient,
             final String endpoint) {
-        final Future<WebClient> sentHealth = Future.future();
+        final Promise<WebClient> sentHealth = Promise.promise();
         httpClient.get(endpoint)
                 .expect(ResponsePredicate.status(HttpURLConnection.HTTP_OK))
                 .send(result -> {
@@ -177,7 +178,7 @@ class VertxBasedHealthCheckServerTest {
                     sentHealth.complete(httpClient);
                 });
 
-        return sentHealth;
+        return sentHealth.future();
     }
 
     private WebClient getWebClient(final Vertx vertx, final VertxBasedHealthCheckServer server, final boolean secure) {

--- a/service-base/src/test/java/org/eclipse/hono/service/amqp/RequestResponseEndpointTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/amqp/RequestResponseEndpointTest.java
@@ -212,7 +212,7 @@ public class RequestResponseEndpointTest {
         verify(receiver, never()).close();
         verify(authService).isAuthorized(Constants.PRINCIPAL_ANONYMOUS, resource, "unauthorized");
         // but not forwarded to the service instance
-        verify(eventBus, never()).send(anyString(), any(), any(DeliveryOptions.class), any(Handler.class));
+        verify(eventBus, never()).request(anyString(), any(), any(DeliveryOptions.class), any(Handler.class));
         // and a response is sent to the client with status 403
         verify(sender).send(argThat(m -> hasStatusCode(m, HttpURLConnection.HTTP_FORBIDDEN)));
     }
@@ -259,7 +259,7 @@ public class RequestResponseEndpointTest {
         verify(delivery).disposition(argThat(d -> d instanceof Accepted), booleanThat(is(Boolean.TRUE)));
         // and forwarded to the service instance
         final ArgumentCaptor<Handler<AsyncResult<io.vertx.core.eventbus.Message<Object>>>> replyHandler = ArgumentCaptor.forClass(Handler.class);
-        verify(eventBus).send(eq(EVENT_BUS_ADDRESS), any(JsonObject.class), any(DeliveryOptions.class), replyHandler.capture());
+        verify(eventBus).request(eq(EVENT_BUS_ADDRESS), any(JsonObject.class), any(DeliveryOptions.class), replyHandler.capture());
 
         // WHEN the service invocation times out
         replyHandler.getValue().handle(Future.failedFuture(error));
@@ -295,7 +295,7 @@ public class RequestResponseEndpointTest {
         verify(delivery).disposition(argThat(d -> d instanceof Accepted), booleanThat(is(Boolean.TRUE)));
 
         // and not forwarded to the service instance
-        verify(eventBus, never()).send(eq(EVENT_BUS_ADDRESS), any(JsonObject.class), any(DeliveryOptions.class), any(Handler.class));
+        verify(eventBus, never()).request(eq(EVENT_BUS_ADDRESS), any(JsonObject.class), any(DeliveryOptions.class), any(Handler.class));
 
         // and a response with the expected status is sent to the client
         verify(sender).send(argThat(m -> hasStatusCode(m, HttpURLConnection.HTTP_BAD_REQUEST)));
@@ -332,7 +332,7 @@ public class RequestResponseEndpointTest {
         verify(authService).isAuthorized(Constants.PRINCIPAL_ANONYMOUS, resource, "get");
         // and forwarded to the service instance
         final ArgumentCaptor<Handler<AsyncResult<io.vertx.core.eventbus.Message<Object>>>> replyHandler = ArgumentCaptor.forClass(Handler.class);
-        verify(eventBus).send(eq(EVENT_BUS_ADDRESS), any(JsonObject.class), any(DeliveryOptions.class), replyHandler.capture());
+        verify(eventBus).request(eq(EVENT_BUS_ADDRESS), any(JsonObject.class), any(DeliveryOptions.class), replyHandler.capture());
 
         // WHEN the service implementation sends the response
         final EventBusMessage response = EventBusMessage.forStatusCode(HttpURLConnection.HTTP_ACCEPTED);

--- a/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionServiceTest.java
+++ b/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionServiceTest.java
@@ -39,6 +39,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.MessageConsumer;
@@ -90,10 +91,10 @@ public class RemoteCacheBasedDeviceConnectionServiceTest {
         final Vertx vertx = mock(Vertx.class);
         when(vertx.eventBus()).thenReturn(eventBus);
 
-        final Future<Void> startFuture = Future.future();
+        final Promise<Void> startPromise = Promise.promise();
         svc.init(vertx, ctx);
-        svc.start(startFuture);
-        return startFuture;
+        svc.start(startPromise);
+        return startPromise.future();
     }
 
     /**


### PR DESCRIPTION
This step of migration to vert.x 3.8.3 tries to remove usage of deprecated API from the service-base module.
Not that in several cases I was not able to simply change a method's signature to accept a `Promise` instead of a `Future` because we forgot to declare the method (or class) `final` :-( Otherwise we would break the API if somebody had extended the class and overridden the method ...