### PR TITLE
Add receiver exception handling; fix wrong span being used

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/RequestResponseEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/RequestResponseEndpoint.java
@@ -164,7 +164,12 @@ public abstract class RequestResponseEndpoint<T extends ServiceConfigProperties>
             // set up handlers
 
             receiver.handler((delivery, message) -> {
-                handleRequestMessage(con, receiver, targetAddress, delivery, message);
+                try {
+                    handleRequestMessage(con, receiver, targetAddress, delivery, message);
+                } catch (final Exception ex) {
+                    logger.warn("error handling message", ex);
+                    ProtonHelper.released(delivery, true);
+                }
             });
             HonoProtonHelper.setCloseHandler(receiver, remoteClose -> onLinkDetach(receiver));
             HonoProtonHelper.setDetachHandler(receiver, remoteDetach -> onLinkDetach(receiver));

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantTraceSamplingHelper.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantTraceSamplingHelper.java
@@ -39,6 +39,21 @@ public final class TenantTraceSamplingHelper {
     }
 
     /**
+     * Gets the trace sampling priority configured for the given tenant.
+     *
+     * @param tenantObjectWithAuthId The tenant object combined with an auth-id.
+     * @return An <em>OptionalInt</em> containing the identified sampling priority or an empty
+     *         <em>OptionalInt</em> if no priority was identified.
+     * @throws NullPointerException if tenantObjectWithAuthId is {@code null}.
+     */
+    public static OptionalInt getTraceSamplingPriority(final TenantObjectWithAuthId tenantObjectWithAuthId) {
+        Objects.requireNonNull(tenantObjectWithAuthId);
+        return Optional.ofNullable(getSamplingMode(tenantObjectWithAuthId))
+                .map(mode -> getSamplingPriority(mode))
+                .orElse(OptionalInt.empty());
+    }
+
+    /**
      * Applies the trace sampling priority configured for the given tenant to the given span.
      *
      * @param tenantObjectWithAuthId The tenant object combined with an auth-id.


### PR DESCRIPTION
Adds `try-catch` for `ProtonReceiver` handler code, acting as a safety net to ensure that receiver credit handling won't get corrupted by an exception in the handler code.

Also fixes a wrong span object being used in AMQP adapter receiver handler (incoming telemetry/event message handling spans should not get the span created during link creation as parent).