### PR TITLE
Provide abstract base classes for implementing device registries

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/MoreFutures.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/MoreFutures.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * Helper class to work with futures.
+ */
+public final class MoreFutures {
+
+    private static final Logger log = LoggerFactory.getLogger(MoreFutures.class);
+
+    private MoreFutures() {}
+
+    /**
+     * Complete the provided handler with the provided future supplier.
+     * <p>
+     * The method will call the supplier for a {@link CompletableFuture}. If that calls
+     * fails, then the handler will be completed directly. Otherwise the future will
+     * be chained to complete the provided handler.
+     *
+     * @param <T> The type of the result.
+     * @param supplier The supplier of a {@link CompletableFuture}.
+     * @param handler The handler to complete.
+     */
+    public static <T> void completeHandler(final Supplier<CompletableFuture<T>> supplier, final Handler<AsyncResult<T>> handler) {
+        if (supplier == null) {
+            handler.handle(Future.failedFuture(new NullPointerException("'future' to handle must not be 'null'")));
+        }
+
+        final CompletableFuture<T> future;
+        try {
+            future = supplier.get();
+        } catch (final Exception e) {
+            log.info("Failed to prepare future", e);
+            handler.handle(Future.failedFuture(e));
+            return;
+        }
+
+        future.whenComplete((result, error) -> {
+            log.debug("Result - {}", result, error);
+            if (error == null) {
+                handler.handle(Future.succeededFuture(result));
+            } else {
+                if (error instanceof CompletionException) {
+                    error = error.getCause();
+                }
+                log.info("Future failed", error);
+                handler.handle(Future.failedFuture(error));
+            }
+        });
+    }
+
+    /**
+     * Return a future which tracks the completion of all provided futures.
+     * <p>
+     * This is a convenience method for calling {@link CompletableFuture#allOf(CompletableFuture...)}
+     * with a list instead of an array.
+     *
+     * @param futures The futures to track.
+     * @return The new future, tracking all provided futures.
+     */
+    public static CompletableFuture<Void> allOf(final List<CompletableFuture<?>> futures) {
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+    }
+
+    /**
+     * Map a vertx future to a Java future.
+     *
+     * @param <T> The result type.
+     * @param future The vertx future to map, must not be {@code null}.
+     * @return A {@link CompletableFuture} future, being completed by the provided vertx future.
+     */
+    public static <T> CompletableFuture<T> map(final Future<T> future) {
+
+        Objects.requireNonNull(future);
+
+        final CompletableFuture<T> result = new CompletableFuture<>();
+
+        future.setHandler(ar -> {
+            if (ar.succeeded()) {
+                result.complete(ar.result());
+            } else {
+                result.completeExceptionally(ar.cause());
+            }
+        });
+
+        return result;
+    }
+
+    /**
+     * Use a {@link CompletableFuture} as a {@link Handler} for vertx.
+     *
+     * @param <T> The result type.
+     * @param future The future to complete with the handler.
+     * @return a handler which will complete the future.
+     */
+    public static <T> Handler<AsyncResult<T>> handler(final CompletableFuture<T> future) {
+        return result -> {
+            if (result.succeeded()) {
+                future.complete(result.result());
+            } else {
+                log.info("Operation failed", result.cause());
+                future.completeExceptionally(result.cause());
+            }
+        };
+    }
+}

--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -1,0 +1,150 @@
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-services</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-service-device-registry-base</artifactId>
+  <name>Hono Base Device Registry Classes</name>
+  <description>Base classes to implement a Hono device registry.</description>
+  <url>https://www.eclipse.org/hono</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-service-base</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>build-docker-image</id>
+      <activation>
+        <property>
+          <name>docker.host</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <build>
+                    <from>${java-base-image.name}</from>
+                    <labels>
+                      <implemented.api.1>Tenant</implemented.api.1>
+                      <implemented.api.2>Device Registration</implemented.api.2>
+                      <implemented.api.3>Credentials</implemented.api.3>
+                    </labels>
+                    <ports>
+                      <port>5671</port>
+                      <port>5672</port>
+                      <port>8080</port>
+                      <port>8443</port>
+                      <port>${vertx.health.port}</port>
+                    </ports>
+                    <cmd>
+                      <exec>
+                        <arg>java</arg>
+                        <arg>--illegal-access=permit</arg>
+                        <arg>-Dvertx.cacheDirBase=/tmp</arg>
+                        <arg>-Dloader.home=/opt/hono</arg>
+                        <arg>-Dloader.path=extensions</arg>
+                        <arg>-cp</arg>
+                        <arg>/opt/hono/${project.artifactId}-${project.version}-${classifier.spring.boot.artifact}.jar</arg>
+                        <arg>org.springframework.boot.loader.PropertiesLauncher</arg>
+                      </exec>
+                    </cmd>
+                    <assembly>
+                      <mode>dir</mode>
+                      <basedir>/</basedir>
+                      <inline>
+                        <fileSets>
+                          <fileSet>
+                            <directory>${project.build.directory}</directory>
+                            <outputDirectory>opt/hono</outputDirectory>
+                            <includes>
+                              <include>${project.artifactId}-${project.version}-${classifier.spring.boot.artifact}.jar</include>
+                            </includes>
+                          </fileSet>
+                        </fileSets>
+                      </inline>
+                    </assembly>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>jaeger</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.jaegertracing</groupId>
+          <artifactId>jaeger-client</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>docker-push-image</id>
+      <build>
+          <plugins>
+              <plugin>
+                  <groupId>io.fabric8</groupId>
+                  <artifactId>docker-maven-plugin</artifactId>
+                  <executions>
+                      <execution>
+                          <id>docker-push-image</id>
+                          <phase>install</phase>
+                          <goals>
+                              <goal>push</goal>
+                          </goals>
+                      </execution>
+                  </executions>
+              </plugin>
+          </plugins>
+      </build>
+  </profile>
+  </profiles>
+
+</project>

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredCredentialsAdapter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredCredentialsAdapter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.autowire;
+
+import org.eclipse.hono.service.credentials.CredentialsService;
+import org.eclipse.hono.service.credentials.EventBusCredentialsAdapter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * A default event bus based service implementation of the {@link CredentialsService}.
+ * <p>
+ * This wires up the actual service instance with the mapping to the event bus implementation. It is intended to be used
+ * in a Spring Boot environment.
+ */
+@Component
+public final class AutowiredCredentialsAdapter extends EventBusCredentialsAdapter {
+
+    private CredentialsService service;
+
+    @Autowired
+    public void setService(final CredentialsService service) {
+        this.service = service;
+    }
+
+    @Override
+    protected CredentialsService getService() {
+        return this.service;
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredCredentialsManagementAdapter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredCredentialsManagementAdapter.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.autowire;
+
+import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
+import org.eclipse.hono.service.management.credentials.EventBusCredentialsManagementAdapter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * A default event bus based service implementation of the {@link CredentialsManagementService}.
+ * <p>
+ * This wires up the actual service instance with the mapping to the event bus implementation. It is intended to be used
+ * in a Spring Boot environment.
+ */
+@Component
+@ConditionalOnBean(CredentialsManagementService.class)
+public final class AutowiredCredentialsManagementAdapter extends EventBusCredentialsManagementAdapter {
+
+    private CredentialsManagementService service;
+
+    @Autowired
+    public void setService(final CredentialsManagementService service) {
+        this.service = service;
+    }
+
+    @Override
+    protected CredentialsManagementService getService() {
+        return this.service;
+    }
+
+}
+

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredDeviceConnectionAdapter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredDeviceConnectionAdapter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.autowire;
+
+import org.eclipse.hono.service.deviceconnection.DeviceConnectionService;
+import org.eclipse.hono.service.deviceconnection.EventBusDeviceConnectionAdapter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * A default event bus based service implementation of the {@link DeviceConnectionService}.
+ * <p>
+ * This wires up the actual service instance with the mapping to the event bus implementation. It is intended to be used
+ * in a Spring Boot environment.
+ */
+@Component
+public final class AutowiredDeviceConnectionAdapter extends EventBusDeviceConnectionAdapter {
+
+    private DeviceConnectionService service;
+
+    @Autowired
+    public void setService(final DeviceConnectionService service) {
+        this.service = service;
+    }
+
+    @Override
+    protected DeviceConnectionService getService() {
+        return this.service;
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredDeviceManagementAdapter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredDeviceManagementAdapter.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.autowire;
+
+import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.service.management.device.EventBusDeviceManagementAdapter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * A default event bus based service implementation of the {@link DeviceManagementService}.
+ * <p>
+ * This wires up the actual service instance with the mapping to the event bus implementation. It is intended to be used
+ * in a Spring Boot environment.
+ */
+@Component
+@ConditionalOnBean(DeviceManagementService.class)
+public final class AutowiredDeviceManagementAdapter extends EventBusDeviceManagementAdapter {
+
+    private DeviceManagementService service;
+
+    @Autowired
+    public void setService(final DeviceManagementService service) {
+        this.service = service;
+    }
+
+    @Override
+    protected DeviceManagementService getService() {
+        return this.service;
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredRegistrationAdapter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredRegistrationAdapter.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.autowire;
+
+import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.service.registration.EventBusRegistrationAdapter;
+import org.eclipse.hono.service.registration.RegistrationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * A default event bus based service implementation of the {@link DeviceManagementService}.
+ * <p>
+ * This wires up the actual service instance with the mapping to the event bus implementation. It is intended to be used
+ * in a Spring Boot environment.
+ */
+@Component
+public final class AutowiredRegistrationAdapter extends EventBusRegistrationAdapter {
+
+    private RegistrationService service;
+
+    @Autowired
+    public void setService(final RegistrationService service) {
+        this.service = service;
+    }
+
+    @Override
+    protected RegistrationService getService() {
+        return this.service;
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredTenantAdapter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredTenantAdapter.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.autowire;
+
+import org.eclipse.hono.service.management.tenant.TenantManagementService;
+import org.eclipse.hono.service.tenant.EventBusTenantAdapter;
+import org.eclipse.hono.service.tenant.TenantService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * A default event bus based service implementation of the {@link TenantManagementService}.
+ * <p>
+ * This wires up the actual service instance with the mapping to the event bus implementation. It is intended to be used
+ * in a Spring Boot environment.
+ */
+@Component
+@ConditionalOnBean(TenantService.class)
+public final class AutowiredTenantAdapter extends EventBusTenantAdapter {
+
+    private TenantService service;
+
+    @Autowired
+    public void setService(final TenantService service) {
+        this.service = service;
+    }
+
+    @Override
+    protected TenantService getService() {
+        return this.service;
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredTenantManagementAdapter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/autowire/AutowiredTenantManagementAdapter.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.autowire;
+
+import org.eclipse.hono.service.management.tenant.EventBusTenantManagementAdapter;
+import org.eclipse.hono.service.management.tenant.TenantManagementService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * A default event bus based service implementation of the {@link TenantManagementService}.
+ * <p>
+ * This wires up the actual service instance with the mapping to the event bus implementation. It is intended to be used
+ * in a Spring Boot environment.
+ */
+@Component
+@ConditionalOnBean(TenantManagementService.class)
+public final class AutowiredTenantManagementAdapter extends EventBusTenantManagementAdapter {
+
+    private TenantManagementService service;
+
+    @Autowired
+    public void setService(final TenantManagementService service) {
+        this.service = service;
+    }
+
+    @Override
+    protected TenantManagementService getService() {
+        return this.service;
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/devcon/AbstractDeviceConnectionService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/devcon/AbstractDeviceConnectionService.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.devcon;
+
+import static org.eclipse.hono.service.MoreFutures.completeHandler;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.hono.service.deviceconnection.DeviceConnectionService;
+import org.eclipse.hono.util.DeviceConnectionResult;
+
+import io.opentracing.Span;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+public abstract class AbstractDeviceConnectionService implements DeviceConnectionService {
+
+    protected abstract CompletableFuture<DeviceConnectionResult> processSetLastKnownGatewayForDevice(final DeviceConnectionKey key, final String gatewayId, final Span span);
+
+    protected abstract CompletableFuture<DeviceConnectionResult> processGetLastKnownGatewayForDevice(final DeviceConnectionKey key, final Span span);
+
+    @Override
+    public void getLastKnownGatewayForDevice(final String tenantId, final String deviceId, final Span span, final Handler<AsyncResult<DeviceConnectionResult>> resultHandler) {
+        final var key = DeviceConnectionKey.deviceConnectionKey(tenantId, deviceId);
+        completeHandler(() -> processGetLastKnownGatewayForDevice(key, span), resultHandler);
+    }
+
+    @Override
+    public void setLastKnownGatewayForDevice(final String tenantId, final String deviceId, final String gatewayId, final Span span,
+            final Handler<AsyncResult<DeviceConnectionResult>> resultHandler) {
+        final var key = DeviceConnectionKey.deviceConnectionKey(tenantId, deviceId);
+        completeHandler(() -> processSetLastKnownGatewayForDevice(key, gatewayId, span), resultHandler);
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/devcon/DeviceConnectionKey.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/devcon/DeviceConnectionKey.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.devcon;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+public final class DeviceConnectionKey {
+
+    private final String tenantId;
+    private final String deviceId;
+
+    private DeviceConnectionKey(final String tenantId, final String deviceId) {
+        this.tenantId = tenantId;
+        this.deviceId = deviceId;
+    }
+
+    public String getTenantId() {
+        return this.tenantId;
+    }
+
+    public String getDeviceId() {
+        return this.deviceId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.deviceId,
+                this.tenantId);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        DeviceConnectionKey other = (DeviceConnectionKey) obj;
+        return Objects.equals(this.deviceId, other.deviceId) &&
+                Objects.equals(this.tenantId, other.tenantId);
+    }
+
+    protected ToStringHelper toStringHelper() {
+        return MoreObjects.toStringHelper(this)
+                .add("tenantId", this.tenantId)
+                .add("deviceId", this.deviceId);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper().toString();
+    }
+
+    public static DeviceConnectionKey deviceConnectionKey(final String tenantId, final String deviceId) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        return new DeviceConnectionKey(tenantId, deviceId);
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/AbstractCredentialsManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/AbstractCredentialsManagementService.java
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.device;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static org.eclipse.hono.deviceregistry.base.device.DeviceKey.deviceKey;
+import static org.eclipse.hono.service.MoreFutures.completeHandler;
+
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PreDestroy;
+
+import org.eclipse.hono.auth.HonoPasswordEncoder;
+import org.eclipse.hono.deviceregistry.base.tenant.TenantInformationService;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
+import org.eclipse.hono.service.management.credentials.PasswordCredential;
+import org.eclipse.hono.service.management.credentials.PasswordSecret;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import io.opentracing.Span;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+public abstract class AbstractCredentialsManagementService implements CredentialsManagementService {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractCredentialsManagementService.class);
+
+    private static final ThreadFactory THREAD_FACTORY = new ThreadFactoryBuilder().setNameFormat("pwd-hash-thread-%d").build();
+
+    private static final int DEFAULT_MAX_CAPACITY = 16 * 1024;
+
+    private static final int DEFAULT_MAX_THREADS = Runtime.getRuntime().availableProcessors();
+
+    private HonoPasswordEncoder passwordEncoder;
+
+    @Autowired
+    protected TenantInformationService tenantInformationService;
+
+    private final ExecutorService encoderThreadPool;
+
+    public AbstractCredentialsManagementService(final HonoPasswordEncoder passwordEncoder) {
+        this(passwordEncoder, DEFAULT_MAX_THREADS);
+    }
+
+    AbstractCredentialsManagementService(final HonoPasswordEncoder passwordEncoder, int hashThreadPoolSize) {
+        log.info("Password encoder thread pool size: {}", hashThreadPoolSize);
+        this.encoderThreadPool = new ThreadPoolExecutor(
+                hashThreadPoolSize, hashThreadPoolSize,
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>(DEFAULT_MAX_CAPACITY),
+                THREAD_FACTORY);
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PreDestroy
+    public void close() {
+        this.encoderThreadPool.shutdown();
+    }
+
+    public void setTenantInformationService(final TenantInformationService tenantInformationService) {
+        this.tenantInformationService = tenantInformationService;
+    }
+
+    @Override
+    public void updateCredentials(final String tenantId, final String deviceId, final List<CommonCredential> credentials, final Optional<String> resourceVersion, final Span span,
+            final Handler<AsyncResult<OperationResult<Void>>> resultHandler) {
+        completeHandler(() -> processUpdateCredentials(tenantId, deviceId, resourceVersion, credentials, span), resultHandler);
+    }
+
+    protected CompletableFuture<OperationResult<Void>> processUpdateCredentials(final String tenantId, final String deviceId, final Optional<String> resourceVersion,
+            final List<CommonCredential> credentials, final Span span) {
+
+        return verifyAndEncodePasswords(credentials)
+                .thenCompose(encodedCredentials -> {
+                    return this.tenantInformationService
+                            .tenantExists(tenantId, HTTP_NOT_FOUND, span)
+                            .thenCompose(tenantHandle -> processSet(deviceKey(tenantHandle, deviceId), resourceVersion, encodedCredentials, span));
+                })
+                .exceptionally(e -> {
+                    log.info("Failed to set credentials", e);
+                    if (Throwables.getRootCause(e) instanceof IllegalStateException) {
+                        // An illegal state exception is actually a bad request
+                        return OperationResult.empty(HttpURLConnection.HTTP_BAD_REQUEST);
+                    } else if (e instanceof RuntimeException) {
+                        // don't pollute the cause chain
+                        throw (RuntimeException) e;
+                    } else {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+    }
+
+    protected abstract CompletableFuture<OperationResult<Void>> processSet(DeviceKey key, Optional<String> resourceVersion, List<CommonCredential> credentials,
+            Span span);
+
+    @Override
+    public void readCredentials(final String tenantId, final String deviceId, final Span span, final Handler<AsyncResult<OperationResult<List<CommonCredential>>>> resultHandler) {
+        completeHandler(() -> processReadCredentials(tenantId, deviceId, span), resultHandler);
+    }
+
+    protected CompletableFuture<OperationResult<List<CommonCredential>>> processReadCredentials(final String tenantId, final String deviceId, final Span span) {
+
+        return this.tenantInformationService
+                .tenantExists(tenantId, HTTP_NOT_FOUND, span)
+                .thenCompose(tenantHandle -> processGet(deviceKey(tenantHandle, deviceId), span));
+
+    }
+
+    protected abstract CompletableFuture<OperationResult<List<CommonCredential>>> processGet(DeviceKey key, Span span);
+
+    private CompletableFuture<List<CommonCredential>> verifyAndEncodePasswords(final List<CommonCredential> credentials) {
+
+        // Check if we need to encode passwords
+
+        if (!needToEncode(credentials)) {
+            // ... no, so don't fork off a worker task, but inline work
+            try {
+                return CompletableFuture.completedFuture(checkCredentials(credentials));
+            } catch (Exception e) {
+                return CompletableFuture.failedFuture(e);
+            }
+        }
+
+        // ... fork off encoding on worker pool
+        return CompletableFuture.supplyAsync(() -> {
+            return checkCredentials(checkCredentials(credentials));
+        }, this.encoderThreadPool);
+    }
+
+    /**
+     * Check if we need to encode any secrets.
+     *
+     * @param credentials The credentials to check.
+     * @return {@code true} is the list contains at least one password which needs to be encoded on the
+     *         server side.
+     */
+    private static boolean needToEncode(final List<CommonCredential> credentials) {
+        return credentials
+                .stream()
+                .filter(PasswordCredential.class::isInstance)
+                .map(PasswordCredential.class::cast)
+                .flatMap(c -> c.getSecrets().stream())
+                .anyMatch(s -> s.getPasswordPlain() != null && !s.getPasswordPlain().isEmpty());
+    }
+
+    protected List<CommonCredential> checkCredentials(final List<CommonCredential> credentials) {
+        for (final CommonCredential credential : credentials) {
+            checkCredential(credential);
+        }
+        return credentials;
+    }
+
+    /**
+     * Validate a secret and hash the password if necessary.
+     *
+     * @param credential The secret to validate.
+     * @throws IllegalStateException if the secret is not valid.
+     */
+    private void checkCredential(final CommonCredential credential) {
+        credential.checkValidity();
+        if (credential instanceof PasswordCredential) {
+            for (final PasswordSecret passwordSecret : ((PasswordCredential) credential).getSecrets()) {
+                passwordSecret.encode(this.passwordEncoder);
+                passwordSecret.checkValidity();
+            }
+        }
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/AbstractCredentialsService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/AbstractCredentialsService.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.device;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static org.eclipse.hono.deviceregistry.base.device.CredentialKey.credentialKey;
+import static org.eclipse.hono.service.MoreFutures.completeHandler;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.hono.deviceregistry.base.tenant.TenantInformation;
+import org.eclipse.hono.deviceregistry.base.tenant.TenantInformationService;
+import org.eclipse.hono.service.credentials.CredentialsService;
+import org.eclipse.hono.util.CredentialsResult;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.opentracing.Span;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+
+public abstract class AbstractCredentialsService implements CredentialsService {
+
+    @Autowired
+    protected TenantInformationService tenantInformationService;
+
+    public void setTenantInformationService(TenantInformationService tenantInformationService) {
+        this.tenantInformationService = tenantInformationService;
+    }
+
+    @Override
+    public void get(final String tenantId, final String type, final String authId, final Span span, final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
+        completeHandler(() -> processGet(tenantId, type, authId, span), resultHandler);
+    }
+
+    @Override
+    public void get(String tenantId, String type, String authId, JsonObject clientContext, Span span, Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
+        get(tenantId, type, authId, span, resultHandler);
+    }
+
+    protected CompletableFuture<CredentialsResult<JsonObject>> processGet(final String tenantId, final String type, final String authId, final Span span) {
+
+        return this.tenantInformationService
+                .tenantExists(tenantId, HTTP_NOT_FOUND, span)
+                .thenCompose(tenantHandle -> processGet(tenantHandle, credentialKey(tenantHandle, authId, type), span));
+
+    }
+
+    protected abstract CompletableFuture<CredentialsResult<JsonObject>> processGet(TenantInformation tenant, CredentialKey key, Span span);
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/AbstractDeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/AbstractDeviceManagementService.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.device;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static org.eclipse.hono.deviceregistry.base.device.DeviceKey.deviceKey;
+import static org.eclipse.hono.service.MoreFutures.completeHandler;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import org.eclipse.hono.deviceregistry.base.tenant.TenantInformationService;
+import org.eclipse.hono.service.management.Id;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.Result;
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.opentracing.Span;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+public abstract class AbstractDeviceManagementService implements DeviceManagementService {
+
+    private final Supplier<String> deviceIdGenerator = () -> UUID.randomUUID().toString();
+
+    @Autowired
+    protected TenantInformationService tenantInformationService;
+
+    public void setTenantInformationService(final TenantInformationService tenantInformationService) {
+        this.tenantInformationService = tenantInformationService;
+    }
+
+    protected abstract CompletableFuture<OperationResult<Id>> processCreateDevice(DeviceKey key, Device device, Span span);
+
+    protected abstract CompletableFuture<OperationResult<Device>> processReadDevice(DeviceKey key, Span span);
+
+    protected abstract CompletableFuture<OperationResult<Id>> processUpdateDevice(DeviceKey key, Device device, Optional<String> resourceVersion, Span span);
+
+    protected abstract CompletableFuture<Result<Void>> processDeleteDevice(DeviceKey key, Optional<String> resourceVersion, Span span);
+
+    @Override
+    public void createDevice(String tenantId, Optional<String> deviceId, Device device, Span span, Handler<AsyncResult<OperationResult<Id>>> resultHandler) {
+        completeHandler(() -> processCreateDevice(tenantId, deviceId, device, span), resultHandler);
+    }
+
+    protected CompletableFuture<OperationResult<Id>> processCreateDevice(final String tenantId, final Optional<String> optionalDeviceId, final Device device, final Span span) {
+
+        final String deviceId = optionalDeviceId.orElseGet(this.deviceIdGenerator);
+
+        return this.tenantInformationService
+                .tenantExists(tenantId, HTTP_NOT_FOUND, span)
+                .thenCompose(tenantHandle -> processCreateDevice(deviceKey(tenantHandle, deviceId), device, span));
+
+    }
+
+    @Override
+    public void readDevice(final String tenantId, final String deviceId, final Span span, final Handler<AsyncResult<OperationResult<Device>>> resultHandler) {
+        completeHandler(() -> processReadDevice(tenantId, deviceId, span), resultHandler);
+    }
+
+    protected CompletableFuture<OperationResult<Device>> processReadDevice(String tenantId, String deviceId, Span span) {
+
+        return this.tenantInformationService
+                .tenantExists(tenantId, HTTP_NOT_FOUND, span)
+                .thenCompose(tenantHandle -> processReadDevice(deviceKey(tenantHandle, deviceId), span));
+
+    }
+
+    @Override
+    public void updateDevice(String tenantId, String deviceId, Device device, Optional<String> resourceVersion, Span span,
+            Handler<AsyncResult<OperationResult<Id>>> resultHandler) {
+        completeHandler(() -> processUpdateDevice(tenantId, deviceId, device, resourceVersion, span), resultHandler);
+    }
+
+    protected CompletableFuture<OperationResult<Id>> processUpdateDevice(String tenantId, String deviceId, Device device, Optional<String> resourceVersion, Span span) {
+
+        return this.tenantInformationService
+                .tenantExists(tenantId, HTTP_NOT_FOUND, span)
+                .thenCompose(tenantHandle -> processUpdateDevice(deviceKey(tenantHandle, deviceId), device, resourceVersion, span));
+
+    }
+
+    @Override
+    public void deleteDevice(String tenantId, String deviceId, Optional<String> resourceVersion, Span span, Handler<AsyncResult<Result<Void>>> resultHandler) {
+        completeHandler(() -> processDeleteDevice(tenantId, deviceId, resourceVersion, span), resultHandler);
+    }
+
+    protected CompletableFuture<Result<Void>> processDeleteDevice(String tenantId, String deviceId, Optional<String> resourceVersion, Span span) {
+
+        return this.tenantInformationService
+                .tenantExists(tenantId, HTTP_NOT_FOUND, span)
+                .thenCompose(tenantHandle -> processDeleteDevice(deviceKey(tenantHandle, deviceId), resourceVersion, span));
+
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/AbstractRegistrationService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/AbstractRegistrationService.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.device;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static org.eclipse.hono.deviceregistry.base.device.DeviceKey.deviceKey;
+import static org.eclipse.hono.service.MoreFutures.completeHandler;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.hono.deviceregistry.base.tenant.TenantInformationService;
+import org.eclipse.hono.util.RegistrationResult;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.opentracing.Span;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+public abstract class AbstractRegistrationService extends org.eclipse.hono.service.registration.AbstractRegistrationService {
+
+    @Autowired
+    protected TenantInformationService tenantInformationService;
+
+    public void setTenantInformationService(final TenantInformationService tenantInformationService) {
+        this.tenantInformationService = tenantInformationService;
+    }
+
+    @Override
+    protected void getDevice(final String tenantId, final String deviceId, final Span span, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+        completeHandler(() -> processGetDevice(tenantId, deviceId, span), resultHandler);
+    }
+
+    protected CompletableFuture<RegistrationResult> processGetDevice(final String tenantName, final String deviceId, final Span span) {
+
+        return this.tenantInformationService
+                .tenantExists(tenantName, HTTP_NOT_FOUND, span)
+                .thenCompose(tenantId -> processGetDevice(deviceKey(tenantId, deviceId), span));
+
+    }
+
+    protected abstract CompletableFuture<RegistrationResult> processGetDevice(DeviceKey key, Span span);
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/CredentialKey.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/CredentialKey.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.device;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.eclipse.hono.deviceregistry.base.tenant.TenantHandle;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+/**
+ * A custom class to be used as key in the back-end key-value storage.
+ * This uses the unique values of a credential to create a unique key to store the credentials
+ * details.
+ */
+public final class CredentialKey implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String tenantId;
+    private final String authId;
+    private final String type;
+
+    /**
+     * Creates a new CredentialsKey. Used by CacheCredentialsService.
+     *
+     * @param tenantId the id of the tenant owning the registration key.
+     * @param authId the auth-id used in the credential.
+     * @param type the the type of the credential.
+     */
+    private CredentialKey(final String tenantId, final String authId, final String type) {
+        this.tenantId = tenantId;
+        this.authId = authId;
+        this.type = type;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CredentialKey that = (CredentialKey) o;
+        return Objects.equals(this.tenantId, that.tenantId) &&
+                Objects.equals(this.authId, that.authId) &&
+                Objects.equals(this.type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tenantId, authId, type);
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public String getAuthId() {
+        return authId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    protected ToStringHelper toStringHelper() {
+        return MoreObjects.toStringHelper(this)
+                .add("tenantId", this.tenantId)
+                .add("authId", this.authId)
+                .add("type", this.type);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper().toString();
+    }
+
+    public static CredentialKey credentialKey(final String tenantId, final String authId, final String type) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(authId);
+        Objects.requireNonNull(type);
+        return new CredentialKey(tenantId, authId, type);
+    }
+
+    public static CredentialKey credentialKey(final TenantHandle tenantHandle, final String authId, final String type) {
+        Objects.requireNonNull(tenantHandle);
+        Objects.requireNonNull(authId);
+        Objects.requireNonNull(type);
+        return new CredentialKey(tenantHandle.getId(), authId, type);
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/DeviceKey.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/device/DeviceKey.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.device;
+
+import java.util.Objects;
+
+import org.eclipse.hono.deviceregistry.base.tenant.TenantHandle;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+/**
+ * A custom class to be used as key in the backend key-value storage.
+ * This uses the unique values of a registration to create a unique key to store the registration
+ * details.
+ */
+public final class DeviceKey {
+
+    private final String tenantId;
+    private final String deviceId;
+
+    /**
+     * Creates a new RegistrationKey. Used by CacheRegistrationService.
+     *
+     * @param tenantId the id of the tenant owning the registration key.
+     * @param deviceId the id of the device being registered.
+     */
+    private DeviceKey(final String tenantId, final String deviceId) {
+        this.tenantId = tenantId;
+        this.deviceId = deviceId;
+    }
+
+    public String getTenantId() {
+        return this.tenantId;
+    }
+
+    public String getDeviceId() {
+        return this.deviceId;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DeviceKey that = (DeviceKey) o;
+        return Objects.equals(tenantId, that.tenantId) &&
+                Objects.equals(deviceId, that.deviceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.tenantId,
+                this.deviceId);
+    }
+
+    private ToStringHelper toStringHelper() {
+        return MoreObjects.toStringHelper(this)
+                .add("tenantId", this.tenantId)
+                .add("deviceId", this.deviceId);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper().toString();
+    }
+
+    public static DeviceKey deviceKey(final TenantHandle tenantHandle, final String deviceId) {
+        Objects.requireNonNull(tenantHandle);
+        Objects.requireNonNull(deviceId);
+
+        return new DeviceKey(tenantHandle.getId(), deviceId);
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/health/AbstractSyncHealthCheck.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/health/AbstractSyncHealthCheck.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.health;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.eclipse.hono.service.HealthCheckProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
+
+public abstract class AbstractSyncHealthCheck implements HealthCheckProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractSyncHealthCheck.class);
+
+    private final Vertx vertx;
+    private final String name;
+
+    public AbstractSyncHealthCheck(final Vertx vertx, final String name) {
+        this.vertx = vertx;
+        this.name = name;
+    }
+
+    protected String getName() {
+        return this.name;
+    }
+
+    /**
+     * Convert a reason and exception to KO status.
+     *
+     * @param reason The reason. Must not be {@code null}.
+     * @param e The exception. May be {@code null}.
+     * @return The status. Never is {@code null}.
+     */
+    protected static Status KO(final String reason, final Throwable e) {
+
+        final JsonObject info = new JsonObject()
+                .put("reason", reason);
+
+        if (e != null) {
+            info.put("message", e.getMessage());
+            final StringWriter sw = new StringWriter();
+            try (final PrintWriter pw = new PrintWriter(sw)) {
+                e.printStackTrace(pw);
+            }
+            info.put("exception", sw.toString());
+        }
+
+        log.debug("Check KO: {}", info);
+
+        return Status.KO(info);
+
+    }
+
+    protected Status checkReadinessSync() {
+        return Status.OK();
+    }
+
+    protected Status checkLivenessSync() {
+        return Status.OK();
+    }
+
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
+        readinessHandler.register(getName(), future -> {
+            this.vertx.executeBlocking(future2 -> {
+
+                try {
+                    future2.complete(checkReadinessSync());
+                } catch (Exception e) {
+                    future2.fail(e);
+                }
+
+            }, false, future);
+        });
+    }
+
+    @Override
+    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
+        livenessHandler.register(getName(), future -> {
+            this.vertx.executeBlocking(future2 -> {
+
+                try {
+                    future2.complete(checkLivenessSync());
+                } catch (Exception e) {
+                    future2.fail(e);
+                }
+
+            }, false, future);
+        });
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/server/DeviceRegistryAmqpServer.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/server/DeviceRegistryAmqpServer.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.server;
+
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.service.amqp.AmqpServiceBase;
+import org.eclipse.hono.util.Constants;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class DeviceRegistryAmqpServer extends AmqpServiceBase<ServiceConfigProperties> {
+
+    @Override
+    protected String getServiceName() {
+        return Constants.SERVICE_NAME_DEVICE_REGISTRY;
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/server/DeviceRegistryRestServer.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/server/DeviceRegistryRestServer.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.server;
+
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.service.http.HttpServiceBase;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeviceRegistryRestServer extends HttpServiceBase<ServiceConfigProperties> {
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/tenant/TenantHandle.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/tenant/TenantHandle.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.tenant;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+public class TenantHandle {
+
+    private final String name;
+    private final String id;
+
+    protected TenantHandle(final String name, final String id) {
+        this.name = name;
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    protected ToStringHelper toStringHelper() {
+        return MoreObjects.toStringHelper(this)
+                .add("name", this.name)
+                .add("id", this.id);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper().toString();
+    }
+
+    public static TenantHandle of(final String name, final String id) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(id);
+        return new TenantHandle(name, id);
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/tenant/TenantInformation.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/tenant/TenantInformation.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.tenant;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.service.management.tenant.Tenant;
+
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+public class TenantInformation extends TenantHandle {
+
+    private final Optional<Tenant> tenant;
+
+    private final String namespace;
+    private final String projectName;
+
+    protected TenantInformation(final String namespace, final String projectName, final String id, final Tenant tenant) {
+        super(namespace + "." + projectName, id);
+        this.namespace = namespace;
+        this.projectName = projectName;
+        this.tenant = Optional.ofNullable(tenant);
+    }
+
+    public Optional<Tenant> getTenant() {
+        return this.tenant;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    @Override
+    protected ToStringHelper toStringHelper() {
+        return super.toStringHelper()
+                .add("tenant", this.tenant);
+    }
+
+    public static TenantInformation of(final String namespace, final String projectName, final String id, final Tenant tenant) {
+        Objects.requireNonNull(namespace);
+        Objects.requireNonNull(projectName);
+        Objects.requireNonNull(id);
+        return new TenantInformation(namespace, projectName, id, tenant);
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/tenant/TenantInformationService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/base/tenant/TenantInformationService.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.base.tenant;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.opentracing.Span;
+
+/**
+ * A service which provides tenant information to internal service implementations.
+ */
+public interface TenantInformationService {
+
+    public CompletableFuture<TenantInformation> tenantExists(String tenantName, int notFoundStatusCode, Span span);
+
+}

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -28,6 +28,7 @@
   <modules>
     <module>auth</module>
     <module>device-connection</module>
+    <module>device-registry-base</module>
     <module>device-registry</module>
   </modules>
 


### PR DESCRIPTION
This PR provides the abstract base classes for implementing a device registry, that we currently have in EnMasse. As discussed last week during the Eclipse IoT F2F with @kaniyan, we create a PR for this early, in order to discuss.

Current open topics are:

* The abstract classes use Java futures, instead of vertx futures. This was just a better fit in the context of Infinispan. However using handlers seemed much more error prone than using futures.
* It currently misses the actual JDBC or Infinispan implementation. So it might seem a bit strange, but it focuses on the refactorings.
* The `TenantInformationService` misses an implementation. We use Kubernetes underneath, however adding this implementation will introduce additional dependencies, also on EnMasse internal structures. My proposal would be to create a `TenantInformationService` based on the AMQP client of Hono.