### PR TITLE
Add NOOP TenantInformationService

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsService.java
@@ -14,6 +14,7 @@ package org.eclipse.hono.deviceregistry.service.credentials;
 
 import java.util.Objects;
 
+import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
 import org.eclipse.hono.service.credentials.CredentialsService;
@@ -31,15 +32,18 @@ import io.vertx.core.json.JsonObject;
  */
 public abstract class AbstractCredentialsService implements CredentialsService {
 
-    protected TenantInformationService tenantInformationService;
+    protected TenantInformationService tenantInformationService = new NoopTenantInformationService();
 
     /**
-     * Set tenant information service.
+     * Sets the service to use for checking existence of tenants.
+     * <p>
+     * If not set, tenant existence will not be verified.
+     * 
      * @param tenantInformationService The tenant information service.
      * @throws NullPointerException if service is {@code null};
      */
-    @Autowired
-    public void setTenantInformationService(final TenantInformationService tenantInformationService) {
+    @Autowired(required = false)
+    public final void setTenantInformationService(final TenantInformationService tenantInformationService) {
         this.tenantInformationService = Objects.requireNonNull(tenantInformationService);
     }
 
@@ -55,12 +59,12 @@ public abstract class AbstractCredentialsService implements CredentialsService {
     protected abstract Future<CredentialsResult<JsonObject>> processGet(TenantKey tenant, CredentialKey key, JsonObject clientContext, Span span);
 
     @Override
-    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId, final Span span) {
+    public final Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId, final Span span) {
         return get(tenantId, type, authId, null, span);
     }
 
     @Override
-    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId, final JsonObject clientContext, final Span span) {
+    public final Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId, final JsonObject clientContext, final Span span) {
         return this.tenantInformationService
                 .tenantExists(tenantId, span)
                 .compose(result -> result.isError()

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractRegistrationService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractRegistrationService.java
@@ -17,6 +17,7 @@ import java.net.HttpURLConnection;
 import java.util.Objects;
 
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
 import org.eclipse.hono.service.registration.RegistrationService;
@@ -53,15 +54,18 @@ public abstract class AbstractRegistrationService implements RegistrationService
 
     private static final Logger log = LoggerFactory.getLogger(AbstractRegistrationService.class);
 
-    protected TenantInformationService tenantInformationService;
+    protected TenantInformationService tenantInformationService = new NoopTenantInformationService();
 
     /**
-     * Set tenant information service.
+     * Sets the service to use for checking existence of tenants.
+     * <p>
+     * If not set, tenant existence will not be verified.
+     * 
      * @param tenantInformationService The tenant information service.
      * @throws NullPointerException if service is {@code null};
      */
-    @Autowired
-    public void setTenantInformationService(final TenantInformationService tenantInformationService) {
+    @Autowired(required = false)
+    public final void setTenantInformationService(final TenantInformationService tenantInformationService) {
         this.tenantInformationService = Objects.requireNonNull(tenantInformationService);
     }
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/NoopTenantInformationService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/NoopTenantInformationService.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceregistry.service.tenant;
+
+import java.net.HttpURLConnection;
+import java.util.Optional;
+
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.Result;
+
+import io.opentracing.Span;
+import io.vertx.core.Future;
+
+
+/**
+ * A simple implementation that is not backed by any real data.
+ *
+ */
+public final class NoopTenantInformationService implements TenantInformationService {
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation always returns a succeeded future containing a key for the given tenant.
+     */
+    @Override
+    public Future<Result<TenantKey>> tenantExists(final String tenantId, final Span span) {
+        return Future.succeededFuture(OperationResult.ok(HttpURLConnection.HTTP_OK, TenantKey.from(tenantId), Optional.empty(), Optional.empty()));
+    }
+
+}


### PR DESCRIPTION
The NOOP implementation always succeeds and serves as the default
implementation being used if no TenantInformationService is set
explicitly.
