### PR TITLE
[#1774] Align management API signatures

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/AbstractCredentialsManagementHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/AbstractCredentialsManagementHttpEndpoint.java
@@ -152,7 +152,8 @@ public abstract class AbstractCredentialsManagementHttpEndpoint extends Abstract
                         span);
         });
 
-        getService().set(tenantId, deviceId, resourceVersion, commonCredentials, span, result);
+        getService().updateCredentials(tenantId, deviceId, commonCredentials, resourceVersion, span, result);
+
     }
 
     private void getCredentialsForDevice(final RoutingContext ctx) {
@@ -190,7 +191,7 @@ public abstract class AbstractCredentialsManagementHttpEndpoint extends Abstract
             }
         });
 
-        getService().get(tenantId, deviceId, span, result);
+        getService().readCredentials(tenantId, deviceId, span, result);
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementService.java
@@ -52,7 +52,7 @@ public interface CredentialsManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/credentials/setAllCredentials">
      *      Device Registry Management API - Update Credentials</a>
      */
-    void set(String tenantId, String deviceId, Optional<String> resourceVersion, List<CommonCredential> credentials,
+    void updateCredentials(String tenantId, String deviceId, List<CommonCredential> credentials, Optional<String> resourceVersion,
             Span span, Handler<AsyncResult<OperationResult<Void>>> resultHandler);
 
     /**
@@ -74,6 +74,6 @@ public interface CredentialsManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/credentials/getAllCredentials">
      *      Device Registry Management API - Get Credentials</a>
      */
-    void get(String tenantId, String deviceId, Span span,
+    void readCredentials(String tenantId, String deviceId, Span span,
             Handler<AsyncResult<OperationResult<List<CommonCredential>>>> resultHandler);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/EventBusCredentialsManagementAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/EventBusCredentialsManagementAdapter.java
@@ -112,7 +112,7 @@ public abstract class EventBusCredentialsManagementAdapter extends EventBusServi
             resultFuture = credentialsFromPayload(request)
                     .compose(secrets -> {
                         final Promise<OperationResult<Void>> result = Promise.promise();
-                        getService().set(tenantId, deviceId, resourceVersion, secrets, span, result);
+                        getService().updateCredentials(tenantId, deviceId, secrets, resourceVersion, span, result);
                         return result.future()
                                 .map(res -> res.createResponse(request, id -> null).setDeviceId(deviceId));
                     });
@@ -210,7 +210,7 @@ public abstract class EventBusCredentialsManagementAdapter extends EventBusServi
         final Span span = Util.newChildSpan(SPAN_NAME_GET_CREDENTIAL, spanContext, tracer, tenantId, deviceId, getClass().getSimpleName());
 
         final Promise<OperationResult<List<CommonCredential>>> getResult = Promise.promise();
-        getService().get(tenantId, deviceId, span, getResult);
+        getService().readCredentials(tenantId, deviceId, span, getResult);
 
         final Future<EventBusMessage> resultFuture = getResult.future()
                 .map(res -> {

--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackend.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackend.java
@@ -90,7 +90,7 @@ public interface AutoProvisioningEnabledDeviceBackend extends DeviceBackend {
                     final String deviceId = r.getPayload().getId();
 
                     final Promise<OperationResult<Void>> credPromise = Promise.promise();
-                    set(tenantId, deviceId, Optional.empty(), List.of(certCredential), span, credPromise);
+                    updateCredentials(tenantId, deviceId, List.of(certCredential), Optional.empty(), span, credPromise);
                     return credPromise.future()
                             .compose(v -> {
                                 if (v.isError()) {

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/AbstractTenantManagementHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/AbstractTenantManagementHttpEndpoint.java
@@ -185,7 +185,7 @@ public abstract class AbstractTenantManagementHttpEndpoint extends AbstractHttpE
                         span);
             });
 
-            getService().add(Optional.ofNullable(tenantId), payload, span, result);
+            getService().createTenant(Optional.ofNullable(tenantId), payload.mapTo(Tenant.class), span, result);
         } else {
             final String msg = "request contains malformed payload";
             logger.debug(msg);
@@ -220,7 +220,7 @@ public abstract class AbstractTenantManagementHttpEndpoint extends AbstractHttpE
                     response.end();
             }
         });
-        getService().read(tenantId, span, result);
+        getService().readTenant(tenantId, span, result);
     }
 
     private void updateTenant(final RoutingContext ctx) {
@@ -246,7 +246,7 @@ public abstract class AbstractTenantManagementHttpEndpoint extends AbstractHttpE
                 Util.writeOperationResponse(ctx, handler.result(), null, span);
             });
 
-            getService().update(tenantId, payload, resourceVersion, span, result);
+            getService().updateTenant(tenantId, payload.mapTo(Tenant.class), resourceVersion, span, result);
         } else {
             final String msg = "request contains malformed payload";
             logger.debug(msg);
@@ -273,7 +273,7 @@ public abstract class AbstractTenantManagementHttpEndpoint extends AbstractHttpE
                     Util.writeResponse(ctx, handler.result(), null, span);
                 });
 
-        getService().remove(tenantId, resourceVersion, span, result);
+        getService().deleteTenant(tenantId, resourceVersion, span, result);
     }
 
     private static String getTenantParamFromPayload(final JsonObject payload) {

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/EventBusTenantManagementAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/EventBusTenantManagementAdapter.java
@@ -109,7 +109,7 @@ public abstract class EventBusTenantManagementAdapter extends EventBusService {
             addNotPresentFieldsWithDefaultValuesForTenant(payload);
 
             final Promise<OperationResult<Id>> addResult = Promise.promise();
-            getService().add(tenantId, payload, span, addResult);
+            getService().createTenant(tenantId, payload.mapTo(Tenant.class), span, addResult);
             resultFuture = addResult.future().map(res -> {
                 final String createdTenantId = Optional.ofNullable(res.getPayload()).map(Id::getId).orElse(null);
                 return res.createResponse(request, JsonObject::mapFrom).setTenant(createdTenantId);
@@ -142,7 +142,7 @@ public abstract class EventBusTenantManagementAdapter extends EventBusService {
             addNotPresentFieldsWithDefaultValuesForTenant(payload);
 
             final Promise<OperationResult<Void>> updateResult = Promise.promise();
-            getService().update(tenantId, payload, resourceVersion, span, updateResult);
+            getService().updateTenant(tenantId, payload.mapTo(Tenant.class), resourceVersion, span, updateResult);
             resultFuture = updateResult.future()
                     .map(res -> res.createResponse(request, JsonObject::mapFrom).setTenant(tenantId));
         } else {
@@ -170,7 +170,7 @@ public abstract class EventBusTenantManagementAdapter extends EventBusService {
             log.debug("deleting tenant [{}]", tenantId);
 
             final Promise<Result<Void>> removeResult = Promise.promise();
-            getService().remove(tenantId, resourceVersion, span, removeResult);
+            getService().deleteTenant(tenantId, resourceVersion, span, removeResult);
             resultFuture = removeResult.future()
                     .map(res -> res.createResponse(request, JsonObject::mapFrom).setTenant(tenantId));
         }
@@ -192,7 +192,7 @@ public abstract class EventBusTenantManagementAdapter extends EventBusService {
         } else {
             log.debug("retrieving tenant [id: {}]", tenantId);
             final Promise<OperationResult<Tenant>> readResult = Promise.promise();
-            getService().read(tenantId, span, readResult);
+            getService().readTenant(tenantId, span, readResult);
             resultFuture = readResult.future()
                     .map(res -> res.createResponse(request, JsonObject::mapFrom).setTenant(tenantId));
         }

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementService.java
@@ -16,7 +16,6 @@ package org.eclipse.hono.service.management.tenant;
 import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.json.JsonObject;
 import java.util.Optional;
 import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
@@ -33,7 +32,7 @@ public interface TenantManagementService {
     /**
      * Creates a new Tenant.
      *
-     * @param tenantId The identifier of the tenant to add.
+     * @param tenantId The identifier of the tenant to create.
      * @param tenantObj The configuration information to add for the tenant (may be {@code null}).
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *              An implementation should log (error) events on this span and it may set tags and use this span as the
@@ -48,7 +47,7 @@ public interface TenantManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/createTenant">
      *      Device Registry Management API - Create Tenant</a>
      */
-    void add(Optional<String> tenantId, JsonObject tenantObj, Span span, Handler<AsyncResult<OperationResult<Id>>> resultHandler);
+    void createTenant(Optional<String> tenantId, Tenant tenantObj, Span span, Handler<AsyncResult<OperationResult<Id>>> resultHandler);
 
     /**
      * Reads tenant configuration information for a tenant identifier.
@@ -67,7 +66,7 @@ public interface TenantManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/getTenant">
      *      Device Registry Management API - Get Tenant</a>
      */
-    void read(String tenantId, Span span, Handler<AsyncResult<OperationResult<Tenant>>> resultHandler);
+    void readTenant(String tenantId, Span span, Handler<AsyncResult<OperationResult<Tenant>>> resultHandler);
 
     /**
      * Updates configuration information of a tenant.
@@ -88,7 +87,7 @@ public interface TenantManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/updateTenant">
      *      Device Registry Management API - Update Tenant</a>
      */
-    void update(String tenantId, JsonObject tenantObj, Optional<String> resourceVersion,
+    void updateTenant(String tenantId, Tenant tenantObj, Optional<String> resourceVersion,
             Span span, Handler<AsyncResult<OperationResult<Void>>> resultHandler);
 
     /**
@@ -109,5 +108,5 @@ public interface TenantManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/deleteTenant">
      *      Device Registry Management API - Delete Tenant</a>
      */
-    void remove(String tenantId, Optional<String> resourceVersion, Span span, Handler<AsyncResult<Result<Void>>> resultHandler);
+    void deleteTenant(String tenantId, Optional<String> resourceVersion, Span span, Handler<AsyncResult<Result<Void>>> resultHandler);
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
@@ -322,7 +322,7 @@ public abstract class AbstractCredentialsServiceTest {
             final ThrowingConsumer<CredentialsResult<JsonObject>> adapterValidation,
             final ExecutionBlock whenComplete) {
 
-        getCredentialsManagementService().get(tenantId, deviceId, NoopSpan.INSTANCE, ctx.succeeding(s3 -> {
+        getCredentialsManagementService().readCredentials(tenantId, deviceId, NoopSpan.INSTANCE, ctx.succeeding(s3 -> {
 
             ctx.verify(() -> {
 
@@ -365,8 +365,9 @@ public abstract class AbstractCredentialsServiceTest {
 
         assertGetMissing(ctx, tenantId, deviceId, authId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, () -> {
 
-            getCredentialsManagementService().set(tenantId, deviceId, Optional.empty(),
-                    Collections.singletonList(secret), NoopSpan.INSTANCE,
+            getCredentialsManagementService().updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
+                    Optional.empty(),
+                    NoopSpan.INSTANCE,
                     ctx.succeeding(s2 -> ctx.verify(() -> {
 
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, s2.getStatus());
@@ -404,8 +405,9 @@ public abstract class AbstractCredentialsServiceTest {
 
         assertGetMissing(ctx, tenantId, deviceId, authId, CredentialsConstants.FIELD_SECRETS_PWD_PLAIN, () -> {
 
-            getCredentialsManagementService().set(tenantId, deviceId, Optional.empty(),
-                    Collections.singletonList(secret), NoopSpan.INSTANCE,
+            getCredentialsManagementService().updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
+                    Optional.empty(),
+                    NoopSpan.INSTANCE,
                     ctx.succeeding(s2 -> ctx.verify(() -> {
 
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, s2.getStatus());
@@ -472,8 +474,9 @@ public abstract class AbstractCredentialsServiceTest {
 
         assertGetMissing(ctx, tenantId, deviceId, authId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, () -> {
 
-            getCredentialsManagementService().set(tenantId, deviceId, Optional.empty(),
-                    Collections.singletonList(secret), NoopSpan.INSTANCE,
+            getCredentialsManagementService().updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
+                    Optional.empty(),
+                    NoopSpan.INSTANCE,
                     ctx.succeeding(s2 -> ctx.verify(() -> {
 
                         assertResourceVersion(s2);
@@ -499,8 +502,9 @@ public abstract class AbstractCredentialsServiceTest {
 
             final var newSecret = createPasswordCredential(authId, "baz");
 
-            getCredentialsManagementService().set(tenantId, deviceId, Optional.empty(),
-                    Collections.singletonList(newSecret), NoopSpan.INSTANCE,
+            getCredentialsManagementService().updateCredentials(tenantId, deviceId,
+                    Collections.singletonList(newSecret), Optional.empty(),
+                    NoopSpan.INSTANCE,
                     ctx.succeeding(s -> ctx.verify(() -> {
 
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, s.getStatus());
@@ -549,8 +553,9 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase1.future().setHandler(ctx.succeeding(s1 -> {
 
-                getCredentialsManagementService().set(tenantId, deviceId, Optional.empty(),
-                        Collections.singletonList(secret), NoopSpan.INSTANCE,
+                getCredentialsManagementService().updateCredentials(tenantId, deviceId,
+                        Collections.singletonList(secret), Optional.empty(),
+                        NoopSpan.INSTANCE,
                         ctx.succeeding(s2 -> {
 
                             checkpoint.flag();
@@ -568,8 +573,9 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase2.future().setHandler(ctx.succeeding(v -> {
 
-            getCredentialsManagementService().set(tenantId, deviceId, Optional.of(UUID.randomUUID().toString()),
-                    Collections.singletonList(secret), NoopSpan.INSTANCE,
+            getCredentialsManagementService().updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
+                    Optional.of(UUID.randomUUID().toString()),
+                    NoopSpan.INSTANCE,
                     ctx.succeeding( s -> ctx.verify(() -> {
 
                         assertEquals(HttpURLConnection.HTTP_PRECON_FAILED, s.getStatus());
@@ -624,8 +630,9 @@ public abstract class AbstractCredentialsServiceTest {
 
             assertGetEmpty(ctx, tenantId, deviceId, authId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, () -> {
 
-                getCredentialsManagementService().set(tenantId, deviceId, Optional.empty(),
-                        Collections.singletonList(secret), NoopSpan.INSTANCE,
+                getCredentialsManagementService().updateCredentials(tenantId, deviceId,
+                        Collections.singletonList(secret), Optional.empty(),
+                        NoopSpan.INSTANCE,
                         ctx.succeeding(s2 -> {
 
                             checkpoint.flag();
@@ -706,7 +713,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase1.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), credentials, NoopSpan.INSTANCE,
+                    .updateCredentials(tenantId, deviceId, credentials, Optional.empty(), NoopSpan.INSTANCE,
                             ctx.succeeding(s -> phase2.complete()));
         }));
 
@@ -778,7 +785,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase1.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), credentials, NoopSpan.INSTANCE,
+                    .updateCredentials(tenantId, deviceId, credentials, Optional.empty(), NoopSpan.INSTANCE,
                             ctx.succeeding(s -> phase2.complete()));
         }));
 
@@ -837,7 +844,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase1.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), credentials, NoopSpan.INSTANCE,
+                    .updateCredentials(tenantId, deviceId, credentials, Optional.empty(), NoopSpan.INSTANCE,
                             ctx.succeeding(s -> phase2.complete()));
         }));
 
@@ -851,7 +858,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase2.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), Collections.singletonList(newCredential),
+                    .updateCredentials(tenantId, deviceId, Collections.singletonList(newCredential), Optional.empty(),
                             NoopSpan.INSTANCE,
                             ctx.succeeding( s -> ctx.verify(() -> {
 
@@ -895,7 +902,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase1.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), credentials, NoopSpan.INSTANCE,
+                    .updateCredentials(tenantId, deviceId, credentials, Optional.empty(), NoopSpan.INSTANCE,
                             ctx.succeeding(s -> phase2.complete()));
         }));
 
@@ -904,7 +911,7 @@ public abstract class AbstractCredentialsServiceTest {
         final Promise<?> phase3 = Promise.promise();
 
         phase2.future().setHandler(ctx.succeeding(n -> {
-            getCredentialsManagementService().get(tenantId, deviceId,
+            getCredentialsManagementService().readCredentials(tenantId, deviceId,
                     NoopSpan.INSTANCE, ctx.succeeding(s -> ctx.verify(() -> {
 
                         assertEquals(HttpURLConnection.HTTP_OK, s.getStatus());
@@ -963,7 +970,8 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase1.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), Collections.singletonList(credential), NoopSpan.INSTANCE,
+                    .updateCredentials(tenantId, deviceId, Collections.singletonList(credential), Optional.empty(),
+                            NoopSpan.INSTANCE,
                             ctx.succeeding(s -> phase2.complete()));
         }));
 
@@ -1009,7 +1017,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase3.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), Collections.singletonList(credentialWithOnlyId),
+                    .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithOnlyId), Optional.empty(),
                             NoopSpan.INSTANCE, ctx.succeeding(s -> phase4.complete()));
         }));
 
@@ -1072,7 +1080,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase1.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), credentials, NoopSpan.INSTANCE,
+                    .updateCredentials(tenantId, deviceId, credentials, Optional.empty(), NoopSpan.INSTANCE,
                             ctx.succeeding(s -> phase2.complete()));
         }));
 
@@ -1111,7 +1119,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase3.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), Collections.singletonList(newCredential),
+                    .updateCredentials(tenantId, deviceId, Collections.singletonList(newCredential), Optional.empty(),
                             NoopSpan.INSTANCE, ctx.succeeding(s -> phase4.complete()));
         }));
 
@@ -1174,7 +1182,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase1.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), credentials, NoopSpan.INSTANCE,
+                    .updateCredentials(tenantId, deviceId, credentials, Optional.empty(), NoopSpan.INSTANCE,
                             ctx.succeeding(s -> phase2.complete()));
         }));
 
@@ -1221,7 +1229,8 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase3.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), Collections.singletonList(credentialWithMetadataUpdate),
+                    .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithMetadataUpdate),
+                            Optional.empty(),
                             NoopSpan.INSTANCE, ctx.succeeding(s -> phase4.complete()));
         }));
 
@@ -1290,7 +1299,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase1.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), credentials, NoopSpan.INSTANCE,
+                    .updateCredentials(tenantId, deviceId, credentials, Optional.empty(), NoopSpan.INSTANCE,
                             ctx.succeeding(s -> phase2.complete()));
         }));
 
@@ -1339,7 +1348,8 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase3.future().setHandler(ctx.succeeding(n -> {
             getCredentialsManagementService()
-                    .set(tenantId, deviceId, Optional.empty(), Collections.singletonList(credentialWithMetadataUpdate),
+                    .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithMetadataUpdate),
+                            Optional.empty(),
                             NoopSpan.INSTANCE, ctx.succeeding(s -> phase4.complete()));
         }));
 
@@ -1397,7 +1407,7 @@ public abstract class AbstractCredentialsServiceTest {
             final List<CommonCredential> secrets) {
 
         final Promise<OperationResult<Void>> result = Promise.promise();
-        svc.set(tenantId, deviceId, Optional.empty(), secrets, NoopSpan.INSTANCE, result);
+        svc.updateCredentials(tenantId, deviceId, secrets, Optional.empty(), NoopSpan.INSTANCE, result);
         return result.future().map(r -> {
             if (HttpURLConnection.HTTP_NO_CONTENT == r.getStatus()) {
                 return r;

--- a/service-base/src/test/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackendTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackendTest.java
@@ -90,7 +90,7 @@ public class AutoProvisioningEnabledDeviceBackendTest {
             final Promise<OperationResult<Void>> promise = invocation.getArgument(5);
             promise.complete(OperationResult.empty(204));
             return null;
-        }).when(underTest).set(any(), any(), any(), any(), any(), any(Handler.class));
+        }).when(underTest).updateCredentials(any(), any(), any(), any(), any(), any(Handler.class));
 
         // WHEN provisioning a device from a certificate
         final Future<OperationResult<String>> result = underTest.provisionDevice(TENANT_ID, cert, NoopSpan.INSTANCE);
@@ -99,7 +99,7 @@ public class AutoProvisioningEnabledDeviceBackendTest {
         result.setHandler(ctx.succeeding(ok -> {
             ctx.verify(() -> {
                 verify(underTest).createDevice(eq(TENANT_ID), any(), any(), any(), any());
-                verify(underTest).set(eq(TENANT_ID), eq(DEVICE_ID), any(), any(), any(), any());
+                verify(underTest).updateCredentials(eq(TENANT_ID), eq(DEVICE_ID), any(), any(), any(), any());
             });
             ctx.completeNow();
         }));
@@ -135,7 +135,7 @@ public class AutoProvisioningEnabledDeviceBackendTest {
             final Promise<OperationResult<Void>> promise = invocation.getArgument(5);
             promise.complete(OperationResult.empty(403)); // creation of credentials fails
             return null;
-        }).when(underTest).set(any(), any(), any(), any(), any(), any(Handler.class));
+        }).when(underTest).updateCredentials(any(), any(), any(), any(), any(), any(Handler.class));
 
         // WHEN provisioning a device from a certificate
         final Future<OperationResult<String>> result = underTest.provisionDevice(TENANT_ID, cert, NoopSpan.INSTANCE);

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsService.java
@@ -461,8 +461,10 @@ public final class FileBasedCredentialsService extends AbstractVerticle
     }
 
     @Override
-    public void set(final String tenantId, final String deviceId, final Optional<String> resourceVersion,
-                    final List<CommonCredential> secrets, final Span span, final Handler<AsyncResult<OperationResult<Void>>> resultHandler) {
+    public void updateCredentials(final String tenantId, final String deviceId, final List<CommonCredential> secrets,
+            final Optional<String> resourceVersion,
+            final Span span,
+            final Handler<AsyncResult<OperationResult<Void>>> resultHandler) {
 
         resultHandler.handle(Future.succeededFuture(set(tenantId, deviceId, resourceVersion, span, secrets)));
 
@@ -681,7 +683,7 @@ public final class FileBasedCredentialsService extends AbstractVerticle
     }
 
     @Override
-    public void get(final String tenantId, final String deviceId, final Span span,
+    public void readCredentials(final String tenantId, final String deviceId, final Span span,
             final Handler<AsyncResult<OperationResult<List<CommonCredential>>>> resultHandler) {
 
         Objects.requireNonNull(tenantId);

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedDeviceBackend.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedDeviceBackend.java
@@ -148,11 +148,11 @@ public class FileBasedDeviceBackend implements AutoProvisioningEnabledDeviceBack
 
                     // now create the empty credentials set
                     final Promise<OperationResult<Void>> f = Promise.promise();
-                    credentialsService.set(
+                    credentialsService.updateCredentials(
                             tenantId,
                             r.getPayload().getId(),
-                            Optional.empty(),
                             Collections.emptyList(),
+                            Optional.empty(),
                             span,
                             f);
 
@@ -258,18 +258,20 @@ public class FileBasedDeviceBackend implements AutoProvisioningEnabledDeviceBack
     }
 
     @Override
-    public void set(final String tenantId, final String deviceId, final Optional<String> resourceVersion,
-            final List<CommonCredential> credentials, final Span span, final Handler<AsyncResult<OperationResult<Void>>> resultHandler) {
+    public void updateCredentials(final String tenantId, final String deviceId,
+            final List<CommonCredential> credentials, final Optional<String> resourceVersion,
+            final Span span,
+            final Handler<AsyncResult<OperationResult<Void>>> resultHandler) {
         //TODO check if device exists
-        credentialsService.set(tenantId, deviceId, resourceVersion, credentials, span, resultHandler);
+        credentialsService.updateCredentials(tenantId, deviceId, credentials, resourceVersion, span, resultHandler);
     }
 
     @Override
-    public void get(final String tenantId, final String deviceId, final Span span,
+    public void readCredentials(final String tenantId, final String deviceId, final Span span,
             final Handler<AsyncResult<OperationResult<List<CommonCredential>>>> resultHandler) {
 
         final Promise<OperationResult<List<CommonCredential>>> f = Promise.promise();
-        credentialsService.get(tenantId, deviceId, span, f);
+        credentialsService.readCredentials(tenantId, deviceId, span, f);
         f.future()
         .compose(r -> {
             if (r.getStatus() == HttpURLConnection.HTTP_NOT_FOUND) {

--- a/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantBackend.java
+++ b/services/device-registry/src/main/java/org/eclipse/hono/deviceregistry/FileBasedTenantBackend.java
@@ -65,26 +65,26 @@ public final class FileBasedTenantBackend extends AbstractVerticle implements Te
     // Tenant management API
 
     @Override
-    public void add(final Optional<String> tenantId, final JsonObject tenantObj,
+    public void createTenant(final Optional<String> tenantId, final Tenant tenantObj,
             final Span span, final Handler<AsyncResult<OperationResult<Id>>> resultHandler) {
-        tenantService.add(tenantId, tenantObj, span, resultHandler);
+        tenantService.createTenant(tenantId, tenantObj, span, resultHandler);
     }
 
     @Override
-    public void read(final String tenantId, final Span span, final Handler<AsyncResult<OperationResult<Tenant>>> resultHandler) {
-        tenantService.read(tenantId, span, resultHandler);
+    public void readTenant(final String tenantId, final Span span, final Handler<AsyncResult<OperationResult<Tenant>>> resultHandler) {
+        tenantService.readTenant(tenantId, span, resultHandler);
     }
 
     @Override
-    public void update(final String tenantId, final JsonObject tenantObj, final Optional<String> resourceVersion,
+    public void updateTenant(final String tenantId, final Tenant tenantObj, final Optional<String> resourceVersion,
             final Span span, final Handler<AsyncResult<OperationResult<Void>>> resultHandler) {
-        tenantService.update(tenantId, tenantObj, resourceVersion, span, resultHandler);
+        tenantService.updateTenant(tenantId, tenantObj, resourceVersion, span, resultHandler);
     }
 
     @Override
-    public void remove(final String tenantId, final Optional<String> resourceVersion, final Span span,
+    public void deleteTenant(final String tenantId, final Optional<String> resourceVersion, final Span span,
             final Handler<AsyncResult<Result<Void>>> resultHandler) {
-        tenantService.remove(tenantId, resourceVersion, span, resultHandler);
+        tenantService.deleteTenant(tenantId, resourceVersion, span, resultHandler);
     }
 
     // Tenant AMQP API

--- a/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsServiceTest.java
+++ b/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedCredentialsServiceTest.java
@@ -324,7 +324,7 @@ public class FileBasedCredentialsServiceTest extends AbstractCredentialsServiceT
                         CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD))
                 .compose(s -> {
                     final Promise<OperationResult<List<CommonCredential>>> result = Promise.promise();
-                    getCredentialsManagementService().get(Constants.DEFAULT_TENANT, "4711", NoopSpan.INSTANCE, result);
+                    getCredentialsManagementService().readCredentials(Constants.DEFAULT_TENANT, "4711", NoopSpan.INSTANCE, result);
                     return result.future().map(r -> {
                         if (r.getStatus() == HttpURLConnection.HTTP_OK) {
                             return null;
@@ -491,9 +491,9 @@ public class FileBasedCredentialsServiceTest extends AbstractCredentialsServiceT
                     final Promise<OperationResult<Void>> result = Promise.promise();
                     // WHEN trying to update the credentials
                     final PasswordCredential newSecret = createPasswordCredential("myId", "baz", OptionalInt.empty());
-                    svc.set("tenant", "device",
-                            Optional.empty(),
+                    svc.updateCredentials("tenant", "device",
                             Collections.singletonList(newSecret),
+                            Optional.empty(),
                             NoopSpan.INSTANCE,
                             result);
                     return result.future();

--- a/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedTenantServiceTest.java
+++ b/services/device-registry/src/test/java/org/eclipse/hono/deviceregistry/FileBasedTenantServiceTest.java
@@ -330,10 +330,10 @@ public class FileBasedTenantServiceTest extends AbstractTenantServiceTest {
         // that has been configured to not allow modification of entries
         props.setModificationEnabled(false);
 
-        // WHEN trying to add a new tenant
-        svc.add(
+        // WHEN trying to create a new tenant
+        svc.createTenant(
                 Optional.of("fancy-new-tenant"),
-                new JsonObject(),
+                new Tenant(),
                 NoopSpan.INSTANCE,
                 ctx.succeeding(s -> {
                     ctx.verify(() -> {
@@ -357,7 +357,7 @@ public class FileBasedTenantServiceTest extends AbstractTenantServiceTest {
         props.setModificationEnabled(false);
 
         // WHEN trying to update the tenant
-        svc.remove(
+        svc.deleteTenant(
                 "tenant",
                 Optional.empty(),
                 NoopSpan.INSTANCE,
@@ -383,9 +383,9 @@ public class FileBasedTenantServiceTest extends AbstractTenantServiceTest {
         props.setModificationEnabled(false);
 
         // WHEN trying to update the tenant
-        svc.update(
+        svc.updateTenant(
                 "tenant",
-                new JsonObject(),
+                new Tenant(),
                 null,
                 NoopSpan.INSTANCE,
                 ctx.succeeding(s -> {


### PR DESCRIPTION
Improve the consistency in method names and parameters order across the 3 components of the management API.

The parameters order is always following the same pattern, obviously when applicable : `tenantId, deviceId, PayloadDetails, ResourceVersion, Span, resultHandler`

Signed-off-by: Jean-Baptiste Trystram <jbtrystram@redhat.com>