### PR TITLE
[#1823] Calculate payload size of the incoming message based on the configured minimum message size

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -54,6 +54,7 @@ import org.eclipse.hono.service.limiting.ConnectionLimitManager;
 import org.eclipse.hono.service.monitoring.ConnectionEventProducer;
 import org.eclipse.hono.service.resourcelimits.NoopResourceLimitChecks;
 import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
+import org.eclipse.hono.service.util.ServiceBaseUtils;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
@@ -621,7 +622,10 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
         Objects.requireNonNull(tenantConfig);
 
-        return resourceLimitChecks.isMessageLimitReached(tenantConfig, payloadSize, spanContext)
+        return resourceLimitChecks
+                .isMessageLimitReached(tenantConfig,
+                        ServiceBaseUtils.calculatePayloadSize(payloadSize, tenantConfig),
+                        spanContext)
                 .recover(t -> Future.succeededFuture(Boolean.FALSE))
                 .compose(isExceeded -> {
                     if (isExceeded) {

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
 import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
+import org.eclipse.hono.service.util.ServiceBaseUtils;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.TenantObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -227,7 +228,7 @@ public class MicrometerBasedMetrics implements Metrics {
             .minimumExpectedValue(0L)
             .tags(tags)
             .register(this.registry)
-            .record(calculatePayloadSize(payloadSize, tenantObject));
+            .record(ServiceBaseUtils.calculatePayloadSize(payloadSize, tenantObject));
 
         updateLastSeenTimestamp(tenantId);
     }
@@ -262,7 +263,7 @@ public class MicrometerBasedMetrics implements Metrics {
             .minimumExpectedValue(0L)
             .tags(tags)
             .register(this.registry)
-            .record(calculatePayloadSize(payloadSize, tenantObject));
+            .record(ServiceBaseUtils.calculatePayloadSize(payloadSize, tenantObject));
 
         updateLastSeenTimestamp(tenantId);
     }
@@ -309,39 +310,6 @@ public class MicrometerBasedMetrics implements Metrics {
             final Supplier<V> instanceSupplier) {
 
         return gaugeForKey(name, map, tenant, Tags.of(MetricsTags.getTenantTag(tenant)), instanceSupplier);
-    }
-
-    /**
-     * Calculates the payload size based on the configured minimum message size.
-     * <p>
-     * If no minimum message size is configured for a tenant then the actual
-     * payload size of the message is returned.
-     * <p>
-     * Example: The minimum message size for a tenant is configured as 4096 bytes (4KB).
-     * So the payload size of a message of size 1KB is calculated as 4KB and for
-     * message of size 10KB is calculated as 12KB.
-     *
-     * @param payloadSize The size of the message payload in bytes.
-     * @param tenantObject The TenantObject.
-     *
-     * @return The calculated payload size.
-     */
-    protected final int calculatePayloadSize(final int payloadSize, final TenantObject tenantObject) {
-
-        if (tenantObject == null) {
-            return payloadSize;
-        }
-
-        final int minimumMessageSize = tenantObject.getMinimumMessageSize();
-        if (minimumMessageSize > 0 && payloadSize > 0) {
-            final int modValue = payloadSize % minimumMessageSize;
-            if (modValue == 0) {
-                return payloadSize;
-            } else {
-                return payloadSize + (minimumMessageSize - modValue);
-            }
-        }
-        return payloadSize;
     }
 
     // visible for testing

--- a/service-base/src/main/java/org/eclipse/hono/service/util/ServiceBaseUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/util/ServiceBaseUtils.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.util;
+
+import org.eclipse.hono.util.TenantObject;
+
+/**
+ * A class offering utility methods for the service base classes.
+ */
+public final class ServiceBaseUtils {
+
+    private ServiceBaseUtils() {
+        // prevents instantiation
+    }
+
+    /**
+     * Calculates the payload size based on the configured minimum message size.
+     * <p>
+     * If no minimum message size is configured for a tenant then the actual
+     * payload size of the message is returned.
+     * <p>
+     * Example: The minimum message size for a tenant is configured as 4096 bytes (4KB).
+     * So the payload size of a message of size 1KB is calculated as 4KB and for
+     * message of size 10KB is calculated as 12KB.
+     *
+     * @param payloadSize The size of the message payload in bytes.
+     * @param tenantObject The TenantObject.
+     *
+     * @return The calculated payload size.
+     */
+    public static long calculatePayloadSize(final long payloadSize, final TenantObject tenantObject) {
+
+        if (tenantObject == null) {
+            return payloadSize;
+        }
+
+        final long minimumMessageSize = tenantObject.getMinimumMessageSize();
+        if (minimumMessageSize > 0 && payloadSize > 0) {
+            final long modValue = payloadSize % minimumMessageSize;
+            if (modValue == 0) {
+                return payloadSize;
+            } else {
+                return payloadSize + (minimumMessageSize - modValue);
+            }
+        }
+        return payloadSize;
+    }
+}


### PR DESCRIPTION
This fixes the issue #1823 