### PR TITLE
[#1441] Make hard-coded event bus send timeout configurable.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -27,7 +27,19 @@ public class ServiceConfigProperties extends ServerConfig {
      */
     public static final int DEFAULT_RECEIVER_LINK_CREDITS = 100;
 
+    /**
+     * The default send timeout value in milliseconds, which is 
+     * to be used when sending a message on the vert.x event bus.
+     */
+    public  static final long DEFAULT_SEND_TIMEOUT_IN_MS = 3000;
+
     private static final int MIN_PAYLOAD_SIZE  = 128; // bytes
+
+    /**
+     * The minimum send timeout value in milliseconds is 500 ms
+     * and any value less than this minimum value is not accepted.
+     */
+    private static final long MIN_SEND_TIMEOUT_IN_MS = 500;
 
     private boolean singleTenant = false;
     private boolean networkDebugLogging = false;
@@ -35,6 +47,7 @@ public class ServiceConfigProperties extends ServerConfig {
     private int maxPayloadSize = 2048;
     private int receiverLinkCredit = DEFAULT_RECEIVER_LINK_CREDITS;
     private String corsAllowedOrigin = "*";
+    private long sendTimeOutInMs = DEFAULT_SEND_TIMEOUT_IN_MS;
 
     /**
      * Sets the maximum size of a message payload this server accepts from clients.
@@ -204,5 +217,34 @@ public class ServiceConfigProperties extends ServerConfig {
      */
     public final void setCorsAllowedOrigin(final String corsAllowedOrigin) {
         this.corsAllowedOrigin = Objects.requireNonNull(corsAllowedOrigin);
+    }
+
+    /**
+     * Gets the send timeout value in milliseconds, which is to be used when sending a 
+     * message on the vert.x event bus.
+     * <p>
+     * The default value of this property is {@link #DEFAULT_SEND_TIMEOUT_IN_MS}.
+     * 
+     * @return The send timeout value in milliseconds.
+     */
+    public final long getSendTimeOut() {
+        return sendTimeOutInMs;
+    }
+
+    /**
+     * Sets the send timeout value in milliseconds, which is to be used when sending a 
+     * message on the vert.x event bus.
+     * <p>
+     * The default value of this property is {@link #DEFAULT_SEND_TIMEOUT_IN_MS}.
+     * 
+     * @param sendTimeOutInMs The send timeout value in milliseconds.
+     * @throws IllegalArgumentException if the timeout value is less than {@link #MIN_SEND_TIMEOUT_IN_MS}.
+     */
+    public final void setSendTimeOut(final long sendTimeOutInMs) {
+        if (sendTimeOutInMs < MIN_SEND_TIMEOUT_IN_MS) {
+            throw new IllegalArgumentException(
+                    String.format("send time out value must be >= %sms", MIN_SEND_TIMEOUT_IN_MS));
+        }
+        this.sendTimeOutInMs = sendTimeOutInMs;
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractEndpoint.java
@@ -138,15 +138,14 @@ public abstract class AbstractEndpoint implements Endpoint {
 
     /**
      * Creates {@code DeliveryOptions} that contain the given {@code SpanContext}.
-     * <p>
-     * To be used when sending a message on the vert.x event bus.
-     *  
+     *
+     * @param sendTimeOutInMs The send timeout value in milliseconds.
      * @param spanContext The {@code SpanContext} (may be {@code null}).
      * @return The {@code DeliveryOptions}.
      */
-    protected final DeliveryOptions createEventBusMessageDeliveryOptions(final SpanContext spanContext) {
+    protected final DeliveryOptions createEventBusMessageDeliveryOptions(final long sendTimeOutInMs, final SpanContext spanContext) {
         final DeliveryOptions deliveryOptions = new DeliveryOptions();
-        deliveryOptions.setSendTimeout(3000);
+        deliveryOptions.setSendTimeout(sendTimeOutInMs);
         TracingHelper.injectSpanContext(tracer, spanContext, deliveryOptions);
         return deliveryOptions;
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/RequestResponseEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/RequestResponseEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -248,7 +248,8 @@ public abstract class RequestResponseEndpoint<T extends ServiceConfigProperties>
         })
         .compose(authorized -> {
             final Promise<io.vertx.core.eventbus.Message<Object>> reply = Promise.promise();
-            final DeliveryOptions options = createEventBusMessageDeliveryOptions(currentSpan.context());
+            final DeliveryOptions options = createEventBusMessageDeliveryOptions(config.getSendTimeOut(),
+                    currentSpan.context());
             vertx.eventBus().request(
                     getEventBusServiceAddress(),
                     request.result().toJson(),

--- a/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.function.IntPredicate;
 
 import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.AbstractEndpoint;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
@@ -52,7 +53,8 @@ import io.vertx.ext.web.handler.CorsHandler;
  *
  * @param <T> The type of configuration properties this endpoint understands.
  */
-public abstract class AbstractHttpEndpoint<T> extends AbstractEndpoint implements HttpEndpoint {
+public abstract class AbstractHttpEndpoint<T extends ServiceConfigProperties> extends AbstractEndpoint
+        implements HttpEndpoint {
 
     /**
      * The key that is used to put a valid JSON payload to the RoutingContext.
@@ -309,7 +311,8 @@ public abstract class AbstractHttpEndpoint<T> extends AbstractEndpoint implement
     protected final void sendAction(final RoutingContext ctx, final JsonObject requestMsg,
             final BiConsumer<Integer, EventBusMessage> responseHandler) {
 
-        final DeliveryOptions options = createEventBusMessageDeliveryOptions(TracingHandler.serverSpanContext(ctx));
+        final DeliveryOptions options = createEventBusMessageDeliveryOptions(config.getSendTimeOut(),
+                TracingHandler.serverSpanContext(ctx));
         vertx.eventBus().request(getEventBusAddress(), requestMsg, options, invocation -> {
             if (invocation.failed()) {
                 HttpUtils.serviceUnavailable(ctx, 2);

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -30,6 +30,8 @@ title = "Release Notes"
   duration limit* for each tenant before accepting any new connection request from the devices. Please 
   refer to the [resource-limits]({{% doclink "/concepts/resource-limits/#connection-duration-limit" %}}) 
   section for more details.
+* Hono supports now setting a time out value when sending a message on the vert.x event bus. This is
+  configured using the property `sendTimeOutInMs` in `org.eclipse.hono.config.ServiceConfigProperties`.
 
 ### Fixes & Enhancements
 


### PR DESCRIPTION
This PR is intended for the issue #1441. 
The hard-coded send time out value can now be configured.
