### PR TITLE
[#1679] Return the version of the updated device.

### DIFF
--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
@@ -52,8 +52,10 @@ import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.FindOptions;
 import io.vertx.ext.mongo.IndexOptions;
 import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.UpdateOptions;
 
 /**
  * This is an implementation of the device registration service and the device management service where data 
@@ -321,9 +323,9 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
                 .document();
         final Promise<JsonObject> updateDevicePromise = Promise.promise();
 
-        mongoClient.findOneAndReplace(config.getCollectionName(), updateDeviceQuery,
+        mongoClient.findOneAndReplaceWithOptions(config.getCollectionName(), updateDeviceQuery,
                 JsonObject.mapFrom(new DeviceDto(tenantId, deviceId, device, new Versioned<>(device).getVersion())),
-                updateDevicePromise);
+                new FindOptions(), new UpdateOptions().setReturningNewDocument(true), updateDevicePromise);
 
         return updateDevicePromise.future()
                 .compose(result -> Optional.ofNullable(result)


### PR DESCRIPTION
To process the update device request, a function named `findOneAndReplace(...)` provided by the _MongoDB_ _Vert.x_ client has been used. By default, the handler for this method returns the document to be updated and not the updated document. This version in the returned document is used to set the _ETag_ header in the response. In order to get the newly updated document instead of the old one, _MongoDB_ client requires an extra flag be set. This is fixed in this PR, so that the new version is returned as _ETag_ instead of the old one.