### PR TITLE
[Idea] Share test helper classes among multiple maven modules

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -53,6 +53,13 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+      <type>test-jar</type>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-legal</artifactId>
     </dependency>
     <dependency>

--- a/client/src/test/java/org/eclipse/hono/client/impl/CredentialsClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CredentialsClientImplTest.java
@@ -24,13 +24,13 @@ import static org.mockito.Mockito.when;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 
-import io.vertx.core.Future;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.test.HonoUnitTestHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsObject;
@@ -47,6 +47,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -80,7 +81,7 @@ public class CredentialsClientImplTest {
 
         span = mock(Span.class);
         when(span.context()).thenReturn(spanContext);
-        final Tracer.SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
+        final Tracer.SpanBuilder spanBuilder = HonoUnitTestHelper.mockSpanBuilder(span);
 
         tracer = mock(Tracer.class);
         when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);

--- a/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
@@ -31,6 +31,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.test.HonoUnitTestHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
@@ -80,7 +81,7 @@ public class DeviceConnectionClientImplTest {
 
         span = mock(Span.class);
         when(span.context()).thenReturn(spanContext);
-        final SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
+        final SpanBuilder spanBuilder = HonoUnitTestHelper.mockSpanBuilder(span);
 
         tracer = mock(Tracer.class);
         when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);

--- a/client/src/test/java/org/eclipse/hono/client/impl/GatewayMapperImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/GatewayMapperImplTest.java
@@ -32,6 +32,7 @@ import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.test.HonoUnitTestHelper;
 import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.junit.Before;
@@ -64,7 +65,7 @@ public class GatewayMapperImplTest {
         final SpanContext spanContext = mock(SpanContext.class);
         span = mock(Span.class);
         when(span.context()).thenReturn(spanContext);
-        final Tracer.SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
+        final Tracer.SpanBuilder spanBuilder = HonoUnitTestHelper.mockSpanBuilder(span);
         final Tracer tracer = mock(Tracer.class);
         when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
 

--- a/client/src/test/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandlerTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/GatewayMappingCommandHandlerTest.java
@@ -29,6 +29,7 @@ import org.eclipse.hono.client.DeviceConnectionClient;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.RegistrationClientFactory;
+import org.eclipse.hono.test.HonoUnitTestHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.eclipse.hono.util.RegistrationConstants;
@@ -68,7 +69,7 @@ public class GatewayMappingCommandHandlerTest {
         final SpanContext spanContext = mock(SpanContext.class);
         final Span span = mock(Span.class);
         when(span.context()).thenReturn(spanContext);
-        final Tracer.SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
+        final Tracer.SpanBuilder spanBuilder = HonoUnitTestHelper.mockSpanBuilder(span);
         final Tracer tracer = mock(Tracer.class);
         when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
 

--- a/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
@@ -13,9 +13,6 @@
 
 package org.eclipse.hono.client.impl;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -23,11 +20,8 @@ import static org.mockito.Mockito.when;
 import org.apache.qpid.proton.amqp.transport.Target;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.mockito.Mockito;
 
-import io.opentracing.Span;
 import io.opentracing.Tracer;
-import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -91,26 +85,6 @@ public final class HonoClientUnitTestHelper {
         when(receiver.isOpen()).thenReturn(Boolean.TRUE);
 
         return receiver;
-    }
-
-    /**
-     * Creates a mocked OpenTracing SpanBuilder for creating a given Span.
-     * <p>
-     * All invocations on the mock are stubbed to return the builder by default.
-     * 
-     * @param spanToCreate The object that the <em>start</em> method of the
-     *                     returned builder should produce.
-     * @return The builder.
-     */
-    public static SpanBuilder mockSpanBuilder(final Span spanToCreate) {
-        final SpanBuilder spanBuilder = mock(SpanBuilder.class, Mockito.RETURNS_SMART_NULLS);
-        when(spanBuilder.addReference(anyString(), any())).thenReturn(spanBuilder);
-        when(spanBuilder.withTag(anyString(), anyBoolean())).thenReturn(spanBuilder);
-        when(spanBuilder.withTag(anyString(), anyString())).thenReturn(spanBuilder);
-        when(spanBuilder.withTag(anyString(), (Number) any())).thenReturn(spanBuilder);
-        when(spanBuilder.ignoreActiveSpan()).thenReturn(spanBuilder);
-        when(spanBuilder.start()).thenReturn(spanToCreate);
-        return spanBuilder;
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientImplTest.java
@@ -31,6 +31,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.test.HonoUnitTestHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
@@ -81,7 +82,7 @@ public class RegistrationClientImplTest {
 
         span = mock(Span.class);
         when(span.context()).thenReturn(spanContext);
-        final SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
+        final SpanBuilder spanBuilder = HonoUnitTestHelper.mockSpanBuilder(span);
 
         tracer = mock(Tracer.class);
         when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);

--- a/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
@@ -37,6 +37,7 @@ import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.test.HonoUnitTestHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.TenantConstants;
@@ -91,7 +92,7 @@ public class TenantClientImplTest {
 
         span = mock(Span.class);
         when(span.context()).thenReturn(spanContext);
-        final SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
+        final SpanBuilder spanBuilder = HonoUnitTestHelper.mockSpanBuilder(span);
 
         tracer = mock(Tracer.class);
         when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -186,6 +186,22 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/test/*</include>
+          </includes>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>

--- a/core/src/test/java/org/eclipse/hono/test/HonoUnitTestHelper.java
+++ b/core/src/test/java/org/eclipse/hono/test/HonoUnitTestHelper.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.mockito.Mockito;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+
+/**
+ * Helper class that provides mocks for objects that are needed by other tests.
+ *
+ */
+public final class HonoUnitTestHelper {
+
+    private HonoUnitTestHelper() {
+    }
+
+    /**
+     * Creates a mocked OpenTracing SpanBuilder for creating a given Span.
+     * <p>
+     * All invocations on the mock are stubbed to return the builder by default.
+     * 
+     * @param spanToCreate The object that the <em>start</em> method of the
+     *                     returned builder should produce.
+     * @return The builder.
+     */
+    public static Tracer.SpanBuilder mockSpanBuilder(final Span spanToCreate) {
+        final Tracer.SpanBuilder spanBuilder = mock(Tracer.SpanBuilder.class, Mockito.RETURNS_SMART_NULLS);
+        when(spanBuilder.addReference(anyString(), any())).thenReturn(spanBuilder);
+        when(spanBuilder.withTag(anyString(), anyBoolean())).thenReturn(spanBuilder);
+        when(spanBuilder.withTag(anyString(), anyString())).thenReturn(spanBuilder);
+        when(spanBuilder.withTag(anyString(), (Number) any())).thenReturn(spanBuilder);
+        when(spanBuilder.ignoreActiveSpan()).thenReturn(spanBuilder);
+        when(spanBuilder.start()).thenReturn(spanToCreate);
+        return spanBuilder;
+    }
+}


### PR DESCRIPTION
While I was writing tests for #1440, I found out that I could reuse a method from a test helper class `HonoClientUnitTestHelper.mockSpanBuilder(...)` in tests across several modules. But it is not currently possible as test classes are not packaged by Maven. In order to share test helper classes among various modules, how about using _maven-jar_ plugin to build a jar with those _test-classes_ and then then add it as a dependency wherever needed. 

For example, a new package `org.eclipse.hono.test` under _tests_ folder in _core_ module could contain test helper classes that could be used by tests in other modules. The classes in this package could be used to create a _test-jar_ as below.

```
     <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-jar-plugin</artifactId>
        <configuration>
          <includes>
            <include>**/test/*</include>
          </includes>
        </configuration>
        <executions>
          <execution>
            <goals>
              <goal>test-jar</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
```

Then the above artifact containing test helper classes could be added as a dependency with type _test-jar_ as below.

```
    <dependency>
      <groupId>org.eclipse.hono</groupId>
      <artifactId>hono-core</artifactId>
      <type>test-jar</type>
      <version>${project.version}</version>
      <scope>test</scope>
    </dependency>
```
WDYT?
