### PR TITLE
[#1645] Add tenant option disabling gateway mapping (HTTP adapter)

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -676,4 +676,16 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
             });
         }
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Marked as final since overriding this method doesn't make sense here (command &amp; control is not
+     * supported for now).
+     */
+    @Override
+    protected final Future<Boolean> isGatewayMappingEnabled(final String tenantId, final String deviceId,
+            final Device authenticatedDevice) {
+        return Future.succeededFuture(true);
+    }
 }

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -46,8 +46,10 @@ import org.eclipse.hono.service.metric.MetricsTags.QoS;
 import org.eclipse.hono.service.metric.MetricsTags.TtdStatus;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.JsonHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -83,6 +85,13 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      * Default file uploads directory used by Vert.x Web.
      */
     protected static final String DEFAULT_UPLOADS_DIRECTORY = "/tmp";
+
+    /**
+     * The name of the boolean field in the tenant configuration (inside the 'ext' field of an 'hono-http' type
+     * 'adapters' entry) that defines whether concurrent requests from gateway to get commands for specific devices
+     * shall be supported.
+     */
+    static final String FIELD_SUPPORT_CONCURRENT_GATEWAY_DEVICE_COMMAND_REQUESTS = "support-concurrent-gateway-device-command-requests";
 
     private static final String KEY_TIMER_ID = "timerId";
 
@@ -1041,22 +1050,30 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             // command consumer is closed by closeHandler, no explicit close necessary here
         };
 
-        final Future<MessageConsumer> commandConsumerFuture;
-        if (gatewayId != null) {
-            // gateway scenario
-            commandConsumerFuture = getCommandConsumerFactory().createCommandConsumer(
-                    tenantObject.getTenantId(),
-                    deviceId,
-                    gatewayId,
-                    commandHandler,
-                    remoteCloseHandler);
-        } else {
-            commandConsumerFuture = getCommandConsumerFactory().createCommandConsumer(
-                    tenantObject.getTenantId(),
-                    deviceId,
-                    commandHandler,
-                    remoteCloseHandler);
-        }
+        // First check whether the tenant has been configured to support concurrent ttd-param requests from the same
+        // gateway for different devices. In that case a device-specific (instead of a gateway-specific) consumer link will be created below
+        // (preventing multiple consumer links on the same gateway address from multiple HTTP adapter instances).
+        final Future<MessageConsumer> commandConsumerFuture = isSupportConcurrentGatewayDeviceCommandRequests(tenantObject)
+                .compose(supportConcurrentGatewayDeviceCommandRequests -> {
+                    if (gatewayId != null && !supportConcurrentGatewayDeviceCommandRequests) {
+                        // gateway scenario
+                        return getCommandConsumerFactory().createCommandConsumer(
+                                tenantObject.getTenantId(),
+                                deviceId,
+                                gatewayId,
+                                commandHandler,
+                                remoteCloseHandler);
+                    } else {
+                        if (gatewayId != null) {
+                            log.trace("gateway mapping disabled for tenant [{}], will create device-specific consumer", tenantObject.getTenantId());
+                        }
+                        return getCommandConsumerFactory().createCommandConsumer(
+                                tenantObject.getTenantId(),
+                                deviceId,
+                                commandHandler,
+                                remoteCloseHandler);
+                    }
+                });
         return commandConsumerFuture
                 .map(consumer -> {
                     if (!requestProcessed.get()) {
@@ -1083,6 +1100,38 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                         return Future.failedFuture(t);
                     }
                 });
+    }
+
+    @Override
+    protected final Future<Boolean> isGatewayMappingEnabled(final String tenantId, final String deviceId,
+            final Device authenticatedDevice) {
+        // If we want to support concurrent ttd requests from one gateway for multiple devices,
+        // we have to disable the gateway mapping.
+        return isSupportConcurrentGatewayDeviceCommandRequests(tenantId)
+                .map(supportConcurrentRequests -> {
+                    if (supportConcurrentRequests) {
+                        log.trace("gateway mapping disabled for tenant [{}]", tenantId);
+                    }
+                    return !supportConcurrentRequests;
+                })
+                .recover(t -> {
+                    log.debug("error determining whether gateway mapping is enabled, assuming true", t);
+                    return Future.succeededFuture(true);
+                });
+    }
+
+    private Future<Boolean> isSupportConcurrentGatewayDeviceCommandRequests(final String tenantId) {
+        return getTenantConfiguration(tenantId, null)
+                .compose(this::isSupportConcurrentGatewayDeviceCommandRequests);
+    }
+
+    private Future<Boolean> isSupportConcurrentGatewayDeviceCommandRequests(final TenantObject tenantObject) {
+        final Boolean result = Optional.ofNullable(tenantObject.getAdapterConfiguration(getTypeName()))
+                .map(conf -> JsonHelper.getValue(conf, TenantConstants.FIELD_EXT, JsonObject.class, null))
+                .map(extension -> JsonHelper.getValue(extension,
+                        FIELD_SUPPORT_CONCURRENT_GATEWAY_DEVICE_COMMAND_REQUESTS, Boolean.class, false))
+                .orElse(false);
+        return Future.succeededFuture(result);
     }
 
     /**

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -677,6 +677,18 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         });
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * Marked as final since the way command handling is implemented here requires the
+     * gateway mapping to be enabled.
+     */
+    @Override
+    protected final Future<Boolean> isGatewayMappingEnabled(final String tenantId, final String deviceId,
+            final Device authenticatedDevice) {
+        return Future.succeededFuture(true);
+    }
+
     private Span newSpan(final String operationName, final MqttEndpoint endpoint, final Device authenticatedDevice,
             final OptionalInt traceSamplingPriority) {
         final Span span = tracer.buildSpan(operationName)

--- a/core/src/main/java/org/eclipse/hono/util/JsonBackedValueObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/JsonBackedValueObject.java
@@ -14,7 +14,6 @@
 package org.eclipse.hono.util;
 
 import java.util.Map;
-import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -81,7 +80,7 @@ abstract class JsonBackedValueObject {
      * @param clazz The target type.
      * @param <T> The type of the property.
      * @return The property value or {@code null} if the property is not set or is of an unexpected type.
-     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
      */
     protected static final <T> T getProperty(final JsonObject parent, final String name, final Class<T> clazz) {
         return getProperty(parent, name, clazz, null);
@@ -92,22 +91,14 @@ abstract class JsonBackedValueObject {
      * 
      * @param parent The JSON to get the property value from.
      * @param name The property name.
-     * @param defaultValue A default value to return if the property is {@code null}.
+     * @param defaultValue A default value to return if the property is {@code null} or is of an unexpected type.
      * @param clazz The target type.
      * @param <T> The type of the property.
      * @return The property value or the given default value if the property is not set or is of an unexpected type.
-     * @throws NullPointerException if any of parent or name are {@code null}.
+     * @throws NullPointerException if any of the parameters except defaultValue is {@code null}.
      */
     protected static final <T> T getProperty(final JsonObject parent, final String name, final Class<T> clazz,
             final T defaultValue) {
-        final Object value = parent.getValue(Objects.requireNonNull(name), defaultValue);
-        if (value == null) {
-            return defaultValue;
-        }
-        try {
-            return clazz.cast(value);
-        } catch (final ClassCastException e) {
-            return defaultValue;
-        }
+        return JsonHelper.getValue(parent, name, clazz, defaultValue);
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/JsonHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/JsonHelper.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.util;
+
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A helper class for working with {@link JsonObject}s.
+ */
+public final class JsonHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JsonHelper.class);
+
+    private JsonHelper() {
+    }
+
+    /**
+     * Gets a value from the given JSON object.
+     *
+     * @param jsonObject The JSON object to get the value from.
+     * @param name The key to return the value for.
+     * @param defaultValue A default value to return if the value is {@code null} or is of an unexpected type.
+     * @param clazz The target type.
+     * @param <T> The type of the value.
+     * @return The value or the given default value if the value is not set or is of an unexpected type.
+     * @throws NullPointerException if any of the parameters except defaultValue is {@code null}.
+     */
+    public static <T> T getValue(final JsonObject jsonObject, final String name, final Class<T> clazz,
+                                             final T defaultValue) {
+        final Object value = jsonObject.getValue(Objects.requireNonNull(name), defaultValue);
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return clazz.cast(value);
+        } catch (final ClassCastException e) {
+            LOG.debug("unexpected value type for field [{}]: {}; expected: {}", name, value.getClass().getSimpleName(),
+                    clazz.getSimpleName());
+            return defaultValue;
+        }
+    }
+}

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -232,6 +232,11 @@ This resource can be used by *gateway* components to publish data *on behalf of*
 
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/http-adapter-config#device-registration-service-connection-configuration" >}}).
 
+{{% note %}}
+When sending requests with the `hono-ttd` header in order to receive a command for a specific device connected to the gateway, it has to be noted that multiple concurrent such requests for the same gateway but different devices may lead to some commands not getting forwarded to the gateway.
+To resolve such potential issues, the corresponding tenant can be configured with a `support-concurrent-gateway-device-command-requests` option set to `true` in the `ext` field of an `adapters` entry of type `hono-http`. Note that with this option it is not supported for the authenticated gateway to send _one_ message with a `hono-ttd` header and no device id to receive commands for *any* device that has last sent a telemetry or event message via this gateway.
+{{% /note %}}
+
 **Examples**
 
 Publish some JSON data for device `4712`:
@@ -397,6 +402,11 @@ content-length: 0
 This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/http-adapter-config#device-registration-service-connection-configuration" >}}).
+
+{{% note %}}
+When sending requests with the `hono-ttd` header in order to receive a command for a specific device connected to the gateway, it has to be noted that multiple concurrent such requests for the same gateway but different devices may lead to some commands not getting forwarded to the gateway.
+To resolve such potential issues, the corresponding tenant can be configured with a `support-concurrent-gateway-device-command-requests` option set to `true` in the `ext` field of an `adapters` entry of type `hono-http`. Note that with this option it is not supported for the authenticated gateway to send _one_ message with a `hono-ttd` header and no device id to receive commands for *any* device that has last sent a telemetry or event message via this gateway.
+{{% /note %}}
 
 **Examples**
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -33,6 +33,15 @@ title = "Release Notes"
   anymore until the adapter instance had been restarted. This has been fixed.
 * The example data grid which can be deployed using the Hono Helm chart can now be scaled
   out to more than one node.
+* A potential issue has been identified where some command messages might not get sent to
+  the corresponding gateway. The scenario here involves the gateway sending event/telemetry
+  messages via HTTP with a `hono-ttd` header in order to receive commands, and doing so
+  with multiple concurrent requests for *different* devices. To resolve this issue, the 
+  corresponding tenant can be configured with a `support-concurrent-gateway-device-command-requests`
+  option set to `true` in the `ext` field of an `adapters` entry of type `hono-http`.
+  Note that with this option it is not supported for the authenticated gateway to send
+  _one_ message with a `hono-ttd` header and no device id to receive commands for *any*
+  device that has last sent a telemetry or event message via this gateway.
 
 ## 1.0.1
 

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -22,6 +22,7 @@ import java.security.KeyPair;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -95,6 +96,7 @@ public abstract class HttpTestBase {
 
     private static final String COMMAND_TO_SEND = "setBrightness";
     private static final String COMMAND_JSON_KEY = "brightness";
+    private static final String FIELD_SUPPORT_CONCURRENT_GATEWAY_DEVICE_COMMAND_REQUESTS = "support-concurrent-gateway-device-command-requests";
 
     private static final String ORIGIN_WILDCARD = "*";
     private static final Vertx VERTX = Vertx.vertx();
@@ -228,6 +230,16 @@ public abstract class HttpTestBase {
                 new HttpCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_SINGLE_DEVICE, false, false),
                 new HttpCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_SINGLE_DEVICE, true, false)
                 );
+    }
+
+    /**
+     * Creates the endpoint configuration variants for Command &amp; Control scenarios where gateway mapping
+     * shall be disabled (the 'GATEWAY_FOR_ALL_DEVICES' case is not supported there).
+     *
+     * @return The configurations.
+     */
+    static Stream<HttpCommandEndpointConfiguration> commandAndControlVariantsForTestsWithGatewayMappingDisabled() {
+        return commandAndControlVariants().filter(endpointConfig -> !endpointConfig.isSubscribeAsGatewayForAllDevices());
     }
 
     /**
@@ -920,6 +932,34 @@ public abstract class HttpTestBase {
             final VertxTestContext ctx) throws InterruptedException {
 
         final Tenant tenant = new Tenant();
+        testUploadMessagesWithTtdThatReplyWithCommand(endpointConfig, tenant, ctx);
+    }
+
+    /**
+     * Verifies that the HTTP adapter delivers a command to a device and accepts the corresponding
+     * response from the device, all while using a tenant that has the "support-concurrent-gateway-device-command-requests"
+     * option set.
+     *
+     * @param endpointConfig The endpoints to use for sending/receiving commands.
+     * @param ctx The test context.
+     * @throws InterruptedException if the test fails.
+     */
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("commandAndControlVariantsForTestsWithGatewayMappingDisabled")
+    public void testUploadMessagesWithTtdThatReplyWithCommandWithGatewayMappingDisabled(
+            final HttpCommandEndpointConfiguration endpointConfig,
+            final VertxTestContext ctx) throws InterruptedException {
+
+        final Tenant tenant = new Tenant();
+        final Adapter adapterConfig = new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_HTTP);
+        adapterConfig.setEnabled(true);
+        adapterConfig.setExtensions(Map.of(FIELD_SUPPORT_CONCURRENT_GATEWAY_DEVICE_COMMAND_REQUESTS, true));
+        tenant.addAdapterConfig(adapterConfig);
+        testUploadMessagesWithTtdThatReplyWithCommand(endpointConfig, tenant, ctx);
+    }
+
+    private void testUploadMessagesWithTtdThatReplyWithCommand(final HttpCommandEndpointConfiguration endpointConfig,
+            final Tenant tenant, final VertxTestContext ctx) throws InterruptedException {
         final VertxTestContext setup = new VertxTestContext();
 
         final MultiMap requestHeaders = MultiMap.caseInsensitiveMultiMap()


### PR DESCRIPTION
This fixes #1645.
This prevents issues with commands not reaching the correct adapter instance in case of concurrent HTTP requests. 
The solution here is to effectively disable the command gateway mapping for HTTP adapters by:
- always creating a device specific command consumer link (even if a gateway is involved)
- always mapping the `last-known-gateway` to the device id itself, not the gateway.

This changed behaviour is only enabled for tenants having the new `support-concurrent-gateway-device-command-requests` option set to `true` in the `adapters/ext` field.

This change can probably be reverted again once #1272 is implemented and adapter-specific command consumer links are introduced.