### PR TITLE
[#1802] Refactor tenant management service

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementService.java
@@ -18,8 +18,7 @@ import java.util.Optional;
 import org.eclipse.hono.service.management.OperationResult;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 
 /**
  * A service for managing device credentials.
@@ -40,7 +39,7 @@ public interface CredentialsManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *         The <em>status</em> will be
      *         <ul>
      *         <li><em>204 No Content</em> if the credentials have been updated successfully.</li>
@@ -52,8 +51,8 @@ public interface CredentialsManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/credentials/setAllCredentials">
      *      Device Registry Management API - Update Credentials</a>
      */
-    void updateCredentials(String tenantId, String deviceId, List<CommonCredential> credentials, Optional<String> resourceVersion,
-            Span span, Handler<AsyncResult<OperationResult<Void>>> resultHandler);
+    Future<OperationResult<Void>> updateCredentials(String tenantId, String deviceId,
+            List<CommonCredential> credentials, Optional<String> resourceVersion, Span span);
 
     /**
      * Gets all credentials registered for a device.
@@ -63,7 +62,7 @@ public interface CredentialsManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *         The <em>status</em> will be
      *         <ul>
      *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
@@ -74,6 +73,5 @@ public interface CredentialsManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/credentials/getAllCredentials">
      *      Device Registry Management API - Get Credentials</a>
      */
-    void readCredentials(String tenantId, String deviceId, Span span,
-            Handler<AsyncResult<OperationResult<List<CommonCredential>>>> resultHandler);
+    Future<OperationResult<List<CommonCredential>>> readCredentials(String tenantId, String deviceId, Span span);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackend.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackend.java
@@ -28,7 +28,6 @@ import org.eclipse.hono.service.management.credentials.X509CertificateSecret;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 
 /**
  * Interface that adds automatic device provisioning to the DeviceBackend.
@@ -84,9 +83,7 @@ public interface AutoProvisioningEnabledDeviceBackend extends DeviceBackend {
 
                     final String deviceId = r.getPayload().getId();
 
-                    final Promise<OperationResult<Void>> credPromise = Promise.promise();
-                    updateCredentials(tenantId, deviceId, List.of(certCredential), Optional.empty(), span, credPromise);
-                    return credPromise.future()
+                    return updateCredentials(tenantId, deviceId, List.of(certCredential), Optional.empty(), span)
                             .compose(v -> {
                                 if (v.isError()) {
                                     return deleteDevice(tenantId, deviceId, Optional.empty(), span)

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementService.java
@@ -20,8 +20,7 @@ import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 
 /**
  * A service for managing tenant information.
@@ -39,7 +38,7 @@ public interface TenantManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *              An implementation should log (error) events on this span and it may set tags and use this span as the
      *              parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>201 Created</em> if the tenant has been added successfully.</li>
@@ -49,7 +48,7 @@ public interface TenantManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/createTenant">
      *      Device Registry Management API - Create Tenant</a>
      */
-    void createTenant(Optional<String> tenantId, Tenant tenantObj, Span span, Handler<AsyncResult<OperationResult<Id>>> resultHandler);
+    Future<OperationResult<Id>> createTenant(Optional<String> tenantId, Tenant tenantObj, Span span);
 
     /**
      * Reads tenant configuration information for a tenant identifier.
@@ -58,7 +57,7 @@ public interface TenantManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation. The <em>status</em> will be
+     * @return A future indicating the outcome of the operation. The <em>status</em> will be
      *            <ul>
      *            <li><em>200 OK</em> if a tenant with the given ID is registered. The <em>payload</em> will contain the
      *            tenant's configuration information.</li>
@@ -68,7 +67,7 @@ public interface TenantManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/getTenant">
      *      Device Registry Management API - Get Tenant</a>
      */
-    void readTenant(String tenantId, Span span, Handler<AsyncResult<OperationResult<Tenant>>> resultHandler);
+    Future<OperationResult<Tenant>> readTenant(String tenantId, Span span);
 
     /**
      * Updates configuration information of a tenant.
@@ -79,7 +78,7 @@ public interface TenantManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *             An implementation should log (error) events on this span and it may set tags and use this span as the
      *             parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>204 No Content</em> if the tenant has been updated successfully.</li>
@@ -89,8 +88,8 @@ public interface TenantManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/updateTenant">
      *      Device Registry Management API - Update Tenant</a>
      */
-    void updateTenant(String tenantId, Tenant tenantObj, Optional<String> resourceVersion,
-            Span span, Handler<AsyncResult<OperationResult<Void>>> resultHandler);
+    Future<OperationResult<Void>> updateTenant(String tenantId, Tenant tenantObj, Optional<String> resourceVersion,
+            Span span);
 
     /**
      * Removes a tenant.
@@ -100,7 +99,7 @@ public interface TenantManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *              An implementation should log (error) events on this span and it may set tags and use this span as the
      *              parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>204 No Content</em> if the tenant has been removed successfully.</li>
@@ -110,5 +109,5 @@ public interface TenantManagementService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/deleteTenant">
      *      Device Registry Management API - Delete Tenant</a>
      */
-    void deleteTenant(String tenantId, Optional<String> resourceVersion, Span span, Handler<AsyncResult<Result<Void>>> resultHandler);
+    Future<Result<Void>> deleteTenant(String tenantId, Optional<String> resourceVersion, Span span);
 }

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantBackend.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantBackend.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Repository;
 import io.opentracing.Span;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Verticle;
 import io.vertx.core.json.JsonObject;
@@ -65,26 +66,27 @@ public final class FileBasedTenantBackend extends AbstractVerticle implements Te
     // Tenant management API
 
     @Override
-    public void createTenant(final Optional<String> tenantId, final Tenant tenantObj,
-            final Span span, final Handler<AsyncResult<OperationResult<Id>>> resultHandler) {
-        tenantService.createTenant(tenantId, tenantObj, span, resultHandler);
+    public Future<OperationResult<Id>> createTenant(final Optional<String> tenantId, final Tenant tenantObj,
+            final Span span) {
+        return tenantService.createTenant(tenantId, tenantObj, span);
     }
 
     @Override
-    public void readTenant(final String tenantId, final Span span, final Handler<AsyncResult<OperationResult<Tenant>>> resultHandler) {
-        tenantService.readTenant(tenantId, span, resultHandler);
+    public Future<OperationResult<Tenant>> readTenant(final String tenantId, final Span span) {
+        return tenantService.readTenant(tenantId, span);
     }
 
     @Override
-    public void updateTenant(final String tenantId, final Tenant tenantObj, final Optional<String> resourceVersion,
-            final Span span, final Handler<AsyncResult<OperationResult<Void>>> resultHandler) {
-        tenantService.updateTenant(tenantId, tenantObj, resourceVersion, span, resultHandler);
+    public Future<OperationResult<Void>> updateTenant(final String tenantId, final Tenant tenantObj,
+            final Optional<String> resourceVersion,
+            final Span span) {
+        return tenantService.updateTenant(tenantId, tenantObj, resourceVersion, span);
     }
 
     @Override
-    public void deleteTenant(final String tenantId, final Optional<String> resourceVersion, final Span span,
-            final Handler<AsyncResult<Result<Void>>> resultHandler) {
-        tenantService.deleteTenant(tenantId, resourceVersion, span, resultHandler);
+    public Future<Result<Void>> deleteTenant(final String tenantId, final Optional<String> resourceVersion,
+            final Span span) {
+        return tenantService.deleteTenant(tenantId, resourceVersion, span);
     }
 
     // Tenant AMQP API

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantService.java
@@ -275,12 +275,11 @@ public final class FileBasedTenantService extends AbstractVerticle implements Te
     }
 
     @Override
-    public void readTenant(final String tenantId, final Span span, final Handler<AsyncResult<OperationResult<Tenant>>> resultHandler) {
+    public Future<OperationResult<Tenant>> readTenant(final String tenantId, final Span span) {
 
         Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(resultHandler);
 
-        resultHandler.handle(Future.succeededFuture(getTenantResult(tenantId, span)));
+        return Future.succeededFuture(getTenantResult(tenantId, span));
     }
 
     OperationResult<Tenant> getTenantResult(final String tenantId, final Span span) {
@@ -345,14 +344,13 @@ public final class FileBasedTenantService extends AbstractVerticle implements Te
     }
 
     @Override
-    public void deleteTenant(final String tenantId, final Optional<String> resourceVersion, final Span span,
-            final Handler<AsyncResult<Result<Void>>> resultHandler) {
+    public Future<Result<Void>> deleteTenant(final String tenantId, final Optional<String> resourceVersion,
+            final Span span) {
 
         Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(resultHandler);
         Objects.requireNonNull(resourceVersion);
 
-        resultHandler.handle(Future.succeededFuture(removeTenant(tenantId, resourceVersion, span)));
+        return Future.succeededFuture(removeTenant(tenantId, resourceVersion, span));
     }
 
     Result<Void> removeTenant(final String tenantId, final Optional<String> resourceVersion, final Span span) {
@@ -381,15 +379,14 @@ public final class FileBasedTenantService extends AbstractVerticle implements Te
     }
 
     @Override
-    public void createTenant(final Optional<String> tenantId, final Tenant tenantSpec,
-            final Span span, final Handler<AsyncResult<OperationResult<Id>>> resultHandler) {
+    public Future<OperationResult<Id>> createTenant(final Optional<String> tenantId, final Tenant tenantSpec,
+            final Span span) {
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(tenantSpec);
-        Objects.requireNonNull(resultHandler);
 
         final String tenantIdValue = tenantId.orElseGet(this::generateTenantId);
-        resultHandler.handle(Future.succeededFuture(add(tenantIdValue, tenantSpec, span)));
+        return Future.succeededFuture(add(tenantIdValue, tenantSpec, span));
     }
 
     /**
@@ -440,18 +437,17 @@ public final class FileBasedTenantService extends AbstractVerticle implements Te
      * @param tenantId The tenant to update
      * @param tenantSpec The new tenant information
      * @param expectedResourceVersion The version identifier of the tenant information to update.
-     * @param resultHandler The handler receiving the result of the operation.
-     *
+     * @return A future indicating the outcome of the operation.
      * @throws NullPointerException if either of the input parameters is {@code null}.
      */
     @Override
-    public void updateTenant(final String tenantId, final Tenant tenantSpec, final Optional<String> expectedResourceVersion,
-            final Span span, final Handler<AsyncResult<OperationResult<Void>>> resultHandler) {
+    public Future<OperationResult<Void>> updateTenant(final String tenantId, final Tenant tenantSpec,
+            final Optional<String> expectedResourceVersion,
+            final Span span) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(tenantSpec);
-        Objects.requireNonNull(resultHandler);
 
-        resultHandler.handle(Future.succeededFuture(update(tenantId, tenantSpec, expectedResourceVersion, span)));
+        return Future.succeededFuture(update(tenantId, tenantSpec, expectedResourceVersion, span));
     }
 
     /**

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantServiceTest.java
@@ -335,8 +335,8 @@ public class FileBasedTenantServiceTest extends AbstractTenantServiceTest {
         svc.createTenant(
                 Optional.of("fancy-new-tenant"),
                 new Tenant(),
-                NoopSpan.INSTANCE,
-                ctx.succeeding(s -> {
+                NoopSpan.INSTANCE)
+                .setHandler(ctx.succeeding(s -> {
                     ctx.verify(() -> {
                         // THEN the request succeeds
                         assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_CREATED);
@@ -361,8 +361,8 @@ public class FileBasedTenantServiceTest extends AbstractTenantServiceTest {
         svc.deleteTenant(
                 "tenant",
                 Optional.empty(),
-                NoopSpan.INSTANCE,
-                ctx.succeeding(s -> {
+                NoopSpan.INSTANCE)
+                .setHandler(ctx.succeeding(s -> {
                     ctx.verify(() -> {
                         // THEN the update fails
                         assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
@@ -388,8 +388,8 @@ public class FileBasedTenantServiceTest extends AbstractTenantServiceTest {
                 "tenant",
                 new Tenant(),
                 null,
-                NoopSpan.INSTANCE,
-                ctx.succeeding(s -> {
+                NoopSpan.INSTANCE)
+                .setHandler(ctx.succeeding(s -> {
                     ctx.verify(() -> {
                         // THEN the update fails
                         assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);


### PR DESCRIPTION
In this PR, the `TenantManagementService` is refactored to return _vertx_ futures and also the related classes have been adapted. This should to be merged after PR #1815.