### PR TITLE
[#1781] Fix use of command response topic with device but no tenant

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -836,8 +836,8 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                         } else {
                             onMessageUndeliverable(context);
                         }
+                        TracingHelper.logError(span, processing.cause());
                         if (context.deviceEndpoint().isConnected()) {
-                            TracingHelper.logError(span, processing.cause());
                             span.log("closing connection to device");
                             context.deviceEndpoint().close();
                         }

--- a/client/src/main/java/org/eclipse/hono/client/CommandResponse.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandResponse.java
@@ -68,6 +68,7 @@ public final class CommandResponse {
      * @param status The HTTP status code indicating the outcome of the command.
      * @return The response or {@code null} if the request ID could not be parsed, the status is {@code null} or if the
      *         status code is &lt; 200 or &gt;= 600.
+     * @throws NullPointerException if tenantId or deviceId is {@code null}.
      */
     public static CommandResponse from(
             final String requestId,
@@ -76,6 +77,9 @@ public final class CommandResponse {
             final Buffer payload,
             final String contentType,
             final Integer status) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
 
         if (requestId == null) {
             LOG.debug("cannot create CommandResponse: request id is null");

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -703,6 +703,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                 final ResourceIdentifier resource = ResourceIdentifier.from(address,
                         authenticatedDevice.getTenantId(), authenticatedDevice.getDeviceId());
                 result.complete(resource);
+            } else if (Strings.isNullOrEmpty(address.getTenantId())) {
+                // use authenticated device's tenant ID
+                final ResourceIdentifier resource = ResourceIdentifier.from(address,
+                        authenticatedDevice.getTenantId(), address.getResourceId());
+                result.complete(resource);
             } else {
                 result.complete(address);
             }

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -494,6 +494,26 @@ public class AbstractProtocolAdapterBaseTest {
 
     /**
      * Verifies that the adapter uses an authenticated device's identity when validating an
+     * address without a tenant ID and device ID.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testValidateAddressUsesDeviceIdentityForAddressWithoutTenantAndDevice(final VertxTestContext ctx) {
+
+        // WHEN an authenticated device publishes a message to an address that does not contain a tenant ID
+        final Device authenticatedDevice = new Device("my-tenant", "4711");
+        final ResourceIdentifier address = ResourceIdentifier.fromString(TelemetryConstants.TELEMETRY_ENDPOINT);
+        adapter.validateAddress(address, authenticatedDevice).setHandler(ctx.succeeding(r -> ctx.verify(() -> {
+            // THEN the validated address contains the authenticated device's tenant and device ID
+            assertEquals("my-tenant", r.getTenantId());
+            assertEquals("4711", r.getResourceId());
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the adapter uses an authenticated device's identity when validating an
      * address without a tenant ID.
      *
      * @param ctx The vert.x test context.
@@ -503,11 +523,11 @@ public class AbstractProtocolAdapterBaseTest {
 
         // WHEN an authenticated device publishes a message to an address that does not contain a tenant ID
         final Device authenticatedDevice = new Device("my-tenant", "4711");
-        final ResourceIdentifier address = ResourceIdentifier.fromString(TelemetryConstants.TELEMETRY_ENDPOINT);
+        final ResourceIdentifier address = ResourceIdentifier.from(TelemetryConstants.TELEMETRY_ENDPOINT, "", "4712");
         adapter.validateAddress(address, authenticatedDevice).setHandler(ctx.succeeding(r -> ctx.verify(() -> {
             // THEN the validated address contains the authenticated device's tenant and device ID
             assertEquals("my-tenant", r.getTenantId());
-            assertEquals("4711", r.getResourceId());
+            assertEquals("4712", r.getResourceId());
             ctx.completeNow();
         })));
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -237,7 +237,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
                     200)
                     .map(response -> {
                         ctx.verify(() -> {
-                            assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_DEVICE_ID, String.class)).isEqualTo(deviceId);
+                            assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_DEVICE_ID, String.class)).isEqualTo(commandTargetDeviceId);
                             assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_TENANT_ID, String.class)).isEqualTo(tenantId);
                         });
                         return response;

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttCommandEndpointConfiguration.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttCommandEndpointConfiguration.java
@@ -84,9 +84,10 @@ public class MqttCommandEndpointConfiguration extends CommandEndpointConfigurati
      * @return The topic name.
      */
     public final String getResponseTopic(final String deviceId, final String requestId, final int status) {
-        return String.format(
-                "%s///res/%s/%d",
-                getSouthboundEndpoint(), requestId, status);
+        if (isSubscribeAsGateway()) {
+            return String.format("%s//%s/res/%s/%d", getSouthboundEndpoint(), deviceId, requestId, status);
+        }
+        return String.format("%s///res/%s/%d", getSouthboundEndpoint(), requestId, status);
     }
 
     void assertCommandPublishTopicStructure(


### PR DESCRIPTION
This fixes #1781.
Fix use of command response MQTT topic with device but no tenant (`command//${device-id}/res/${req-id}/${status}`). Such a topic is to be used by authenticated gateways.
Also fixes integration tests - that topic wasn't used there.