### PR TITLE
Update pipeline scripts in accordance with the refactored device registry

### DIFF
--- a/deploy/src/main/sandbox/sandbox_deploy.sh
+++ b/deploy/src/main/sandbox/sandbox_deploy.sh
@@ -170,7 +170,7 @@ docker service create $CREATE_OPTIONS --name ${hono.registration.service} -p 256
   --env SPRING_PROFILES_ACTIVE=dev,prometheus \
   --mount type=volume,source=device-registry,target=/var/lib/hono/device-registry \
   --mount type=volume,source=hono-extensions,target=/opt/hono/extensions,readonly \
-  ${docker.image.org-name}/hono-service-device-registry:$HONO_VERSION
+  ${docker.image.org-name}/hono-service-device-registry-file:$HONO_VERSION
 echo ... done
 
 echo

--- a/jenkins/Hono-Deploy-Eclipse-Pipeline.groovy
+++ b/jenkins/Hono-Deploy-Eclipse-Pipeline.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -57,7 +57,7 @@ def buildAndDeploy(def utils) {
                 jdk: utils.getJDKVersion(),
                 mavenLocalRepo: '.repository',
                 options: [jacocoPublisher(disabled: true), artifactsPublisher(disabled: true)]) {
-            sh "mvn --projects :hono-service-auth,:hono-service-device-registry,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am deploy -DskipTests=true -DcreateJavadoc=true -DenableEclipseJarSigner=true -DskipStaging=true"
+            sh "mvn --projects :hono-service-auth,:hono-service-device-registry-file,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am deploy -DskipTests=true -DcreateJavadoc=true -DenableEclipseJarSigner=true -DskipStaging=true"
         }
     }
 }

--- a/jenkins/Hono-Deploy-Maven-Central-Pipeline.groovy
+++ b/jenkins/Hono-Deploy-Maven-Central-Pipeline.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -62,7 +62,7 @@ def buildAndDeploy(def utils) {
                 mavenLocalRepo: '.repository',
                 mavenSettingsFilePath: "${params.MAVEN_SETTINGS_FILE}",
                 options: [jacocoPublisher(disabled: true), artifactsPublisher(disabled: true)]) {
-            sh "mvn deploy -X -pl :hono-service-auth,:hono-service-device-registry,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am -DskipTests=true -DcreateGPGSignature=true -DcreateJavadoc=true -DenableEclipseJarSigner=true"
+            sh "mvn deploy -X -pl :hono-service-auth,:hono-service-device-registry-file,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am -DskipTests=true -DcreateGPGSignature=true -DcreateJavadoc=true -DenableEclipseJarSigner=true"
         }
     }
 }

--- a/jenkins/Hono-Nightly-Pipeline.groovy
+++ b/jenkins/Hono-Nightly-Pipeline.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -50,7 +50,7 @@ def nightlyBuild(def utils) {
     stage('Build') {
         withMaven(maven: utils.getMavenVersion(), jdk: utils.getJDKVersion(), options: [jacocoPublisher(disabled: true), artifactsPublisher(disabled: true)]) {
             sh 'mvn clean package javadoc:aggregate'
-            sh 'mvn --projects :hono-service-auth,:hono-service-device-registry,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am deploy -DcreateJavadoc=true -DenableEclipseJarSigner=true'
+            sh 'mvn --projects :hono-service-auth,:hono-service-device-registry-file,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am deploy -DcreateJavadoc=true -DenableEclipseJarSigner=true'
         }
     }
 }

--- a/push_hono_images.sh
+++ b/push_hono_images.sh
@@ -23,7 +23,7 @@ IMAGES="hono-adapter-amqp-vertx \
         hono-adapter-sigfox-vertx \
         hono-service-auth \
         hono-service-device-connection \
-        hono-service-device-registry"
+        hono-service-device-registry-file"
 
 if [ -n "$TAG" ]
 then

--- a/site/documentation/content/admin-guide/device-registry-config.md
+++ b/site/documentation/content/admin-guide/device-registry-config.md
@@ -14,7 +14,7 @@ There is no particular technical reason to implement these three APIs in one com
 
 The Device Registry component also exposes [HTTP based resources]({{< relref "/user-guide/device-registry.md" >}}) for managing tenants and the registration information and credentials of devices.
 
-The Device Registry is implemented as a Spring Boot application. It can be run either directly from the command line or by means of starting the corresponding [Docker image](https://hub.docker.com/r/eclipse/hono-service-device-registry/) created from it.
+The Device Registry is implemented as a Spring Boot application. It can be run either directly from the command line or by means of starting the corresponding [Docker image](https://hub.docker.com/r/eclipse/hono-service-device-registry-file/) created from it.
 
 
 ## Service Configuration

--- a/site/documentation/content/deployment/helm-based-deployment.md
+++ b/site/documentation/content/deployment/helm-based-deployment.md
@@ -52,7 +52,7 @@ The image names that Hono should use for starting up containers can be configure
 
 ```yaml
 deviceRegistryExample:
-  imageName: "my.registry.io/eclipse/hono-service-device-registry:1.0.3-CUSTOM"
+  imageName: "my.registry.io/eclipse/hono-service-device-registry-file:1.0.3-CUSTOM"
 authServer:
   imageName: "my.registry.io/eclipse/hono-service-auth:1.0.3-CUSTOM"
 deviceConnectionService:


### PR DESCRIPTION
The jenkins pipeline scripts have been updated to use the  artifact _hono-service-device-registry-file_ instead of _hono-service-device-registry_, which exists no more after the device registry got refactored. Once the _mongodb_ based device registry is available then in addition to the _hono-service-device-registry-file_ it (_hono-service-device-registry-mongodb_) could also be added.