### PR TITLE
[#1802] Refactor device registration service

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,8 +16,7 @@ package org.eclipse.hono.service.registration;
 import org.eclipse.hono.util.RegistrationResult;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 
 /**
  * A minimal service for keeping record of device identities.
@@ -32,7 +31,7 @@ public interface RegistrationService {
      *
      * @param tenantId The tenant the device belongs to.
      * @param deviceId The ID of the device to get the assertion for.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>200 OK</em> if a device with the given ID is registered for
@@ -45,19 +44,19 @@ public interface RegistrationService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/device-registration/#assert-device-registration">
      *      Device Registration API - Assert Device Registration</a>
      */
-    void assertRegistration(String tenantId, String deviceId, Handler<AsyncResult<RegistrationResult>> resultHandler);
+    Future<RegistrationResult> assertRegistration(String tenantId, String deviceId);
 
     /**
      * Asserts that a device is registered with a given tenant and is enabled.
      * <p>
-     * This default implementation simply returns the result of {@link #assertRegistration(String, String, Handler)}.
+     * This default implementation simply returns the result of {@link #assertRegistration(String, String)}.
      *
      * @param tenantId The tenant the device belongs to.
      * @param deviceId The ID of the device to get the assertion for.
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>200 OK</em> if a device with the given ID is registered for
@@ -70,9 +69,9 @@ public interface RegistrationService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/device-registration/#assert-device-registration">
      *      Device Registration API - Assert Device Registration</a>
      */
-    default void assertRegistration(final String tenantId, final String deviceId, final Span span,
-            final Handler<AsyncResult<RegistrationResult>> resultHandler) {
-        assertRegistration(tenantId, deviceId, resultHandler);
+    default Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId,
+            final Span span) {
+        return assertRegistration(tenantId, deviceId);
     }
 
     /**
@@ -88,7 +87,7 @@ public interface RegistrationService {
      * @param tenantId The tenant the device belongs to.
      * @param deviceId The ID of the device to get the assertion for.
      * @param gatewayId The gateway that wants to act on behalf of the device.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>200 OK</em> if a device with the given ID is registered for
@@ -103,7 +102,7 @@ public interface RegistrationService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/device-registration/#assert-device-registration">
      *      Device Registration API - Assert Device Registration</a>
      */
-    void assertRegistration(String tenantId, String deviceId, String gatewayId, Handler<AsyncResult<RegistrationResult>> resultHandler);
+    Future<RegistrationResult> assertRegistration(String tenantId, String deviceId, String gatewayId);
 
     /**
      * Asserts that a device is authorized to act as a <em>gateway</em> for another device.
@@ -115,7 +114,7 @@ public interface RegistrationService {
      * Such a check might be based on a specific role that the client needs to have or on an
      * explicitly defined relation between the gateway and the device(s).
      * <p>
-     * This default implementation simply returns the result of {@link #assertRegistration(String, String, String, Handler)}.
+     * This default implementation simply returns the result of {@link #assertRegistration(String, String, String)}.
      *
      * @param tenantId The tenant the device belongs to.
      * @param deviceId The ID of the device to get the assertion for.
@@ -123,7 +122,7 @@ public interface RegistrationService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>200 OK</em> if a device with the given ID is registered for
@@ -138,10 +137,9 @@ public interface RegistrationService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/device-registration/#assert-device-registration">
      *      Device Registration API - Assert Device Registration</a>
      */
-    default void assertRegistration(final String tenantId, final String deviceId, final String gatewayId,
-            final Span span,
-            final Handler<AsyncResult<RegistrationResult>> resultHandler) {
-        assertRegistration(tenantId, deviceId, gatewayId, resultHandler);
+    default Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId,
+            final String gatewayId, final Span span) {
+        return assertRegistration(tenantId, deviceId, gatewayId);
     }
 
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
@@ -155,11 +155,12 @@ public abstract class AbstractRegistrationServiceTest {
                     assertEquals(HttpURLConnection.HTTP_OK, s.getStatus());
                     assertNotNull(s.getPayload());
 
-                    getRegistrationService().assertRegistration(TENANT, DEVICE, ctx.succeeding(s2 -> {
-                        assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
-                        assertNotNull(s2.getPayload());
-                        ctx.completeNow();
-                    }));
+                    getRegistrationService().assertRegistration(TENANT, DEVICE)
+                            .setHandler(ctx.succeeding(s2 -> {
+                                assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
+                                assertNotNull(s2.getPayload());
+                                ctx.completeNow();
+                            }));
                 })));
     }
 
@@ -190,17 +191,18 @@ public abstract class AbstractRegistrationServiceTest {
                     assertNotNull(s.getPayload());
                     assertEquals(vias, s.getPayload().getVia());
                     assertEquals(viaGroups, s.getPayload().getViaGroups());
-                    getRegistrationService().assertRegistration(TENANT, deviceId, ctx.succeeding(s2 -> {
-                        assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
-                        assertNotNull(s2.getPayload());
+                    getRegistrationService().assertRegistration(TENANT, deviceId)
+                            .setHandler(ctx.succeeding(s2 -> {
+                                assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
+                                assertNotNull(s2.getPayload());
 
-                        // assert "via"
-                        final JsonArray viaJson = s2.getPayload().getJsonArray("via");
-                        assertNotNull(viaJson);
-                        assertEquals(vias, viaJson.stream().map(Object::toString).collect(Collectors.toList()));
+                                // assert "via"
+                                final JsonArray viaJson = s2.getPayload().getJsonArray("via");
+                                assertNotNull(viaJson);
+                                assertEquals(vias, viaJson.stream().map(Object::toString).collect(Collectors.toList()));
 
-                        ctx.completeNow();
-                    }));
+                                ctx.completeNow();
+                            }));
                 })));
     }
 
@@ -235,17 +237,18 @@ public abstract class AbstractRegistrationServiceTest {
                     assertNotNull(s.getPayload());
                     assertEquals(vias, s.getPayload().getVia());
 
-                    getRegistrationService().assertRegistration(TENANT, deviceId, gatewayId, ctx.succeeding(s2 -> {
-                        assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
-                        assertNotNull(s2.getPayload());
+                    getRegistrationService().assertRegistration(TENANT, deviceId, gatewayId)
+                            .setHandler(ctx.succeeding(s2 -> {
+                                assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
+                                assertNotNull(s2.getPayload());
 
-                        // assert "via"
-                        final JsonArray viaJson = s2.getPayload().getJsonArray("via");
-                        assertNotNull(viaJson);
-                        assertEquals(new JsonArray().add("a").add("b").add("c"), viaJson);
+                                // assert "via"
+                                final JsonArray viaJson = s2.getPayload().getJsonArray("via");
+                                assertNotNull(viaJson);
+                                assertEquals(new JsonArray().add("a").add("b").add("c"), viaJson);
 
-                        ctx.completeNow();
-                    }));
+                                ctx.completeNow();
+                            }));
 
                 })));
     }
@@ -297,17 +300,18 @@ public abstract class AbstractRegistrationServiceTest {
                     assertNotNull(s.getPayload());
                     assertEquals(vias, s.getPayload().getVia());
 
-                    getRegistrationService().assertRegistration(TENANT, deviceId, gatewayId, ctx.succeeding(s2 -> {
-                        assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
-                        assertNotNull(s2.getPayload());
+                    getRegistrationService().assertRegistration(TENANT, deviceId, gatewayId)
+                            .setHandler(ctx.succeeding(s2 -> {
+                                assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
+                                assertNotNull(s2.getPayload());
 
-                        // assert "via"
-                        final JsonArray viaJson = s2.getPayload().getJsonArray("via");
-                        assertNotNull(viaJson);
-                        assertEquals(new JsonArray().add("a").add("b").add("c"), viaJson);
+                                // assert "via"
+                                final JsonArray viaJson = s2.getPayload().getJsonArray("via");
+                                assertNotNull(viaJson);
+                                assertEquals(new JsonArray().add("a").add("b").add("c"), viaJson);
 
-                        ctx.completeNow();
-                    }));
+                                ctx.completeNow();
+                            }));
 
                 })));
     }
@@ -358,17 +362,18 @@ public abstract class AbstractRegistrationServiceTest {
                     assertNotNull(s.getPayload());
                     assertEquals(vias, s.getPayload().getVia());
 
-                    getRegistrationService().assertRegistration(TENANT, deviceId, gatewayId, ctx.succeeding(s2 -> {
-                        assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
-                        assertNotNull(s2.getPayload());
+                    getRegistrationService().assertRegistration(TENANT, deviceId, gatewayId)
+                            .setHandler(ctx.succeeding(s2 -> {
+                                assertEquals(HttpURLConnection.HTTP_OK, s2.getStatus());
+                                assertNotNull(s2.getPayload());
 
-                        // assert "via"
-                        final JsonArray viaJson = s2.getPayload().getJsonArray("via");
-                        assertNotNull(viaJson);
-                        assertEquals(new JsonArray().add("a").add("b").add("c"), viaJson);
+                                // assert "via"
+                                final JsonArray viaJson = s2.getPayload().getJsonArray("via");
+                                assertNotNull(viaJson);
+                                assertEquals(new JsonArray().add("a").add("b").add("c"), viaJson);
 
-                        ctx.completeNow();
-                    }));
+                                ctx.completeNow();
+                            }));
 
                 })));
     }
@@ -416,12 +421,13 @@ public abstract class AbstractRegistrationServiceTest {
                     assertNotNull(s.getPayload());
                     assertEquals(vias, s.getPayload().getVia());
 
-                    getRegistrationService().assertRegistration(TENANT, deviceId, gatewayId, ctx.succeeding(s2 -> {
-                        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, s2.getStatus());
-                        assertNull(s2.getPayload());
+                    getRegistrationService().assertRegistration(TENANT, deviceId, gatewayId)
+                            .setHandler(ctx.succeeding(s2 -> {
+                                assertEquals(HttpURLConnection.HTTP_FORBIDDEN, s2.getStatus());
+                                assertNull(s2.getPayload());
 
-                        ctx.completeNow();
-                    }));
+                                ctx.completeNow();
+                            }));
 
                 })));
     }
@@ -548,8 +554,7 @@ public abstract class AbstractRegistrationServiceTest {
                 }).compose(rr -> {
                     final String resourceVersion = rr.getResourceVersion().orElse(null);
 
-                    return getDeviceManagementService().updateDevice(
-                            TENANT, DEVICE,
+                    return getDeviceManagementService().updateDevice(TENANT, DEVICE,
                             new JsonObject().put("ext", new JsonObject().put("customKey", "customValue"))
                                     .mapTo(Device.class),
                             Optional.of(resourceVersion + "abc"), NoopSpan.INSTANCE);
@@ -557,7 +562,7 @@ public abstract class AbstractRegistrationServiceTest {
                         ctx.succeeding(response -> ctx.verify(() -> {
                             assertEquals(HttpURLConnection.HTTP_PRECON_FAILED, response.getStatus());
                             register.flag();
-                })));
+                        })));
     }
 
     /**
@@ -739,19 +744,15 @@ public abstract class AbstractRegistrationServiceTest {
 
         // read adapter data
 
-        final Promise<RegistrationResult> f2 = Promise.promise();
-        if (gatewayId.isPresent()) {
-            getRegistrationService().assertRegistration(tenant, deviceId, gatewayId.get(), f2);
-        } else {
-            getRegistrationService().assertRegistration(tenant, deviceId, f2);
-        }
-
+        final Future<RegistrationResult> f2 = gatewayId
+                .map(id -> getRegistrationService().assertRegistration(tenant, deviceId, id))
+                .orElseGet(() -> getRegistrationService().assertRegistration(tenant, deviceId));
         return CompositeFuture.all(
                 f1.map(r -> {
                     managementAssertions.handle(r);
                     return null;
                 }),
-                f2.future().map(r -> {
+                f2.map(r -> {
                     adapterAssertions.handle(r);
                     return null;
                 }));

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/BaseRegistrationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,9 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.opentracing.Span;
 import io.opentracing.noop.NoopSpan;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Checkpoint;
@@ -59,13 +57,14 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationService();
 
         // WHEN trying to assert the device's registration status
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4712", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the assertion fails with a 404
-            assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
-            //  and the response payload is empty
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4712")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the assertion fails with a 404
+                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    // and the response payload is empty
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
     }
 
     /**
@@ -80,13 +79,14 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationService();
 
         // WHEN trying to assert a device's registration status
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "non-existent", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the assertion fails with a 404
-            assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
-            //  and the response payload is empty
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "non-existent")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the assertion fails with a 404
+                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    // and the response payload is empty
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
     }
 
     /**
@@ -101,13 +101,14 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationService();
 
         // WHEN trying to assert the device's registration status for a gateway
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4711", "non-existent-gw", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the assertion fails with a 403 status
-            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
-            //  and the response payload is empty
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4711", "non-existent-gw")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the assertion fails with a 403 status
+                    assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
+                    // and the response payload is empty
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
     }
 
     /**
@@ -124,13 +125,14 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationService();
 
         // WHEN trying to assert the device's registration status for a gateway
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4713", "gw-3", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the assertion fails with a 403 status
-            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
-            //  and the response payload is empty
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4713", "gw-3")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the assertion fails with a 403 status
+                    assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
+                    // and the response payload is empty
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
     }
 
     /**
@@ -148,13 +150,14 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationService();
 
         // WHEN trying to assert the device's registration status for the wrong gateway
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4711", "gw-2", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the assertion fails with a 403 status
-            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
-            // and the response payload is empty
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4711", "gw-2")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the assertion fails with a 403 status
+                    assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
+                    // and the response payload is empty
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
     }
 
     /**
@@ -172,13 +175,14 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationService();
 
         // WHEN trying to assert the device's registration status for the wrong gateway group
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-2", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the assertion fails with a 403 status
-            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
-            // and the response payload is empty
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-2")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the assertion fails with a 403 status
+                    assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
+                    // and the response payload is empty
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
     }
 
 
@@ -197,13 +201,14 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationService();
 
         // WHEN trying to assert the device's registration status for the wrong gateway group
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-3", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the assertion fails with a 403 status
-            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
-            // and the response payload is empty
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-3")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the assertion fails with a 403 status
+                    assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
+                    // and the response payload is empty
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
     }
 
     /**
@@ -221,18 +226,19 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationService();
 
         // WHEN trying to assert the device's registration status for the wrong gateway group
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4716", "gw-4", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the assertion fails with a 403 status
-            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
-            // and the response payload is empty
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4716", "gw-4")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the assertion fails with a 403 status
+                    assertEquals(HttpURLConnection.HTTP_FORBIDDEN, result.getStatus());
+                    // and the response payload is empty
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
     }
 
     /**
      * Verifies that the getDevice method returns "not implemented" if the base
-     * {@link AbstractRegistrationService#getDevice(String, String, Span, Handler)} implementation is used.
+     * {@link AbstractRegistrationService#getDevice(String, String, Span)} implementation is used.
      *
      * @param ctx The vert.x unit test context.
      */
@@ -243,14 +249,14 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = newRegistrationServiceWithoutImpls();
 
         // WHEN trying to get a device's data
-        registrationService.getDevice(Constants.DEFAULT_TENANT, "4711", NoopSpan.INSTANCE,
-                ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the assertion fails with a status code 501
-            assertEquals(HttpURLConnection.HTTP_NOT_IMPLEMENTED, result.getStatus());
-            // and the response payload is empty
-            assertNull(result.getPayload());
-            ctx.completeNow();
-        })));
+        registrationService.getDevice(Constants.DEFAULT_TENANT, "4711", NoopSpan.INSTANCE)
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the assertion fails with a status code 501
+                    assertEquals(HttpURLConnection.HTTP_NOT_IMPLEMENTED, result.getStatus());
+                    // and the response payload is empty
+                    assertNull(result.getPayload());
+                    ctx.completeNow();
+                })));
     }
 
     /**
@@ -265,18 +271,19 @@ public class BaseRegistrationServiceTest {
         final AbstractRegistrationService registrationService = spy(newRegistrationService());
 
         // WHEN trying to assert the device's registration status
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4711", ctx.succeeding(result -> ctx.verify(() -> {
-            assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
-            final JsonObject payload = result.getPayload();
-            assertNotNull(payload);
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4711")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    final JsonObject payload = result.getPayload();
+                    assertNotNull(payload);
 
-            // THEN the response contains the registered default content type
-            final JsonObject defaults = payload.getJsonObject(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS);
-            assertNotNull(defaults);
-            assertEquals("application/default", defaults.getString(MessageHelper.SYS_PROPERTY_CONTENT_TYPE));
+                    // THEN the response contains the registered default content type
+                    final JsonObject defaults = payload.getJsonObject(RegistrationConstants.FIELD_PAYLOAD_DEFAULTS);
+                    assertNotNull(defaults);
+                    assertEquals("application/default", defaults.getString(MessageHelper.SYS_PROPERTY_CONTENT_TYPE));
 
-            ctx.completeNow();
-        })));
+                    ctx.completeNow();
+                })));
     }
 
     /**
@@ -297,28 +304,30 @@ public class BaseRegistrationServiceTest {
 
 
         // WHEN trying to assert the device's registration status for gateway 1
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-5", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the response contains a 200 status
-            assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
-            final JsonObject payload = result.getPayload();
-            assertNotNull(payload);
-            final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
-            assertNotNull(via);
-            assertEquals(via, new JsonArray().add("gw-5").add("gw-6"));
-            assertion.flag();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-5")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the response contains a 200 status
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    final JsonObject payload = result.getPayload();
+                    assertNotNull(payload);
+                    final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
+                    assertNotNull(via);
+                    assertEquals(via, new JsonArray().add("gw-5").add("gw-6"));
+                    assertion.flag();
+                })));
 
         // WHEN trying to assert the device's registration status for gateway 4
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-6", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the response contains a 200 status
-            assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
-            final JsonObject payload = result.getPayload();
-            assertNotNull(payload);
-            final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
-            assertNotNull(via);
-            assertEquals(via, new JsonArray().add("gw-5").add("gw-6"));
-            assertion.flag();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4715", "gw-6")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the response contains a 200 status
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    final JsonObject payload = result.getPayload();
+                    assertNotNull(payload);
+                    final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
+                    assertNotNull(via);
+                    assertEquals(via, new JsonArray().add("gw-5").add("gw-6"));
+                    assertion.flag();
+                })));
     }
 
     /**
@@ -337,28 +346,30 @@ public class BaseRegistrationServiceTest {
         final Checkpoint assertion = ctx.checkpoint(2);
 
         // WHEN trying to assert the device's registration status for gateway 1
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4714", "gw-1", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the response contains a 200 status
-            assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
-            final JsonObject payload = result.getPayload();
-            assertNotNull(payload);
-            final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
-            assertNotNull(via);
-            assertEquals(via, new JsonArray().add("gw-1").add("gw-4"));
-            assertion.flag();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4714", "gw-1")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the response contains a 200 status
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    final JsonObject payload = result.getPayload();
+                    assertNotNull(payload);
+                    final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
+                    assertNotNull(via);
+                    assertEquals(via, new JsonArray().add("gw-1").add("gw-4"));
+                    assertion.flag();
+                })));
 
         // WHEN trying to assert the device's registration status for gateway 4
-        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4714", "gw-4", ctx.succeeding(result -> ctx.verify(() -> {
-            // THEN the response contains a 200 status
-            assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
-            final JsonObject payload = result.getPayload();
-            assertNotNull(payload);
-            final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
-            assertNotNull(via);
-            assertEquals(via, new JsonArray().add("gw-1").add("gw-4"));
-            assertion.flag();
-        })));
+        registrationService.assertRegistration(Constants.DEFAULT_TENANT, "4714", "gw-4")
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN the response contains a 200 status
+                    assertEquals(HttpURLConnection.HTTP_OK, result.getStatus());
+                    final JsonObject payload = result.getPayload();
+                    assertNotNull(payload);
+                    final JsonArray via = payload.getJsonArray(RegistrationConstants.FIELD_VIA);
+                    assertNotNull(via);
+                    assertEquals(via, new JsonArray().add("gw-1").add("gw-4"));
+                    assertion.flag();
+                })));
     }
 
     /**
@@ -376,17 +387,15 @@ public class BaseRegistrationServiceTest {
         return new AbstractRegistrationService() {
 
             @Override
-            public void getDevice(final String tenantId, final String deviceId, final Span span,
-                    final Handler<AsyncResult<RegistrationResult>> resultHandler) {
-                devices.apply(deviceId).setHandler(resultHandler);
+            public Future<RegistrationResult> getDevice(final String tenantId, final String deviceId, final Span span) {
+                return devices.apply(deviceId);
             }
 
             @Override
-            protected void resolveGroupMembers(final String tenantId, final JsonArray viaGroups, final Span span, final Handler<AsyncResult<JsonArray>> resultHandler) {
-                resolveGatewayGroups.apply(viaGroups).setHandler(resultHandler);
+            protected Future<JsonArray> resolveGroupMembers(final String tenantId, final JsonArray viaGroups,
+                    final Span span) {
+                return resolveGatewayGroups.apply(viaGroups);
             }
-
-
         };
     }
 
@@ -400,17 +409,15 @@ public class BaseRegistrationServiceTest {
         return new AbstractRegistrationService() {
 
             @Override
-            protected void getDevice(final String tenantId, final String deviceId, final Span span,
-                    final Handler<AsyncResult<RegistrationResult>> resultHandler) {
-                resultHandler.handle(
-                        Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_NOT_IMPLEMENTED)));
+            protected Future<RegistrationResult> getDevice(final String tenantId, final String deviceId,
+                    final Span span) {
+                return Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
             }
 
             @Override
-            protected void resolveGroupMembers(final String tenantId, final JsonArray viaGroups, final Span span, final Handler<AsyncResult<JsonArray>> resultHandler) {
-                resultHandler.handle(
-                        Future.succeededFuture(new JsonArray())
-                );
+            protected Future<JsonArray> resolveGroupMembers(final String tenantId, final JsonArray viaGroups,
+                    final Span span) {
+                return Future.succeededFuture(new JsonArray());
             }
         };
     }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/DummyRegistrationService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/DummyRegistrationService.java
@@ -23,9 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -38,31 +36,28 @@ import io.vertx.core.json.JsonObject;
 public class DummyRegistrationService extends AbstractRegistrationService {
 
     @Override
-    public void assertRegistration(final String tenantId, final String deviceId, final Span span,
-            final Handler<AsyncResult<RegistrationResult>> resultHandler) {
-        assertRegistration(tenantId, deviceId, null, span, resultHandler);
+    public Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId, final Span span) {
+        return assertRegistration(tenantId, deviceId, null, span);
     }
 
     @Override
-    public void assertRegistration(final String tenantId, final String deviceId, final String gatewayId,
-            final Span span, final Handler<AsyncResult<RegistrationResult>> resultHandler) {
+    public Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId,
+            final String gatewayId, final Span span) {
         final JsonObject deviceData = new JsonObject();
-        getAssertionPayload(tenantId, deviceId, deviceData)
+        return getAssertionPayload(tenantId, deviceId, deviceData)
                 .compose(payload -> Future.succeededFuture(RegistrationResult.from(HttpURLConnection.HTTP_OK, payload)))
-                .recover(thr -> Future.succeededFuture(RegistrationResult.from(ServiceInvocationException.extractStatusCode(thr))))
-                .setHandler(resultHandler);
+                .recover(thr -> Future
+                        .succeededFuture(RegistrationResult.from(ServiceInvocationException.extractStatusCode(thr))));
     }
 
     @Override
-    protected void getDevice(final String tenantId, final String deviceId, final Span span,
-            final Handler<AsyncResult<RegistrationResult>> resultHandler) {
-        resultHandler.handle(Future.failedFuture("Not implemented"));
+    protected Future<RegistrationResult> getDevice(final String tenantId, final String deviceId, final Span span) {
+        return Future.failedFuture("Not implemented");
     }
 
     @Override
-    protected void resolveGroupMembers(final String tenantId, final JsonArray viaGroups, final Span span,
-            final Handler<AsyncResult<JsonArray>> resultHandler) {
-        resultHandler.handle(Future.failedFuture("Not implemented"));
+    protected Future<JsonArray> resolveGroupMembers(final String tenantId, final JsonArray viaGroups, final Span span) {
+        return Future.failedFuture("Not implemented");
     }
 
 }

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
@@ -88,15 +88,14 @@ public class FileBasedDeviceBackend implements AutoProvisioningEnabledDeviceBack
     // DEVICES
 
     @Override
-    public void assertRegistration(final String tenantId, final String deviceId,
-            final Handler<AsyncResult<RegistrationResult>> resultHandler) {
-        registrationService.assertRegistration(tenantId, deviceId, resultHandler);
+    public Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId) {
+        return registrationService.assertRegistration(tenantId, deviceId);
     }
 
     @Override
-    public void assertRegistration(final String tenantId, final String deviceId, final String gatewayId,
-            final Handler<AsyncResult<RegistrationResult>> resultHandler) {
-        registrationService.assertRegistration(tenantId, deviceId, gatewayId, resultHandler);
+    public Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId,
+            final String gatewayId) {
+        return registrationService.assertRegistration(tenantId, deviceId, gatewayId);
     }
 
     @Override


### PR DESCRIPTION
As part of this PR, the `RegistrationService` is refactored to return _vertx_ futures and also the related implementations. This should to be merged after PR #1803.