### PR TITLE
[#1679] Add mongodb based implementation of device registration and management services

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -156,6 +156,11 @@
         <version>${vertx.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-mongo-client</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -196,6 +196,11 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-service-device-registry-base</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-core</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -214,10 +214,6 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED = "device-authentication-required";
     /**
-     * The name of the JSON property containing the device identifier.
-     */
-    public static final String FIELD_DEVICE = "device";
-    /**
      * The name of the JSON array containing device registration information for a tenant.
      */
     public static final String FIELD_DEVICES = "devices";
@@ -274,16 +270,6 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      * a {@link TracingSamplingMode} value.
      */
     public static final String FIELD_TRACING_SAMPLING_MODE_PER_AUTH_ID = "sampling-mode-per-auth-id";
-
-    /**
-     * The name of the JSON property containing the last modification date and time.
-     */
-    public static final String FIELD_UPDATED_ON = "updatedOn";
-
-    /**
-     * The name of the JSON property containing the version of the tenant or device or credentials information.
-     */
-    public static final String FIELD_VERSION = "version";
 
     private static final Set<String> ACTIONS = new HashSet<>(
             Arrays.asList(ACTION_CREATE, ACTION_GET, ACTION_DELETE, ACTION_UPDATE));

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -214,6 +214,10 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED = "device-authentication-required";
     /**
+     * The name of the JSON property containing the device identifier.
+     */
+    public static final String FIELD_DEVICE = "device";
+    /**
      * The name of the JSON array containing device registration information for a tenant.
      */
     public static final String FIELD_DEVICES = "devices";
@@ -270,6 +274,16 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      * a {@link TracingSamplingMode} value.
      */
     public static final String FIELD_TRACING_SAMPLING_MODE_PER_AUTH_ID = "sampling-mode-per-auth-id";
+
+    /**
+     * The name of the JSON property containing the last modification date and time.
+     */
+    public static final String FIELD_UPDATED_ON = "updatedOn";
+
+    /**
+     * The name of the JSON property containing the version of the tenant or device or credentials information.
+     */
+    public static final String FIELD_VERSION = "version";
 
     private static final Set<String> ACTIONS = new HashSet<>(
             Arrays.asList(ACTION_CREATE, ACTION_GET, ACTION_DELETE, ACTION_UPDATE));

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.deviceregistry.util;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.eclipse.hono.service.management.tenant.Tenant;
@@ -123,5 +124,14 @@ public final class DeviceRegistryUtils {
         } else {
             return CacheDirective.noCacheDirective();
         }
+    }
+
+    /**
+     * Gets a unique identifier generated using {@link UUID#randomUUID()}.
+     * 
+     * @return The generated unique identifier.
+     */
+    public static String getUniqueIdentifier() {
+        return UUID.randomUUID().toString();
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
@@ -12,18 +12,30 @@
  *******************************************************************************/
 package org.eclipse.hono.deviceregistry.util;
 
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import javax.security.auth.x500.X500Principal;
+
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.RegistryManagementConstants;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.opentracing.Span;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -32,6 +44,8 @@ import io.vertx.core.json.JsonObject;
  *
  */
 public final class DeviceRegistryUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceRegistryUtils.class);
 
     private DeviceRegistryUtils() {
         // prevent instantiation
@@ -133,5 +147,53 @@ public final class DeviceRegistryUtils {
      */
     public static String getUniqueIdentifier() {
         return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Gets the certificate of the device to be provisioned from the client context.
+     *
+     * @param tenantId The tenant to which the device belongs.
+     * @param authId The authentication identifier.
+     * @param clientContext The client context that can be used to get the X.509 certificate 
+     *                      of the device to be provisioned.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
+     *             implementation should log (error) events on this span and it may set tags and use this span 
+     *             as the parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation. If the operation succeeds, the
+     *         retrieved certificate is returned. Else {@link Optional#empty()} is returned.
+     * @throws NullPointerException if any of the parameters except span is {@code null}.
+     */
+    public static Future<Optional<X509Certificate>> getCertificateFromClientContext(
+            final String tenantId,
+            final String authId,
+            final JsonObject clientContext,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(authId);
+        Objects.requireNonNull(clientContext);
+
+        try {
+            final byte[] bytes = clientContext.getBinary(CredentialsConstants.FIELD_CLIENT_CERT);
+            if (bytes == null) {
+                throw new IllegalArgumentException(
+                        String.format("The client context doesn't contain a certificate for tenant [%s]", tenantId));
+            }
+            final CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            final X509Certificate cert = (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(bytes));
+
+            if (!cert.getSubjectX500Principal().getName(X500Principal.RFC2253).equals(authId)) {
+                throw new IllegalArgumentException(
+                        String.format("Subject DN of the client certificate does not match authId [%s] for tenant [%s]",
+                                authId, tenantId));
+            }
+            return Future.succeededFuture(Optional.of(cert));
+        } catch (final CertificateException | ClassCastException | IllegalArgumentException error) {
+            final String errorMessage = String.format(
+                    "Error getting certificate from client context with authId [%s] for tenant [%s]", authId, tenantId);
+            LOG.error(errorMessage, error);
+            TracingHelper.logError(span, errorMessage, error);
+            return Future.succeededFuture(Optional.empty());
+        }
     }
 }

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-services</artifactId>
+        <version>1.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>hono-service-device-registry-mongodb</artifactId>
+    <name>Hono Mongodb Based Device Registry</name>
+    <description>A Mongodb based device registry for Hono implementing the Device Registration and Credentials APIs.
+    </description>
+    <url>https://www.eclipse.org/hono</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-service-device-registry-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-mongo-client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>build-docker-image</id>
+            <activation>
+                <property>
+                    <name>docker.host</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <build>
+                                        <from>${java-base-image.name}</from>
+                                        <labels>
+                                            <implemented.api.1>Tenant</implemented.api.1>
+                                            <implemented.api.2>Device Registration</implemented.api.2>
+                                            <implemented.api.3>Credentials</implemented.api.3>
+                                        </labels>
+                                        <ports>
+                                            <port>5671</port>
+                                            <port>5672</port>
+                                            <port>8080</port>
+                                            <port>8443</port>
+                                            <port>${vertx.health.port}</port>
+                                        </ports>
+                                        <cmd>
+                                            <exec>
+                                                <arg>java</arg>
+                                                <arg>--illegal-access=permit</arg>
+                                                <arg>-Dvertx.cacheDirBase=/tmp</arg>
+                                                <arg>-Dloader.home=/opt/hono</arg>
+                                                <arg>-Dloader.path=extensions</arg>
+                                                <arg>-cp</arg>
+                                                <arg>/opt/hono/${project.artifactId}-${project.version}-${classifier.spring.boot.artifact}.jar</arg>
+                                                <arg>org.springframework.boot.loader.PropertiesLauncher</arg>
+                                            </exec>
+                                        </cmd>
+                                        <assembly>
+                                            <mode>dir</mode>
+                                            <basedir>/</basedir>
+                                            <inline>
+                                                <fileSets>
+                                                    <fileSet>
+                                                        <directory>${project.build.directory}</directory>
+                                                        <outputDirectory>opt/hono</outputDirectory>
+                                                        <includes>
+                                                            <include>${project.artifactId}-${project.version}-${classifier.spring.boot.artifact}.jar</include>
+                                                        </includes>
+                                                    </fileSet>
+                                                </fileSets>
+                                            </inline>
+                                        </assembly>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>jaeger</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.jaegertracing</groupId>
+                    <artifactId>jaeger-client</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>docker-push-image</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>docker-push-image</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>org.eclipse.hono</groupId>
             <artifactId>hono-service-device-registry-base</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-services</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/Application.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/Application.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.hono.service.AbstractBaseApplication;
+import org.eclipse.hono.service.HealthCheckProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Verticle;
+
+/**
+ * A Spring Boot application exposing an AMQP and a HTTP based endpoint that implements Hono's device registry.
+ * <p>
+ * The application implements Hono's <a href="https://www.eclipse.org/hono/docs/api/device-registration/">Device Registration API</a>
+ * and <a href="https://www.eclipse.org/hono/docs/api/credentials/">Credentials API</a>.
+ * </p>
+ */
+@ComponentScan(basePackages = "org.eclipse.hono.service.auth", excludeFilters = @ComponentScan.Filter(Deprecated.class))
+@ComponentScan(basePackages = "org.eclipse.hono.service.metric", excludeFilters = @ComponentScan.Filter(Deprecated.class))
+@ComponentScan(basePackages = "org.eclipse.hono.deviceregistry", excludeFilters = @ComponentScan.Filter(Deprecated.class))
+@Configuration
+@EnableAutoConfiguration
+public class Application extends AbstractBaseApplication {
+
+    /**
+     * All the verticles.
+     */
+    private List<Verticle> verticles;
+
+    /**
+     * All the health check providers.
+     */
+    private List<HealthCheckProvider> healthCheckProviders;
+
+    @Autowired
+    public void setVerticles(final List<Verticle> verticles) {
+        this.verticles = verticles;
+    }
+
+    @Autowired
+    public void setHealthCheckProviders(final List<HealthCheckProvider> healthCheckProviders) {
+        this.healthCheckProviders = healthCheckProviders;
+    }
+
+    @Override
+    protected final Future<?> deployVerticles() {
+
+        return super.deployVerticles().compose(ok -> {
+
+            @SuppressWarnings("rawtypes")
+            final List<Future> futures = new LinkedList<>();
+
+            for (final Verticle verticle : this.verticles) {
+                log.info("Deploying: {}", verticle);
+                final Promise<String> result = Promise.promise();
+                getVertx().deployVerticle(verticle, result);
+                futures.add(result.future());
+            }
+
+            return CompositeFuture.all(futures);
+
+        });
+
+    }
+
+    /**
+     * Registers any additional health checks that the service implementation components provide.
+     *
+     * @return A succeeded future.
+     */
+    @Override
+    protected Future<Void> postRegisterServiceVerticles() {
+        return super.postRegisterServiceVerticles().compose(ok -> {
+            this.healthCheckProviders.forEach(this::registerHealthchecks);
+            return Future.succeededFuture();
+        });
+    }
+
+    /**
+     * Starts the Device Registry Server.
+     *
+     * @param args command line arguments to pass to the server.
+     */
+    public static void main(final String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -1,0 +1,294 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry;
+
+import java.util.Optional;
+
+import org.eclipse.hono.config.ApplicationConfigProperties;
+import org.eclipse.hono.config.ServerConfig;
+import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.config.VertxProperties;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedRegistrationService;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbCallExecutor;
+import org.eclipse.hono.deviceregistry.service.credentials.AutowiredCredentialsAmqpEndpoint;
+import org.eclipse.hono.deviceregistry.service.credentials.AutowiredCredentialsManagementHttpEndpoint;
+import org.eclipse.hono.deviceregistry.service.device.AutowiredDeviceManagementHttpEndpoint;
+import org.eclipse.hono.deviceregistry.service.device.AutowiredRegistrationAmqpEndpoint;
+import org.eclipse.hono.deviceregistry.service.deviceconnection.MapBasedDeviceConnectionsConfigProperties;
+import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantAmqpEndpoint;
+import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantManagementHttpEndpoint;
+import org.eclipse.hono.service.HealthCheckServer;
+import org.eclipse.hono.service.VertxBasedHealthCheckServer;
+import org.eclipse.hono.service.amqp.AmqpEndpoint;
+import org.eclipse.hono.service.deviceconnection.DeviceConnectionAmqpEndpoint;
+import org.eclipse.hono.service.http.HttpEndpoint;
+import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.util.Constants;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+
+/**
+ * Spring Boot configuration for the mongodb based device registry application.
+ */
+@Configuration
+public class ApplicationConfig {
+
+    /**
+     * Exposes a Vert.x instance as a Spring bean.
+     * <p>
+     * This method creates new Vert.x default options and invokes
+     * {@link VertxProperties#configureVertx(VertxOptions)} on the object returned
+     * by {@link #vertxProperties()}.
+     *
+     * @return The Vert.x instance.
+     */
+    @Bean
+    public Vertx vertx() {
+        return Vertx.vertx(vertxProperties().configureVertx(new VertxOptions()));
+    }
+
+    /**
+     * Exposes configuration properties for Vert.x.
+     *
+     * @return The properties.
+     */
+    @ConfigurationProperties("hono.vertx")
+    @Bean
+    public VertxProperties vertxProperties() {
+        return new VertxProperties();
+    }
+
+    /**
+     * Exposes an OpenTracing {@code Tracer} as a Spring Bean.
+     * <p>
+     * The Tracer will be resolved by means of a Java service lookup.
+     * If no tracer can be resolved this way, the {@code NoopTracer} is
+     * returned.
+     *
+     * @return The tracer.
+     */
+    @Bean
+    public Tracer getTracer() {
+
+        return Optional.ofNullable(TracerResolver.resolveTracer())
+                .orElse(NoopTracerFactory.create());
+    }
+
+    /**
+     * Gets general properties for configuring the Device Registry Spring Boot application.
+     *
+     * @return The properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.app")
+    public ApplicationConfigProperties applicationConfigProperties() {
+        return new ApplicationConfigProperties();
+    }
+
+    /**
+     * Exposes properties for configuring the health check as a Spring bean.
+     *
+     * @return The health check configuration properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.health-check")
+    public ServerConfig healthCheckConfigProperties() {
+        return new ServerConfig();
+    }
+
+    /**
+     * Gets properties for configuring the Device Registry's AMQP 1.0 endpoint.
+     *
+     * @return The properties.
+     */
+    @Qualifier(Constants.QUALIFIER_AMQP)
+    @Bean
+    @ConfigurationProperties(prefix = "hono.registry.amqp")
+    public ServiceConfigProperties amqpServerProperties() {
+        final ServiceConfigProperties props = new ServiceConfigProperties();
+        return props;
+    }
+
+    /**
+     * Creates a new instance of an AMQP 1.0 protocol handler for Hono's <em>Device Registration</em> API.
+     *
+     * @return The handler.
+     */
+    @Bean
+    @Scope("prototype")
+    public AmqpEndpoint registrationAmqpEndpoint() {
+        return new AutowiredRegistrationAmqpEndpoint(vertx());
+    }
+
+    /**
+     * Creates a new instance of an AMQP 1.0 protocol handler for Hono's <em>Credentials</em> API.
+     * 
+     * @return The handler.
+     */
+    @Bean
+    @Scope("prototype")
+    public AmqpEndpoint credentialsAmqpEndpoint() {
+        return new AutowiredCredentialsAmqpEndpoint(vertx());
+    }
+
+    /**
+     * Creates a new instance of an AMQP 1.0 protocol handler for Hono's <em>Tenant</em> API.
+     *
+     * @return The handler.
+     */
+    @Bean
+    @Scope("prototype")
+    public AmqpEndpoint tenantAmqpEndpoint() {
+        return new AutowiredTenantAmqpEndpoint(vertx());
+    }
+
+    /**
+     * Creates a new instance of an AMQP 1.0 protocol handler for Hono's <em>Device Connection</em> API.
+     *
+     * @return The handler.
+     */
+    @Bean
+    @Scope("prototype")
+    public AmqpEndpoint deviceConnectionAmqpEndpoint() {
+        return new DeviceConnectionAmqpEndpoint(vertx());
+    }
+
+    /**
+     * Gets properties for configuring the HTTP based Device Registry Management endpoint.
+     *
+     * @return The properties.
+     */
+    @Qualifier(Constants.QUALIFIER_REST)
+    @Bean
+    @ConfigurationProperties(prefix = "hono.registry.http")
+    public ServiceConfigProperties httpServerProperties() {
+        return new ServiceConfigProperties();
+    }
+
+    /**
+     * Creates a new instance of an HTTP protocol handler for the <em>devices</em> resources
+     * of Hono's Device Registry Management API's.
+     *
+     * @return The handler.
+     */
+    @Bean
+    @Scope("prototype")
+    public HttpEndpoint deviceHttpEndpoint() {
+        return new AutowiredDeviceManagementHttpEndpoint(vertx());
+    }
+
+    /**
+     * Creates a new instance of an HTTP protocol handler for the <em>credentials</em> resources
+     * of Hono's Device Registry Management API's.
+     *
+     * @return The handler.
+     */
+    @Bean
+    @Scope("prototype")
+    public HttpEndpoint credentialsHttpEndpoint() {
+        return new AutowiredCredentialsManagementHttpEndpoint(vertx());
+    }
+
+    /**
+     * Creates a new instance of an HTTP protocol handler for the <em>tenants</em> resources
+     * of Hono's Device Registry Management API's.
+     *
+     * @return The handler.
+     */
+    @Bean
+    @Scope("prototype")
+    public HttpEndpoint tenantHttpEndpoint() {
+        return new AutowiredTenantManagementHttpEndpoint(vertx());
+    }
+
+    /**
+     * Gets properties for configuring {@code InMemoryDeviceConnectionService} which implements
+     * the <em>Device Connection</em> API.
+     *
+     * @return The properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.device-connection.svc")
+    public MapBasedDeviceConnectionsConfigProperties deviceConnectionsProperties() {
+        return new MapBasedDeviceConnectionsConfigProperties();
+    }
+
+    /**
+     * Gets the mongodb config properties.
+     *
+     * @return The mongodb config properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.mongodb")
+    public MongoDbConfigProperties mongoDbConfigProperties() {
+        return new MongoDbConfigProperties();
+    }
+
+    /**
+     * Gets properties for configuring {@link MongoDbBasedRegistrationService} which implements the <em>Device
+     * Registration</em> API.
+     *
+     * @return The properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.registry.svc")
+    public MongoDbBasedRegistrationConfigProperties serviceProperties() {
+        return new MongoDbBasedRegistrationConfigProperties();
+    }
+
+    /**
+     * Customizer for meter registry.
+     *
+     * @return The new meter registry customizer.
+     */
+    @Bean
+    public MeterRegistryCustomizer<MeterRegistry> commonTags() {
+
+        return r -> r.config().commonTags(MetricsTags.forService(Constants.SERVICE_NAME_DEVICE_REGISTRY));
+
+    }
+
+    /**
+     * Exposes the health check server as a Spring bean.
+     *
+     * @return The health check server.
+     */
+    @Bean
+    public HealthCheckServer healthCheckServer() {
+        return new VertxBasedHealthCheckServer(vertx(), healthCheckConfigProperties());
+    }
+
+    /**
+     * Gets a {@link MongoDbCallExecutor} instance containing helper methods for mongodb interaction.
+     *
+     * @return An instance of the helper class {@link MongoDbCallExecutor}.
+     */
+    @Bean
+    public MongoDbCallExecutor mongoDBCallExecutor() {
+        return new MongoDbCallExecutor(vertx(), mongoDbConfigProperties());
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -33,7 +33,7 @@ import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantManagementH
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.amqp.AmqpEndpoint;
-import org.eclipse.hono.service.deviceconnection.DeviceConnectionAmqpEndpoint;
+import org.eclipse.hono.service.deviceconnection.AutowiredDeviceConnectionAmqpEndpoint;
 import org.eclipse.hono.service.http.HttpEndpoint;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
@@ -174,7 +174,7 @@ public class ApplicationConfig {
     @Bean
     @Scope("prototype")
     public AmqpEndpoint deviceConnectionAmqpEndpoint() {
-        return new DeviceConnectionAmqpEndpoint(vertx());
+        return new AutowiredDeviceConnectionAmqpEndpoint(vertx());
     }
 
     /**

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/AbstractMongoDbBasedRegistryConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/AbstractMongoDbBasedRegistryConfigProperties.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.mongodb.config;
+
+/**
+ * Common configuration properties for Mongodb based implementations of the APIs of Hono's device registry as own server.
+ * <p>
+ * This class is intended to be used as base class for property classes that configure a specific mongodb based API implementation.
+ */
+public abstract class AbstractMongoDbBasedRegistryConfigProperties {
+
+    /**
+     * The default number of seconds that information returned by the service's
+     * operations may be cached for.
+     */
+    public static final int DEFAULT_MAX_AGE_SECONDS = 180;
+    private int cacheMaxAge = DEFAULT_MAX_AGE_SECONDS;
+    /**
+     * Mongodb collection name for individual device registry service entity type.
+     */
+    private String collectionName = getDefaultCollectionName();
+    /**
+     * Option if modification on device registry is permitted.
+     */
+    private boolean modificationEnabled = true;
+
+    /**
+     * Gets the Mongodb collection name that the registry should be persisted to periodically.
+     * <p>
+     *
+     * @return The Mongodb collection name .
+     */
+    protected abstract String getDefaultCollectionName();
+
+    /**
+     * Gets the Mongodb collection name that the registry should be persisted to
+     * periodically.
+     * <p>
+     *
+     * @return The Mongodb collection name.
+     */
+    public final String getCollectionName() {
+        return collectionName;
+    }
+
+    /**
+     * Sets the Mongodb collection name that the registry should be persisted to
+     * periodically.
+     * <p>
+     *
+     * @param collectionName The Mongodb collection name to persist to.
+     */
+    public final void setCollectionName(final String collectionName) {
+        this.collectionName = collectionName;
+    }
+
+    /**
+     * Checks whether this registry allows the creation, modification and removal of entries.
+     * <p>
+     * If set to {@code false} then methods for creating, updating or deleting an entry should return a <em>403 Forbidden</em> response.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @return The flag.
+     */
+    public final boolean isModificationEnabled() {
+        return modificationEnabled;
+    }
+
+    /**
+     * Sets whether this registry allows creation, modification and removal of entries.
+     * <p>
+     * If set to {@code false} then for creating, updating or deleting an entry should return a <em>403 Forbidden</em> response.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @param flag The flag.
+     */
+    public final void setModificationEnabled(final boolean flag) {
+        modificationEnabled = flag;
+    }
+
+    /**
+     * Gets the maximum period of time that information returned by the service's
+     * operations may be cached for.
+     * <p>
+     * The default value of this property is {@link #DEFAULT_MAX_AGE_SECONDS} seconds.
+     *
+     * @return The period of time in seconds.
+     */
+    public final int getCacheMaxAge() {
+        return cacheMaxAge;
+    }
+
+    /**
+     * Sets the maximum period of time that information returned by the service's
+     * operations may be cached for.
+     * <p>
+     * The default value of this property is {@link #DEFAULT_MAX_AGE_SECONDS} seconds.
+     *
+     * @param maxAge The period of time in seconds.
+     * @throws IllegalArgumentException if max age is &lt; 0.
+     */
+    public final void setCacheMaxAge(final int maxAge) {
+        if (maxAge < 0) {
+            throw new IllegalArgumentException("max age must be >= 0");
+        }
+        this.cacheMaxAge = maxAge;
+    }
+
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedRegistrationConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedRegistrationConfigProperties.java
@@ -13,7 +13,7 @@
 package org.eclipse.hono.deviceregistry.mongodb.config;
 
 /**
- * Configuration properties for Hono's device registry tenant API.
+ * Configuration properties for Hono's device registration and management APIs.
  */
 public final class MongoDbBasedRegistrationConfigProperties extends AbstractMongoDbBasedRegistryConfigProperties {
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedRegistrationConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedRegistrationConfigProperties.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.config;
+
+/**
+ * Configuration properties for Hono's device registry tenant API.
+ */
+public final class MongoDbBasedRegistrationConfigProperties extends AbstractMongoDbBasedRegistryConfigProperties {
+
+    /**
+     * The value indicating an <em>unlimited</em> number of devices to be allowed for a tenant.
+     */
+    public static final int UNLIMITED_DEVICES_PER_TENANT = -1;
+
+    /**
+     * The name of the mongodb collection where devices information are stored.
+     */
+    private static final String DEFAULT_DEVICE_COLLECTION_NAME = "devices";
+
+    private int maxDevicesPerTenant = UNLIMITED_DEVICES_PER_TENANT;
+
+    /**
+     * Gets the maximum number of devices that can be registered for each tenant.
+     * <p>
+     * The default value of this property is {@link #UNLIMITED_DEVICES_PER_TENANT}.
+     *
+     * @return The maximum number of devices.
+     */
+    public int getMaxDevicesPerTenant() {
+        return maxDevicesPerTenant;
+    }
+
+    /**
+     * Sets the maximum number of devices that can be registered for each tenant.
+     * <p>
+     * The default value of this property is {@link #UNLIMITED_DEVICES_PER_TENANT}.
+     *
+     * @param maxDevices The maximum number of devices.
+     * @throws IllegalArgumentException if the number of devices is is set to less
+     *                                  than {@link #UNLIMITED_DEVICES_PER_TENANT}.
+     */
+    public void setMaxDevicesPerTenant(final int maxDevices) {
+        if (maxDevices < UNLIMITED_DEVICES_PER_TENANT) {
+            throw new IllegalArgumentException(
+                    String.format("Maximum devices must be set to value >= %s", UNLIMITED_DEVICES_PER_TENANT));
+        }
+        this.maxDevicesPerTenant = maxDevices;
+    }
+
+    @Override
+    protected String getDefaultCollectionName() {
+        return DEFAULT_DEVICE_COLLECTION_NAME;
+    }
+
+
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbConfigProperties.java
@@ -1,0 +1,270 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.mongodb.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A POJO for configuring MongoDB properties used by the
+ * MongoDbBasedRegistrationService.
+ */
+public class MongoDbConfigProperties {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDbConfigProperties.class);
+
+    private String host;
+    private int port = 0;
+    private String dbName;
+    private String username;
+    private String password;
+    private String connectionString;
+    private int serverSelectionTimeoutMS = 0;
+    private int connectTimeoutMS = 0;
+    private int createIndicesTimeoutMS = 3000;
+
+    /**
+     * Gets the name or literal IP address of the host the MongoDB instance is
+     * running on.
+     *
+     * @return host name
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Sets the name or literal IP address of the host the MongoDB instance is
+     * running on.
+     *
+     * @param host host name or IP address
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setHost(final String host) {
+        this.host = host;
+        return this;
+    }
+
+    /**
+     * Gets the ports the MongoDB is listening on.
+     *
+     * @return port number
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Sets the ports the MongoDB is listening on.
+     *
+     * @param port port number
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setPort(final int port) {
+        this.port = port;
+        return this;
+    }
+
+    /**
+     * Gets the database name.
+     *
+     * @return database name
+     */
+    public String getDbName() {
+        return dbName;
+    }
+
+    /**
+     * Sets the database name.
+     *
+     * @param dbName database name
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setDbName(final String dbName) {
+        this.dbName = dbName;
+        return this;
+    }
+
+    /**
+     * Gets the user name used for authentication.
+     *
+     * @return user name
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Sets the user name used for authentication.
+     *
+     * @param username user name
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setUsername(final String username) {
+        this.username = username;
+        return this;
+    }
+
+    /**
+     * Gets the password used for authentication.
+     *
+     * @return password
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Sets the password used for authentication.
+     *
+     * @param password the password
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setPassword(final String password) {
+        this.password = password;
+        return this;
+    }
+
+    /**
+     * Gets the connection string for the MongoDB client.
+     *
+     * @return connection string
+     */
+    public String getConnectionString() {
+        return connectionString;
+    }
+
+    /**
+     * Sets the connection string for the MongoDB client. If set, the connection
+     * string overrides the other connection settings. Format:
+     * mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+     *
+     * @param connectionString connection string
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setConnectionString(final String connectionString) {
+        this.connectionString = connectionString;
+        return this;
+    }
+
+    /**
+     * Gets the time in milliseconds that the mongo driver will wait to select a
+     * server for an operation before raising an error.
+     *
+     * @return time in milliseconds
+     */
+    public int getServerSelectionTimeout() {
+        return serverSelectionTimeoutMS;
+    }
+
+    /**
+     * Sets the time in milliseconds that the mongo driver will wait to select a
+     * server for an operation before raising an error.
+     *
+     * @param timeout timeout in milliseconds. Setting to zero means the default
+     *                value of Vert.x should be used.
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setServerSelectionTimeout(final int timeout) {
+        this.serverSelectionTimeoutMS = timeout;
+        return this;
+    }
+
+    /**
+     * Gets the time in milliseconds to attempt a connection before timing out.
+     *
+     * @return time in milliseconds
+     */
+    public int getConnectTimeout() {
+        return connectTimeoutMS;
+    }
+
+    /**
+     * Sets the time in milliseconds to attempt a connection before timing out.
+     *
+     * @param connectTimeout timeout in milliseconds. Setting to zero means the default
+     *                       value of Vert.x should be used.
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setConnectTimeout(final int connectTimeout) {
+        this.connectTimeoutMS = connectTimeout;
+        return this;
+    }
+
+    /**
+     * Gets the time in milliseconds to create indices during startup.
+     *
+     * @return time in milliseconds
+     */
+    public int getCreateIndicesTimeout() {
+        return createIndicesTimeoutMS;
+    }
+
+    /**
+     * Sets the time in milliseconds that the startup will try to create indices
+     * during startup.
+     *
+     * @param timeout timeout in milliseconds.
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setCreateIndicesTimeout(final int timeout) {
+        this.createIndicesTimeoutMS = timeout;
+        return this;
+    }
+
+    /**
+     * Returns the properties of this instance in a JsonObject suitable for
+     * initializing a Vertx MongoClient object. Note: if the connectionString is
+     * set, it will override all other connection settings.
+     *
+     * @return MongoDB client config object
+     */
+    public JsonObject asMongoClientConfigJson() {
+        final JsonObject config = new JsonObject();
+        if (connectionString != null) {
+            config.put("connection_string", connectionString);
+
+            if (host != null || port != 0 || dbName != null || username != null || password != null
+                    || serverSelectionTimeoutMS > 0 || connectTimeoutMS > 0) {
+                LOG.warn(
+                        "asMongoClientConfigJson: connectionString is set, other connection properties will be ignored");
+            }
+        } else {
+            if (host != null) {
+                config.put("host", host);
+            }
+            if (port != 0) {
+                config.put("port", port);
+            }
+            if (dbName != null) {
+                config.put("db_name", dbName);
+            }
+            if (username != null) {
+                config.put("username", username);
+            }
+            if (password != null) {
+                config.put("password", password);
+            }
+            if (serverSelectionTimeoutMS > 0) {
+                config.put("serverSelectionTimeoutMS", serverSelectionTimeoutMS);
+            }
+            if (connectTimeoutMS > 0) {
+                config.put("connectTimeoutMS", connectTimeoutMS);
+            }
+        }
+        return config;
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbConfigProperties.java
@@ -13,75 +13,83 @@
 
 package org.eclipse.hono.deviceregistry.mongodb.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Objects;
 
-import io.vertx.core.json.JsonObject;
+import org.eclipse.hono.util.PortConfigurationHelper;
 
 /**
- * A POJO for configuring MongoDB properties used by the
- * MongoDbBasedRegistrationService.
+ * A POJO for configuring mongodb properties used by the
+ * {@link org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedRegistrationService}.
  */
-public class MongoDbConfigProperties {
+public final class MongoDbConfigProperties {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MongoDbConfigProperties.class);
+    private static final int DEFAULT_CREATE_INDICES_TIMEOUT_IN_MS = 3000;
+    private static final int DEFAULT_PORT = 27017;
 
-    private String host;
-    private int port = 0;
+    private String host = "localhost";
+    private int port = DEFAULT_PORT;
     private String dbName;
     private String username;
     private String password;
     private String connectionString;
-    private int serverSelectionTimeoutMS = 0;
-    private int connectTimeoutMS = 0;
-    private int createIndicesTimeoutMS = 3000;
+    private int serverSelectionTimeoutInMs = 0;
+    private int connectionTimeoutInMs = 0;
+    private int createIndicesTimeoutInMs = DEFAULT_CREATE_INDICES_TIMEOUT_IN_MS;
 
     /**
-     * Gets the name or literal IP address of the host the MongoDB instance is
+     * Gets the name or literal IP address of the host the mongodb instance is
      * running on.
      *
-     * @return host name
+     * @return The host name.
      */
     public String getHost() {
         return host;
     }
 
     /**
-     * Sets the name or literal IP address of the host the MongoDB instance is
+     * Sets the name or literal IP address of the host the mongodb instance is
      * running on.
      *
      * @param host host name or IP address
-     * @return This instance for setter chaining.
+     * @return A reference to this for fluent use.
+     * @throws NullPointerException if host is {@code null}.
      */
     public MongoDbConfigProperties setHost(final String host) {
-        this.host = host;
+        this.host = Objects.requireNonNull(host);
         return this;
     }
 
     /**
-     * Gets the ports the MongoDB is listening on.
+     * Gets the TCP port that the mongodb is listening on.
      *
-     * @return port number
+     * @return The port number.
      */
     public int getPort() {
         return port;
     }
 
     /**
-     * Sets the ports the MongoDB is listening on.
+     * Sets the TCP port that the mongodb is listening on.
+     * <p>
+     * The default port value is {@link #DEFAULT_PORT}.
      *
-     * @param port port number
-     * @return This instance for setter chaining.
+     * @param port The port number.
+     * @return A reference to this for fluent use.
+     * @throws IllegalArgumentException if port &lt; 1000 or port &gt; 65535.
      */
     public MongoDbConfigProperties setPort(final int port) {
-        this.port = port;
+        if (PortConfigurationHelper.isValidPort(port)) {
+            this.port = port;
+        } else {
+            throw new IllegalArgumentException("invalid port number");
+        }
         return this;
     }
 
     /**
      * Gets the database name.
      *
-     * @return database name
+     * @return The database name.
      */
     public String getDbName() {
         return dbName;
@@ -90,18 +98,19 @@ public class MongoDbConfigProperties {
     /**
      * Sets the database name.
      *
-     * @param dbName database name
-     * @return This instance for setter chaining.
+     * @param dbName The database name
+     * @return A reference to this for fluent use.
+     * @throws NullPointerException if dbName is {@code null}.
      */
     public MongoDbConfigProperties setDbName(final String dbName) {
-        this.dbName = dbName;
+        this.dbName = Objects.requireNonNull(dbName);
         return this;
     }
 
     /**
      * Gets the user name used for authentication.
      *
-     * @return user name
+     * @return The user name.
      */
     public String getUsername() {
         return username;
@@ -110,18 +119,19 @@ public class MongoDbConfigProperties {
     /**
      * Sets the user name used for authentication.
      *
-     * @param username user name
-     * @return This instance for setter chaining.
+     * @param username The user name.
+     * @return A reference to this for fluent use.
+     * @throws NullPointerException if the username is {@code null}.
      */
     public MongoDbConfigProperties setUsername(final String username) {
-        this.username = username;
+        this.username = Objects.requireNonNull(username);
         return this;
     }
 
     /**
      * Gets the password used for authentication.
      *
-     * @return password
+     * @return The password.
      */
     public String getPassword() {
         return password;
@@ -131,32 +141,34 @@ public class MongoDbConfigProperties {
      * Sets the password used for authentication.
      *
      * @param password the password
-     * @return This instance for setter chaining.
+     * @return A reference to this for fluent use.
+     * @throws NullPointerException if password is {@code null}.
      */
     public MongoDbConfigProperties setPassword(final String password) {
-        this.password = password;
+        this.password = Objects.requireNonNull(password);
         return this;
     }
 
     /**
-     * Gets the connection string for the MongoDB client.
+     * Gets the connection string for the mongodb client.
      *
-     * @return connection string
+     * @return The connection string.
      */
     public String getConnectionString() {
         return connectionString;
     }
 
     /**
-     * Sets the connection string for the MongoDB client. If set, the connection
-     * string overrides the other connection settings. Format:
+     * Sets the connection string for the mongodb client. If set, the connection string
+     * overrides the other connection settings. Format:
      * mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
      *
-     * @param connectionString connection string
-     * @return This instance for setter chaining.
+     * @param connectionString The connection string.
+     * @return A reference to this for fluent use.
+     * @throws NullPointerException if the connectionString is {@code null}.
      */
     public MongoDbConfigProperties setConnectionString(final String connectionString) {
-        this.connectionString = connectionString;
+        this.connectionString = Objects.requireNonNull(connectionString);
         return this;
     }
 
@@ -164,107 +176,81 @@ public class MongoDbConfigProperties {
      * Gets the time in milliseconds that the mongo driver will wait to select a
      * server for an operation before raising an error.
      *
-     * @return time in milliseconds
+     * @return The server selection timeout in milliseconds.
      */
     public int getServerSelectionTimeout() {
-        return serverSelectionTimeoutMS;
+        return serverSelectionTimeoutInMs;
     }
 
     /**
-     * Sets the time in milliseconds that the mongo driver will wait to select a
-     * server for an operation before raising an error.
-     *
-     * @param timeout timeout in milliseconds. Setting to zero means the default
-     *                value of Vert.x should be used.
-     * @return This instance for setter chaining.
+     * Sets the timeout in milliseconds that the mongo driver will wait to select a server 
+     * for an operation before raising an error.
+     * <p>
+     * When this property is set to 0, the default value of Vert.x should be used.
+     * 
+     * @param serverSelectionTimeoutInMs The server selection timeout in milliseconds.
+     * @return A reference to this for fluent use.
+     * @throws IllegalArgumentException if the timeout is set to &lt;= 0.
      */
-    public MongoDbConfigProperties setServerSelectionTimeout(final int timeout) {
-        this.serverSelectionTimeoutMS = timeout;
+    public MongoDbConfigProperties setServerSelectionTimeout(final int serverSelectionTimeoutInMs) {
+        if (serverSelectionTimeoutInMs <= 0) {
+            throw new IllegalArgumentException("server selection timeout must be greater than zero");
+        }
+        this.serverSelectionTimeoutInMs = serverSelectionTimeoutInMs;
         return this;
     }
 
     /**
-     * Gets the time in milliseconds to attempt a connection before timing out.
+     * Gets the timeout in milliseconds to attempt a connection before timing out.
      *
-     * @return time in milliseconds
+     * @return The connection timeout in milliseconds.
      */
     public int getConnectTimeout() {
-        return connectTimeoutMS;
+        return connectionTimeoutInMs;
     }
 
     /**
-     * Sets the time in milliseconds to attempt a connection before timing out.
+     * Sets the timeout in milliseconds to attempt a connection before timing out.
+     * <p>
+     * When this property is set to 0, the default value of Vert.x should be used.
      *
-     * @param connectTimeout timeout in milliseconds. Setting to zero means the default
-     *                       value of Vert.x should be used.
-     * @return This instance for setter chaining.
+     * @param connectionTimeoutInMs The connection timeout in milliseconds.
+     * @return A reference to this for fluent use.
+     * @throws IllegalArgumentException if the timeout is set to &lt;= 0.
      */
-    public MongoDbConfigProperties setConnectTimeout(final int connectTimeout) {
-        this.connectTimeoutMS = connectTimeout;
+    public MongoDbConfigProperties setConnectTimeout(final int connectionTimeoutInMs) {
+        if (connectionTimeoutInMs <= 0) {
+            throw new IllegalArgumentException("connection timeout must be greater than zero");
+        }
+        this.connectionTimeoutInMs = connectionTimeoutInMs;
         return this;
     }
 
     /**
-     * Gets the time in milliseconds to create indices during startup.
+     * Gets the timeout in milliseconds to create indices during startup.
      *
-     * @return time in milliseconds
+     * @return The create indices timeout in milliseconds
      */
     public int getCreateIndicesTimeout() {
-        return createIndicesTimeoutMS;
+        return createIndicesTimeoutInMs;
     }
 
     /**
-     * Sets the time in milliseconds that the startup will try to create indices
+     * Sets the time in milliseconds that the startup will try to create indices 
      * during startup.
+     * <p>
+     * The default value of this property is {@link #DEFAULT_CREATE_INDICES_TIMEOUT_IN_MS}.
      *
-     * @param timeout timeout in milliseconds.
-     * @return This instance for setter chaining.
+     * @param createIndicesTimeoutInMs The create indices timeout in milliseconds.
+     * @return A reference to this for fluent use.
+     * @throws IllegalArgumentException if the timeout is set to &lt;= 0.
      */
-    public MongoDbConfigProperties setCreateIndicesTimeout(final int timeout) {
-        this.createIndicesTimeoutMS = timeout;
+    public MongoDbConfigProperties setCreateIndicesTimeout(final int createIndicesTimeoutInMs) {
+        if (connectionTimeoutInMs <= 0) {
+            throw new IllegalArgumentException("create indices timeout must be greater than zero");
+        }
+        this.createIndicesTimeoutInMs = createIndicesTimeoutInMs;
         return this;
     }
 
-    /**
-     * Returns the properties of this instance in a JsonObject suitable for
-     * initializing a Vertx MongoClient object. Note: if the connectionString is
-     * set, it will override all other connection settings.
-     *
-     * @return MongoDB client config object
-     */
-    public JsonObject asMongoClientConfigJson() {
-        final JsonObject config = new JsonObject();
-        if (connectionString != null) {
-            config.put("connection_string", connectionString);
-
-            if (host != null || port != 0 || dbName != null || username != null || password != null
-                    || serverSelectionTimeoutMS > 0 || connectTimeoutMS > 0) {
-                LOG.warn(
-                        "asMongoClientConfigJson: connectionString is set, other connection properties will be ignored");
-            }
-        } else {
-            if (host != null) {
-                config.put("host", host);
-            }
-            if (port != 0) {
-                config.put("port", port);
-            }
-            if (dbName != null) {
-                config.put("db_name", dbName);
-            }
-            if (username != null) {
-                config.put("username", username);
-            }
-            if (password != null) {
-                config.put("password", password);
-            }
-            if (serverSelectionTimeoutMS > 0) {
-                config.put("serverSelectionTimeoutMS", serverSelectionTimeoutMS);
-            }
-            if (connectTimeoutMS > 0) {
-                config.put("connectTimeoutMS", connectTimeoutMS);
-            }
-        }
-        return config;
-    }
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbConfigProperties.java
@@ -23,7 +23,6 @@ import org.eclipse.hono.util.PortConfigurationHelper;
  */
 public final class MongoDbConfigProperties {
 
-    private static final int DEFAULT_CREATE_INDICES_TIMEOUT_IN_MS = 3000;
     private static final int DEFAULT_PORT = 27017;
 
     private String host = "localhost";
@@ -32,9 +31,8 @@ public final class MongoDbConfigProperties {
     private String username;
     private String password;
     private String connectionString;
-    private int serverSelectionTimeoutInMs = 0;
-    private int connectionTimeoutInMs = 0;
-    private int createIndicesTimeoutInMs = DEFAULT_CREATE_INDICES_TIMEOUT_IN_MS;
+    private Integer serverSelectionTimeoutInMs;
+    private Integer connectionTimeoutInMs;
 
     /**
      * Gets the name or literal IP address of the host the mongodb instance is
@@ -177,11 +175,11 @@ public final class MongoDbConfigProperties {
      * Gets the time in milliseconds that the mongo driver will wait to select a
      * server for an operation before raising an error.
      * <p>
-     * When this property is set to 0, the default value by Vert.x mongodb client is used.
+     * When this property is not set, the Vert.x mongodb client uses a default value of 300000 ms.
      *
      * @return The server selection timeout in milliseconds.
      */
-    public int getServerSelectionTimeout() {
+    public Integer getServerSelectionTimeout() {
         return serverSelectionTimeoutInMs;
     }
 
@@ -189,15 +187,15 @@ public final class MongoDbConfigProperties {
      * Sets the timeout in milliseconds that the mongo driver will wait to select a server 
      * for an operation before raising an error.
      * <p>
-     * When this property is set to 0, the default value by Vert.x mongodb client is used.
+     * When this property is not set, the Vert.x mongodb client uses a default value of 300000 ms.
      * 
      * @param serverSelectionTimeoutInMs The server selection timeout in milliseconds.
      * @return A reference to this for fluent use.
-     * @throws IllegalArgumentException if the timeout is set to &lt;= 0.
+     * @throws IllegalArgumentException if the timeout is set to &lt; 0.
      */
     public MongoDbConfigProperties setServerSelectionTimeout(final int serverSelectionTimeoutInMs) {
-        if (serverSelectionTimeoutInMs <= 0) {
-            throw new IllegalArgumentException("server selection timeout must be greater than zero");
+        if (serverSelectionTimeoutInMs < 0) {
+            throw new IllegalArgumentException("server selection timeout must not be negative");
         }
         this.serverSelectionTimeoutInMs = serverSelectionTimeoutInMs;
         return this;
@@ -206,58 +204,28 @@ public final class MongoDbConfigProperties {
     /**
      * Gets the timeout in milliseconds to attempt a connection before timing out.
      * <p>
-     * When this property is set to 0, the default value by Vert.x mongodb client is used.
+     * When this property is not set, the Vert.x mongodb client uses a default value of 10000 ms.
      *
      * @return The connection timeout in milliseconds.
      */
-    public int getConnectTimeout() {
+    public Integer getConnectTimeout() {
         return connectionTimeoutInMs;
     }
 
     /**
      * Sets the timeout in milliseconds to attempt a connection before timing out.
      * <p>
-     * When this property is set to 0, the default value by Vert.x mongodb client is used.
+     * When this property is not set, the Vert.x mongodb client uses a default value of 10000 ms.
      *
      * @param connectionTimeoutInMs The connection timeout in milliseconds.
      * @return A reference to this for fluent use.
-     * @throws IllegalArgumentException if the timeout is set to &lt;= 0.
+     * @throws IllegalArgumentException if the timeout is set to &lt; 0.
      */
     public MongoDbConfigProperties setConnectTimeout(final int connectionTimeoutInMs) {
-        if (connectionTimeoutInMs <= 0) {
-            throw new IllegalArgumentException("connection timeout must be greater than zero");
+        if (connectionTimeoutInMs < 0) {
+            throw new IllegalArgumentException("connection timeout must not be negative");
         }
         this.connectionTimeoutInMs = connectionTimeoutInMs;
         return this;
     }
-
-    /**
-     * Gets the timeout in milliseconds to create indices during startup.
-     * <p>
-     * The default value of this property is {@link #DEFAULT_CREATE_INDICES_TIMEOUT_IN_MS}.
-     *
-     * @return The create indices timeout in milliseconds
-     */
-    public int getCreateIndicesTimeout() {
-        return createIndicesTimeoutInMs;
-    }
-
-    /**
-     * Sets the time in milliseconds that the startup will try to create indices 
-     * during startup.
-     * <p>
-     * The default value of this property is {@link #DEFAULT_CREATE_INDICES_TIMEOUT_IN_MS}.
-     *
-     * @param createIndicesTimeoutInMs The create indices timeout in milliseconds.
-     * @return A reference to this for fluent use.
-     * @throws IllegalArgumentException if the timeout is set to &lt;= 0.
-     */
-    public MongoDbConfigProperties setCreateIndicesTimeout(final int createIndicesTimeoutInMs) {
-        if (connectionTimeoutInMs <= 0) {
-            throw new IllegalArgumentException("create indices timeout must be greater than zero");
-        }
-        this.createIndicesTimeoutInMs = createIndicesTimeoutInMs;
-        return this;
-    }
-
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbConfigProperties.java
@@ -166,6 +166,7 @@ public final class MongoDbConfigProperties {
      * @param connectionString The connection string.
      * @return A reference to this for fluent use.
      * @throws NullPointerException if the connectionString is {@code null}.
+     * @see "https://docs.mongodb.com/manual/reference/connection-string/"
      */
     public MongoDbConfigProperties setConnectionString(final String connectionString) {
         this.connectionString = Objects.requireNonNull(connectionString);
@@ -175,6 +176,8 @@ public final class MongoDbConfigProperties {
     /**
      * Gets the time in milliseconds that the mongo driver will wait to select a
      * server for an operation before raising an error.
+     * <p>
+     * When this property is set to 0, the default value by Vert.x mongodb client is used.
      *
      * @return The server selection timeout in milliseconds.
      */
@@ -186,7 +189,7 @@ public final class MongoDbConfigProperties {
      * Sets the timeout in milliseconds that the mongo driver will wait to select a server 
      * for an operation before raising an error.
      * <p>
-     * When this property is set to 0, the default value of Vert.x should be used.
+     * When this property is set to 0, the default value by Vert.x mongodb client is used.
      * 
      * @param serverSelectionTimeoutInMs The server selection timeout in milliseconds.
      * @return A reference to this for fluent use.
@@ -202,6 +205,8 @@ public final class MongoDbConfigProperties {
 
     /**
      * Gets the timeout in milliseconds to attempt a connection before timing out.
+     * <p>
+     * When this property is set to 0, the default value by Vert.x mongodb client is used.
      *
      * @return The connection timeout in milliseconds.
      */
@@ -212,7 +217,7 @@ public final class MongoDbConfigProperties {
     /**
      * Sets the timeout in milliseconds to attempt a connection before timing out.
      * <p>
-     * When this property is set to 0, the default value of Vert.x should be used.
+     * When this property is set to 0, the default value by Vert.x mongodb client is used.
      *
      * @param connectionTimeoutInMs The connection timeout in milliseconds.
      * @return A reference to this for fluent use.
@@ -228,6 +233,8 @@ public final class MongoDbConfigProperties {
 
     /**
      * Gets the timeout in milliseconds to create indices during startup.
+     * <p>
+     * The default value of this property is {@link #DEFAULT_CREATE_INDICES_TIMEOUT_IN_MS}.
      *
      * @return The create indices timeout in milliseconds
      */

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/BaseDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/BaseDto.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.annotation.HonoTimestamp;
+import org.eclipse.hono.util.RegistryManagementConstants;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * TODO.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class BaseDto {
+
+    @JsonProperty(value = RegistryManagementConstants.FIELD_VERSION, required = true)
+    protected String version;
+    @JsonProperty(value = RegistryManagementConstants.FIELD_UPDATED_ON, required = true)
+    @HonoTimestamp
+    protected Instant updatedOn;
+
+    /**
+     * Default constructor for serialisation/deserialization.
+     */
+    public BaseDto() {
+        // Explicit default constructor.
+    }
+
+    /**
+     * Gets the version of the document.
+     * 
+     * @return The version of the document or {@code null} if not set.
+     */
+    public final String getVersion() {
+        return version;
+    }
+
+    /**
+     * Sets the given version of the document.
+     * 
+     * @param version The version of the document.
+     * @throws NullPointerException if the version is {@code null}.
+     */
+    public final void setVersion(final String version) {
+        this.version = Objects.requireNonNull(version);
+    }
+
+    /**
+     * Gets the date and time of last modification.
+     *
+     * @return The date and time of last modification.
+     */
+    public final Instant getUpdatedOn() {
+        return updatedOn;
+    }
+
+    /**
+     * Sets the date and time of last modification.
+     * 
+     * @param updatedOn The date and time of last modification.
+     * @throws NullPointerException if the last modification date and time is {@code null}.
+     */
+    public final void setUpdatedOn(final Instant updatedOn) {
+        this.updatedOn = Objects.requireNonNull(updatedOn);
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/BaseDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/BaseDto.java
@@ -16,24 +16,24 @@ import java.time.Instant;
 import java.util.Objects;
 
 import org.eclipse.hono.annotation.HonoTimestamp;
-import org.eclipse.hono.util.RegistryManagementConstants;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDeviceRegistryUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * TODO.
+ * The base class for implementing a DTO (Data Transfer Object) to store data in mongodb.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class BaseDto {
 
-    @JsonProperty(value = RegistryManagementConstants.FIELD_VERSION, required = true)
-    protected String version;
-    @JsonProperty(value = RegistryManagementConstants.FIELD_UPDATED_ON, required = true)
+    @JsonProperty(value = MongoDbDeviceRegistryUtils.FIELD_VERSION, required = true)
+    private String version;
+    @JsonProperty(value = MongoDbDeviceRegistryUtils.FIELD_UPDATED_ON, required = true)
     @HonoTimestamp
-    protected Instant updatedOn;
+    private Instant updatedOn;
 
     /**
      * Default constructor for serialisation/deserialization.
@@ -45,16 +45,16 @@ public abstract class BaseDto {
     /**
      * Gets the version of the document.
      * 
-     * @return The version of the document or {@code null} if not set.
+     * @return The version of the document.
      */
     public final String getVersion() {
         return version;
     }
 
     /**
-     * Sets the given version of the document.
+     * Sets the version of the document.
      * 
-     * @param version The version of the document.
+     * @param version The version of the document or {@code null} if not set.
      * @throws NullPointerException if the version is {@code null}.
      */
     public final void setVersion(final String version) {

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/DeviceDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/DeviceDto.java
@@ -15,13 +15,14 @@ package org.eclipse.hono.deviceregistry.mongodb.model;
 import java.time.Instant;
 import java.util.Objects;
 
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDeviceRegistryUtils;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * TODO.
+ * A DTO (Data Transfer Object) class to store device information in mongodb.
  */
 public final class DeviceDto extends BaseDto {
 
@@ -31,7 +32,7 @@ public final class DeviceDto extends BaseDto {
     @JsonProperty(value = RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID, required = true)
     private String deviceId;
 
-    @JsonProperty(RegistryManagementConstants.FIELD_DEVICE)
+    @JsonProperty(MongoDbDeviceRegistryUtils.FIELD_DEVICE)
     private Device device;
 
     /**
@@ -44,18 +45,16 @@ public final class DeviceDto extends BaseDto {
     /**
      * @param tenantId The tenant identifier.
      * @param deviceId The device identifier.
-     * @param device The device.
+     * @param device The device information.
      * @param version The version of tenant to be sent as request header.
-     * @param updatedOn The date and time of last update.
      * @throws NullPointerException if any of the parameters except the device are {@code null}
      */
-    public DeviceDto(final String tenantId, final String deviceId, final Device device, final String version,
-            final Instant updatedOn) {
-        this.tenantId = Objects.requireNonNull(tenantId);
-        this.deviceId = Objects.requireNonNull(deviceId);
-        this.device = device;
-        this.version = Objects.requireNonNull(version);
-        this.updatedOn = Objects.requireNonNull(updatedOn);
+    public DeviceDto(final String tenantId, final String deviceId, final Device device, final String version) {
+        setTenantId(tenantId);
+        setDeviceId(deviceId);
+        setDevice(device);
+        setVersion(version);
+        setUpdatedOn(Instant.now());
     }
 
     /**
@@ -84,11 +83,11 @@ public final class DeviceDto extends BaseDto {
     /**
      * Sets the identifier of the device.
      *
-     * @param deviceId The device's identifier.
+     * @param deviceId The identifier of the device.
      * @throws NullPointerException if the deviceId is {@code null}.
      */
     public void setDeviceId(final String deviceId) {
-        this.deviceId = deviceId;
+        this.deviceId = Objects.requireNonNull(deviceId);
     }
 
     /**

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/DeviceDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/DeviceDto.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.util.RegistryManagementConstants;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * TODO.
+ */
+public final class DeviceDto extends BaseDto {
+
+    @JsonProperty(value = RegistryManagementConstants.FIELD_PAYLOAD_TENANT_ID, required = true)
+    private String tenantId;
+
+    @JsonProperty(value = RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID, required = true)
+    private String deviceId;
+
+    @JsonProperty(RegistryManagementConstants.FIELD_DEVICE)
+    private Device device;
+
+    /**
+     * Default constructor for serialisation/deserialization.
+     */
+    public DeviceDto() {
+        // Explicit default constructor.
+    }
+
+    /**
+     * @param tenantId The tenant identifier.
+     * @param deviceId The device identifier.
+     * @param device The device.
+     * @param version The version of tenant to be sent as request header.
+     * @param updatedOn The date and time of last update.
+     * @throws NullPointerException if any of the parameters except the device are {@code null}
+     */
+    public DeviceDto(final String tenantId, final String deviceId, final Device device, final String version,
+            final Instant updatedOn) {
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.deviceId = Objects.requireNonNull(deviceId);
+        this.device = device;
+        this.version = Objects.requireNonNull(version);
+        this.updatedOn = Objects.requireNonNull(updatedOn);
+    }
+
+    /**
+     * Gets the identifier of the tenant.
+     *
+     * @return The identifier of the tenant.
+     */
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Sets the identifier of the tenant.
+     *
+     * @param tenantId The tenant's identifier.
+     * @throws NullPointerException if the tenantId is {@code null}.
+     */
+    public void setTenantId(final String tenantId) {
+        this.tenantId = Objects.requireNonNull(tenantId);
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    /**
+     * Sets the identifier of the device.
+     *
+     * @param deviceId The device's identifier.
+     * @throws NullPointerException if the deviceId is {@code null}.
+     */
+    public void setDeviceId(final String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    /**
+     * Gets the device information.
+     *
+     * @return The device information or {@code null} if not set.
+     */
+    public Device getDevice() {
+        return device;
+    }
+
+    /**
+     * Sets the device information.
+     *
+     * @param device The device information.
+     */
+    public void setDevice(final Device device) {
+        this.device = device;
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialsService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialsService.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.service;
+
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.service.credentials.CredentialsService;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.Result;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
+import org.eclipse.hono.util.CredentialsResult;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import io.opentracing.Span;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * This is an implementation of the credentials service and the credentials management service where data is 
+ * stored in a mongodb database.
+ * 
+ * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/">Credentials API</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/management/">Device Registry Management API</a>
+ */
+@Component
+@Qualifier("serviceImpl")
+public class MongoDbBasedCredentialsService extends AbstractVerticle
+        implements CredentialsManagementService, CredentialsService {
+
+    @Override
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type,
+            final String authId, final Span span) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type,
+            final String authId,
+            final JsonObject clientContext, final Span span) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public Future<OperationResult<Void>> updateCredentials(final String tenantId, final String deviceId,
+            final List<CommonCredential> credentials, final Optional<String> resourceVersion, final Span span) {
+        // TODO
+        return Future.succeededFuture(
+                OperationResult.ok(HttpURLConnection.HTTP_NO_CONTENT, null, Optional.empty(), Optional.empty()));
+    }
+
+    @Override
+    public Future<OperationResult<List<CommonCredential>>> readCredentials(final String tenantId,
+            final String deviceId,
+            final Span span) {
+        // TODO
+        return null;
+    }
+
+    /**
+     * Remove all the credentials for the given device ID.
+     *
+     * @param tenantId the Id of the tenant which the device belongs to.
+     * @param deviceId the id of the device that is deleted.
+     * @param span The active OpenTracing span for this operation.
+     * @return A future indicating the outcome of the operation.
+     *         The <em>status</em> will be <em>204 No Content</em> 
+     *         if the operation completed successfully.
+     * @throws NullPointerException if any of the parameters except span is {@code null}.
+     */
+    public Future<Result<Void>> removeCredentials(final String tenantId, final String deviceId, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        // TODO
+        return Future.succeededFuture(Result.from(HttpURLConnection.HTTP_NO_CONTENT));
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
@@ -173,9 +173,7 @@ public class MongoDbBasedDeviceBackend implements AutoProvisioningEnabledDeviceB
                                                         return getNewCredentials(tenantId, authId, span);
                                                     }
                                                 }))
-                                        .orElse(Future.succeededFuture(
-                                                createErrorCredentialsResult(HttpURLConnection.HTTP_BAD_REQUEST,
-                                                        "Not able to get the certificate from the client context"))));
+                                        .orElse(Future.succeededFuture(result)));
                     }
                     return Future.succeededFuture(result);
                 });

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
@@ -1,0 +1,268 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.service;
+
+import java.io.ByteArrayInputStream;
+import java.net.HttpURLConnection;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.hono.service.management.Id;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.Result;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.service.management.device.AutoProvisioningEnabledDeviceBackend;
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.eclipse.hono.util.CredentialsResult;
+import org.eclipse.hono.util.RegistrationResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+import io.opentracing.Span;
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A device backend that leverages and unifies {@link MongoDbBasedRegistrationService} and
+ * {@link MongoDbBasedCredentialsService}.
+ */
+@Repository
+@Qualifier("backend")
+public class MongoDbBasedDeviceBackend implements AutoProvisioningEnabledDeviceBackend {
+
+    private final MongoDbBasedRegistrationService registrationService;
+    private final MongoDbBasedCredentialsService credentialsService;
+
+    /**
+     * Create a new instance.
+     * 
+     * @param registrationService an implementation of registration service.
+     * @param credentialsService an implementation of credentials service.
+     */
+    @Autowired
+    public MongoDbBasedDeviceBackend(
+            @Qualifier("serviceImpl") final MongoDbBasedRegistrationService registrationService,
+            @Qualifier("serviceImpl") final MongoDbBasedCredentialsService credentialsService) {
+        this.registrationService = registrationService;
+        this.credentialsService = credentialsService;
+    }
+
+    // DEVICES
+
+    @Override
+    public Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId) {
+        return registrationService.assertRegistration(tenantId, deviceId);
+    }
+
+    @Override
+    public Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId,
+            final String gatewayId) {
+        return registrationService.assertRegistration(tenantId, deviceId, gatewayId);
+    }
+
+    @Override
+    public Future<OperationResult<Device>> readDevice(final String tenantId, final String deviceId, final Span span) {
+        return registrationService.readDevice(tenantId, deviceId, span);
+    }
+
+    @Override
+    public Future<Result<Void>> deleteDevice(final String tenantId, final String deviceId,
+            final Optional<String> resourceVersion,
+            final Span span) {
+
+        return registrationService.deleteDevice(tenantId, deviceId, resourceVersion, span)
+                .compose(result -> {
+                    if (result.getStatus() != HttpURLConnection.HTTP_NO_CONTENT) {
+                        return Future.succeededFuture(result);
+                    }
+                    // now delete the credentials set and pass on the original result
+                    return credentialsService.removeCredentials(
+                            tenantId,
+                            deviceId,
+                            span)
+                            .map(result);
+                });
+    }
+
+    @Override
+    public Future<OperationResult<Id>> createDevice(
+            final String tenantId,
+            final Optional<String> deviceId,
+            final Device device,
+            final Span span) {
+
+        return registrationService.createDevice(tenantId, deviceId, device, span)
+                .compose(result -> {
+                    if (result.getStatus() != HttpURLConnection.HTTP_CREATED) {
+                        return Future.succeededFuture(result);
+                    }
+                    // now create the empty credentials set and pass on the original result
+                    return credentialsService.updateCredentials(
+                            tenantId,
+                            result.getPayload().getId(),
+                            Collections.emptyList(),
+                            Optional.empty(),
+                            span
+                    ).map(result);
+                });
+    }
+
+    @Override
+    public Future<OperationResult<Id>> updateDevice(final String tenantId, final String deviceId, final Device device,
+            final Optional<String> resourceVersion, final Span span) {
+        return registrationService.updateDevice(tenantId, deviceId, device, resourceVersion, span);
+    }
+
+    // CREDENTIALS
+
+    @Override
+    public final Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type,
+            final String authId) {
+        return credentialsService.get(tenantId, type, authId);
+    }
+
+    @Override
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId,
+            final Span span) {
+        return credentialsService.get(tenantId, type, authId, span);
+    }
+
+    @Override
+    public final Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type,
+            final String authId, final JsonObject clientContext) {
+        return get(tenantId, type, authId, clientContext, NoopSpan.INSTANCE);
+    }
+
+    @Override
+    public  Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId, final JsonObject clientContext,
+            final Span span) {
+        return credentialsService.get(tenantId, type, authId, clientContext, span)
+                .compose(result -> {
+                    if (result.getStatus() == HttpURLConnection.HTTP_NOT_FOUND
+                            && isAutoProvisioningEnabled(type, clientContext)) {
+                        return provisionDevice(tenantId, authId, clientContext, span);
+                    }
+                    return Future.succeededFuture(result);
+                });
+    }
+
+    /**
+     * Parses certificate, provisions device and returns the new credentials.
+     */
+    private Future<CredentialsResult<JsonObject>> provisionDevice(final String tenantId, final String authId,
+            final JsonObject clientContext,
+            final Span span) {
+
+        final X509Certificate cert;
+        try {
+            final byte[] bytes = clientContext.getBinary(CredentialsConstants.FIELD_CLIENT_CERT);
+            final CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            cert = (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(bytes));
+
+            if (!cert.getSubjectX500Principal().getName(X500Principal.RFC2253).equals(authId)) {
+                throw new IllegalArgumentException("Subject DN of the client certificate does not match authId");
+            }
+        } catch (final CertificateException | ClassCastException | IllegalArgumentException e) {
+            TracingHelper.logError(span, e);
+            final int status = HttpURLConnection.HTTP_BAD_REQUEST;
+            return Future.succeededFuture(createErrorCredentialsResult(status, e.getMessage()));
+        }
+
+        return provisionDevice(tenantId, cert, span)
+                .compose(r -> {
+                    if (r.isError()) {
+                        TracingHelper.logError(span, r.getPayload());
+                        return Future.succeededFuture(createErrorCredentialsResult(r.getStatus(), r.getPayload()));
+                    } else {
+                        return getNewCredentials(tenantId, authId, span);
+                    }
+                });
+    }
+
+    private Future<CredentialsResult<JsonObject>> getNewCredentials(final String tenantId, final String authId,
+            final Span span) {
+
+        return credentialsService.get(tenantId, CredentialsConstants.SECRETS_TYPE_X509_CERT, authId, span)
+                .map(r -> r.isOk() ? CredentialsResult.from(HttpURLConnection.HTTP_CREATED, r.getPayload()) : r);
+    }
+
+    private boolean isAutoProvisioningEnabled(final String type, final JsonObject clientContext) {
+        return type.equals(CredentialsConstants.SECRETS_TYPE_X509_CERT)
+                && clientContext != null
+                && clientContext.containsKey(CredentialsConstants.FIELD_CLIENT_CERT);
+    }
+
+    private CredentialsResult<JsonObject> createErrorCredentialsResult(final int status, final String message) {
+        return CredentialsResult.from(status, new JsonObject().put("description", message));
+    }
+
+    @Override
+    public Future<OperationResult<Void>> updateCredentials(final String tenantId, final String deviceId,
+            final List<CommonCredential> credentials, final Optional<String> resourceVersion,
+            final Span span) {
+        return credentialsService.updateCredentials(tenantId, deviceId, credentials, resourceVersion, span);
+    }
+
+    @Override
+    public Future<OperationResult<List<CommonCredential>>> readCredentials(final String tenantId, final String deviceId,
+            final Span span) {
+
+        return credentialsService.readCredentials(tenantId, deviceId, span)
+                .compose(result -> {
+                    if (result.getStatus() == HttpURLConnection.HTTP_NOT_FOUND) {
+                        return registrationService.readDevice(tenantId, deviceId, span)
+                                .map(d -> {
+                                    if (d.getStatus() == HttpURLConnection.HTTP_OK) {
+                                        return OperationResult.ok(HttpURLConnection.HTTP_OK,
+                                                Collections.emptyList(),
+                                                result.getCacheDirective(),
+                                                result.getResourceVersion());
+                                    } else {
+                                        return result;
+                                    }
+                                });
+                    } else {
+                        return Future.succeededFuture(result);
+                    }
+                });
+    }
+
+    /**
+     * Creator for {@link ToStringHelper}.
+     * 
+     * @return A new instance for this instance.
+     */
+    protected ToStringHelper toStringHelper() {
+        return MoreObjects.toStringHelper(this)
+                .add("credentialsService", this.credentialsService)
+                .add("registrationService", this.registrationService);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper().toString();
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
@@ -1,0 +1,368 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.service;
+
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.model.DeviceDto;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbCallExecutor;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDocumentBuilder;
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
+import org.eclipse.hono.deviceregistry.util.Versioned;
+import org.eclipse.hono.service.management.Id;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.Result;
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.service.registration.AbstractRegistrationService;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.eclipse.hono.util.RegistrationResult;
+import org.eclipse.hono.util.RegistryManagementConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoException;
+
+import io.opentracing.Span;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Verticle;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.IndexOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.MongoClientDeleteResult;
+import io.vertx.ext.mongo.MongoClientUpdateResult;
+
+/**
+ * This is an implementation of the device registration service and the device management service where data 
+ * is stored in a mongodb database.
+ *
+ * @see <a href="https://www.eclipse.org/hono/docs/api/device-registration/">Device Registration API</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/management/">Device Registry Management API</a>
+ */
+@Component
+@Qualifier("serviceImpl")
+public final class MongoDbBasedRegistrationService extends AbstractRegistrationService implements DeviceManagementService, Verticle {
+
+    private static final Logger log = LoggerFactory.getLogger(MongoDbBasedRegistrationService.class);
+    private MongoClient mongoClient;
+    private MongoDbBasedRegistrationConfigProperties config;
+    private MongoDbCallExecutor mongoDbCallExecutor;
+    private Vertx vertx;
+
+    /**
+     * Creates an instance of the {@link MongoDbCallExecutor}.
+     *
+     * @param mongoDbCallExecutor An instance of the mongoDbCallExecutor.
+     * @throws NullPointerException if the mongoDbCallExecutor is {@code null}.
+     */
+    @Autowired
+    public void setExecutor(final MongoDbCallExecutor mongoDbCallExecutor) {
+        this.mongoDbCallExecutor = Objects.requireNonNull(mongoDbCallExecutor);
+        this.mongoClient = this.mongoDbCallExecutor.getMongoClient();
+    }
+
+    /**
+     * Sets the configuration properties for this service.
+     *
+     * @param config The configuration properties.
+     * @throws NullPointerException if the config is {@code null}.
+     */
+    @Autowired
+    public void setConfig(final MongoDbBasedRegistrationConfigProperties config) {
+        this.config = Objects.requireNonNull(config);
+    }
+
+    /**
+     * Sets the Vert.x instance to deploy the service to.
+     *
+     * @param vertx The vertx instance.
+     * @throws NullPointerException if vertx is {@code null}.
+     */
+    @Autowired
+    public void setVertx(final Vertx vertx) {
+        this.vertx = Objects.requireNonNull(vertx);
+    }
+
+    @Override
+    public Vertx getVertx() {
+        return vertx;
+    }
+
+    @Override
+    public void init(final Vertx vertx, final Context context) {
+    }
+
+    @Override
+    public void start(final Future<Void> startFuture) {
+    }
+
+    @Override
+    public void start(final Promise<Void> startPromise) {
+
+        mongoDbCallExecutor.createCollectionIndex(config.getCollectionName(),
+                new JsonObject().put(RegistrationConstants.FIELD_PAYLOAD_TENANT_ID, 1)
+                        .put(RegistrationConstants.FIELD_PAYLOAD_DEVICE_ID, 1),
+                new IndexOptions().unique(true))
+                .map(success -> {
+                    startPromise.complete();
+                    return null;
+                })
+                .onFailure(error -> {
+                    log.error("Index creation failed", error);
+                    startPromise.fail(error);
+                });
+    }
+
+    @Override
+    public void stop(final Future<Void> stopFuture) {
+    }
+
+    @Override
+    public void stop(final Promise<Void> stopPromise) {
+        mongoClient.close();
+        stopPromise.complete();
+    }
+
+    @Override
+    public Future<OperationResult<Id>> createDevice(final String tenantId, final Optional<String> deviceId,
+            final Device device, final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        final String deviceIdValue = deviceId.orElse(DeviceRegistryUtils.getUniqueIdentifier());
+        final Versioned<Device> versionedDevice = new Versioned<>(device);
+        final DeviceDto deviceDto = new DeviceDto(tenantId, deviceIdValue, versionedDevice.getValue(),
+                versionedDevice.getVersion(), Instant.now());
+
+        final Promise<Long> findExistingNoOfDevicesPromise = Promise.promise();
+        mongoClient.count(config.getCollectionName(), new JsonObject(), findExistingNoOfDevicesPromise);
+        return findExistingNoOfDevicesPromise.future()
+                .compose(existingNoOfDevices -> {
+                    if (config
+                            .getMaxDevicesPerTenant() != MongoDbBasedRegistrationConfigProperties.UNLIMITED_DEVICES_PER_TENANT
+                            && existingNoOfDevices >= config.getMaxDevicesPerTenant()) {
+                        log.debug("Maximum number of devices limit already reached for the tenant [{}]", tenantId);
+                        TracingHelper.logError(span, String.format(
+                                "Maximum number of devices limit already reached for the tenant [%s]", tenantId));
+                        return Future
+                                .succeededFuture(Result.from(HttpURLConnection.HTTP_FORBIDDEN, OperationResult::empty));
+                    } else {
+                        return processCreateDevice(deviceDto, span);
+                    }
+                });
+    }
+
+    @Override
+    public Future<OperationResult<Device>> readDevice(final String tenantId, final String deviceId, final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return processReadDevice(tenantId, deviceId, span);
+    }
+
+    @Override
+    public Future<OperationResult<Id>> updateDevice(final String tenantId, final String deviceId, final Device device,
+            final Optional<String> resourceVersion, final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        if (!config.isModificationEnabled()) {
+            final String errorMsg = String.format("Modification is disabled for tenant [%s]", tenantId);
+            TracingHelper.logError(span, errorMsg);
+            log.debug(errorMsg);
+            return Future.succeededFuture(Result.from(HttpURLConnection.HTTP_FORBIDDEN, OperationResult::empty));
+        }
+        // TODO: To check for the version mismatch.
+
+        final Versioned<Device> versionedDevice = new Versioned<>(device);
+        final DeviceDto deviceDto = new DeviceDto(tenantId, deviceId, versionedDevice.getValue(),
+                versionedDevice.getVersion(), Instant.now());
+
+        return processUpdateDevice(tenantId, deviceId, deviceDto, span);
+    }
+
+    @Override
+    public Future<Result<Void>> deleteDevice(final String tenantId, final String deviceId,
+            final Optional<String> resourceVersion, final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        if (!config.isModificationEnabled()) {
+            final String errorMsg = String.format("Modification is disabled for tenant [%s]", tenantId);
+            TracingHelper.logError(span, errorMsg);
+            log.debug(errorMsg);
+            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_FORBIDDEN));
+        }
+
+        // TODO: To check for the version mismatch.
+
+        return processDeleteDevice(tenantId, deviceId, span);
+    }
+
+    @Override
+    protected Future<RegistrationResult> getDevice(final String tenantId, final String deviceId, final Span span) {
+
+        return processReadDevice(tenantId, deviceId, span)
+                .compose(result -> Future.succeededFuture(RegistrationResult.from(result.getStatus(),
+                        convertDevice(deviceId, result.getPayload()), result.getCacheDirective().orElse(null))));
+    }
+
+    @Override
+    protected Future<JsonArray> resolveGroupMembers(final String tenantId, final JsonArray viaGroups,
+            final Span span) {
+        // TODO.
+        return null;
+    }
+
+    private JsonObject convertDevice(final String deviceId, final Device payload) {
+
+        if (payload == null) {
+            return null;
+        }
+
+        final JsonObject data = JsonObject.mapFrom(payload);
+
+        return new JsonObject()
+                .put(RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID, deviceId)
+                .put("data", data);
+    }
+
+    private Future<DeviceDto> findDevice(final String tenantId, final String deviceId) {
+        final JsonObject findDeviceQuery = new MongoDbDocumentBuilder()
+                .withTenantId(tenantId)
+                .withDeviceId(deviceId)
+                .document();
+        final Promise<JsonObject> readDevicePromise = Promise.promise();
+        mongoClient.findOne(config.getCollectionName(), findDeviceQuery, null, readDevicePromise);
+        return readDevicePromise.future()
+                .compose(result -> Optional.ofNullable(result)
+                        .map(ok -> result.mapTo(DeviceDto.class))
+                        .map(Future::succeededFuture)
+                        .orElseGet(() -> {
+                            log.debug("Device [{}] not found.", deviceId);
+                            return Future.succeededFuture(null);
+                        }));
+    }
+
+    private boolean isDuplicateKeyError(final Throwable throwable) {
+        if (throwable instanceof MongoException) {
+            final MongoException mongoException = (MongoException) throwable;
+            return ErrorCategory.fromErrorCode(mongoException.getCode()) == ErrorCategory.DUPLICATE_KEY;
+        }
+        return false;
+    }
+
+    private Future<OperationResult<Id>> processCreateDevice(final DeviceDto device, final Span span) {
+        final Promise<String> addDevicePromise = Promise.promise();
+        mongoClient.insert(config.getCollectionName(), JsonObject.mapFrom(device), addDevicePromise);
+        return addDevicePromise.future()
+                .map(success -> OperationResult.ok(
+                        HttpURLConnection.HTTP_CREATED,
+                        Id.of(device.getDeviceId()),
+                        Optional.empty(),
+                        Optional.of(device.getVersion())))
+                .recover(error -> {
+                    if (isDuplicateKeyError(error)) {
+                        log.debug("Device [{}] already exists for the tenant [{}]", device.getDeviceId(),
+                                device.getTenantId(), error);
+                        TracingHelper.logError(span, String.format("Device [%s] already exists for the tenant [%s]",
+                                device.getDeviceId(), device.getTenantId()));
+                        return Future.succeededFuture(
+                                OperationResult.empty(HttpURLConnection.HTTP_CONFLICT));
+                    } else {
+                        log.error("Error adding device [{}] for the tenant [{}]", device.getDeviceId(),
+                                device.getTenantId(), error);
+                        TracingHelper.logError(span, String.format("Error adding device [%s] for the tenant [%s]",
+                                device.getDeviceId(), device.getTenantId()), error);
+                        return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_INTERNAL_ERROR));
+                    }
+                });
+    }
+
+    private Future<Result<Void>> processDeleteDevice(final String tenantId, final String deviceId, final Span span) {
+        final Promise<MongoClientDeleteResult> deleteDevicePromise = Promise.promise();
+        final JsonObject removeDeviceQuery = new MongoDbDocumentBuilder()
+                .withTenantId(tenantId)
+                .withDeviceId(deviceId)
+                .document();
+        mongoClient.removeDocument(config.getCollectionName(), removeDeviceQuery, deleteDevicePromise);
+        return deleteDevicePromise.future()
+                .compose(successDeleteDevice -> {
+                    if (successDeleteDevice.getRemovedCount() == 1) {
+                        return Future.succeededFuture(Result.from(HttpURLConnection.HTTP_NO_CONTENT));
+                    } else {
+                        log.debug("Device [{}] not found.", deviceId);
+                        TracingHelper.logError(span, String.format("Device [%s] not found.", deviceId));
+                        return Future.succeededFuture(Result.from(HttpURLConnection.HTTP_NOT_FOUND));
+                    }
+                });
+    }
+
+    private Future<OperationResult<Device>> processReadDevice(final String tenantId, final String deviceId,
+            final Span span) {
+        return findDevice(tenantId, deviceId)
+                .compose(deviceDto -> Optional.ofNullable(deviceDto)
+                        .map(ok -> Future.succeededFuture(
+                                OperationResult.ok(
+                                        HttpURLConnection.HTTP_OK,
+                                        deviceDto.getDevice(),
+                                        Optional.ofNullable(
+                                                DeviceRegistryUtils.getCacheDirective(config.getCacheMaxAge())),
+                                        Optional.ofNullable(deviceDto.getVersion()))))
+                        .orElseGet(() -> {
+                            TracingHelper.logError(span, String.format("Device [%s] not found.", deviceId));
+                            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_NOT_FOUND));
+                        }));
+    }
+
+    private Future<OperationResult<Id>> processUpdateDevice(final String tenantId, final String deviceId,
+            final DeviceDto deviceDto, final Span span) {
+        final JsonObject updateDeviceQuery = new MongoDbDocumentBuilder()
+                .withTenantId(tenantId)
+                .withDeviceId(deviceId)
+                .document();
+        final Promise<MongoClientUpdateResult> updateDevicePromise = Promise.promise();
+        mongoClient.updateCollection(config.getCollectionName(), updateDeviceQuery,
+                new JsonObject().put("$set", JsonObject.mapFrom(deviceDto)), updateDevicePromise);
+        return updateDevicePromise.future()
+                .map(updateResult -> {
+                    if (updateResult.getDocMatched() == 0) {
+                        TracingHelper.logError(span, String.format("Device [%s] not found.", deviceId));
+                        return OperationResult.empty(HttpURLConnection.HTTP_NOT_FOUND);
+                    } else {
+                        return OperationResult.ok(
+                                HttpURLConnection.HTTP_NO_CONTENT,
+                                Id.of(deviceId),
+                                Optional.empty(),
+                                Optional.of(deviceDto.getVersion()));
+                    }
+                });
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
@@ -13,13 +13,15 @@
 package org.eclipse.hono.deviceregistry.mongodb.service;
 
 import java.net.HttpURLConnection;
-import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.model.DeviceDto;
 import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbCallExecutor;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDeviceRegistryUtils;
 import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDocumentBuilder;
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.deviceregistry.util.Versioned;
@@ -52,8 +54,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.IndexOptions;
 import io.vertx.ext.mongo.MongoClient;
-import io.vertx.ext.mongo.MongoClientDeleteResult;
-import io.vertx.ext.mongo.MongoClientUpdateResult;
 
 /**
  * This is an implementation of the device registration service and the device management service where data 
@@ -67,6 +67,7 @@ import io.vertx.ext.mongo.MongoClientUpdateResult;
 public final class MongoDbBasedRegistrationService extends AbstractRegistrationService implements DeviceManagementService, Verticle {
 
     private static final Logger log = LoggerFactory.getLogger(MongoDbBasedRegistrationService.class);
+    private static final int INDEX_CREATION_MAX_RETRIES = 3;
     private MongoClient mongoClient;
     private MongoDbBasedRegistrationConfigProperties config;
     private MongoDbCallExecutor mongoDbCallExecutor;
@@ -112,18 +113,16 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
     @Override
     public void start(final Promise<Void> startPromise) {
 
-        mongoDbCallExecutor.createCollectionIndex(config.getCollectionName(),
-                new JsonObject().put(RegistrationConstants.FIELD_PAYLOAD_TENANT_ID, 1)
-                        .put(RegistrationConstants.FIELD_PAYLOAD_DEVICE_ID, 1),
-                new IndexOptions().unique(true))
+        mongoDbCallExecutor
+                .createCollectionIndex(config.getCollectionName(),
+                        new JsonObject().put(RegistrationConstants.FIELD_PAYLOAD_TENANT_ID, 1)
+                                .put(RegistrationConstants.FIELD_PAYLOAD_DEVICE_ID, 1),
+                        new IndexOptions().unique(true), INDEX_CREATION_MAX_RETRIES)
                 .map(success -> {
                     startPromise.complete();
                     return null;
                 })
-                .onFailure(error -> {
-                    log.error("Index creation failed", error);
-                    startPromise.fail(error);
-                });
+                .onFailure(startPromise::fail);
     }
 
     @Override
@@ -142,28 +141,15 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(span);
 
-        final String deviceIdValue = deviceId.orElse(DeviceRegistryUtils.getUniqueIdentifier());
-        final Versioned<Device> versionedDevice = new Versioned<>(device);
-        final DeviceDto deviceDto = new DeviceDto(tenantId, deviceIdValue, versionedDevice.getValue(),
-                versionedDevice.getVersion(), Instant.now());
-
-        final Promise<Long> findExistingNoOfDevicesPromise = Promise.promise();
-        mongoClient.count(config.getCollectionName(), new JsonObject(), findExistingNoOfDevicesPromise);
-        return findExistingNoOfDevicesPromise.future()
-                .compose(existingNoOfDevices -> {
-                    if (config
-                            .getMaxDevicesPerTenant() != MongoDbBasedRegistrationConfigProperties.UNLIMITED_DEVICES_PER_TENANT
-                            && existingNoOfDevices >= config.getMaxDevicesPerTenant()) {
-                        log.debug("Maximum number of devices limit already reached for the tenant [{}]", tenantId);
-                        TracingHelper.logError(span, String.format(
-                                "Maximum number of devices limit already reached for the tenant [%s]", tenantId));
-                        return Future
-                                .succeededFuture(Result.from(HttpURLConnection.HTTP_FORBIDDEN, OperationResult::empty));
-                    } else {
-                        return processCreateDevice(deviceDto, span);
-                    }
-                });
+        return MongoDbDeviceRegistryUtils.isAllowedToModify(config, tenantId)
+                .compose(ok -> isMaxDevicesLimitReached(tenantId))
+                .compose(ok -> processCreateDevice(
+                        new DeviceDto(tenantId, deviceId.orElse(DeviceRegistryUtils.getUniqueIdentifier()), device,
+                                new Versioned<>(device).getVersion()),
+                        span))
+                .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
     }
 
     @Override
@@ -171,8 +157,10 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(span);
 
-        return processReadDevice(tenantId, deviceId, span);
+        return processReadDevice(tenantId, deviceId)
+                .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
     }
 
     @Override
@@ -181,20 +169,12 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(resourceVersion);
+        Objects.requireNonNull(span);
 
-        if (!config.isModificationEnabled()) {
-            final String errorMsg = String.format("Modification is disabled for tenant [%s]", tenantId);
-            TracingHelper.logError(span, errorMsg);
-            log.debug(errorMsg);
-            return Future.succeededFuture(Result.from(HttpURLConnection.HTTP_FORBIDDEN, OperationResult::empty));
-        }
-        // TODO: To check for the version mismatch.
-
-        final Versioned<Device> versionedDevice = new Versioned<>(device);
-        final DeviceDto deviceDto = new DeviceDto(tenantId, deviceId, versionedDevice.getValue(),
-                versionedDevice.getVersion(), Instant.now());
-
-        return processUpdateDevice(tenantId, deviceId, deviceDto, span);
+        return MongoDbDeviceRegistryUtils.isAllowedToModify(config, tenantId)
+                .compose(deviceDto -> processUpdateDevice(tenantId, deviceId, device, resourceVersion, span))
+                .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
     }
 
     @Override
@@ -203,23 +183,22 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(resourceVersion);
+        Objects.requireNonNull(span);
 
-        if (!config.isModificationEnabled()) {
-            final String errorMsg = String.format("Modification is disabled for tenant [%s]", tenantId);
-            TracingHelper.logError(span, errorMsg);
-            log.debug(errorMsg);
-            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_FORBIDDEN));
-        }
-
-        // TODO: To check for the version mismatch.
-
-        return processDeleteDevice(tenantId, deviceId, span);
+        return MongoDbDeviceRegistryUtils.isAllowedToModify(config, tenantId)
+                .compose(ok -> processDeleteDevice(tenantId, deviceId, resourceVersion, span))
+                .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
     }
 
     @Override
     protected Future<RegistrationResult> getDevice(final String tenantId, final String deviceId, final Span span) {
 
-        return processReadDevice(tenantId, deviceId, span)
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(span);
+
+        return processReadDevice(tenantId, deviceId)
                 .compose(result -> Future.succeededFuture(RegistrationResult.from(result.getStatus(),
                         convertDevice(deviceId, result.getPayload()), result.getCacheDirective().orElse(null))));
     }
@@ -255,10 +234,8 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
                 .compose(result -> Optional.ofNullable(result)
                         .map(ok -> result.mapTo(DeviceDto.class))
                         .map(Future::succeededFuture)
-                        .orElseGet(() -> {
-                            log.debug("Device [{}] not found.", deviceId);
-                            return Future.succeededFuture(null);
-                        }));
+                        .orElseGet(() -> Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND,
+                                String.format("Device [%s] not found.", deviceId)))));
     }
 
     private boolean isDuplicateKeyError(final Throwable throwable) {
@@ -271,13 +248,18 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
 
     private Future<OperationResult<Id>> processCreateDevice(final DeviceDto device, final Span span) {
         final Promise<String> addDevicePromise = Promise.promise();
+
         mongoClient.insert(config.getCollectionName(), JsonObject.mapFrom(device), addDevicePromise);
+
         return addDevicePromise.future()
-                .map(success -> OperationResult.ok(
-                        HttpURLConnection.HTTP_CREATED,
-                        Id.of(device.getDeviceId()),
-                        Optional.empty(),
-                        Optional.of(device.getVersion())))
+                .map(success -> {
+                    span.log(String.format("successfully registered device [%s]", device.getDeviceId()));
+                    return OperationResult.ok(
+                            HttpURLConnection.HTTP_CREATED,
+                            Id.of(device.getDeviceId()),
+                            Optional.empty(),
+                            Optional.of(device.getVersion()));
+                })
                 .recover(error -> {
                     if (isDuplicateKeyError(error)) {
                         log.debug("Device [{}] already exists for the tenant [{}]", device.getDeviceId(),
@@ -296,63 +278,104 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
                 });
     }
 
-    private Future<Result<Void>> processDeleteDevice(final String tenantId, final String deviceId, final Span span) {
-        final Promise<MongoClientDeleteResult> deleteDevicePromise = Promise.promise();
-        final JsonObject removeDeviceQuery = new MongoDbDocumentBuilder()
+    private Future<Result<Void>> processDeleteDevice(final String tenantId, final String deviceId,
+            final Optional<String> resourceVersion, final Span span) {
+        final JsonObject deleteDeviceQuery = resourceVersion
+                .map(version -> new MongoDbDocumentBuilder().withVersion(version))
+                .orElse(new MongoDbDocumentBuilder())
                 .withTenantId(tenantId)
                 .withDeviceId(deviceId)
                 .document();
-        mongoClient.removeDocument(config.getCollectionName(), removeDeviceQuery, deleteDevicePromise);
+        final Promise<JsonObject> deleteDevicePromise = Promise.promise();
+
+        mongoClient.findOneAndDelete(config.getCollectionName(), deleteDeviceQuery, deleteDevicePromise);
+
         return deleteDevicePromise.future()
-                .compose(successDeleteDevice -> {
-                    if (successDeleteDevice.getRemovedCount() == 1) {
-                        return Future.succeededFuture(Result.from(HttpURLConnection.HTTP_NO_CONTENT));
-                    } else {
-                        log.debug("Device [{}] not found.", deviceId);
-                        TracingHelper.logError(span, String.format("Device [%s] not found.", deviceId));
-                        return Future.succeededFuture(Result.from(HttpURLConnection.HTTP_NOT_FOUND));
-                    }
-                });
+                .compose(result -> Optional.ofNullable(result)
+                        .map(deleted -> {
+                            span.log(String.format("successfully deleted device [%s]", deviceId));
+                            return Future.succeededFuture(Result.<Void> from(HttpURLConnection.HTTP_NO_CONTENT));
+                        })
+                        .orElse(checkForVersionMismatchAndFail(tenantId, deviceId, resourceVersion)));
     }
 
-    private Future<OperationResult<Device>> processReadDevice(final String tenantId, final String deviceId,
-            final Span span) {
+    private Future<OperationResult<Device>> processReadDevice(final String tenantId, final String deviceId) {
+
         return findDevice(tenantId, deviceId)
-                .compose(deviceDto -> Optional.ofNullable(deviceDto)
-                        .map(ok -> Future.succeededFuture(
-                                OperationResult.ok(
-                                        HttpURLConnection.HTTP_OK,
-                                        deviceDto.getDevice(),
-                                        Optional.ofNullable(
-                                                DeviceRegistryUtils.getCacheDirective(config.getCacheMaxAge())),
-                                        Optional.ofNullable(deviceDto.getVersion()))))
-                        .orElseGet(() -> {
-                            TracingHelper.logError(span, String.format("Device [%s] not found.", deviceId));
-                            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_NOT_FOUND));
-                        }));
+                .compose(deviceDto -> Future.succeededFuture(
+                        OperationResult.ok(
+                                HttpURLConnection.HTTP_OK,
+                                deviceDto.getDevice(),
+                                Optional.ofNullable(
+                                        DeviceRegistryUtils.getCacheDirective(config.getCacheMaxAge())),
+                                Optional.ofNullable(deviceDto.getVersion()))));
     }
 
     private Future<OperationResult<Id>> processUpdateDevice(final String tenantId, final String deviceId,
-            final DeviceDto deviceDto, final Span span) {
-        final JsonObject updateDeviceQuery = new MongoDbDocumentBuilder()
+            final Device device, final Optional<String> resourceVersion, final Span span) {
+        final JsonObject updateDeviceQuery = resourceVersion
+                .map(version -> new MongoDbDocumentBuilder().withVersion(version))
+                .orElse(new MongoDbDocumentBuilder())
                 .withTenantId(tenantId)
                 .withDeviceId(deviceId)
                 .document();
-        final Promise<MongoClientUpdateResult> updateDevicePromise = Promise.promise();
-        mongoClient.updateCollection(config.getCollectionName(), updateDeviceQuery,
-                new JsonObject().put("$set", JsonObject.mapFrom(deviceDto)), updateDevicePromise);
+        final Promise<JsonObject> updateDevicePromise = Promise.promise();
+
+        mongoClient.findOneAndReplace(config.getCollectionName(), updateDeviceQuery,
+                JsonObject.mapFrom(new DeviceDto(tenantId, deviceId, device, new Versioned<>(device).getVersion())),
+                updateDevicePromise);
+
         return updateDevicePromise.future()
-                .map(updateResult -> {
-                    if (updateResult.getDocMatched() == 0) {
-                        TracingHelper.logError(span, String.format("Device [%s] not found.", deviceId));
-                        return OperationResult.empty(HttpURLConnection.HTTP_NOT_FOUND);
-                    } else {
-                        return OperationResult.ok(
-                                HttpURLConnection.HTTP_NO_CONTENT,
-                                Id.of(deviceId),
-                                Optional.empty(),
-                                Optional.of(deviceDto.getVersion()));
+                .compose(result -> Optional.ofNullable(result)
+                        .map(updated -> {
+                            span.log(String.format("successfully updated device [%s]", deviceId));
+                            return Future.succeededFuture(OperationResult.ok(
+                                    HttpURLConnection.HTTP_NO_CONTENT,
+                                    Id.of(deviceId),
+                                    Optional.empty(),
+                                    Optional.of(result.getString(MongoDbDeviceRegistryUtils.FIELD_VERSION))));
+                        })
+                        .orElse(checkForVersionMismatchAndFail(tenantId, deviceId, resourceVersion)));
+    }
+
+    private <T> Future<T> checkForVersionMismatchAndFail(final String tenantId, final String deviceId,
+            final Optional<String> versionFromRequest) {
+        if (versionFromRequest.isPresent()) {
+            return findDevice(tenantId, deviceId)
+                    .compose(foundDevice -> {
+                        if (!foundDevice.getVersion().equals(versionFromRequest.get())) {
+                            return Future.failedFuture(
+                                    new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
+                                            "Resource version mismatch"));
+                        }
+                        return Future.failedFuture(
+                                new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR,
+                                        String.format("Error updating resource [%s].", deviceId)));
+                    });
+        } else {
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND,
+                    String.format("Device [%s] not found.", deviceId)));
+        }
+    }
+
+    private <T> Future<T> isMaxDevicesLimitReached(final String tenantId) {
+
+        if (config.getMaxDevicesPerTenant() == MongoDbBasedRegistrationConfigProperties.UNLIMITED_DEVICES_PER_TENANT) {
+            return Future.succeededFuture();
+        }
+        final Promise<Long> findExistingNoOfDevicesPromise = Promise.promise();
+        mongoClient.count(config.getCollectionName(), new MongoDbDocumentBuilder().withTenantId(tenantId).document(),
+                findExistingNoOfDevicesPromise);
+
+        return findExistingNoOfDevicesPromise.future()
+                .compose(existingNoOfDevices -> {
+                    if (existingNoOfDevices >= config.getMaxDevicesPerTenant()) {
+                        return Future.failedFuture(
+                                new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, String.format(
+                                        "Maximum number of devices limit already reached for the tenant [%s]",
+                                        tenantId)));
                     }
+                    return Future.succeededFuture();
                 });
     }
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
@@ -95,17 +95,6 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
         this.config = Objects.requireNonNull(config);
     }
 
-    /**
-     * Sets the Vert.x instance to deploy the service to.
-     *
-     * @param vertx The vertx instance.
-     * @throws NullPointerException if vertx is {@code null}.
-     */
-    @Autowired
-    public void setVertx(final Vertx vertx) {
-        this.vertx = Objects.requireNonNull(vertx);
-    }
-
     @Override
     public Vertx getVertx() {
         return vertx;
@@ -113,6 +102,7 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
 
     @Override
     public void init(final Vertx vertx, final Context context) {
+        this.vertx = Objects.requireNonNull(vertx);
     }
 
     @Override

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbCallExecutor.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbCallExecutor.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.mongodb.utils;
+
+import java.util.Objects;
+
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbConfigProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.MongoSocketException;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.IndexOptions;
+import io.vertx.ext.mongo.MongoClient;
+
+/**
+ * Utility for vertx mongodb client access.
+ */
+public final class MongoDbCallExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(MongoDbCallExecutor.class);
+
+    private final MongoClient mongoClient;
+    private final MongoDbConfigProperties mongoDbConfig;
+    private final Vertx vertx;
+
+    /**
+     * Creates an instance of the {@link MongoDbCallExecutor}.
+     *
+     * @param vertx         The Vert.x instance to use.
+     * @param mongoDbConfig The mongodb configuration properties to use.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public MongoDbCallExecutor(final Vertx vertx, final MongoDbConfigProperties mongoDbConfig) {
+        this.vertx = Objects.requireNonNull(vertx);
+        this.mongoDbConfig = Objects.requireNonNull(mongoDbConfig);
+        final JsonObject mongoConfigJson = this.mongoDbConfig.asMongoClientConfigJson();
+        this.mongoClient = MongoClient.createShared(vertx, mongoConfigJson);
+    }
+
+    /**
+     * Gets the mongo client.
+     *
+     * @return The mongo client.
+     */
+    public MongoClient getMongoClient() {
+        return mongoClient;
+    }
+
+    /**
+     * Creates mongodb collection index. Wrapper of {@link #createIndex(String, JsonObject, IndexOptions, Handler)}
+     *
+     * @param collectionName The name of the collection of documents.
+     * @param keys           The keys to be indexed.
+     * @param options        The options used to configure index, which is optional.
+     * @return A succeeded Future if the tenant creation is successful,
+     * else failed future with the error reason.
+     */
+    public Future<Void> createCollectionIndex(final String collectionName, final JsonObject keys,
+                                              final IndexOptions options) {
+        final Promise<Void> indexCreationPromise = Promise.promise();
+        createIndex(collectionName, keys, options, res -> {
+            if (res.succeeded()) {
+                indexCreationPromise.complete();
+            } else if (res.cause() instanceof MongoSocketException) {
+                log.info("Create indices failed, wait for retry, cause:", res.cause());
+                vertx.setTimer(this.mongoDbConfig.getCreateIndicesTimeout(),
+                        timer -> createIndex(collectionName, keys, options, res2 -> {
+                            if (res2.succeeded()) {
+                                indexCreationPromise.complete();
+                            } else if (res2.cause() instanceof MongoSocketException) {
+                                log.info("Create indices failed, wait for second retry, cause:", res2.cause());
+                                vertx.setTimer(this.mongoDbConfig.getCreateIndicesTimeout(),
+                                        timer2 -> createIndex(collectionName, keys, options, res3 -> {
+                                            if (res3.succeeded()) {
+                                                indexCreationPromise.complete();
+                                            } else {
+                                                log.error("Error creating index", res3.cause());
+                                                indexCreationPromise.fail(res3.cause());
+                                            }
+                                        }));
+                            } else {
+                                log.error("Error creating index", res2.cause());
+                                indexCreationPromise.fail(res2.cause());
+                            }
+                        }));
+            } else {
+                log.error("Error creating index", res.cause());
+                indexCreationPromise.fail(res.cause());
+            }
+        });
+        return indexCreationPromise.future();
+    }
+
+    /**
+     * Creates mongodb indexes.
+     *
+     * @param collectionName       The name of the collection of documents.
+     * @param keys                 The keys to be indexed.
+     * @param options              The options used to configure index, which is optional.
+     * @param indexCreationTracker The callback handler.
+     */
+    private void createIndex(final String collectionName, final JsonObject keys, final IndexOptions options,
+                             final Handler<AsyncResult<Void>> indexCreationTracker) {
+        log.info("Create indices");
+        mongoClient.createIndexWithOptions(collectionName, keys, options, indexCreationTracker);
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbCallExecutor.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbCallExecutor.java
@@ -143,9 +143,14 @@ public final class MongoDbCallExecutor {
                     .put("port", config.getPort())
                     .put("db_name", config.getDbName())
                     .put("username", config.getUsername())
-                    .put("password", config.getPassword())
-                    .put("serverSelectionTimeoutMS", config.getServerSelectionTimeout())
-                    .put("connectTimeoutMS", config.getConnectTimeout());
+                    .put("password", config.getPassword());
+
+            if (config.getServerSelectionTimeout() > 0) {
+                configJson.put("serverSelectionTimeoutMS", config.getServerSelectionTimeout());
+            }
+            if (config.getConnectTimeout() > 0) {
+                configJson.put("connectTimeoutMS", config.getConnectTimeout());
+            }
         }
         return configJson;
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDeviceRegistryUtils.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDeviceRegistryUtils.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.utils;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.deviceregistry.mongodb.config.AbstractMongoDbBasedRegistryConfigProperties;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.vertx.core.Future;
+
+/**
+ * A collection of constants and utility methods for implementing the mongodb based device registry.
+ *
+ */
+public final class MongoDbDeviceRegistryUtils {
+
+    /**
+     * The name of the JSON property containing the last modification date and time.
+     */
+    public static final String FIELD_UPDATED_ON = "updatedOn";
+    /**
+     * The name of the JSON property containing the version of the tenant or device or credentials information.
+     */
+    public static final String FIELD_VERSION = "version";
+    /**
+     * The name of the JSON property containing the device identifier.
+     */
+    public static final String FIELD_DEVICE = "device";
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDbDeviceRegistryUtils.class);
+
+    private MongoDbDeviceRegistryUtils() {
+        // prevents instantiation
+    }
+
+    /**
+     /**
+     * Checks whether this registry allows the creation, modification and removal of entries.
+     *
+     * @param config the config properties
+     * @param tenantId The tenant identifier.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will succeed if write operation is allowed.
+     *         Otherwise the future will fail with a {@link ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static Future<Void> isAllowedToModify(final AbstractMongoDbBasedRegistryConfigProperties config,
+            final String tenantId) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(tenantId);
+
+        if (config.isModificationEnabled()) {
+            return Future.succeededFuture();
+        }
+        return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN,
+                String.format("Modification is disabled for tenant [%s]", tenantId)));
+    }
+
+    /**
+     * Maps the given error to an {@link OperationResult} containing the appropriate HTTP status code.
+     * 
+     * @param error The error.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
+     *             implementation should log (error) events on this span and it may set tags and use this span as the
+     *             parent for any spans created in this method.
+     *
+     * @param <T> The type of the resource.
+     *
+     * @return The result of the mapped error.
+     * @throws NullPointerException if the error is {@code null}.
+     */
+    public static <T> OperationResult<T> mapErrorToResult(final Throwable error, final Span span) {
+        Objects.requireNonNull(error);
+
+        LOG.error(error.getMessage(), error);
+        TracingHelper.logError(span, error.getMessage(), error);
+        if (error instanceof ClientErrorException) {
+            return OperationResult.empty(((ClientErrorException) error).getErrorCode());
+        }
+        return OperationResult.empty(HttpURLConnection.HTTP_INTERNAL_ERROR);
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.mongodb.utils;
+
+import org.eclipse.hono.util.RegistrationConstants;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Utility class for building Json documents for mongodb.
+ */
+public final class MongoDbDocumentBuilder {
+
+    private final JsonObject document = new JsonObject();
+
+    /**
+     * Sets the json object with the given tenant id.
+     *
+     * @param tenantId The tenant id.
+     * @return a reference to this for fluent use.
+     */
+    public MongoDbDocumentBuilder withTenantId(final String tenantId) {
+        document.put(RegistrationConstants.FIELD_PAYLOAD_TENANT_ID, tenantId);
+        return this;
+    }
+
+    /**
+     * Sets the json object with the given device id.
+     *
+     * @param deviceId The device id.
+     * @return a reference to this for fluent use.
+     */
+    public MongoDbDocumentBuilder withDeviceId(final String deviceId) {
+        document.put(RegistrationConstants.FIELD_PAYLOAD_DEVICE_ID, deviceId);
+        return this;
+    }
+
+    /**
+     * Returns the json document.
+     * 
+     * @return the json document.
+     */
+    public JsonObject document() {
+        return document;
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
@@ -47,6 +47,17 @@ public final class MongoDbDocumentBuilder {
     }
 
     /**
+     * Sets the json object with the given version.
+     *
+     * @param version The version of the document.
+     * @return a reference to this for fluent use.
+     */
+    public MongoDbDocumentBuilder withVersion(final String version) {
+        document.put(MongoDbDeviceRegistryUtils.FIELD_VERSION, version);
+        return this;
+    }
+
+    /**
      * Returns the json document.
      * 
      * @return the json document.

--- a/services/device-registry-mongodb/src/main/resources/banner.txt
+++ b/services/device-registry-mongodb/src/main/resources/banner.txt
@@ -1,0 +1,15 @@
+
+  ______     _ _                  _    _                   
+ |  ____|   | (_)                | |  | |                  
+ | |__   ___| |_ _ __  ___  ___  | |__| | ___  _ __   ___  
+ |  __| / __| | | '_ \/ __|/ _ \ |  __  |/ _ \| '_ \ / _ \ 
+ | |___| (__| | | |_) \__ \  __/ | |  | | (_) | | | | (_) |
+ |______\___|_|_| .__/|___/\___| |_|  |_|\___/|_| |_|\___/ 
+                | |                                        
+                |_|                                        
+
+Eclipse Hono Device Registry Server ${application.formatted-version}
+using Spring Boot ${spring-boot.formatted-version}
+
+Go to https://www.eclipse.org/hono for more information.
+

--- a/services/device-registry-mongodb/src/main/resources/banner.txt
+++ b/services/device-registry-mongodb/src/main/resources/banner.txt
@@ -8,7 +8,7 @@
                 | |                                        
                 |_|                                        
 
-Eclipse Hono Device Registry Server ${application.formatted-version}
+Eclipse Hono Mongo DB Based Device Registry Server ${application.formatted-version}
 using Spring Boot ${spring-boot.formatted-version}
 
 Go to https://www.eclipse.org/hono for more information.

--- a/services/device-registry-mongodb/src/main/resources/logback-spring.xml
+++ b/services/device-registry-mongodb/src/main/resources/logback-spring.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <springProfile name="dev">
+    <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.connection" level="DEBUG"/>
+    <logger name="org.eclipse.hono.deviceregistry" level="DEBUG"/>
+    <logger name="org.eclipse.hono.service" level="DEBUG"/>
+
+    <logger name="io.netty.handler.logging.LoggingHandler" level="DEBUG"/>
+    <logger name="io.netty.resolver.dns" level="INFO"/>
+
+    <logger name="io.vertx.proton.impl" level="INFO"/>
+    <logger name="io.vertx.core.net.impl" level="INFO"/>
+  </springProfile>
+
+  <springProfile name="prod">
+    <logger name="org.eclipse.hono" level="INFO"/>
+
+    <logger name="io.netty.handler.logging.LoggingHandler" level="INFO"/>
+    <logger name="io.netty.resolver.dns" level="INFO"/>
+
+    <logger name="io.vertx.proton.impl" level="INFO"/>
+    <logger name="io.vertx.core.net.impl" level="INFO"/>
+  </springProfile>
+
+</configuration>

--- a/services/device-registry-mongodb/src/main/resources/logback-spring.xml
+++ b/services/device-registry-mongodb/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -30,6 +30,7 @@
     <module>device-connection</module>
     <module>device-registry-base</module>
     <module>device-registry-file</module>
+    <module>device-registry-mongodb</module>
   </modules>
 
   <name>Hono Services</name>


### PR DESCRIPTION
This PR is for the issue #1679, which is to provide a _mongodb_ based device registry. As a first step towards it, in this PR `DeviceManagementService `and `RegistrationService` have been implemented. In spite of some work left, I have raised this PR to collect some feedback. The tests will be added incrementally. Also some optimisations like pulling common configuration properties to the base module is in progress.