### PR TITLE
[#1679] Update JavaDoc of the Device Management APIs for status codes

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/credentials/CredentialsService.java
@@ -35,12 +35,9 @@ public interface CredentialsService {
      * @param type The type of credentials to get.
      * @param authId The authentication identifier of the device to get credentials for (may be {@code null}.
      * @return A future indicating the outcome of the operation.
-     *         The <em>status</em> will be
-     *         <ul>
-     *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
-     *         <em>payload</em> will contain the credentials.</li>
-     *         <li><em>404 Not Found</em> if no credentials matching the criteria exist.</li>
-     *         </ul>
+     *         The <em>status code</em> is set as specified in the
+     *         <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
+     *         Credentials API - Get Credentials</a>
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
      *      Credentials API - Get Credentials</a>
@@ -61,12 +58,9 @@ public interface CredentialsService {
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
      * @return A future indicating the outcome of the operation.
-     *         The <em>status</em> will be
-     *         <ul>
-     *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
-     *         <em>payload</em> will contain the credentials.</li>
-     *         <li><em>404 Not Found</em> if no credentials matching the criteria exist.</li>
-     *         </ul>
+     *         The <em>status code</em> is set as specified in the
+     *         <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
+     *         Credentials API - Get Credentials</a>
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
      *      Credentials API - Get Credentials</a>
@@ -81,12 +75,9 @@ public interface CredentialsService {
      * @param authId The authentication identifier of the device to get credentials for (may be {@code null}.
      * @param clientContext Optional bag of properties that can be used to identify the device.
      * @return A future indicating the outcome of the operation.
-     *         The <em>status</em> will be
-     *         <ul>
-     *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
-     *         <em>payload</em> will contain the credentials.</li>
-     *         <li><em>404 Not Found</em> if no credentials matching the criteria exist.</li>
-     *         </ul>
+     *         The <em>status code</em> is set as specified in the
+     *         <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
+     *         Credentials API - Get Credentials</a>
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
      *      Credentials API - Get Credentials</a>
@@ -109,12 +100,9 @@ public interface CredentialsService {
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
      * @return A future indicating the outcome of the operation.
-     *         The <em>status</em> will be
-     *         <ul>
-     *         <li><em>200 OK</em> if credentials of the given type and authentication identifier have been found. The
-     *         <em>payload</em> will contain the credentials.</li>
-     *         <li><em>404 Not Found</em> if no credentials matching the criteria exist.</li>
-     *         </ul>
+     *         The <em>status code</em> is set as specified in the
+     *         <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
+     *         Credentials API - Get Credentials</a>
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/#get-credentials">
      *      Credentials API - Get Credentials</a>

--- a/service-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
@@ -39,11 +39,10 @@ public interface DeviceManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @return A future indicating the outcome of the operation. The <em>status</em> will be
-     *            <ul>
-     *            <li><em>201 Created</em> if the device has been registered successfully.</li>
-     *            <li><em>409 Conflict</em> if a device with the given identifier already exists for the tenant.</li>
-     *            </ul>
+     * @return A future indicating the outcome of the operation.
+     *         The <em>status code</em> is set as specified in the 
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/createDeviceRegistration"> 
+     *         Device Registry Management API - Create Device Registration </a>
      * @throws NullPointerException if any of tenant, device ID or result handler is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/createDeviceRegistration">
      *      Device Registry Management API - Create Device Registration</a>
@@ -58,12 +57,10 @@ public interface DeviceManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @return A future indicating the outcome of the operation. The <em>status</em> will be
-     *            <ul>
-     *            <li><em>200 OK</em> if a device with the given ID is registered for the tenant. The <em>payload</em>
-     *            will contain the properties registered for the device.</li>
-     *            <li><em>404 Not Found</em> if no device with the given identifier is registered for the tenant.</li>
-     *            </ul>
+     * @return A future indicating the outcome of the operation.
+     *         The <em>status code</em> is set as specified in the 
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/getRegistration"> 
+     *         Device Registry Management API - Get Device Registration </a>
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/getRegistration">
      *      Device Registry Management API - Get Device Registration</a>
@@ -80,11 +77,10 @@ public interface DeviceManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @return A future indicating the outcome of the operation. The <em>status</em> will be
-     *            <ul>
-     *            <li><em>204 No Content</em> if the registration information has been updated successfully.</li>
-     *            <li><em>404 Not Found</em> if no device with the given identifier is registered for the tenant.</li>
-     *            </ul>
+     * @return A future indicating the outcome of the operation.
+     *         The <em>status code</em> is set as specified in the 
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/updateRegistration"> 
+     *         Device Registry Management API - Update Device Registration </a>
      * @throws NullPointerException if any of tenant, device ID or result handler is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/updateRegistration">
      *      Device Registry Management API - Update Device Registration</a>
@@ -101,12 +97,10 @@ public interface DeviceManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *          An implementation should log (error) events on this span and it may set tags and use this span as the
      *          parent for any spans created in this method.
-     * @return  A future indicating the outcome of the operation. The <em>status</em> will be
-     *             <ul>
-     *             <li><em>204 No Content</em> if the device has been removed successfully.</li>
-     *             <li><em>404 Not Found</em> if no device with the given identifier is
-     *             registered for the tenant.</li>
-     *             </ul>
+     * @return  A future indicating the outcome of the operation.
+     *         The <em>status code</em> is set as specified in the 
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/deleteRegistration"> 
+     *         Device Registry Management API - Delete Device Registration </a>
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/deleteRegistration">
      *      Device Registry Management API - Delete Device Registration</a>

--- a/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementService.java
@@ -39,11 +39,9 @@ public interface TenantManagementService {
      *              An implementation should log (error) events on this span and it may set tags and use this span as the
      *              parent for any spans created in this method.
      * @return A future indicating the outcome of the operation.
-     *             The <em>status</em> will be
-     *             <ul>
-     *             <li><em>201 Created</em> if the tenant has been added successfully.</li>
-     *             <li><em>409 Conflict</em> if a tenant with the given identifier and version already exists.</li>
-     *             </ul>
+     *         The <em>status code</em> is set as specified in the
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/createTenant">
+     *         Device Registry Management API - Create Tenant</a>
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/createTenant">
      *      Device Registry Management API - Create Tenant</a>
@@ -57,12 +55,10 @@ public interface TenantManagementService {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @return A future indicating the outcome of the operation. The <em>status</em> will be
-     *            <ul>
-     *            <li><em>200 OK</em> if a tenant with the given ID is registered. The <em>payload</em> will contain the
-     *            tenant's configuration information.</li>
-     *            <li><em>404 Not Found</em> if no tenant with the given identifier and version exists.</li>
-     *            </ul>
+     * @return A future indicating the outcome of the operation.
+     *         The <em>status code</em> is set as specified in the
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/getTenant">
+     *         Device Registry Management API - Get Tenant</a>
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/getTenant">
      *      Device Registry Management API - Get Tenant</a>
@@ -79,11 +75,9 @@ public interface TenantManagementService {
      *             An implementation should log (error) events on this span and it may set tags and use this span as the
      *             parent for any spans created in this method.
      * @return A future indicating the outcome of the operation.
-     *             The <em>status</em> will be
-     *             <ul>
-     *             <li><em>204 No Content</em> if the tenant has been updated successfully.</li>
-     *             <li><em>404 Not Found</em> if no tenant with the given identifier and version exists.</li>
-     *             </ul>
+     *         The <em>status code</em> is set as specified in the 
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/updateTenant">
+     *         Device Registry Management API - Update Tenant</a>
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/updateTenant">
      *      Device Registry Management API - Update Tenant</a>
@@ -100,11 +94,9 @@ public interface TenantManagementService {
      *              An implementation should log (error) events on this span and it may set tags and use this span as the
      *              parent for any spans created in this method.
      * @return A future indicating the outcome of the operation.
-     *             The <em>status</em> will be
-     *             <ul>
-     *             <li><em>204 No Content</em> if the tenant has been removed successfully.</li>
-     *             <li><em>404 Not Found</em> if no tenant with the given identifier and version exists.</li>
-     *             </ul>
+     *         The <em>status code</em> is set as specified in the 
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/deleteTenant">
+     *         Device Registry Management API - Delete Tenant</a>
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/deleteTenant">
      *      Device Registry Management API - Delete Tenant</a>


### PR DESCRIPTION
The _JavaDoc_ of the _device management_ interface has been fixed now with the missing response codes to make it sync with that of the API definition in https://www.eclipse.org/hono/docs/api/management/.