### PR TITLE
Align PSK secret for default device of local deployment with sandbox.

### DIFF
--- a/deploy/src/main/deploy/example-credentials.json
+++ b/deploy/src/main/deploy/example-credentials.json
@@ -33,16 +33,16 @@
         ]
       },
       {
-        "device-id" : "4711",
-        "type" : "psk",
-        "auth-id" : "sensor1",
-        "enabled" : true,
-        "secrets" : [
+        "device-id": "4711",
+        "type": "psk",
+        "auth-id": "sensor1",
+        "enabled": true,
+        "secrets": [
           {
-            "not-before": "2018-01-01T00:00:00+01:00",
+            "not-before": "2020-01-01T00:00:00+01:00",
             "not-after": "2037-06-01T14:00:00+01:00",
-            "comment": "coap preshared key: coap-secret",
-            "key" : "Y29hcC1zZWNyZXQ="
+            "comment": "key: hono-secret",
+            "key": "aG9uby1zZWNyZXQ="
           }
         ]
       },


### PR DESCRIPTION
Use hono-secret instead of coap-secret.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>