### PR TITLE
Prevent NPE in closeAndFree() if connection is not established

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -353,10 +353,12 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
      * <p>
      * This method is equivalent to {@link #closeAndFree(ProtonLink, long, Handler)}
      * but will use an implementation specific default time-out value.
+     * <p>
+     * If this connection is not established, the given handler is invoked immediately.
      *
      * @param link The link to close. If {@code null}, the given handler is invoked immediately.
      * @param closeHandler The handler to notify once the link has been closed.
-     * @throws NullPointerException if context or close handler are {@code null}.
+     * @throws NullPointerException if close handler is {@code null}.
      */
     void closeAndFree(ProtonLink<?> link, Handler<Void> closeHandler);
 
@@ -369,13 +371,15 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
      * <li>the given number of milliseconds have passed</li>
      * </ul>
      * Afterwards the link's resources are freed up.
+     * <p>
+     * If this connection is not established, the given handler is invoked immediately.
      *
      * @param link The link to close. If {@code null}, the given handler is invoked immediately.
      * @param detachTimeOut The maximum number of milliseconds to wait for the peer's
      *                      detach frame or 0, if this method should wait indefinitely
      *                      for the peer's detach frame.
      * @param closeHandler The handler to notify once the link has been closed.
-     * @throws NullPointerException if context or close handler are {@code null}.
+     * @throws NullPointerException if close handler is {@code null}.
      * @throws IllegalArgumentException if detach time-out is &lt; 0.
      */
     void closeAndFree(

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
@@ -597,14 +597,19 @@ public class HonoConnectionImpl implements HonoConnection {
      *
      * @param link The link to close. If {@code null}, the given handler is invoked immediately.
      * @param closeHandler The handler to notify once the link has been closed.
-     * @throws NullPointerException if context or close handler are {@code null}.
+     * @throws NullPointerException if close handler is {@code null}.
      */
     @Override
     public void closeAndFree(
             final ProtonLink<?> link,
             final Handler<Void> closeHandler) {
 
-        HonoProtonHelper.closeAndFree(context, link, closeHandler);
+        if (context == null) {
+            // this means that the connection to the peer is not established (yet)
+            closeHandler.handle(null);
+        } else {
+            HonoProtonHelper.closeAndFree(context, link, closeHandler);
+        }
     }
 
     /**
@@ -619,7 +624,12 @@ public class HonoConnectionImpl implements HonoConnection {
             final long detachTimeOut,
             final Handler<Void> closeHandler) {
 
-        HonoProtonHelper.closeAndFree(context, link, detachTimeOut, closeHandler);
+        if (context == null) {
+            // this means that the connection to the peer is not established (yet)
+            closeHandler.handle(null);
+        } else {
+            HonoProtonHelper.closeAndFree(context, link, detachTimeOut, closeHandler);
+        }
     }
 
     /**


### PR DESCRIPTION
This prevents an NPE like this:
````
2019-11-18 10:34:59.443 [vert.x-eventloop-thread-0] DEBUG o.e.h.client.impl.AbstractHonoClient - locally closing receiver link [command_response/someTenant/someDevice]
Nov 18, 2019 10:34:59 AM io.vertx.core.impl.ContextImpl
SEVERE: Unhandled exception
java.lang.NullPointerException
  at java.base/java.util.Objects.requireNonNull(Objects.java:221)
  at org.eclipse.hono.util.HonoProtonHelper.closeAndFree(HonoProtonHelper.java:236)
  at org.eclipse.hono.util.HonoProtonHelper.closeAndFree(HonoProtonHelper.java:207)
  at org.eclipse.hono.client.impl.HonoConnectionImpl.closeAndFree(HonoConnectionImpl.java:582)
  at org.eclipse.hono.client.impl.AbstractHonoClient.lambda$closeLinks$1(AbstractHonoClient.java:183)
  at org.eclipse.hono.client.impl.AbstractHonoClient.lambda$closeLinks$2(AbstractHonoClient.java:188)
  at org.eclipse.hono.util.HonoProtonHelper.lambda$closeAndFree$8(HonoProtonHelper.java:273)
  at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:125)
  at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:132)
  at org.eclipse.hono.util.HonoProtonHelper.lambda$closeAndFree$5(HonoProtonHelper.java:253)
  at io.vertx.core.impl.VertxImpl$InternalTimerHandler.handle(VertxImpl.java:911)
  at io.vertx.core.impl.VertxImpl$InternalTimerHandler.handle(VertxImpl.java:875)
  at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
  at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43)
  at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:188)
  at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:180)
  at io.vertx.core.impl.VertxImpl$InternalTimerHandler.run(VertxImpl.java:901)
  at io.netty.util.concurrent.PromiseTask$RunnableAdapter.call(PromiseTask.java:38)
  at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:139)
  at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
  at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:510)
  at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:518)
  at io.netty.util.concurrent.SingleThreadEventExecutor$6.run(SingleThreadEventExecutor.java:1044)
  at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
  at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
  at java.base/java.lang.Thread.run(Thread.java:834)
````
