### PR TITLE
[#1802] Refactor credentials service

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/AbstractCredentialsAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/AbstractCredentialsAmqpEndpoint.java
@@ -22,14 +22,12 @@ import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.service.amqp.AbstractRequestResponseEndpoint;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CredentialsConstants;
-import org.eclipse.hono.util.CredentialsResult;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
@@ -154,11 +152,8 @@ public abstract class AbstractCredentialsAmqpEndpoint extends AbstractRequestRes
         log.debug("getting credentials [tenant: {}, type: {}, auth-id: {}]", tenantId, type, authId);
         TracingHelper.TAG_CREDENTIALS_TYPE.set(span, type);
         TracingHelper.TAG_AUTH_ID.set(span, authId);
-        final Promise<CredentialsResult<JsonObject>> result = Promise.promise();
 
-        getService().get(tenantId, type, authId, payload, span, result);
-
-        return result.future()
+        return getService().get(tenantId, type, authId, payload, span)
                 .map(res -> {
                     final String deviceIdFromPayload = Optional.ofNullable(res.getPayload())
                             .map(p -> getTypesafeValueForField(String.class, p,
@@ -171,8 +166,7 @@ public abstract class AbstractCredentialsAmqpEndpoint extends AbstractRequestRes
                             CredentialsConstants.CREDENTIALS_ENDPOINT,
                             tenantId,
                             request,
-                            res
-                    );
+                            res);
                 });
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,8 +17,7 @@ import org.eclipse.hono.util.CredentialsResult;
 
 import io.opentracing.Span;
 import io.opentracing.noop.NoopSpan;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -35,7 +34,7 @@ public interface CredentialsService {
      * @param tenantId The tenant the device belongs to.
      * @param type The type of credentials to get.
      * @param authId The authentication identifier of the device to get credentials for (may be {@code null}.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *         The <em>status</em> will be
      *         <ul>
      *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
@@ -46,15 +45,14 @@ public interface CredentialsService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
      *      Credentials API - Get Credentials</a>
      */
-    default void get(final String tenantId, final String type, final String authId,
-            final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
-        get(tenantId, type, authId, NoopSpan.INSTANCE, resultHandler);
+    default Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId) {
+        return get(tenantId, type, authId, NoopSpan.INSTANCE);
     }
 
     /**
      * Gets credentials for a device.
      * <p>
-     * This default implementation simply returns the result of {@link #get(String, String, String, Handler)}.
+     * This default implementation simply returns the result of {@link #get(String, String, String)}.
      * 
      * @param tenantId The tenant the device belongs to.
      * @param type The type of credentials to get.
@@ -62,7 +60,7 @@ public interface CredentialsService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *         The <em>status</em> will be
      *         <ul>
      *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
@@ -73,8 +71,7 @@ public interface CredentialsService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
      *      Credentials API - Get Credentials</a>
      */
-    void get(String tenantId, String type, String authId, Span span,
-            Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler);
+    Future<CredentialsResult<JsonObject>> get(String tenantId, String type, String authId, Span span);
 
     /**
      * Gets credentials for a device, providing additional client connection context.
@@ -83,7 +80,7 @@ public interface CredentialsService {
      * @param type The type of credentials to get.
      * @param authId The authentication identifier of the device to get credentials for (may be {@code null}.
      * @param clientContext Optional bag of properties that can be used to identify the device
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *         The <em>status</em> will be
      *         <ul>
      *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
@@ -94,15 +91,15 @@ public interface CredentialsService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
      *      Credentials API - Get Credentials</a>
      */
-    default void get(final String tenantId, final String type, final String authId, final JsonObject clientContext,
-            final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
-        get(tenantId, type, authId, clientContext, NoopSpan.INSTANCE, resultHandler);
+    default Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId,
+            final JsonObject clientContext) {
+        return get(tenantId, type, authId, clientContext, NoopSpan.INSTANCE);
     }
 
     /**
      * Gets credentials for a device, providing additional client connection context.
      * <p>
-     * This default implementation simply returns the result of {@link #get(String, String, String, JsonObject, Handler)}.
+     * This default implementation simply returns the result of {@link #get(String, String, String, JsonObject)}.
      *
      * @param tenantId The tenant the device belongs to.
      * @param type The type of credentials to get.
@@ -111,7 +108,7 @@ public interface CredentialsService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *         The <em>status</em> will be
      *         <ul>
      *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
@@ -122,7 +119,7 @@ public interface CredentialsService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
      *      Credentials API - Get Credentials</a>
      */
-    void get(String tenantId, String type, String authId, JsonObject clientContext, Span span,
-            Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler);
+    Future<CredentialsResult<JsonObject>> get(String tenantId, String type, String authId, JsonObject clientContext,
+            Span span);
 
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/EventBusCredentialsAdapter.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/EventBusCredentialsAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,7 +20,6 @@ import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.EventBusService;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CredentialsConstants;
-import org.eclipse.hono.util.CredentialsResult;
 import org.eclipse.hono.util.EventBusMessage;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.TenantConstants;
@@ -30,7 +29,6 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.core.json.JsonObject;
 
@@ -145,9 +143,7 @@ public abstract class EventBusCredentialsAdapter extends EventBusService impleme
         log.debug("getting credentials [tenant: {}, type: {}, auth-id: {}]", tenantId, type, authId);
         TracingHelper.TAG_CREDENTIALS_TYPE.set(span, type);
         TracingHelper.TAG_AUTH_ID.set(span, authId);
-        final Promise<CredentialsResult<JsonObject>> result = Promise.promise();
-        getService().get(tenantId, type, authId, payload, span, result);
-        return result.future()
+        return getService().get(tenantId, type, authId, payload, span)
                 .map(res -> {
                     final String deviceIdFromPayload = Optional.ofNullable(res.getPayload())
                             .map(p -> getTypesafeValueForField(String.class, p,

--- a/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/credentials/BaseCredentialsServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -26,8 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -112,13 +111,17 @@ public class BaseCredentialsServiceTest {
         final var service = new CredentialsService() {
 
             @Override
-            public void get(final String tenantId, final String type, final String authId, final Span span,
-                    final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
+            public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type,
+                    final String authId,
+                    final Span span) {
+                return null;
             }
 
             @Override
-            public void get(final String tenantId, final String type, final String authId, final JsonObject clientContext, final Span span,
-                    final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
+            public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type,
+                    final String authId,
+                    final JsonObject clientContext, final Span span) {
+                return null;
             }
         };
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/DummyCredentialsService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/DummyCredentialsService.java
@@ -28,9 +28,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -44,14 +42,15 @@ public final class DummyCredentialsService implements CredentialsService {
     private static final String PWD_HASH = getBase64EncodedSha256HashForPassword("hono-secret");
 
     @Override
-    public void get(final String tenantId, final String type, final String authId, final Span span,
-            final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
-        get(tenantId, type, authId, null, span, resultHandler);
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId,
+            final Span span) {
+        return get(tenantId, type, authId, null, span);
     }
 
     @Override
-    public void get(final String tenantId, final String type, final String authId, final JsonObject clientContext,
-            final Span span, final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId,
+            final JsonObject clientContext,
+            final Span span) {
 
         final JsonObject result = JsonObject.mapFrom(CredentialsObject.fromHashedPassword(
                 authId,
@@ -60,8 +59,8 @@ public final class DummyCredentialsService implements CredentialsService {
                 CredentialsConstants.HASH_FUNCTION_SHA256,
                 null, null,
                 null));
-        resultHandler.handle(Future.succeededFuture(
-                CredentialsResult.from(HttpURLConnection.HTTP_OK, JsonObject.mapFrom(result), CacheDirective.noCacheDirective())));
+        return Future.succeededFuture(CredentialsResult
+                .from(HttpURLConnection.HTTP_OK, JsonObject.mapFrom(result), CacheDirective.noCacheDirective()));
     }
 
     private static String getBase64EncodedSha256HashForPassword(final String password) {

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsService.java
@@ -283,9 +283,9 @@ public final class FileBasedCredentialsService extends AbstractVerticle
      * The result object will include a <em>no-cache</em> directive.
      */
     @Override
-    public void get(final String tenantId, final String type, final String authId, final Span span,
-            final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
-        get(tenantId, type, authId, null, span, resultHandler);
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId,
+            final Span span) {
+        return get(tenantId, type, authId, null, span);
     }
 
     /**
@@ -296,25 +296,23 @@ public final class FileBasedCredentialsService extends AbstractVerticle
      * directive will be included.
      */
     @Override
-    public void get(
+    public Future<CredentialsResult<JsonObject>> get(
             final String tenantId,
             final String type,
             final String authId,
             final JsonObject clientContext,
-            final Span span,
-            final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
+            final Span span) {
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(type);
         Objects.requireNonNull(authId);
-        Objects.requireNonNull(resultHandler);
 
         final JsonObject data = getSingleCredentials(tenantId, authId, type, clientContext, span);
         if (data == null) {
-            resultHandler.handle(Future.succeededFuture(CredentialsResult.from(HttpURLConnection.HTTP_NOT_FOUND)));
+            return Future.succeededFuture(CredentialsResult.from(HttpURLConnection.HTTP_NOT_FOUND));
         } else {
-            resultHandler.handle(Future.succeededFuture(
-                    CredentialsResult.from(HttpURLConnection.HTTP_OK, data.copy(), getCacheDirective(type))));
+            return Future.succeededFuture(
+                    CredentialsResult.from(HttpURLConnection.HTTP_OK, data.copy(), getCacheDirective(type)));
         }
     }
 
@@ -829,15 +827,14 @@ public final class FileBasedCredentialsService extends AbstractVerticle
     }
 
     @Override
-    public void get(final String tenantId, final String type, final String authId,
-            final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
-        get(tenantId, type, authId, NoopSpan.INSTANCE, resultHandler);
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId) {
+        return get(tenantId, type, authId, NoopSpan.INSTANCE);
     }
 
     @Override
-    public void get(final String tenantId, final String type, final String authId, final JsonObject clientContext,
-            final Handler<AsyncResult<CredentialsResult<JsonObject>>> resultHandler) {
-        get(tenantId, type, authId, clientContext, NoopSpan.INSTANCE, resultHandler);
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId,
+            final JsonObject clientContext) {
+        return get(tenantId, type, authId, clientContext, NoopSpan.INSTANCE);
     }
 
     /**

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
@@ -48,7 +48,6 @@ import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
-import org.eclipse.hono.util.CredentialsResult;
 import org.eclipse.hono.util.RegistryManagementConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -591,14 +590,12 @@ public class FileBasedCredentialsServiceTest extends AbstractCredentialsServiceT
                 .compose(ok -> {
                     // WHEN trying to retrieve credentials for a device that provided
                     // a client context that contains a value for the property
-                    final Promise<CredentialsResult<JsonObject>> result = Promise.promise();
-                    getCredentialsService().get(
+                    return getCredentialsService().get(
                             tenantId,
                             CredentialsConstants.SECRETS_TYPE_PRESHARED_KEY,
                             authId,
-                            new JsonObject().put("property-to-match", providedContextValue),
-                            result);
-                    return result.future();
+                            new JsonObject().put("property-to-match", providedContextValue)
+                    );
                 })
                 .setHandler(ctx.succeeding(s -> {
                     // THEN the request contains the expected status code


### PR DESCRIPTION
In this PR, the `CredentialsService` is refactored to return _vertx_ futures and also the related classes have been adapted. This should to be merged after PR #1810.