### PR TITLE
Add tracer instance in HotrodBasedDeviceConnectionInfo

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfo.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
@@ -42,14 +43,18 @@ public final class HotrodBasedDeviceConnectionInfo implements DeviceConnectionIn
     private static final Logger LOG = LoggerFactory.getLogger(HotrodBasedDeviceConnectionInfo.class);
 
     final RemoteCache<String, String> cache;
+    final Tracer tracer;
 
     /**
      * Creates a client for accessing device connection information.
      * 
      * @param cache The remote cache that contains the data.
+     * @param tracer The tracer instance.
+     * @throws NullPointerException if cache or tracer is {@code null}.
      */
-    public HotrodBasedDeviceConnectionInfo(final RemoteCache<String, String> cache) {
+    public HotrodBasedDeviceConnectionInfo(final RemoteCache<String, String> cache, final Tracer tracer) {
         this.cache = Objects.requireNonNull(cache);
+        this.tracer = Objects.requireNonNull(tracer);
     }
 
     private static String getKey(final String tenantId, final String deviceId) {

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfoTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfoTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.vertx.core.Future;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
@@ -46,6 +47,7 @@ class HotrodBasedDeviceConnectionInfoTest {
 
     private DeviceConnectionInfo info;
     private RemoteCache<String, String> cache;
+    private Tracer tracer;
 
     /**
      * Sets up the fixture.
@@ -54,7 +56,8 @@ class HotrodBasedDeviceConnectionInfoTest {
     @BeforeEach
     void setUp() {
         cache = mock(RemoteCache.class);
-        info = new HotrodBasedDeviceConnectionInfo(cache);
+        tracer = mock(Tracer.class);
+        info = new HotrodBasedDeviceConnectionInfo(cache, tracer);
     }
 
     /**

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/ApplicationConfig.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/ApplicationConfig.java
@@ -182,7 +182,7 @@ public class ApplicationConfig {
      */
     @Bean
     public HotrodCache<String, String> remoteCache(final Vertx vertx) {
-        return new HotrodCache<String, String>(
+        return new HotrodCache<>(
                 vertx,
                 remoteCacheManager(),
                 DeviceConnectionConstants.CACHE_NAME,
@@ -194,11 +194,13 @@ public class ApplicationConfig {
      * Exposes a Device Connection service as a Spring bean.
      * 
      * @param cache The remote cache.
+     * @param tracer The tracer instance.
      * @return The service implementation.
      */
     @Bean
-    public RemoteCacheBasedDeviceConnectionService deviceConnectionService(final HotrodCache<String, String> cache) {
-        return new RemoteCacheBasedDeviceConnectionService(new HotrodBasedDeviceConnectionInfo(cache));
+    public RemoteCacheBasedDeviceConnectionService deviceConnectionService(final HotrodCache<String, String> cache,
+            final Tracer tracer) {
+        return new RemoteCacheBasedDeviceConnectionService(new HotrodBasedDeviceConnectionInfo(cache, tracer));
     }
 
     /**

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
@@ -23,7 +23,6 @@ import org.eclipse.hono.service.HealthCheckProvider;
 import org.eclipse.hono.service.deviceconnection.DeviceConnectionService;
 import org.eclipse.hono.service.deviceconnection.EventBusDeviceConnectionAdapter;
 import org.eclipse.hono.util.DeviceConnectionResult;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.opentracing.Span;
 import io.vertx.core.AsyncResult;
@@ -45,7 +44,7 @@ public class RemoteCacheBasedDeviceConnectionService extends EventBusDeviceConne
      * @param cache The remote cache.
      * @throws NullPointerException if the cache is {@code null}.
      */
-    public RemoteCacheBasedDeviceConnectionService(@Autowired final DeviceConnectionInfo cache) {
+    public RemoteCacheBasedDeviceConnectionService(final DeviceConnectionInfo cache) {
         this.cache = Objects.requireNonNull(cache);
     }
 


### PR DESCRIPTION
A Tracer instance is now available in `HotrodBasedDeviceConnectionInfo`, making it possible to create extra spans in the `DeviceConnectionInfo` method implementations. 
This will be extra useful for the additional Device Connection API methods to be created for #1272.