### PR TITLE
[#1272] Add new Device Connection API methods

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClient.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,6 +14,7 @@
 
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.hono.client.DeviceConnectionClient;
@@ -103,7 +104,6 @@ public final class HotrodBasedDeviceConnectionClient implements DeviceConnection
      */
     @Override
     public Future<Void> setLastKnownGatewayForDevice(final String deviceId, final String gatewayId, final SpanContext context) {
-
         return cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, context);
     }
 
@@ -112,7 +112,30 @@ public final class HotrodBasedDeviceConnectionClient implements DeviceConnection
      */
     @Override
     public Future<JsonObject> getLastKnownGatewayForDevice(final String deviceId, final SpanContext context) {
-
         return cache.getLastKnownGatewayForDevice(tenantId, deviceId, context);
+    }
+
+    @Override
+    public Future<Void> setCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
+            final SpanContext context) {
+        // TODO use this:
+//        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, context);
+        return Future.failedFuture("not implemented yet");
+    }
+
+    @Override
+    public Future<Void> removeCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
+            final SpanContext context) {
+        // TODO use this:
+//        return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, context);
+        return Future.failedFuture("not implemented yet");
+    }
+
+    @Override
+    public Future<JsonObject> getCommandHandlingAdapterInstances(final String deviceId, final List<String> viaGateways,
+            final SpanContext context) {
+        // TODO use this:
+//        return cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), context);
+        return Future.failedFuture("not implemented yet");
     }
 }

--- a/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,6 +12,8 @@
  *******************************************************************************/
 
 package org.eclipse.hono.client;
+
+import java.util.List;
 
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
@@ -35,7 +37,7 @@ public interface DeviceConnectionClient extends RequestResponseClient {
      *
      * @param deviceId The device id.
      * @param gatewayId The gateway id (or the device id if the last message came from the device directly).
-     * @param context The currently active OpenTracing span or {@code null} if no span is currently active.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            An implementation should use this as the parent for any span it creates for tracing
      *            the execution of this operation.
      * @return A future indicating whether the operation succeeded or not.
@@ -50,7 +52,7 @@ public interface DeviceConnectionClient extends RequestResponseClient {
      * is returned.
      *
      * @param deviceId The device id.
-     * @param context The currently active OpenTracing span or {@code null} if no span is currently active.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            An implementation should use this as the parent for any span it creates for tracing
      *            the execution of this operation.
      * @return A future indicating the result of the operation.
@@ -64,4 +66,57 @@ public interface DeviceConnectionClient extends RequestResponseClient {
      * @throws NullPointerException if device id is {@code null}.
      */
     Future<JsonObject> getLastKnownGatewayForDevice(String deviceId, SpanContext context);
+
+    /**
+     * Sets the protocol adapter instance that handles commands for the given device.
+     *
+     * @param deviceId The device id.
+     * @param adapterInstanceId The protocol adapter instance id.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            An implementation should use this as the parent for any span it creates for tracing
+     *            the execution of this operation.
+     * @return A future indicating whether the operation succeeded or not.
+     * @throws NullPointerException if device id or adapter instance id is {@code null}.
+     */
+    Future<Void> setCommandHandlingAdapterInstance(String deviceId, String adapterInstanceId, SpanContext context);
+
+    /**
+     * Removes the mapping information that associates the given device with the given protocol adapter instance
+     * that handles commands for the given device. The mapping entry is only deleted if its value
+     * contains the given protocol adapter instance id.
+     *
+     * @param deviceId The device id.
+     * @param adapterInstanceId The protocol adapter instance id that the entry to be removed has to contain.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            An implementation should use this as the parent for any span it creates for tracing
+     *            the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the entry was successfully removed.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if device id or adapter instance id is {@code null}.
+     */
+    Future<Void> removeCommandHandlingAdapterInstance(String deviceId, String adapterInstanceId, SpanContext context);
+
+    /**
+     * Gets information about the adapter instances that can handle a command for the given device.
+     * <p>
+     * See Hono's <a href="https://www.eclipse.org/hono/docs/api/device-connection/">Device Connection API
+     * specification</a> for a detailed description of the method's behaviour and the returned JSON object.
+     * <p>
+     * If no adapter instances are found, the returned future is failed.
+     *
+     * @param deviceId The device id.
+     * @param viaGateways The list of gateways that may act on behalf of the given device.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            Implementing classes should use this as the parent for any span they create for tracing the execution
+     *            of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         If instances were found, the future will be succeeded with a JSON object containing one or more mappings
+     *         from device id to adapter instance id. Otherwise the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters except context is {@code null}.
+     */
+    Future<JsonObject> getCommandHandlingAdapterInstances(String deviceId, List<String> viaGateways, SpanContext context);
 }

--- a/core/src/main/java/org/eclipse/hono/util/DeviceConnectionConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/DeviceConnectionConstants.java
@@ -29,11 +29,27 @@ public final class DeviceConnectionConstants extends RequestResponseApiConstants
      * The name of the field that contains the identifier of a gateway.
      */
     public static final String FIELD_GATEWAY_ID = "gateway-id";
+
     /**
      * The name of the optional field in the result of the <em>get last known gateway for device</em> operation
      * that contains the date when the last known gateway id was last updated.
      */
     public static final String FIELD_LAST_UPDATED = "last-updated";
+
+    /**
+     * The name of the field that contains the list of objects with protocol adapter instance id and device id.
+     */
+    public static final String FIELD_ADAPTER_INSTANCES = "adapter-instances";
+
+    /**
+     * The name of the field that contains the identifier of the protocol adapter instance.
+     */
+    public static final String FIELD_ADAPTER_INSTANCE_ID = "adapter-instance-id";
+
+    /**
+     * The name of the field that contains the array of gateway ids.
+     */
+    public static final String FIELD_GATEWAY_IDS = "gateway-ids";
 
     /**
      * The name of the Device Connection API endpoint.
@@ -57,6 +73,18 @@ public final class DeviceConnectionConstants extends RequestResponseApiConstants
          * The <em>set last known gateway for device</em> operation.
          */
         SET_LAST_GATEWAY("set-last-gw"),
+        /**
+         * The <em>get command handling protocol adapter instances</em> operation.
+         */
+        GET_CMD_HANDLING_ADAPTER_INSTANCES("get-cmd-handling-adapter-instances"),
+        /**
+         * The <em>set command handling protocol adapter instance</em> operation.
+         */
+        SET_CMD_HANDLING_ADAPTER_INSTANCE("set-cmd-handling-adapter-instance"),
+        /**
+         * The <em>remove command handling protocol adapter instance</em> operation.
+         */
+        REMOVE_CMD_HANDLING_ADAPTER_INSTANCE("remove-cmd-handling-adapter-instance"),
         /**
          * The <em>unknown</em> operation.
          */

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -73,6 +73,10 @@ public final class MessageHelper {
      */
     public static final String APP_PROPERTY_GATEWAY_ID = "gateway_id";
     /**
+     * The name of the AMQP 1.0 message application property containing the id of a protocol adapter instance.
+     */
+    public static final String APP_PROPERTY_ADAPTER_INSTANCE_ID = "adapter_instance_id";
+    /**
      * The name of the AMQP 1.0 application property that is used to convey the address that a message has been
      * originally published to by a device.
      */

--- a/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DeviceConnectionService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DeviceConnectionService.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.service.deviceconnection;
 
+import java.util.List;
+
 import org.eclipse.hono.util.DeviceConnectionResult;
 
 import io.opentracing.Span;
@@ -70,4 +72,62 @@ public interface DeviceConnectionService {
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     Future<DeviceConnectionResult> getLastKnownGatewayForDevice(String tenantId, String deviceId, Span span);
+
+    /**
+     * Sets the protocol adapter instance that handles commands for the given device or gateway.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id.
+     * @param adapterInstanceId The protocol adapter instance id.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
+     *            implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         The <em>status</em> will be <em>204 No Content</em> if the operation completed successfully.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<DeviceConnectionResult> setCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId, Span span);
+
+    /**
+     * Removes the mapping information that associates the given device with the given protocol adapter instance
+     * that handles commands for the given device. The mapping entry is only deleted if its value
+     * contains the given protocol adapter instance id.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id.
+     * @param adapterInstanceId The protocol adapter instance id that the entry to be removed has to contain.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
+     *            implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         The <em>status</em> will be <em>204 No Content</em> if the entry was successfully removed.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<DeviceConnectionResult> removeCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId, Span span);
+
+    /**
+     * Gets information about the adapter instances that can handle a command for the given device.
+     * <p>
+     * See Hono's <a href="https://www.eclipse.org/hono/docs/api/device-connection/">Device Connection API
+     * specification</a> for a detailed description of the method's behaviour and the returned JSON object.
+     * <p>
+     * If no adapter instances are found, the result handler will be invoked with an error status.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id.
+     * @param viaGateways The list of gateways that may act on behalf of the given device.
+     * @param span The currently active OpenTracing span or {@code null} if no span is currently active.
+     *            Implementing classes should use this as the parent for any span they create for tracing
+     *            the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         The <em>status</em> will be
+     *         <ul>
+     *         <li><em>200 OK</em> if instances have been found. The
+     *         <em>payload</em> will consist of the JSON object containing one or more mappings from device id
+     *         to adapter instance id.</li>
+     *         <li><em>404 Not Found</em> if no instances were found.</li>
+     *         </ul>
+     * @throws NullPointerException if any of the parameters except context is {@code null}.
+     */
+    Future<DeviceConnectionResult> getCommandHandlingAdapterInstances(String tenantId, String deviceId, List<String> viaGateways, Span span);
 }

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
@@ -15,6 +15,7 @@
 package org.eclipse.hono.deviceconnection.infinispan;
 
 import java.net.HttpURLConnection;
+import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.hono.client.ServiceInvocationException;
@@ -73,6 +74,39 @@ public class RemoteCacheBasedDeviceConnectionService extends EventBusDeviceConne
         return cache.getLastKnownGatewayForDevice(tenantId, deviceId, span.context())
                 .map(json -> DeviceConnectionResult.from(HttpURLConnection.HTTP_OK, json))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
+    }
+
+    @Override
+    public Future<DeviceConnectionResult> setCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
+            final String adapterInstanceId, final Span span) {
+        // TODO use this:
+//        cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span.context())
+//                .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
+//                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)))
+//                .setHandler(resultHandler);
+        return Future.failedFuture("not implemented yet");
+    }
+
+    @Override
+    public Future<DeviceConnectionResult> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
+            final String adapterInstanceId, final Span span) {
+        // TODO use this:
+//        cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span.context())
+//                .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
+//                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)))
+//                .setHandler(resultHandler);
+        return Future.failedFuture("not implemented yet");
+    }
+
+    @Override
+    public Future<DeviceConnectionResult> getCommandHandlingAdapterInstances(final String tenantId, final String deviceId,
+            final List<String> viaGateways, final Span span) {
+        // TODO use this:
+//        cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), span.context())
+//                .map(json -> DeviceConnectionResult.from(HttpURLConnection.HTTP_OK, json))
+//                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)))
+//                .setHandler(resultHandler);
+        return Future.failedFuture("not implemented yet");
     }
 
     /**

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionService.java
@@ -17,7 +17,9 @@ import java.net.HttpURLConnection;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,6 +36,7 @@ import org.springframework.stereotype.Repository;
 import io.opentracing.Span;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -47,6 +50,9 @@ public final class MapBasedDeviceConnectionService extends AbstractVerticle impl
 
     // <tenantId, <deviceId, lastKnownGatewayJson>>
     private final Map<String, Map<String, JsonObject>> lastKnownGatewaysMap = new HashMap<>();
+
+    // <tenantId, <deviceId, adapterInstanceIdJson>>
+    private final Map<String, Map<String, JsonObject>> commandHandlingAdapterInstancesMap = new HashMap<>();
 
     private MapBasedDeviceConnectionsConfigProperties config;
 
@@ -105,6 +111,125 @@ public final class MapBasedDeviceConnectionService extends AbstractVerticle impl
         return Future.succeededFuture(result);
     }
 
+    @Override
+    public Future<DeviceConnectionResult> setCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
+            final String protocolAdapterInstanceId, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(protocolAdapterInstanceId);
+
+        final Map<String, JsonObject> adapterInstancesForTenantMap = commandHandlingAdapterInstancesMap.computeIfAbsent(tenantId,
+                k -> new ConcurrentHashMap<>());
+        final DeviceConnectionResult result;
+        final int currentMapSize = adapterInstancesForTenantMap.size();
+        if (currentMapSize < getConfig().getMaxDevicesPerTenant()
+                || (currentMapSize == getConfig().getMaxDevicesPerTenant() && adapterInstancesForTenantMap.containsKey(deviceId))) {
+            adapterInstancesForTenantMap.put(deviceId, createAdapterInstanceIdJson(protocolAdapterInstanceId));
+            result = DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT);
+        } else {
+            log.debug("cannot set protocol adapter instance for handling commands of device [{}], tenant [{}]: max number of entries per tenant reached ({})",
+                    deviceId, tenantId, getConfig().getMaxDevicesPerTenant());
+            result = DeviceConnectionResult.from(HttpURLConnection.HTTP_FORBIDDEN);
+        }
+        return Future.succeededFuture(result);
+    }
+
+    @Override
+    public Future<DeviceConnectionResult> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
+            final String adapterInstanceId, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(adapterInstanceId);
+
+        final Map<String, JsonObject> adapterInstancesForTenantMap = commandHandlingAdapterInstancesMap.computeIfAbsent(tenantId,
+                k -> new ConcurrentHashMap<>());
+
+        final JsonObject adapterInstanceIdJson = adapterInstancesForTenantMap.get(deviceId);
+        final Future<DeviceConnectionResult> resultFuture;
+        if (adapterInstanceIdJson != null) {
+            // remove entry only if existing value contains matching adapterInstanceId
+            final boolean removed = adapterInstanceId.equals(getAdapterInstanceIdFromJson(adapterInstanceIdJson))
+                    && adapterInstancesForTenantMap.remove(deviceId, adapterInstanceIdJson);
+            if (removed) {
+                resultFuture = Future.succeededFuture(DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT));
+            } else {
+                log.debug("cannot remove command handling adapter instance for device [{}], tenant [{}] - given value does not match current",
+                        deviceId, tenantId);
+                resultFuture = Future.succeededFuture(DeviceConnectionResult.from(HttpURLConnection.HTTP_PRECON_FAILED));
+            }
+        } else {
+            resultFuture = Future.succeededFuture(DeviceConnectionResult.from(HttpURLConnection.HTTP_NOT_FOUND));
+        }
+        return resultFuture;
+    }
+
+    @Override
+    public Future<DeviceConnectionResult> getCommandHandlingAdapterInstances(final String tenantId,
+            final String deviceId, final List<String> viaGateways, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        final Map<String, JsonObject> commandHandlersForTenantMap = commandHandlingAdapterInstancesMap.get(tenantId);
+        final DeviceConnectionResult result;
+        if (commandHandlersForTenantMap != null) {
+            // resultMap has device id as key and adapter instance id as value
+            final Map<String, String> resultMap = new HashMap<>();
+            final JsonObject deviceAdapterInstanceIdJson = commandHandlersForTenantMap.get(deviceId);
+            if (deviceAdapterInstanceIdJson != null) {
+                // found mapping for given device id
+                resultMap.put(deviceId, getAdapterInstanceIdFromJson(deviceAdapterInstanceIdJson));
+            } else if (!viaGateways.isEmpty()) {
+                // no mapping found for given device; check last known gateway of device
+                final Map<String, JsonObject> lastKnownGatewaysForTenantMap = lastKnownGatewaysMap.get(tenantId);
+                if (lastKnownGatewaysForTenantMap != null) {
+                    final JsonObject lastKnownGatewayJson = lastKnownGatewaysForTenantMap.get(deviceId);
+                    if (lastKnownGatewayJson != null) {
+                        final String gatewayId = getGatewayIdFromLastKnownGatewayJson(lastKnownGatewayJson);
+                        if (viaGateways.contains(gatewayId)) {
+                            // get command handler for found gateway device
+                            final JsonObject gwAdapterInstanceIdJson = commandHandlersForTenantMap.get(gatewayId);
+                            if (gwAdapterInstanceIdJson != null) {
+                                resultMap.put(gatewayId, getAdapterInstanceIdFromJson(gwAdapterInstanceIdJson));
+                            }
+                        } else {
+                            log.trace("ignoring found last known gateway [{}]; gateway is not in given via list", gatewayId);
+                        }
+                    }
+                }
+            }
+            if (resultMap.isEmpty() && !viaGateways.isEmpty()) {
+                log.trace("no command handling adapter instance found for given device or last known gateway; getting instances for all via gateways");
+                for (final String viaGateway : viaGateways) {
+                    final JsonObject gwAdapterInstanceIdJson = commandHandlersForTenantMap.get(viaGateway);
+                    if (gwAdapterInstanceIdJson != null) {
+                        resultMap.put(viaGateway, getAdapterInstanceIdFromJson(gwAdapterInstanceIdJson));
+                    }
+                }
+            }
+            if (!resultMap.isEmpty()) {
+                result = DeviceConnectionResult.from(HttpURLConnection.HTTP_OK, getResultJson(resultMap));
+            } else {
+                result = DeviceConnectionResult.from(HttpURLConnection.HTTP_NOT_FOUND);
+            }
+        } else {
+            result = DeviceConnectionResult.from(HttpURLConnection.HTTP_NOT_FOUND);
+        }
+        return Future.succeededFuture(result);
+    }
+
+    private JsonObject getResultJson(final Map<String, String> deviceToAdapterInstanceMap) {
+        final JsonObject jsonObject = new JsonObject();
+        final JsonArray adapterInstancesArray = new JsonArray(new ArrayList<>(deviceToAdapterInstanceMap.size()));
+        for (final Map.Entry<String, String> resultEntry : deviceToAdapterInstanceMap.entrySet()) {
+            final JsonObject entryJson = new JsonObject();
+            entryJson.put(DeviceConnectionConstants.FIELD_PAYLOAD_DEVICE_ID, resultEntry.getKey());
+            entryJson.put(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID, resultEntry.getValue());
+            adapterInstancesArray.add(entryJson);
+        }
+        jsonObject.put(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCES, adapterInstancesArray);
+        return jsonObject;
+    }
+
     private JsonObject createLastKnownGatewayJson(final String gatewayId) {
         final JsonObject lastKnownGatewayJson = new JsonObject();
         lastKnownGatewayJson.put(DeviceConnectionConstants.FIELD_GATEWAY_ID, gatewayId);
@@ -112,10 +237,25 @@ public final class MapBasedDeviceConnectionService extends AbstractVerticle impl
         return lastKnownGatewayJson;
     }
 
+    private String getGatewayIdFromLastKnownGatewayJson(final JsonObject lastKnownGatewayJson) {
+        return lastKnownGatewayJson.getString(DeviceConnectionConstants.FIELD_GATEWAY_ID);
+    }
+
     private JsonObject setLastUpdateDate(final JsonObject lastKnownGatewayJson) {
         lastKnownGatewayJson.put(DeviceConnectionConstants.FIELD_LAST_UPDATED,
                 ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT));
         return lastKnownGatewayJson;
+    }
+
+    private JsonObject createAdapterInstanceIdJson(final String adapterInstanceId) {
+        final JsonObject adapterInstanceIdJson = new JsonObject();
+        adapterInstanceIdJson.put(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID, adapterInstanceId);
+        setLastUpdateDate(adapterInstanceIdJson);
+        return adapterInstanceIdJson;
+    }
+
+    private String getAdapterInstanceIdFromJson(final JsonObject adapterInstanceIdJson) {
+        return adapterInstanceIdJson.getString(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID);
     }
 
 }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionServiceTest.java
@@ -13,11 +13,16 @@
 
 package org.eclipse.hono.deviceregistry.service.deviceconnection;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
@@ -29,9 +34,10 @@ import io.opentracing.Span;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-
 
 /**
  * Tests verifying behavior of {@link MapBasedDeviceConnectionService}.
@@ -63,8 +69,8 @@ public class MapBasedDeviceConnectionServiceTest {
     }
 
     /**
-     * Verifies that the last known gateway id can be set via the <em>setLastKnownGatewayForDevice</em> operation
-     * and retrieved via <em>getLastKnownGatewayForDevice</em>.
+     * Verifies that the last known gateway id can be set via the <em>setLastKnownGatewayForDevice</em> operation and
+     * retrieved via <em>getLastKnownGatewayForDevice</em>.
      *
      * @param ctx The vert.x context.
      */
@@ -88,8 +94,8 @@ public class MapBasedDeviceConnectionServiceTest {
     }
 
     /**
-     * Verifies that the <em>getLastKnownGatewayForDevice</em> operation fails if no such entry is associated
-     * with the given device.
+     * Verifies that the <em>getLastKnownGatewayForDevice</em> operation fails if no such entry is associated with the
+     * given device.
      *
      * @param ctx The vert.x context.
      */
@@ -105,8 +111,33 @@ public class MapBasedDeviceConnectionServiceTest {
     }
 
     /**
-     * Verifies that the <em>setLastKnownGatewayForDevice</em> operation fails if the maximum number of entries
-     * for the given tenant is reached.
+     * Verifies that the <em>getLastKnownGatewayForDevice</em> operation fails if no such entry is associated with the
+     * given device, while there is another last-known-gateway entry associated with a different device of the same
+     * tenant.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetLastKnownGatewayForOtherTenantDeviceNotFound(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String otherDeviceId = "otherTestDevice";
+        final String gatewayId = "testGateway";
+        svc.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, otherDeviceId, gatewayId, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.getLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>setLastKnownGatewayForDevice</em> operation fails if the maximum number of entries for the
+     * given tenant is reached.
      *
      * @param ctx The vert.x context.
      */
@@ -128,4 +159,565 @@ public class MapBasedDeviceConnectionServiceTest {
                     ctx.completeNow();
                 })));
     }
+
+    /**
+     * Verifies that the <em>setCommandHandlingAdapterInstance</em> operation succeeds.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testSetCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, span)
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_NO_CONTENT, result.getStatus());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>setCommandHandlingAdapterInstance</em> operation fails if the maximum number of entries for
+     * the given tenant is reached.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testSetCommandHandlingAdapterInstanceFailsIfLimitReached(final VertxTestContext ctx) {
+        props.setMaxDevicesPerTenant(1);
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    // set another entry
+                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, "testDevice2",
+                            adapterInstance, span);
+                }).setHandler(ctx.succeeding(deviceConnectionResult -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_FORBIDDEN, deviceConnectionResult.getStatus());
+                    assertNull(deviceConnectionResult.getPayload());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>removeCommandHandlingAdapterInstance</em> operation succeeds if there was an entry to be
+     * deleted.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_NO_CONTENT, result.getStatus());
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>removeCommandHandlingAdapterInstance</em> operation fails with a NOT_FOUND status if no
+     * entry was registered for the device. Only an adapter instance for another device of the tenant was registered.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceFailsForOtherDevice(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, "otherDevice",
+                            adapterInstance, span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>removeCommandHandlingAdapterInstance</em> operation fails with a PRECON_FAILED status if
+     * the given adapter instance parameter doesn't match the one of the entry registered for the given device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceFailsForOtherAdapterInstance(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId,
+                            "otherAdapterInstance", span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_PRECON_FAILED, result.getStatus());
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds if an adapter instance has been
+     * registered for the given device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesForDevice(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId,
+                            Collections.emptyList(), span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    assertNotNull(result.getPayload());
+                    assertGetInstancesResultMapping(result.getPayload(), deviceId, adapterInstance);
+                    assertGetInstancesResultSize(result.getPayload(), 1);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation fails for a device with no viaGateways,
+     * if no matching instance has been registered.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesFails(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final List<String> viaGateways = Collections.emptyList();
+        svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, span)
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds if an adapter instance has been
+     * registered for the last known gateway associated with the given device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesForLastKnownGateway(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final List<String> viaGateways = List.of(gatewayId, otherGatewayId);
+        // set command handling adapter instance for gateway
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    // set command handling adapter instance for other gateway
+                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId,
+                            otherAdapterInstance, span);
+                }).compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, span);
+                }).compose(deviceConnectionResult2 -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult2.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    assertNotNull(result.getPayload());
+                    assertGetInstancesResultMapping(result.getPayload(), gatewayId, adapterInstance);
+                    // be sure that only the mapping for the last-known-gateway is returned, not the mappings for both
+                    // via gateways
+                    assertGetInstancesResultSize(result.getPayload(), 1);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds if multiple adapter instances
+     * have been registered for gateways of the given device, but the last known gateway associated with the given
+     * device is not in the viaGateways list of the device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesWithMultiResultAndLastKnownGatewayNotInVia(
+            final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final String gatewayIdNotInVia = "gw-old";
+        final List<String> viaGateways = List.of(gatewayId, otherGatewayId);
+        // set command handling adapter instance for gateway
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    // set command handling adapter instance for other gateway
+                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId,
+                            otherAdapterInstance, span);
+                }).compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayIdNotInVia,
+                            span);
+                }).compose(deviceConnectionResult2 -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult2.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    assertNotNull(result.getPayload());
+                    assertGetInstancesResultMapping(result.getPayload(), gatewayId, adapterInstance);
+                    assertGetInstancesResultMapping(result.getPayload(), otherGatewayId, otherAdapterInstance);
+                    // last-known-gateway is not in via list, therefore no single result is returned
+                    assertGetInstancesResultSize(result.getPayload(), 2);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds if multiple adapter instances
+     * have been registered for gateways of the given device, but the last known gateway associated with the given
+     * device has no adapter associated with it.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesWithMultiResultAndNoAdapterForLastKnownGateway(
+            final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final String gatewayWithNoAdapterInstance = "gw-other";
+        final List<String> viaGateways = List.of(gatewayId, otherGatewayId, gatewayWithNoAdapterInstance);
+        // set command handling adapter instance for gateway
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    // set command handling adapter instance for other gateway
+                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId,
+                            otherAdapterInstance, span);
+                }).compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId,
+                            gatewayWithNoAdapterInstance, span);
+                }).compose(deviceConnectionResult2 -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult2.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    assertNotNull(result.getPayload());
+                    assertGetInstancesResultMapping(result.getPayload(), gatewayId, adapterInstance);
+                    assertGetInstancesResultMapping(result.getPayload(), otherGatewayId, otherAdapterInstance);
+                    // no adapter registered for last-known-gateway, therefore no single result is returned
+                    assertGetInstancesResultSize(result.getPayload(), 2);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation fails if an adapter instance has been
+     * registered for the last known gateway associated with the given device, but that gateway isn't in the given
+     * viaGateways set.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesForLastKnownGatewayNotInVia(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String gatewayId = "gw-1";
+        final List<String> viaGateways = Collections.singletonList("otherGatewayId");
+        // set command handling adapter instance for gateway
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, span);
+                }).compose(deviceConnectionResult2 -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult2.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds with a result containing just
+     * the mapping of *the given device* to its command handling adapter instance, even though an adapter instance is
+     * also registered for the last known gateway associated with the given device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesWithLastKnownGatewayIsGivingDevicePrecedence(
+            final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final List<String> viaGateways = List.of(gatewayId);
+        // set command handling adapter instance for device
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    // set command handling adapter instance for other gateway
+                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId,
+                            otherAdapterInstance, span);
+                }).compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, span);
+                }).compose(deviceConnectionResult2 -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult2.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    assertNotNull(result.getPayload());
+                    assertGetInstancesResultMapping(result.getPayload(), deviceId, adapterInstance);
+                    // be sure that only the mapping for the device is returned, not the mappings for the gateway
+                    assertGetInstancesResultSize(result.getPayload(), 1);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds with a result containing just
+     * the mapping of *the given device* to its command handling adapter instance, even though an adapter instance is
+     * also registered for the last known gateway associated with the given device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesWithoutLastKnownGatewayIsGivingDevicePrecedence(
+            final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final List<String> viaGateways = List.of(gatewayId);
+        // set command handling adapter instance for device
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    // set command handling adapter instance for other gateway
+                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId,
+                            otherAdapterInstance, span);
+                }).compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    assertNotNull(result.getPayload());
+                    assertGetInstancesResultMapping(result.getPayload(), deviceId, adapterInstance);
+                    // be sure that only the mapping for the device is returned, not the mappings for the gateway
+                    assertGetInstancesResultSize(result.getPayload(), 1);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds with a result containing the
+     * mapping of a gateway, even though there is no last known gateway set for the device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesForOneSubscribedVia(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final List<String> viaGateways = List.of(gatewayId, otherGatewayId);
+        // set command handling adapter instance for gateway
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    assertNotNull(result.getPayload());
+                    assertGetInstancesResultMapping(result.getPayload(), gatewayId, adapterInstance);
+                    assertGetInstancesResultSize(result.getPayload(), 1);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds with a result containing the
+     * mappings of gateways, even though there is no last known gateway set for the device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesForMultipleSubscribedVias(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final List<String> viaGateways = List.of(gatewayId, otherGatewayId);
+        // set command handling adapter instance for gateway
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    // set command handling adapter instance for other gateway
+                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId,
+                            otherAdapterInstance, span);
+                }).compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    assertNotNull(result.getPayload());
+                    assertGetInstancesResultMapping(result.getPayload(), gatewayId, adapterInstance);
+                    assertGetInstancesResultMapping(result.getPayload(), otherGatewayId, otherAdapterInstance);
+                    assertGetInstancesResultSize(result.getPayload(), 2);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation fails for a device with a non-empty set
+     * of given viaGateways, if no matching instance has been registered.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesFailsWithGivenGateways(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String gatewayId = "gw-1";
+        final List<String> viaGateways = List.of(gatewayId);
+        svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, span)
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation fails if no matching instance has been
+     * registered. An adapter instance has been registered for another device of the same tenant though.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesFailsForOtherTenantDevice(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final List<String> viaGateways = List.of(gatewayId);
+        // set command handling adapter instance for other gateway
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, adapterInstance, span)
+                .compose(deviceConnectionResult -> {
+                    ctx.verify(() -> {
+                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
+                    });
+                    return svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways,
+                            span);
+                }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Asserts the the given result JSON of the <em>getCommandHandlingAdapterInstances</em> method contains an
+     * "adapter-instances" entry with the given device id and adapter instance id.
+     */
+    private void assertGetInstancesResultMapping(final JsonObject resultJson, final String deviceId,
+            final String adapterInstanceId) {
+        assertNotNull(resultJson);
+        final JsonArray adapterInstancesJson = resultJson
+                .getJsonArray(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCES);
+        assertNotNull(adapterInstancesJson);
+        boolean entryFound = false;
+        for (int i = 0; i < adapterInstancesJson.size(); i++) {
+            final JsonObject entry = adapterInstancesJson.getJsonObject(i);
+            if (deviceId.equals(entry.getString(DeviceConnectionConstants.FIELD_PAYLOAD_DEVICE_ID))) {
+                entryFound = true;
+                assertEquals(adapterInstanceId, entry.getString(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID));
+            }
+        }
+        assertTrue(entryFound);
+    }
+
+    private void assertGetInstancesResultSize(final JsonObject resultJson, final int size) {
+        assertNotNull(resultJson);
+        final JsonArray adapterInstancesJson = resultJson
+                .getJsonArray(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCES);
+        assertNotNull(adapterInstancesJson);
+        assertEquals(size, adapterInstancesJson.size());
+    }
+
 }


### PR DESCRIPTION
This is the first step for #1272:
Three new methods have been added to the Device Connection API.

In order to keep this PR smaller, the implementation for the `HotrodBasedDeviceConnectionClient` will be added in a subsequent commit (see TODO comments in this PR).