### PR TITLE
[#1710] stop registry to return hashed-passwords details

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -105,6 +105,10 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      * The name of the field that contains the number of credentials contained in a message.
      */
     public static final String FIELD_CREDENTIALS_TOTAL           = "total";
+    /**
+     * The name of the field that contains the id of the entity (e.g. secret id).
+     */
+    public static final String FIELD_ID = "id";
 
     /* secrets fields */
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
@@ -31,6 +31,9 @@ public abstract class CommonSecret {
     @JsonProperty
     private Boolean enabled;
 
+    @JsonProperty
+    private String id;
+
     @JsonProperty(RegistryManagementConstants.FIELD_SECRETS_NOT_BEFORE)
     @HonoTimestamp
     private Instant notBefore;
@@ -52,6 +55,22 @@ public abstract class CommonSecret {
      */
     public CommonSecret setEnabled(final Boolean enabled) {
         this.enabled = enabled;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the ID of the secret. This id may be assigned by the device registry.
+     * The id must be unique within the credentials set containing it.
+     *
+     * @param id The string to set as the id.
+     * @return   a reference to this for fluent use.
+     */
+    public CommonSecret setId(final String id) {
+        this.id = id;
         return this;
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericSecret.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericSecret.java
@@ -35,5 +35,4 @@ public class GenericSecret extends CommonSecret {
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
-
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
@@ -112,6 +112,9 @@ public class PasswordSecret extends CommonSecret {
     @Override
     public void checkValidity() {
         super.checkValidity();
+        if (containsOnlySecretId()) {
+            return;
+        }
         if (!Strings.isNullOrEmpty(passwordPlain)) {
             throw new IllegalStateException(String.format("'%s' must be empty", RegistryManagementConstants.FIELD_SECRETS_PWD_PLAIN));
         }
@@ -121,6 +124,18 @@ public class PasswordSecret extends CommonSecret {
         if (Strings.isNullOrEmpty(passwordHash)) {
             throw new IllegalStateException(String.format("'%s' must not be empty", RegistryManagementConstants.FIELD_SECRETS_PWD_HASH));
         }
+    }
+
+    /**
+     * Asserts if the secret do not contain secret details and only an id.
+     *
+     * @return        true if an ID is present and no new secret detail is set.
+     */
+    public boolean containsOnlySecretId() {
+        return (!Strings.isNullOrEmpty(getId())
+                && Strings.isNullOrEmpty(passwordPlain)
+                && Strings.isNullOrEmpty(hashFunction)
+                && Strings.isNullOrEmpty(passwordHash));
     }
 
     /**

--- a/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsServiceTest.java
+++ b/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsServiceTest.java
@@ -391,7 +391,7 @@ public class FileBasedCredentialsServiceTest extends AbstractCredentialsServiceT
         hashedPassword.setHashFunction(CredentialsConstants.HASH_FUNCTION_BCRYPT);
         passwordCredential.setSecrets(Collections.singletonList(hashedPassword));
 
-        // 4711
+        // 4711RegistryManagementConstants.FIELD_ID
         final PskCredential pskCredential = new PskCredential();
         pskCredential.setAuthId("sensor1");
 

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -385,8 +385,6 @@ paths:
                      schema:
                         $ref: '#/components/schemas/CredentialsSet'
                      examples:
-                        Full Credentials:
-                           $ref: '#/components/examples/HashedPasswordExample'
                         Credentials Metadata:
                            $ref: '#/components/examples/MetaPasswordExample'
                headers:
@@ -911,8 +909,8 @@ components:
                     format: byte
                     description: The clear text value of the password to be hashed by the device registry.
                                  If this property is specified, the device registry will ignore user-provided hash properties (`hash-function`, `pwd-hash` and `salt`).
-                                 This property should never be stored by the device registry.
-                                 This property should be empty when returning passwords from the device registry.
+                                 This property must never be stored by the device registry.
+                                 This property must be empty when returning passwords from the device registry.
 
       PSKSecret:
          additionalProperties: false
@@ -1098,15 +1096,9 @@ components:
             }]
       MetaPasswordExample:
          value:
-           [{
-               auth-id: sensor1,
-               type: hashed-password,
-               secrets: [{
-                  "id": "349556ea-4902-47c7-beb0-1009ab693fb4",
-                  "not-after": "2027-12-24T19:00:00Z",
-                  "pwd-plain": "",
-                  "pwd-hash": "",
-                  "salt": "",
-                  "hash-function": ""
-               }]
+            auth-id: sensor1
+            type: hashed-password
+            secrets: [{
+               "id": "349556ea-4902-47c7-beb0-1009ab693fb4",
+               "not-after": "2027-12-24T19:00:00Z",
             }]

--- a/site/documentation/content/user-guide/device-registry.md
+++ b/site/documentation/content/user-guide/device-registry.md
@@ -300,8 +300,8 @@ ETag: becc93d7-ab0f-48ec-ad26-debdf339cbf4x
 ~~~
     
 This uses a convenient option which lets the Device Registry do the hashing of the password. The following command retrieves the credentials that are stored by the Device Registry as a result of the command above: 
-    
-~~~sh    
+ 
+~~~sh
 curl -i http://localhost:28080/v1/credentials/DEFAULT_TENANT/4710
 
 HTTP/1.1 200 OK
@@ -314,23 +314,21 @@ ETag: becc93d7-ab0f-48ec-ad26-debdf339cbf4x
   "enabled": true,
   "secrets": [
     {
-      "pwd-hash": "$2a$10$uc.qVDwXeDRE1DWa1sM9iOaY9wuevjfALGMtXmHKP.SJDEqg0q7M6",
-      "hash-function": "bcrypt"
+      "id": "349556ea-4902-47c7-beb0-1009ab693fb4"
     }
   ]
 }]
 ~~~
-    
-The following commands add some `hashed-password` credentials for device `4720` using authentication identifier `sensor20`:
+The above result does not contain `pwd_hash` and `hash_function` of the secret, as these values are confidential.
+
+The following commands set some `hashed-password` credentials for device `4720` using authentication identifier `sensor20`:
 
 ~~~sh
-PWD_HASH=$(echo -n "mylittlesecret" | openssl dgst -binary -sha512 | base64 -w 0)
 curl -i -X PUT -H 'Content-Type: application/json' --data-binary '[{
     "type": "hashed-password",
     "auth-id": "sensor20",
     "secrets": [{
-        "hash-function": "sha-512",
-        "pwd-hash": "'$PWD_HASH'"
+        "pwd-plain": "mylittlesecret"
     }]
   }]' http://localhost:28080/v1/credentials/DEFAULT_TENANT/4720
 
@@ -341,14 +339,12 @@ ETag: 02c99fb5-af8c-409f-8520-b405e224b27f
 The following command adds an expiration date to the `hashed-password` credentials for authentication identifier `sensor20`:
 
 ~~~sh
-PWD_HASH=$(echo -n "mylittlesecret" | openssl dgst -binary -sha512 | base64 -w 0)
 curl -i -X PUT -H 'Content-Type: application/json' --data-binary '{
     "device-id": "4720",
     "type": "hashed-password",
     "auth-id": "sensor20",
     "secrets": [{
-        "hash-function": "sha-512",
-        "pwd-hash": "'$PWD_HASH'",
+        "pwd-plain": "mylittlesecret",
         "not-after": "2018-01-01T00:00:00+01:00"
     }]
 }' http://localhost:28080/v1/credentials/DEFAULT_TENANT/4720
@@ -367,8 +363,7 @@ curl -i -X PUT -H 'Content-Type: application/json' --data-binary '[
     "type": "hashed-password",
     "auth-id": "sensor20",
     "secrets": [{
-        "hash-function": "bcrypt",
-        "pwd-hash": "$2a$10$uc.qVDwXeDRE1DWa1sM9iOaY9wuevjfALGMtXmHKP.SJDEqg0q7M6"
+        "pwd-plain": "mylittlesecret"
     }]
 },
 {
@@ -403,7 +398,7 @@ ETag: d383ba4d-1853-4d03-b322-b7ff5af05ae2
 
 **Example**
 
-The following command retrieves credentials for device `4720`:
+The following command retrieves credentials metadata for device `4720`:
 
 ~~~sh
 curl -i http://localhost:28080/v1/credentials/DEFAULT_TENANT/4720
@@ -418,8 +413,12 @@ ETag: f3449b77-2c84-4b09-8d04-2b305876e0cb
         "enabled": true,
         "secrets": [
             {
-                "hash-function": "sha-512",
-                "pwd-hash": "tnxz0zDFs+pJGdCVSuoPE4TnamXsfIjBEOb0rg3e9WFD9KfbCkoRuwVZKgRWInfqp87kCLsoV/HEwdJwgw793Q=="
+                "id": "d383ba4d-1853-4d03-b322-b7ff5af05ae2"
+                "not-after": "2020-02-1T00:00:00+01:00"
+            },
+            {
+                "id": "46810d5c-133e-4c1c-994d-ed7745516b8e"
+                "not-before": "2020-01-01T00:00:00+01:00"
             }
         ],
         "type": "hashed-password"

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -2,6 +2,14 @@
 title = "Release Notes"
 +++
 
+## 1.2.0 (Not Released yet)
+
+### API Changes
+
+ * The device registry credentials endpoint will no longer handout sensitive details for hashed-password secrets.
+   `pwd-hash`, `salt` and `hash-function` are stored by the device registry but not returned to the user.
+   Each secret is given an ID which is now returned, along with the other metadata (time validity and optional fields).
+
 ## 1.1.0
 
 ### New Features


### PR DESCRIPTION
The device registry now only returns metadata and a secret ID for each secret.

Signed-off-by: Jean-Baptiste Trystram <jbtrystram@redhat.com>