### PR TITLE
Fix example deployment to Kubernetes 1.16

### DIFF
--- a/deploy/src/main/deploy/helm/requirements.yaml
+++ b/deploy/src/main/deploy/helm/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: prometheus
-    version: ~8.15.0
+    version: ~9.3.0
     repository: "@stable"
     condition: prometheus.createInstance
   - name: grafana
-    version: ~3.7.3
+    version: ~3.8.15
     repository: "@stable"
     condition: grafana.enabled

--- a/deploy/src/main/deploy/helm/values.yaml
+++ b/deploy/src/main/deploy/helm/values.yaml
@@ -777,6 +777,18 @@ prometheus:
 grafana:
   enabled: true
   adminPassword: admin
+
+  # labels to be added to the Grafana Deployment
+  labels:
+    app.kubernetes.io/name: eclipse-hono
+    app.kubernetes.io/component: dashboard
+
+  # labels to be added to the Grafana Pod(s)
+  podLabels:
+    app.kubernetes.io/name: eclipse-hono
+    app.kubernetes.io/component: dashboard
+
+  
   ## Expose the grafana service to be accessed from outside the cluster (LoadBalancer service).
   ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
   ## ref: http://kubernetes.io/docs/user-guide/services/

--- a/site/documentation/content/deployment/helm-based-deployment.md
+++ b/site/documentation/content/deployment/helm-based-deployment.md
@@ -26,8 +26,10 @@ running Hono on another version, please try to deploy to 1.15.4 before raising a
 
 #### Helm
 
-Helm is a tool for managing (complex) Kubernetes applications. In this guide it is used to deploy Hono to the cluster.
+Helm is a tool for managing Kubernetes applications. In this guide, Helm is used to deploy Hono to the cluster.
 [Helm's installation instructions](https://helm.sh/docs/install/) provide more details.
+The Hono chart has been written for Helm version 2. It has not been tested (yet) with the recently released
+Helm 3 version.
 
 #### Kubectl
 
@@ -64,10 +66,12 @@ helm get hono
 ~~~
 
 {{% note title="Kubernetes 1.16" %}}
-Hono can not be deployed to Kubernetes 1.16 using Helm because current versions (< 2.15) of Helm [don't support installation of
-the Tiller component to Kubernetes 1.16](https://github.com/helm/helm/issues/6374).
-Until that problem is fixed in Helm, the workaround is to either deploy to an earlier version of Kubernetes or deploy using
-the *kubectl* command as described in the next section.
+Deploying the Hono chart to Kubernetes 1.16 or later requires Helm version 2.15 or later. Earlier versions [lack the ability to install
+the Tiller component to Kubernetes 1.16](https://github.com/helm/helm/issues/6374). Note that deploying the Hono chart using the recently
+release Helm 3 has not been tested yet.
+
+If using a recent version of Helm 2 is not an option, a workaround is to either deploy to an earlier version of Kubernetes
+or deploy using the *kubectl* command as described in the next section.
 {{% /note %}}
 
 ### Deploying Hono using kubectl
@@ -82,19 +86,6 @@ mkdir resources
 helm dep update eclipse-hono/
 helm template --name hono --namespace hono --output-dir resources eclipse-hono/
 ~~~
-
-{{% note title="Kubernetes 1.16" %}}
-Hono can currently only be deployed to Kubernetes 1.16 if Prometheus and Grafana are disabled.
-This is due to a [bug](https://github.com/helm/charts/pull/17268) in the Prometheus Helm chart which is used to deploy
-Prometheus as part of Hono' example deployment.
-Until the bug is fixed, the workaround is to disable deployment of Prometheus and Grafana by setting the following
-configuration properties when creating the resource descriptors:
-
-```sh
-# in directory: eclipse-hono-$VERSION
-helm template --name hono --namespace hono --set prometheus.createInstance=false --set grafana.enabled=false --output-dir resources eclipse-hono/
-```
-{{% /note %}}
 
 This will create a `resources/eclipse-hono` folder containing all the resource descriptors which can then be deployed to the cluster using `kubectl`:
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -12,6 +12,10 @@ title = "Release Notes"
   OpenTracing.
 * A lorawan provider has been added for the loriot network provider.
 
+### Fixes & Enhancements
+
+* The example deployment now also works with Kubernetes 1.16 using Helm 2.15 and later.
+
 ## 1.0.1
 
 ### Fixes & Enhancements


### PR DESCRIPTION
Updated Prometheus and Grafana charts to more recent versions which
support deployment to Kubernetes 1.16 and later.

This might also be a candidate for a 1.0.2 service release as IMHO people will quickly start to use Kubernetes 1.16 ...