### PR TITLE
Allow unit tests to be run in parallel

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterLegacyEndpointTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterLegacyEndpointTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.hono.adapter.amqp.impl;
 
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
 
 /**
  * Verifies the behavior of {@link VertxBasedAmqpProtocolAdapter} using the legacy Command & Control endpoint.
  */
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class VertxBasedAmqpProtocolAdapterLegacyEndpointTest extends VertxBasedAmqpProtocolAdapterTest {
 
     @Override

--- a/adapters/amqp-vertx/src/test/resources/logback-test.xml
+++ b/adapters/amqp-vertx/src/test/resources/logback-test.xml
@@ -22,14 +22,14 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
+  <root level="WARN">
     <appender-ref ref="STDOUT" />
   </root>
 
-  <logger name="org.eclipse.hono.adapter" level="INFO"/>
-  <logger name="org.eclipse.hono.auth" level="INFO"/>
-  <logger name="org.eclipse.hono.config" level="INFO"/>
-  <logger name="org.eclipse.hono.connection" level="INFO"/>
-  <logger name="org.eclipse.hono.util" level="INFO"/>
+  <logger name="org.eclipse.hono.adapter" level="WARN"/>
+  <logger name="org.eclipse.hono.auth" level="WARN"/>
+  <logger name="org.eclipse.hono.config" level="WARN"/>
+  <logger name="org.eclipse.hono.connection" level="WARN"/>
+  <logger name="org.eclipse.hono.util" level="WARN"/>
 
 </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -122,6 +122,10 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/org/eclipse/hono/auth/SpringBasedHonoPasswordEncoderTest.java
+++ b/core/src/test/java/org/eclipse/hono/auth/SpringBasedHonoPasswordEncoderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,9 +14,9 @@
 
 package org.eclipse.hono.auth;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -26,8 +26,8 @@ import java.util.Base64;
 
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.JsonObject;
 
@@ -45,7 +45,7 @@ public class SpringBasedHonoPasswordEncoderTest {
     /**
      * Sets up the fixture.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         encoder = new SpringBasedHonoPasswordEncoder(4);
     }

--- a/core/src/test/java/org/eclipse/hono/config/KeyLoaderTest.java
+++ b/core/src/test/java/org/eclipse/hono/config/KeyLoaderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,9 +12,13 @@
  *******************************************************************************/
 package org.eclipse.hono.config;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.Vertx;
 
@@ -44,10 +48,11 @@ public class KeyLoaderTest {
     /**
      * Verifies that the loader fails to load a non-existing key store.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLoaderFailsForNonExistingKeyStore() {
 
-        KeyLoader.fromKeyStore(vertx, "non-existing.p12", "secret".toCharArray());
+        assertThatThrownBy(() -> KeyLoader.fromKeyStore(vertx, "non-existing.p12", "secret".toCharArray()))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     /**
@@ -94,20 +99,22 @@ public class KeyLoaderTest {
      * Verifies that the loader fails to load a private key from
      * a non-existing PEM file.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLoaderFailsForNonExistingKeyFile() {
 
-        KeyLoader.fromFiles(vertx, "non-existing-key.pem", PREFIX_KEY_PATH + "auth-server-cert.pem");
+        assertThatThrownBy(() -> KeyLoader.fromFiles(vertx, "non-existing-key.pem", PREFIX_KEY_PATH + "auth-server-cert.pem"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     /**
      * Verifies that the loader fails to load a certificate from
      * a non-existing PEM file.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLoaderFailsForNonExistingCertFile() {
 
-        KeyLoader.fromFiles(vertx, PREFIX_KEY_PATH + "auth-server-key.pem", "non-existing-cert.pem");
+        assertThatThrownBy(() -> KeyLoader.fromFiles(vertx, PREFIX_KEY_PATH + "auth-server-key.pem", "non-existing-cert.pem"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     /**

--- a/core/src/test/java/org/eclipse/hono/tracing/MessageAnnotationsInjectExtractAdapterTest.java
+++ b/core/src/test/java/org/eclipse/hono/tracing/MessageAnnotationsInjectExtractAdapterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,7 @@
 
 package org.eclipse.hono.tracing;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,7 +21,7 @@ import java.util.Map;
 import org.apache.qpid.proton.codec.WritableBuffer;
 import org.apache.qpid.proton.message.Message;
 import org.apache.qpid.proton.message.impl.MessageImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests verifying the behavior of {@link MessageAnnotationsInjectAdapter} and {@link MessageAnnotationsExtractAdapter}.
@@ -59,7 +58,7 @@ public class MessageAnnotationsInjectExtractAdapterTest {
         // extract the properties from the decoded message
         final MessageAnnotationsExtractAdapter extractAdapter = new MessageAnnotationsExtractAdapter(decodedMessage, propertiesMapName);
         extractAdapter.iterator().forEachRemaining(extractedEntry -> {
-            assertThat(extractedEntry.getValue(), is(testEntries.get(extractedEntry.getKey())));
+            assertThat(extractedEntry.getValue()).isEqualTo(testEntries.get(extractedEntry.getKey()));
         });
     }
 }

--- a/core/src/test/java/org/eclipse/hono/tracing/TracingHelperTest.java
+++ b/core/src/test/java/org/eclipse/hono/tracing/TracingHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,16 +13,14 @@
 
 package org.eclipse.hono.tracing;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import io.opentracing.Span;
@@ -48,10 +46,10 @@ public class TracingHelperTest {
         verify(span).log(itemsCaptor.capture());
 
         final Map<?, ?> capturedItemsMap = itemsCaptor.getValue();
-        assertThat(capturedItemsMap, is(notNullValue()));
-        assertThat(capturedItemsMap.size(), is(2));
-        assertThat(capturedItemsMap.get(Fields.MESSAGE), is(errorMessage));
-        assertThat(capturedItemsMap.get(Fields.EVENT), is(Tags.ERROR.getKey()));
+        assertThat(capturedItemsMap).isNotNull();
+        assertThat(capturedItemsMap).hasSize(2);
+        assertThat(capturedItemsMap.get(Fields.MESSAGE)).isEqualTo(errorMessage);
+        assertThat(capturedItemsMap.get(Fields.EVENT)).isEqualTo(Tags.ERROR.getKey());
     }
 
     /**
@@ -68,10 +66,10 @@ public class TracingHelperTest {
         verify(span).log(itemsCaptor.capture());
 
         final Map<?, ?> capturedItemsMap = itemsCaptor.getValue();
-        assertThat(capturedItemsMap, is(notNullValue()));
-        assertThat(capturedItemsMap.size(), is(2));
-        assertThat(capturedItemsMap.get(Fields.MESSAGE), is(errorMessage));
-        assertThat(capturedItemsMap.get(Fields.EVENT), is(Tags.ERROR.getKey()));
+        assertThat(capturedItemsMap).isNotNull();
+        assertThat(capturedItemsMap).hasSize(2);
+        assertThat(capturedItemsMap.get(Fields.MESSAGE)).isEqualTo(errorMessage);
+        assertThat(capturedItemsMap.get(Fields.EVENT)).isEqualTo(Tags.ERROR.getKey());
     }
 
     /**
@@ -88,9 +86,9 @@ public class TracingHelperTest {
         verify(span).log(itemsCaptor.capture());
 
         final Map<?, ?> capturedItemsMap = itemsCaptor.getValue();
-        assertThat(capturedItemsMap, is(notNullValue()));
-        assertThat(capturedItemsMap.size(), is(2));
-        assertThat(capturedItemsMap.get(Fields.ERROR_OBJECT), is(exception));
-        assertThat(capturedItemsMap.get(Fields.EVENT), is(Tags.ERROR.getKey()));
+        assertThat(capturedItemsMap).isNotNull();
+        assertThat(capturedItemsMap).hasSize(2);
+        assertThat(capturedItemsMap.get(Fields.ERROR_OBJECT)).isEqualTo(exception);
+        assertThat(capturedItemsMap.get(Fields.EVENT)).isEqualTo(Tags.ERROR.getKey());
     }
 }

--- a/core/src/test/java/org/eclipse/hono/util/CredentialsObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/CredentialsObjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,11 +13,12 @@
 
 package org.eclipse.hono.util;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.JsonObject;
 
@@ -57,10 +58,10 @@ public class CredentialsObjectTest {
      * Verifies that credentials that do not contain any secrets are
      * detected as invalid.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCheckSecretsDetectsMissingSecrets() {
         final CredentialsObject creds = new CredentialsObject("tenant", "device", "x509-cert");
-        creds.checkSecrets();
+        assertThatThrownBy(() -> creds.checkSecrets()).isInstanceOf(IllegalStateException.class);
     }
 
     /**
@@ -78,63 +79,66 @@ public class CredentialsObjectTest {
      * Verifies that credentials that contain a malformed not-before value are
      * detected as invalid.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCheckSecretsDetectsMalformedNotBefore() {
         final CredentialsObject creds = new CredentialsObject("tenant", "device", "x509-cert");
         creds.setType(CredentialsConstants.SECRETS_TYPE_PRESHARED_KEY);
         creds.addSecret(new JsonObject()
                 .put(CredentialsConstants.FIELD_SECRETS_NOT_BEFORE, "malformed"));
-        creds.checkSecrets();
+
+        assertThatThrownBy(() -> creds.checkSecrets()).isInstanceOf(IllegalStateException.class);
     }
 
     /**
      * Verifies that credentials that contain a malformed not-before value are
      * detected as invalid.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCheckSecretsDetectsMalformedNotAfter() {
         final CredentialsObject creds = new CredentialsObject("tenant", "device", "x509-cert");
         creds.setType(CredentialsConstants.SECRETS_TYPE_PRESHARED_KEY);
         creds.addSecret(new JsonObject()
                 .put(CredentialsConstants.FIELD_SECRETS_NOT_AFTER, "malformed"));
-        creds.checkSecrets();
+
+        assertThatThrownBy(() -> creds.checkSecrets()).isInstanceOf(IllegalStateException.class);
     }
 
     /**
      * Verifies that credentials that contain inconsistent values for not-before
      * and not-after are detected as invalid.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCheckSecretsDetectsInconsistentValidityPeriod() {
         final CredentialsObject creds = new CredentialsObject("tenant", "device", "x509-cert");
         creds.setType(CredentialsConstants.SECRETS_TYPE_PRESHARED_KEY);
         creds.addSecret(new JsonObject()
                 .put(CredentialsConstants.FIELD_SECRETS_NOT_BEFORE, "2018-10-10T00:00:00+00:00")
                 .put(CredentialsConstants.FIELD_SECRETS_NOT_AFTER, "2018-10-01T00:00:00+00:00"));
-        creds.checkSecrets();
+
+        assertThatThrownBy(() -> creds.checkSecrets()).isInstanceOf(IllegalStateException.class);
     }
 
     /**
      * Verifies that hashed-password credentials that do not contain the hash function name are
      * detected as invalid.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCheckSecretsDetectsMissingHashFunction() {
         final CredentialsObject creds = new CredentialsObject("tenant", "device", "x509-cert");
         creds.setType(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD);
         creds.addSecret(new JsonObject().put(CredentialsConstants.FIELD_SECRETS_PWD_HASH, "hash"));
-        creds.checkSecrets();
+        assertThatThrownBy(() -> creds.checkSecrets()).isInstanceOf(IllegalStateException.class);
     }
 
     /**
      * Verifies that hashed-password credentials that do not contain the hash value are
      * detected as invalid.
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCheckSecretsDetectsMissingHashValue() {
         final CredentialsObject creds = new CredentialsObject("tenant", "device", "x509-cert");
         creds.setType(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD);
         creds.addSecret(new JsonObject().put(CredentialsConstants.FIELD_SECRETS_HASH_FUNCTION, CredentialsConstants.HASH_FUNCTION_SHA256));
-        creds.checkSecrets();
+        assertThatThrownBy(() -> creds.checkSecrets()).isInstanceOf(IllegalStateException.class);
     }
 }

--- a/core/src/test/java/org/eclipse/hono/util/JwtHelperTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/JwtHelperTest.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.hono.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -22,7 +22,7 @@ import java.util.Date;
 
 import javax.crypto.SecretKey;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;

--- a/core/src/test/java/org/eclipse/hono/util/MessageTapTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/MessageTapTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,7 +14,7 @@
 
 package org.eclipse.hono.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.proton.ProtonHelper;
 

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -23,14 +23,13 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
+  <root level="WARN">
     <appender-ref ref="STDOUT" />
   </root>
 
-  <logger name="org.eclipse.hono.adapter" level="INFO"/>
-  <logger name="org.eclipse.hono.auth" level="INFO"/>
-  <logger name="org.eclipse.hono.config" level="INFO"/>
-  <logger name="org.eclipse.hono.connection" level="INFO"/>
-  <logger name="org.eclipse.hono.util" level="INFO"/>
+  <logger name="org.eclipse.hono.auth" level="WARN"/>
+  <logger name="org.eclipse.hono.config" level="WARN"/>
+  <logger name="org.eclipse.hono.connection" level="WARN"/>
+  <logger name="org.eclipse.hono.util" level="WARN"/>
 
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -302,12 +302,21 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>2.22.2</version>
+          <configuration>
+            <properties>
+              <configurationParameters>
+                junit.jupiter.execution.parallel.enabled = true
+                junit.jupiter.execution.parallel.mode.default = same_thread
+                junit.jupiter.execution.parallel.mode.classes.default = concurrent
+              </configurationParameters>
+            </properties>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>2.22.2</version>
         </plugin>
         <plugin>
           <!--


### PR DESCRIPTION
Added configuration properties to the Surefire plugin that allows JUnit
5 based unit test classes to be run in parallel. The individual test
methods of each class are still run on the same thread in order to
prevent race conditions arising from field access.