### PR TITLE
[#1785] Fix gateway id getting set in reply-to address

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -372,7 +372,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                             200)
                             .map(response -> {
                                 ctx.verify(() -> {
-                                    assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_DEVICE_ID, String.class)).isEqualTo(deviceId);
+                                    assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_DEVICE_ID, String.class)).isEqualTo(commandTargetDeviceId);
                                     assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_TENANT_ID, String.class)).isEqualTo(tenantId);
                                 });
                                 return response;


### PR DESCRIPTION
This fixes #1785.
The target device id instead of the gateway id has to be set in the reply-to address of a command message. Otherwise command response messages will get the wrong `device_id` property value.
AMQP integration tests now check for the correct property value.