### PR TITLE
Improve logging in Sender classes

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/EventSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/EventSenderImpl.java
@@ -155,4 +155,10 @@ public final class EventSenderImpl extends AbstractDownstreamSender {
         Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_PRODUCER);
         return span;
     }
+
+    @Override
+    protected void logMessageSendingError(final String format, final Object... arguments) {
+        // log on INFO instead of DEBUG level since events are usually brokered and therefore errors here might indicate issues with the broker
+        log.info(format, arguments);
+    }
 }


### PR DESCRIPTION
This changes the log level of message sending errors from DEBUG to INFO in the {EventSenderImpl} class. 

Event messages are usually brokered and so issues when sending event messages may point to issues with the broker infrastructure, deserving a log level that gets more attention than DEBUG here.

Also the message address was added to log entries here.