### PR TITLE
[#1750] Fix shutdown/disconnect if used on event loop thread.

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -186,7 +186,9 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
      * permission information from an authorization service. If after connecting to the server the permissions
      * from the service have changed, then it will be necessary to drop the connection and connect back to the server
      * to retrieve the updated permissions.
-     *
+     * <p>
+     * If not called from a Vert.x event loop thread, this method waits for at most half of the configured
+     * connect timeout for the connection to be closed properly.
      */
     @Override
     void disconnect();
@@ -194,7 +196,10 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
     /**
      * Closes this client's connection to the Hono server.
      * <p>
-     * This method waits for at most 5 seconds for the connection to be closed properly. Any subsequent attempts to
+     * If not called from a Vert.x event loop thread, this method waits for at most half of the configured
+     * connect timeout for the connection to be closed properly.
+     * <p>
+     * Any senders or consumers opened by this client will be implicitly closed as well. Any subsequent attempts to
      * connect this client again will fail.
      */
     void shutdown();


### PR DESCRIPTION
This fixes #1750.

The timeout used in `closeConnection()` and in `shutdown()`, `disconnect()`
has also been reduced to *half* the connect timeout.
IMHO, waiting 2,5s (= half the 5s default connect timeout) should be enough by default.

