### PR TITLE
Add HonoConnection#getRemoteContainer, use it in client span

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -219,6 +219,17 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
     boolean isShutdown();
 
     /**
+     * Gets the remote container id as advertised by the peer.
+     * <p>
+     * This default implementation simply returns {@code N/A}.
+     *
+     * @return The remote container id or {@code null}.
+     */
+    default String getRemoteContainer() {
+        return "N/A";
+    }
+
+    /**
      * Checks if this client supports a certain capability.
      * <p>
      * The result of this method should only be considered reliable if this client is connected to the server.

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClient.java
@@ -104,6 +104,7 @@ public abstract class AbstractHonoClient {
      * <li>{@link Tags#COMPONENT} - set to <em>hono-client</em></li>
      * <li>{@link Tags#PEER_HOSTNAME} - set to {@link ClientConfigProperties#getHost()}</li>
      * <li>{@link Tags#PEER_PORT} - set to {@link ClientConfigProperties#getPort()}</li>
+     * <li>{@link TracingHelper#TAG_PEER_CONTAINER} - set to {@link HonoConnection#getRemoteContainer()}</li>
      * </ul>
      * 
      * @param parent The existing span. If not {@code null} then the new span will have a
@@ -124,6 +125,7 @@ public abstract class AbstractHonoClient {
      * <li>{@link Tags#COMPONENT} - set to <em>hono-client</em></li>
      * <li>{@link Tags#PEER_HOSTNAME} - set to {@link ClientConfigProperties#getHost()}</li>
      * <li>{@link Tags#PEER_PORT} - set to {@link ClientConfigProperties#getPort()}</li>
+     * <li>{@link TracingHelper#TAG_PEER_CONTAINER} - set to {@link HonoConnection#getRemoteContainer()}</li>
      * </ul>
      * 
      * @param parent The existing span. If not {@code null} then the new span will have a
@@ -143,6 +145,7 @@ public abstract class AbstractHonoClient {
                 .withTag(Tags.COMPONENT.getKey(), "hono-client")
                 .withTag(Tags.PEER_HOSTNAME.getKey(), connection.getConfig().getHost())
                 .withTag(Tags.PEER_PORT.getKey(), connection.getConfig().getPort())
+                .withTag(TracingHelper.TAG_PEER_CONTAINER.getKey(), connection.getRemoteContainer())
                 .start();
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
@@ -463,6 +463,9 @@ public class HonoConnectionImpl implements HonoConnection {
                                             new ClientErrorException(HttpURLConnection.HTTP_CONFLICT,
                                                     "client is already shut down")));
                                 } else {
+                                    log.debug("attempt [#{}]: connected to server [{}:{}]; remote container: {}",
+                                            connectAttempts.get() + 1, connectionFactory.getHost(),
+                                            connectionFactory.getPort(), newConnection.getRemoteContainer());
                                     setConnection(newConnection);
                                     wrappedConnectionHandler.handle(Future.succeededFuture(this));
                                 }
@@ -995,6 +998,19 @@ public class HonoConnectionImpl implements HonoConnection {
             completionHandler.handle(Future.failedFuture(
                     new ClientErrorException(HttpURLConnection.HTTP_CONFLICT, "already disconnecting")));
         }
+    }
+
+    /**
+     * Gets the remote container id as advertised by the peer.
+     *
+     * @return The remote container id or {@code null}.
+     */
+    @Override
+    public String getRemoteContainer() {
+        if (!isConnectedInternal()) {
+            return null;
+        }
+        return connection.getRemoteContainer();
     }
 
     //-----------------------------------< private methods >---

--- a/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
@@ -106,7 +106,7 @@ public final class HonoClientUnitTestHelper {
         final SpanBuilder spanBuilder = mock(SpanBuilder.class, Mockito.RETURNS_SMART_NULLS);
         when(spanBuilder.addReference(anyString(), any())).thenReturn(spanBuilder);
         when(spanBuilder.withTag(anyString(), anyBoolean())).thenReturn(spanBuilder);
-        when(spanBuilder.withTag(anyString(), anyString())).thenReturn(spanBuilder);
+        when(spanBuilder.withTag(anyString(), (String) any())).thenReturn(spanBuilder);
         when(spanBuilder.withTag(anyString(), (Number) any())).thenReturn(spanBuilder);
         when(spanBuilder.ignoreActiveSpan()).thenReturn(spanBuilder);
         when(spanBuilder.start()).thenReturn(spanToCreate);

--- a/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/TracingHelper.java
@@ -90,6 +90,10 @@ public final class TracingHelper {
      */
     public static final StringTag TAG_REMOTE_STATE = new StringTag("message_bus.remote_state");
     /**
+     * An OpenTracing tag that indicates the container id of a remote peer.
+     */
+    public static final StringTag TAG_PEER_CONTAINER = new StringTag("peer.container");
+    /**
      * An OpenTracing tag indicating if a client's connection is secured using TLS.
      */
     public static final BooleanTag TAG_TLS = new BooleanTag("tls");


### PR DESCRIPTION
This adds a tag to tracing spans created by `AbstractHonoClient` implementations, containing the remote container id of the AMQP connection (as advertised in the `open` frame by the peer).

For that, a `HoneConnection#getRemoteContainer` method is added.

The remote container id information in traces can be useful in cases where the AMQP messaging network is represented by multiple containers behind a load balancer. For debugging error scenarios, it can be helpful to know to which container exactly a connection has been established.