### PR TITLE
[#1802] Refactor device management service to return future

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
@@ -14,8 +14,8 @@
 package org.eclipse.hono.service.management.device;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
+
 import java.util.Optional;
 
 import org.eclipse.hono.service.management.Id;
@@ -39,7 +39,7 @@ public interface DeviceManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation. The <em>status</em> will be
+     * @return A future indicating the outcome of the operation. The <em>status</em> will be
      *            <ul>
      *            <li><em>201 Created</em> if the device has been registered successfully.</li>
      *            <li><em>409 Conflict</em> if a device with the given identifier already exists for the tenant.</li>
@@ -48,8 +48,7 @@ public interface DeviceManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/createDeviceRegistration">
      *      Device Registry Management API - Create Device Registration</a>
      */
-    void createDevice(String tenantId, Optional<String> deviceId, Device device, Span span,
-            Handler<AsyncResult<OperationResult<Id>>> resultHandler);
+    Future<OperationResult<Id>> createDevice(String tenantId, Optional<String> deviceId, Device device, Span span);
 
     /**
      * Gets device registration data by device ID.
@@ -59,7 +58,7 @@ public interface DeviceManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation. The <em>status</em> will be
+     * @return A future indicating the outcome of the operation. The <em>status</em> will be
      *            <ul>
      *            <li><em>200 OK</em> if a device with the given ID is registered for the tenant. The <em>payload</em>
      *            will contain the properties registered for the device.</li>
@@ -69,8 +68,7 @@ public interface DeviceManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/getRegistration">
      *      Device Registry Management API - Get Device Registration</a>
      */
-    void readDevice(String tenantId, String deviceId, Span span,
-            Handler<AsyncResult<OperationResult<Device>>> resultHandler);
+    Future<OperationResult<Device>> readDevice(String tenantId, String deviceId, Span span);
 
     /**
      * Updates device registration data.
@@ -82,7 +80,7 @@ public interface DeviceManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation. The <em>status</em> will be
+     * @return A future indicating the outcome of the operation. The <em>status</em> will be
      *            <ul>
      *            <li><em>204 No Content</em> if the registration information has been updated successfully.</li>
      *            <li><em>404 Not Found</em> if no device with the given identifier is registered for the tenant.</li>
@@ -91,8 +89,8 @@ public interface DeviceManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/updateRegistration">
      *      Device Registry Management API - Update Device Registration</a>
      */
-    void updateDevice(String tenantId, String deviceId, Device device, Optional<String> resourceVersion, Span span,
-            Handler<AsyncResult<OperationResult<Id>>> resultHandler);
+    Future<OperationResult<Id>> updateDevice(String tenantId, String deviceId, Device device,
+            Optional<String> resourceVersion, Span span);
 
     /**
      * Removes a device.
@@ -103,8 +101,7 @@ public interface DeviceManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
-     *             The <em>status</em> will be
+     * @return  A future indicating the outcome of the operation. The <em>status</em> will be
      *             <ul>
      *             <li><em>204 No Content</em> if the device has been removed successfully.</li>
      *             <li><em>404 Not Found</em> if no device with the given identifier is
@@ -114,6 +111,5 @@ public interface DeviceManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/deleteRegistration">
      *      Device Registry Management API - Delete Device Registration</a>
      */
-    void deleteDevice(String tenantId, String deviceId, Optional<String> resourceVersion, Span span,
-            Handler<AsyncResult<Result<Void>>> resultHandler);
+    Future<Result<Void>> deleteDevice(String tenantId, String deviceId, Optional<String> resourceVersion, Span span);
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackendTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackendTest.java
@@ -80,11 +80,9 @@ public class AutoProvisioningEnabledDeviceBackendTest {
         final AutoProvisioningEnabledDeviceBackend underTest = mock(AutoProvisioningEnabledDeviceBackend.class);
         when(underTest.provisionDevice(anyString(), any(), any())).thenCallRealMethod();
 
-        doAnswer(invocation -> {
-            final Promise<OperationResult<Id>> promise = invocation.getArgument(4);
-            promise.complete(OperationResult.ok(201, Id.of(DEVICE_ID), Optional.empty(), Optional.empty()));
-            return null;
-        }).when(underTest).createDevice(any(), any(), any(), any(), any(Handler.class));
+        when(underTest.createDevice(any(), any(), any(), any()))
+                .thenReturn(Future.succeededFuture(
+                        OperationResult.ok(201, Id.of(DEVICE_ID), Optional.empty(), Optional.empty())));
 
         doAnswer(invocation -> {
             final Promise<OperationResult<Void>> promise = invocation.getArgument(5);
@@ -98,7 +96,7 @@ public class AutoProvisioningEnabledDeviceBackendTest {
         // THEN the device is created and credentials are set
         result.setHandler(ctx.succeeding(ok -> {
             ctx.verify(() -> {
-                verify(underTest).createDevice(eq(TENANT_ID), any(), any(), any(), any());
+                verify(underTest).createDevice(eq(TENANT_ID), any(), any(), any());
                 verify(underTest).updateCredentials(eq(TENANT_ID), eq(DEVICE_ID), any(), any(), any(), any());
             });
             ctx.completeNow();
@@ -119,17 +117,12 @@ public class AutoProvisioningEnabledDeviceBackendTest {
         final AutoProvisioningEnabledDeviceBackend underTest = mock(AutoProvisioningEnabledDeviceBackend.class);
         when(underTest.provisionDevice(anyString(), any(), any())).thenCallRealMethod();
 
-        doAnswer(invocation -> {
-            final Promise<OperationResult<Id>> promise = invocation.getArgument(4);
-            promise.complete(OperationResult.ok(201, Id.of(DEVICE_ID), Optional.empty(), Optional.empty()));
-            return null;
-        }).when(underTest).createDevice(any(), any(), any(), any(), any(Handler.class));
+        when(underTest.createDevice(any(), any(), any(), any()))
+                .thenReturn(Future.succeededFuture(
+                        OperationResult.ok(201, Id.of(DEVICE_ID), Optional.empty(), Optional.empty())));
 
-        doAnswer(invocation -> {
-            final Promise<Result<Void>> promise = invocation.getArgument(4);
-            promise.complete(Result.from(204));
-            return null;
-        }).when(underTest).deleteDevice(any(), any(), any(), any(), any(Handler.class));
+        when(underTest.deleteDevice(any(), any(), any(), any()))
+                .thenReturn(Future.succeededFuture(Result.from(204)));
 
         doAnswer(invocation -> {
             final Promise<OperationResult<Void>> promise = invocation.getArgument(5);
@@ -142,7 +135,7 @@ public class AutoProvisioningEnabledDeviceBackendTest {
 
         // THEN the device is deleted
         result.setHandler(ctx.succeeding(ok -> {
-            ctx.verify(() -> verify(underTest).deleteDevice(eq(TENANT_ID), eq(DEVICE_ID), any(), any(), any()));
+            ctx.verify(() -> verify(underTest).deleteDevice(eq(TENANT_ID), eq(DEVICE_ID), any(), any()));
             ctx.completeNow();
         }));
     }

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationService.java
@@ -339,7 +339,8 @@ public class FileBasedRegistrationService extends AbstractVerticle
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(resultHandler);
 
-        resultHandler.handle(Future.succeededFuture(convertResult(deviceId, readDevice(tenantId, deviceId, NoopSpan.INSTANCE))));
+        resultHandler.handle(Future
+                .succeededFuture(convertResult(deviceId, processReadDevice(tenantId, deviceId, NoopSpan.INSTANCE))));
     }
 
     private void resolveGroupMembers(final String tenantId, final JsonArray viaGroups,
@@ -378,17 +379,15 @@ public class FileBasedRegistrationService extends AbstractVerticle
     }
 
     @Override
-    public void readDevice(final String tenantId, final String deviceId, final Span span,
-            final Handler<AsyncResult<OperationResult<Device>>> resultHandler) {
+    public Future<OperationResult<Device>> readDevice(final String tenantId, final String deviceId, final Span span) {
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
-        Objects.requireNonNull(resultHandler);
 
-        resultHandler.handle(Future.succeededFuture(readDevice(tenantId, deviceId, span)));
+        return Future.succeededFuture(processReadDevice(tenantId, deviceId, span));
     }
 
-    OperationResult<Device> readDevice(final String tenantId, final String deviceId, final Span span) {
+    OperationResult<Device> processReadDevice(final String tenantId, final String deviceId, final Span span) {
         final Versioned<Device> device = getRegistrationData(tenantId, deviceId);
 
         if (device == null) {
@@ -415,18 +414,18 @@ public class FileBasedRegistrationService extends AbstractVerticle
     }
 
     @Override
-    public void deleteDevice(final String tenantId, final String deviceId, final Optional<String> resourceVersion,
-            final Span span, final Handler<AsyncResult<Result<Void>>> resultHandler) {
+    public Future<Result<Void>> deleteDevice(final String tenantId, final String deviceId,
+            final Optional<String> resourceVersion,
+            final Span span) {
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(resourceVersion);
-        Objects.requireNonNull(resultHandler);
 
-        resultHandler.handle(Future.succeededFuture(deleteDevice(tenantId, deviceId, resourceVersion, span)));
+        return Future.succeededFuture(processDeleteDevice(tenantId, deviceId, resourceVersion, span));
     }
 
-    Result<Void> deleteDevice(final String tenantId, final String deviceId,
+    Result<Void> processDeleteDevice(final String tenantId, final String deviceId,
             final Optional<String> resourceVersion, final Span span) {
 
         Objects.requireNonNull(tenantId);
@@ -460,14 +459,16 @@ public class FileBasedRegistrationService extends AbstractVerticle
     }
 
     @Override
-    public void createDevice(final String tenantId, final Optional<String> deviceId, final Device device,
-           final Span span, final Handler<AsyncResult<OperationResult<Id>>> resultHandler) {
+    public Future<OperationResult<Id>> createDevice(
+            final String tenantId, 
+            final Optional<String> deviceId,
+            final Device device,
+            final Span span) {
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
-        Objects.requireNonNull(resultHandler);
 
-        resultHandler.handle(Future.succeededFuture(createDevice(tenantId, deviceId, device, span)));
+        return Future.succeededFuture(processCreateDevice(tenantId, deviceId, device, span));
     }
 
     /**
@@ -479,7 +480,7 @@ public class FileBasedRegistrationService extends AbstractVerticle
      * @param span The tracing span to use.
      * @return The outcome of the operation indicating success or failure.
      */
-    public OperationResult<Id> createDevice(final String tenantId, final Optional<String> deviceId,
+    public OperationResult<Id> processCreateDevice(final String tenantId, final Optional<String> deviceId,
             final Device device, final Span span) {
 
         Objects.requireNonNull(tenantId);
@@ -504,19 +505,17 @@ public class FileBasedRegistrationService extends AbstractVerticle
     }
 
     @Override
-    public void updateDevice(final String tenantId, final String deviceId, final Device device,
-            final Optional<String> resourceVersion, final Span span,
-            final Handler<AsyncResult<OperationResult<Id>>> resultHandler) {
+    public Future<OperationResult<Id>> updateDevice(final String tenantId, final String deviceId, final Device device,
+            final Optional<String> resourceVersion, final Span span) {
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(resourceVersion);
-        Objects.requireNonNull(resultHandler);
 
-        resultHandler.handle(Future.succeededFuture(updateDevice(tenantId, deviceId, device, resourceVersion, span)));
+        return Future.succeededFuture(processUpdateDevice(tenantId, deviceId, device, resourceVersion, span));
     }
 
-    OperationResult<Id> updateDevice(final String tenantId, final String deviceId, final Device device,
+    OperationResult<Id> processUpdateDevice(final String tenantId, final String deviceId, final Device device,
             final Optional<String> resourceVersion, final Span span) {
 
         Objects.requireNonNull(tenantId);

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
@@ -402,13 +402,13 @@ public class FileBasedRegistrationServiceTest extends AbstractRegistrationServic
         registrationService.createDevice(TENANT, Optional.of(DEVICE), new Device(), NoopSpan.INSTANCE);
 
         // WHEN registering an additional device for the tenant
-        final OperationResult<Id> result = registrationService.createDevice(TENANT, Optional.of("newDevice"),
+        final OperationResult<Id> result = registrationService.processCreateDevice(TENANT, Optional.of("newDevice"),
                 new Device(), NoopSpan.INSTANCE);
 
         // THEN the result contains a FORBIDDEN status code and the device has not been added to the registry
         assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
         assertEquals(HttpURLConnection.HTTP_NOT_FOUND,
-                registrationService.readDevice(TENANT, "newDevice", NoopSpan.INSTANCE).getStatus());
+                registrationService.processReadDevice(TENANT, "newDevice", NoopSpan.INSTANCE).getStatus());
     }
 
     /**
@@ -425,12 +425,12 @@ public class FileBasedRegistrationServiceTest extends AbstractRegistrationServic
 
         // WHEN trying to update the device
         final OperationResult<Id> result = registrationService
-                .updateDevice(TENANT, DEVICE, new Device().putExtension("value", "2"), Optional.empty(),
+                .processUpdateDevice(TENANT, DEVICE, new Device().putExtension("value", "2"), Optional.empty(),
                         NoopSpan.INSTANCE);
 
         // THEN the result contains a FORBIDDEN status code and the device has not been updated
         assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
-        final var device = registrationService.readDevice(TENANT, DEVICE, NoopSpan.INSTANCE);
+        final var device = registrationService.processReadDevice(TENANT, DEVICE, NoopSpan.INSTANCE);
         assertNotNull(device);
         assertNotNull(device.getPayload());
         assertNotNull(device.getPayload().getExtensions());
@@ -449,13 +449,13 @@ public class FileBasedRegistrationServiceTest extends AbstractRegistrationServic
         registrationService.createDevice(TENANT, Optional.of(DEVICE), new Device(), NoopSpan.INSTANCE);
 
         // WHEN trying to remove the device
-        final Result<Void> result = registrationService.deleteDevice(TENANT, DEVICE, Optional.empty(),
+        final Result<Void> result = registrationService.processDeleteDevice(TENANT, DEVICE, Optional.empty(),
                 NoopSpan.INSTANCE);
 
         // THEN the result contains a FORBIDDEN status code and the device has not been removed
         assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
         assertEquals(HttpURLConnection.HTTP_OK,
-                registrationService.readDevice(TENANT, DEVICE, NoopSpan.INSTANCE).getStatus());
+                registrationService.processReadDevice(TENANT, DEVICE, NoopSpan.INSTANCE).getStatus());
     }
 
     /**


### PR DESCRIPTION
The idea is to incrementally address the issue #1802 in a series of PRs, so that it is easier to review. As part of this PR the `DeviceManagementService` is refactored to return _vertx_ futures and also the related implementations.