### PR TITLE
Fix wrong command response URI getting used in tests

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpCommandEndpointConfiguration.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpCommandEndpointConfiguration.java
@@ -32,7 +32,10 @@ public final class HttpCommandEndpointConfiguration extends CommandEndpointConfi
         super(subscriberRole);
     }
 
-    String getCommandResponseUri(final String reqId) {
+    String getCommandResponseUri(final String tenantId, final String deviceId, final String reqId) {
+        if (isSubscribeAsGateway()) {
+            return String.format("/%s/res/%s/%s/%s", getSouthboundEndpoint(), tenantId, deviceId, reqId);
+        }
         return String.format("/%s/res/%s", getSouthboundEndpoint(), reqId);
     }
 }


### PR DESCRIPTION
The wrong command response URI was getting used in HTTP adapter integration tests involving a gateway.
This caused a wrong `device_id` property value to get set on the command response message.