### PR TITLE
[#1716] Add new resource-limits based on the device connection duration

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/ConnectionDuration.java
+++ b/core/src/main/java/org/eclipse/hono/util/ConnectionDuration.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.hono.annotation.HonoTimestamp;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+/**
+ * The resource limits definition corresponding to the connection duration.
+ */
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class ConnectionDuration {
+
+    @JsonProperty(value = TenantConstants.FIELD_EFFECTIVE_SINCE, required = true)
+    @HonoTimestamp
+    private Instant effectiveSince;
+
+    @JsonProperty(TenantConstants.FIELD_MAX_MINUTES)
+    private long maxMinutes = TenantConstants.UNLIMITED_MINUTES;
+
+    @JsonProperty(value = TenantConstants.FIELD_PERIOD, required = true)
+    private ResourceLimitsPeriod period;
+
+    /**
+     * Gets the point in time on which the connection duration limit came into effect.
+     *
+     * @return The instant on which the connection duration limit came into effective or 
+     *         {@code null} if not set.
+     */
+    public final Instant getEffectiveSince() {
+        return effectiveSince;
+    }
+
+    /**
+     * Sets the point in time on which the connection duration limit came into effect.
+     *
+     * @param effectiveSince the point in time on which the connection duration limit came into effect
+     *                       and it comply to the {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME}.
+     * @return  a reference to this for fluent use.
+     * @throws NullPointerException if effectiveSince is {@code null}.
+     */
+    public final ConnectionDuration setEffectiveSince(final Instant effectiveSince) {
+        this.effectiveSince = Objects.requireNonNull(effectiveSince);
+        return this;
+    }
+
+    /**
+     * Gets the maximum device connection duration in minutes to be allowed for the time period 
+     * defined by the {@link TenantConstants#FIELD_PERIOD_MODE} and 
+     * {@link TenantConstants#FIELD_PERIOD_NO_OF_DAYS}.
+     *
+     * @return The maximum connection duration in minutes or {@link TenantConstants#UNLIMITED_MINUTES}
+     *         if not set.
+     */
+    public final long getMaxMinutes(){
+        return maxMinutes;
+    }
+
+    /**
+     * Sets the maximum device connection duration in minutes to be allowed for the time period
+     * defined by the {@link TenantConstants#FIELD_PERIOD_MODE} and 
+     * {@link TenantConstants#FIELD_PERIOD_NO_OF_DAYS}.
+     *
+     * @param maxMinutes The maximum connection duration in minutes to be allowed.
+     * @return  a reference to this for fluent use.
+     * @throws IllegalArgumentException if the maximum number of minutes is set to less than 
+     *                                  {@link TenantConstants#UNLIMITED_MINUTES}.
+     */
+    public final ConnectionDuration setMaxDuration(final long maxMinutes) {
+        if (maxMinutes < TenantConstants.UNLIMITED_MINUTES) {
+            throw new IllegalArgumentException(
+                    String.format("Maximum minutes must be set to value >= %s", TenantConstants.UNLIMITED_MINUTES));
+        }
+        this.maxMinutes = maxMinutes;
+        return this;
+    }
+
+    /**
+     * Gets the period for the connection duration calculation.
+     *
+     * @return The period for the connection duration calculation.
+     */
+    public final ResourceLimitsPeriod getPeriod() {
+        return period;
+    }
+
+    /**
+     * Sets the period for the connection duration calculation.
+     *
+     * @param period The period for the connection duration calculation.
+     * @return a reference to this for fluent use.
+     * @throws NullPointerException if period is {@code null}.
+     */
+    public final ConnectionDuration setPeriod(final ResourceLimitsPeriod period) {
+        this.period = Objects.requireNonNull(period);
+        return this;
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/DataVolume.java
+++ b/core/src/main/java/org/eclipse/hono/util/DataVolume.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -91,7 +91,10 @@ public class DataVolume {
      * Gets the period for the data usage calculation.
      *
      * @return The period for the data usage calculation.
+     * @deprecated From Hono 2.0.0, this method will return {@link org.eclipse.hono.util.ResourceLimitsPeriod} 
+     * instead of {@link org.eclipse.hono.util.DataVolumePeriod}.
      */
+    @Deprecated
     public final DataVolumePeriod getPeriod() {
         return period;
     }
@@ -101,7 +104,10 @@ public class DataVolume {
      *
      * @param period The period for the data usage calculation.
      * @return  a reference to this for fluent use.
+     * @deprecated From Hono 2.0.0, this method will take {@link org.eclipse.hono.util.ResourceLimitsPeriod}
+     * as an argument instead of {@link org.eclipse.hono.util.DataVolumePeriod}.
      */
+    @Deprecated
     public final DataVolume setPeriod(final DataVolumePeriod period) {
         this.period = period;
         return this;

--- a/core/src/main/java/org/eclipse/hono/util/DataVolumePeriod.java
+++ b/core/src/main/java/org/eclipse/hono/util/DataVolumePeriod.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * Data volume period definition of the tenant resource limits .
+ * @deprecated This class will be removed in Hono 2.0.0. Use {@link org.eclipse.hono.util.ResourceLimitsPeriod} instead.
  */
+@Deprecated
 @JsonInclude(Include.NON_DEFAULT)
 public class DataVolumePeriod {
 

--- a/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceLimits.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -34,6 +34,9 @@ public class ResourceLimits {
 
     @JsonProperty(TenantConstants.FIELD_DATA_VOLUME)
     private DataVolume dataVolume;
+
+    @JsonProperty(TenantConstants.FIELD_CONNECTION_DURATION)
+    private ConnectionDuration connectionDuration;
 
     @JsonProperty(RegistryManagementConstants.FIELD_EXT)
     @JsonInclude(Include.NON_EMPTY)
@@ -107,6 +110,26 @@ public class ResourceLimits {
      */
     public final ResourceLimits setDataVolume(final DataVolume dataVolume) {
         this.dataVolume = dataVolume;
+        return this;
+    }
+
+    /**
+     * Gets the properties that are required for the connection duration verification.
+     *
+     * @return The connection duration properties.
+     */
+    public final ConnectionDuration getConnectionDuration() {
+        return connectionDuration;
+    }
+
+    /**
+     * Sets the properties that are required for the connection duration verification.
+     *
+     * @param connectionDuration the connection duration properties.
+     * @return a reference to this for fluent use.
+     */
+    public final ResourceLimits setConnectionDuration(final ConnectionDuration connectionDuration) {
+        this.connectionDuration = connectionDuration;
         return this;
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/ResourceLimitsPeriod.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceLimitsPeriod.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * The period definition corresponding to a resource limit for a tenant.
+ */
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class ResourceLimitsPeriod {
+
+    @JsonProperty(value = TenantConstants.FIELD_PERIOD_MODE, required = true)
+    private String mode;
+
+    @JsonProperty(value = TenantConstants.FIELD_PERIOD_NO_OF_DAYS)
+    private int noOfDays;
+
+    /**
+     * Gets the mode of period for resource limit calculation.
+     *
+     * @return The mode of period for resource limit calculation.
+     */
+    public final String getMode() {
+        return mode;
+    }
+
+    /**
+     * Sets the mode of period for resource limit calculation.
+     *
+     * @param mode The mode of period for resource limit calculation.
+     * @return  a reference to this for fluent use.
+     * @throws NullPointerException if mode is {@code null}.
+     */
+    public final ResourceLimitsPeriod setMode(final String mode) {
+        this.mode = Objects.requireNonNull(mode);
+        return this;
+    }
+
+    /**
+     * Gets the number of days for which resource usage is calculated.
+     *
+     * @return The number of days for a resource limit calculation.
+     */
+    public final int getNoOfDays() {
+        return noOfDays;
+    }
+
+    /**
+     * Sets the number of days for which resource usage is calculated.
+     *
+     * @param noOfDays The number of days for which resource usage is calculated.
+     * @return  a reference to this for fluent use.
+     * @throws IllegalArgumentException if the number of days is negative.
+     */
+    public final ResourceLimitsPeriod setNoOfDays(final int noOfDays) {
+        if (noOfDays < 0) {
+            throw new IllegalArgumentException("Number of days property must be  set to value >= 0");
+        }
+        this.noOfDays = noOfDays;
+        return this;
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -38,6 +38,10 @@ public final class TenantConstants extends RequestResponseApiConstants {
      */
     public static final int UNLIMITED_CONNECTIONS = -1;
     /**
+     * The value indicating an <em>unlimited</em> number of minutes to be allowed for a tenant.
+     */
+    public static final long UNLIMITED_MINUTES = -1;
+    /**
      * The value indicating <em>unlimited</em> time-to-live for downstream events.
      */
     public static final long UNLIMITED_TTL = -1;
@@ -61,6 +65,13 @@ public final class TenantConstants extends RequestResponseApiConstants {
      * automatically provision new devices. 
      */
     public static final String FIELD_AUTO_PROVISIONING_ENABLED = "auto-provisioning-enabled";
+
+    /**
+     * The name of the property that contains the configuration options to limit 
+     * the device connection duration of tenants.
+     */
+    public static final String FIELD_CONNECTION_DURATION = "connection-duration";
+
     /**
      * The name of the property that contains the configuration options for the data volume.
      */
@@ -80,7 +91,11 @@ public final class TenantConstants extends RequestResponseApiConstants {
     /**
      * The name of the property that contains the maximum number of connections to be allowed for a tenant.
      */
-    public static final String FIELD_MAX_CONNECTIONS = "max-connections";    
+    public static final String FIELD_MAX_CONNECTIONS = "max-connections";
+    /**
+     * The name of the property that contains the maximum connection duration in minutes to be allowed for a tenant.
+     */
+    public static final String FIELD_MAX_MINUTES = "max-minutes";
     /**
      * The name of the property that contains the maximum <em>time til disconnect</em> (seconds) that protocol
      * adapters should use for a tenant.

--- a/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/NoopResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/NoopResourceLimitChecks.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -40,6 +40,12 @@ public class NoopResourceLimitChecks implements ResourceLimitChecks {
 
     @Override
     public Future<Boolean> isMessageLimitReached(final TenantObject tenantObject, final long payloadSize,
+            final SpanContext spanContext) {
+        return Future.succeededFuture(Boolean.FALSE);
+    }
+
+    @Override
+    public Future<Boolean> isConnectionDurationLimitReached(final TenantObject tenantObject,
             final SpanContext spanContext) {
         return Future.succeededFuture(Boolean.FALSE);
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/ResourceLimitChecks.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/resourcelimits/ResourceLimitChecks.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -86,4 +86,22 @@ public interface ResourceLimitChecks {
      *         if the check could not be performed.
      */
     Future<Boolean> isMessageLimitReached(TenantObject tenantObject, long payloadSize, SpanContext spanContext);
+
+    /**
+     * Checks if the maximum limit of device connection duration configured for a tenant
+     * have been reached.
+     *
+     * @param tenantObject The tenant configuration to check the limit against.
+     * @param spanContext The currently active OpenTracing span context that is used to
+     *                    trace the limits verification or {@code null}
+     *                    if no span is currently active.
+     * @return A future indicating the outcome of the check.
+     *         <p>
+     *         The future will be failed with a {@link ServiceInvocationException}
+     *         if the check could not be performed.
+     * @throws NullPointerException if the tenant object is null.
+     */
+    default Future<Boolean> isConnectionDurationLimitReached(TenantObject tenantObject, SpanContext spanContext) {
+        return Future.succeededFuture(Boolean.FALSE);
+    }
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -218,7 +218,12 @@ public class TenantTest {
                                 .put(TenantConstants.FIELD_EFFECTIVE_SINCE, "2019-04-25T14:30:00+02:00")
                                 .put(TenantConstants.FIELD_PERIOD, new JsonObject()
                                         .put(TenantConstants.FIELD_PERIOD_MODE, "days")
-                                        .put(TenantConstants.FIELD_PERIOD_NO_OF_DAYS, 90))));
+                                        .put(TenantConstants.FIELD_PERIOD_NO_OF_DAYS, 90)))
+                        .put(TenantConstants.FIELD_CONNECTION_DURATION, new JsonObject()
+                                .put(TenantConstants.FIELD_MAX_MINUTES, 20_000_000)
+                                .put(TenantConstants.FIELD_EFFECTIVE_SINCE, "2019-04-25T14:30:00+02:00")
+                                .put(TenantConstants.FIELD_PERIOD, new JsonObject()
+                                        .put(TenantConstants.FIELD_PERIOD_MODE, "monthly"))));
 
         final Tenant tenant = tenantSpec.mapTo(Tenant.class);
         assertNotNull(tenant);
@@ -236,6 +241,14 @@ public class TenantTest {
         assertNotNull(limits.getDataVolume().getPeriod());
         assertEquals("days", limits.getDataVolume().getPeriod().getMode());
         assertEquals(90, limits.getDataVolume().getPeriod().getNoOfDays());
+        assertNotNull(limits.getConnectionDuration());
+        assertEquals(
+                DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse("2019-04-25T14:30:00+02:00", OffsetDateTime::from)
+                        .toInstant(),
+                limits.getConnectionDuration().getEffectiveSince());
+        assertEquals(20_000_000, limits.getConnectionDuration().getMaxMinutes());
+        assertNotNull(limits.getConnectionDuration().getPeriod());
+        assertEquals("monthly", limits.getConnectionDuration().getPeriod().getMode());
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/resourcelimits/PrometheusBasedResourceLimitChecksTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/resourcelimits/PrometheusBasedResourceLimitChecksTest.java
@@ -270,7 +270,7 @@ public class PrometheusBasedResourceLimitChecksTest {
         // Monthly mode
         // The case where the effectiveSince lies on the past months of the target date.
         assertEquals(maxBytes,
-                limitChecksImpl.calculateDataVolume(
+                limitChecksImpl.calculateEffectiveLimit(
                         OffsetDateTime.parse("2019-08-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         OffsetDateTime.parse("2019-09-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         PrometheusBasedResourceLimitChecks.PeriodMode.MONTHLY,
@@ -278,7 +278,7 @@ public class PrometheusBasedResourceLimitChecksTest {
         // The case where the effectiveSince lies on the the same month as of the target date 
         // and first day of the month.
         assertEquals(9300,
-                limitChecksImpl.calculateDataVolume(
+                limitChecksImpl.calculateEffectiveLimit(
                         OffsetDateTime.parse("2019-09-01T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         OffsetDateTime.parse("2019-09-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         PrometheusBasedResourceLimitChecks.PeriodMode.MONTHLY,
@@ -286,7 +286,7 @@ public class PrometheusBasedResourceLimitChecksTest {
         // The case where the effectiveSince lies on the the same month as of the target date
         // and not on the first day of the month.
         assertEquals(8990,
-                limitChecksImpl.calculateDataVolume(
+                limitChecksImpl.calculateEffectiveLimit(
                         OffsetDateTime.parse("2019-09-02T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         OffsetDateTime.parse("2019-09-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         PrometheusBasedResourceLimitChecks.PeriodMode.MONTHLY,
@@ -294,7 +294,7 @@ public class PrometheusBasedResourceLimitChecksTest {
 
         // Days mode
         assertEquals(maxBytes,
-                limitChecksImpl.calculateDataVolume(
+                limitChecksImpl.calculateEffectiveLimit(
                         OffsetDateTime.parse("2019-09-02T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         OffsetDateTime.parse("2019-09-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         PrometheusBasedResourceLimitChecks.PeriodMode.DAYS,
@@ -302,23 +302,23 @@ public class PrometheusBasedResourceLimitChecksTest {
     }
 
     /**
-     * Verifies the calculated data usage period for various scenarios.
+     * Verifies the resource usage period calculation for various scenarios.
      *
      */
     @Test
-    public void testCalculateDataUsagePeriod() {
+    public void verifyResourceUsagePeriodCalculation() {
         final long noOfDays = 30;
         // Monthly mode
         // The case where the effectiveSince lies on the past months of the target date.
         assertEquals(6,
-                limitChecksImpl.calculateDataUsagePeriod(
+                limitChecksImpl.calculateResourceUsagePeriod(
                         OffsetDateTime.parse("2019-08-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         OffsetDateTime.parse("2019-09-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         PrometheusBasedResourceLimitChecks.PeriodMode.MONTHLY,
                         noOfDays));
         // The case where the effectiveSince lies on the the same month as of the target date.
         assertEquals(5,
-                limitChecksImpl.calculateDataUsagePeriod(
+                limitChecksImpl.calculateResourceUsagePeriod(
                         OffsetDateTime.parse("2019-09-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         OffsetDateTime.parse("2019-09-10T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         PrometheusBasedResourceLimitChecks.PeriodMode.MONTHLY,
@@ -327,14 +327,14 @@ public class PrometheusBasedResourceLimitChecksTest {
         // Days mode
         // The case where the effectiveSince lies on the past months of the target date.
         assertEquals(6,
-                limitChecksImpl.calculateDataUsagePeriod(
+                limitChecksImpl.calculateResourceUsagePeriod(
                         OffsetDateTime.parse("2019-08-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         OffsetDateTime.parse("2019-09-10T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         PrometheusBasedResourceLimitChecks.PeriodMode.DAYS,
                         noOfDays));
         // The case where the effectiveSince lies on the the same month as of the target date.
         assertEquals(5,
-                limitChecksImpl.calculateDataUsagePeriod(
+                limitChecksImpl.calculateResourceUsagePeriod(
                         OffsetDateTime.parse("2019-09-06T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         OffsetDateTime.parse("2019-09-10T14:30:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                         PrometheusBasedResourceLimitChecks.PeriodMode.DAYS,

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -642,6 +642,8 @@ components:
                   to use milliseconds.
             "data-volume":
                $ref: '#/components/schemas/DataVolume'
+            "connection-duration":
+               $ref: '#/components/schemas/ConnectionDuration'
             "ext":
                $ref: '#/components/schemas/Extensions'
 
@@ -712,6 +714,26 @@ components:
                description: The maximum number of bytes to be allowed for a tenant for the
                             defined period.
                             A value of -1 (the default) indicates that no limit is set.
+            "period":
+               $ref: '#/components/schemas/Period'
+
+      ConnectionDuration:
+         type: object
+         additionalProperties: false
+         required:
+            - effective-since
+            - period
+         properties:
+            "effective-since":
+               type: string
+               format: date-time
+               description: The date-time on which the connection duration limit came into effect.
+            "max-minutes":
+               type: integer
+               default: -1
+               description: The maximum number of minutes to be allowed for a tenant for the
+                  defined period.
+                  A value of -1 (the default) indicates that no limit is set.
             "period":
                $ref: '#/components/schemas/Period'
 


### PR DESCRIPTION
This PR is for the issue #1716. This PR extends the Tenant API to support a new additional _resource-limit_ configuration for _device connection duration_. Also the `ResourceLimitChecks` API has been extended to validate if the max connection duration of a tenant is reached or not.

NB: This PR has been raised even though the implementation is not complete, so that the concept can be reviewed at an early stage. 