### PR TITLE
[#1802] Refactor device connection service

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DeviceConnectionService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DeviceConnectionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,8 +16,7 @@ package org.eclipse.hono.service.deviceconnection;
 import org.eclipse.hono.util.DeviceConnectionResult;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 
 /**
  * A service for keeping record of device connection information.
@@ -38,15 +37,15 @@ public interface DeviceConnectionService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *             The <em>status</em> will be <em>204 No Content</em> if the operation completed successfully.
      *             <br>
      *             An implementation may return a <em>404 Not Found</em> status in order to indicate that 
      *             no device and/or gateway with the given identifier exists for the given tenant.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    void setLastKnownGatewayForDevice(String tenantId, String deviceId, String gatewayId, Span span,
-            Handler<AsyncResult<DeviceConnectionResult>> resultHandler);
+    Future<DeviceConnectionResult> setLastKnownGatewayForDevice(String tenantId, String deviceId, String gatewayId,
+            Span span);
 
     /**
      * Gets the gateway that last acted on behalf of the given device.
@@ -59,7 +58,7 @@ public interface DeviceConnectionService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
      *            implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @param resultHandler The handler to invoke with the result of the operation.
+     * @return A future indicating the outcome of the operation.
      *            The <em>status</em> will be
      *            <ul>
      *            <li><em>200 OK</em> if a result could be determined. The <em>payload</em>
@@ -70,6 +69,5 @@ public interface DeviceConnectionService {
      *            no device with the given identifier exists for the given tenant.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    void getLastKnownGatewayForDevice(String tenantId, String deviceId, Span span,
-            Handler<AsyncResult<DeviceConnectionResult>> resultHandler);
+    Future<DeviceConnectionResult> getLastKnownGatewayForDevice(String tenantId, String deviceId, Span span);
 }

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
@@ -25,8 +25,7 @@ import org.eclipse.hono.service.deviceconnection.EventBusDeviceConnectionAdapter
 import org.eclipse.hono.util.DeviceConnectionResult;
 
 import io.opentracing.Span;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 
 
@@ -52,32 +51,28 @@ public class RemoteCacheBasedDeviceConnectionService extends EventBusDeviceConne
      * {@inheritDoc}
      */
     @Override
-    public void setLastKnownGatewayForDevice(
+    public Future<DeviceConnectionResult> setLastKnownGatewayForDevice(
             final String tenantId,
             final String deviceId,
             final String gatewayId,
-            final Span span,
-            final Handler<AsyncResult<DeviceConnectionResult>> resultHandler) {
+            final Span span) {
 
-        cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, span.context())
-            .map(ok -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
-            .setHandler(resultHandler);
+        return cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, span.context())
+                .map(ok -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void getLastKnownGatewayForDevice(
+    public Future<DeviceConnectionResult> getLastKnownGatewayForDevice(
             final String tenantId,
             final String deviceId,
-            final Span span,
-            final Handler<AsyncResult<DeviceConnectionResult>> resultHandler) {
+            final Span span) {
 
-        cache.getLastKnownGatewayForDevice(tenantId, deviceId, span.context())
-            .map(json -> DeviceConnectionResult.from(HttpURLConnection.HTTP_OK, json))
-            .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)))
-            .setHandler(resultHandler);
+        return cache.getLastKnownGatewayForDevice(tenantId, deviceId, span.context())
+                .map(json -> DeviceConnectionResult.from(HttpURLConnection.HTTP_OK, json))
+                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
 
     /**

--- a/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionServiceTest.java
+++ b/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionServiceTest.java
@@ -27,7 +27,6 @@ import java.net.HttpURLConnection;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
 import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.DeviceConnectionResult;
 import org.infinispan.client.hotrod.RemoteCacheContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -107,11 +106,7 @@ public class RemoteCacheBasedDeviceConnectionServiceTest {
             .thenReturn(Future.succeededFuture());
 
         givenAStartedService()
-        .compose(ok -> {
-            final Promise<DeviceConnectionResult> setLastGwResult = Promise.promise();
-            svc.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, span, setLastGwResult);
-            return setLastGwResult.future();
-        })
+        .compose(ok -> svc.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, span))
         .setHandler(ctx.succeeding(result -> {
             ctx.verify(() -> {
                 assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
@@ -135,11 +130,7 @@ public class RemoteCacheBasedDeviceConnectionServiceTest {
             .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
 
         givenAStartedService()
-        .compose(ok -> {
-            final Promise<DeviceConnectionResult> getLastGwResult = Promise.promise();
-            svc.getLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, span, getLastGwResult);
-            return getLastGwResult.future();
-        })
+        .compose(ok -> svc.getLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, span))
         .setHandler(ctx.succeeding(deviceConnectionResult -> {
             ctx.verify(() -> {
                 assertThat(deviceConnectionResult.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionService.java
@@ -33,9 +33,7 @@ import org.springframework.stereotype.Repository;
 
 import io.opentracing.Span;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -62,8 +60,8 @@ public final class MapBasedDeviceConnectionService extends AbstractVerticle impl
     }
 
     @Override
-    public void setLastKnownGatewayForDevice(final String tenantId, final String deviceId, final String gatewayId,
-            final Span span, final Handler<AsyncResult<DeviceConnectionResult>> resultHandler) {
+    public Future<DeviceConnectionResult> setLastKnownGatewayForDevice(final String tenantId, final String deviceId,
+            final String gatewayId, final Span span) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(gatewayId);
@@ -83,12 +81,12 @@ public final class MapBasedDeviceConnectionService extends AbstractVerticle impl
                     deviceId, tenantId, getConfig().getMaxDevicesPerTenant());
             result = DeviceConnectionResult.from(HttpURLConnection.HTTP_FORBIDDEN);
         }
-        resultHandler.handle(Future.succeededFuture(result));
+        return Future.succeededFuture(result);
     }
 
     @Override
-    public void getLastKnownGatewayForDevice(final String tenantId, final String deviceId, final Span span,
-            final Handler<AsyncResult<DeviceConnectionResult>> resultHandler) {
+    public Future<DeviceConnectionResult> getLastKnownGatewayForDevice(final String tenantId, final String deviceId,
+            final Span span) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
 
@@ -104,7 +102,7 @@ public final class MapBasedDeviceConnectionService extends AbstractVerticle impl
         } else {
             result = DeviceConnectionResult.from(HttpURLConnection.HTTP_NOT_FOUND);
         }
-        resultHandler.handle(Future.succeededFuture(result));
+        return Future.succeededFuture(result);
     }
 
     private JsonObject createLastKnownGatewayJson(final String gatewayId) {

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -13,11 +13,14 @@ title = "Release Notes"
 
 ### API Changes
 
- * The device registry credentials endpoint will no longer handout sensitive details for hashed-password secrets.
-   `pwd-hash`, `salt` and `hash-function` are stored by the device registry but not returned to the user.
-   Each secret is given an ID which is now returned, along with the other metadata (time validity and optional fields).
+* The device registry credentials endpoint will no longer handout sensitive details for hashed-password secrets.
+  `pwd-hash`, `salt` and `hash-function` are stored by the device registry but not returned to the user.
+  Each secret is given an ID which is now returned, along with the other metadata (time validity and optional fields).
 * The `tenant` and `devices` endpoints of the management HTTP API now accept creation requests without a body.
-    As there is no mandatory field, having a mandatory body was confusing. 
+  As there is no mandatory field, having a mandatory body was confusing. 
+* The methods of the service base classes `CredentialsManagementService`, `CredentialsService`,
+  `DeviceConnectionService`, `DeviceManagementService`, `RegistrationService`, `TenantManagementService` and 
+  `TenantService` have been refactored to now return a Vert.x Future instead of taking a Handler as an argument.
 
 ## 1.1.1
 


### PR DESCRIPTION
In this PR, the `DeviceConnectionService` is refactored to return _vertx_ future and also the related classes have been adapted. Also the release notes has been updated for #1802.