### PR TITLE
[#1726] Fix: accept command responses without payload in AMQP adapter.

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -978,20 +978,20 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                     "empty notifications must not contain payload"));
         }
 
-        return contentTypeCheck.future()
-                .compose(ok -> {
-                    switch (context.getEndpoint()) {
-                    case TELEMETRY:
-                        return doUploadMessage(context, resource, getTelemetrySender(resource.getTenantId()), currentSpan);
-                    case EVENT:
-                        return doUploadMessage(context, resource, getEventSender(resource.getTenantId()), currentSpan);
-                    case COMMAND_RESPONSE:
-                        return doUploadCommandResponseMessage(context, resource, currentSpan);
-                    default:
-                        return Future
-                                .failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND, "unknown endpoint"));
-                    }
-                });
+        switch (context.getEndpoint()) {
+        case TELEMETRY:
+            return contentTypeCheck.future()
+                    .compose(ok -> doUploadMessage(context, resource, getTelemetrySender(resource.getTenantId()),
+                            currentSpan));
+        case EVENT:
+            return contentTypeCheck.future()
+                    .compose(ok -> doUploadMessage(context, resource, getEventSender(resource.getTenantId()),
+                            currentSpan));
+        case COMMAND_RESPONSE:
+            return doUploadCommandResponseMessage(context, resource, currentSpan);
+        default:
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND, "unknown endpoint"));
+        }
     }
 
     private Future<ProtonDelivery> doUploadMessage(

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -1278,6 +1278,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                         String.format("command-request-id [%s] or status code [%s] is missing/invalid",
                                 commandRequestId, responseStatus)));
 
+        final int payloadSize = Optional.ofNullable(payload).map(Buffer::length).orElse(0);
         CompositeFuture.all(tenantTracker, commandResponseTracker)
                 .compose(commandResponse -> {
                     final Future<JsonObject> deviceRegistrationTracker = getRegistrationAssertion(
@@ -1287,7 +1288,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                             currentSpan.context());
                     final Future<Void> tenantValidationTracker = CompositeFuture
                             .all(isAdapterEnabled(tenantTracker.result()),
-                                    checkMessageLimit(tenantTracker.result(), payload.length(), currentSpan.context()))
+                                    checkMessageLimit(tenantTracker.result(), payloadSize, currentSpan.context()))
                             .map(ok -> null);
 
                     return CompositeFuture.all(tenantValidationTracker, deviceRegistrationTracker)
@@ -1303,7 +1304,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                                         tenant,
                                         tenantTracker.result(),
                                         ProcessingOutcome.FORWARDED,
-                                        payload.length(),
+                                        payloadSize,
                                         getMicrometerSample(ctx));
                                 ctx.response().setStatusCode(HttpURLConnection.HTTP_ACCEPTED);
                                 ctx.response().end();

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -544,7 +544,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
 
         // WHEN a device publishes a command response with an empty payload
-        final Buffer payload = Buffer.buffer();
+        final Buffer payload = null;
         final HttpServerResponse response = mock(HttpServerResponse.class);
         final RoutingContext ctx = newRoutingContext(payload, "application/text", mock(HttpServerRequest.class), response);
         when(ctx.addBodyEndHandler(any(Handler.class))).thenAnswer(invocation -> {
@@ -563,7 +563,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
                 eq("tenant"),
                 any(),
                 eq(ProcessingOutcome.FORWARDED),
-                eq(payload.length()),
+                eq(0),
                 any());
     }
 

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -528,6 +528,46 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     }
 
     /**
+     * Verifies that the adapter accepts a command response message with an empty body.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUploadEmptyCommandResponseSucceeds() {
+
+        // GIVEN an adapter with a downstream application attached
+        final CommandResponseSender sender = mock(CommandResponseSender.class);
+        when(sender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
+
+        when(commandConsumerFactory.getCommandResponseSender(anyString(), anyString())).thenReturn(Future.succeededFuture(sender));
+
+        final HttpServer server = getHttpServer(false);
+        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+
+        // WHEN a device publishes a command response with an empty payload
+        final Buffer payload = Buffer.buffer();
+        final HttpServerResponse response = mock(HttpServerResponse.class);
+        final RoutingContext ctx = newRoutingContext(payload, "application/text", mock(HttpServerRequest.class), response);
+        when(ctx.addBodyEndHandler(any(Handler.class))).thenAnswer(invocation -> {
+            final Handler<Void> handler = invocation.getArgument(0);
+            handler.handle(null);
+            return 0;
+        });
+
+        adapter.uploadCommandResponseMessage(ctx, "tenant", "device", CMD_REQ_ID, 200);
+
+        // then it is forwarded successfully
+        verify(response).setStatusCode(202);
+        verify(response).end();
+        verify(metrics).reportCommand(
+                eq(Direction.RESPONSE),
+                eq("tenant"),
+                any(),
+                eq(ProcessingOutcome.FORWARDED),
+                eq(payload.length()),
+                any());
+    }
+
+    /**
      * Verifies that the adapter fails the upload of a command response with a 403
      * if the adapter is disabled for the device's tenant.
      */

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1104,12 +1104,13 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                 .withTag(TracingHelper.TAG_AUTHENTICATED.getKey(), ctx.authenticatedDevice() != null)
                 .start();
 
+            final int payloadSize = Optional.ofNullable(ctx.message().payload()).map(Buffer::length).orElse(0);
             final Future<JsonObject> tokenTracker = getRegistrationAssertion(targetAddress.getTenantId(),
                     targetAddress.getResourceId(), ctx.authenticatedDevice(), currentSpan.context());
             final Future<TenantObject> tenantTracker = getTenantConfiguration(targetAddress.getTenantId(), ctx.getTracingContext());
             final Future<TenantObject> tenantValidationTracker = CompositeFuture.all(
                                     isAdapterEnabled(tenantTracker.result()),
-                                    checkMessageLimit(tenantTracker.result(), ctx.message().payload().length(), currentSpan.context()))
+                                    checkMessageLimit(tenantTracker.result(), payloadSize, currentSpan.context()))
                                     .map(success -> tenantTracker.result());
 
         return CompositeFuture.all(tenantTracker, commandResponseTracker)
@@ -1124,7 +1125,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                             targetAddress.getTenantId(),
                             tenantTracker.result(),
                             ProcessingOutcome.FORWARDED,
-                            ctx.message().payload().length(),
+                            payloadSize,
                             ctx.getTimer());
                     // check that the remote MQTT client is still connected before sending PUBACK
                     if (ctx.deviceEndpoint().isConnected() && ctx.message().qosLevel() == MqttQoS.AT_LEAST_ONCE) {
@@ -1141,7 +1142,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                             targetAddress.getTenantId(),
                             tenantTracker.result(),
                             ProcessingOutcome.from(t),
-                            ctx.message().payload().length(),
+                            payloadSize,
                             ctx.getTimer());
                     return Future.failedFuture(t);
                 });

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -708,7 +708,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(messageFromDevice.topicName()).thenReturn("command///res/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/200");
 
         // ... with an empty payload
-        when(messageFromDevice.payload()).thenReturn(Buffer.buffer());
+        when(messageFromDevice.payload()).thenReturn(null);
         final ResourceIdentifier address = ResourceIdentifier
                 .fromString("command/my-tenant/4712/res/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/200");
         adapter.uploadCommandResponseMessage(newMqttContext(messageFromDevice, endpoint), address)

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -720,17 +720,18 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
                 .fromString("command/my-tenant/4712/res/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/200");
         adapter.uploadCommandResponseMessage(newMqttContext(messageFromDevice, endpoint), address)
                 .setHandler(ctx.succeeding(result -> {
-                    verify(sender).sendCommandResponse(any(), any());
-                    // then it is forwarded successfully
-                    verify(metrics).reportCommand(
-                            eq(MetricsTags.Direction.RESPONSE),
-                            eq("my-tenant"),
-                            any(TenantObject.class),
-                            eq(MetricsTags.ProcessingOutcome.FORWARDED),
-                            eq(0),
-                            any());
-
-                    ctx.completeNow();
+                    ctx.verify(() -> {
+                        verify(sender).sendCommandResponse(any(), any());
+                        // then it is forwarded successfully
+                        verify(metrics).reportCommand(
+                                eq(MetricsTags.Direction.RESPONSE),
+                                eq("my-tenant"),
+                                any(TenantObject.class),
+                                eq(MetricsTags.ProcessingOutcome.FORWARDED),
+                                eq(0),
+                                any());
+                        ctx.completeNow();
+                    });
                 }));
     }
 

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -144,7 +144,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
         regClient = mock(RegistrationClient.class);
         final JsonObject result = new JsonObject();
-        when(regClient.assertRegistration(anyString(), (String) any(), (SpanContext) any())).thenReturn(Future.succeededFuture(result));
+        when(regClient.assertRegistration(anyString(), (String) any(), (SpanContext) any()))
+                .thenReturn(Future.succeededFuture(result));
 
         tenantClient = mock(TenantClient.class);
         when(tenantClient.get(anyString(), (SpanContext) any())).thenAnswer(invocation -> {
@@ -152,19 +153,24 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         });
 
         tenantClientFactory = mock(TenantClientFactory.class);
-        when(tenantClientFactory.isConnected()).thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
+        when(tenantClientFactory.isConnected())
+                .thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
         when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
         when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
 
         credentialsClientFactory = mock(CredentialsClientFactory.class);
-        when(credentialsClientFactory.isConnected()).thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
+        when(credentialsClientFactory.isConnected())
+                .thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
         when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
         downstreamSenderFactory = mock(DownstreamSenderFactory.class);
-        when(downstreamSenderFactory.isConnected()).thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
+        when(downstreamSenderFactory.isConnected())
+                .thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
         when(downstreamSenderFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
-        when(downstreamSenderFactory.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(mock(DownstreamSender.class)));
-        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(mock(DownstreamSender.class)));
+        when(downstreamSenderFactory.getOrCreateEventSender(anyString()))
+                .thenReturn(Future.succeededFuture(mock(DownstreamSender.class)));
+        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString()))
+                .thenReturn(Future.succeededFuture(mock(DownstreamSender.class)));
 
         registrationClientFactory = mock(RegistrationClientFactory.class);
         when(registrationClientFactory.isConnected()).thenReturn(
@@ -247,8 +253,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     // TODO: startup fail test
 
     /**
-     * Verifies that a connection attempt from a device is refused if
-     * the adapter is not connected to all of the services it depends on.
+     * Verifies that a connection attempt from a device is refused if the adapter is not connected to all of the
+     * services it depends on.
      */
     @Test
     public void testEndpointHandlerFailsWithoutDownstreamConnections() {
@@ -300,7 +306,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         final TenantObject myTenantConfig = TenantObject.from("my-tenant", true);
         myTenantConfig.addAdapter(new Adapter(ADAPTER_TYPE).setEnabled(Boolean.FALSE));
         when(tenantClient.get(eq("my-tenant"), (SpanContext) any())).thenReturn(Future.succeededFuture(myTenantConfig));
-        when(authHandler.authenticateDevice(any(MqttContext.class))).thenReturn(Future.succeededFuture(new DeviceUser("my-tenant", "4711")));
+        when(authHandler.authenticateDevice(any(MqttContext.class)))
+                .thenReturn(Future.succeededFuture(new DeviceUser("my-tenant", "4711")));
         final AbstractVertxBasedMqttProtocolAdapter<MqttProtocolAdapterProperties> adapter = getAdapter(server);
         forceClientMocksToConnected();
 
@@ -313,8 +320,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that an adapter that is configured to require devices to authenticate rejects
-     * connections from devices which do not provide proper credentials.
+     * Verifies that an adapter that is configured to require devices to authenticate rejects connections from devices
+     * which do not provide proper credentials.
      */
     @Test
     public void testEndpointHandlerRejectsUnauthenticatedDevices() {
@@ -401,7 +408,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         final MqttServer server = getMqttServer(false);
         final AbstractVertxBasedMqttProtocolAdapter<MqttProtocolAdapterProperties> adapter = getAdapter(server);
         forceClientMocksToConnected();
-        when(authHandler.authenticateDevice(any(MqttContext.class))).thenReturn(Future.succeededFuture(new DeviceUser("DEFAULT_TENANT", "4711")));
+        when(authHandler.authenticateDevice(any(MqttContext.class)))
+                .thenReturn(Future.succeededFuture(new DeviceUser("DEFAULT_TENANT", "4711")));
 
         // WHEN a device tries to connect with valid credentials
         final MqttEndpoint endpoint = getMqttEndpointAuthenticated();
@@ -426,7 +434,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         final AbstractVertxBasedMqttProtocolAdapter<MqttProtocolAdapterProperties> adapter = getAdapter(server);
         forceClientMocksToConnected();
         // which is connected to a Credentials service that has credentials on record for device 9999
-        when(authHandler.authenticateDevice(any(MqttContext.class))).thenReturn(Future.succeededFuture(new DeviceUser("DEFAULT_TENANT", "9999")));
+        when(authHandler.authenticateDevice(any(MqttContext.class)))
+                .thenReturn(Future.succeededFuture(new DeviceUser("DEFAULT_TENANT", "9999")));
         // but for which no registration information is available
         when(regClient.assertRegistration(eq("9999"), (String) any(), (SpanContext) any()))
                 .thenReturn(Future.failedFuture(new ClientErrorException(
@@ -469,8 +478,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that the adapter discards messages that contain a malformed
-     * topic.
+     * Verifies that the adapter discards messages that contain a malformed topic.
      */
     @Test
     public void testHandlePublishedMessageFailsForMalformedTopic() {
@@ -502,8 +510,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that the adapter does not forward a message published by a device if
-     * the topic is empty and closes the connection to the device.
+     * Verifies that the adapter does not forward a message published by a device if the topic is empty and closes the
+     * connection to the device.
      */
     @Test
     public void testUploadTelemetryMessageFailsForEmptyTopic() {
@@ -592,9 +600,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that the adapter does not forward a message published by a device
-     * if the device belongs to a tenant for which the adapter has been disabled
-     * and that the adapter closes the connection to the device.
+     * Verifies that the adapter does not forward a message published by a device if the device belongs to a tenant for
+     * which the adapter has been disabled and that the adapter closes the connection to the device.
      */
     @Test
     public void testUploadTelemetryMessageFailsForDisabledTenant() {
@@ -659,8 +666,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that the adapter waits for a QoS 1 telemetry message being settled
-     * and accepted by a downstream peer before sending a PUBACK package to the device.
+     * Verifies that the adapter waits for a QoS 1 telemetry message being settled and accepted by a downstream peer
+     * before sending a PUBACK package to the device.
      *
      * @param ctx The vert.x test context.
      */
@@ -712,16 +719,19 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         final ResourceIdentifier address = ResourceIdentifier
                 .fromString("command/my-tenant/4712/res/1010f8ab0b53-bd96-4d99-9d9c-56b868474a6a/200");
         adapter.uploadCommandResponseMessage(newMqttContext(messageFromDevice, endpoint), address)
-                .setHandler(ctx.completing());
+                .setHandler(ctx.succeeding(result -> {
+                    verify(sender).sendCommandResponse(any(), any());
+                    // then it is forwarded successfully
+                    verify(metrics).reportCommand(
+                            eq(MetricsTags.Direction.RESPONSE),
+                            eq("my-tenant"),
+                            any(TenantObject.class),
+                            eq(MetricsTags.ProcessingOutcome.FORWARDED),
+                            eq(0),
+                            any());
 
-        // then it is forwarded successfully
-        verify(metrics).reportCommand(
-                eq(MetricsTags.Direction.RESPONSE),
-                eq("my-tenant"),
-                any(TenantObject.class),
-                eq(MetricsTags.ProcessingOutcome.FORWARDED),
-                eq(0),
-                any());
+                    ctx.completeNow();
+                }));
     }
 
     private void testUploadQoS1MessageSendsPubAckOnSuccess(
@@ -817,8 +827,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that the adapter includes a message annotation in a downstream
-     * message if the device publishes a message with its <em>retain</em> flag set.
+     * Verifies that the adapter includes a message annotation in a downstream message if the device publishes a message
+     * with its <em>retain</em> flag set.
      *
      * @param ctx The vert.x test context.
      */
@@ -853,7 +863,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
                 final ArgumentCaptor<Message> msgCaptor = ArgumentCaptor.forClass(Message.class);
                 verify(sender).sendAndWaitForOutcome(msgCaptor.capture(), (SpanContext) any());
                 // including the "retain" annotation
-                assertThat(MessageHelper.getAnnotation(msgCaptor.getValue(), MessageHelper.ANNOTATION_X_OPT_RETAIN, Boolean.class)).isTrue();
+                assertThat(MessageHelper.getAnnotation(msgCaptor.getValue(), MessageHelper.ANNOTATION_X_OPT_RETAIN,
+                        Boolean.class)).isTrue();
                 verify(metrics).reportTelemetry(
                         eq(MetricsTags.EndpointType.TELEMETRY),
                         eq("my-tenant"),
@@ -899,8 +910,9 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
         // WHEN a device subscribes to commands
         final MessageConsumer commandConsumer = mock(MessageConsumer.class);
-        when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class), any(Handler.class), anyLong()))
-            .thenReturn(Future.succeededFuture(commandConsumer));
+        when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class),
+                any(Handler.class), anyLong()))
+                        .thenReturn(Future.succeededFuture(commandConsumer));
         final List<MqttTopicSubscription> subscriptions = Collections.singletonList(
                 newMockTopicSubscription(getCommandSubscriptionTopic("tenant", "deviceId"), qos));
         final MqttSubscribeMessage msg = mock(MqttSubscribeMessage.class);
@@ -908,11 +920,13 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(msg.topicSubscriptions()).thenReturn(subscriptions);
 
         final CommandHandler<MqttProtocolAdapterProperties> cmdHandler = new CommandHandler<>(vertx, config);
-        endpoint.closeHandler(handler-> adapter.close(endpoint, new Device("tenant", "deviceId"), cmdHandler, OptionalInt.empty()));
+        endpoint.closeHandler(
+                handler -> adapter.close(endpoint, new Device("tenant", "deviceId"), cmdHandler, OptionalInt.empty()));
         adapter.onSubscribe(endpoint, null, msg, cmdHandler, OptionalInt.empty());
 
         // THEN the adapter creates a command consumer that is checked periodically
-        verify(commandConsumerFactory).createCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class), any(Handler.class), anyLong());
+        verify(commandConsumerFactory).createCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class),
+                any(Handler.class), anyLong());
         // and the adapter registers a hook on the connection to the device
         final ArgumentCaptor<Handler<Void>> closeHookCaptor = ArgumentCaptor.forClass(Handler.class);
         verify(endpoint).closeHandler(closeHookCaptor.capture());
@@ -927,8 +941,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that the adapter includes a status code for each topic filter
-     * in its SUBACK packet.
+     * Verifies that the adapter includes a status code for each topic filter in its SUBACK packet.
      */
     @SuppressWarnings("unchecked")
     @Test
@@ -949,10 +962,13 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         subscriptions.add(newMockTopicSubscription("bumlux/+/+/#", MqttQoS.AT_MOST_ONCE));
         subscriptions.add(newMockTopicSubscription("bumlux/+/+/#", MqttQoS.AT_MOST_ONCE));
         // and for subscribing to commands
-        when(commandConsumerFactory.createCommandConsumer(eq("tenant-1"), eq("device-A"), any(Handler.class), any(Handler.class), anyLong()))
-            .thenReturn(Future.succeededFuture(mock(MessageConsumer.class)));
-        subscriptions.add(newMockTopicSubscription(getCommandSubscriptionTopic("tenant-1", "device-A"), MqttQoS.AT_MOST_ONCE));
-        subscriptions.add(newMockTopicSubscription(getCommandSubscriptionTopic("tenant-1", "device-B"), MqttQoS.EXACTLY_ONCE));
+        when(commandConsumerFactory.createCommandConsumer(eq("tenant-1"), eq("device-A"), any(Handler.class),
+                any(Handler.class), anyLong()))
+                        .thenReturn(Future.succeededFuture(mock(MessageConsumer.class)));
+        subscriptions.add(
+                newMockTopicSubscription(getCommandSubscriptionTopic("tenant-1", "device-A"), MqttQoS.AT_MOST_ONCE));
+        subscriptions.add(
+                newMockTopicSubscription(getCommandSubscriptionTopic("tenant-1", "device-B"), MqttQoS.EXACTLY_ONCE));
         final MqttSubscribeMessage msg = mock(MqttSubscribeMessage.class);
         when(msg.messageId()).thenReturn(15);
         when(msg.topicSubscriptions()).thenReturn(subscriptions);
@@ -986,8 +1002,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
     /**
      *
-     * Verifies that the adapter will accept uploading messages to standard as well
-     * as shortened topic names.
+     * Verifies that the adapter will accept uploading messages to standard as well as shortened topic names.
      *
      * @param ctx The vert.x test context.
      */
@@ -1064,7 +1079,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         final AbstractVertxBasedMqttProtocolAdapter<MqttProtocolAdapterProperties> adapter = getAdapter(server);
 
         forceClientMocksToConnected();
-        when(authHandler.authenticateDevice(any(MqttContext.class))).thenReturn(Future.succeededFuture(new DeviceUser("DEFAULT_TENANT", "4711")));
+        when(authHandler.authenticateDevice(any(MqttContext.class)))
+                .thenReturn(Future.succeededFuture(new DeviceUser("DEFAULT_TENANT", "4711")));
 
         final MqttEndpoint endpoint = getMqttEndpointAuthenticated();
         adapter.handleEndpointConnection(endpoint);
@@ -1192,7 +1208,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
                         // THEN the message has not been sent downstream
                         verify(sender, never()).send(any(Message.class));
                         // because the message limit is exceeded
-                        assertThat(((ClientErrorException) t).getErrorCode()).isEqualTo(HttpUtils.HTTP_TOO_MANY_REQUESTS);
+                        assertThat(((ClientErrorException) t).getErrorCode())
+                                .isEqualTo(HttpUtils.HTTP_TOO_MANY_REQUESTS);
                         // and the message has been reported as unprocessable
                         verify(metrics).reportTelemetry(
                                 any(MetricsTags.EndpointType.class),
@@ -1239,7 +1256,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
                         // THEN the message has not been sent downstream
                         verify(sender, never()).send(any(Message.class));
                         // because the message limit is exceeded
-                        assertThat(((ClientErrorException) t).getErrorCode()).isEqualTo(HttpUtils.HTTP_TOO_MANY_REQUESTS);
+                        assertThat(((ClientErrorException) t).getErrorCode())
+                                .isEqualTo(HttpUtils.HTTP_TOO_MANY_REQUESTS);
                         // and the message has been reported as unprocessable
                         verify(metrics).reportTelemetry(
                                 any(MetricsTags.EndpointType.class),
@@ -1284,7 +1302,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
                     ctx.verify(() -> {
 
                         // THEN the request fails with a 429 error
-                        assertThat(((ClientErrorException) t).getErrorCode()).isEqualTo(HttpUtils.HTTP_TOO_MANY_REQUESTS);
+                        assertThat(((ClientErrorException) t).getErrorCode())
+                                .isEqualTo(HttpUtils.HTTP_TOO_MANY_REQUESTS);
 
                         // AND has reported the message as unprocessable
                         verify(metrics).reportCommand(
@@ -1300,8 +1319,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that the TTL for a downstream event is set to the given <em>time-to-live</em> value 
-     * in the <em>property-bag</em>.
+     * Verifies that the TTL for a downstream event is set to the given <em>time-to-live</em> value in the
+     * <em>property-bag</em>.
      *
      * @param ctx The vert.x test context.
      */
@@ -1337,9 +1356,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that the TTL for a downstream event is limited by the <em>max-ttl</em> specified for
-     * a tenant, if the given <em>time-to-live</em> duration in the <em>property-bag</em> exceeds 
-     * the <em>max-ttl</em> value.
+     * Verifies that the TTL for a downstream event is limited by the <em>max-ttl</em> specified for a tenant, if the
+     * given <em>time-to-live</em> duration in the <em>property-bag</em> exceeds the <em>max-ttl</em> value.
      *
      * @param ctx The vert.x test context.
      */
@@ -1478,10 +1496,13 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
 
         final DownstreamSender sender = mock(DownstreamSender.class);
         when(sender.getEndpoint()).thenReturn(TelemetryConstants.TELEMETRY_ENDPOINT);
-        when(sender.send(any(Message.class), (SpanContext) any())).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
-        when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenThrow(new UnsupportedOperationException());
+        when(sender.send(any(Message.class), (SpanContext) any()))
+                .thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
+        when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any()))
+                .thenThrow(new UnsupportedOperationException());
 
-        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString()))
+                .thenReturn(Future.succeededFuture(sender));
         return sender;
     }
 
@@ -1492,7 +1513,8 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(sender.send(any(Message.class), (SpanContext) any())).thenThrow(new UnsupportedOperationException());
         when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(outcome.future());
 
-        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString()))
+                .thenReturn(Future.succeededFuture(sender));
         return sender;
     }
 }


### PR DESCRIPTION
This fixes #1726.