### PR TITLE
[#1272] Remove workaround to support concurrent TTD requests

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -652,18 +652,6 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         });
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * Marked as final since the way command handling is implemented here requires the
-     * gateway mapping to be enabled.
-     */
-    @Override
-    protected final Future<Boolean> isGatewayMappingEnabled(final String tenantId, final String deviceId,
-            final Device authenticatedDevice) {
-        return Future.succeededFuture(true);
-    }
-
     private Span newSpan(final String operationName, final MqttEndpoint endpoint, final Device authenticatedDevice,
             final OptionalInt traceSamplingPriority) {
         final Span span = tracer.buildSpan(operationName)

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -1094,35 +1094,12 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             return Future.succeededFuture(registrationAssertion);
         }
 
-        final Future<String> gatewayId = isGatewayMappingEnabled(tenantId, deviceId, authenticatedDevice)
-                .compose(enabled -> enabled ? getGatewayId(tenantId, deviceId, authenticatedDevice)
-                        : Future.succeededFuture(deviceId));
-
-        return gatewayId
+        final Future<String> gatewayIdFuture = getGatewayId(tenantId, deviceId, authenticatedDevice);
+        return gatewayIdFuture
                 .compose(gwId -> getDeviceConnectionClient(tenantId))
                 .compose(client -> client.setLastKnownGatewayForDevice(deviceId,
-                        Optional.ofNullable(gatewayId.result()).orElse(deviceId), context))
+                        Optional.ofNullable(gatewayIdFuture.result()).orElse(deviceId), context))
                 .map(registrationAssertion);
-    }
-
-    /**
-     * Checks whether this adapter supports mapping of incoming command messages to the gateway that the target device
-     * is connected to. If not, the {@link #updateLastGateway(JsonObject, String, String, Device, SpanContext)} method
-     * will associate the device id with itself instead of with the gateway, causing the mapping to be disabled.
-     * <p>
-     * This default implementation returns a succeeded future with {@code true} as value here.
-     * <p>
-     * May be overridden by sub-classes to disable the gateway mapping for this adapter.
-     *
-     * @param tenantId The tenant that the device belongs to.
-     * @param deviceId The device to update the last known gateway for.
-     * @param authenticatedDevice The device that has authenticated to this protocol adapter.
-     * @return A succeeded future indicating the outcome of the operation. Its value will be {@code true} if gateway
-     *         mapping is enabled for this adapter.
-     */
-    protected Future<Boolean> isGatewayMappingEnabled(final String tenantId, final String deviceId,
-            final Device authenticatedDevice) {
-        return Future.succeededFuture(true);
     }
 
     private boolean isGatewaySupportedForDevice(final JsonObject registrationAssertion) {

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -305,10 +305,6 @@ If a device is configured in such a way that there can be *one* gateway, acting 
 
 If a device is configured to be used with *multiple* gateways, the particular gateway that last acted on behalf of the device will be the target that commands for that device will be routed to. The mapping of device and gateway last used by the device is updated whenever a device sends a telemetry, event or command response message via the gateway. This means that for a device configured to be used via multiple gateways to receive commands, the device first has to send at least one telemetry or event message to establish which gateway to use for receiving commands for that device.
 
-{{% note title="Authenticated gateway receiving commands for a specific device" %}}
-An authenticated gateway opening multiple `command/${tenant}/${device-id}` links for different devices should do so using the same AMQP connection. Otherwise some commands might not get routed properly if multiple protocol adapter instances are involved. 
-{{% /note %}}
-
 ### Sending a Response to a Command
 
 A device only needs to respond to commands that contain a *reply-to* address and a *correlation-id*. However, if the application expects a response, then devices must publish a response back to the application. Devices may use the same anonymous sender link for this purpose that they also use for sending telemetry data and events.

--- a/site/documentation/content/user-guide/coap-adapter.md
+++ b/site/documentation/content/user-guide/coap-adapter.md
@@ -264,16 +264,6 @@ publishes data for.
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion*
 for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
 
-{{% note %}}
-When sending requests with the *hono-ttd* query parameter in order to receive a command for a specific device connected to the authenticated gateway,
-it has to be noted that multiple concurrent such requests for the same gateway but different devices may lead to some commands not getting
-forwarded to the gateway.
-To resolve such potential issues, the corresponding tenant can be configured with the *support-concurrent-gateway-device-command-requests*
-option set to `true` in the *ext* field of an *adapters* entry of type `hono-coap`. Note that with this option set, it is not supported for
-the authenticated gateway to send a single request with a *hono-ttd* query parameter but no device id in order to receive commands for
-*any* device that has last sent a telemetry or event message via the authenticated gateway.
-{{% /note %}}
-
 **Examples**
 
 Publish some JSON data for device `4712` using default message type `CON` (*at least once*):
@@ -501,16 +491,6 @@ publishes data for.
 
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion*
 for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
-
-{{% note %}}
-When sending requests with the *hono-ttd* query parameter in order to receive a command for a specific device connected to the authenticated gateway,
-it has to be noted that multiple concurrent such requests for the same gateway but different devices may lead to some commands not getting
-forwarded to the gateway.
-To resolve such potential issues, the corresponding tenant can be configured with the *support-concurrent-gateway-device-command-requests*
-option set to `true` in the *ext* field of an *adapters* entry of type `hono-coap`. Note that with this option set, it is not supported for
-the authenticated gateway to send a single request with a *hono-ttd* query parameter but no device id in order to receive commands for
-*any* device that has last sent a telemetry or event message via the authenticated gateway.
-{{% /note %}}
 
 **Examples**
 

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -232,11 +232,6 @@ This resource can be used by *gateway* components to publish data *on behalf of*
 
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
 
-{{% note %}}
-When sending requests with the `hono-ttd` header in order to receive a command for a specific device connected to the gateway, it has to be noted that multiple concurrent such requests for the same gateway but different devices may lead to some commands not getting forwarded to the gateway.
-To resolve such potential issues, the corresponding tenant can be configured with a `support-concurrent-gateway-device-command-requests` option set to `true` in the `ext` field of an `adapters` entry of type `hono-http`. Note that with this option it is not supported for the authenticated gateway to send _one_ message with a `hono-ttd` header and no device id to receive commands for *any* device that has last sent a telemetry or event message via this gateway.
-{{% /note %}}
-
 **Examples**
 
 Publish some JSON data for device `4712`:
@@ -402,11 +397,6 @@ content-length: 0
 This resource can be used by *gateway* components to publish data *on behalf of* other devices which do not connect to a protocol adapter directly but instead are connected to the gateway, e.g. using some low-bandwidth radio based technology like [SigFox](https://www.sigfox.com) or [LoRa](https://lora-alliance.org/). In this case the credentials provided by the gateway during connection establishment with the protocol adapter are used to authenticate the gateway whereas the parameters from the URI are used to identify the device that the gateway publishes data for.
 
 The protocol adapter checks the gateway's authority to publish data on behalf of the device implicitly by means of retrieving a *registration assertion* for the device from the [configured Device Registration service]({{< relref "/admin-guide/common-config#device-registration-service-connection-configuration" >}}).
-
-{{% note %}}
-When sending requests with the `hono-ttd` header in order to receive a command for a specific device connected to the gateway, it has to be noted that multiple concurrent such requests for the same gateway but different devices may lead to some commands not getting forwarded to the gateway.
-To resolve such potential issues, the corresponding tenant can be configured with a `support-concurrent-gateway-device-command-requests` option set to `true` in the `ext` field of an `adapters` entry of type `hono-http`. Note that with this option it is not supported for the authenticated gateway to send _one_ message with a `hono-ttd` header and no device id to receive commands for *any* device that has last sent a telemetry or event message via this gateway.
-{{% /note %}}
 
 **Examples**
 

--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -321,10 +321,6 @@ An authenticated gateway MUST use the topic filter `command//+/req/#` to subscri
 
 To subscribe only to commands for a specific device, an authenticated gateway MUST use the topic filter `command//${device-id}/req/#`.
 
-{{% note %}}
-An authenticated gateway opening multiple `command//${device-id}/req/#` subscriptions for different devices should do so using the same MQTT connection. Otherwise some commands might not get routed properly if multiple protocol adapter instances are involved. 
-{{% /note %}}
-
 {{% note title="Deprecation" %}}
 Previous versions of Hono required authenticated gateways to use `command/+/+/req/#` for subscribing to commands.
 This old topic filter is deprecated. Gateways MAY still use it until support for it will be removed in a future Hono version.

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -22,7 +22,6 @@ import java.security.KeyPair;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -96,7 +95,6 @@ public abstract class HttpTestBase {
 
     private static final String COMMAND_TO_SEND = "setBrightness";
     private static final String COMMAND_JSON_KEY = "brightness";
-    private static final String FIELD_SUPPORT_CONCURRENT_GATEWAY_DEVICE_COMMAND_REQUESTS = "support-concurrent-gateway-device-command-requests";
 
     private static final String ORIGIN_WILDCARD = "*";
     private static final Vertx VERTX = Vertx.vertx();
@@ -222,16 +220,6 @@ public abstract class HttpTestBase {
                 new HttpCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_ALL_DEVICES),
                 new HttpCommandEndpointConfiguration(SubscriberRole.GATEWAY_FOR_SINGLE_DEVICE)
                 );
-    }
-
-    /**
-     * Creates the endpoint configuration variants for Command &amp; Control scenarios where gateway mapping
-     * shall be disabled (the 'GATEWAY_FOR_ALL_DEVICES' case is not supported there).
-     *
-     * @return The configurations.
-     */
-    static Stream<HttpCommandEndpointConfiguration> commandAndControlVariantsForTestsWithGatewayMappingDisabled() {
-        return commandAndControlVariants().filter(endpointConfig -> !endpointConfig.isSubscribeAsGatewayForAllDevices());
     }
 
     /**
@@ -1002,29 +990,6 @@ public abstract class HttpTestBase {
             final VertxTestContext ctx) throws InterruptedException {
 
         final Tenant tenant = new Tenant();
-        testUploadMessagesWithTtdThatReplyWithCommand(endpointConfig, tenant, ctx);
-    }
-
-    /**
-     * Verifies that the HTTP adapter delivers a command to a device and accepts the corresponding
-     * response from the device, all while using a tenant that has the "support-concurrent-gateway-device-command-requests"
-     * option set.
-     *
-     * @param endpointConfig The endpoints to use for sending/receiving commands.
-     * @param ctx The test context.
-     * @throws InterruptedException if the test fails.
-     */
-    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
-    @MethodSource("commandAndControlVariantsForTestsWithGatewayMappingDisabled")
-    public void testUploadMessagesWithTtdThatReplyWithCommandWithGatewayMappingDisabled(
-            final HttpCommandEndpointConfiguration endpointConfig,
-            final VertxTestContext ctx) throws InterruptedException {
-
-        final Tenant tenant = new Tenant();
-        final Adapter adapterConfig = new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_HTTP);
-        adapterConfig.setEnabled(true);
-        adapterConfig.setExtensions(Map.of(FIELD_SUPPORT_CONCURRENT_GATEWAY_DEVICE_COMMAND_REQUESTS, true));
-        tenant.addAdapterConfig(adapterConfig);
         testUploadMessagesWithTtdThatReplyWithCommand(endpointConfig, tenant, ctx);
     }
 


### PR DESCRIPTION
This is for #1272:

The workarounds introduced for #1645 and #1644 are obsolete with the new Command & Control implementation and are therefore removed here.
The `AbstractProtocolAdapterBase#isGatewayMappingEnabled()` method has also been removed - the gateway mapping can't be disabled with the new approach.