### PR TITLE
[#1802] Refactor tenant service

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/AbstractTenantAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/AbstractTenantAmqpEndpoint.java
@@ -26,12 +26,10 @@ import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TenantConstants;
-import org.eclipse.hono.util.TenantResult;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
@@ -142,9 +140,8 @@ public abstract class AbstractTenantAmqpEndpoint extends AbstractRequestResponse
     private Future<Message> processGetByIdRequest(final Message request, final String tenantId,
             final Span span) {
 
-        final Promise<TenantResult<JsonObject>> getResult = Promise.promise();
-        getService().get(tenantId, span, getResult);
-        return getResult.future().map(tr -> TenantConstants.getAmqpReply(TenantConstants.TENANT_ENDPOINT, tenantId, request, tr));
+        return getService().get(tenantId, span)
+                .map(tr -> TenantConstants.getAmqpReply(TenantConstants.TENANT_ENDPOINT, tenantId, request, tr));
     }
 
     private Future<Message> processGetByCaRequest(final Message request, final String subjectDn,
@@ -153,9 +150,7 @@ public abstract class AbstractTenantAmqpEndpoint extends AbstractRequestResponse
         try {
             final X500Principal dn = new X500Principal(subjectDn);
             log.debug("retrieving tenant [subject DN: {}]", subjectDn);
-            final Promise<TenantResult<JsonObject>> getResult = Promise.promise();
-            getService().get(dn, span, getResult);
-            return getResult.future().map(tr -> {
+            return getService().get(dn, span).map(tr -> {
                 String tenantId = null;
                 if (tr.isOk() && tr.getPayload() != null) {
                     tenantId = getTypesafeValueForField(String.class, tr.getPayload(),

--- a/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tenant/TenantService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,9 +18,9 @@ import javax.security.auth.x500.X500Principal;
 import org.eclipse.hono.util.TenantResult;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+
 
 /**
  * A service for keeping record of tenant information.
@@ -34,7 +34,7 @@ public interface TenantService {
      * Gets tenant configuration information for a tenant identifier.
      *
      * @param tenantId The identifier of the tenant.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>200 OK</em> if a tenant with the given ID is registered.
@@ -45,18 +45,18 @@ public interface TenantService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/tenant/#get-tenant-information">
      *      Tenant API - Get Tenant Information</a>
      */
-    void get(String tenantId, Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler);
+    Future<TenantResult<JsonObject>> get(String tenantId);
 
     /**
      * Gets tenant configuration information for a tenant identifier.
      * <p>
-     * This default implementation simply returns the result of {@link #get(String, Handler)}.
+     * This default implementation simply returns the result of {@link #get(String)}.
      *
      * @param tenantId The identifier of the tenant.
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>200 OK</em> if a tenant with the given ID is registered.
@@ -67,9 +67,8 @@ public interface TenantService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/tenant/#get-tenant-information">
      *      Tenant API - Get Tenant Information</a>
      */
-    default void get(final String tenantId, final Span span,
-            final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
-        get(tenantId, resultHandler);
+    default Future<TenantResult<JsonObject>> get(final String tenantId, final Span span) {
+        return get(tenantId);
     }
 
     /**
@@ -82,7 +81,7 @@ public interface TenantService {
      *
      * @param subjectDn The <em>subject DN</em> of the trusted CA certificate
      *                  that has been configured for the tenant.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>200 OK</em> if a tenant with a matching trusted certificate authority exists.
@@ -93,7 +92,7 @@ public interface TenantService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/tenant/#get-tenant-information">
      *      Tenant API - Get Tenant Information</a>
      */
-    void get(X500Principal subjectDn, Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler);
+    Future<TenantResult<JsonObject>> get(X500Principal subjectDn);
 
     /**
      * Gets tenant configuration information for a <em>subject DN</em>
@@ -103,14 +102,14 @@ public interface TenantService {
      * an X.509 client certificate. Using this method, the <em>issuer DN</em> from the
      * client's certificate can be used to determine the tenant that the device belongs to.
      * <p>
-     * This default implementation simply returns the result of {@link #get(X500Principal, Handler)}.
+     * This default implementation simply returns the result of {@link #get(X500Principal)}.
      * 
      * @param subjectDn The <em>subject DN</em> of the trusted CA certificate
      *                  that has been configured for the tenant.
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be
      *             <ul>
      *             <li><em>200 OK</em> if a tenant with a matching trusted certificate authority exists.
@@ -121,8 +120,7 @@ public interface TenantService {
      * @see <a href="https://www.eclipse.org/hono/docs/api/tenant/#get-tenant-information">
      *      Tenant API - Get Tenant Information</a>
      */
-    default void get(final X500Principal subjectDn, final Span span,
-            final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
-        get(subjectDn, resultHandler);
+    default Future<TenantResult<JsonObject>> get(final X500Principal subjectDn, final Span span) {
+        return get(subjectDn);
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/DummyTenantService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/DummyTenantService.java
@@ -25,9 +25,7 @@ import org.springframework.stereotype.Service;
 
 import io.opentracing.Span;
 import io.opentracing.noop.NoopSpan;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -39,23 +37,20 @@ import io.vertx.core.json.JsonObject;
 public class DummyTenantService implements TenantService {
 
     @Override
-    public void get(final String tenantId, final Span span,
-            final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
+    public Future<TenantResult<JsonObject>> get(final String tenantId, final Span span) {
         final TenantObject tenant = new TenantObject();
         tenant.setTenantId(tenantId);
         tenant.setEnabled(true);
-        resultHandler.handle(Future.succeededFuture(TenantResult.from(HttpURLConnection.HTTP_OK,
-                JsonObject.mapFrom(tenant),
-                null)));
+        return Future.succeededFuture(TenantResult.from(HttpURLConnection.HTTP_OK, JsonObject.mapFrom(tenant), null));
     }
 
     @Override
-    public void get(final String tenantId, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
-        get(tenantId, NoopSpan.INSTANCE, resultHandler);
+    public Future<TenantResult<JsonObject>> get(final String tenantId) {
+        return get(tenantId, NoopSpan.INSTANCE);
     }
 
     @Override
-    public void get(final X500Principal subjectDn, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
-        get(subjectDn, NoopSpan.INSTANCE, resultHandler);
+    public Future<TenantResult<JsonObject>> get(final X500Principal subjectDn) {
+        return get(subjectDn, NoopSpan.INSTANCE);
     }
 }

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantBackend.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantBackend.java
@@ -30,9 +30,7 @@ import org.springframework.stereotype.Repository;
 
 import io.opentracing.Span;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Verticle;
 import io.vertx.core.json.JsonObject;
 
@@ -92,12 +90,12 @@ public final class FileBasedTenantBackend extends AbstractVerticle implements Te
     // Tenant AMQP API
 
     @Override
-    public void get(final String tenantId, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
-        tenantService.get(tenantId, resultHandler);
+    public Future<TenantResult<JsonObject>> get(final String tenantId) {
+        return tenantService.get(tenantId);
     }
 
     @Override
-    public void get(final X500Principal subjectDn, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
-        tenantService.get(subjectDn, resultHandler);
+    public Future<TenantResult<JsonObject>> get(final X500Principal subjectDn) {
+        return tenantService.get(subjectDn);
     }
 }

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantService.java
@@ -48,9 +48,7 @@ import org.springframework.stereotype.Component;
 
 import io.opentracing.Span;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
@@ -256,22 +254,21 @@ public final class FileBasedTenantService extends AbstractVerticle implements Te
     }
 
     @Override
-    public void get(final String tenantId, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
-        get(tenantId, null, resultHandler);
+    public Future<TenantResult<JsonObject>> get(final String tenantId) {
+        return get(tenantId, null);
     }
 
     @Override
-    public void get(final String tenantId, final Span span, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
-        resultHandler.handle(Future.succeededFuture(getTenantObjectResult(tenantId, span)));
+    public Future<TenantResult<JsonObject>> get(final String tenantId, final Span span) {
+        return Future.succeededFuture(getTenantObjectResult(tenantId, span));
     }
 
     @Override
-    public void get(final X500Principal subjectDn, final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
+    public Future<TenantResult<JsonObject>> get(final X500Principal subjectDn) {
 
         Objects.requireNonNull(subjectDn);
-        Objects.requireNonNull(resultHandler);
 
-        resultHandler.handle(Future.succeededFuture(getForCertificateAuthority(subjectDn, null)));
+        return Future.succeededFuture(getForCertificateAuthority(subjectDn, null));
     }
 
     @Override
@@ -314,13 +311,11 @@ public final class FileBasedTenantService extends AbstractVerticle implements Te
     }
 
     @Override
-    public void get(final X500Principal subjectDn, final Span span,
-            final Handler<AsyncResult<TenantResult<JsonObject>>> resultHandler) {
+    public Future<TenantResult<JsonObject>> get(final X500Principal subjectDn, final Span span) {
 
         Objects.requireNonNull(subjectDn);
-        Objects.requireNonNull(resultHandler);
 
-        resultHandler.handle(Future.succeededFuture(getForCertificateAuthority(subjectDn, span)));
+        return Future.succeededFuture(getForCertificateAuthority(subjectDn, span));
     }
 
     private TenantResult<JsonObject> getForCertificateAuthority(final X500Principal subjectDn, final Span span) {


### PR DESCRIPTION
In this PR, the `TenantService` is refactored to return _vertx_ futures and also the related classes have been adapted. This should to be merged after PR #1816.