### PR TITLE
Require vertx param in HonoConnection to be not null

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -72,11 +72,11 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
      * <strong>Note:</strong> Instances of {@link ClientConfigProperties} are not thread safe and not immutable.
      * They must therefore not be modified after calling this method.
      *
-     * @param vertx The vert.x instance to use or {@code null}, if a new vert.x instance should be created.
+     * @param vertx The vert.x instance to use.
      * @param clientConfigProperties The client properties to use.
      * @return The newly created connection. Note that the underlying AMQP connection will not be established
      *         until one of its <em>connect</em> methods is invoked.
-     * @throws NullPointerException if properties are {@code null}.
+     * @throws NullPointerException if vertx or clientConfigProperties is {@code null}.
      */
     static HonoConnection newConnection(final Vertx vertx, final ClientConfigProperties clientConfigProperties) {
         return new HonoConnectionImpl(vertx, clientConfigProperties);

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
@@ -124,9 +124,9 @@ public class HonoConnectionImpl implements HonoConnection {
      * This constructor creates a connection factory using
      * {@link ConnectionFactory#newConnectionFactory(Vertx, ClientConfigProperties)}.
      *
-     * @param vertx The Vert.x instance to execute the client on, if {@code null} a new Vert.x instance is used.
+     * @param vertx The Vert.x instance to execute the client on.
      * @param clientConfigProperties The configuration properties to use.
-     * @throws NullPointerException if clientConfigProperties is {@code null}
+     * @throws NullPointerException if vertx or clientConfigProperties is {@code null}.
      */
     public HonoConnectionImpl(final Vertx vertx, final ClientConfigProperties clientConfigProperties) {
         this(vertx, null, clientConfigProperties);
@@ -138,22 +138,19 @@ public class HonoConnectionImpl implements HonoConnection {
      * <em>NB</em> Make sure to always use the same set of configuration properties for both the connection factory as
      * well as the Hono client in order to prevent unexpected behavior.
      *
-     * @param vertx The Vert.x instance to execute the client on, if {@code null} a new Vert.x instance is used.
+     * @param vertx The Vert.x instance to execute the client on.
      * @param connectionFactory The factory to use for creating an AMQP connection to the Hono server.
      * @param clientConfigProperties The configuration properties to use.
-     * @throws NullPointerException if clientConfigProperties is {@code null}
+     * @throws NullPointerException if vertx or clientConfigProperties is {@code null}.
      */
     public HonoConnectionImpl(final Vertx vertx, final ConnectionFactory connectionFactory,
             final ClientConfigProperties clientConfigProperties) {
 
+        Objects.requireNonNull(vertx);
         Objects.requireNonNull(clientConfigProperties);
 
-        if (vertx != null) {
-            this.vertx = vertx;
-        } else {
-            this.vertx = Vertx.vertx();
-        }
-        deferredConnectionCheckHandler = new DeferredConnectionCheckHandler(vertx);
+        this.vertx = vertx;
+        this.deferredConnectionCheckHandler = new DeferredConnectionCheckHandler(vertx);
         if (connectionFactory != null) {
             this.connectionFactory = connectionFactory;
         } else {

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -55,6 +55,7 @@ title = "Release Notes"
   (or the respective shorthand version). Note that the AMQP Messaging Network still needs to be
   configured in such a way that protocol adapters can send and receive messages on the `control/*`
   address pattern. This is now used for internal communication between protocol adapters only.
+* The `create` method in `org.eclipse.hono.client.HonoConnection` now requires its Vertx parameter to be not null.
 
 ## 1.0.3
 


### PR DESCRIPTION
Creating a new vertx instance in the `HonoConnectionImpl` constructor will likely cause issues on application shutdown, as this instance won't get closed automatically and therefore can prevent termination of the application.