### PR TITLE
[#1860] Use unique adapter instance id per consumer factory

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -225,14 +225,19 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
 
     /**
      * Gets the remote container id as advertised by the peer.
-     * <p>
-     * This default implementation simply returns {@code N/A}.
      *
      * @return The remote container id or {@code null}.
      */
-    default String getRemoteContainer() {
-        return "N/A";
-    }
+    String getRemoteContainerId();
+
+    /**
+     * Gets the container id that is advertised to the peer.
+     * <p>
+     * The identifier is supposed to be unique for this HonoConnection.
+     *
+     * @return The container id.
+     */
+    String getContainerId();
 
     /**
      * Checks if this client supports a certain capability.

--- a/client/src/main/java/org/eclipse/hono/client/ProtocolAdapterCommandConsumerFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/ProtocolAdapterCommandConsumerFactory.java
@@ -30,12 +30,11 @@ public interface ProtocolAdapterCommandConsumerFactory extends ConnectionLifecyc
      * Creates a new factory for an existing connection.
      *
      * @param connection The connection to the AMQP network.
-     * @param adapterInstanceId The id of the protocol adapter instance that this factory is running in.
      * @return The factory.
      * @throws NullPointerException if connection or gatewayMapper is {@code null}.
      */
-    static ProtocolAdapterCommandConsumerFactory create(final HonoConnection connection, final String adapterInstanceId) {
-        return new ProtocolAdapterCommandConsumerFactoryImpl(connection, adapterInstanceId);
+    static ProtocolAdapterCommandConsumerFactory create(final HonoConnection connection) {
+        return new ProtocolAdapterCommandConsumerFactoryImpl(connection);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClient.java
@@ -104,7 +104,7 @@ public abstract class AbstractHonoClient {
      * <li>{@link Tags#COMPONENT} - set to <em>hono-client</em></li>
      * <li>{@link Tags#PEER_HOSTNAME} - set to {@link ClientConfigProperties#getHost()}</li>
      * <li>{@link Tags#PEER_PORT} - set to {@link ClientConfigProperties#getPort()}</li>
-     * <li>{@link TracingHelper#TAG_PEER_CONTAINER} - set to {@link HonoConnection#getRemoteContainer()}</li>
+     * <li>{@link TracingHelper#TAG_PEER_CONTAINER} - set to {@link HonoConnection#getRemoteContainerId()}</li>
      * </ul>
      * 
      * @param parent The existing span. If not {@code null} then the new span will have a
@@ -125,7 +125,7 @@ public abstract class AbstractHonoClient {
      * <li>{@link Tags#COMPONENT} - set to <em>hono-client</em></li>
      * <li>{@link Tags#PEER_HOSTNAME} - set to {@link ClientConfigProperties#getHost()}</li>
      * <li>{@link Tags#PEER_PORT} - set to {@link ClientConfigProperties#getPort()}</li>
-     * <li>{@link TracingHelper#TAG_PEER_CONTAINER} - set to {@link HonoConnection#getRemoteContainer()}</li>
+     * <li>{@link TracingHelper#TAG_PEER_CONTAINER} - set to {@link HonoConnection#getRemoteContainerId()}</li>
      * </ul>
      * 
      * @param parent The existing span. If not {@code null} then the new span will have a
@@ -145,7 +145,7 @@ public abstract class AbstractHonoClient {
                 .withTag(Tags.COMPONENT.getKey(), "hono-client")
                 .withTag(Tags.PEER_HOSTNAME.getKey(), connection.getConfig().getHost())
                 .withTag(Tags.PEER_PORT.getKey(), connection.getConfig().getPort())
-                .withTag(TracingHelper.TAG_PEER_CONTAINER.getKey(), connection.getRemoteContainer())
+                .withTag(TracingHelper.TAG_PEER_CONTAINER.getKey(), connection.getRemoteContainerId())
                 .start();
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandler.java
@@ -39,7 +39,7 @@ import io.vertx.proton.ProtonDelivery;
 import io.vertx.proton.ProtonHelper;
 
 /**
- * Handler for commands received at the protocol adapter specific address.
+ * Handler for commands received at the protocol adapter instance specific address.
  */
 public final class AdapterInstanceCommandHandler {
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -64,6 +64,11 @@ public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClien
      */
     private CachingClientFactory<MessageConsumer> mappingAndDelegatingCommandConsumerFactory;
 
+    /**
+     * Identifier that has to be unique to this factory instance.
+     * Will be used to represent the protocol adapter instance that this factory instance is used in, when registering
+     * command handlers with the Device Connection service.
+     */
     private final String adapterInstanceId;
     private final AdapterInstanceCommandHandler adapterInstanceCommandHandler;
     private final AtomicBoolean recreatingConsumers = new AtomicBoolean(false);
@@ -78,12 +83,12 @@ public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClien
      * Creates a new factory for an existing connection.
      * 
      * @param connection The connection to the AMQP network.
-     * @param adapterInstanceId The id of the protocol adapter instance that this factory is running in.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    public ProtocolAdapterCommandConsumerFactoryImpl(final HonoConnection connection, final String adapterInstanceId) {
+    public ProtocolAdapterCommandConsumerFactoryImpl(final HonoConnection connection) {
         super(connection);
-        this.adapterInstanceId = Objects.requireNonNull(adapterInstanceId);
+        // the container id contains a UUID therefore it can be used as a unique adapter instance id
+        adapterInstanceId = connection.getContainerId();
 
         adapterInstanceCommandHandler = new AdapterInstanceCommandHandler(connection.getTracer(), adapterInstanceId);
     }

--- a/client/src/test/java/org/eclipse/hono/client/impl/DisconnectHandlerProvidingConnectionFactory.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DisconnectHandlerProvidingConnectionFactory.java
@@ -65,6 +65,18 @@ public class DisconnectHandlerProvidingConnectionFactory implements ConnectionFa
             final Handler<AsyncResult<ProtonConnection>> closeHandler,
             final Handler<ProtonConnection> disconnectHandler,
             final Handler<AsyncResult<ProtonConnection>> connectionResultHandler) {
+        connect(options, null, null, null, closeHandler, disconnectHandler, connectionResultHandler);
+    }
+
+    @Override
+    public void connect(
+            final ProtonClientOptions options,
+            final String username,
+            final String password,
+            final String containerId,
+            final Handler<AsyncResult<ProtonConnection>> closeHandler,
+            final Handler<ProtonConnection> disconnectHandler,
+            final Handler<AsyncResult<ProtonConnection>> connectionResultHandler) {
 
         this.closeHandler = closeHandler;
         this.disconnectHandler = disconnectHandler;
@@ -75,11 +87,6 @@ public class DisconnectHandlerProvidingConnectionFactory implements ConnectionFa
             expectedSucceedingConnectionAttempts.countDown();
             connectionResultHandler.handle(Future.succeededFuture(connectionToCreate));
         }
-    }
-
-    @Override
-    public String getName() {
-        return "client";
     }
 
     @Override

--- a/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
@@ -104,6 +104,7 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
         props = new ClientConfigProperties();
 
         connection = HonoClientUnitTestHelper.mockHonoConnection(vertx, props);
+        when(connection.getContainerId()).thenReturn(adapterInstanceId);
 
         adapterInstanceCommandReceiver = mock(ProtonReceiver.class);
         adapterInstanceCommandConsumerAddress = CommandConstants.INTERNAL_COMMAND_ENDPOINT + "/" + adapterInstanceId;
@@ -133,7 +134,7 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
                 .thenReturn(Future.succeededFuture(devConClient));
         when(devConClient.setCommandHandlingAdapterInstance(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
 
-        commandConsumerFactory = new ProtocolAdapterCommandConsumerFactoryImpl(connection, adapterInstanceId);
+        commandConsumerFactory = new ProtocolAdapterCommandConsumerFactoryImpl(connection);
         commandConsumerFactory.initialize(commandTargetMapper, deviceConnectionClientFactory);
     }
 

--- a/core/src/main/java/org/eclipse/hono/config/ClientConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ClientConfigProperties.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.hono.config;
 
-import java.util.UUID;
-
 import org.eclipse.hono.util.Constants;
 
 /**
@@ -70,7 +68,6 @@ public class ClientConfigProperties extends AuthenticatingClientConfigProperties
      */
     public static final long DEFAULT_SEND_MESSAGE_TIMEOUT = 1000L; // ms
 
-    private final String containerIdUuidPart = UUID.randomUUID().toString();
     private String amqpHostname;
     private int connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT;
     private long flowLatency = DEFAULT_FLOW_LATENCY;
@@ -119,7 +116,6 @@ public class ClientConfigProperties extends AuthenticatingClientConfigProperties
      * Gets the name being indicated as part of the <em>container-id</em> in the client's AMQP <em>Open</em> frame.
      * 
      * @return The name or {@code null} if no name has been set.
-     * @see #getContainerId()
      */
     public final String getName() {
         return name;
@@ -129,7 +125,6 @@ public class ClientConfigProperties extends AuthenticatingClientConfigProperties
      * Sets the name to indicate as part of the <em>container-id</em> in the client's AMQP <em>Open</em> frame.
      * 
      * @param name The name to set.
-     * @see #getContainerId()
      */
     public final void setName(final String name) {
         this.name = name;
@@ -151,17 +146,6 @@ public class ClientConfigProperties extends AuthenticatingClientConfigProperties
      */
     public final void setAmqpHostname(final String amqpHostname) {
         this.amqpHostname = amqpHostname;
-    }
-
-    /**
-     * Gets the identifier being indicated as the <em>container-id</em> in the client's AMQP <em>Open</em> frame.
-     * <p>
-     * The identifier consists of the name returned by {@link #getName()} plus a UUID.
-     *
-     * @return The identifier.
-     */
-    public final String getContainerId() {
-        return String.format("%s-%s", getName(), containerIdUuidPart);
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -449,21 +449,7 @@ public abstract class AbstractAdapterConfig {
     @Bean
     @Scope("prototype")
     public ProtocolAdapterCommandConsumerFactory commandConsumerFactory() {
-        return ProtocolAdapterCommandConsumerFactory.create(commandConsumerConnection(), getAdapterInstanceId());
-    }
-
-    /**
-     * Exposes the protocol adapter instance identifier.
-     * <p>
-     * It is equivalent to the <em>container-id</em> advertised on the connection to
-     * the AMQP Messaging Network used for receiving commands.
-     *
-     * @return The identifier.
-     */
-    @Qualifier("adapterInstanceId")
-    @Bean
-    public String getAdapterInstanceId() {
-        return commandConsumerFactoryConfig().getContainerId();
+        return ProtocolAdapterCommandConsumerFactory.create(commandConsumerConnection());
     }
 
     /**

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -8,6 +8,13 @@ title = "Release Notes"
 
 * An admin guide for the CoAP adapter has been added.
 
+### API Changes
+
+* The `getRemoteContainer` method in `org.eclipse.hono.client.HonoConnection` has been
+  renamed to `getRemoteContainerId`.
+* The `getName` method in `org.eclipse.hono.connection.ConnectionFactory` has been removed
+  and an additional `connect` method has been added.  
+
 ## 1.2.2 (not yet released)
 
 ### Fixes & Enhancements


### PR DESCRIPTION
Fix for #1860.

Makes sure that each `ProtocolAdapterCommandConsumerFactory` instance gets assigned its own unique `adapterInstanceId` (which then kind of represents the `AbstractProtocolAdapterBase` instance that the command consumer factory instance is used in).