### PR TITLE
[#1674] Make resource requests/limits of containers configurable

### DIFF
--- a/deploy/src/main/deploy/helm/templates/artemis/artemis-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/artemis/artemis-deployment.yaml
@@ -48,11 +48,10 @@ spec:
           containerPort: 5671
           protocol: TCP
         imagePullPolicy: IfNotPresent
+        {{- with .Values.amqpMessagingNetworkExample.broker.artemis.resources }}
         resources:
-          limits:
-            memory: "512Mi"
-          requests:
-            memory: "256Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           initialDelaySeconds: 20
           periodSeconds: 9

--- a/deploy/src/main/deploy/helm/templates/dispatch-router/dispatch-router-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/dispatch-router/dispatch-router-deployment.yaml
@@ -47,9 +47,10 @@ spec:
         - name: internal
           containerPort: 5673
           protocol: TCP
+        {{- with .Values.amqpMessagingNetworkExample.dispatchRouter.resources }}
         resources:
-          limits:
-            memory: "512Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           initialDelaySeconds: 180
           periodSeconds: 9

--- a/deploy/src/main/deploy/helm/templates/example-data-grid/statefulset.yaml
+++ b/deploy/src/main/deploy/helm/templates/example-data-grid/statefulset.yaml
@@ -74,9 +74,10 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 80
+        {{- with .Values.dataGridExample.resources }}
         resources:
-          limits:
-            memory: "512Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         terminationMessagePath: /dev/termination-log
       volumes:
       - name: conf

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-amqp/hono-adapter-amqp-vertx-deployment.yaml
@@ -57,9 +57,10 @@ spec:
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.amqp ) | indent 8 }}
+        {{- with .Values.adapters.amqp.resources }}
         resources:
-          limits:
-            memory: "256Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /liveness

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-coap/hono-adapter-coap-vertx-deployment.yaml
@@ -58,9 +58,10 @@ spec:
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.coap ) | indent 8 }}
+        {{- with .Values.adapters.coap.resources }}
         resources:
-          limits:
-            memory: "256Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /liveness

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-http/hono-adapter-http-vertx-deployment.yaml
@@ -57,9 +57,10 @@ spec:
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.http ) | indent 8 }}
+        {{- with .Values.adapters.http.resources }}
         resources:
-          limits:
-            memory: "256Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /liveness

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-kura/hono-adapter-kura-deployment.yaml
@@ -58,9 +58,10 @@ spec:
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.kura ) | indent 8 }}
+        {{- with .Values.adapters.kura.resources }}
         resources:
-          limits:
-            memory: "256Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /readiness

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-lora/hono-adapter-lora-vertx-deployment.yaml
@@ -58,9 +58,10 @@ spec:
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.lora ) | indent 8 }}
+        {{- with .Values.adapters.lora.resources }}
         resources:
-          limits:
-            memory: "256Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /liveness

--- a/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-adapter-mqtt/hono-adapter-mqtt-vertx-deployment.yaml
@@ -57,9 +57,10 @@ spec:
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.adapters.mqtt ) | indent 8 }}
+        {{- with .Values.adapters.mqtt.resources }}
         resources:
-          limits:
-            memory: "256Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /liveness

--- a/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-auth/hono-service-auth-deployment.yaml
@@ -55,9 +55,10 @@ spec:
               fieldPath: metadata.namespace
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.authServer ) | indent 8 }}
+        {{- with .Values.authServer.resources }}
         resources:
-          limits:
-            memory: "196Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /liveness

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-connection/hono-service-device-connection-deployment.yaml
@@ -58,9 +58,10 @@ spec:
         {{- include "hono.jaeger.clientConf" $args | indent 8 }}
         volumeMounts:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.deviceConnectionService ) | indent 8 }}
+        {{- with .Values.deviceConnectionService.resources }}
         resources:
-          limits:
-            memory: "256Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /liveness

--- a/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/hono-service-device-registry/hono-service-device-registry-deployment.yaml
@@ -85,9 +85,10 @@ spec:
         {{- include "hono.container.secretVolumeMounts" ( dict "name" $args.name "conf" .Values.deviceRegistryExample ) | indent 8 }}
         - name: "registry"
           mountPath: "/var/lib/hono/device-registry"
+        {{- with .Values.deviceRegistryExample.resources }}
         resources:
-          limits:
-            memory: "256Mi"
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /liveness

--- a/deploy/src/main/deploy/helm/templates/jaeger/jaeger-deployment.yaml
+++ b/deploy/src/main/deploy/helm/templates/jaeger/jaeger-deployment.yaml
@@ -45,6 +45,10 @@ spec:
           protocol: TCP
         - containerPort: 16686
           protocol: TCP
+        {{- with .Values.jaegerBackendExample.resources }}
+        resources:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         readinessProbe:
           httpGet:
             path: "/"

--- a/deploy/src/main/deploy/helm/values.yaml
+++ b/deploy/src/main/deploy/helm/values.yaml
@@ -27,13 +27,35 @@ amqpMessagingNetworkExample:
     svc:
       annotations: {}
       loadBalancerIP:
+    # resources contains the container's 'requests and limits for CPU and memory
+    # as defined by the Kubernetes API.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
+      requests:
+        cpu: "0.1"
+        memory: "64M"
+      limits:
+        cpu: "1"
+        memory: "256M"
   # AMQP Messaging Network Broker configuration.
   broker:
     type: artemis
     artemis:
-    # imageName contains the name (including tag) of the container
-    # image to use for the example AMQP Messaging Network Broker
+      # imageName contains the name (including tag) of the container
+      # image to use for the example AMQP Messaging Network Broker
       imageName: ${artemis.image.name}
+      # resources contains the container's 'requests and limits for CPU and memory
+      # as defined by the Kubernetes API.
+      # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+      # for a description of the properties' semantics.
+      resources:
+        requests:
+          cpu: "0.05"
+          memory: "256M"
+        limits:
+          cpu: "1"
+          memory: "512M"
    # Azure Service Bus as alternative to self-hosted Artemis ActiveMQ for event persistence
     servicebus:
       saslUsername:
@@ -51,6 +73,17 @@ dataGridExample:
   # imageName contains the name (including tag)
   # of the container image to use for the example data grid.
   imageName: ${infinispan.image.name}
+  # resources contains the container's 'requests and limits for CPU and memory
+  # as defined by the Kubernetes API.
+  # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  # for a description of the properties' semantics.
+  resources:
+    requests:
+      cpu: "0.1"
+      memory: "256M"
+    limits:
+      cpu: "0.5"
+      memory: "512M"
   # authUsername contains the name of the user that is authorized to connect to the example data grid.
   authUsername: "hono"
   # authPassword contains the secret of the user that is authorized to connect to the example data grid
@@ -65,6 +98,17 @@ jaegerBackendExample:
   # allInOneImage contains the name (including tag)
   # of the container image to use for the example Jaeger back end.
   allInOneImage: ${jaeger-all-in-one.image.name}
+  # resources contains the container's 'requests and limits for CPU and memory
+  # as defined by the Kubernetes API.
+  # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  # for a description of the properties' semantics.
+  resources:
+    requests:
+      cpu: "0.1"
+      memory: "256M"
+    limits:
+      cpu: "1"
+      memory: "512M"
   svc:
     annotations: {}
     loadBalancerIP:
@@ -174,6 +218,17 @@ adapters:
     # imageName contains the name (including registry and tag)
     # of the container image to use for the AMQP adapter
     imageName: ${docker.repository}/hono-adapter-amqp-vertx:${project.version}
+    # resources contains the container's 'requests and limits for CPU and memory
+    # as defined by the Kubernetes API.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
+      requests:
+        cpu: "0.05"
+        memory: "300M"
+      limits:
+        cpu: "1"
+        memory: "512M"
 
     svc:
       annotations: {}
@@ -232,6 +287,17 @@ adapters:
     # imageName contains the name (including registry and tag)
     # of the container image to use for the CoAP adapter
     imageName: ${docker.repository}/hono-adapter-coap-vertx:${project.version}
+    # resources contains the container's 'requests and limits for CPU and memory
+    # as defined by the Kubernetes API.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
+      requests:
+        cpu: "0.05"
+        memory: "256M"
+      limits:
+        cpu: "1"
+        memory: "512M"
 
     svc:
       annotations: {}
@@ -277,6 +343,17 @@ adapters:
     # imageName contains the name (including registry and tag)
     # of the container image to use for the HTTP adapter
     imageName: ${docker.repository}/hono-adapter-http-vertx:${project.version}
+    # resources contains the container's 'requests and limits for CPU and memory
+    # as defined by the Kubernetes API.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
+      requests:
+        cpu: "0.05"
+        memory: "300M"
+      limits:
+        cpu: "1"
+        memory: "512M"
 
     svc:
       annotations: {}
@@ -333,6 +410,17 @@ adapters:
     # imageName contains the name (including registry and tag)
     # of the container image to use for the LoRa adapter
     imageName: ${docker.repository}/hono-adapter-lora-vertx:${project.version}
+    # resources contains the container's 'requests and limits for CPU and memory
+    # as defined by the Kubernetes API.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
+      requests:
+        cpu: "0.05"
+        memory: "300M"
+      limits:
+        cpu: "1"
+        memory: "512M"
 
     svc:
       annotations: {}
@@ -386,6 +474,17 @@ adapters:
     # imageName contains the name (including registry and tag)
     # of the container image to use for the MQTT adapter
     imageName: ${docker.repository}/hono-adapter-mqtt-vertx:${project.version}
+    # resources contains the container's 'requests and limits for CPU and memory
+    # as defined by the Kubernetes API.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
+      requests:
+        cpu: "0.05"
+        memory: "300M"
+      limits:
+        cpu: "1"
+        memory: "512M"
 
     svc:
       annotations: {}
@@ -442,6 +541,18 @@ adapters:
     # imageName contains the name (including registry and tag)
     # of the container image to use for the Kura adapter
     imageName: ${docker.repository}/hono-adapter-kura:${project.version}
+    # resources contains the container's 'requests and limits for CPU and memory
+    # as defined by the Kubernetes API.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
+      requests:
+        cpu: "0.05"
+        memory: "300M"
+      limits:
+        cpu: "1"
+        memory: "512M"
+
     svc:
       annotations: {}
       loadBalancerIP:
@@ -498,6 +609,17 @@ authServer:
   # imageName contains the name (including registry and tag)
   # of the container image to use for the Auth Server
   imageName: ${docker.repository}/hono-service-auth:${project.version}
+  # resources contains the container's 'requests and limits for CPU and memory
+  # as defined by the Kubernetes API.
+  # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  # for a description of the properties' semantics.
+  resources:
+    requests:
+      cpu: "0.05"
+      memory: "196M"
+    limits:
+      cpu: "0.2"
+      memory: "256M"
 
   # extraSecretMounts describes additional secrets that should be mounted into the
   # Auth Server's' container filesystem. The files from the secret(s) can
@@ -572,6 +694,17 @@ deviceRegistryExample:
   # imageName contains the name (including registry and tag)
   # of the container image to use for the example Device Registry
   imageName: ${docker.repository}/hono-service-device-registry:${project.version}
+  # resources contains the container's 'requests and limits for CPU and memory
+  # as defined by the Kubernetes API.
+  # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  # for a description of the properties' semantics.
+  resources:
+    requests:
+      cpu: "0.05"
+      memory: "256M"
+    limits:
+      cpu: "0.3"
+      memory: "256M"
 
   svc:
     annotations: {}
@@ -664,6 +797,18 @@ deviceConnectionService:
   # imageName contains the name (including registry and tag)
   # of the container image to use for the Device Connection service
   imageName: ${docker.repository}/hono-service-device-connection:${project.version}
+  # resources contains the container's 'requests and limits for CPU and memory
+  # as defined by the Kubernetes API.
+  # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  # for a description of the properties' semantics.
+  resources:
+    requests:
+      cpu: "0.05"
+      memory: "256M"
+    limits:
+      cpu: "0.5"
+      memory: "256M"
+
   svc:
     annotations: {}
 
@@ -777,6 +922,17 @@ prometheus:
       scrape_interval: 10s
     service:
       servicePort: 9090
+    # resources contains the container's 'requests and limits for CPU and memory
+    # as defined by the Kubernetes API.
+    # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # for a description of the properties' semantics.
+    resources:
+      requests:
+        cpu: "0.05"
+        memory: "64M"
+      limits:
+        cpu: "0.5"
+        memory: "256M"
 
   alertmanager:
     enabled: false
@@ -803,6 +959,18 @@ grafana:
   podLabels:
     app.kubernetes.io/name: eclipse-hono
     app.kubernetes.io/component: dashboard
+
+  # resources contains the container's 'requests and limits for CPU and memory
+  # as defined by the Kubernetes API.
+  # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  # for a description of the properties' semantics.
+  resources:
+    requests:
+      cpu: "0.05"
+      memory: "64M"
+    limits:
+      cpu: "0.3"
+      memory: "256M"
 
   
   ## Expose the grafana service to be accessed from outside the cluster (LoadBalancer service).


### PR DESCRIPTION
All containers' resource requests and limits can now be configured using
configuration properties of the Helm chart. Reasonable defaults for the
example deployment have also been added.
