### PR TITLE
[#1802] Refactor credentials management service

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementService.java
@@ -18,8 +18,7 @@ import java.util.Optional;
 import org.eclipse.hono.service.management.OperationResult;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 
 /**
  * A service for managing device credentials.
@@ -40,7 +39,7 @@ public interface CredentialsManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *         The <em>status</em> will be
      *         <ul>
      *         <li><em>204 No Content</em> if the credentials have been updated successfully.</li>
@@ -52,8 +51,8 @@ public interface CredentialsManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/credentials/setAllCredentials">
      *      Device Registry Management API - Update Credentials</a>
      */
-    void updateCredentials(String tenantId, String deviceId, List<CommonCredential> credentials, Optional<String> resourceVersion,
-            Span span, Handler<AsyncResult<OperationResult<Void>>> resultHandler);
+    Future<OperationResult<Void>> updateCredentials(String tenantId, String deviceId,
+            List<CommonCredential> credentials, Optional<String> resourceVersion, Span span);
 
     /**
      * Gets all credentials registered for a device.
@@ -63,7 +62,7 @@ public interface CredentialsManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *         The <em>status</em> will be
      *         <ul>
      *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
@@ -74,6 +73,5 @@ public interface CredentialsManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/credentials/getAllCredentials">
      *      Device Registry Management API - Get Credentials</a>
      */
-    void readCredentials(String tenantId, String deviceId, Span span,
-            Handler<AsyncResult<OperationResult<List<CommonCredential>>>> resultHandler);
+    Future<OperationResult<List<CommonCredential>>> readCredentials(String tenantId, String deviceId, Span span);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackend.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackend.java
@@ -28,7 +28,6 @@ import org.eclipse.hono.service.management.credentials.X509CertificateSecret;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 
 /**
  * Interface that adds automatic device provisioning to the DeviceBackend.
@@ -84,9 +83,7 @@ public interface AutoProvisioningEnabledDeviceBackend extends DeviceBackend {
 
                     final String deviceId = r.getPayload().getId();
 
-                    final Promise<OperationResult<Void>> credPromise = Promise.promise();
-                    updateCredentials(tenantId, deviceId, List.of(certCredential), Optional.empty(), span, credPromise);
-                    return credPromise.future()
+                    return updateCredentials(tenantId, deviceId, List.of(certCredential), Optional.empty(), span)
                             .compose(v -> {
                                 if (v.isError()) {
                                     return deleteDevice(tenantId, deviceId, Optional.empty(), span)


### PR DESCRIPTION
In this PR, the `CredentialsManagementService` is refactored to return _vertx_ futures and also the related classes have been adapted. This should to be merged after PR #1814.