### PR TITLE
[#1272] Implement new Device Connection API methods

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -546,6 +546,12 @@
         <version>${infinispan.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-query-dsl</artifactId>
+        <version>${infinispan.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${jackson.version}</version>

--- a/client-device-connection-infinispan/pom.xml
+++ b/client-device-connection-infinispan/pom.xml
@@ -23,6 +23,12 @@
       <artifactId>infinispan-client-hotrod</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-query-dsl</artifactId>
+      <!-- This is currently only needed to mock a RemoteCache instance in a test. -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
     </dependency>
@@ -45,10 +51,17 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -57,14 +70,17 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
+import java.util.Set;
+
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
@@ -33,7 +35,7 @@ public interface DeviceConnectionInfo {
      * @param deviceId The device identifier.
      * @param gatewayId The gateway identifier. This may be the same as the device identifier if the device is
      *                  (currently) not connected via a gateway but directly to a protocol adapter.
-     * @param context The currently active OpenTracing span or {@code null} if no span is currently active.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            Implementing classes should use this as the parent for any span they create for tracing
      *            the execution of this operation.
      * @return A future indicating the outcome of the operation.
@@ -52,7 +54,7 @@ public interface DeviceConnectionInfo {
      *
      * @param tenant The tenant that the device belongs to.
      * @param deviceId The device identifier.
-     * @param context The currently active OpenTracing span or {@code null} if no span is currently active.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            Implementing classes should use this as the parent for any span they create for tracing
      *            the execution of this operation.
      * @return A future indicating the outcome of the operation.
@@ -64,4 +66,63 @@ public interface DeviceConnectionInfo {
      * @throws NullPointerException if tenant or device id are {@code null}.
      */
     Future<JsonObject> getLastKnownGatewayForDevice(String tenant, String deviceId, SpanContext context);
+
+    /**
+     * Sets the protocol adapter instance that handles commands for the given device or gateway.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id.
+     * @param adapterInstanceId The protocol adapter instance id.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            Implementing classes should use this as the parent for any span they create for tracing
+     *            the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the device connection information has been updated.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters except context is {@code null}.
+     */
+    Future<Void> setCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId, SpanContext context);
+
+    /**
+     * Removes the mapping information that associates the given device with the given protocol adapter instance
+     * that handles commands for the given device. The mapping entry is only deleted if its value
+     * contains the given protocol adapter instance id.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id.
+     * @param adapterInstanceId The protocol adapter instance id that the entry to be removed has to contain.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            Implementing classes should use this as the parent for any span they create for tracing
+     *            the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the entry was successfully removed.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters except context is {@code null}.
+     */
+    Future<Void> removeCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId, SpanContext context);
+
+    /**
+     * Gets information about the adapter instances that can handle a command for the given device.
+     * <p>
+     * See Hono's <a href="https://www.eclipse.org/hono/docs/api/device-connection/">Device Connection API
+     * specification</a> for a detailed description of the method's behaviour and the returned JSON object.
+     * <p>
+     * If no adapter instances are found, the returned future is failed.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id.
+     * @param viaGateways The set of gateways that may act on behalf of the given device.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            Implementing classes should use this as the parent for any span they create for tracing
+     *            the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         If instances were found, the future will be succeeded with a JSON object containing one or more mappings
+     *         from device id to adapter instance id.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters except context is {@code null}.
+     */
+    Future<JsonObject> getCommandHandlingAdapterInstances(String tenantId, String deviceId, Set<String> viaGateways, SpanContext context);
 }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClient.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionClient.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -118,24 +119,18 @@ public final class HotrodBasedDeviceConnectionClient implements DeviceConnection
     @Override
     public Future<Void> setCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
             final SpanContext context) {
-        // TODO use this:
-//        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, context);
-        return Future.failedFuture("not implemented yet");
+        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, context);
     }
 
     @Override
     public Future<Void> removeCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
             final SpanContext context) {
-        // TODO use this:
-//        return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, context);
-        return Future.failedFuture("not implemented yet");
+        return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, context);
     }
 
     @Override
     public Future<JsonObject> getCommandHandlingAdapterInstances(final String deviceId, final List<String> viaGateways,
             final SpanContext context) {
-        // TODO use this:
-//        return cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), context);
-        return Future.failedFuture("not implemented yet");
+        return cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), context);
     }
 }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfo.java
@@ -15,7 +15,12 @@
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServerErrorException;
@@ -28,6 +33,7 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.healthchecks.Status;
@@ -40,7 +46,25 @@ import io.vertx.ext.healthchecks.Status;
  */
 public final class HotrodBasedDeviceConnectionInfo implements DeviceConnectionInfo, HealthCheckProvider {
 
+    /**
+     * For <em>viaGateways</em> parameter value lower or equal to this value, the {@link #getCommandHandlingAdapterInstances(String, String, Set, SpanContext)}
+     * method will use an optimized approach, potentially saving additional cache requests.
+     */
+    static final int VIA_GATEWAYS_OPTIMIZATION_THRESHOLD = 3;
+
     private static final Logger LOG = LoggerFactory.getLogger(HotrodBasedDeviceConnectionInfo.class);
+
+    /**
+     * Prefix for cache entries having gateway id values, concerning <em>lastKnownGatewayForDevice</em>
+     * operations.
+     */
+    private static final String KEY_PREFIX_GATEWAY_ENTRIES_VALUE = "gw";
+    /**
+     * Prefix for cache entries having protocol adapter instance id values, concerning
+     * <em>commandHandlingAdapterInstance</em> operations.
+     */
+    private static final String KEY_PREFIX_ADAPTER_INSTANCE_VALUES = "ai";
+    private static final String KEY_SEPARATOR = "@@";
 
     final RemoteCache<String, String> cache;
     final Tracer tracer;
@@ -57,24 +81,19 @@ public final class HotrodBasedDeviceConnectionInfo implements DeviceConnectionIn
         this.tracer = Objects.requireNonNull(tracer);
     }
 
-    private static String getKey(final String tenantId, final String deviceId) {
-        return String.format("%s@@%s", tenantId, deviceId);
-    }
-
-
-    private static JsonObject getResult(final String gatewayId) {
-        return new JsonObject().put(DeviceConnectionConstants.FIELD_GATEWAY_ID, gatewayId);
-    }
-
     /**
      * {@inheritDoc}
      * 
      * If this method is invoked from a vert.x Context, then the returned future will be completed on that context.
      */
     @Override
-    public Future<Void> setLastKnownGatewayForDevice(final String tenantId, final String deviceId, final String gatewayId, final SpanContext context) {
+    public Future<Void> setLastKnownGatewayForDevice(final String tenantId, final String deviceId,
+            final String gatewayId, final SpanContext context) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(gatewayId);
 
-        return cache.put(getKey(tenantId, deviceId), gatewayId)
+        return cache.put(getGatewayEntryKey(tenantId, deviceId), gatewayId)
             .map(replacedValue -> {
                 LOG.debug("set last known gateway [tenant: {}, device-id: {}, gateway: {}]", tenantId, deviceId,
                         gatewayId);
@@ -91,9 +110,12 @@ public final class HotrodBasedDeviceConnectionInfo implements DeviceConnectionIn
      * {@inheritDoc}
      */
     @Override
-    public Future<JsonObject> getLastKnownGatewayForDevice(final String tenantId, final String deviceId, final SpanContext context) {
+    public Future<JsonObject> getLastKnownGatewayForDevice(final String tenantId, final String deviceId,
+            final SpanContext context) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
 
-        return cache.get(getKey(tenantId, deviceId))
+        return cache.get(getGatewayEntryKey(tenantId, deviceId))
                 .compose(gatewayId -> {
                     if (gatewayId == null) {
                         LOG.debug("could not find last known gateway for device [tenant: {}, device-id: {}]", tenantId,
@@ -102,7 +124,7 @@ public final class HotrodBasedDeviceConnectionInfo implements DeviceConnectionIn
                     } else {
                         LOG.debug("found last known gateway for device [tenant: {}, device-id: {}]: {}", tenantId,
                                 deviceId, gatewayId);
-                        return Future.succeededFuture(getResult(gatewayId));
+                        return Future.succeededFuture(getLastKnownGatewayResultJson(gatewayId));
                     }
                 })
                 .recover(t -> {
@@ -110,6 +132,284 @@ public final class HotrodBasedDeviceConnectionInfo implements DeviceConnectionIn
                             tenantId, deviceId, t);
                     return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, t));
                 });
+    }
+
+    @Override
+    public Future<Void> setCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
+            final String adapterInstanceId, final SpanContext context) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(adapterInstanceId);
+
+        return cache.put(getAdapterInstanceEntryKey(tenantId, deviceId), adapterInstanceId)
+                .map(replacedValue -> {
+                    LOG.debug("set command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}]",
+                            tenantId, deviceId, adapterInstanceId);
+                    return (Void) null;
+                })
+                .recover(t -> {
+                    LOG.debug("failed to set command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}]",
+                            tenantId, deviceId, adapterInstanceId, t);
+                    return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, t));
+                });
+    }
+
+    @Override
+    public Future<Void> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
+            final String adapterInstanceId, final SpanContext context) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(adapterInstanceId);
+
+        final String key = getAdapterInstanceEntryKey(tenantId, deviceId);
+        return cache.getWithVersion(key)
+               .recover(t -> {
+                    LOG.debug("failed to get cache entry when trying to remove command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}]",
+                            tenantId, deviceId, adapterInstanceId, t);
+                    return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, t));
+                }).compose(versioned -> {
+                    if (versioned == null) {
+                        LOG.debug("command handling adapter instance was not removed, entry not found [tenant: {}, device-id: {}, adapter-instance: {}]",
+                                tenantId, deviceId, adapterInstanceId);
+                        return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                    }
+                    if (!adapterInstanceId.equals(versioned.getValue())) {
+                        LOG.debug("command handling adapter instance was not removed, value '{}' didn't match [tenant: {}, device-id: {}, adapter-instance: {}]",
+                                versioned.getValue(), tenantId, deviceId, adapterInstanceId);
+                        return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED));
+                    }
+                    return cache.removeWithVersion(key, versioned.getVersion())
+                            .recover(t -> {
+                                LOG.debug("failed to remove command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}]", tenantId, deviceId,
+                                        adapterInstanceId, t);
+                                return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, t));
+                            }).compose(removed -> {
+                                if (removed) {
+                                    LOG.debug("removed command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}]",
+                                            tenantId, deviceId, adapterInstanceId);
+                                    return Future.succeededFuture();
+                                } else {
+                                    LOG.debug("command handling adapter instance was not removed, has been updated in the meantime [tenant: {}, device-id: {}, adapter-instance: {}]",
+                                            tenantId, deviceId, adapterInstanceId);
+                                    return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED));
+                                }
+                            });
+                });
+    }
+
+    @Override
+    public Future<JsonObject> getCommandHandlingAdapterInstances(final String tenantId, final String deviceId,
+            final Set<String> viaGateways, final SpanContext context) {
+
+        if (viaGateways.isEmpty()) {
+             // get the command handling adapter instance for the device (no gateway involved)
+            return cache.get(getAdapterInstanceEntryKey(tenantId, deviceId))
+                    .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t))
+                    .compose(adapterInstanceId -> {
+                        if (adapterInstanceId == null) {
+                            LOG.debug("no command handling adapter instances found [tenant: {}, device-id: {}]",
+                                    tenantId, deviceId);
+                            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                        } else {
+                            LOG.debug("found command handling adapter instance '{}' [tenant: {}, device-id: {}]",
+                                    adapterInstanceId, tenantId, deviceId);
+                            return Future.succeededFuture(getAdapterInstancesResultJson(deviceId, adapterInstanceId));
+                        }
+                    });
+        } else if (viaGateways.size() <= VIA_GATEWAYS_OPTIMIZATION_THRESHOLD) {
+            return getInstancesQueryingAllGatewaysFirst(tenantId, deviceId, viaGateways);
+        } else {
+            // number of viaGateways is more than threshold value - reduce cache accesses by not checking *all* viaGateways,
+            // instead trying the last known gateway first
+            return getInstancesGettingLastKnownGatewayFirst(tenantId, deviceId, viaGateways);
+        }
+    }
+
+    private Future<JsonObject> getInstancesQueryingAllGatewaysFirst(final String tenantId, final String deviceId, final Set<String> viaGateways) {
+        // get the command handling adapter instances for the device and *all* via-gateways in one call first
+        // (this saves the extra lastKnownGateway check if only one adapter instance is returned)
+        return cache.getAll(getAdapterInstanceEntryKeys(tenantId, deviceId, viaGateways))
+                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t))
+                .compose(getAllMap -> {
+                    final Map<String, String> deviceToInstanceMap = convertAdapterInstanceEntryKeys(getAllMap);
+                    final Future<JsonObject> resultFuture;
+                    if (deviceToInstanceMap.isEmpty()) {
+                        LOG.debug("no command handling adapter instances found [tenant: {}, device-id: {}]",
+                                tenantId, deviceId);
+                        resultFuture = Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                    } else if (deviceToInstanceMap.containsKey(deviceId)) {
+                        // there is a adapter instance set for the device itself - that gets precedence
+                        resultFuture = getAdapterInstanceFoundForDeviceItselfResult(tenantId, deviceId, deviceToInstanceMap.get(deviceId));
+                    } else if (deviceToInstanceMap.size() > 1) {
+                        // multiple gateways found - check last known gateway
+                        resultFuture = cache.get(getGatewayEntryKey(tenantId, deviceId))
+                                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t))
+                                .compose(lastKnownGateway -> {
+                                    if (lastKnownGateway == null) {
+                                        // no last known gateway found - just return all found mapping entries
+                                        LOG.debug("returning {} command handling adapter instances for device gateways (no last known gateway found) [tenant: {}, device-id: {}]",
+                                                deviceToInstanceMap.size(), tenantId, deviceId);
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                                    } else if (!viaGateways.contains(lastKnownGateway)) {
+                                        // found gateway is not valid anymore - just return all found mapping entries
+                                        LOG.debug("returning {} command handling adapter instances for device gateways (last known gateway not valid anymore) [tenant: {}, device-id: {}, lastKnownGateway: {}]",
+                                                deviceToInstanceMap.size(), tenantId, deviceId, lastKnownGateway);
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                                    } else if (!deviceToInstanceMap.containsKey(lastKnownGateway)) {
+                                        // found gateway has no command handling instance assigned - just return all found mapping entries
+                                        LOG.debug("returning {} command handling adapter instances for device gateways (last known gateway not in that list) [tenant: {}, device-id: {}, lastKnownGateway: {}]",
+                                                deviceToInstanceMap.size(), tenantId, deviceId, lastKnownGateway);
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                                    } else {
+                                        LOG.debug("returning command handling adapter instance {} for last known gateway [tenant: {}, device-id: {}, lastKnownGateway: {}]",
+                                                deviceToInstanceMap.get(lastKnownGateway), tenantId, deviceId, lastKnownGateway);
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(lastKnownGateway,
+                                                deviceToInstanceMap.get(lastKnownGateway)));
+                                    }
+                                });
+                    } else {
+                        // one command handling instance found
+                        final Map.Entry<String, String> foundEntry = deviceToInstanceMap.entrySet().iterator().next();
+                        LOG.debug("returning command handling adapter instance {} associated with gateway {} [tenant: {}, device-id: {}]",
+                                foundEntry.getValue(), foundEntry.getKey(), tenantId, deviceId);
+                        resultFuture = Future.succeededFuture(getAdapterInstancesResultJson(foundEntry.getKey(),
+                                foundEntry.getValue()));
+                    }
+                    return resultFuture;
+                });
+    }
+
+    private Future<JsonObject> getInstancesGettingLastKnownGatewayFirst(final String tenantId, final String deviceId, final Set<String> viaGateways) {
+        return cache.get(getGatewayEntryKey(tenantId, deviceId))
+                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t))
+                .compose(lastKnownGateway -> {
+                    if (lastKnownGateway == null) {
+                        LOG.trace("no last known gateway found [tenant: {}, device-id: {}]", tenantId, deviceId);
+                    } else if (!viaGateways.contains(lastKnownGateway)) {
+                        LOG.trace("found gateway is not valid for the device anymore [tenant: {}, device-id: {}]", tenantId, deviceId);
+                    }
+                    if (lastKnownGateway != null && viaGateways.contains(lastKnownGateway)) {
+                        // fetch command handling instances for lastKnownGateway and device
+                        return cache.getAll(getAdapterInstanceEntryKeys(tenantId, deviceId, lastKnownGateway))
+                                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t))
+                                .compose(getAllMap -> {
+                                    final Map<String, String> deviceToInstanceMap = convertAdapterInstanceEntryKeys(getAllMap);
+                                    if (deviceToInstanceMap.isEmpty()) {
+                                        // no adapter instances found for last-known-gateway and device - check all via gateways
+                                        return getAdapterInstancesWithoutLastKnownGatewayCheck(tenantId, deviceId, viaGateways);
+                                    } else if (deviceToInstanceMap.containsKey(deviceId)) {
+                                        // there is a adapter instance set for the device itself - that gets precedence
+                                        return getAdapterInstanceFoundForDeviceItselfResult(tenantId, deviceId, deviceToInstanceMap.get(deviceId));
+                                    } else {
+                                        // adapter instance found for last known gateway
+                                        LOG.debug("returning command handling adapter instance {} for last known gateway [tenant: {}, device-id: {}, lastKnownGateway: {}]",
+                                                deviceToInstanceMap.get(lastKnownGateway), tenantId, deviceId, lastKnownGateway);
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                                    }
+                                });
+                    } else {
+                        // last-known-gateway not found or invalid - look for all adapter instances for device and viaGateways
+                        return getAdapterInstancesWithoutLastKnownGatewayCheck(tenantId, deviceId, viaGateways);
+                    }
+                });
+    }
+
+    private Future<JsonObject> getAdapterInstancesWithoutLastKnownGatewayCheck(final String tenantId,
+            final String deviceId, final Set<String> viaGateways) {
+        return cache.getAll(getAdapterInstanceEntryKeys(tenantId, deviceId, viaGateways))
+                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t))
+                .compose(getAllMap -> {
+                    final Map<String, String> deviceToInstanceMap = convertAdapterInstanceEntryKeys(getAllMap);
+                    final Future<JsonObject> resultFuture;
+                    if (deviceToInstanceMap.isEmpty()) {
+                        LOG.debug("no command handling adapter instances found [tenant: {}, device-id: {}]",
+                                tenantId, deviceId);
+                        resultFuture = Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                    } else if (deviceToInstanceMap.containsKey(deviceId)) {
+                        // there is a command handling instance set for the device itself - that gets precedence
+                        resultFuture = getAdapterInstanceFoundForDeviceItselfResult(tenantId, deviceId, deviceToInstanceMap.get(deviceId));
+                    } else {
+                        LOG.debug("returning {} command handling adapter instance(s) (no last known gateway found) [tenant: {}, device-id: {}]",
+                                deviceToInstanceMap.size(), tenantId, deviceId);
+                        resultFuture = Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                    }
+                    return resultFuture;
+                });
+    }
+
+    private Future<JsonObject> getAdapterInstanceFoundForDeviceItselfResult(final String tenantId,
+            final String deviceId, final String adapterInstanceId) {
+        LOG.debug("returning command handling adapter instance {} for device itself [tenant: {}, device-id: {}]",
+                adapterInstanceId, tenantId, deviceId);
+        return Future.succeededFuture(getAdapterInstancesResultJson(deviceId, adapterInstanceId));
+    }
+
+    private <T> Future<T> failedToGetEntriesWhenGettingInstances(final String tenantId, final String deviceId, final Throwable t) {
+        LOG.debug("failed to get cache entries when trying to get command handling adapter instances [tenant: {}, device-id: {}]",
+                tenantId, deviceId, t);
+        return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, t));
+    }
+
+    private static String getGatewayEntryKey(final String tenantId, final String deviceId) {
+        return KEY_PREFIX_GATEWAY_ENTRIES_VALUE + KEY_SEPARATOR + tenantId + KEY_SEPARATOR + deviceId;
+    }
+
+    private static String getAdapterInstanceEntryKey(final String tenantId, final String deviceId) {
+        return KEY_PREFIX_ADAPTER_INSTANCE_VALUES + KEY_SEPARATOR + tenantId + KEY_SEPARATOR + deviceId;
+    }
+
+    private static Set<String> getAdapterInstanceEntryKeys(final String tenantId, final String deviceIdA,
+            final String deviceIdB) {
+        final HashSet<String> keys = new HashSet<>(2);
+        keys.add(getAdapterInstanceEntryKey(tenantId, deviceIdA));
+        keys.add(getAdapterInstanceEntryKey(tenantId, deviceIdB));
+        return keys;
+    }
+
+    /**
+     * Puts the entries from the given map, having {@link #getAdapterInstanceEntryKey(String, String)} keys, into
+     * a new map with just the extracted device ids as keys.
+     *
+     * @param map Map to get the entries from.
+     * @return New map with keys containing just the device id.
+     */
+    private static Map<String, String> convertAdapterInstanceEntryKeys(final Map<String, String> map) {
+        return map.entrySet().stream()
+                .collect(Collectors.toMap(entry -> getDeviceIdFromAdapterInstanceEntryKey(entry.getKey()), Map.Entry::getValue));
+    }
+
+    private static String getDeviceIdFromAdapterInstanceEntryKey(final String key) {
+        final int pos = key.lastIndexOf(KEY_SEPARATOR);
+        return key.substring(pos + KEY_SEPARATOR.length());
+    }
+
+    private static Set<String> getAdapterInstanceEntryKeys(final String tenantId, final String deviceIdA,
+            final Set<String> additionalDeviceIds) {
+        final HashSet<String> keys = new HashSet<>(additionalDeviceIds.size() + 1);
+        keys.add(getAdapterInstanceEntryKey(tenantId, deviceIdA));
+        additionalDeviceIds.forEach(id -> keys.add(getAdapterInstanceEntryKey(tenantId, id)));
+        return keys;
+    }
+
+    private static JsonObject getLastKnownGatewayResultJson(final String gatewayId) {
+        return new JsonObject().put(DeviceConnectionConstants.FIELD_GATEWAY_ID, gatewayId);
+    }
+
+    private static JsonObject getAdapterInstancesResultJson(final Map<String, String> deviceToAdapterInstanceMap) {
+        final JsonObject jsonObject = new JsonObject();
+        final JsonArray adapterInstancesArray = new JsonArray(new ArrayList<>(deviceToAdapterInstanceMap.size()));
+        for (final Map.Entry<String, String> resultEntry : deviceToAdapterInstanceMap.entrySet()) {
+            final JsonObject entryJson = new JsonObject();
+            entryJson.put(DeviceConnectionConstants.FIELD_PAYLOAD_DEVICE_ID, resultEntry.getKey());
+            entryJson.put(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID, resultEntry.getValue());
+            adapterInstancesArray.add(entryJson);
+        }
+        jsonObject.put(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCES, adapterInstancesArray);
+        return jsonObject;
+    }
+
+    private static JsonObject getAdapterInstancesResultJson(final String deviceId, final String adapterInstanceId) {
+        return getAdapterInstancesResultJson(Map.of(deviceId, adapterInstanceId));
     }
 
     /**

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/RemoteCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/RemoteCache.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
+import java.util.Map;
+import java.util.Set;
+
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
@@ -44,6 +47,16 @@ public interface RemoteCache<K, V> {
     Future<V> put(K key, V value);
 
     /**
+     * Removes the cache entry for a key only if the currently mapped entry has the given version.
+     *
+     * @param key The key.
+     * @param version The version of the cache entry to match.
+     * @return A succeeded future containing {@code true} if the value was removed
+     *         and {@code false} otherwise.
+     */
+    Future<Boolean> removeWithVersion(K key, long version);
+
+    /**
      * Gets a value from the cache.
      * 
      * @param key The key.
@@ -52,4 +65,22 @@ public interface RemoteCache<K, V> {
      *         A failed future if the value could not be read from the cache.
      */
     Future<V> get(K key);
+
+    /**
+     * Gets a value from the cache.
+     *
+     * @param key The key.
+     * @return A succeeded future containing the value or {@code null} if the
+     *         cache didn't contain the key yet.
+     *         A failed future if the value could not be read from the cache.
+     */
+    Future<Versioned<V>> getWithVersion(K key);
+
+    /**
+     * Gets the values for the specified keys from the cache.
+     *
+     * @param keys The keys.
+     * @return A succeeded future containing a map with key/value pairs.
+     */
+    Future<Map<K, V>> getAll(Set<? extends K> keys);
 }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Versioned.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Versioned.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceconnection.infinispan.client;
+
+/**
+ * A versioned entry.
+ * 
+ * @param <T> The payload type.
+ */
+public final class Versioned<T> {
+
+    private final long version;
+    private final T value;
+
+    /**
+     * Created a new versioned entry.
+     * 
+     * @param version The version.
+     * @param value The value.
+     */
+    public Versioned(final long version, final T value) {
+        this.version = version;
+        this.value = value;
+    }
+
+    public T getValue() {
+        return this.value;
+    }
+
+    public long getVersion() {
+        return this.version;
+    }
+
+}

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfoTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodBasedDeviceConnectionInfoTest.java
@@ -15,12 +15,23 @@
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.Constants;
@@ -28,10 +39,14 @@ import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -45,9 +60,27 @@ import io.vertx.junit5.VertxTestContext;
 @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
 class HotrodBasedDeviceConnectionInfoTest {
 
+    private static final String PARAMETERIZED_TEST_NAME_PATTERN = "{displayName} [{index}]; parameters: {arguments}";
+
     private DeviceConnectionInfo info;
     private RemoteCache<String, String> cache;
     private Tracer tracer;
+    private SpanContext spanContext;
+
+    static Stream<Set<String>> extraUnusedViaGateways() {
+        return Stream.of(
+                Collections.emptySet(),
+                getViaGatewaysExceedingThreshold()
+        );
+    }
+
+    private static Set<String> getViaGatewaysExceedingThreshold() {
+        final HashSet<String> set = new HashSet<>();
+        for (int i = 0; i < HotrodBasedDeviceConnectionInfo.VIA_GATEWAYS_OPTIMIZATION_THRESHOLD + 1; i++) {
+            set.add("gw#" + i);
+        }
+        return set;
+    }
 
     /**
      * Sets up the fixture.
@@ -55,8 +88,9 @@ class HotrodBasedDeviceConnectionInfoTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp() {
-        cache = mock(RemoteCache.class);
+        cache = new SimpleTestRemoteCache();
         tracer = mock(Tracer.class);
+        spanContext = mock(SpanContext.class);
         info = new HotrodBasedDeviceConnectionInfo(cache, tracer);
     }
 
@@ -67,8 +101,9 @@ class HotrodBasedDeviceConnectionInfoTest {
      */
     @Test
     void testSetLastKnownGatewaySucceeds(final VertxTestContext ctx) {
-
-        when(cache.put(anyString(), anyString())).thenReturn(Future.succeededFuture("oldValue"));
+        final RemoteCache<String, String> mockedCache = mock(RemoteCache.class);
+        info = new HotrodBasedDeviceConnectionInfo(mockedCache, tracer);
+        when(mockedCache.put(anyString(), anyString())).thenReturn(Future.succeededFuture("oldValue"));
         info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, "device-id", "gw-id", null)
             .setHandler(ctx.completing());
     }
@@ -80,8 +115,9 @@ class HotrodBasedDeviceConnectionInfoTest {
      */
     @Test
     void testSetLastKnownGatewayFails(final VertxTestContext ctx) {
-
-        when(cache.put(anyString(), anyString())).thenReturn(Future.failedFuture(new IOException("not available")));
+        final RemoteCache<String, String> mockedCache = mock(RemoteCache.class);
+        info = new HotrodBasedDeviceConnectionInfo(mockedCache, tracer);
+        when(mockedCache.put(anyString(), anyString())).thenReturn(Future.failedFuture(new IOException("not available")));
         info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, "device-id", "gw-id", mock(SpanContext.class))
             .setHandler(ctx.failing(t -> {
                 ctx.verify(() -> assertThat(t).isInstanceOf(ServiceInvocationException.class));
@@ -96,8 +132,9 @@ class HotrodBasedDeviceConnectionInfoTest {
      */
     @Test
     void testGetLastKnownGatewaySucceeds(final VertxTestContext ctx) {
-
-        when(cache.get(anyString())).thenReturn(Future.succeededFuture("gw-id"));
+        final RemoteCache<String, String> mockedCache = mock(RemoteCache.class);
+        info = new HotrodBasedDeviceConnectionInfo(mockedCache, tracer);
+        when(mockedCache.get(anyString())).thenReturn(Future.succeededFuture("gw-id"));
         info.getLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, "device-id", null)
             .setHandler(ctx.succeeding(value -> {
                 ctx.verify(() -> {
@@ -114,12 +151,507 @@ class HotrodBasedDeviceConnectionInfoTest {
      */
     @Test
     void testGetLastKnownGatewayFails(final VertxTestContext ctx) {
-
-        when(cache.get(anyString())).thenReturn(Future.failedFuture(new IOException("not available")));
+        final RemoteCache<String, String> mockedCache = mock(RemoteCache.class);
+        info = new HotrodBasedDeviceConnectionInfo(mockedCache, tracer);
+        when(mockedCache.get(anyString())).thenReturn(Future.failedFuture(new IOException("not available")));
         info.getLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, "device-id", mock(SpanContext.class))
             .setHandler(ctx.failing(t -> {
                 ctx.verify(() -> assertThat(t).isInstanceOf(ServiceInvocationException.class));
                 ctx.completeNow();
             }));
     }
+
+
+    /**
+     * Verifies that the <em>setCommandHandlingAdapterInstance</em> operation succeeds.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testSetCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, spanContext)
+                .setHandler(ctx.succeeding(result -> ctx.completeNow()));
+    }
+
+
+    /**
+     * Verifies that the <em>removeCommandHandlingAdapterInstance</em> operation succeeds if there was an entry to be deleted.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, spanContext)
+        .compose(v -> info.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId,
+                adapterInstance, spanContext))
+        .setHandler(ctx.succeeding(result -> ctx.completeNow()));
+    }
+
+    /**
+     * Verifies that the <em>removeCommandHandlingAdapterInstance</em> operation fails with a NOT_FOUND status if
+     * no entry was registered for the device. Only an adapter instance for another device of the tenant was
+     * registered.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceFailsForOtherDevice(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, spanContext)
+        .compose(v -> {
+            return info.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, "otherDevice", adapterInstance, spanContext);
+        }).setHandler(ctx.failing(t -> ctx.verify(() -> {
+            assertThat(t).isInstanceOf(ServiceInvocationException.class);
+            assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>removeCommandHandlingAdapterInstance</em> operation fails with a PRECON_FAILED status
+     * if the given adapter instance parameter doesn't match the one of the entry registered for the given device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceFailsForOtherAdapterInstance(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, spanContext)
+        .compose(v -> {
+            return info.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, "otherAdapterInstance", spanContext);
+        }).setHandler(ctx.failing(t -> ctx.verify(() -> {
+            assertThat(t).isInstanceOf(ServiceInvocationException.class);
+            assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds if an adapter instance had
+     * been registered for the given device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesForDevice(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, spanContext)
+        .compose(v -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, Collections.emptySet(), spanContext);
+        }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+            assertNotNull(result);
+            assertGetInstancesResultMapping(result, deviceId, adapterInstance);
+            assertGetInstancesResultSize(result, 1);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation fails for a device with no
+     * viaGateways, if no matching instance has been registered.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testGetCommandHandlingAdapterInstancesFails(final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final Set<String> viaGateways = Collections.emptySet();
+        info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext)
+                .setHandler(ctx.failing(t -> ctx.verify(() -> {
+                    assertThat(t).isInstanceOf(ServiceInvocationException.class);
+                    assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds if an adapter instance has
+     * been registered for the last known gateway associated with the given device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesForLastKnownGateway(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId));
+        viaGateways.addAll(extraUnusedViaGateways);
+        // set command handling adapter instance for gateway
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, spanContext)
+        .compose(v -> {
+            // set command handling adapter instance for other gateway
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, spanContext);
+        }).compose(deviceConnectionResult -> {
+            return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, spanContext);
+        }).compose(u -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
+        }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+            assertNotNull(result);
+            assertGetInstancesResultMapping(result, gatewayId, adapterInstance);
+            // be sure that only the mapping for the last-known-gateway is returned, not the mappings for both via gateways
+            assertGetInstancesResultSize(result, 1);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds if multiple adapter instances
+     * have been registered for gateways of the given device, but the last known gateway associated with the given
+     * device is not in the viaGateways list of the device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesWithMultiResultAndLastKnownGatewayNotInVia(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final String gatewayIdNotInVia = "gw-old";
+        final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId));
+        viaGateways.addAll(extraUnusedViaGateways);
+        // set command handling adapter instance for gateway
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, spanContext)
+        .compose(v -> {
+            // set command handling adapter instance for other gateway
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, spanContext);
+        }).compose(deviceConnectionResult -> {
+            return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayIdNotInVia, spanContext);
+        }).compose(u -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
+        }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+            assertNotNull(result);
+            assertGetInstancesResultMapping(result, gatewayId, adapterInstance);
+            assertGetInstancesResultMapping(result, otherGatewayId, otherAdapterInstance);
+            // last-known-gateway is not in via list, therefore no single result is returned
+            assertGetInstancesResultSize(result, 2);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds if multiple adapter instances
+     * have been registered for gateways of the given device, but the last known gateway associated with the given
+     * device has no adapter associated with it.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesWithMultiResultAndNoAdapterForLastKnownGateway(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final String gatewayWithNoAdapterInstance = "gw-other";
+        final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId, gatewayWithNoAdapterInstance));
+        viaGateways.addAll(extraUnusedViaGateways);
+        // set command handling adapter instance for gateway
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, spanContext)
+                .compose(v -> {
+                    // set command handling adapter instance for other gateway
+                    return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, spanContext);
+                }).compose(deviceConnectionResult -> {
+            return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayWithNoAdapterInstance, spanContext);
+        }).compose(u -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
+        }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+            assertNotNull(result);
+            assertGetInstancesResultMapping(result, gatewayId, adapterInstance);
+            assertGetInstancesResultMapping(result, otherGatewayId, otherAdapterInstance);
+            // no adapter registered for last-known-gateway, therefore no single result is returned
+            assertGetInstancesResultSize(result, 2);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation fails if an adapter instance has
+     * been registered for the last known gateway associated with the given device, but that gateway isn't in the
+     * given viaGateways set.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesForSingleResultAndLastKnownGatewayNotInVia(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String gatewayId = "gw-1";
+        final Set<String> viaGateways = new HashSet<>(Set.of("otherGatewayId"));
+        viaGateways.addAll(extraUnusedViaGateways);
+        // set command handling adapter instance for gateway
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, spanContext)
+        .compose(deviceConnectionResult -> {
+            return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, spanContext);
+        }).compose(u -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
+        }).setHandler(ctx.failing(t -> ctx.verify(() -> {
+            assertThat(t).isInstanceOf(ServiceInvocationException.class);
+            assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds with a result containing just
+     * the mapping of *the given device* to its command handling adapter instance, even though an adapter instance is
+     * also registered for the last known gateway associated with the given device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesWithLastKnownGatewayIsGivingDevicePrecedence(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId));
+        viaGateways.addAll(extraUnusedViaGateways);
+        // set command handling adapter instance for device
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, spanContext)
+        .compose(v -> {
+            // set command handling adapter instance for other gateway
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, otherAdapterInstance, spanContext);
+        }).compose(u -> {
+            return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, spanContext);
+        }).compose(w -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
+        }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+            assertNotNull(result);
+            assertGetInstancesResultMapping(result, deviceId, adapterInstance);
+            // be sure that only the mapping for the device is returned, not the mappings for the gateway
+            assertGetInstancesResultSize(result, 1);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds with a result containing just
+     * the mapping of *the given device* to its command handling adapter instance, even though an adapter instance is
+     * also registered for the other gateway given in the viaGateway.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesWithoutLastKnownGatewayIsGivingDevicePrecedence(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId));
+        viaGateways.addAll(extraUnusedViaGateways);
+        // set command handling adapter instance for device
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, spanContext)
+        .compose(v -> {
+            // set command handling adapter instance for other gateway
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, otherAdapterInstance, spanContext);
+        }).compose(w -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
+        }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+            assertNotNull(result);
+            assertGetInstancesResultMapping(result, deviceId, adapterInstance);
+            // be sure that only the mapping for the device is returned, not the mappings for the gateway
+            assertGetInstancesResultSize(result, 1);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds with a result containing
+     * the mapping of a gateway, even though there is no last known gateway set for the device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesForOneSubscribedVia(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId));
+        viaGateways.addAll(extraUnusedViaGateways);
+        // set command handling adapter instance for gateway
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, spanContext)
+        .compose(v -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
+        }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+            assertNotNull(result);
+            assertGetInstancesResultMapping(result, gatewayId, adapterInstance);
+            assertGetInstancesResultSize(result, 1);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation succeeds with a result containing
+     * the mappings of gateways, even though there is no last known gateway set for the device.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesForMultipleSubscribedVias(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String otherAdapterInstance = "otherAdapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId));
+        viaGateways.addAll(extraUnusedViaGateways);
+        // set command handling adapter instance for gateway
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, spanContext)
+        .compose(v -> {
+            // set command handling adapter instance for other gateway
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, spanContext);
+        }).compose(u -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
+        }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+            assertNotNull(result);
+            assertGetInstancesResultMapping(result, gatewayId, adapterInstance);
+            assertGetInstancesResultMapping(result, otherGatewayId, otherAdapterInstance);
+            assertGetInstancesResultSize(result, 2);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation fails for a device with a
+     * non-empty set of given viaGateways, if no matching instance has been registered.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesFailsWithGivenGateways(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String gatewayId = "gw-1";
+        final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId));
+        viaGateways.addAll(extraUnusedViaGateways);
+        info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext)
+        .setHandler(ctx.failing(t -> ctx.verify(() -> {
+            assertThat(t).isInstanceOf(ServiceInvocationException.class);
+            assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation fails if no matching instance
+     * has been registered. An adapter instance has been registered for another device of the same tenant though.
+     *
+     * @param ctx The vert.x context.
+     */
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("extraUnusedViaGateways")
+    public void testGetCommandHandlingAdapterInstancesFailsForOtherTenantDevice(final Set<String> extraUnusedViaGateways, final VertxTestContext ctx) {
+        final String deviceId = "testDevice";
+        final String adapterInstance = "adapterInstance";
+        final String gatewayId = "gw-1";
+        final String otherGatewayId = "gw-2";
+        final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId));
+        viaGateways.addAll(extraUnusedViaGateways);
+        // set command handling adapter instance for other gateway
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, adapterInstance, spanContext)
+        .compose(v -> {
+            return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
+        }).setHandler(ctx.failing(t -> ctx.verify(() -> {
+            assertThat(t).isInstanceOf(ServiceInvocationException.class);
+            assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+            ctx.completeNow();
+        })));
+    }
+
+    /**
+     * Asserts the the given result JSON of the <em>getCommandHandlingAdapterInstances</em> method contains
+     * an "adapter-instances" entry with the given device id and adapter instance id.
+     */
+    private void assertGetInstancesResultMapping(final JsonObject resultJson, final String deviceId, final String adapterInstanceId) {
+        assertNotNull(resultJson);
+        final JsonArray adapterInstancesJson = resultJson.getJsonArray(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCES);
+        assertNotNull(adapterInstancesJson);
+        boolean entryFound = false;
+        for (int i = 0; i < adapterInstancesJson.size(); i++) {
+            final JsonObject entry = adapterInstancesJson.getJsonObject(i);
+            if (deviceId.equals(entry.getString(DeviceConnectionConstants.FIELD_PAYLOAD_DEVICE_ID))) {
+                entryFound = true;
+                assertEquals(adapterInstanceId, entry.getString(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID));
+            }
+        }
+        assertTrue(entryFound);
+    }
+
+    private void assertGetInstancesResultSize(final JsonObject resultJson, final int size) {
+        assertNotNull(resultJson);
+        final JsonArray adapterInstancesJson = resultJson.getJsonArray(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCES);
+        assertNotNull(adapterInstancesJson);
+        assertEquals(size, adapterInstancesJson.size());
+    }
+
+    /**
+     * {@link RemoteCache} test implementation backed by a map.
+     */
+    private static class SimpleTestRemoteCache implements RemoteCache<String, String> {
+
+        final ConcurrentHashMap<String, Versioned<String>> map = new ConcurrentHashMap<>();
+        long versionCounter = 1L;
+
+        @Override
+        public Future<JsonObject> checkForCacheAvailability() {
+            return Future.failedFuture("not supported");
+        }
+
+        @Override
+        public Future<String> put(final String key, final String value) {
+            final Versioned<String> oldValue = map.put(key, new Versioned<>(versionCounter++, value));
+            return Future.succeededFuture(oldValue != null ? oldValue.getValue() : null);
+        }
+
+        @Override
+        public Future<Boolean> removeWithVersion(final String key, final long version) {
+            final Versioned<String> versioned = map.get(key);
+            if (versioned == null || versioned.getVersion() != version) {
+                return Future.succeededFuture(false);
+            }
+            map.remove(key);
+            return Future.succeededFuture(true);
+        }
+
+        @Override
+        public Future<String> get(final String key) {
+            final Versioned<String> versioned = map.get(key);
+            return Future.succeededFuture(versioned != null ? versioned.getValue() : null);
+        }
+
+        @Override
+        public Future<Versioned<String>> getWithVersion(final String key) {
+            return Future.succeededFuture(map.get(key));
+        }
+
+        @Override
+        public Future<Map<String, String>> getAll(final Set<? extends String> keys) {
+            final Map<String, String> filteredMap = map.entrySet().stream()
+                    .filter(entry -> keys.contains(entry.getKey()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getValue()));
+            return Future.succeededFuture(filteredMap);
+        }
+    }
+
 }

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionService.java
@@ -15,6 +15,7 @@
 package org.eclipse.hono.deviceconnection.infinispan;
 
 import java.net.HttpURLConnection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -79,34 +80,25 @@ public class RemoteCacheBasedDeviceConnectionService extends EventBusDeviceConne
     @Override
     public Future<DeviceConnectionResult> setCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
             final String adapterInstanceId, final Span span) {
-        // TODO use this:
-//        cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span.context())
-//                .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
-//                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)))
-//                .setHandler(resultHandler);
-        return Future.failedFuture("not implemented yet");
+        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span.context())
+                .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
+                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
 
     @Override
     public Future<DeviceConnectionResult> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
             final String adapterInstanceId, final Span span) {
-        // TODO use this:
-//        cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span.context())
-//                .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
-//                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)))
-//                .setHandler(resultHandler);
-        return Future.failedFuture("not implemented yet");
+        return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span.context())
+                .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
+                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
 
     @Override
     public Future<DeviceConnectionResult> getCommandHandlingAdapterInstances(final String tenantId, final String deviceId,
             final List<String> viaGateways, final Span span) {
-        // TODO use this:
-//        cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), span.context())
-//                .map(json -> DeviceConnectionResult.from(HttpURLConnection.HTTP_OK, json))
-//                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)))
-//                .setHandler(resultHandler);
-        return Future.failedFuture("not implemented yet");
+        return cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), span.context())
+                .map(json -> DeviceConnectionResult.from(HttpURLConnection.HTTP_OK, json))
+                .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
 
     /**

--- a/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionServiceTest.java
+++ b/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheBasedDeviceConnectionServiceTest.java
@@ -139,4 +139,29 @@ public class RemoteCacheBasedDeviceConnectionServiceTest {
             ctx.completeNow();
         }));
     }
+
+    /**
+     * Verifies that the <em>setCommandHandlingAdapterInstance</em> operation succeeds and invokes the
+     * corresponding method on the {@link DeviceConnectionInfo} instance.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testSetCommandHandlingAdapterInstance(final VertxTestContext ctx) {
+
+        final String deviceId = "testDevice";
+        final String adapterInstanceId = "adapterInstanceId";
+        when(cache.setCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(SpanContext.class)))
+                .thenReturn(Future.succeededFuture());
+
+        givenAStartedService()
+                .compose(ok -> svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstanceId, span))
+                .setHandler(ctx.succeeding(result -> {
+                    ctx.verify(() -> {
+                        assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
+                        verify(cache).setCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(SpanContext.class));
+                    });
+                    ctx.completeNow();
+                }));
+    }
 }


### PR DESCRIPTION
This is for #1272:
Adds an implementation for the new Device Connection API methods to the Infinispan client.