### PR TITLE
[#1681] Upgrade to Opentracing 0.33

### DIFF
--- a/adapters/http-vertx-base/pom.xml
+++ b/adapters/http-vertx-base/pom.xml
@@ -27,10 +27,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-vertx-web</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -38,6 +38,8 @@ import org.eclipse.hono.service.http.ComponentMetaDataDecorator;
 import org.eclipse.hono.service.http.DefaultFailureHandler;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.service.http.TenantTraceSamplingHandler;
+import org.eclipse.hono.service.http.TracingHandler;
+import org.eclipse.hono.service.http.WebSpanDecorator;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
 import org.eclipse.hono.service.metric.MetricsTags.EndpointType;
@@ -55,8 +57,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import io.micrometer.core.instrument.Timer.Sample;
 import io.opentracing.Span;
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
-import io.opentracing.contrib.vertx.ext.web.WebSpanDecorator;
 import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -53,6 +53,7 @@ import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.http.HttpUtils;
+import org.eclipse.hono.service.http.TracingHandler;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
 import org.eclipse.hono.service.metric.MetricsTags.EndpointType;
@@ -76,7 +77,6 @@ import org.mockito.Mockito;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;

--- a/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -69,6 +69,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.SLF4JLogDelegateFactory;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -129,6 +130,8 @@ public class VertxBasedHttpProtocolAdapterTest {
     @SuppressWarnings("unchecked")
     @BeforeClass
     public static void deployAdapter(final TestContext ctx) {
+
+        System.setProperty("vertx.logger-delegate-factory-class-name", SLF4JLogDelegateFactory.class.getName());
         vertx = Vertx.vertx();
 
         tenantClientFactory = mock(TenantClientFactory.class);

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -46,6 +46,7 @@ import org.eclipse.hono.service.auth.device.X509AuthProvider;
 import org.eclipse.hono.service.http.HonoBasicAuthHandler;
 import org.eclipse.hono.service.http.HonoChainAuthHandler;
 import org.eclipse.hono.service.http.HttpUtils;
+import org.eclipse.hono.service.http.TracingHandler;
 import org.eclipse.hono.service.http.X509AuthHandler;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
@@ -58,7 +59,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
 import io.opentracing.noop.NoopSpan;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Future;

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -38,9 +38,9 @@
     <infinispan.version>9.4.16.Final</infinispan.version>
     <infinispan.image.name>jboss/infinispan-server:9.4.11.Final</infinispan.image.name>
     <jackson.version>2.9.10</jackson.version>
-    <jaeger.version>0.34.0</jaeger.version>
-    <jaeger-agent.image.name>jaegertracing/jaeger-agent:1.13.1</jaeger-agent.image.name>
-    <jaeger-all-in-one.image.name>jaegertracing/all-in-one:1.13.1</jaeger-all-in-one.image.name>
+    <jaeger.version>0.35.2</jaeger.version>
+    <jaeger-agent.image.name>jaegertracing/jaeger-agent:1.16.0</jaeger-agent.image.name>
+    <jaeger-all-in-one.image.name>jaegertracing/all-in-one:1.16.0</jaeger-all-in-one.image.name>
     <java-base-image.name>docker.io/openjdk:11-jre-slim</java-base-image.name>
     <jaxb.api.version>2.2.12</jaxb.api.version>
     <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
@@ -52,9 +52,8 @@
     <mockito.version>2.24.5</mockito.version>
     <netty.version>4.1.42.Final</netty.version>
     <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
-    <opentracing.version>0.31.0</opentracing.version>
-    <opentracing-resolver.version>0.1.5</opentracing-resolver.version>
-    <opentracing-vertx-web.version>0.1.0</opentracing-vertx-web.version>
+    <opentracing.version>0.33.0</opentracing.version>
+    <opentracing-resolver.version>0.1.8</opentracing-resolver.version>
     <proton.version>0.33.2</proton.version>
     <qpid-jms.version>0.47.0</qpid-jms.version>
     <slf4j.version>1.7.28</slf4j.version>
@@ -466,11 +465,6 @@
         <groupId>io.opentracing</groupId>
         <artifactId>opentracing-noop</artifactId>
         <version>${opentracing.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.opentracing.contrib</groupId>
-        <artifactId>opentracing-vertx-web</artifactId>
-        <version>${opentracing-vertx-web.version}</version>
       </dependency>
       <dependency>
         <groupId>io.opentracing.contrib</groupId>

--- a/legal/src/main/resources/legal/NOTICE.md
+++ b/legal/src/main/resources/legal/NOTICE.md
@@ -206,7 +206,7 @@ is also available at http://www.apache.org/licenses/LICENSE-2.0.html.
 
 The source code is available from [Maven Central](http://search.maven.org/remotecontent?filepath=io/opentracing/contrib/opentracing-tracerresolver/${opentracing-resolver.version}/opentracing-tracerresolver-${opentracing-resolver.version}-sources.jar).
 
-### OpenTracing Vert.x Web Instrumentation ${opentracing-vertx-web.version}
+### OpenTracing Vert.x Web Instrumentation 0.1.0
 
 This product includes software developed by the [OpenTracing Vert.x Web Instrumentation project](https://github.com/opentracing-contrib/java-vertx-web).
 

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -131,10 +131,6 @@
       <artifactId>opentracing-tracerresolver</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-vertx-web</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
     </dependency>

--- a/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
@@ -31,7 +31,6 @@ import org.eclipse.hono.util.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;

--- a/service-base/src/main/java/org/eclipse/hono/service/http/ComponentMetaDataDecorator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/ComponentMetaDataDecorator.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
-import io.opentracing.contrib.vertx.ext.web.WebSpanDecorator;
 import io.opentracing.log.Fields;
 import io.opentracing.tag.Tags;
 import io.vertx.core.http.HttpServerRequest;

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HonoBasicAuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HonoBasicAuthHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.hono.tracing.TracingHelper;
 
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
 import io.opentracing.noop.NoopSpanContext;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceBase.java
@@ -28,8 +28,6 @@ import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
-import io.opentracing.contrib.vertx.ext.web.WebSpanDecorator;
 import io.opentracing.tag.Tags;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;

--- a/service-base/src/main/java/org/eclipse/hono/service/http/TenantTraceSamplingHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/TenantTraceSamplingHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.hono.service.tenant.ExecutionContextTenantAndAuthIdProvider;
 import org.eclipse.hono.service.tenant.TenantTraceSamplingHelper;
 
 import io.opentracing.Span;
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
 import io.opentracing.noop.NoopSpan;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;

--- a/service-base/src/main/java/org/eclipse/hono/service/http/TracingHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/TracingHandler.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.http;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.hono.tracing.MultiMapExtractAdapter;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Handler which creates tracing data for all server requests. It should be added to
+ * {@link io.vertx.ext.web.Route#handler(Handler)} and {@link io.vertx.ext.web.Route#failureHandler(Handler)} as the
+ * first in the chain.
+ * <p>
+ * This class has been copied from the <a href="https://github.com/opentracing-contrib/java-vertx-web">
+ * OpenTracing Vert.x Web Instrumentation</a> project.
+ * It has been adapted to support Opentracing 0.33 and slightly adapted to Hono's code style guide.
+ * 
+ * @author Pavol Loffay
+ */
+public class TracingHandler implements Handler<RoutingContext> {
+
+    public static final String CURRENT_SPAN = TracingHandler.class.getName() + ".severSpan";
+
+    private static final Logger log = LoggerFactory.getLogger(TracingHandler.class);
+
+    private final Tracer tracer;
+    private final List<WebSpanDecorator> decorators;
+
+    /**
+     * Creates a new handler for an OpenTracing Tracer.
+     * 
+     * @param tracer The tracer to use for tracking the processing of HTTP requests.
+     */
+    public TracingHandler(final Tracer tracer) {
+        this(tracer, Collections.singletonList(new WebSpanDecorator.StandardTags()));
+    }
+
+    /**
+     * Creates a new handler for an OpenTracing Tracer.
+     * 
+     * @param tracer The tracer to use for tracking the processing of HTTP requests.
+     * @param decorators The decorators to invoke before and after each HTTP request
+     *                   gets processed.
+     */
+    public TracingHandler(final Tracer tracer, final List<WebSpanDecorator> decorators) {
+        this.tracer = tracer;
+        this.decorators = new ArrayList<>(decorators);
+    }
+
+    @Override
+    public void handle(final RoutingContext routingContext) {
+        if (routingContext.failed()) {
+            handlerFailure(routingContext);
+        } else {
+            handlerNormal(routingContext);
+        }
+    }
+
+    /**
+     * Handles an HTTP request.
+     * 
+     * @param routingContext The routing context for the request.
+     */
+    protected void handlerNormal(final RoutingContext routingContext) {
+
+        // reroute
+        final Object object = routingContext.get(CURRENT_SPAN);
+        if (object instanceof Span) {
+            final Span span = (Span) object;
+            decorators.forEach(spanDecorator ->
+                    spanDecorator.onReroute(routingContext.request(), span));
+
+            // TODO in 3.3.3 it was sufficient to add this when creating the span
+            routingContext.addBodyEndHandler(finishEndHandler(routingContext, span));
+            routingContext.next();
+            return;
+        }
+
+        final SpanContext extractedContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
+                new MultiMapExtractAdapter(routingContext.request().headers()));
+
+        final Span span = tracer.buildSpan(routingContext.request().method().toString())
+                .asChildOf(extractedContext)
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                .start();
+
+        decorators.forEach(spanDecorator ->
+                spanDecorator.onRequest(routingContext.request(), span));
+
+        routingContext.put(CURRENT_SPAN, span);
+        // TODO it's not guaranteed that body end handler is always called
+        // https://github.com/vert-x3/vertx-web/issues/662
+        routingContext.addBodyEndHandler(finishEndHandler(routingContext, span));
+        routingContext.next();
+    }
+
+    /**
+     * Handles a failed HTTP request.
+     * 
+     * @param routingContext The routing context for the request.
+     */
+    protected void handlerFailure(final RoutingContext routingContext) {
+        final Object object = routingContext.get(CURRENT_SPAN);
+        if (object instanceof Span) {
+            final Span span = (Span) object;
+            routingContext.addBodyEndHandler(event -> decorators.forEach(spanDecorator ->
+                    spanDecorator.onFailure(routingContext.failure(), routingContext.response(), span)));
+        }
+
+        routingContext.next();
+    }
+
+    private Handler<Void> finishEndHandler(final RoutingContext routingContext, final Span span) {
+        return handler -> {
+            decorators.forEach(spanDecorator ->
+                    spanDecorator.onResponse(routingContext.request(), span));
+            span.finish();
+        };
+    }
+
+    /**
+     * Helper method for accessing server span context associated with current request.
+     *
+     * @param routingContext routing context
+     * @return server span context or null if not present
+     */
+    public static SpanContext serverSpanContext(final RoutingContext routingContext) {
+        SpanContext serverContext = null;
+
+        final Object object = routingContext.get(CURRENT_SPAN);
+        if (object instanceof Span) {
+            final Span span = (Span) object;
+            serverContext = span.context();
+        } else {
+            log.error("Sever SpanContext is null or not an instance of SpanContext");
+        }
+
+        return serverContext;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/http/WebSpanDecorator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/WebSpanDecorator.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.service.http;
+
+import io.vertx.core.Handler;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+
+/**
+ * Decorate server span at different stages. Do not call blocking code inside decorators!
+ * <p>
+ * This class has been copied from the <a href="https://github.com/opentracing-contrib/java-vertx-web">
+ * OpenTracing Vert.x Web Instrumentation</a> project.
+ * It has been adapted to support Opentracing 0.33 and slightly adapted to Hono's code style guide.
+ *
+ * @author Pavol Loffay
+ */
+public interface WebSpanDecorator {
+    /**
+     * Decorate span when span is started.
+     *
+     * @param request server request
+     * @param span server span
+     */
+    void onRequest(HttpServerRequest request, Span span);
+
+    /**
+     * Decorate span when span is rerouted.
+     *
+     * @param request server request
+     * @param span server span
+     */
+    void onReroute(HttpServerRequest request, Span span);
+
+    /**
+     * Decorate span when the response is known. This is effectively invoked in BodyEndHandler which is added to
+     * - {@link io.vertx.ext.web.RoutingContext#addBodyEndHandler(Handler)}
+     *
+     * @param request server request
+     * @param span server span
+     */
+    void onResponse(HttpServerRequest request, Span span);
+
+    /**
+     * Decorate request when an exception is thrown during request processing.
+     *
+     * @param throwable an exception thrown when processing the request
+     * @param response server response
+     * @param span server span
+     */
+    void onFailure(Throwable throwable, HttpServerResponse response, Span span);
+
+    /**
+     * Decorator which adds standard set of tags e.g. HTTP/PEER/ERROR tags.
+     */
+    class StandardTags implements WebSpanDecorator {
+        @Override
+        public void onRequest(final HttpServerRequest request, final Span span) {
+            Tags.COMPONENT.set(span, "vertx");
+            Tags.HTTP_METHOD.set(span, request.method().toString());
+            Tags.HTTP_URL.set(span, request.absoluteURI());
+        }
+
+        @Override
+        public void onReroute(final HttpServerRequest request, final Span span) {
+            final Map<String, String> logs = new HashMap<>(2);
+            logs.put("event", "reroute");
+            logs.put(Tags.HTTP_URL.getKey(), request.absoluteURI());
+            logs.put(Tags.HTTP_METHOD.getKey(), request.method().toString());
+            span.log(logs);
+        }
+
+        @Override
+        public void onResponse(final HttpServerRequest request, final Span span) {
+            Tags.HTTP_STATUS.set(span, request.response().getStatusCode());
+        }
+
+        @Override
+        public void onFailure(final Throwable throwable, final HttpServerResponse response, final Span span) {
+            Tags.ERROR.set(span, Boolean.TRUE);
+
+            if (throwable != null) {
+                span.log(exceptionLogs(throwable));
+            }
+        }
+
+        public static Map<String, Object> exceptionLogs(final Throwable throwable) {
+            final Map<String, Object> errorLog = new HashMap<>(2);
+            errorLog.put("event", Tags.ERROR.getKey());
+            errorLog.put("error.object", throwable);
+
+            return errorLog;
+        }
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/http/X509AuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/X509AuthHandler.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.opentracing.SpanContext;
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;

--- a/service-base/src/test/java/org/eclipse/hono/service/http/TenantTraceSamplingHandlerTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/http/TenantTraceSamplingHandlerTest.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.api.Test;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
 import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;

--- a/service-base/src/test/java/org/eclipse/hono/service/http/X509AuthHandlerTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/http/X509AuthHandlerTest.java
@@ -49,7 +49,6 @@ import org.junit.Test;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.contrib.vertx.ext.web.TracingHandler;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -25,6 +25,12 @@ title = "Release Notes"
   mechanisms advertised to a client connecting to these components. This can be used to
   restrict the support to only one of the SASL PLAIN and EXTERNAL mechanisms instead of both. 
 
+### Fixes & Enhancements
+
+* Hono's OpenTracing instrumentation has been upgraded to Opentracing 0.33.0.
+  The example deployment now uses the Jaeger Java client in version 0.35.2 and the
+  Jaeger 1.16 agent and back end components.
+
 ## 1.0.2
 
 ### Fixes & Enhancements


### PR DESCRIPTION
The TracingHandler classes have been copied to the service-base module
so that we can more easily adapt them to our needs. The upstream project
doesn't seem to be very active and it is just a few classes.

Also upgraded to Jaeger java-client 0.35.2 and Jaeger backend 1.16.