### PR TITLE
[#1440] Track resource limit checks using OpenTracing.

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactoryTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactoryTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.HttpURLConnection;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import org.apache.qpid.proton.engine.Record;
@@ -135,8 +135,10 @@ public class AmqpAdapterSaslAuthenticatorFactoryTest {
     public void testHandshakeFailsIfTenantLevelConnectionLimitIsExceeded() {
 
         // GIVEN a device belonging to a tenant for which the connection limit has been reached
-        final Function<TenantObject, Future<Void>> tenantConnectionLimit = tenant -> Future.failedFuture(
-                new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, "maximum number of connections exceeded"));
+        final BiFunction<TenantObject, SpanContext, Future<Void>> tenantConnectionLimit = (tenant,
+                spanContext) -> Future.failedFuture(
+                        new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN,
+                                "maximum number of connections exceeded"));
         final Buffer credentials = getPlainCredentials("sensor1@tenant", "secret");
 
         // WHEN the device starts a SASL PLAIN handshake
@@ -178,7 +180,8 @@ public class AmqpAdapterSaslAuthenticatorFactoryTest {
         // WHEN the device starts a SASL PLAIN handshake with an adapter
         // whose connection limit has been reached
         when(adapterConnectionLimit.isLimitExceeded()).thenReturn(Boolean.TRUE);
-        final Function<TenantObject, Future<Void>> tenantConnectionLimit = tenant -> Future.succeededFuture();
+        final BiFunction<TenantObject, SpanContext, Future<Void>> tenantConnectionLimit = (tenant,
+                spanContext) -> Future.succeededFuture();
         final AmqpAdapterSaslAuthenticatorFactory factory = new AmqpAdapterSaslAuthenticatorFactory(
                 tenantClientFactory,
                 props,

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -179,7 +179,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
         resourceLimitChecks = mock(ResourceLimitChecks.class);
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.FALSE));
 
         config = new AmqpAdapterProperties();
@@ -864,7 +864,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         // which is enabled for a tenant
         final TenantObject tenantObject = givenAConfiguredTenant(TEST_TENANT_ID, true);
         // WHEN the message limit exceeds
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         // WHEN a device uploads telemetry data to the adapter (and wants to be notified of failure)
         final ProtonDelivery delivery = mock(ProtonDelivery.class);
@@ -909,7 +909,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         // which is enabled for a tenant
         final TenantObject tenantObject = givenAConfiguredTenant(TEST_TENANT_ID, true);
         // WHEN the message limit exceeds
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         // WHEN a device uploads telemetry data to the adapter (and wants to be notified of failure)
         final ProtonDelivery delivery = mock(ProtonDelivery.class);
@@ -955,7 +955,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         // which is enabled for a tenant
         final TenantObject tenantObject = givenAConfiguredTenant(TEST_TENANT_ID, true);
         // WHEN the message limit exceeds
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         // WHEN a device uploads a command response to the adapter
         final String replyToAddress = String.format("%s/%s/%s", getCommandEndpoint(), TEST_TENANT_ID,

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -625,7 +625,8 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
             final Future<TenantObject> tenantTracker = getTenantConfiguration(device.getTenantId(), currentSpan.context());
             final Future<TenantObject> tenantValidationTracker = tenantTracker
                     .compose(tenantObject -> CompositeFuture
-                            .all(isAdapterEnabled(tenantObject), checkMessageLimit(tenantObject, payload.length()))
+                            .all(isAdapterEnabled(tenantObject),
+                                    checkMessageLimit(tenantObject, payload.length(), currentSpan.context()))
                             .map(success -> tenantObject));
             return CompositeFuture.all(tokenTracker, senderTracker, tenantValidationTracker).compose(ok -> {
                     final DownstreamSender sender = senderTracker.result();

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -151,7 +151,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
         resourceLimitChecks = mock(ResourceLimitChecks.class);
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.FALSE));
     }
 
@@ -534,7 +534,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true, null);
 
         // WHEN the message limit exceeds
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
 
         // WHEN a device publishes a telemetry message
@@ -573,7 +573,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true, null);
 
         // WHEN the message limit exceeds
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
 
         // WHEN a device publishes an event message

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -650,7 +650,8 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
         final Future<TenantObject> tenantTracker = getTenantConfiguration(tenant, currentSpan.context());
         final Future<TenantObject> tenantValidationTracker = tenantTracker
                 .compose(tenantObject -> CompositeFuture
-                        .all(isAdapterEnabled(tenantObject), checkMessageLimit(tenantObject, payloadSize))
+                        .all(isAdapterEnabled(tenantObject),
+                                checkMessageLimit(tenantObject, payloadSize, currentSpan.context()))
                         .map(success -> tenantObject));
 
         // we only need to consider TTD if the device and tenant are enabled and the adapter
@@ -981,7 +982,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             if (isCommandValid(command, currentSpan)) {
 
                 if (requestProcessed.compareAndSet(false, true)) {
-                    checkMessageLimit(tenantObject, command.getPayloadSize())
+                    checkMessageLimit(tenantObject, command.getPayloadSize(), currentSpan.context())
                     .setHandler(result -> {
                         if (result.succeeded()) {
                             addMicrometerSample(commandContext, commandSample);
@@ -1204,7 +1205,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                             currentSpan.context());
                     final Future<Void> tenantValidationTracker = CompositeFuture
                             .all(isAdapterEnabled(tenantTracker.result()),
-                                    checkMessageLimit(tenantTracker.result(), payload.length()))
+                                    checkMessageLimit(tenantTracker.result(), payload.length(), currentSpan.context()))
                             .map(ok -> null);
 
                     return CompositeFuture.all(tenantValidationTracker, deviceRegistrationTracker)

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -183,7 +183,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), any(Handler.class), any(Handler.class)))
             .thenReturn(Future.succeededFuture(commandConsumer));
         resourceLimitChecks = mock(ResourceLimitChecks.class);
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.FALSE));
     }
 
@@ -831,7 +831,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         final RoutingContext routingContext = newRoutingContext(payload);
 
         // WHEN the message limit exceeds
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         // WHEN a device that belongs to "my-tenant" publishes a telemetry message
         adapter.uploadTelemetryMessage(routingContext, "my-tenant", "the-device", payload, "application/text");
@@ -868,7 +868,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         final RoutingContext routingContext = newRoutingContext(payload);
 
         // WHEN the message limit exceeds
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         // WHEN a device that belongs to "my-tenant" publishes an event message
         adapter.uploadEventMessage(routingContext, "my-tenant", "the-device", payload, "application/text");
@@ -902,7 +902,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         givenACommandResponseSenderForOutcome(outcome.future());
 
         // WHEN the message limit exceeds
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         // WHEN a device publishes a command response
         final Buffer payload = Buffer.buffer("some payload");

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -190,9 +190,9 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
         authHandler = mock(AuthHandler.class);
         resourceLimitChecks = mock(ResourceLimitChecks.class);
-        when(resourceLimitChecks.isConnectionLimitReached(any(TenantObject.class)))
+        when(resourceLimitChecks.isConnectionLimitReached(any(TenantObject.class), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.FALSE));
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.FALSE));
 
         tenantObjectWithAuthIdProvider = mock(ExecutionContextTenantAndAuthIdProvider.class);
@@ -1102,7 +1102,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         // WHEN a device tries to establish a connection
         when(authHandler.authenticateDevice(any(MqttContext.class)))
                 .thenReturn(Future.succeededFuture(new DeviceUser("DEFAULT_TENANT", "4711")));
-        when(resourceLimitChecks.isConnectionLimitReached(any(TenantObject.class)))
+        when(resourceLimitChecks.isConnectionLimitReached(any(TenantObject.class), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         final MqttEndpoint endpoint = getMqttEndpointAuthenticated();
         adapter.handleEndpointConnection(endpoint);
@@ -1126,7 +1126,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
                 getMqttServer(false));
         forceClientMocksToConnected();
 
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         final DownstreamSender sender = mock(DownstreamSender.class);
         when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString()))
@@ -1171,7 +1171,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
                 getMqttServer(false));
         forceClientMocksToConnected();
 
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
         final DownstreamSender sender = mock(DownstreamSender.class);
         when(downstreamSenderFactory.getOrCreateEventSender(anyString()))
@@ -1217,7 +1217,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         forceClientMocksToConnected();
 
         // WHEN the message limit exceeds
-        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong()))
+        when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
 
         // WHEN a device of "tenant" publishes a command response message

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -535,6 +535,6 @@ public abstract class AbstractAdapterConfig {
     public ResourceLimitChecks resourceLimitChecks() {
         final PrometheusBasedResourceLimitChecksConfig config = resourceLimitChecksConfig();
         return new PrometheusBasedResourceLimitChecks(WebClient.create(vertx()), config,
-                newCaffeineCache(config.getCacheMinSize(), config.getCacheMaxSize()));
+                newCaffeineCache(config.getCacheMinSize(), config.getCacheMaxSize()), getTracer());
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/NoopResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/NoopResourceLimitChecks.java
@@ -12,8 +12,10 @@
  *******************************************************************************/
 package org.eclipse.hono.service.resourcelimits;
 
-import io.vertx.core.Future;
 import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
 
 /**
  * A no-op implementation for the limit check which always passes all checks.
@@ -26,8 +28,19 @@ public class NoopResourceLimitChecks implements ResourceLimitChecks {
     }
 
     @Override
+    public Future<Boolean> isConnectionLimitReached(final TenantObject tenantObject, final SpanContext spanContext) {
+        return Future.succeededFuture(Boolean.FALSE);
+    }
+
+    @Override
     public Future<Boolean> isMessageLimitReached(final TenantObject tenantObject,
             final long payloadSize) {
+        return Future.succeededFuture(Boolean.FALSE);
+    }
+
+    @Override
+    public Future<Boolean> isMessageLimitReached(final TenantObject tenantObject, final long payloadSize,
+            final SpanContext spanContext) {
         return Future.succeededFuture(Boolean.FALSE);
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/ResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/ResourceLimitChecks.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.service.resourcelimits;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.TenantObject;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 
 /**
@@ -31,8 +32,27 @@ public interface ResourceLimitChecks {
      *         <p>
      *         The future will be failed with a {@link ServiceInvocationException}
      *         if the check could not be performed.
+     * @throws NullPointerException if the tenant object is null.
+     * @deprecated Use {@link #isConnectionLimitReached(TenantObject, SpanContext)} instead.
      */
+    @Deprecated
     Future<Boolean> isConnectionLimitReached(TenantObject tenantObject);
+
+    /**
+     * Checks if the maximum number of connections configured for a tenant
+     * have been reached.
+     *
+     * @param tenantObject The tenant configuration to check the limit against.
+     * @param spanContext The currently active OpenTracing span context that is used to
+     *                    trace the limits verification or {@code null}
+     *                    if no span is currently active.
+     * @return A future indicating the outcome of the check.
+     *         <p>
+     *         The future will be failed with a {@link ServiceInvocationException}
+     *         if the check could not be performed.
+     * @throws NullPointerException if the tenant object is null.
+     */
+    Future<Boolean> isConnectionLimitReached(TenantObject tenantObject, SpanContext spanContext);
 
     /**
      * Checks if the maximum limit for the messages configured for a tenant
@@ -44,6 +64,26 @@ public interface ResourceLimitChecks {
      *         <p>
      *         The future will be failed with a {@link ServiceInvocationException}
      *         if the check could not be performed.
+     * @throws NullPointerException if the tenant object is null.
+     * @deprecated Use {@link #isMessageLimitReached(TenantObject, long, SpanContext)} instead.
      */
+    @Deprecated
     Future<Boolean> isMessageLimitReached(TenantObject tenantObject, long payloadSize);
+
+    /**
+     * Checks if the maximum limit for the messages configured for a tenant
+     * have been reached.
+     *
+     * @param tenantObject The tenant configuration to check the limit against.
+     * @param payloadSize The message payload size in bytes.
+     * @param spanContext The currently active OpenTracing span context that is used to
+     *                    trace the limits verification or {@code null}
+     *                    if no span is currently active.
+     * @throws NullPointerException if the tenant object is null.
+     * @return A future indicating the outcome of the check.
+     *         <p>
+     *         The future will be failed with a {@link ServiceInvocationException}
+     *         if the check could not be performed.
+     */
+    Future<Boolean> isMessageLimitReached(TenantObject tenantObject, long payloadSize, SpanContext spanContext);
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -524,12 +524,14 @@ public class AbstractProtocolAdapterBaseTest {
         // GIVEN an tenant for which the maximum number of connections has been reached
         final TenantObject tenant = TenantObject.from("my-tenant", Boolean.TRUE);
         final ResourceLimitChecks checks = mock(ResourceLimitChecks.class);
-        when(checks.isConnectionLimitReached(any(TenantObject.class))).thenReturn(Future.succeededFuture(Boolean.TRUE));
-        when(checks.isMessageLimitReached(any(TenantObject.class), anyLong())).thenReturn(Future.succeededFuture(Boolean.FALSE));
+        when(checks.isConnectionLimitReached(any(TenantObject.class), any(SpanContext.class)))
+                .thenReturn(Future.succeededFuture(Boolean.TRUE));
+        when(checks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
+                .thenReturn(Future.succeededFuture(Boolean.FALSE));
         adapter.setResourceLimitChecks(checks);
 
         // WHEN a device tries to connect
-        adapter.checkConnectionLimit(tenant).setHandler(ctx.failing(t -> {
+        adapter.checkConnectionLimit(tenant, mock(SpanContext.class)).setHandler(ctx.failing(t -> {
             // THEN the connection limit check fails
             ctx.verify(() -> assertThat(((ClientErrorException) t).getErrorCode(), is(HttpURLConnection.HTTP_FORBIDDEN)));
             ctx.completeNow();
@@ -547,12 +549,14 @@ public class AbstractProtocolAdapterBaseTest {
         // GIVEN an tenant for which the message limit has been reached
         final TenantObject tenant = TenantObject.from("my-tenant", Boolean.TRUE);
         final ResourceLimitChecks checks = mock(ResourceLimitChecks.class);
-        when(checks.isConnectionLimitReached(any(TenantObject.class))).thenReturn(Future.succeededFuture(Boolean.FALSE));
-        when(checks.isMessageLimitReached(any(TenantObject.class), anyLong())).thenReturn(Future.succeededFuture(Boolean.TRUE));
+        when(checks.isConnectionLimitReached(any(TenantObject.class), any(SpanContext.class)))
+                .thenReturn(Future.succeededFuture(Boolean.FALSE));
+        when(checks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
+                .thenReturn(Future.succeededFuture(Boolean.TRUE));
         adapter.setResourceLimitChecks(checks);
 
         // WHEN a device tries to connect
-        adapter.checkConnectionLimit(tenant).setHandler(ctx.failing(t -> {
+        adapter.checkConnectionLimit(tenant, mock(SpanContext.class)).setHandler(ctx.failing(t -> {
             // THEN the connection limit check fails
             ctx.verify(() -> assertThat(((ClientErrorException) t).getErrorCode(), is(HttpURLConnection.HTTP_FORBIDDEN)));
             ctx.completeNow();


### PR DESCRIPTION
This is a PR for  #1440. 

_Summary of changes:_
* The _ResourceLimitChecks_ interface has been extended here with methods to include an argument of type `SpanContext` to support tracing and the old methods are deprecated.
* Now in the default Prometheus based _resource-limits_ implementation several events are being traced.
* The existing methods `checkConnectionLimit(...)` and `checkMessageLimit(..)` in the base adapter class are deprecated and new methods that take an extra argument of type `SpanContext`are added.
* The protocol adapters now support the tracing of resource limit checks by making use of the above methods with an extra `SpanContext` argument.