### PR TITLE
Add Hotrod based DeviceConnectionClient

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -35,7 +35,7 @@
     <guava.version>28.0-jre</guava.version>
     <caffeine.version>2.8.0</caffeine.version>
     <hamcrest-core.version>2.1</hamcrest-core.version>
-    <infinispan.version>9.4.16.Final</infinispan.version>
+    <infinispan.version>9.4.17.Final</infinispan.version>
     <infinispan.image.name>jboss/infinispan-server:9.4.11.Final</infinispan.image.name>
     <jackson.version>2.9.10</jackson.version>
     <jaeger.version>0.34.0</jaeger.version>
@@ -568,6 +568,11 @@
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${jackson.version}</version>
         <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>client-device-connection-infinispan</artifactId>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/client-device-connection-infinispan/pom.xml
+++ b/client-device-connection-infinispan/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-bom</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+    <relativePath>../bom</relativePath>
+  </parent>
+  <artifactId>client-device-connection-infinispan</artifactId>
+  <name>Hotrod Device Connection client</name>
+  <description>A Hotrod based client for accessing device connection information in an Infinispan data grid.</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-legal</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-client-hotrod</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfoCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfoCache.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceconnection.infinispan.client;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A repository for keeping connection information about devices.
+ *
+ */
+public interface DeviceConnectionInfoCache {
+
+    /**
+     * Sets the gateway that last acted on behalf of a device.
+     * <p>
+     * If a device connects directly instead of through a gateway, the device identifier itself is to be used as value
+     * for the <em>gatewayId</em> parameter.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceId The device identifier.
+     * @param gatewayId The gateway identifier. This may be the same as the device identifier if the device is
+     *                  (currently) not connected via a gateway but directly to a protocol adapter.
+     * @param context The currently active OpenTracing span or {@code null} if no span is currently active.
+     *            Implementing classes should use this as the parent for any span they create for tracing
+     *            the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the device connection information has been updated.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if tenant, device id or gateway id are {@code null}.
+     */
+    Future<Void> setLastKnownGatewayForDevice(String tenant, String deviceId, String gatewayId, SpanContext context);
+
+    /**
+     * Gets the gateway that last acted on behalf of a device.
+     * <p>
+     * If no last known gateway has been set for the given device yet, a failed future with status
+     * <em>404</em> is returned.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceId The device identifier.
+     * @param context The currently active OpenTracing span or {@code null} if no span is currently active.
+     *            Implementing classes should use this as the parent for any span they create for tracing
+     *            the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded with a JSON object containing the currently mapped gateway ID
+     *         in the <em>gateway-id</em> property, if device connection information has been found for
+     *         the given device.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if tenant or device id are {@code null}.
+     */
+    Future<JsonObject> getLastKnownGatewayForDevice(String tenant, String deviceId, SpanContext context);
+}

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClient.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClient.java
@@ -14,11 +14,9 @@
 
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
-import java.net.HttpURLConnection;
 import java.util.Objects;
 
 import org.eclipse.hono.client.DeviceConnectionClient;
-import org.eclipse.hono.client.ServerErrorException;
 
 import io.opentracing.SpanContext;
 import io.vertx.core.AsyncResult;
@@ -65,7 +63,7 @@ public final class HotrodBasedDeviceConnectionClient implements DeviceConnection
      */
     @Override
     public boolean isOpen() {
-        return cache != null;
+        return true;
     }
 
     /**
@@ -106,11 +104,7 @@ public final class HotrodBasedDeviceConnectionClient implements DeviceConnection
     @Override
     public Future<Void> setLastKnownGatewayForDevice(final String deviceId, final String gatewayId, final SpanContext context) {
 
-        if (isOpen()) {
-            return cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, context);
-        } else {
-            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no connection to remote cache"));
-        }
+        return cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, context);
     }
 
     /**
@@ -119,10 +113,6 @@ public final class HotrodBasedDeviceConnectionClient implements DeviceConnection
     @Override
     public Future<JsonObject> getLastKnownGatewayForDevice(final String deviceId, final SpanContext context) {
 
-        if (isOpen()) {
-            return cache.getLastKnownGatewayForDevice(tenantId, deviceId, context);
-        } else {
-            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no connection to remote cache"));
-        }
+        return cache.getLastKnownGatewayForDevice(tenantId, deviceId, context);
     }
 }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClient.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClient.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceconnection.infinispan.client;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.eclipse.hono.client.DeviceConnectionClient;
+import org.eclipse.hono.client.ServerErrorException;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+
+
+/**
+ * A client for accessing device connection information in a data grid using the
+ * Hotrod protocol.
+ *
+ */
+public final class HotrodBasedDeviceConnectionClient implements DeviceConnectionClient {
+
+    final String tenantId;
+    final DeviceConnectionInfoCache cache;
+
+    /**
+     * Creates a client for accessing device connection information.
+     * 
+     * @param tenantId The tenant that this client is scoped to.
+     * @param cache The remote cache that contains the data.
+     */
+    public HotrodBasedDeviceConnectionClient(final String tenantId, final DeviceConnectionInfoCache cache) {
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.cache = Objects.requireNonNull(cache);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * The given handler will immediately be invoked with a succeeded result.
+     */
+    @Override
+    public void close(final Handler<AsyncResult<Void>> closeHandler) {
+        closeHandler.handle(Future.succeededFuture());
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @return {@code true} if this client is connected to the data grid.
+     */
+    @Override
+    public boolean isOpen() {
+        return cache != null;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * Invocations of this method are ignored.
+     */
+    @Override
+    public void setRequestTimeout(final long timoutMillis) {
+        // ignored
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @return Always 1.
+     */
+    @Override
+    public int getCredit() {
+        return 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * The given handler will be invoked immediately.
+     */
+    @Override
+    public void sendQueueDrainHandler(final Handler<Void> handler) {
+        handler.handle(null);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * If this method is invoked from a vert.x Context, then the returned future will be completed on that context.
+     */
+    @Override
+    public Future<Void> setLastKnownGatewayForDevice(final String deviceId, final String gatewayId, final SpanContext context) {
+
+        if (isOpen()) {
+            return cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, context);
+        } else {
+            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no connection to remote cache"));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<JsonObject> getLastKnownGatewayForDevice(final String deviceId, final SpanContext context) {
+
+        if (isOpen()) {
+            return cache.getLastKnownGatewayForDevice(tenantId, deviceId, context);
+        } else {
+            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no connection to remote cache"));
+        }
+    }
+}

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClientFactory.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClientFactory.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceconnection.infinispan.client;
+
+import java.util.Objects;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.eclipse.hono.client.BasicDeviceConnectionClientFactory;
+import org.eclipse.hono.client.DeviceConnectionClient;
+import org.infinispan.client.hotrod.RemoteCacheContainer;
+import org.infinispan.commons.api.BasicCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.vertx.core.Future;
+
+
+/**
+ * A factory for creating Device Connection service clients that connect directly to
+ * an Infinispan cluster for reading and writing device connection information.
+ *
+ */
+public final class HotrodBasedDeviceConnectionClientFactory implements BasicDeviceConnectionClientFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HotrodBasedDeviceConnectionClientFactory.class);
+
+    private final Cache<String, HotrodBasedDeviceConnectionClient> clients = Caffeine.newBuilder()
+            .maximumSize(100)
+            .build();
+    private RemoteCacheContainer cacheManager;
+    private BasicCache<String, String> cache;
+
+    /**
+     * Sets the cache manager to use for retrieving a cache.
+     * 
+     * @param cacheManager The cache manager.
+     * @throws NullPointerException if cache manager is {@code null}.
+     */
+    @Autowired
+    public void setCacheManager(final RemoteCacheContainer cacheManager) {
+        this.cacheManager = Objects.requireNonNull(cacheManager);
+        LOG.info("using cache manager [{}]", cacheManager.getClass().getName());
+    }
+
+    void setCache(final BasicCache<String, String> cache) {
+        this.cache = cache;
+    }
+
+    /**
+     * Starts up the factory.
+     */
+    @PostConstruct
+    public void start() {
+        cacheManager.start();
+        cache = cacheManager.getCache("device-connection");
+        cache.start();
+        LOG.info("successfully connected to remote cache");
+    }
+
+    /**
+     * Shuts down the factory and releases all resources.
+     */
+    @PreDestroy
+    public void stop() {
+        clients.invalidateAll();
+        if (cacheManager != null) {
+            cacheManager.stop();
+            LOG.info("connection(s) to remote cache stopped successfully");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @throws IllegalStateException if the factory is not connected to the data grid.
+     */
+    @Override
+    public Future<DeviceConnectionClient> getOrCreateDeviceConnectionClient(final String tenantId) {
+        if (cache == null) {
+            throw new IllegalStateException("not connected to remote cache");
+        } else {
+            final DeviceConnectionClient result = clients.get(tenantId, key -> {
+                final DeviceConnectionInfoCache infoCache = new HotrodBasedDeviceConnectionInfoCache(cache);
+                return new HotrodBasedDeviceConnectionClient(key, infoCache);
+            });
+            return Future.succeededFuture(result);
+        }
+    }
+}

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClientFactory.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClientFactory.java
@@ -66,9 +66,14 @@ public final class HotrodBasedDeviceConnectionClientFactory implements BasicDevi
 
     /**
      * Starts up the factory.
+     * 
+     * @throws IllegalStateException if the cache manager is not set.
      */
     @PostConstruct
     public void start() {
+        if (cacheManager == null) {
+            throw new IllegalStateException("cache manager must be set");
+        }
         cacheManager.start();
         cache = cacheManager.getCache("device-connection");
         cache.start();

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfoCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfoCache.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceconnection.infinispan.client;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.util.DeviceConnectionConstants;
+import org.eclipse.hono.util.HonoProtonHelper;
+import org.infinispan.commons.api.BasicCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+
+/**
+ * A client for accessing device connection information in a data grid using the
+ * Hotrod protocol.
+ *
+ */
+public final class HotrodBasedDeviceConnectionInfoCache implements DeviceConnectionInfoCache {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HotrodBasedDeviceConnectionInfoCache.class);
+
+    final BasicCache<String, String> cache;
+
+    /**
+     * Creates a client for accessing device connection information.
+     * 
+     * @param cache The remote cache that contains the data.
+     */
+    public HotrodBasedDeviceConnectionInfoCache(final BasicCache<String, String> cache) {
+        this.cache = Objects.requireNonNull(cache);
+    }
+
+    private static String getKey(final String tenantId, final String deviceId) {
+        return String.format("%s@@%s", tenantId, deviceId);
+    }
+
+
+    private static JsonObject getResult(final String gatewayId) {
+        return new JsonObject().put(DeviceConnectionConstants.FIELD_GATEWAY_ID, gatewayId);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * If this method is invoked from a vert.x Context, then the returned future will be completed on that context.
+     */
+    @Override
+    public Future<Void> setLastKnownGatewayForDevice(final String tenantId, final String deviceId, final String gatewayId, final SpanContext context) {
+
+        final Promise<Void> result = Promise.promise();
+
+        if (cache == null) {
+            result.fail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no connection to remote cache"));
+        } else {
+            cache
+            .putAsync(getKey(tenantId, deviceId), gatewayId)
+            .whenComplete((replacedValue, error) -> {
+                if (error == null) {
+                    LOG.debug("set last known gateway [tenant: {}, device-id: {}, gateway: {}]", tenantId, deviceId, gatewayId);
+                    result.complete();
+                } else {
+                    LOG.debug("failed to set last known gateway [tenant: {}, device-id: {}, gateway: {}]",
+                            tenantId, deviceId, gatewayId, error);
+                    result.fail(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, error));
+                }
+            });
+        }
+
+        return HonoProtonHelper.handleOnContext(result, Vertx.currentContext());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<JsonObject> getLastKnownGatewayForDevice(final String tenantId, final String deviceId, final SpanContext context) {
+
+        final Promise<JsonObject> result = Promise.promise();
+
+        if (cache == null) {
+            result.fail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no connection to remote cache"));
+        } else {
+            cache.getAsync(getKey(tenantId, deviceId))
+            .whenComplete((gatewayId, error) -> {
+                if (error != null) {
+                    LOG.debug("failed to find last known gateway for device [tenant: {}, device-id: {}]",
+                            tenantId, deviceId, error);
+                    result.fail(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, error));
+                } else if (gatewayId == null) {
+                    LOG.debug("could not find last known gateway for device [tenant: {}, device-id: {}]", tenantId, deviceId);
+                    result.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                } else {
+                    LOG.debug("found last known gateway for device [tenant: {}, device-id: {}]: {}", tenantId, deviceId, gatewayId);
+                    result.complete(getResult(gatewayId));
+                }
+            });
+        }
+
+        return HonoProtonHelper.handleOnContext(result, Vertx.currentContext());
+    }
+}

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfoCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfoCache.java
@@ -71,22 +71,18 @@ public final class HotrodBasedDeviceConnectionInfoCache implements DeviceConnect
 
         final Promise<Void> result = Promise.promise();
 
-        if (cache == null) {
-            result.fail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no connection to remote cache"));
-        } else {
-            cache
-            .putAsync(getKey(tenantId, deviceId), gatewayId)
-            .whenComplete((replacedValue, error) -> {
-                if (error == null) {
-                    LOG.debug("set last known gateway [tenant: {}, device-id: {}, gateway: {}]", tenantId, deviceId, gatewayId);
-                    result.complete();
-                } else {
-                    LOG.debug("failed to set last known gateway [tenant: {}, device-id: {}, gateway: {}]",
-                            tenantId, deviceId, gatewayId, error);
-                    result.fail(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, error));
-                }
-            });
-        }
+        cache.putAsync(getKey(tenantId, deviceId), gatewayId)
+                .whenComplete((replacedValue, error) -> {
+                    if (error == null) {
+                        LOG.debug("set last known gateway [tenant: {}, device-id: {}, gateway: {}]", tenantId, deviceId,
+                                gatewayId);
+                        result.complete();
+                    } else {
+                        LOG.debug("failed to set last known gateway [tenant: {}, device-id: {}, gateway: {}]",
+                                tenantId, deviceId, gatewayId, error);
+                        result.fail(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, error));
+                    }
+                });
 
         return HonoProtonHelper.handleOnContext(result, Vertx.currentContext());
     }
@@ -99,24 +95,22 @@ public final class HotrodBasedDeviceConnectionInfoCache implements DeviceConnect
 
         final Promise<JsonObject> result = Promise.promise();
 
-        if (cache == null) {
-            result.fail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "no connection to remote cache"));
-        } else {
-            cache.getAsync(getKey(tenantId, deviceId))
-            .whenComplete((gatewayId, error) -> {
-                if (error != null) {
-                    LOG.debug("failed to find last known gateway for device [tenant: {}, device-id: {}]",
-                            tenantId, deviceId, error);
-                    result.fail(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, error));
-                } else if (gatewayId == null) {
-                    LOG.debug("could not find last known gateway for device [tenant: {}, device-id: {}]", tenantId, deviceId);
-                    result.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
-                } else {
-                    LOG.debug("found last known gateway for device [tenant: {}, device-id: {}]: {}", tenantId, deviceId, gatewayId);
-                    result.complete(getResult(gatewayId));
-                }
-            });
-        }
+        cache.getAsync(getKey(tenantId, deviceId))
+                .whenComplete((gatewayId, error) -> {
+                    if (error != null) {
+                        LOG.debug("failed to find last known gateway for device [tenant: {}, device-id: {}]",
+                                tenantId, deviceId, error);
+                        result.fail(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, error));
+                    } else if (gatewayId == null) {
+                        LOG.debug("could not find last known gateway for device [tenant: {}, device-id: {}]", tenantId,
+                                deviceId);
+                        result.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                    } else {
+                        LOG.debug("found last known gateway for device [tenant: {}, device-id: {}]: {}", tenantId,
+                                deviceId, gatewayId);
+                        result.complete(getResult(gatewayId));
+                    }
+                });
 
         return HonoProtonHelper.handleOnContext(result, Vertx.currentContext());
     }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationProperties.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/InfinispanRemoteConfigurationProperties.java
@@ -12,7 +12,7 @@
  */
 
 
-package org.eclipse.hono.deviceconnection.infinispan;
+package org.eclipse.hono.deviceconnection.infinispan.client;
 
 import java.util.Map;
 
@@ -23,10 +23,7 @@ import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 /**
  * Configuration properties for a Hotrod connection to a remote cache.
  *
- * @deprecated Use {@link org.eclipse.hono.deviceconnection.infinispan.client.InfinispanRemoteConfigurationProperties}
- *             instead.
  */
-@Deprecated(forRemoval = true)
 public class InfinispanRemoteConfigurationProperties extends ConfigurationProperties {
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/BasicDeviceConnectionClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/BasicDeviceConnectionClientFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client;
+
+import io.vertx.core.Future;
+
+/**
+ * A factory for creating clients for Hono's Device Connection API.
+ *
+ */
+public interface BasicDeviceConnectionClientFactory {
+
+    /**
+     * Gets a client for invoking operations on a service implementing Hono's <em>Device Connection</em> API.
+     *
+     * @param tenantId The tenant to manage device connection data for.
+     * @return A future that will complete with the device connection client (if successful) or fail if the client
+     *         cannot be created, e.g. because the underlying connection is not established or if a concurrent
+     *         request to create a client for the same tenant is already being executed.
+     * @throws NullPointerException if the tenant is {@code null}.
+     */
+    Future<DeviceConnectionClient> getOrCreateDeviceConnectionClient(String tenantId);
+}

--- a/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClientFactory.java
@@ -16,13 +16,11 @@ package org.eclipse.hono.client;
 
 import org.eclipse.hono.client.impl.DeviceConnectionClientFactoryImpl;
 
-import io.vertx.core.Future;
-
 /**
  * A factory for creating clients for Hono's Device Connection API.
  *
  */
-public interface DeviceConnectionClientFactory extends ConnectionLifecycle<HonoConnection> {
+public interface DeviceConnectionClientFactory extends BasicDeviceConnectionClientFactory, ConnectionLifecycle<HonoConnection> {
 
     /**
      * Creates a new factory for an existing connection.
@@ -34,15 +32,4 @@ public interface DeviceConnectionClientFactory extends ConnectionLifecycle<HonoC
     static DeviceConnectionClientFactory create(final HonoConnection connection) {
         return new DeviceConnectionClientFactoryImpl(connection);
     }
-
-    /**
-     * Gets a client for invoking operations on a service implementing Hono's <em>Device Connection</em> API.
-     *
-     * @param tenantId The tenant to manage device connection data for.
-     * @return A future that will complete with the device connection client (if successful) or fail if the client
-     *         cannot be created, e.g. because the underlying connection is not established or if a concurrent
-     *         request to create a client for the same tenant is already being executed.
-     * @throws NullPointerException if the tenant is {@code null}.
-     */
-    Future<DeviceConnectionClient> getOrCreateDeviceConnectionClient(String tenantId);
 }

--- a/client/src/main/java/org/eclipse/hono/client/GatewayMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/GatewayMapper.java
@@ -34,8 +34,11 @@ public interface GatewayMapper extends ConnectionLifecycle<HonoConnection> {
      * @return The GatewayMapper instance.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    static GatewayMapper create(final RegistrationClientFactory registrationClientFactory,
-            final DeviceConnectionClientFactory deviceConnectionClientFactory, final Tracer tracer) {
+    static GatewayMapper create(
+            final RegistrationClientFactory registrationClientFactory,
+            final BasicDeviceConnectionClientFactory deviceConnectionClientFactory,
+            final Tracer tracer) {
+
         return new GatewayMapperImpl(registrationClientFactory, deviceConnectionClientFactory, tracer);
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/GatewayMapperImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/GatewayMapperImpl.java
@@ -16,9 +16,9 @@ package org.eclipse.hono.client.impl;
 import java.net.HttpURLConnection;
 import java.util.Objects;
 
+import org.eclipse.hono.client.BasicDeviceConnectionClientFactory;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ConnectionLifecycle;
-import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.GatewayMapper;
 import org.eclipse.hono.client.HonoConnection;
@@ -48,12 +48,12 @@ import io.vertx.core.json.JsonObject;
 /**
  * A component that maps a given device to the gateway through which data was last published for the given device.
  */
-public class GatewayMapperImpl implements GatewayMapper, ConnectionLifecycle<HonoConnection> {
+public class GatewayMapperImpl implements GatewayMapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(GatewayMapperImpl.class);
 
     private final RegistrationClientFactory registrationClientFactory;
-    private final DeviceConnectionClientFactory deviceConnectionClientFactory;
+    private final BasicDeviceConnectionClientFactory deviceConnectionClientFactory;
     private final Tracer tracer;
 
     /**
@@ -64,8 +64,11 @@ public class GatewayMapperImpl implements GatewayMapper, ConnectionLifecycle<Hon
      * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    public GatewayMapperImpl(final RegistrationClientFactory registrationClientFactory,
-            final DeviceConnectionClientFactory deviceConnectionClientFactory, final Tracer tracer) {
+    public GatewayMapperImpl(
+            final RegistrationClientFactory registrationClientFactory,
+            final BasicDeviceConnectionClientFactory deviceConnectionClientFactory,
+            final Tracer tracer) {
+
         this.registrationClientFactory = Objects.requireNonNull(registrationClientFactory);
         this.deviceConnectionClientFactory = Objects.requireNonNull(deviceConnectionClientFactory);
         this.tracer = Objects.requireNonNull(tracer);
@@ -156,43 +159,69 @@ public class GatewayMapperImpl implements GatewayMapper, ConnectionLifecycle<Hon
     @Override
     public Future<HonoConnection> connect() {
         final Future<HonoConnection> registrationFuture = registrationClientFactory.connect();
-        final Future<HonoConnection> deviceConnectionFuture = deviceConnectionClientFactory.connect();
-        return CompositeFuture.all(registrationFuture, deviceConnectionFuture).map(cf -> deviceConnectionFuture.result());
+        if (deviceConnectionClientFactory instanceof ConnectionLifecycle) {
+            final Future<?> deviceConnectionFuture = ((ConnectionLifecycle<?>) deviceConnectionClientFactory).connect();
+            return CompositeFuture.all(registrationFuture, deviceConnectionFuture)
+                    .map(ok -> registrationFuture.result());
+        } else {
+            return registrationFuture;
+        }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void addDisconnectListener(final DisconnectListener<HonoConnection> listener) {
         registrationClientFactory.addDisconnectListener(listener);
-        deviceConnectionClientFactory.addDisconnectListener(listener);
+        if (deviceConnectionClientFactory instanceof ConnectionLifecycle) {
+            ((ConnectionLifecycle<HonoConnection>) deviceConnectionClientFactory).addDisconnectListener(listener);
+        }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void addReconnectListener(final ReconnectListener<HonoConnection> listener) {
         registrationClientFactory.addReconnectListener(listener);
-        deviceConnectionClientFactory.addReconnectListener(listener);
+        if (deviceConnectionClientFactory instanceof ConnectionLifecycle) {
+            ((ConnectionLifecycle<HonoConnection>) deviceConnectionClientFactory).addReconnectListener(listener);
+        }
     }
 
     @Override
     public Future<Void> isConnected() {
         final Future<Void> registrationFuture = registrationClientFactory.isConnected();
-        final Future<Void> deviceConnectionFuture = deviceConnectionClientFactory.isConnected();
-        return CompositeFuture.all(registrationFuture, deviceConnectionFuture).mapEmpty();
+        if (deviceConnectionClientFactory instanceof ConnectionLifecycle) {
+            final Future<Void> deviceConnectionFuture = ((ConnectionLifecycle<?>) deviceConnectionClientFactory).isConnected();
+            return CompositeFuture.all(registrationFuture, deviceConnectionFuture)
+                    .mapEmpty();
+        } else {
+            return registrationFuture;
+        }
     }
 
     @Override
     public void disconnect() {
         registrationClientFactory.disconnect();
-        deviceConnectionClientFactory.disconnect();
+        if (deviceConnectionClientFactory instanceof ConnectionLifecycle) {
+            ((ConnectionLifecycle<?>) deviceConnectionClientFactory).disconnect();
+        }
     }
 
     @Override
     public void disconnect(final Handler<AsyncResult<Void>> completionHandler) {
 
         final Promise<Void> registrationDisconnectPromise = Promise.promise();
-        registrationClientFactory.disconnect(registrationDisconnectPromise);
         final Promise<Void> deviceConnectionDisconnectPromise = Promise.promise();
-        deviceConnectionClientFactory.disconnect(deviceConnectionDisconnectPromise);
+
+        registrationClientFactory.disconnect(registrationDisconnectPromise);
+
+        if (deviceConnectionClientFactory instanceof ConnectionLifecycle) {
+            ((ConnectionLifecycle<?>) deviceConnectionClientFactory).disconnect(deviceConnectionDisconnectPromise);
+        } else {
+            deviceConnectionDisconnectPromise.complete();
+        }
+
         CompositeFuture.all(registrationDisconnectPromise.future(), deviceConnectionDisconnectPromise.future())
-                .map(obj -> deviceConnectionDisconnectPromise.future().result()).setHandler(completionHandler);
+        .map(ok -> (Void) null)
+        .setHandler(completionHandler);
     }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -122,6 +122,10 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/org/eclipse/hono/util/HonoProtonHelperTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/HonoProtonHelperTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+
+/**
+ * Tests verifying behavior of {@link HonoProtonHelper}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+class HonoProtonHelperTest {
+
+    /**
+     * Verifies that code is scheduled to be executed on a given Context
+     * other than the current Context.
+     * 
+     * @param ctx The vert.x test context.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    public void testExecuteOnContextRunsOnGivenContext(final VertxTestContext ctx) {
+
+        final Context mockContext = mock(Context.class);
+        doAnswer(invocation -> {
+            final Handler<Void> codeToRun = invocation.getArgument(0);
+            codeToRun.handle(null);
+            return null;
+        }).when(mockContext).runOnContext(any(Handler.class));
+
+        HonoProtonHelper.executeOnContext(mockContext, result -> result.complete("done"))
+        .setHandler(ctx.succeeding(s -> {
+            ctx.verify(() -> {
+                verify(mockContext).runOnContext(any(Handler.class));
+                assertThat(s).isEqualTo("done");
+            });
+            ctx.completeNow();
+        }));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    public void testHandleOnContextCompletesOnGivenContext(final VertxTestContext ctx) {
+
+        final Context context = mock(Context.class);
+        doAnswer(invocation -> {
+            final Handler<Void> codeToRun = invocation.getArgument(0);
+            codeToRun.handle(null);
+            return null;
+        }).when(context).runOnContext(any(Handler.class));
+
+        final Vertx vertx = Vertx.vertx();
+        final Context currentContext = vertx.getOrCreateContext();
+
+        final Promise<String> outcome = Promise.promise();
+        final Future<String> result = HonoProtonHelper.handleOnContext(outcome, context);
+        result.setHandler(ctx.succeeding(s -> {
+            ctx.verify(() -> {
+                verify(context).runOnContext(any(Handler.class));
+                assertThat(s).isEqualTo("done");
+            });
+            ctx.completeNow();
+        }));
+
+        currentContext.runOnContext(go -> outcome.complete("done"));
+    }
+}

--- a/deploy/src/main/deploy/helm/templates/_helpers.tpl
+++ b/deploy/src/main/deploy/helm/templates/_helpers.tpl
@@ -198,6 +198,17 @@ credentials:
   {{- required ".Values.adapters.credentialsSpec MUST be set if example Device Registry is disabled" .dot.Values.adapters.credentialsSpec | toYaml | nindent 2 }}
 {{- end }}
 deviceConnection:
+{{- if .dot.Values.dataGridSpec }}
+  {{- .dot.Values.dataGridSpec | toYaml | nindent 2 }}
+{{- else }}
+{{- if .dot.Values.dataGridExample.enabled }}
+  {{- $serverName := printf "%s-data-grid" .dot.Release.Name }}
+  serverList: {{ printf "%s:11222" $serverName | quote }}
+  authServerName: {{ $serverName | quote }}
+  authUsername: {{ .dot.Values.dataGridExample.authUsername | quote }}
+  authPassword: {{ .dot.Values.dataGridExample.authPassword | quote }}
+  maxRetries: 100
+{{- else }}
 {{- if .dot.Values.adapters.deviceConnectionSpec }}
   {{- range $key, $value := .dot.Values.adapters.deviceConnectionSpec }}
   {{ $key }}: {{ $value }}
@@ -217,6 +228,8 @@ deviceConnection:
   credentialsPath: /etc/hono/adapter.credentials
   trustStorePath: /etc/hono/trusted-certs.pem
   hostnameVerificationRequired: false
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-connection/hono-service-device-connection-secret.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-connection/hono-service-device-connection-secret.yaml
@@ -45,6 +45,9 @@ stringData:
           certPath: "/etc/hono/cert.pem"
           {{- end }}
         remote:
+        {{- if .Values.dataGridSpec }}
+          {{- .Values.dataGridSpec | toYaml | nindent 10 }}
+        {{- else }}
         {{- if .Values.deviceConnectionService.hono.deviceConnection.remote }}
           {{- .Values.deviceConnectionService.hono.deviceConnection.remote | toYaml | nindent 10 }}
         {{- else }}
@@ -58,6 +61,7 @@ stringData:
           {{- else }}
             {{- required "A .Values.deviceConnectionService.hono.deviceConnection.remote needs to be set when deploying the (production) Device Connection service" .Values.deviceConnectionService.hono.deviceConnection.remote }}
           {{- end }}
+        {{- end }}
         {{- end }}
       {{- include "hono.healthServerConfig" .Values.deviceConnectionService.hono.healthCheck | nindent 6 }}
 {{- if not .Values.deviceConnectionService.extraSecretMounts }}

--- a/deploy/src/main/deploy/helm/values.yaml
+++ b/deploy/src/main/deploy/helm/values.yaml
@@ -56,6 +56,25 @@ dataGridExample:
   # authPassword contains the secret of the user that is authorized to connect to the example data grid
   authPassword: "hono-secret"
 
+# dataGridSpec contains properties for configuring the Infinispan Hotrod connection
+# to the existing data grid (i.e. not the example grid) that should be used for storing
+# the device connection data.
+# This property MUST be set if "deviceConnectionService.enabled" is set to true
+# and "dataGridExample.enabled" is set to false (the default).
+# Please refer to https://docs.jboss.org/infinispan/9.4/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description
+# for a list of configuration properties.
+dataGridSpec:
+  # serverList contains the hostname:port of the data grid node(s)
+  # This property only needs to be set when using an existing data grid other than the
+  # example grid.
+  #serverList: my-grid.example.com:11222
+  # authServerName contains the name that Hotrod clients need to use for establishing a
+  # connection to the data grid.
+  #authServerName:
+  # authUsername contains the name of the user that is authorized to connect to the data grid.
+  #authUsername:
+  # authPassword contains the secret of the user that is authorized to connect to the data grid
+  #authPassword:
 
 jaegerBackendExample:
 
@@ -712,6 +731,7 @@ deviceConnectionService:
       #  insecurePortEnabled: true
       #  insecurePortBindAddress: "0.0.0.0"
 
+      # DEPRECATED use the dataGridSpec property instead
       # remote contains properties for configuring the Infinispan Hotrod connection
       # to the data grid that should be used for storing the device connection data.
       # This property MUST be set if "deviceConnectionService.enabled" is set to true

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@
     <module>core</module>
     <module>cli</module>
     <module>client</module>
+    <module>client-device-connection-infinispan</module>
     <module>demo-certs</module>
     <module>deploy</module>
     <module>example</module>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -83,6 +83,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
+      <artifactId>client-device-connection-infinispan</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-legal</artifactId>
     </dependency>
     <dependency>

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -15,6 +15,8 @@ package org.eclipse.hono.service;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -23,6 +25,7 @@ import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.client.BasicDeviceConnectionClientFactory;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandConsumerFactory;
 import org.eclipse.hono.client.CommandContext;
@@ -106,7 +109,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     private DownstreamSenderFactory downstreamSenderFactory;
     private RegistrationClientFactory registrationClientFactory;
     private TenantClientFactory tenantClientFactory;
-    private DeviceConnectionClientFactory deviceConnectionClientFactory;
+    private BasicDeviceConnectionClientFactory deviceConnectionClientFactory;
     private CredentialsClientFactory credentialsClientFactory;
     private CommandConsumerFactory commandConsumerFactory;
     private ConnectionLimitManager connectionLimitManager;
@@ -197,7 +200,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     @Qualifier(DeviceConnectionConstants.DEVICE_CONNECTION_ENDPOINT)
     @Autowired
-    public final void setDeviceConnectionClientFactory(final DeviceConnectionClientFactory factory) {
+    public final void setDeviceConnectionClientFactory(final BasicDeviceConnectionClientFactory factory) {
         this.deviceConnectionClientFactory = Objects.requireNonNull(factory);
     }
 
@@ -205,9 +208,16 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * Gets the factory used for creating a client for the Device Connection service.
      *
      * @return The factory.
+     * @deprecated Use {@link #getDeviceConnectionClient(String)} in order to access
+     *             device connection information.
      */
+    @Deprecated(forRemoval = true)
     public final DeviceConnectionClientFactory getDeviceConnectionClientFactory() {
-        return deviceConnectionClientFactory;
+        if (deviceConnectionClientFactory instanceof DeviceConnectionClientFactory) {
+            return (DeviceConnectionClientFactory) deviceConnectionClientFactory;
+        } else {
+             return null;
+        }
     }
 
     /**
@@ -215,9 +225,14 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      *
      * @param tenantId The tenant that the client is scoped to.
      * @return The client.
+     * @throws IllegalStateException if no client factory is set.
      */
     protected final Future<DeviceConnectionClient> getDeviceConnectionClient(final String tenantId) {
-        return getDeviceConnectionClientFactory().getOrCreateDeviceConnectionClient(tenantId);
+
+        if (deviceConnectionClientFactory == null) {
+            throw new IllegalStateException("Device Connection client factory is not set");
+        }
+        return deviceConnectionClientFactory.getOrCreateDeviceConnectionClient(tenantId);
     }
 
     /**
@@ -417,7 +432,9 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             connectToService(downstreamSenderFactory, "AMQP Messaging Network");
             connectToService(registrationClientFactory, "Device Registration service");
             connectToService(credentialsClientFactory, "Credentials service");
-            connectToService(deviceConnectionClientFactory, "Device Connection service");
+            if (deviceConnectionClientFactory instanceof DeviceConnectionClientFactory) {
+                connectToService((DeviceConnectionClientFactory) deviceConnectionClientFactory, "Device Connection service");
+            }
 
             connectToService(
                     commandConsumerFactory,
@@ -482,19 +499,27 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
     private Future<?> closeServiceClients() {
 
-        return CompositeFuture.all(
-                disconnectFromService(downstreamSenderFactory),
-                disconnectFromService(tenantClientFactory),
-                disconnectFromService(registrationClientFactory),
-                disconnectFromService(credentialsClientFactory),
-                disconnectFromService(deviceConnectionClientFactory),
-                disconnectFromService(commandConsumerFactory));
+        @SuppressWarnings("rawtypes")
+        final List<Future> results = new ArrayList<>();
+        results.add(disconnectFromService(downstreamSenderFactory));
+        results.add(disconnectFromService(tenantClientFactory));
+        results.add(disconnectFromService(registrationClientFactory));
+        results.add(disconnectFromService(credentialsClientFactory));
+        results.add(disconnectFromService(commandConsumerFactory));
+        if (deviceConnectionClientFactory instanceof DeviceConnectionClientFactory) {
+            results.add(disconnectFromService((DeviceConnectionClientFactory) deviceConnectionClientFactory));
+        }
+        return CompositeFuture.all(results);
     }
 
     private Future<Void> disconnectFromService(final ConnectionLifecycle<HonoConnection> connection) {
 
         final Promise<Void> disconnectTracker = Promise.promise();
-        connection.disconnect(disconnectTracker);
+        if (connection == null) {
+            disconnectTracker.complete();
+        } else {
+            connection.disconnect(disconnectTracker);
+        }
         return disconnectTracker.future();
     }
 
@@ -855,33 +880,36 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     protected Future<Void> isConnected() {
 
-        final Future<Void> tenantCheck = Optional.ofNullable(tenantClientFactory)
+        @SuppressWarnings("rawtypes")
+        final List<Future> connections = new ArrayList<>();
+        connections.add(Optional.ofNullable(tenantClientFactory)
                 .map(client -> client.isConnected())
                 .orElse(Future.failedFuture(new ServerErrorException(
-                        HttpURLConnection.HTTP_UNAVAILABLE, "Tenant client factory is not set")));
-        final Future<Void> registrationCheck = Optional.ofNullable(registrationClientFactory)
+                        HttpURLConnection.HTTP_UNAVAILABLE, "Tenant client factory is not set"))));
+        connections.add(Optional.ofNullable(registrationClientFactory)
                 .map(client -> client.isConnected())
                 .orElse(Future
                         .failedFuture(new ServerErrorException(
-                                HttpURLConnection.HTTP_UNAVAILABLE, "Device Registration client factory is not set")));
-        final Future<Void> credentialsCheck = Optional.ofNullable(credentialsClientFactory)
+                                HttpURLConnection.HTTP_UNAVAILABLE, "Device Registration client factory is not set"))));
+        connections.add(Optional.ofNullable(credentialsClientFactory)
                 .map(client -> client.isConnected())
                 .orElse(Future.failedFuture(new ServerErrorException(
-                        HttpURLConnection.HTTP_UNAVAILABLE, "Credentials client factory is not set")));
-        final Future<Void> messagingCheck = Optional.ofNullable(downstreamSenderFactory)
+                        HttpURLConnection.HTTP_UNAVAILABLE, "Credentials client factory is not set"))));
+        connections.add(Optional.ofNullable(downstreamSenderFactory)
                 .map(client -> client.isConnected())
                 .orElse(Future.failedFuture(new ServerErrorException(
-                        HttpURLConnection.HTTP_UNAVAILABLE, "Messaging client is not set")));
-        final Future<Void> commandCheck = Optional.ofNullable(commandConsumerFactory)
+                        HttpURLConnection.HTTP_UNAVAILABLE, "Messaging client is not set"))));
+        connections.add(Optional.ofNullable(commandConsumerFactory)
                 .map(client -> client.isConnected())
                 .orElse(Future.failedFuture(new ServerErrorException(
-                        HttpURLConnection.HTTP_UNAVAILABLE, "Command & Control client factory is not set")));
-        final Future<Void> deviceConnectionCheck = Optional.ofNullable(deviceConnectionClientFactory)
-                .map(client -> client.isConnected())
-                .orElse(Future.failedFuture(new ServerErrorException(
-                        HttpURLConnection.HTTP_UNAVAILABLE, "Device Connection client factory is not set")));
-        return CompositeFuture.all(tenantCheck, registrationCheck, credentialsCheck, messagingCheck, commandCheck,
-                deviceConnectionCheck).mapEmpty();
+                        HttpURLConnection.HTTP_UNAVAILABLE, "Command & Control client factory is not set"))));
+        if (deviceConnectionClientFactory instanceof DeviceConnectionClientFactory) {
+            connections.add(Optional.ofNullable(deviceConnectionClientFactory)
+                    .map(client -> ((DeviceConnectionClientFactory) client).isConnected())
+                    .orElse(Future.failedFuture(new ServerErrorException(
+                            HttpURLConnection.HTTP_UNAVAILABLE, "Device Connection client factory is not set"))));
+        }
+        return CompositeFuture.all(connections).mapEmpty();
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -903,12 +903,16 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                 .map(client -> client.isConnected())
                 .orElse(Future.failedFuture(new ServerErrorException(
                         HttpURLConnection.HTTP_UNAVAILABLE, "Command & Control client factory is not set"))));
-        if (deviceConnectionClientFactory instanceof DeviceConnectionClientFactory) {
-            connections.add(Optional.ofNullable(deviceConnectionClientFactory)
-                    .map(client -> ((DeviceConnectionClientFactory) client).isConnected())
-                    .orElse(Future.failedFuture(new ServerErrorException(
-                            HttpURLConnection.HTTP_UNAVAILABLE, "Device Connection client factory is not set"))));
-        }
+        connections.add(Optional.ofNullable(deviceConnectionClientFactory)
+                .map(client -> {
+                    if (deviceConnectionClientFactory instanceof DeviceConnectionClientFactory) {
+                        return ((DeviceConnectionClientFactory) client).isConnected();
+                    } else {
+                        return Future.succeededFuture();
+                    }
+                })
+                .orElse(Future.failedFuture(new ServerErrorException(
+                        HttpURLConnection.HTTP_UNAVAILABLE, "Device Connection client factory is not set"))));
         return CompositeFuture.all(connections).mapEmpty();
     }
 

--- a/services/device-connection/pom.xml
+++ b/services/device-connection/pom.xml
@@ -25,6 +25,10 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>client-device-connection-infinispan</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/ApplicationConfig.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/ApplicationConfig.java
@@ -19,6 +19,7 @@ import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ServerConfig;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.config.VertxProperties;
+import org.eclipse.hono.deviceconnection.infinispan.InfinispanRemoteConfigurationProperties;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.deviceconnection.DeviceConnectionAmqpEndpoint;


### PR DESCRIPTION
The client implementation connects directly to an Infinispan data grid
to access device connection information. This client is an optimized
version of the existing client, skipping the Device Connection service
altogether. Note that this also means that the client can access all
data for all tenants and should therefore not be used with custom
protocol adapters.
