### PR TITLE
Pr/1072 gateway groups

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RegistrationConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistrationConstants.java
@@ -48,10 +48,28 @@ public final class RegistrationConstants extends RequestResponseApiConstants {
     public static final String FIELD_DATA         = "data";
 
     /**
-     * The name of the field in a device's registration information that contains
+     * The name of the field in a device registration information that contains
      * the identifier of the gateway that it is connected to (either as string value or inside a JSON array).
+     * Note, that it is only possible to either set the 'via' or the 'memberOf' property since gateways of gateways
+     * are currently not supported.
      */
     public static final String FIELD_VIA = "via";
+
+    /**
+     * The name of the field in the device registration information that contains the identifier of the gateways groups
+     * that the device is connected to (either as String value or inside a JSON array).
+     * Note, that is is only possible to either set the 'viaGroups' or the 'memberOf' property since groups of groups
+     * are currently not supported.
+     */
+    public static final String FIELD_VIA_GROUPS = "viaGroups";
+
+    /**
+     * The name of the field in a device registration information that contains the identifier of the names
+     * of the groups in which the device is member of (either as string value or inside a JSON array).
+     * Note, that it is only possible to either set the 'via' or the 'memberOf' property since groups of groups
+     * are currently not supported.
+     */
+    public static final String FIELD_MEMBER_OF = "memberOf";
 
     /**
      * The name of the Device Registration API endpoint.

--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/Device.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/Device.java
@@ -46,6 +46,14 @@ public class Device {
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
     private List<String> via = new LinkedList<>();
 
+    @JsonInclude(value = Include.NON_EMPTY)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    private List<String> viaGroups = new LinkedList<>();
+
+    @JsonInclude(value = Include.NON_EMPTY)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    private List<String> memberOf = new LinkedList<>();
+
     /**
      * Creates a new Device instance.
      */
@@ -68,6 +76,13 @@ public class Device {
         }
         if (other.via != null) {
             this.via = new ArrayList<>(other.via);
+        }
+        if (other.viaGroups != null) {
+            this.viaGroups = new ArrayList<>(other.viaGroups);
+        }
+
+        if (other.memberOf != null) {
+            this.memberOf = new ArrayList<>(other.memberOf);
         }
     }
 
@@ -160,9 +175,65 @@ public class Device {
      * 
      * @param via The via property to set.
      * @return    a reference to this for fluent use.
+     * @throws IllegalArgumentException if trying to set the 'via' property while the 'memberOf' property is already set.
      */
     public Device setVia(final List<String> via) {
+        if (memberOf != null && memberOf.size() > 0) {
+            throw new IllegalArgumentException("Trying to set the 'via' property while the 'memberOf' property is already set though both properties must not be set at the same time.");
+        }
         this.via = via;
         return this;
     }
+
+    /**
+     * Gets the identifiers of the gateway groups that this device may connect via.
+     *
+     * @return The group identifiers
+     */
+    public List<String> getViaGroups() {
+        return viaGroups;
+    }
+
+    /**
+     * Sets the identifiers of the gateway groups that this device may connect via.
+     *
+     * @param viaGroups The viaGroups property to set.
+     * @return a reference to this for fluent use.
+     * @throws IllegalArgumentException if trying to set the 'viaGroups' property while the 'memberOf' property is already set.
+     */
+    public Device setViaGroups(final List<String> viaGroups) {
+        if (memberOf != null && memberOf.size() > 0) {
+            throw new IllegalArgumentException("Trying to set the 'viaGroups' property while the 'memberOf' property is already set though both properties must not be set at the same time.");
+        }
+        this.viaGroups = viaGroups;
+        return this;
+    }
+
+    /**
+     * Gets the identifiers of the gateway groups in which the device is a member.
+     *
+     * @return The identifiers.
+     */
+    public List<String> getMemberOf() {
+        return memberOf;
+    }
+
+    /**
+     * Sets the identifiers of the gateway groups in which the device is a member.
+     *
+     * @param memberOf The memberOf property to set.
+     * @return    a reference to this for fluent use.
+     * @throws IllegalArgumentException if trying to set the 'memberOf' property while the 'via' or 'viaGroups' Fproperty is already set.
+     */
+    public Device setMemberOf(final List<String> memberOf) {
+        if (via != null && via.size() > 0) {
+            throw new IllegalArgumentException("Trying to set the 'memberOf' property while the 'via' property is already set though both properties must not be set at the same time.");
+        }
+        if (viaGroups != null && viaGroups.size() > 0) {
+            throw new IllegalArgumentException("Trying to set the 'memberOf' property while the 'viaGroups' property is already set though both properties must not be set at the same time.");
+        }
+        this.memberOf = memberOf;
+        return this;
+    }
+
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/management/device/DeviceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/management/device/DeviceTest.java
@@ -15,10 +15,13 @@ package org.eclipse.hono.service.management.device;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
 
 /**
  * Verifies {@link Device}.
@@ -106,6 +109,58 @@ public class DeviceTest {
         assertThat(json).isNotNull();
         assertThat(json.getBoolean("enabled")).isFalse();
         assertThat(json.getJsonObject("ext")).isNull();
+    }
+
+    /**
+     * Check whether 'via' cannot be set while 'memberOf' is set.
+     */
+    @Test
+    public void testSettingMemberOfAndVia() {
+        final var device = new Device();
+        final ArrayList<String> list = new ArrayList<>();
+        list.add("a");
+        device.setMemberOf(list);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> device.setVia(list),
+                "Property 'memberOf' and 'via' must not be set at the same time");
+    }
+
+    /**
+     * Check whether 'viaGroups' cannot be set while 'memberOf' is set.
+     */
+    @Test
+    public void testSettingMemberOfAndViaGroups() {
+        final var device = new Device();
+        final ArrayList<String> list = new ArrayList<>();
+        list.add("a");
+        device.setMemberOf(list);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> device.setViaGroups(list),
+                "Property 'memberOf' and 'viaGroups' must not be set at the same time");
+    }
+
+    /**
+     * Check whether 'memberOf' cannot be set while 'via' is set.
+     */
+    @Test
+    public void testSettingViaAndMemberOf() {
+        final var device = new Device();
+        final ArrayList<String> list = new ArrayList<>();
+        list.add("a");
+        device.setVia(list);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> device.setMemberOf(list),
+                "Property 'via' and 'memberOf' must not be set at the same time");
+    }
+
+    /**
+     * Check whether 'memberOf' cannot be set while 'viaGroups' is set.
+     */
+    @Test
+    public void testSettingViaGroupsAndMemberOf() {
+        final var device = new Device();
+        final ArrayList<String> list = new ArrayList<>();
+        list.add("a");
+        device.setViaGroups(list);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> device.setMemberOf(list),
+                "Property 'viaGroups' and 'memberOf' must not be set at the same time");
     }
 
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
@@ -158,6 +158,79 @@ public class BaseRegistrationServiceTest {
     }
 
     /**
+     * Verifies that a device's status cannot be asserted by a gateway that does not
+     * match the device's configured gateway group.
+     *
+     * @param ctx The vert.x unit test context.
+     */
+    @Test
+    public void testAssertDeviceRegistrationFailsForWrongGatewayGroup(final VertxTestContext ctx) {
+
+        // GIVEN a registry that contains an enabled device and two gateways:
+        // 1. the gateway that is member of the group the device is configured for.
+        // 2. another gateway which is not member of that group
+        final AbstractRegistrationService registrationService = newRegistrationService();
+
+        // WHEN trying to assert the device's registration status for the wrong gateway group
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-2", ctx.succeeding(result -> ctx.verify(() -> {
+            // THEN the assertion fails with a 403 status
+            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
+            // and the response payload is empty
+            assertNull(result.getPayload());
+            ctx.completeNow();
+        })));
+    }
+
+
+    /**
+     * Verifies that a device's status which use a gateway group cannot be asserted by a gateway that does not
+     * have any group membership configured.
+     *
+     * @param ctx The vert.x unit test context.
+     */
+    @Test
+    public void testAssertDeviceRegistrationFailsForGatewayWithNoGroup(final VertxTestContext ctx) {
+
+        // GIVEN a registry that contains an enabled device and two gateways:
+        // 1. the gateway that is member of the group the device is configured for.
+        // 2. another gateway which is not member of that group
+        final AbstractRegistrationService registrationService = newRegistrationService();
+
+        // WHEN trying to assert the device's registration status for the wrong gateway group
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-3", ctx.succeeding(result -> ctx.verify(() -> {
+            // THEN the assertion fails with a 403 status
+            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
+            // and the response payload is empty
+            assertNull(result.getPayload());
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that a device's status which use a gateway group cannot be asserted by a gateway that does not
+     * have any group membership configured.
+     *
+     * @param ctx The vert.x unit test context.
+     */
+    @Test
+    public void testAssertDeviceRegistrationFailsWithNoVia(final VertxTestContext ctx) {
+
+        // GIVEN a registry that contains an enabled device and two gateways:
+        // 1. the gateway that is member of the group the device is configured for.
+        // 2. another gateway which is not member of that group
+        final AbstractRegistrationService registrationService = newRegistrationService();
+
+        // WHEN trying to assert the device's registration status for the wrong gateway group
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4716", "gw-4", ctx.succeeding(result -> ctx.verify(() -> {
+            // THEN the assertion fails with a 403 status
+            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
+            // and the response payload is empty
+            assertNull(result.getPayload());
+            ctx.completeNow();
+        })));
+    }
+
+    /**
      * Verifies that the getDevice method returns "not implemented" if the base
      * {@link AbstractRegistrationService#getDevice(String, String, Span, Handler)} implementation is used.
      *
@@ -207,6 +280,48 @@ public class BaseRegistrationServiceTest {
     }
 
     /**
+     * Verifies that a device's status can be asserted by any existing member of gateway group
+     * where the device has been configured to connect via.
+     *
+     * @param ctx The vert.x unit test context.
+     */
+    @Test
+    public void testAssertDeviceRegistrationSucceedsForExistingGroup(final VertxTestContext ctx) {
+
+        // GIVEN a registry that contains an enabled device that is configured to
+        // connect via any of two enabled gateways.
+        final AbstractRegistrationService registrationService = newRegistrationService();
+
+        final Checkpoint assertion = ctx.checkpoint(2);
+
+
+
+        // WHEN trying to assert the device's registration status for gateway 1
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-5", ctx.succeeding(result -> ctx.verify(() -> {
+            // THEN the response contains a 200 status
+            assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+            final JsonObject payload = result.getPayload();
+            assertNotNull(payload);
+            final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
+            assertNotNull(via);
+            assertEquals(via, new JsonArray().add("gw-5").add("gw-6"));
+            assertion.flag();
+        })));
+
+        // WHEN trying to assert the device's registration status for gateway 4
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-6", ctx.succeeding(result -> ctx.verify(() -> {
+            // THEN the response contains a 200 status
+            assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+            final JsonObject payload = result.getPayload();
+            assertNotNull(payload);
+            final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
+            assertNotNull(via);
+            assertEquals(via, new JsonArray().add("gw-5").add("gw-6"));
+            assertion.flag();
+        })));
+    }
+
+    /**
      * Verifies that a device's status can be asserted by any existing gateway
      * it has been configured to connect via.
      *
@@ -227,6 +342,9 @@ public class BaseRegistrationServiceTest {
             assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
             final JsonObject payload = result.getPayload();
             assertNotNull(payload);
+            final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
+            assertNotNull(via);
+            assertEquals(via, new JsonArray().add("gw-1").add("gw-4"));
             assertion.flag();
         })));
 
@@ -236,6 +354,9 @@ public class BaseRegistrationServiceTest {
             assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
             final JsonObject payload = result.getPayload();
             assertNotNull(payload);
+            final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
+            assertNotNull(via);
+            assertEquals(via, new JsonArray().add("gw-1").add("gw-4"));
             assertion.flag();
         })));
     }
@@ -246,11 +367,11 @@ public class BaseRegistrationServiceTest {
      * @return New BaseRegistrationService instance.
      */
     private AbstractRegistrationService newRegistrationService() {
-        return newRegistrationService(this::getDevice);
+        return newRegistrationService(this::getDevice, this::resolveGatewayGroup);
     }
 
     private AbstractRegistrationService newRegistrationService(
-            final Function<String, Future<RegistrationResult>> devices) {
+            final Function<String, Future<RegistrationResult>> devices, final Function<JsonArray, Future<JsonArray>> resolveGatewayGroups) {
 
         return new AbstractRegistrationService() {
 
@@ -260,11 +381,17 @@ public class BaseRegistrationServiceTest {
                 devices.apply(deviceId).setHandler(resultHandler);
             }
 
+            @Override
+            protected void resolveGroupMembers(final String tenantId, final JsonArray viaGroups, final Span span, final Handler<AsyncResult<JsonArray>> resultHandler) {
+                resolveGatewayGroups.apply(viaGroups).setHandler(resultHandler);
+            }
+
+
         };
     }
 
     /**
-     * Create a BaseRegistrationService where the <em>getDevice</em> method is not implemented.
+     * Create a BaseRegistrationService where the <em>getDevice</em> and resolveGroupMembers methods are not implemented.
      *
      * @return New BaseRegistrationService instance.
      */
@@ -277,6 +404,13 @@ public class BaseRegistrationServiceTest {
                     final Handler<AsyncResult<RegistrationResult>> resultHandler) {
                 resultHandler.handle(
                         Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_NOT_IMPLEMENTED)));
+            }
+
+            @Override
+            protected void resolveGroupMembers(final String tenantId, final JsonArray viaGroups, final Span span, final Handler<AsyncResult<JsonArray>> resultHandler) {
+                resultHandler.handle(
+                        Future.succeededFuture(new JsonArray())
+                );
             }
         };
     }
@@ -328,6 +462,20 @@ public class BaseRegistrationServiceTest {
                                 .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, "application/default"))
                         .put(RegistrationConstants.FIELD_VIA, new JsonArray().add("gw-1").add("gw-4")));
             return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("4715".equals(deviceId)) {
+            final JsonObject responsePayload = getResultPayload(
+                    "4715",
+                    new JsonObject()
+                            .put(RegistrationConstants.FIELD_ENABLED, true)
+                            .put(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS, new JsonObject()
+                                    .put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, "application/default"))
+                            .put(RegistrationConstants.FIELD_VIA_GROUPS, "group-1"));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("4716".equals(deviceId)) {
+            final JsonObject responsePayload = getResultPayload(
+                    "4716",
+                    new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
         } else if ("gw-1".equals(deviceId)) {
             final JsonObject responsePayload = getResultPayload(
                     "gw-1",
@@ -336,7 +484,9 @@ public class BaseRegistrationServiceTest {
         } else if ("gw-2".equals(deviceId)) {
             final JsonObject responsePayload = getResultPayload(
                     "gw-2",
-                    new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true));
+                    new JsonObject()
+                            .put(RegistrationConstants.FIELD_ENABLED, true)
+                            .put(RegistrationConstants.FIELD_MEMBER_OF, "group-2"));
             return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
         } else if ("gw-3".equals(deviceId)) {
             final JsonObject responsePayload = getResultPayload(
@@ -348,8 +498,30 @@ public class BaseRegistrationServiceTest {
                     "gw-4",
                     new JsonObject().put(RegistrationConstants.FIELD_ENABLED, true));
             return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("gw-5".equals(deviceId)) {
+            final JsonObject responsePayload = getResultPayload(
+                    "gw-5",
+                    new JsonObject()
+                            .put(RegistrationConstants.FIELD_ENABLED, true)
+                            .put(RegistrationConstants.FIELD_MEMBER_OF, "group-1"));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
+        } else if ("gw-6".equals(deviceId)) {
+            final JsonObject responsePayload = getResultPayload(
+                    "gw-6",
+                    new JsonObject()
+                            .put(RegistrationConstants.FIELD_ENABLED, true)
+                            .put(RegistrationConstants.FIELD_MEMBER_OF, new JsonArray().add("group-1").add("group-2")));
+            return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, responsePayload));
         } else {
             return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_NOT_FOUND));
+        }
+    }
+
+    private Future<JsonArray> resolveGatewayGroup(final JsonArray via) {
+        if (new JsonArray().add("group-1").equals(via)) {
+            return Future.succeededFuture(new JsonArray().add("gw-5").add("gw-6"));
+        } else {
+            return Future.succeededFuture(new JsonArray());
         }
     }
 }

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyRegistrationService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/DummyRegistrationService.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.deviceregistry;
 
 import java.net.HttpURLConnection;
 
+import io.vertx.core.json.JsonArray;
 import org.eclipse.hono.service.registration.AbstractRegistrationService;
 import org.eclipse.hono.util.RegistrationResult;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -45,16 +46,23 @@ public class DummyRegistrationService extends AbstractRegistrationService {
     public void assertRegistration(final String tenantId, final String deviceId, final String gatewayId,
             final Span span, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
        final JsonObject deviceData = new JsonObject();
-
-        resultHandler.handle(Future.succeededFuture(RegistrationResult.from(
+        getAssertionPayload(tenantId, deviceId, deviceData)
+                .compose(payload -> Future.succeededFuture(RegistrationResult.from(
                 HttpURLConnection.HTTP_OK,
-                getAssertionPayload(tenantId, deviceId, deviceData))));
+                payload))).setHandler(resultHandler);
     }
 
     @Override
     protected void getDevice(final String tenantId, final String deviceId, final Span span,
             final Handler<AsyncResult<RegistrationResult>> resultHandler) {
         resultHandler.handle(Future.failedFuture("Not implemented"));
+    }
+
+    @Override
+    protected void resolveGroupMembers(final String tenantId, final JsonArray viaGroups, final Span span,
+                                       final Handler<AsyncResult<JsonArray>> resultHandler) {
+        resultHandler.handle(Future.failedFuture("Not implemented"));
+
     }
 
 }

--- a/services/device-registry/src/test/resources/device-identities.json
+++ b/services/device-registry/src/test/resources/device-identities.json
@@ -39,11 +39,52 @@
         }
       },
       {
+        "device-id": "4714",
+        "data": {
+          "enabled": true,
+          "comment": [
+            "this device connects only via the gateway indicated by the 'via' property",
+            "therefore, no credentials are registered for the device"
+          ],
+          "via": ["gw-1"],
+          "viaGroups": ["group-1"]
+        }
+      },
+      {
+        "device-id": "4715",
+        "data": {
+          "enabled": true,
+          "comment": [
+            "this device connects only via the gateway indicated by the 'via' property",
+            "therefore, no credentials are registered for the device"
+          ],
+          "viaGroups": "group-2"
+        }
+      },
+      {
         "device-id": "gw-1",
         "data": {
           "enabled": true,
           "comment": "this device is authorized to publish data on behalf of device 4712"
         }
+      },
+      {
+        "device-id": "gw-2",
+        "data": {
+          "enabled": true,
+          "comment": "this device is authorized to publish data on behalf of device 4714 and 4715"
+        },
+        "memberOf": [
+          "group-1", "group-2"
+        ]
+      },
+      {
+        "device-id": "gw-3",
+        "data": {
+          "enabled": true,
+          "comment": "this device is authorized to publish data on behalf of device 4714"
+        },
+        "memberOf": "group-1"
       }
     ]
   }

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -36,7 +36,7 @@ info:
    license:
       name: EPL-2.0
       url: https://www.eclipse.org/legal/epl-2.0/
-   version: 1.0.1
+   version: 1.1.0
 
 externalDocs:
    description: Eclipse Hono™ web page
@@ -765,7 +765,17 @@ components:
                type: array
                items:
                   type: string
-               description: The device IDs of the gateways this device is assigned to.
+               description: The device IDs of the gateways that are registered to act on behalf of this device. Note that "via" and "memberOf" must not be set at the same time.
+            "viaGroups":
+               type: array
+               items:
+                  type: string
+               description: The IDs of the gateway groups that are registered to act on behalf of this device. Note that "viaGroups" and "memberOf" must not be set at the same time.
+            "memberOf":
+               type: array
+               items:
+                  type: string
+               description: The IDs of the gateway groups in which this device is a member. Note that "via" and "memberOf" must not be set at the same time. The same applies for "viaGroups" and "memberOf" which must not be set at the same time too. The reason is that Eclipse Hono does not support groups of gateway groups.
             "ext":
                $ref: '#/components/schemas/Extensions'
 

--- a/site/documentation/content/concepts/gateways.md
+++ b/site/documentation/content/concepts/gateways.md
@@ -1,0 +1,29 @@
++++
+title = "Gateways"
+weight = 182
++++
+
+This page describes how gateways and groups of gateways are represented and identified throughout Hono and its APIs.
+<!--more-->
+ ---
+
+In some circumstances, a device may not directly communicate with Hono. An example is a device that does not have the capabilities to directly communicate with one of the protocol adapters.  Instead, such devices can connect to Hono through a gateway. A gateway is a device or software system that acts on behalf of other devices. From the perspective of Hono a gateway is another device following the description in [Device Identity]({{< relref "device-identity" >}}).
+
+When a device wants to communicate over a gateway that gateway needs to be registered as gateway for the device. One can perform this registration as part of the [Device Registry Management API]({{< relref "/api/management" >}}) of the Device Registry. In that API each device representation has a 'via' property which is a list with the ids of the devices that can act on behalf of the represented device as a gateway. 
+
+Part of the functionality provided by the  [Device Registration API]({{< relref "/api/device-registration" >}}) is to assert that a device is actually registered to act for a given device as a gateway. Thus, for instance, the protocol adapters use this API to verify that the involved devices and the combination of device and gateway are valid.
+
+In general, it is possible to register multiple gateways with a device. Sometimes, for instance, while sending commands to the device, Hono needs to decide which of the possible gateways should be used to transmit that message to the device. One solution is to choose the last known gateway over which the device has communicated in the past. To store and retrieve this information the [Device Connection API]({{< relref "/api/device-connection" >}}) offers the opportunity to set and get the last known gateway for each device.
+
+
+## Gateway Groups
+For more complex or larger scenarios like with a larger number of gateways per device or where many devices use the same gateways, it can become cumbersome to list all possible gateways in each 'via' property of the affected devices. This becomes even more complex when the gateways change frequently. To overcome such situations it is possible to define gateway groups in the Device Registry of Hono which describe a set of gateways.  
+
+To add a device to a gateway group, one can add the id of the gateway group to the list in the 'memberOf' property of that device. In the representation of the device that shall communicate via one of the members of a gateway group one can add the id of the group to the list in 'viaGroups' property of the device representation.
+
+It is important to note that the concept of gateway groups is only known in the scope of the Device Registry. 
+This means that the ids of the groups are not known or used by other services within Hono. 
+As a consequence, the "Assert Device Registration" endpoint in the [Device Registration API]({{< relref "/api/device-registration" >}}) does not 
+include the ids of gateway groups when it includes the registered gateways for a device in a response message. 
+Instead, the endpoint resolves the members of the gateway groups and adds them to the 'via' property of the response message. 
+Note that the endpoint will not resolve gateway groups recursively. Thus, every potential gateway needs to be either mentioned in the 'via' property of the device in question or a direct member of a group mentioned in the 'viaGroups' property of the device in question.


### PR DESCRIPTION
Added a "memberOf" property to the devices endpoint in the Device Registration API. This property defines the membership of a device to a gateway group that can be used in the 'via' property of another device instead of listing the members of the group in that 'via' list.