### PR TITLE
Fix tracing of received commands

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandConsumerFactoryImpl.java
@@ -394,7 +394,7 @@ public class CommandConsumerFactoryImpl extends AbstractHonoClientFactory implem
                     }
                     final Command command = Command.from(message, tenantId, deviceId);
                     final SpanContext spanContext = TracingHelper.extractSpanContext(connection.getTracer(), message);
-                    final Span currentSpan = CommandConsumer.createSpan("delegate and send command", tenantId, deviceId, connection.getTracer(), spanContext);
+                    final Span currentSpan = CommandConsumer.createSpan("delegate and send command", tenantId, deviceId, null, connection.getTracer(), spanContext);
                     CommandConsumer.logReceivedCommandToSpan(command, currentSpan);
                     final CommandContext commandContext = CommandContext.from(command, originalMessageDelivery, receiverRefHolder.get(), currentSpan);
                     if (command.isValid()) {

--- a/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
@@ -76,8 +76,6 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
         Objects.requireNonNull(rawMessage);
 
         final Span span = startSpan(parent, rawMessage);
-        span.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, MessageHelper.getTenantId(rawMessage));
-        span.setTag(MessageHelper.APP_PROPERTY_DEVICE_ID, MessageHelper.getDeviceId(rawMessage));
         TracingHelper.injectSpanContext(connection.getTracer(), span.context(), rawMessage);
 
         return runSendAndWaitForOutcomeOnContext(rawMessage, span);
@@ -182,8 +180,20 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
         Objects.requireNonNull(command);
         final String replyToAddress = command.isOneWay() ? null
                 : String.format("%s/%s/%s", command.getReplyToEndpoint(), command.getTenant(), command.getReplyToId());
-        return sendAndWaitForOutcome(createDelegatedCommandMessage(command.getCommandMessage(), replyToAddress),
-                spanContext);
+
+        final Message rawMessage = createDelegatedCommandMessage(command.getCommandMessage(), replyToAddress);
+
+        final Span span = startSpan(spanContext, rawMessage);
+        span.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, command.getTenant());
+        if (command.isTargetedAtGateway()) {
+            span.setTag(MessageHelper.APP_PROPERTY_DEVICE_ID, command.getOriginalDeviceId());
+            span.setTag(MessageHelper.APP_PROPERTY_GATEWAY_ID, command.getDeviceId());
+        } else {
+            span.setTag(MessageHelper.APP_PROPERTY_DEVICE_ID, command.getDeviceId());
+        }
+        TracingHelper.injectSpanContext(connection.getTracer(), span.context(), rawMessage);
+
+        return runSendAndWaitForOutcomeOnContext(rawMessage, span);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/DestinationCommandConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DestinationCommandConsumer.java
@@ -144,7 +144,7 @@ public final class DestinationCommandConsumer extends CommandConsumer {
         return receiver.isOpen() && !closedCalled.get();
     }
 
-    private void handleCommandMessage(final Message msg,  final ProtonDelivery delivery) {
+    private void handleCommandMessage(final Message msg, final ProtonDelivery delivery) {
         // command could have been mapped to a gateway, but the original address stays the same in the message address in that case
         // (the case of the address being null means that the message was sent by an application to the legacy control endpoint)
         final String originalDeviceId = msg.getAddress() != null
@@ -157,8 +157,10 @@ public final class DestinationCommandConsumer extends CommandConsumer {
             final Tracer tracer = connection.getTracer();
             // try to extract Span context from incoming message
             final SpanContext spanContext = TracingHelper.extractSpanContext(tracer, msg);
-            final Span currentSpan = createSpan("send command", tenantId, gatewayOrDeviceId,
-                    tracer, spanContext);
+            final String targetDeviceId = originalDeviceId != null ? originalDeviceId : gatewayOrDeviceId;
+            final String gatewayId = gatewayOrDeviceId.equals(targetDeviceId) ? null : gatewayOrDeviceId;
+            final Span currentSpan = createSpan("send command", tenantId, targetDeviceId,
+                    gatewayId, tracer, spanContext);
             logReceivedCommandToSpan(command, currentSpan);
             commandHandler.handleCommand(CommandContext.from(command, delivery, this.receiver, currentSpan));
         } else {


### PR DESCRIPTION
This fixes the `delegate Command request` tracing span containing `null` values for tenant and device id.
It also sets a `gateway_id` span tag if applicable.