### PR TITLE
Add command and control to coap.

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -307,13 +307,13 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
     private Future<CoapServer> bindSecureEndpoint(final CoapServer startingServer, final NetworkConfig config) {
 
         final ApplicationLevelInfoSupplier deviceResolver = Optional.ofNullable(honoDeviceResolver)
-                .orElse(new DefaultDeviceResolver(context, getConfig(), getCredentialsClientFactory()));
+                .orElse(new DefaultDeviceResolver(context, tracer, getTypeName(), getConfig(), getCredentialsClientFactory()));
         final PskStore store = Optional.ofNullable(pskStore)
                 .orElseGet(() -> {
                     if (deviceResolver instanceof PskStore) {
                         return (PskStore) deviceResolver;
                     } else {
-                        return new DefaultDeviceResolver(context, getConfig(), getCredentialsClientFactory());
+                        return new DefaultDeviceResolver(context, tracer, getTypeName(), getConfig(), getCredentialsClientFactory());
                     }
                 });
 

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapErrorResponse.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapErrorResponse.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.adapter.coap;
 import java.net.HttpURLConnection;
 
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.MessageFormatException;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.server.resources.CoapExchange;
@@ -91,6 +92,7 @@ public class CoapErrorResponse {
     public static void respond(final CoapExchange exchange, final String message, final ResponseCode code) {
         final Response response = new Response(code);
         response.setPayload(message);
+        response.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
         exchange.respond(response);
     }
 

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResource.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResource.java
@@ -22,6 +22,8 @@ import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -36,6 +38,7 @@ import io.vertx.core.Future;
  */
 public abstract class TracingSupportingHonoResource extends CoapResource {
 
+    protected final Logger log = LoggerFactory.getLogger(getClass());
     final Tracer tracer;
     final String adapterName;
 
@@ -94,9 +97,11 @@ public abstract class TracingSupportingHonoResource extends CoapResource {
                 break;
         }
         responseCode.otherwise(t -> {
+            log.debug("failed:", t);
             return CoapErrorResponse.respond(coapExchange, t);
         })
         .setHandler(r -> {
+            log.debug("response: {}", r.result());
             currentSpan.setTag("coap.response_code", r.result().toString());
             currentSpan.finish();
         });

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -56,6 +56,7 @@ import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.metric.MetricsTags.TtdStatus;
 import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.TenantObject;
@@ -346,6 +347,7 @@ public class AbstractVertxBasedCoapAdapterTest {
                 eq(MetricsTags.ProcessingOutcome.UNPROCESSABLE),
                 eq(MetricsTags.QoS.AT_MOST_ONCE),
                 eq(payload.length()),
+                eq(TtdStatus.NONE),
                 any());        
     }
 
@@ -376,7 +378,11 @@ public class AbstractVertxBasedCoapAdapterTest {
 
         // until the event has been accepted
         outcome.complete(mock(ProtonDelivery.class));
-        verify(coapExchange).respond(ResponseCode.CHANGED);
+
+        final ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(coapExchange).respond(captor.capture());
+        assertThat(captor.getValue().getCode()).isEqualTo(ResponseCode.CHANGED);
+
         verify(metrics).reportTelemetry(
                 eq(MetricsTags.EndpointType.EVENT),
                 eq("tenant"),
@@ -384,6 +390,7 @@ public class AbstractVertxBasedCoapAdapterTest {
                 eq(MetricsTags.ProcessingOutcome.FORWARDED),
                 eq(MetricsTags.QoS.AT_LEAST_ONCE),
                 eq(payload.length()),
+                eq(TtdStatus.NONE),
                 any());
     }
 
@@ -421,6 +428,7 @@ public class AbstractVertxBasedCoapAdapterTest {
                 eq(MetricsTags.ProcessingOutcome.UNPROCESSABLE),
                 eq(MetricsTags.QoS.AT_LEAST_ONCE),
                 eq(payload.length()),
+                eq(TtdStatus.NONE),
                 any());        
     }
 
@@ -451,7 +459,11 @@ public class AbstractVertxBasedCoapAdapterTest {
 
         // until the telemetry message has been accepted
         outcome.complete(mock(ProtonDelivery.class));
-        verify(coapExchange).respond(ResponseCode.CHANGED);
+
+        final ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(coapExchange).respond(captor.capture());
+        assertThat(captor.getValue().getCode()).isEqualTo(ResponseCode.CHANGED);
+
         verify(metrics).reportTelemetry(
                 eq(MetricsTags.EndpointType.TELEMETRY),
                 eq("tenant"),
@@ -459,6 +471,7 @@ public class AbstractVertxBasedCoapAdapterTest {
                 eq(MetricsTags.ProcessingOutcome.FORWARDED),
                 eq(MetricsTags.QoS.AT_MOST_ONCE),
                 eq(payload.length()),
+                eq(TtdStatus.NONE),
                 any());
     }
 
@@ -489,7 +502,11 @@ public class AbstractVertxBasedCoapAdapterTest {
 
         // until the telemetry message has been accepted
         outcome.complete(mock(ProtonDelivery.class));
-        verify(coapExchange).respond(ResponseCode.CHANGED);
+
+        final ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(coapExchange).respond(captor.capture());
+        assertThat(captor.getValue().getCode()).isEqualTo(ResponseCode.CHANGED);
+
         verify(metrics).reportTelemetry(
                 eq(MetricsTags.EndpointType.TELEMETRY),
                 eq("tenant"),
@@ -497,6 +514,7 @@ public class AbstractVertxBasedCoapAdapterTest {
                 eq(MetricsTags.ProcessingOutcome.FORWARDED),
                 eq(MetricsTags.QoS.AT_LEAST_ONCE),
                 eq(payload.length()),
+                eq(TtdStatus.NONE),
                 any());        
     }
 
@@ -536,6 +554,7 @@ public class AbstractVertxBasedCoapAdapterTest {
                 eq(MetricsTags.ProcessingOutcome.UNPROCESSABLE),
                 eq(MetricsTags.QoS.AT_MOST_ONCE),
                 eq(payload.length()),
+                eq(TtdStatus.NONE),
                 any());
     }
 
@@ -575,6 +594,7 @@ public class AbstractVertxBasedCoapAdapterTest {
                 eq(MetricsTags.ProcessingOutcome.UNPROCESSABLE),
                 eq(MetricsTags.QoS.AT_LEAST_ONCE),
                 eq(payload.length()),
+                eq(TtdStatus.NONE),
                 any());        
     }
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <artemis.image.name>quay.io/enmasse/artemis-base:2.10.1</artemis.image.name>
     <assertj-core.version>3.13.2</assertj-core.version>
-    <californium.version>2.0.0</californium.version>
+    <californium.version>2.1.0</californium.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.10.0</dispatch-router.image.name>
     <guava.version>28.0-jre</guava.version>
     <caffeine.version>2.8.0</caffeine.version>


### PR DESCRIPTION
Use query-parameter for "hono-ttd" instead of option and replace
content-type "application/vnd.eclipse-hono-empty-notification" by
query-parameter "empty". Both, custom option and content-type, would
require a code-point reservation at IANA. Though the use-case is very
hono specific, I think using query-parameters is more appropriate.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>