### PR TITLE
[#1679] Extract utility methods for reuse in device registry implementations

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.util;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.RegistryManagementConstants;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantObject;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A collection of utility methods for implementing device registries.
+ *
+ */
+public final class DeviceRegistryUtils {
+
+    private DeviceRegistryUtils() {
+        // prevent instantiation
+    }
+
+    /**
+     * Converts tenant object of type {@link Tenant} to an object of type {@link TenantObject}.
+     *
+     * @param tenantId The identifier of the tenant.
+     * @param source   The source tenant object.
+     * @return The converted tenant object of type {@link TenantObject}
+     * @throws NullPointerException if the tenantId or source is null.
+     */
+    public static JsonObject convertTenant(final String tenantId, final Tenant source) {
+        return convertTenant(tenantId, source, false);
+    }
+
+    /**
+     * Converts tenant object of type {@link Tenant} to an object of type {@link TenantObject}.
+     *
+     * @param tenantId The identifier of the tenant.
+     * @param source   The source tenant object.
+     * @param filterAuthorities if set to true filter out CAs which are not valid at this point in time.
+     * @return The converted tenant object of type {@link TenantObject}
+     * @throws NullPointerException if the tenantId or source is null.
+     */
+    public static JsonObject convertTenant(final String tenantId, final Tenant source, final boolean filterAuthorities) {
+
+        final Instant now = Instant.now();
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(source);
+
+        final TenantObject target = TenantObject.from(tenantId, Optional.ofNullable(source.isEnabled()).orElse(true));
+        target.setResourceLimits(source.getResourceLimits());
+        target.setTracingConfig(source.getTracing());
+
+        Optional.ofNullable(source.getMinimumMessageSize())
+        .ifPresent(size -> target.setMinimumMessageSize(size));
+
+        Optional.ofNullable(source.getDefaults())
+        .map(JsonObject::new)
+        .ifPresent(defaults -> target.setDefaults(defaults));
+
+        Optional.ofNullable(source.getAdapters())
+                .filter(adapters -> !adapters.isEmpty())
+                .map(adapters -> adapters.stream()
+                                .map(adapter -> JsonObject.mapFrom(adapter))
+                                .map(json -> json.mapTo(org.eclipse.hono.util.Adapter.class))
+                                .collect(Collectors.toList()))
+                .ifPresent(adapters -> target.setAdapters(adapters));
+
+        Optional.ofNullable(source.getExtensions())
+        .map(JsonObject::new)
+        .ifPresent(extensions -> target.setProperty(RegistryManagementConstants.FIELD_EXT, extensions));
+
+        Optional.ofNullable(source.getTrustedCertificateAuthorities())
+        .map(list -> list.stream()
+                .filter(ca -> {
+                    if (filterAuthorities) {
+                        // filter out CAs which are not valid at this point in time
+                        return !now.isBefore(ca.getNotBefore()) && !now.isAfter(ca.getNotAfter());
+                    } else {
+                        return true;
+                    }
+                })
+                .map(ca -> JsonObject.mapFrom(ca))
+                .map(json -> {
+                    // validity period is not included in TenantObject
+                    json.remove(RegistryManagementConstants.FIELD_SECRETS_NOT_BEFORE);
+                    json.remove(RegistryManagementConstants.FIELD_SECRETS_NOT_AFTER);
+                    return json;
+                })
+                .collect(JsonArray::new, JsonArray::add, JsonArray::add))
+        .ifPresent(authorities -> target.setProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, authorities));
+
+        return JsonObject.mapFrom(target);
+    }
+
+    /**
+     * Gets the cache directive corresponding to the given max age for the cache.
+     *
+     * @param cacheMaxAge the maximum period of time in seconds that the information
+     *                    returned by the service's operations may be cached for.
+     * @return the cache directive corresponding to the given max age for the cache.
+     */
+    public static CacheDirective getCacheDirective(final int cacheMaxAge) {
+        if (cacheMaxAge > 0) {
+            return CacheDirective.maxAgeDirective(cacheMaxAge);
+        } else {
+            return CacheDirective.noCacheDirective();
+        }
+    }
+}

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationService.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.deviceregistry.util.Versioned;
 import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
@@ -34,7 +35,6 @@ import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.registration.AbstractRegistrationService;
 import org.eclipse.hono.service.registration.RegistrationService;
 import org.eclipse.hono.tracing.TracingHelper;
-import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.RegistrationResult;
 import org.eclipse.hono.util.RegistryManagementConstants;
@@ -389,7 +389,7 @@ public class FileBasedRegistrationService extends AbstractVerticle
 
         return OperationResult.ok(HttpURLConnection.HTTP_OK,
                 new Device(device.getValue()),
-                Optional.ofNullable(getCacheDirective(deviceId, tenantId)),
+                Optional.ofNullable(DeviceRegistryUtils.getCacheDirective(config.getCacheMaxAge())),
                 Optional.ofNullable(device.getVersion()));
     }
 
@@ -551,14 +551,6 @@ public class FileBasedRegistrationService extends AbstractVerticle
 
     private ConcurrentMap<String, Versioned<Device>> getDevicesForTenant(final String tenantId) {
         return identities.computeIfAbsent(tenantId, id -> new ConcurrentHashMap<>());
-    }
-
-    private CacheDirective getCacheDirective(final String deviceId, final String tenantId) {
-        if (getConfig().getCacheMaxAge() > 0) {
-            return CacheDirective.maxAgeDirective(getConfig().getCacheMaxAge());
-        } else {
-            return CacheDirective.noCacheDirective();
-        }
     }
 
     /**

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantServiceTest.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.deviceregistry.DeviceRegistryTestUtils;
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
 import org.eclipse.hono.service.management.tenant.TrustedCertificateAuthority;
@@ -443,7 +444,7 @@ public class FileBasedTenantServiceTest extends AbstractTenantServiceTest {
                 .put(TenantConstants.FIELD_PAYLOAD_KEY_ALGORITHM, "EC")
                 .put(TenantConstants.FIELD_AUTO_PROVISIONING_ENABLED, false));
 
-        final JsonObject target = FileBasedTenantService.convertTenant("4711", source, true);
+        final JsonObject target = DeviceRegistryUtils.convertTenant("4711", source, true);
 
         assertThat(target.getString(TenantConstants.FIELD_PAYLOAD_TENANT_ID)).isEqualTo("4711");
         assertThat(target.getBoolean(TenantConstants.FIELD_ENABLED)).isTrue();


### PR DESCRIPTION
While working on #1679, I noticed that these methods in this PR could be reused among various device registry implementations and hence extracted them to a utility class in the device registry base module.