### PR TITLE
[#1661, #504] Include MQTT client ID in Credentials.get request

### DIFF
--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/ConnectPacketAuthHandlerTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/ConnectPacketAuthHandlerTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.mqtt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
+import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.mqtt.MqttAuth;
+import io.vertx.mqtt.MqttEndpoint;
+
+
+/**
+ * Tests verifying behavior of {@link ConnectPacketAuthHandler}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+public class ConnectPacketAuthHandlerTest {
+
+    private ConnectPacketAuthHandler authHandler;
+    private HonoClientBasedAuthProvider<UsernamePasswordCredentials> authProvider;
+
+    /**
+     * Sets up the fixture.
+     */
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    public void setUp() {
+        authProvider = mock(HonoClientBasedAuthProvider.class);
+        authHandler = new ConnectPacketAuthHandler(authProvider, NoopTracerFactory.create());
+    }
+
+    /**
+     * Verifies that the handler includes the MQTT client identifier in the authentication
+     * information retrieved from a device's CONNECT packet.
+     * 
+     * @param ctx The vert.x test context.
+     * @throws SSLPeerUnverifiedException if the client certificate cannot be determined.
+     */
+    @Test
+    public void testParseCredentialsIncludesMqttClientId(final VertxTestContext ctx) throws SSLPeerUnverifiedException {
+
+        // GIVEN an auth handler configured with an auth provider
+
+        // WHEN trying to authenticate a device using a username and password
+        final MqttAuth auth = mock(MqttAuth.class);
+        when(auth.getUsername()).thenReturn("sensor1@DEFAULT_TENANT");
+        when(auth.getPassword()).thenReturn("secret");
+
+        final MqttEndpoint endpoint = mock(MqttEndpoint.class);
+        when(endpoint.auth()).thenReturn(auth);
+        when(endpoint.clientIdentifier()).thenReturn("mqtt-device");
+
+        final MqttContext context = MqttContext.fromConnectPacket(endpoint);
+        authHandler.parseCredentials(context)
+            // THEN the auth info is correctly retrieved from the client certificate
+            .setHandler(ctx.succeeding(info -> {
+                ctx.verify(() -> {
+                    assertThat(info.getString("username")).isEqualTo("sensor1@DEFAULT_TENANT");
+                    assertThat(info.getString("password")).isEqualTo("secret");
+                    assertThat(info.getString(X509AuthHandler.PROPERTY_CLIENT_IDENTIFIER)).isEqualTo("mqtt-device");
+                });
+                ctx.completeNow();
+            }));
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/AuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/AuthHandler.java
@@ -37,6 +37,7 @@ public interface AuthHandler<T extends ExecutionContext> {
      * 
      * @param context The execution context.
      * @return The credentials.
+     * @throws NullPointerException if the context is {@code null}
      */
     Future<JsonObject> parseCredentials(T context);
 
@@ -45,6 +46,7 @@ public interface AuthHandler<T extends ExecutionContext> {
      * 
      * @param context The execution context.
      * @return The authenticated device.
+     * @throws NullPointerException if the context is {@code null}
      */
     Future<DeviceUser> authenticateDevice(T context);
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/ExecutionContextAuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/ExecutionContextAuthHandler.java
@@ -72,24 +72,23 @@ public abstract class ExecutionContextAuthHandler<T extends ExecutionContext> im
 
         final Promise<DeviceUser> result = Promise.promise();
         parseCredentials(context)
-        .compose(authInfo -> {
-            final Promise<User> authResult = Promise.promise();
-            getAuthProvider(context).authenticate(authInfo, authResult);
-            return authResult.future();
-        })
-        .setHandler(authAttempt -> {
-            if (authAttempt.succeeded()) {
-                if (authAttempt.result() instanceof DeviceUser) {
-                    result.complete((DeviceUser) authAttempt.result());
-                } else {
-                    log.warn("configured AuthProvider does not return DeviceUser instances [type returned: {}",
-                            authAttempt.result().getClass().getName());
-                    result.fail(new ClientErrorException(HttpURLConnection.HTTP_UNAUTHORIZED));
-                }
-            } else {
-                result.fail(authAttempt.cause());
-            }
-        });
+                .compose(authInfo -> {
+                    final Promise<User> authResult = Promise.promise();
+                    getAuthProvider(context).authenticate(authInfo, authResult);
+                    return authResult.future();
+                }).setHandler(authAttempt -> {
+                    if (authAttempt.succeeded()) {
+                        if (authAttempt.result() instanceof DeviceUser) {
+                            result.complete((DeviceUser) authAttempt.result());
+                        } else {
+                            log.warn("configured AuthProvider does not return DeviceUser instances [type returned: {}",
+                                    authAttempt.result().getClass().getName());
+                            result.fail(new ClientErrorException(HttpURLConnection.HTTP_UNAUTHORIZED));
+                        }
+                    } else {
+                        result.fail(authAttempt.cause());
+                    }
+                });
         return result.future();
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/ExecutionContextAuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/ExecutionContextAuthHandler.java
@@ -15,6 +15,7 @@
 package org.eclipse.hono.service.auth.device;
 
 import java.net.HttpURLConnection;
+import java.util.Objects;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.auth.DeviceUser;
@@ -34,6 +35,12 @@ import io.vertx.ext.auth.User;
  * @param <T> The type of execution context this handler can authenticate.
  */
 public abstract class ExecutionContextAuthHandler<T extends ExecutionContext> implements AuthHandler<T> {
+
+    /**
+     * The name of the property that contains an authenticated device's transport protocol specific
+     * client identifier, e.g. the MQTT client identifier or an AMQP 1.0 container name.
+     */
+    public static final String PROPERTY_CLIENT_IDENTIFIER = "client-id";
 
     static final String AUTH_PROVIDER_CONTEXT_KEY = ExecutionContextAuthHandler.class.getName() + ".provider";
 
@@ -61,25 +68,28 @@ public abstract class ExecutionContextAuthHandler<T extends ExecutionContext> im
     @Override
     public Future<DeviceUser> authenticateDevice(final T context) {
 
+        Objects.requireNonNull(context);
+
         final Promise<DeviceUser> result = Promise.promise();
         parseCredentials(context)
-                .compose(authInfo -> {
-                    final Promise<User> authResult = Promise.promise();
-                    getAuthProvider(context).authenticate(authInfo, authResult);
-                    return authResult.future();
-                }).setHandler(authAttempt -> {
-                    if (authAttempt.succeeded()) {
-                        if (authAttempt.result() instanceof DeviceUser) {
-                            result.complete((DeviceUser) authAttempt.result());
-                        } else {
-                            log.warn("configured AuthProvider does not return DeviceUser instances [type returned: {}",
-                                    authAttempt.result().getClass().getName());
-                            result.fail(new ClientErrorException(HttpURLConnection.HTTP_UNAUTHORIZED));
-                        }
-                    } else {
-                        result.fail(authAttempt.cause());
-                    }
-                });
+        .compose(authInfo -> {
+            final Promise<User> authResult = Promise.promise();
+            getAuthProvider(context).authenticate(authInfo, authResult);
+            return authResult.future();
+        })
+        .setHandler(authAttempt -> {
+            if (authAttempt.succeeded()) {
+                if (authAttempt.result() instanceof DeviceUser) {
+                    result.complete((DeviceUser) authAttempt.result());
+                } else {
+                    log.warn("configured AuthProvider does not return DeviceUser instances [type returned: {}",
+                            authAttempt.result().getClass().getName());
+                    result.fail(new ClientErrorException(HttpURLConnection.HTTP_UNAUTHORIZED));
+                }
+            } else {
+                result.fail(authAttempt.cause());
+            }
+        });
         return result.future();
     }
 

--- a/service-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
@@ -60,6 +60,9 @@ import io.vertx.junit5.VertxTestContext.ExecutionBlock;
  */
 public abstract class AbstractCredentialsServiceTest {
 
+    protected static final JsonObject CLIENT_CONTEXT = new JsonObject()
+            .put("client-id", "some-client-identifier");
+
     /**
      * Gets credentials service being tested.
      * @return The credentials service
@@ -125,7 +128,7 @@ public abstract class AbstractCredentialsServiceTest {
     }
 
     /**
-     * Verifies that the service returns 404 if a client wants to retrieve non-existing credentials.
+     * Verifies that the service returns credentials for an existing device.
      *
      * @param ctx The vert.x test context.
      */
@@ -331,8 +334,11 @@ public abstract class AbstractCredentialsServiceTest {
 
                 mangementValidation.accept(s3);
 
-                getCredentialsService().get(tenantId, type,
+                getCredentialsService().get(
+                        tenantId,
+                        type,
                         authId,
+                        CLIENT_CONTEXT,
                         ctx.succeeding(s4 -> ctx.verify(() -> {
 
                             adapterValidation.accept(s4);

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
@@ -399,6 +399,29 @@ public final class FileBasedCredentialsService extends AbstractVerticle
                 continue;
             }
 
+            if (clientContext != null && !clientContext.isEmpty()) {
+
+                final JsonObject extensionProperties = authIdCredential.getJsonObject(RegistryManagementConstants.FIELD_EXT, new JsonObject());
+
+                final boolean credentialsOnRecordMatchClientContext = clientContext.stream()
+                        .filter(entry -> entry.getValue() != null)
+                        .allMatch(entry -> {
+                            final Object valueOnRecord = extensionProperties.getValue(entry.getKey());
+                            log.debug("comparing client context property [name: {}, value: {}] to value on record: {}",
+                                    entry.getKey(), entry.getValue(), valueOnRecord);
+                            if (valueOnRecord == null) {
+                                return true;
+                            } else {
+                                return entry.getValue().equals(valueOnRecord);
+                            }
+                        });
+
+                if (!credentialsOnRecordMatchClientContext) {
+                    continue;
+                }
+
+            }
+
             // copy
             final var authIdCredentialCopy = authIdCredential.copy();
             final var secrets = authIdCredentialCopy.getJsonArray(CredentialsConstants.FIELD_SECRETS);

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
@@ -25,7 +25,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.hono.auth.BCryptHelper;
@@ -391,29 +390,13 @@ public final class FileBasedCredentialsService extends AbstractVerticle
             final JsonObject authIdCredential = (JsonObject) authIdCredentialEntry;
 
             if (!type.equals(authIdCredential.getString(CredentialsConstants.FIELD_TYPE))) {
-                // auth-id doesn't match ... continue search
+                // credentials type doesn't match ... continue search
                 continue;
             }
 
             if (Boolean.FALSE.equals(authIdCredential.getBoolean(CredentialsConstants.FIELD_ENABLED, true))) {
                 // do not report disabled
                 continue;
-            }
-
-            if (clientContext != null) {
-                final AtomicBoolean match = new AtomicBoolean(true);
-                clientContext.forEach(field -> {
-                    if (authIdCredential.containsKey(field.getKey())) {
-                        if (!authIdCredential.getString(field.getKey()).equals(field.getValue())) {
-                            match.set(false);
-                        }
-                    } else {
-                        match.set(false);
-                    }
-                });
-                if (!match.get()) {
-                    continue;
-                }
             }
 
             // copy

--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -22,13 +22,18 @@ The adapter tries to authenticate the device using these mechanisms in the follo
 
 ### Client Certificate
 
-When a device uses a client certificate for authentication during the TLS handshake, the adapter tries to determine the tenant that the device belongs to, based on the *issuer DN* contained in the certificate. In order for the lookup to succeed, the tenant's trust anchor needs to be configured by means of registering the [trusted certificate authority]({{< relref "/api/tenant#tenant-information-format" >}}). The device's client certificate will then be validated using the registered trust anchor, thus implicitly establishing the tenant that the device belongs to. In a second step, the adapter then uses the Credentials API's *get* operation with the client certificate's *subject DN* as the *auth-id* and `x509-cert` as the *type* of secret as query parameters.
+When a device uses a client certificate for authentication during the TLS handshake, the adapter tries to determine the tenant that the device belongs to based on the *issuer DN* contained in the certificate.
+In order for the lookup to succeed, the tenant's trust anchor needs to be configured by means of registering the [trusted certificate authority]({{< relref "/api/tenant#tenant-information-format" >}}).
+The device's client certificate will then be validated using the registered trust anchor, thus implicitly establishing the tenant that the device belongs to.
+In a second step, the adapter uses the Credentials API's *get* operation to retrieve the credentials on record, including the client certificate's *subject DN* as the *auth-id*, `x509-cert` as the *type* of secret and the MQTT client identifier as *client-id* in the request payload.
 
 **NB** The adapter needs to be [configured for TLS]({{< relref "/admin-guide/secure_communication.md#mqtt-adapter" >}}) in order to support this mechanism.
 
 ### Username/Password
 
-When a device wants to authenticate using this mechanism, it needs to provide a *username* and a *password* in the MQTT *CONNECT* packet it sends in order to initiate the connection. The *username* must have the form *auth-id@tenant*, e.g. `sensor1@DEFAULT_TENANT`. The adapter verifies the credentials provided by the client against the credentials the [configured Credentials service]({{< relref "/admin-guide/mqtt-adapter-config.md#credentials-service-connection-configuration" >}}) has on record for the client. The adapter uses the Credentials API's *get* operation to retrieve the credentials on record with the *tenant* and *auth-id* provided by the client in the *username* and `hashed-password` as the *type* of secret as query parameters.
+When a device wants to authenticate using this mechanism, it needs to provide a *username* and a *password* in the MQTT *CONNECT* packet it sends in order to initiate the connection. The *username* must have the form *auth-id@tenant*, e.g. `sensor1@DEFAULT_TENANT`.
+The adapter verifies the credentials provided by the client against the credentials that the [configured Credentials service]({{< relref "/admin-guide/mqtt-adapter-config.md#credentials-service-connection-configuration" >}}) has on record for the client.
+The adapter uses the Credentials API's *get* operation to retrieve the credentials on record, including the *tenant* and *auth-id* provided by the client in the *username*, `hashed-password` as the *type* of secret and the MQTT client identifier as *client-id* in the request payload.
 
 The examples below refer to devices `4711` and `gw-1` of tenant `DEFAULT_TENANT` using *auth-ids* `sensor1` and `gw1` and corresponding passwords. The example deployment as described in the [Deployment Guides]({{< relref "deployment" >}}) comes pre-configured with the corresponding entities in its device registry component.
 


### PR DESCRIPTION
The MQTT adapter now always includes the device's MQTT client identifier
in the *client context* which is sent to the Credentials service in the
get request.

In order for this to work, the example Credentials service
implementation had to be changed so that it no longer asserts that a
device's credentials on record also contain the properties submitted in
the client context. This check doesn't seem to make much sense in the
context of the use case at hand anyway. The overall idea of including
the client context was not to have additional matching criteria for
credentials but to allow a Credentials service implementation to e.g.
use information from the client context as the device ID or
authentication identifier (as in the Kapua case)

Fixes #1661

Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>