### PR TITLE
Add missing check for Command without replyId in reply-to

### DIFF
--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderTest.java
@@ -450,7 +450,7 @@ public class KerlinkProviderTest {
                 CommandConstants.COMMAND_ENDPOINT, "bumlux", "bumlux"));
         message.setSubject("subject");
         message.setCorrelationId("correlation_id");
-        message.setReplyTo(CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT + "/bumlux");
+        message.setReplyTo(CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT + "/bumlux/replyId");
 
         final JsonObject payload = new JsonObject();
         payload.put(LoraConstants.FIELD_LORA_DOWNLINK_PAYLOAD, "bumlux".getBytes(Charsets.UTF_8));

--- a/client/src/main/java/org/eclipse/hono/client/Command.java
+++ b/client/src/main/java/org/eclipse/hono/client/Command.java
@@ -140,7 +140,7 @@ public final class Command {
                     validationErrorJoiner.add("reply-to not targeted at tenant " + tenantId + ": " + message.getReplyTo());
                 } else {
                     originalReplyToId = replyTo.getPathWithoutBase();
-                    if (originalReplyToId == null) {
+                    if (originalReplyToId.isEmpty()) {
                         validationErrorJoiner.add("reply-to part after tenant not set: " + message.getReplyTo());
                     } else {
                         message.setReplyTo(
@@ -148,7 +148,7 @@ public final class Command {
                                         getDeviceFacingReplyToId(originalReplyToId, deviceId)));
                     }
                 }
-            } catch (IllegalArgumentException e) {
+            } catch (final IllegalArgumentException e) {
                 // reply-to could not be parsed
                 validationErrorJoiner.add("reply-to cannot be parsed: " + message.getReplyTo());
             }
@@ -411,7 +411,7 @@ public final class Command {
      * @param correlationId The identifier to use for correlating the response with the request.
      * @param replyToId An arbitrary identifier to encode into the request ID.
      * @param deviceId The target of the command.
-     * @return The request identifier or {@code null} if any the correlationId or the deviceId is {@code null}.
+     * @return The request identifier or {@code null} if correlationId or deviceId is {@code null}.
      */
     public static String getRequestId(final String correlationId, final String replyToId, final String deviceId) {
 
@@ -419,14 +419,13 @@ public final class Command {
             return null;
         }
 
-        final String correlationIdOrEmpty = Optional.ofNullable(correlationId).orElse("");
         String replyToIdWithoutDeviceOrEmpty = Optional.ofNullable(replyToId).orElse("");
         final boolean replyToContainedDeviceId = replyToIdWithoutDeviceOrEmpty.startsWith(deviceId + "/");
         if (replyToContainedDeviceId) {
             replyToIdWithoutDeviceOrEmpty = replyToIdWithoutDeviceOrEmpty.substring(deviceId.length() + 1);
         }
         return String.format("%s%02x%s%s", encodeReplyToOptions(replyToContainedDeviceId),
-                correlationIdOrEmpty.length(), correlationIdOrEmpty, replyToIdWithoutDeviceOrEmpty);
+                correlationId.length(), correlationId, replyToIdWithoutDeviceOrEmpty);
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/CommandResponseTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandResponseTest.java
@@ -304,7 +304,7 @@ public class CommandResponseTest {
     }
 
     /**
-     * Verifies that the device-id is not part of the reply-to-id.
+     * Verifies that the device-id is not part of the CommandResponse replyToId.
      */
     @Test
     public void testForNoDeviceIdInReplyToId() {
@@ -312,12 +312,29 @@ public class CommandResponseTest {
         final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId);
         final Message message = ProtonHelper.message();
         message.setAddress(ResourceIdentifier
-                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%srid-1", DEVICE_ID, replyToOptionsBitFlag)).toString());
+                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%s%s", DEVICE_ID, replyToOptionsBitFlag, "rid-1")).toString());
         message.setCorrelationId(CORRELATION_ID);
         MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
         final CommandResponse response = CommandResponse.from(message);
         assertThat(response).isNotNull();
         assertThat(response.getReplyToId()).isEqualTo("rid-1");
+    }
+
+    /**
+     * Verifies that creating a response fails for a message with an invalid address, having an empty id
+     * after the replyToOptions bit.
+     */
+    @Test
+    public void testFromMessageFailsForInvalidAddressWithEmptyReplyId() {
+        final boolean replyToContainedDeviceId = false;
+        final String replyToOptionsBitFlag = Command.encodeReplyToOptions(replyToContainedDeviceId);
+        final Message message = ProtonHelper.message();
+        message.setAddress(ResourceIdentifier
+                .from(getCommandResponseEndpoint(), TENANT_ID, String.format("%s/%s%s", DEVICE_ID, replyToOptionsBitFlag, "")).toString());
+        message.setCorrelationId(CORRELATION_ID);
+        MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        final CommandResponse response = CommandResponse.from(message);
+        assertThat(response).isNull();
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/CommandTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandTest.java
@@ -272,10 +272,10 @@ public class CommandTest {
 
     /**
      * Verifies that a command cannot be created from a message that contains
-     * a malformed reply-to address.
+     * a reply-to address with the wrong tenant.
      */
     @Test
-    public void testFromMessageFailsForMalformedReplyToAddress() {
+    public void testFromMessageFailsForReplyToWithWrongTenant() {
         final String correlationId = "the-correlation-id";
         final Message message = mock(Message.class);
         when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
@@ -283,7 +283,7 @@ public class CommandTest {
         when(message.getSubject()).thenReturn("doThis");
         when(message.getCorrelationId()).thenReturn(correlationId);
         when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s",
-                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, "4711", Constants.DEFAULT_TENANT));
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, "wrong_tenant", "4711"));
         final Command command = Command.from(message, Constants.DEFAULT_TENANT, "4711");
         assertFalse(command.isValid());
         assertThat(command.getInvalidCommandReason()).contains("reply-to");
@@ -291,11 +291,10 @@ public class CommandTest {
 
     /**
      * Verifies that a command cannot be created from a message that contains
-     * a reply-to address that does not match the target device.
+     * a reply-to address without a reply id.
      */
     @Test
-    public void testFromMessageFailsForNonMatchingReplyToAddress() {
-        final String replyToId = "the-reply-to-id";
+    public void testFromMessageFailsForReplyToWithoutReplyId() {
         final String correlationId = "the-correlation-id";
         final Message message = mock(Message.class);
         when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
@@ -303,7 +302,7 @@ public class CommandTest {
         when(message.getSubject()).thenReturn("doThis");
         when(message.getCorrelationId()).thenReturn(correlationId);
         when(message.getReplyTo()).thenReturn(String.format("%s/%s",
-                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, replyToId));
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT));
         final Command command = Command.from(message, Constants.DEFAULT_TENANT, "4712");
         assertFalse(command.isValid());
         assertThat(command.getInvalidCommandReason()).contains("reply-to");


### PR DESCRIPTION
The command message reply-to address must contain a non-empty
reply-id, otherwise preparing the CommandResponse message will
result in an exception. The missing check has been added,
along with corresponding tests.