### PR TITLE
Refactor Tenant AMQP endpoint not to use event bus

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/AbstractRequestResponseEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/AbstractRequestResponseEndpoint.java
@@ -1,0 +1,545 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.amqp;
+
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.auth.HonoUser;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.service.auth.AuthorizationService;
+import org.eclipse.hono.service.auth.ClaimsBasedAuthorizationService;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.HonoProtonHelper;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RequestResponseApiConstants;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * An abstract base class for implementing endpoints that implement a request response pattern.
+ * <p>
+ * It is used e.g. in the implementation of the device registration and the credentials API endpoints.
+ *
+ * @param <T> The type of configuration properties this endpoint uses.
+ */
+public abstract class AbstractRequestResponseEndpoint<T extends ServiceConfigProperties> extends AbstractAmqpEndpoint<T> {
+
+    /**
+     * A logger to be shared by subclasses.
+     */
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final Map<String, ProtonSender> replyToSenderMap = new HashMap<>();
+
+    private AuthorizationService authorizationService = new ClaimsBasedAuthorizationService();
+
+    /**
+     * Creates an endpoint for a Vertx instance.
+     *
+     * @param vertx The Vertx instance to use.
+     * @throws NullPointerException if vertx is {@code null};
+     */
+    protected AbstractRequestResponseEndpoint(final Vertx vertx) {
+        super(Objects.requireNonNull(vertx));
+    }
+
+    /**
+     * Creates the message to send to the service implementation
+     * via the vert.x event bus in order to invoke an operation.
+     *
+     * @param requestMessage The AMQP message representing the service invocation request.
+     * @param targetAddress The address the message is sent to.
+     * @return A future indicating the outcome of the operation.
+     */
+    protected abstract Future<Message> handleRequestMessage(
+            Message requestMessage,
+            ResourceIdentifier targetAddress);
+
+    /**
+     * Gets the object to use for making authorization decisions.
+     *
+     * @return The service.
+     */
+    public final AuthorizationService getAuthorizationService() {
+        return authorizationService;
+    }
+
+    /**
+     * Sets the object to use for making authorization decisions.
+     * <p>
+     * If not set a {@link ClaimsBasedAuthorizationService} instance is used.
+     *
+     * @param authService The service.
+     */
+    @Autowired(required = false)
+    public final void setAuthorizationService(final AuthorizationService authService) {
+        this.authorizationService = authService;
+    }
+
+    /**
+     * Handles a client's request to establish a link for sending service invocation requests.
+     * <p>
+     * Configure and check the receiver link of the endpoint.
+     * The remote link of the receiver must not demand the AT_MOST_ONCE QoS (not supported).
+     * The receiver link itself is configured with the AT_LEAST_ONCE QoS and grants the configured credits
+     * ({@link ServiceConfigProperties#getReceiverLinkCredit()}) with autoAcknowledge.
+     * <p>
+     * Handling of request messages is delegated to
+     * {@link #handleRequestMessage(ProtonConnection, ProtonReceiver, ResourceIdentifier, ProtonDelivery, Message)}.
+     *
+     * @param con The AMQP connection that the link is part of.
+     * @param receiver The ProtonReceiver that has already been created for this endpoint.
+     * @param targetAddress The resource identifier for this endpoint (see {@link ResourceIdentifier} for details).
+     */
+    @Override
+    public final void onLinkAttach(final ProtonConnection con, final ProtonReceiver receiver, final ResourceIdentifier targetAddress) {
+
+        if (ProtonQoS.AT_MOST_ONCE.equals(receiver.getRemoteQoS())) {
+            logger.debug("client wants to use unsupported AT MOST ONCE delivery mode for endpoint [{}], closing link ...", getName());
+            receiver.setCondition(ProtonHelper.condition(AmqpError.PRECONDITION_FAILED.toString(), "endpoint requires AT_LEAST_ONCE QoS"));
+            receiver.close();
+        } else {
+
+            logger.debug("establishing link for receiving request messages from client [{}]", receiver.getName());
+
+            receiver.setQoS(ProtonQoS.AT_LEAST_ONCE);
+            receiver.setAutoAccept(true); // settle received messages if the handler succeeds
+            receiver.setTarget(receiver.getRemoteTarget());
+            receiver.setSource(receiver.getRemoteSource());
+            // We do manual flow control, credits are replenished after responses have been sent.
+            receiver.setPrefetch(0);
+
+            // set up handlers
+
+            receiver.handler((delivery, message) -> {
+                try {
+                    handleRequestMessage(con, receiver, targetAddress, delivery, message);
+                } catch (final Exception ex) {
+                    logger.warn("error handling message", ex);
+                    ProtonHelper.released(delivery, true);
+                }
+            });
+            HonoProtonHelper.setCloseHandler(receiver, remoteClose -> onLinkDetach(receiver));
+            HonoProtonHelper.setDetachHandler(receiver, remoteDetach -> onLinkDetach(receiver));
+
+            // acknowledge the remote open
+            receiver.open();
+
+            // send out initial credits, after opening
+            logger.debug("flowing {} credits to client", config.getReceiverLinkCredit());
+            receiver.flow(config.getReceiverLinkCredit());
+        }
+    }
+
+    /**
+     * Handles a request message received from a client.
+     * <p>
+     * The message gets rejected if
+     * <ul>
+     * <li>the message does not pass {@linkplain #passesFormalVerification(ResourceIdentifier, Message) formal
+     * verification} or</li>
+     * <li>the client is not {@linkplain #isAuthorized(HonoUser, ResourceIdentifier, Message) authorized to execute the
+     * operation} indicated by the message's <em>subject</em> or</li>
+     * <li>its payload cannot be parsed</li>
+     * </ul>
+     *
+     * @param con The connection with the client.
+     * @param receiver The link over which the message has been received.
+     * @param targetAddress The address the message is sent to.
+     * @param delivery The message's delivery status.
+     * @param requestMessage The request message.
+     */
+    protected final void handleRequestMessage(
+            final ProtonConnection con,
+            final ProtonReceiver receiver,
+            final ResourceIdentifier targetAddress,
+            final ProtonDelivery delivery,
+            final Message requestMessage) {
+
+        final HonoUser clientPrincipal = Constants.getClientPrincipal(con);
+        final String replyTo = requestMessage.getReplyTo();
+        final SpanContext spanContext = TracingHelper.extractSpanContext(tracer, requestMessage);
+        final Span currentSpan = TracingHelper.buildChildSpan(tracer, spanContext, "process request message")
+                .ignoreActiveSpan()
+                .withTag(Tags.COMPONENT.getKey(), getName())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                .withTag(Tags.HTTP_METHOD.getKey(), requestMessage.getSubject())
+                .withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), targetAddress.toString())
+                .start();
+
+        if (!passesFormalVerification(targetAddress, requestMessage)) {
+            MessageHelper.rejected(delivery, new ErrorCondition(Constants.AMQP_BAD_REQUEST, "malformed request message"));
+            flowCreditToRequestor(receiver, replyTo);
+            TracingHelper.logError(currentSpan, "malformed request message");
+            currentSpan.finish();
+            return;
+        }
+
+        ProtonHelper.accepted(delivery, true);
+        currentSpan.log("request message accepted");
+
+        getSenderForConnection(con, replyTo)
+                .compose(sender -> isAuthorized(clientPrincipal, targetAddress, requestMessage)
+                        .map(authorized -> {
+
+                            logger.debug("client [{}] is {}authorized to {}:{}", clientPrincipal.getName(),
+                                    authorized ? "" : "not ", targetAddress, requestMessage.getSubject());
+
+                            if (authorized) {
+                                return authorized;
+                            } else {
+                                throw new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, "not authorized to invoke operation");
+                            }
+                        })
+                        .compose(authorized -> handleRequestMessage(requestMessage, targetAddress))
+                        .compose(amqpMessage -> filterResponse(clientPrincipal, requestMessage, amqpMessage))
+                        .otherwise(t -> {
+
+                            logger.debug("error processing request [resource: {}, op: {}]: {}", targetAddress,
+                                    requestMessage.getSubject(), t.getMessage());
+                            currentSpan.log("error processing request");
+                            TracingHelper.logError(currentSpan, t);
+
+                            final ServiceInvocationException ex = getServiceInvocationException(t);
+                            Tags.HTTP_STATUS.set(currentSpan, ex.getErrorCode());
+                            return RequestResponseApiConstants.getErrorMessage(ex.getErrorCode(), ex.getMessage(), requestMessage);
+                        })
+                        .map(amqpMessage -> {
+                            Tags.HTTP_STATUS.set(currentSpan, MessageHelper.getStatus(amqpMessage));
+                            if (sender.isOpen()) {
+                                final ProtonDelivery responseDelivery = sender.send(amqpMessage);
+                                //TODO handle send exception
+                                logger.debug("sent response message to client  [correlation-id: {}, content-type: {}]",
+                                        amqpMessage.getCorrelationId(), amqpMessage.getContentType());
+                                currentSpan.log("sent response message to client");
+                                return responseDelivery;
+                            } else {
+                                TracingHelper.logError(currentSpan, "cannot send response, reply-to link is closed");
+                                return null;
+                            }
+                        }))
+                .setHandler(s -> {
+                    // allow client to send another request
+                    flowCreditToRequestor(receiver, replyTo);
+                    currentSpan.finish();
+                });
+    }
+
+    /**
+     * Applies arbitrary filters on the response before it is sent to the client.
+     * <p>
+     * Subclasses may override this method in order to e.g. filter the payload based on
+     * the client's authorities.
+     * <p>
+     * This default implementation simply returns a succeeded future containing the
+     * original response.
+     *
+     * @param clientPrincipal The client's identity and authorities.
+     * @param request The request message.
+     * @param response The response to send to the client.
+     * @return A future indicating the outcome.
+     *         If the future succeeds it will contain the (filtered) response to be sent to the client.
+     *         Otherwise the future will fail with a {@link ServiceInvocationException} indicating the
+     *         problem.
+     */
+    protected Future<Message> filterResponse(final HonoUser clientPrincipal, final Message request, final Message response) {
+
+        return Future.succeededFuture(Objects.requireNonNull(response));
+    }
+
+    /**
+     * Checks if the client is authorized to execute a given operation.
+     *
+     * This method is invoked for every request message received from a client.
+     * <p>
+     * This default implementation simply delegates to {@link AuthorizationService#isAuthorized(HonoUser, ResourceIdentifier, String)}.
+     * <p>
+     * Subclasses may override this method in order to do more sophisticated checks.
+     *
+     * @param clientPrincipal The client.
+     * @param resource The resource the message belongs to.
+     * @param message The message for which the authorization shall be checked.
+     * @return A future indicating the outcome of the check.
+     *         The future will be succeeded if the client is authorized to execute the operation.
+     *         Otherwise the future will be failed with a {@link ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected Future<Boolean> isAuthorized(final HonoUser clientPrincipal, final ResourceIdentifier resource, final Message message) {
+
+        Objects.requireNonNull(message);
+        return getAuthorizationService().isAuthorized(clientPrincipal, resource, message.getSubject());
+    }
+
+    /**
+     * Handles a client's request to establish a link for receiving responses to service invocations.
+     * <p>
+     * This method opens a sender for sending request replies back to the client.
+     *
+     * @param con The AMQP connection that the link is part of.
+     * @param sender The link to establish.
+     * @param replyToAddress The reply-to address to create a consumer on the event bus for.
+     */
+    @Override
+    public final void onLinkAttach(final ProtonConnection con, final ProtonSender sender,
+            final ResourceIdentifier replyToAddress) {
+
+        if (!isValidReplyToAddress(replyToAddress)) {
+            logger.debug("client [{}] provided invalid reply-to address", sender.getName());
+            sender.setCondition(ProtonHelper.condition(AmqpError.INVALID_FIELD,
+                    String.format("reply-to address must have the following format %s/<tenant>/<reply-address>",
+                            getName())));
+            sender.close();
+            return;
+        }
+
+        final String replyTo = replyToAddress.toString();
+
+        if (this.replyToSenderMap.containsKey(replyTo)) {
+            logger.debug("client [{}] wanted to subscribe to already subscribed reply-to address [{}]",
+                    sender.getName(), replyTo);
+            sender.setCondition(ProtonHelper.condition(AmqpError.ILLEGAL_STATE,
+                    String.format("reply-to address [%s] is already subscribed", replyTo)));
+            sender.close();
+            return;
+        }
+
+        logger.debug("establishing response sender link with client [{}]", sender.getName());
+        sender.setQoS(ProtonQoS.AT_LEAST_ONCE);
+        sender.setSource(sender.getRemoteSource());
+        sender.setTarget(sender.getRemoteTarget());
+        registerSenderForReplyTo(replyTo, sender);
+
+
+        HonoProtonHelper.setCloseHandler(sender, remoteClose -> {
+            logger.debug("client [{}] closed sender link", sender.getName());
+            unregisterSenderForReplyTo(replyTo);
+            sender.close();
+        });
+        HonoProtonHelper.setDetachHandler(sender, remoteDetach -> {
+            logger.debug("client [{}] detached sender link", sender.getName());
+            unregisterSenderForReplyTo(replyTo);
+            sender.close();
+        });
+
+        sender.open();
+    }
+
+    @Override
+    public void onConnectionClosed(final ProtonConnection connection) {
+
+        Objects.requireNonNull(connection);
+        deallocateAllSendersForConnection(connection);
+    }
+
+    private Future<ProtonSender> getSenderForConnection(final ProtonConnection con, final String replytoAddress) {
+
+        final Promise<ProtonSender> result = Promise.promise();
+        final ProtonSender sender = replyToSenderMap.get(replytoAddress);
+        if (sender != null && sender.isOpen() && sender.getSession().getConnection() == con) {
+            result.complete(sender);
+        } else {
+            result.fail(new ClientErrorException(
+                    HttpURLConnection.HTTP_PRECON_FAILED,
+                    "must open receiver link for reply-to address first"));
+        }
+        return result.future();
+    }
+
+    private void registerSenderForReplyTo(final String replyTo, final ProtonSender sender) {
+
+        final ProtonSender oldSender = replyToSenderMap.put(replyTo, sender);
+
+        if (oldSender == null || oldSender == sender) {
+            logger.debug("registered sender [{}] for replies to [{}]", sender, replyTo);
+        } else {
+            logger.info("replaced existing sender [{}] for replies to [{}] with sender [{}]",
+                    oldSender, replyTo, sender);
+        }
+    }
+
+    private void unregisterSenderForReplyTo(final String replyTo) {
+
+        final ProtonSender sender = replyToSenderMap.remove(replyTo);
+        if (sender == null) {
+            logger.warn("sender was not allocated for replyTo address [{}]", replyTo);
+        } else {
+            logger.debug("deallocated sender [{}] for replies to [{}]", sender.getName(), replyTo);
+        }
+
+    }
+
+    private void deallocateAllSendersForConnection(final ProtonConnection connection) {
+        replyToSenderMap
+                .entrySet()
+                .removeIf(entry -> entry.getValue().getSession().getConnection() == connection);
+    }
+
+    private void flowCreditToRequestor(final ProtonReceiver receiver, final String replyTo) {
+
+        receiver.flow(1);
+        logger.trace("replenished client [reply-to: {}, current credit: {}]", replyTo,
+                receiver.getCredit());
+    }
+
+    /**
+     * Checks if a resource identifier constitutes a valid reply-to address
+     * for this service endpoint.
+     * <p>
+     * This method is invoked during establishment of the reply-to link between
+     * the client and this endpoint. The link will only be established if this method
+     * returns {@code true}.
+     * <p>
+     * This default implementation verifies that the address consists of three
+     * segments: an endpoint identifier, a tenant identifier and a resource identifier.
+     * <p>
+     * Subclasses should override this method if the service they provide an endpoint for
+     * uses a different reply-to address format.
+     *
+     * @param replyToAddress The address to check.
+     * @return {@code true} if the address is valid.
+     */
+    protected boolean isValidReplyToAddress(final ResourceIdentifier replyToAddress) {
+
+        if (replyToAddress == null) {
+            return false;
+        } else {
+            return replyToAddress.getResourcePath().length >= 3;
+        }
+    }
+
+    /**
+     * Gets a property value of a given type from a JSON object.
+     *
+     * @param clazz Type class of the type
+     * @param payload The object to get the property from.
+     * @param field The name of the property.
+     * @param <T> The type of the field.
+     * @return The property value or {@code null} if no such property exists or is not of the expected type.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected static final <T> T getTypesafeValueForField(final Class<T> clazz, final JsonObject payload,
+            final String field) {
+
+        Objects.requireNonNull(clazz);
+        Objects.requireNonNull(payload);
+        Objects.requireNonNull(field);
+
+        final Object result = payload.getValue(field);
+
+        if (clazz.isInstance(result)) {
+            return clazz.cast(result);
+        }
+
+        return null;
+    }
+
+    /**
+     * Composes the given future so that the given <em>OpenTracing</em> span is finished when the future completes.
+     * <p>
+     * The result or exception of the given future will be used to set a {@link Tags#HTTP_STATUS} tag on the span
+     * and to set a {@link Tags#ERROR} tag in case of an exception or a result with error status.
+     *
+     * @param span The span to finish.
+     * @param resultFuture The future to be composed.
+     * @return The composed future.
+     */
+    protected Future<Message> finishSpanOnFutureCompletion(final Span span, final Future<Message> resultFuture) {
+        return resultFuture.compose(message -> {
+            final Integer status = MessageHelper.getStatus(message);
+            Tags.HTTP_STATUS.set(span, MessageHelper.getStatus(message));
+            if (status != null && (status < 100 || status >= 600)) {
+                Tags.ERROR.set(span, true);
+            }
+            span.finish();
+            return Future.succeededFuture(message);
+        }).recover(t -> {
+            Tags.HTTP_STATUS.set(span, ServiceInvocationException.extractStatusCode(t));
+            TracingHelper.logError(span, t);
+            span.finish();
+            return Future.failedFuture(t);
+        });
+    }
+
+    private ServiceInvocationException getServiceInvocationException(final Throwable error) {
+
+        if (error instanceof ServiceInvocationException) {
+            return (ServiceInvocationException) error;
+        } else if (error instanceof ReplyException) {
+            final ReplyException ex = (ReplyException) error;
+            switch(ex.failureType()) {
+            case TIMEOUT:
+                return new ServerErrorException(
+                        HttpURLConnection.HTTP_UNAVAILABLE,
+                        "request could not be processed at the moment");
+            default:
+                return new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR);
+            }
+        } else {
+            return new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR);
+        }
+    }
+
+    /**
+     * Creates a new <em>OpenTracing</em> span for tracing the execution of a tenant service operation.
+     * <p>
+     * The returned span will already contain a tag for the given tenant (if it is not {@code null}).
+     *
+     * @param operationName The operation name that the span should be created for.
+     * @param spanContext Existing span context.
+     * @param tenantId The tenant id.
+     * @return The new {@code Span}.
+     * @throws NullPointerException if operationName is {@code null}.
+     */
+    protected final Span newChildSpan(final String operationName, final SpanContext spanContext, final String tenantId) {
+        Objects.requireNonNull(operationName);
+        // we set the component tag to the class name because we have no access to
+        // the name of the enclosing component we are running in
+        final Tracer.SpanBuilder spanBuilder = TracingHelper.buildChildSpan(tracer, spanContext, operationName)
+                .ignoreActiveSpan()
+                .withTag(Tags.COMPONENT.getKey(), getClass().getSimpleName())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
+        if (tenantId != null) {
+            spanBuilder.withTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
+        }
+        return spanBuilder.start();
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/AbstractTenantAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/AbstractTenantAmqpEndpoint.java
@@ -1,0 +1,285 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.tenant;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.auth.HonoUser;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.service.amqp.AbstractRequestResponseEndpoint;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantResult;
+import javax.security.auth.x500.X500Principal;
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+/**
+ * An {@code AmqpEndpoint} for managing tenant information.
+ * <p>
+ * This endpoint implements Hono's <a href="https://www.eclipse.org/hono/docs/api/tenant/">Tenant API</a>. It receives AMQP 1.0
+ * messages representing requests and sends them to an address on the vertx event bus for processing. The outcome is
+ * then returned to the peer in a response message.
+ */
+public abstract class AbstractTenantAmqpEndpoint extends AbstractRequestResponseEndpoint<ServiceConfigProperties> {
+
+    private static final String SPAN_NAME_GET_TENANT = "get Tenant";
+
+    private static final String TAG_SUBJECT_DN_NAME = "subject_dn_name";
+
+    /**
+     * Creates a new tenant endpoint for a vertx instance.
+     *
+     * @param vertx The vertx instance to use.
+     */
+    public AbstractTenantAmqpEndpoint(final Vertx vertx) {
+        super(vertx);
+    }
+
+    @Override
+    public final String getName() {
+        return TenantConstants.TENANT_ENDPOINT;
+    }
+
+    /**
+     * The service to forward requests to.
+     *
+     * @return The service to bind to, must never return {@code null}.
+     */
+    protected abstract TenantService getService();
+
+    @Override
+    protected Future<Message> handleRequestMessage(final Message requestMessage, final ResourceIdentifier targetAddress) {
+
+        Objects.requireNonNull(requestMessage);
+
+        switch (TenantConstants.TenantAction.from(requestMessage.getSubject())) {
+            case get:
+                return processGetRequest(requestMessage);
+            default:
+                return processCustomTenantMessage(requestMessage);
+        }
+    }
+
+    private Future<Message> processGetRequest(final Message request) {
+
+        final SpanContext spanContext = TracingHelper.extractSpanContext(tracer, request);
+
+        final String tenantId = MessageHelper.getTenantId(request);
+        final Span span = newChildSpan(SPAN_NAME_GET_TENANT, spanContext, tenantId);
+
+        JsonObject payload = null;
+        try {
+            payload = MessageHelper.getJsonPayload(request);
+        } catch (DecodeException e) {
+            logger.debug("failed to decode AMQP request message", e);
+            return Future.failedFuture(
+                    new ClientErrorException(
+                            HttpURLConnection.HTTP_BAD_REQUEST,
+                            "request message body contains malformed JSON"));
+        }
+
+        final Future<Message> resultFuture;
+        if (tenantId == null && payload == null) {
+            TracingHelper.logError(span, "request does not contain any query parameters");
+            log.debug("request does not contain any query parameters");
+            resultFuture = Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
+
+        } else if (tenantId != null) {
+
+            // deprecated API
+            log.debug("retrieving tenant [{}] using deprecated variant of get tenant request", tenantId);
+            span.log("using deprecated variant of get tenant request");
+            // span will be finished in processGetByIdRequest
+            resultFuture = processGetByIdRequest(request, tenantId, span);
+
+        } else {
+
+            final String tenantIdFromPayload = getTypesafeValueForField(String.class, payload,
+                    TenantConstants.FIELD_PAYLOAD_TENANT_ID);
+            final String subjectDn = getTypesafeValueForField(String.class, payload,
+                    TenantConstants.FIELD_PAYLOAD_SUBJECT_DN);
+
+            if (tenantIdFromPayload == null && subjectDn == null) {
+                TracingHelper.logError(span, "request does not contain any query parameters");
+                log.debug("payload does not contain any query parameters");
+                resultFuture = Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
+            } else if (tenantIdFromPayload != null) {
+                log.debug("retrieving tenant [id: {}]", tenantIdFromPayload);
+                span.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenantIdFromPayload);
+                resultFuture = processGetByIdRequest(request, tenantIdFromPayload, span);
+            } else {
+                span.setTag(TAG_SUBJECT_DN_NAME, subjectDn);
+                resultFuture = processGetByCaRequest(request, subjectDn, span);
+            }
+        }
+
+        return finishSpanOnFutureCompletion(span, resultFuture);
+    }
+
+    private Future<Message> processGetByIdRequest(final Message request, final String tenantId,
+            final Span span) {
+
+        final Promise<TenantResult<JsonObject>> getResult = Promise.promise();
+        getService().get(tenantId, span, getResult);
+        return getResult.future().map(tr -> TenantConstants.getAmqpReply(TenantConstants.TENANT_ENDPOINT, tenantId, request, tr));
+    }
+
+    private Future<Message> processGetByCaRequest(final Message request, final String subjectDn,
+            final Span span) {
+
+        try {
+            final X500Principal dn = new X500Principal(subjectDn);
+            log.debug("retrieving tenant [subject DN: {}]", subjectDn);
+            final Promise<TenantResult<JsonObject>> getResult = Promise.promise();
+            getService().get(dn, span, getResult);
+            return getResult.future().map(tr -> {
+                String tenantId = null;
+                if (tr.isOk() && tr.getPayload() != null) {
+                    tenantId = getTypesafeValueForField(String.class, tr.getPayload(),
+                            TenantConstants.FIELD_PAYLOAD_TENANT_ID);
+                    span.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
+                }
+                return TenantConstants.getAmqpReply(TenantConstants.TENANT_ENDPOINT, tenantId, request, tr);
+            });
+        } catch (final IllegalArgumentException e) {
+            TracingHelper.logError(span, "illegal subject DN provided by client: " + subjectDn);
+            // the given subject DN is invalid
+            log.debug("cannot parse subject DN [{}] provided by client", subjectDn);
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
+        }
+    }
+
+    /**
+     * Processes a request for a non-standard operation.
+     * <p>
+     * Subclasses should override this method in order to support additional, custom
+     * operations that are not defined by Hono's Tenant API.
+     * <p>
+     * This default implementation simply returns a future that is failed with a
+     * {@link ClientErrorException} with an error code <em>400 Bad Request</em>.
+     *
+     * @param request The request to process.
+     * @return A future indicating the outcome of the service invocation.
+     */
+    protected Future<Message> processCustomTenantMessage(final Message request) {
+        log.debug("invalid operation in request message [{}]", request.getSubject());
+        return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
+    }
+
+    /**
+     * Verifies that a response only contains tenant information that the
+     * client is authorized to retrieve.
+     * <p>
+     * If the response does not contain a tenant ID nor a payload, then the
+     * returned future will succeed with the response <em>as-is</em>.
+     * Otherwise the tenant ID is used together with the endpoint and operation
+     * name to check the client's authority to retrieve the data. If the client
+     * is authorized, the returned future will succeed with the response as-is,
+     * otherwise the future will fail with a {@link ClientErrorException} containing a
+     * <em>403 Forbidden</em> status.
+     */
+    @Override
+    protected Future<Message> filterResponse(
+            final HonoUser clientPrincipal,
+            final Message request, final Message response) {
+
+        Objects.requireNonNull(clientPrincipal);
+        Objects.requireNonNull(response);
+
+        final String tenantId = MessageHelper.getTenantId(response);
+        final JsonObject payload = MessageHelper.getJsonPayload(response);
+
+        if (tenantId == null || payload == null) {
+            return Future.succeededFuture(response);
+        } else {
+            // verify that payload contains tenant that the client is authorized for
+            final ResourceIdentifier resourceId = ResourceIdentifier.from(TenantConstants.TENANT_ENDPOINT, tenantId, null);
+            return getAuthorizationService().isAuthorized(clientPrincipal, resourceId, request.getSubject())
+                    .map(isAuthorized -> {
+                        if (isAuthorized) {
+                            return response;
+                        } else {
+                            throw new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN);
+                        }
+                    });
+        }
+    }
+
+    @Override
+    protected boolean passesFormalVerification(final ResourceIdentifier linkTarget, final Message msg) {
+        return TenantMessageFilter.verify(linkTarget, msg);
+    }
+
+    /**
+     * Checks if a resource identifier constitutes a valid reply-to address
+     * for the Tenant service.
+     *
+     * @param replyToAddress The address to check.
+     * @return {@code true} if the address contains two segments.
+     */
+    @Override
+    protected boolean isValidReplyToAddress(final ResourceIdentifier replyToAddress) {
+
+        if (replyToAddress == null) {
+            return false;
+        } else {
+            return replyToAddress.getResourcePath().length >= 2;
+        }
+    }
+
+    /**
+     * Checks if the client is authorized to invoke an operation.
+     * <p>
+     * If the request does not include a <em>tenant_id</em> application property
+     * then the request is authorized by default. This behavior allows clients to
+     * invoke operations that do not require a tenant ID as a parameter.
+     * <p>
+     * If the request does contain a tenant ID parameter in its application properties
+     * then this tenant ID is used for the authorization check together with the
+     * endpoint and operation name.
+     *
+     * @param clientPrincipal The client.
+     * @param resource The resource the operation belongs to.
+     * @param request The message for which the authorization shall be checked.
+     * @return The outcome of the check.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    @Override
+    protected Future<Boolean> isAuthorized(final HonoUser clientPrincipal, final ResourceIdentifier resource, final Message request) {
+
+        Objects.requireNonNull(request);
+
+        final String tenantId = MessageHelper.getTenantId(request);
+        if (tenantId == null) {
+            // delegate authorization check to filterResource operation
+            return Future.succeededFuture(Boolean.TRUE);
+        } else {
+            final ResourceIdentifier specificTenantAddress =
+                    ResourceIdentifier.fromPath(new String[] { resource.getEndpoint(), tenantId });
+
+            return getAuthorizationService().isAuthorized(clientPrincipal, specificTenantAddress, request.getSubject());
+        }
+    }
+
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/EventBusTenantAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/EventBusTenantAdapter.java
@@ -43,7 +43,10 @@ import io.vertx.core.json.JsonObject;
  * In particular, this base class provides support for receiving service invocation request messages
  * via vert.x' event bus and routing them to specific methods accepting the
  * query parameters contained in the request message.
+ * @deprecated This class will be removed in future versions as AMQP endpoint does not use event bus anymore.
+ *             Please use {@link org.eclipse.hono.service.tenant.AbstractTenantAmqpEndpoint} based implementation in the future.
  */
+@Deprecated
 public abstract class EventBusTenantAdapter extends EventBusService implements Verticle {
 
     private static final String SPAN_NAME_GET_TENANT = "get Tenant";

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantAmqpEndpoint.java
@@ -38,7 +38,10 @@ import io.vertx.core.json.DecodeException;
  * This endpoint implements Hono's <a href="https://www.eclipse.org/hono/docs/api/tenant/">Tenant API</a>. It receives AMQP 1.0
  * messages representing requests and sends them to an address on the vertx event bus for processing. The outcome is
  * then returned to the peer in a response message.
+ * @deprecated This class will be removed in future versions as AMQP endpoint does not use event bus anymore.
+ *             Please use {@link org.eclipse.hono.service.tenant.AbstractTenantAmqpEndpoint} based implementation in the future.
  */
+@Deprecated(forRemoval = true)
 public class TenantAmqpEndpoint extends RequestResponseEndpoint<ServiceConfigProperties> {
 
     /**

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/AutowiredTenantAmqpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/AutowiredTenantAmqpEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,10 +10,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-
 package org.eclipse.hono.deviceregistry.service.tenant;
 
-import org.eclipse.hono.service.tenant.EventBusTenantAdapter;
+import io.vertx.core.Vertx;
+
+import org.eclipse.hono.service.tenant.AbstractTenantAmqpEndpoint;
 import org.eclipse.hono.service.tenant.TenantService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -24,24 +25,30 @@ import org.springframework.stereotype.Component;
  * <p>
  * This wires up the actual service instance with the mapping to the AMQP endpoint. It is intended to be used
  * in a Spring Boot environment.
- * @deprecated This class will be removed in future versions as AMQP endpoint does not use event bus anymore.
- *             Please use {@link org.eclipse.hono.service.tenant.AbstractTenantAmqpEndpoint} based implementation in the future.
  */
 @Component
-@Deprecated(forRemoval = true)
-public final class AutowiredTenantAdapter extends EventBusTenantAdapter {
+public class AutowiredTenantAmqpEndpoint extends AbstractTenantAmqpEndpoint {
 
     private TenantService service;
+
+    /**
+     * Creates a new tenant endpoint for a vertx instance.
+     *
+     * @param vertx The vertx instance to use.
+     */
+    @Autowired
+    public AutowiredTenantAmqpEndpoint(final Vertx vertx) {
+        super(vertx);
+    }
+
+    @Override
+    protected TenantService getService() {
+        return service;
+    }
 
     @Autowired
     @Qualifier("backend")
     public void setService(final TenantService service) {
         this.service = service;
     }
-
-    @Override
-    protected TenantService getService() {
-        return this.service;
-    }
-
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/AutowiredTenantManagementAdapter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/AutowiredTenantManagementAdapter.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
  * in a Spring Boot environment.
  *
  * @deprecated This class will be removed in future versions as HTTP endpoint does not use event bus anymore.
- *             Please use {@link org.eclipse.hono.service.management.tenant.AbstractTenantManagementHttpEndpoint} based implementation in the future. *
+ *             Please use {@link org.eclipse.hono.service.management.tenant.AbstractTenantManagementHttpEndpoint} based implementation in the future.
  */
 @Component
 @ConditionalOnBean(TenantManagementService.class)

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -25,6 +25,7 @@ import org.eclipse.hono.deviceregistry.file.FileBasedCredentialsConfigProperties
 import org.eclipse.hono.deviceregistry.file.FileBasedRegistrationConfigProperties;
 import org.eclipse.hono.deviceregistry.file.FileBasedTenantsConfigProperties;
 import org.eclipse.hono.deviceregistry.service.deviceconnection.MapBasedDeviceConnectionsConfigProperties;
+import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantAmqpEndpoint;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.amqp.AmqpEndpoint;
@@ -36,7 +37,6 @@ import org.eclipse.hono.service.http.HttpEndpoint;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.registration.RegistrationAmqpEndpoint;
 import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantManagementHttpEndpoint;
-import org.eclipse.hono.service.tenant.TenantAmqpEndpoint;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
@@ -165,7 +165,7 @@ public class ApplicationConfig {
     @Bean
     @Scope("prototype")
     public AmqpEndpoint tenantAmqpEndpoint() {
-        return new TenantAmqpEndpoint(vertx());
+        return new AutowiredTenantAmqpEndpoint(vertx());
     }
 
     /**


### PR DESCRIPTION
This is a first stub at creating a base and tenant AMQP endpoint implementation that doesn't use event bus. It's mostly based on the existing implementation. There are things I would improve, but I think it's a solid base we can continue working on (implement other services and improve things on the go).