### PR TITLE
Add base work for the JDBC device registry implementation

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -155,6 +155,11 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
+        <artifactId>vertx-jdbc-client</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
         <artifactId>vertx-mongo-client</artifactId>
         <version>${vertx.version}</version>
       </dependency>
@@ -207,6 +212,16 @@
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml.version}</version>
         <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
@@ -568,6 +583,11 @@
       <dependency>
         <groupId>org.eclipse.hono</groupId>
         <artifactId>client-device-connection-infinispan</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>service-base-jdbc</artifactId>
         <version>${project.version}</version>
       </dependency>
     </dependencies>

--- a/services/base-jdbc/pom.xml
+++ b/services/base-jdbc/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-bom</artifactId>
+        <version>1.3.0-SNAPSHOT</version>
+        <relativePath>../../bom</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>hono-service-base-jdbc</artifactId>
+    <name>Base classes for JDBC services</name>
+    <description>Base classes for working with JDBC</description>
+    <url>https://www.eclipse.org/hono</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-service-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-service-device-registry-base</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-jdbc-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-health-check</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </dependency>
+
+        <!-- testing -->
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+      </dependency>
+
+    </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+        </plugin>
+      </plugins>
+    </build>
+</project>

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/config/JdbcDeviceProperties.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/config/JdbcDeviceProperties.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ *
+ */
+@JsonInclude(value = Include.NON_NULL)
+public class JdbcDeviceProperties {
+
+    private JdbcProperties adapter;
+    private JdbcProperties management;
+    private Mode mode = Mode.JSON_TREE;
+
+    public JdbcProperties getAdapter() {
+        return adapter;
+    }
+
+    public void setAdapter(final JdbcProperties adapter) {
+        this.adapter = adapter;
+    }
+
+    public JdbcProperties getManagement() {
+        return management;
+    }
+
+    public void setManagement(final JdbcProperties management) {
+        this.management = management;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public void setMode(final Mode mode) {
+        this.mode = mode;
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/config/JdbcProperties.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/config/JdbcProperties.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.jdbc.JDBCClient;
+import io.vertx.ext.sql.SQLClient;
+
+/**
+ * Configuration properties for a JDBC service.
+ */
+@JsonInclude(value = Include.NON_NULL)
+public class JdbcProperties {
+
+    private static final Logger log = LoggerFactory.getLogger(JdbcProperties.class);
+
+    private String url;
+    private String driverClass;
+    private String username;
+    private String password;
+    private Integer maximumPoolSize;
+
+    private String tableName;
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+    public String getUrl() {
+        return url;
+    }
+
+    public void setDriverClass(final String driverClassName) {
+        this.driverClass = driverClassName;
+    }
+    public String getDriverClass() {
+        return driverClass;
+    }
+
+    public void setUsername(final String username) {
+        this.username = username;
+    }
+    public String getUsername() {
+        return username;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+    public String getPassword() {
+        return password;
+    }
+
+    public void setMaximumPoolSize(final Integer maximumPoolSize) {
+        this.maximumPoolSize = maximumPoolSize;
+    }
+    public Integer getMaximumPoolSize() {
+        return maximumPoolSize;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+    public void setTableName(final String tableName) {
+        this.tableName = tableName;
+    }
+
+    /**
+     * Create a {@link SQLClient} from the configuration properties.
+     * @param vertx The vertx instance to use.
+     * @param dataSourceProperties The properties.
+     * @return The new SQL client.
+     */
+    public static SQLClient dataSource(final Vertx vertx, final JdbcProperties dataSourceProperties) {
+
+        final JsonObject config = new JsonObject()
+                .put("url", dataSourceProperties.getUrl())
+                .put("user", dataSourceProperties.getUsername());
+
+        // password is added later, after logging
+
+        if (dataSourceProperties.getDriverClass() != null) {
+            config.put("driver_class", dataSourceProperties.getDriverClass());
+        }
+        if (dataSourceProperties.getMaximumPoolSize() != null) {
+            config.put("max_pool_size", dataSourceProperties.getMaximumPoolSize());
+        }
+
+        log.info("Creating new SQL client: {} - table: {}", config, dataSourceProperties.getTableName());
+
+        // put password after logging
+
+        config
+            .put("password", dataSourceProperties.getPassword());
+
+        // create new client
+
+        return JDBCClient.createShared(vertx, config);
+
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/config/Mode.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/config/Mode.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.config;
+
+/**
+ * The data model model.
+ */
+public enum Mode {
+    JSON_FLAT,
+    JSON_TREE,
+    TABLE;
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/AbstractStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/AbstractStore.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.eclipse.hono.service.HealthCheckProvider;
+import org.eclipse.hono.service.base.jdbc.store.Statement.ExpandedStatement;
+import org.eclipse.hono.tracing.TracingHelper;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLClient;
+import io.vertx.ext.sql.UpdateResult;
+
+/**
+ * An abstract JDBC based data store.
+ */
+public abstract class AbstractStore implements HealthCheckProvider, AutoCloseable {
+
+    private static final String DEFAULT_CHECK_SQL = "SELECT 1";
+
+    private final SQLClient client;
+    private final Tracer tracer;
+
+    private final ExpandedStatement checkSql;
+
+    /**
+     * Create a new instance.
+     *
+     * @param client The SQL client to use.
+     * @param tracer The tracer to use.
+     * @param checkSql An optional SQL statement, which will be used to check if the connection to the
+     *        database is OK. It this value is empty, the default statement {@value #DEFAULT_CHECK_SQL} will be used.
+     */
+    public AbstractStore(final SQLClient client, final Tracer tracer, final Optional<Statement> checkSql) {
+        this.client = Objects.requireNonNull(client);
+        this.tracer = Objects.requireNonNull(tracer);
+        this.checkSql = checkSql.orElseGet(() -> Statement.statement(DEFAULT_CHECK_SQL)).expand();
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.client.close();
+    }
+
+    @Override
+    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
+    }
+
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
+        readinessHandler.register("sql", Duration.ofSeconds(10).toMillis(), p -> {
+            this.checkSql
+                    .query(this.client)
+                    .map(Status.OK())
+                    .setHandler(p);
+        });
+    }
+
+    /**
+     * Check of an optimistic lock outcome.
+     * <p>
+     * This method will take the result of a simple update and, in case of a versioned update, try to
+     * figure out of the optimistic lock held.
+     * <p>
+     * The implementation will do a simple, post update query to the entity, in case no rows got
+     * updated, and then check for the existence of the entity. So there still is a race condition
+     * possible, of an object not being updated because it doesn't exist, and a new, matching entity
+     * being created at the same time. Or a failed update, and someone deleting the object at the same
+     * time. The state in the database would always be consistent.
+     * <p>
+     * So it might be that the method reports a "nothing updated" condition, although when the update
+     * statement was updated, it was a broken optimistic lock condition. However, the final result still
+     * is that the update failed, and the object is now deleted.
+     *
+     * @param result The original result, from updating the entity.
+     * @param reader The reader to use for fetching the entity, by key only.
+     * @param resourceVersion The optional resource version.
+     * @param span The tracing span.
+     * @return If the resource version is not set, it will return the result unaltered. Otherwise it
+     *         will read the entity by key only. If it finds the entity, then this is considered a
+     *         broken optimistic lock, and a failed future will be returned. Otherwise it is considered
+     *         an "object not found" condition.
+     */
+    protected Future<UpdateResult> checkOptimisticLock(final Future<UpdateResult> result, final Span span,
+            final Optional<String> resourceVersion,
+            final Function<Span, Future<ResultSet>> reader) {
+
+        // if we don't have a resource version ...
+        if (resourceVersion.isEmpty()) {
+            /// ... then there is no need to check
+            return result;
+        }
+
+        return result
+                .<UpdateResult>flatMap(r -> {
+
+                    span.log(ImmutableMap.<String, Object>builder()
+                            .put("event", "check update result")
+                            .put("update_count", r.getUpdated())
+                            .build());
+
+                    // if we updated something ...
+                    if (r.getUpdated() != 0) {
+                        // ... then we optimistic lock held
+                        return Future.succeededFuture(r);
+                    }
+
+                    final Span readSpan = TracingHelper.buildChildSpan(this.tracer, span.context(), "check optimistic lock", getClass().getSimpleName())
+                            .withTag("resource_version", resourceVersion.get())
+                            .start();
+
+                    // we did not update anything, we need to check why ...
+                    final var f = reader.apply(readSpan)
+                            .<UpdateResult>flatMap(readResult -> {
+
+                                span.log(Map.of(
+                                        "event", "check read result",
+                                        "read_count", readResult.getNumRows()));
+
+                                // ... having read the current state, without the version ...
+                                if (readResult.getNumRows() <= 0) {
+                                    // ... we know that the entry simply doesn't exist
+                                    return Future.succeededFuture(r);
+                                } else {
+                                    // ... we know that the entry does exists, just had the wrong version, and the lock broke
+                                    return Future.failedFuture(new OptimisticLockingException());
+                                }
+                            });
+
+                    return f.onComplete(x -> readSpan.finish());
+                });
+
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/DuplicateKeyException.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/DuplicateKeyException.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+/**
+ * An exception indicating a duplicate key condition.
+ */
+public class DuplicateKeyException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create a new instance without root cause.
+     */
+    public DuplicateKeyException() {
+    }
+
+    /**
+     * Create a new instance with root cause.
+     * @param cause The root cause.
+     */
+    public DuplicateKeyException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/EntityNotFoundException.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/EntityNotFoundException.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+/**
+ * An exception indicating a entity not found condition.
+ */
+public class EntityNotFoundException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create a new instance without root cause.
+     */
+    public EntityNotFoundException() {
+    }
+
+    /**
+     * Create a new instance with root cause.
+     * @param cause The root cause.
+     */
+    public EntityNotFoundException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/OptimisticLockingException.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/OptimisticLockingException.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+/**
+ * An exception indicating a optimistic lock failure.
+ */
+public class OptimisticLockingException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create a new instance without root cause.
+     */
+    public OptimisticLockingException() {
+    }
+
+    /**
+     * Create a new instance with root cause.
+     * @param cause The root cause.
+     */
+    public OptimisticLockingException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/SQL.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/SQL.java
@@ -1,0 +1,253 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+import java.net.URI;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.log.Fields;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.ext.sql.SQLConnection;
+
+/**
+ * SQL helper methods.
+ */
+public final class SQL {
+
+    private static final Logger log = LoggerFactory.getLogger(SQL.class);
+
+    private SQL() {
+    }
+
+    /**
+     * Translate from a generic SQL exception to a more typed exception.
+     *
+     * @param <T> The type of the future.
+     * @param e The exception to translate.
+     * @return The result, as a future. This will always be a failed future.
+     */
+    public static <T> Future<T> translateException(final Throwable e) {
+
+        final var sqlError = causeOf(e, SQLException.class).orElse(null);
+
+        if (sqlError == null) {
+            return Future.failedFuture(e);
+        }
+
+        log.debug("SQL Error: {}", sqlError.getSQLState());
+        final String code = sqlError.getSQLState();
+        if (code == null) {
+            return Future.failedFuture(e);
+        }
+
+        switch (code) {
+            case "23000": //$FALL-THROUGH$
+            case "23505":
+                return Future.failedFuture(new DuplicateKeyException(e));
+        }
+
+        return Future.failedFuture(e);
+    }
+
+    /**
+     * Enable auto-commit.
+     *
+     * @param tracer The tracer.
+     * @param context The span.
+     * @param connection The database connection to change.
+     * @param state The auto-commit state.
+     * @return A future for tracking the outcome.
+     */
+    public static Future<SQLConnection> setAutoCommit(final Tracer tracer, final SpanContext context, final SQLConnection connection, final boolean state) {
+        final Span span = startSqlSpan(tracer, context, "set autocommit", builder -> {
+            builder.withTag("db.autocommit", state);
+        });
+        final Promise<Void> promise = Promise.promise();
+        connection.setAutoCommit(state, promise);
+        return finishSpan(promise.future().map(connection), span, null);
+    }
+
+    /**
+     * Perform commit operation.
+     *
+     * @param tracer The tracer.
+     * @param context The span.
+     * @param connection The database connection to work on.
+     *
+     * @return A future for tracking the outcome.
+     */
+    public static Future<SQLConnection> commit(final Tracer tracer, final SpanContext context, final SQLConnection connection) {
+        final Span span = startSqlSpan(tracer, context, "commit", null);
+        final Promise<Void> promise = Promise.promise();
+        connection.commit(promise);
+        return finishSpan(promise.future().map(connection), span, null);
+    }
+
+    /**
+     * Perform rollback operation.
+     *
+     * @param tracer The tracer.
+     * @param context The span.
+     * @param connection The database connection to work on.
+     *
+     * @return A future for tracking the outcome.
+     */
+    public static Future<SQLConnection> rollback(final Tracer tracer, final SpanContext context, final SQLConnection connection) {
+        final Span span = startSqlSpan(tracer, context, "rollback", null);
+        final Promise<Void> promise = Promise.promise();
+        connection.rollback(promise);
+        return finishSpan(promise.future().map(connection), span, null);
+    }
+
+    /**
+     * Start a new span for an SQL operation.
+     *
+     * @param tracer The tracer to use.
+     * @param context The current span context.
+     * @param operationName The name of the operation.
+     * @param customizer An optional customizer.
+     * @return The newly created span. The caller is required to finish the span.
+     */
+    public static Span startSqlSpan(final Tracer tracer, final SpanContext context, final String operationName, final Consumer<Tracer.SpanBuilder> customizer) {
+
+        if (tracer == null || context == null) {
+            return null;
+        }
+
+        final SpanBuilder builder = TracingHelper
+                .buildChildSpan(tracer, context, operationName, SQL.class.getSimpleName())
+                .withTag(Tags.DB_TYPE.getKey(), "sql");
+
+        if (customizer != null) {
+            customizer.accept(builder);
+        }
+
+        return builder.start();
+
+    }
+
+    /**
+     * Finish an SQL span.
+     *
+     * @param <T> The type of the future.
+     * @param future The future of the SQL operation.
+     * @param span The span to log to.
+     * @param extractor An optional way to extract more information to the span. All properties added to
+     *        the provided map will be logged in case of a successful operation.
+     * @return The
+     */
+    public static <T> Future<T> finishSpan(final Future<T> future, final Span span, final BiConsumer<T, Map<String, Object>> extractor) {
+        if (span == null) {
+            return future;
+        }
+
+        return future
+                .onComplete(result -> {
+                    if (result.succeeded()) {
+                        traceSuccess(result.result(), span, extractor);
+                    } else {
+                        traceError(result.cause(), span);
+                    }
+                });
+    }
+
+    private static <T> void traceSuccess(final T result, final Span span, final BiConsumer<T, Map<String, Object>> extractor) {
+        final Map<String, Object> log = new HashMap<>();
+        log.put(Fields.EVENT, "success");
+        if (extractor != null) {
+            extractor.accept(result, log);
+        }
+        span.log(log);
+        span.finish();
+    }
+
+    private static void traceError(final Throwable e, final Span span) {
+        span.log(Map.of(
+                Fields.EVENT, "error",
+                Fields.ERROR_KIND, e.getClass().getName(),
+                Fields.ERROR_OBJECT, e,
+                Fields.MESSAGE, e.getMessage(),
+                Fields.STACK, Throwables.getStackTraceAsString(e)));
+        Tags.ERROR.set(span, true);
+        span.finish();
+    }
+
+    /**
+     * Extract the database type from the JDBC URL.
+     *
+     * @param url A JDBC URL.
+     * @return The type of the database.
+     * @throws IllegalArgumentException if the URL is not a JDBC URL, it must start with {@code jdbc:}.
+     */
+    public static String getDatabaseDialect(final String url) {
+        final URI uri = URI.create(url);
+        final String scheme = uri.getScheme();
+        if (!"jdbc".equals(scheme)) {
+            throw new IllegalArgumentException("URL is not a JDBC url: " + url);
+        }
+        final URI subUri = URI.create(uri.getSchemeSpecificPart());
+        return subUri.getScheme();
+    }
+
+    /**
+     * Find a cause of provided type.
+     *
+     * @param <T> The cause type to look for.
+     * @param e The throwable to search.
+     * @param clazz The class to look for.
+     * @return An {@link Optional} with the cause of type {@code <T>}, should that exist in the cause
+     *         chain. Otherwise, or of the throwable provided is {@code null}, {@link Optional#empty()}
+     *         will be returned.
+     */
+    public static <T extends Throwable> Optional<T> causeOf(final Throwable e, final Class<T> clazz) {
+        if (e == null) {
+            return Optional.empty();
+        }
+        return Throwables.getCausalChain(e)
+                .stream()
+                .filter(clazz::isInstance)
+                .findFirst()
+                .map(clazz::cast);
+    }
+
+    /**
+     * Check if the throwable has a cause of the provided type.
+     *
+     * @param <T> The cause type to look for.
+     * @param e The throwable to search.
+     * @param clazz The class to look for.
+     * @return {@code true} if the cause chain contains the requested exception, {@code false}
+     *         otherwise. If the throwable to check is {@code null}, false will be returned as well.
+     */
+    public static <T extends Throwable> boolean hasCauseOf(final Throwable e, final Class<T> clazz) {
+        return causeOf(e, clazz).isPresent();
+    }
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/Statement.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/Statement.java
@@ -1,0 +1,300 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.base.MoreObjects;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLOperations;
+import io.vertx.ext.sql.UpdateResult;
+
+/**
+ * An SQL statement, which can map named parameters to positional parameters.
+ */
+public final class Statement {
+
+    private static final Pattern DEFAULT_PATTERN = Pattern.compile("(?<pre>^|[^\\:]):(?<name>[a-zA-Z_]+)");
+
+    private static final Object NOT_FOUND_MARKER = new Object();
+
+    private final String sql;
+    private final List<Map.Entry<String, Integer>> mappings;
+
+    private Statement(final String sql, final List<Map.Entry<String, Integer>> mappings) {
+        Objects.requireNonNull(sql);
+        Objects.requireNonNull(mappings);
+
+        this.sql = sql;
+        this.mappings = mappings;
+    }
+
+    /**
+     * Validate that all named parameters can be filled.
+     *
+     * @param availableParameters The parameters are available for expanding the statement.
+     * @return The instance, for chained invocations.
+     * @throws IllegalStateException if the statement uses a named parameters, which is not provided as
+     *         "available".
+     */
+    public Statement validateParameters(final String... availableParameters) {
+        if (availableParameters == null || availableParameters.length <= 0) {
+            return this;
+        }
+
+        // sort for binary search
+        Arrays.sort(availableParameters);
+
+        final Set<String> missingKeys = new HashSet<>();
+        for (final Map.Entry<String, Integer> entry : this.mappings) {
+            if (Arrays.binarySearch(availableParameters, entry.getKey()) < 0) {
+                missingKeys.add(entry.getKey());
+            }
+        }
+
+        if (!missingKeys.isEmpty()) {
+            final String[] keys = missingKeys.toArray(String[]::new);
+            // sort for stable output order
+            Arrays.sort(keys);
+
+            throw new IllegalStateException(String.format(
+                    "Statement uses keys which are not available - missing: %s, available: %s, statement: %s",
+                    Arrays.toString(keys),
+                    Arrays.toString(availableParameters),
+                    this.sql));
+        }
+
+        return this;
+    }
+
+    /**
+     * Expand the statement with an empty map.
+     * <p>
+     * This actually calls {@link #expand(Map)} with an empty map.
+     *
+     * @return The expanded SQL statement.
+     * @throws IllegalArgumentException If a named field is present for which there is not mapped
+     *         parameter.
+     */
+    public ExpandedStatement expand() {
+        return expand(Collections.emptyMap());
+    }
+
+    /**
+     * Expand the statement with the provided named parameters.
+     *
+     * @param mapBuilder Allows you to build a map, rather then providing one.
+     * @return The expanded statement.
+     * @throws IllegalArgumentException If a named field is present for which there is not mapped
+     *         parameter.
+     */
+    public ExpandedStatement expand(final Consumer<Map<String, Object>> mapBuilder) {
+        final Map<String, Object> map = new HashMap<>();
+        mapBuilder.accept(map);
+        return expand(map);
+    }
+
+    /**
+     * Expand the statement with the provided named parameters.
+     *
+     * @param parameters The named parameters, may be empty, but must not be {@code null}.
+     * @return The expanded statement.
+     * @throws IllegalArgumentException If a named field is present for which there is not mapped
+     *         parameter.
+     */
+    public ExpandedStatement expand(final Map<String, Object> parameters) {
+        final Object[] params = new Object[this.mappings.size()];
+
+        for (Map.Entry<String, Integer> entry : this.mappings) {
+            final Object value = parameters.getOrDefault(entry.getKey(), NOT_FOUND_MARKER);
+            if (value == NOT_FOUND_MARKER) { // we explicitly check here for equality of the object reference
+                throw new IllegalArgumentException(String.format("Value for named parameter '%s' is missing", entry.getKey()));
+            }
+            params[entry.getValue()] = value;
+        }
+
+        return new ExpandedStatement(this.sql, params);
+    }
+
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("sql", this.sql)
+                .add("mappings", this.mappings)
+                .toString();
+    }
+
+    /**
+     * Create a new SQL statement instance.
+     * <p>
+     * This will parse the SQL statement for named parameters, and record the information for expanding
+     * it later on.
+     *
+     * @param sql The SQL statement to process. This is a formatted string according to
+     *        {@link String#format(String, Object...)}.
+     * @param values The values to replace in the parameter {@code sql}.
+     * @return The statement, or {@code null} if the provided SQL as {@code null}.
+     */
+    public static Statement statement(final String sql, final Object... values) {
+        if (sql == null) {
+            return null;
+        }
+
+        final String sqlFormatted = String.format(sql, values);
+
+        final Pattern pattern = DEFAULT_PATTERN;
+        final Matcher m = pattern.matcher(sqlFormatted);
+
+        int idx = 0;
+        final StringBuilder sb = new StringBuilder();
+        final List<Map.Entry<String, Integer>> mappings = new ArrayList<>();
+        while (m.find()) {
+            m.appendReplacement(sb, "${pre}?");
+            mappings.add(new SimpleImmutableEntry<>(m.group("name"), idx));
+            idx++;
+        }
+        m.appendTail(sb);
+
+        return new Statement(sb.toString(), mappings);
+    }
+
+    /**
+     * An expanded statement.
+     * <p>
+     * This class contains the positional parameters, and their values, expanded from a named parameter
+     * statement.
+     */
+    public static class ExpandedStatement {
+        private final String sql;
+        private final Object[] parameters;
+
+        private final Tracer tracer;
+        private final Span span;
+
+        private ExpandedStatement(final String sql, final Object[] parameters, final Tracer tracer, final Span span) {
+            this.sql = sql;
+            this.parameters = parameters;
+            this.tracer = tracer;
+            this.span = span;
+        }
+
+        private ExpandedStatement(final String sql, final Object[] parameters) {
+            this(sql, parameters, null, null);
+        }
+
+        public String getSql() {
+            return this.sql;
+        }
+
+        public Object[] getParameters() {
+            return this.parameters;
+        }
+
+        public JsonArray getParametersAsJson() {
+            return new JsonArray(Arrays.asList(this.parameters));
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                    .add("sql", this.sql)
+                    .add("parameters", this.parameters)
+                    .toString();
+        }
+
+        /**
+         * Attach a span to an expanded statement.
+         *
+         * @param tracer The tracer to create spans with.
+         * @param span The span to log to.
+         * @return The new instance, containing the span.
+         */
+        public ExpandedStatement trace(final Tracer tracer, final Span span) {
+            return new ExpandedStatement(this.sql, this.parameters, tracer, span);
+        }
+
+        @FunctionalInterface
+        private interface Operation<T> {
+            void run(String sql, JsonArray params, Handler<AsyncResult<T>> handler);
+        }
+
+        private <T> Future<T> run(final Operation<T> operation) {
+            final Promise<T> promise = Promise.promise();
+            operation.run(this.sql, getParametersAsJson(), promise);
+            return promise.future();
+        }
+
+        /**
+         * Start a new span for this SQL statement.
+         * @return The newly created span.
+         */
+        public Span startSqlSpan() {
+            if (this.tracer == null || this.span == null) {
+                return null;
+            }
+
+            return SQL.startSqlSpan(this.tracer, this.span.context(), "execute SQL", builder -> {
+                builder.withTag(Tags.DB_STATEMENT.getKey(), this.sql);
+            });
+        }
+
+        /**
+         * Execute this statement as a query.
+         * @param connection The connection to work on.
+         * @return A future tracking the query result.
+         */
+        public Future<ResultSet> query(final SQLOperations connection) {
+            final Span sqlSpan = startSqlSpan();
+            return SQL.finishSpan(run(connection::queryWithParams), sqlSpan, (r, log) -> {
+                log.put("rows", r.getNumRows());
+            });
+        }
+
+        /**
+         * Execute this statement as a update.
+         * @param connection The connection to work on.
+         * @return A future tracking the update result.
+         */
+        public Future<UpdateResult> update(final SQLOperations connection) {
+            final Span sqlSpan = startSqlSpan();
+            return SQL.finishSpan(run(connection::updateWithParams), sqlSpan, (r, log) -> {
+                log.put("rows", r.getUpdated());
+            });
+        }
+
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/StatementConfiguration.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/StatementConfiguration.java
@@ -1,0 +1,253 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+/**
+ * A configuration mechanism for making SQL statements configurable.
+ */
+public class StatementConfiguration {
+
+    public static final Path DEFAULT_PATH = Paths.get("/etc/config/sql");
+
+    private static final Logger log = LoggerFactory.getLogger(StatementConfiguration.class);
+
+    private final Map<String, Statement> statements;
+    private final Object[] formatArguments;
+
+    private StatementConfiguration(final Map<String, Statement> statements, final Object[] formatArguments) {
+        this.statements = statements;
+        this.formatArguments = formatArguments;
+    }
+
+    /**
+     * Override the current state with additional configuration.
+     * <p>
+     * The state of this instance will not be changed. The overridden configuration will be returned.
+     *
+     * @param path The file to read the configuration from.
+     * @param ignoreMissing Ignore if the resource is missing.
+     * @return A new instance, with the overridden configuration.
+     * @throws IOException in case an IO error occurs.
+     */
+    public StatementConfiguration overrideWith(final Path path, final boolean ignoreMissing) throws IOException {
+
+        if (ignoreMissing && !Files.exists(path)) {
+            log.info("Ignoring missing statement configuration file: {}", path);
+            return this;
+        }
+
+        log.info("Loading statement configuration file: {}", path);
+
+        try (InputStream input = Files.newInputStream(path)) {
+            return overrideWith(input, false);
+        }
+
+    }
+
+    /**
+     * Override the current state with additional configuration.
+     * <p>
+     * The state of this instance will not be changed. The overridden configuration will be returned.
+     *
+     * @param input The input stream to read the configuration from.
+     * @param ignoreMissing Ignore if the resource is missing.
+     * @return A new instance, with the overridden configuration.
+     * @throws IllegalArgumentException if the input is null, and the {@code ignoreMissing} parameter is
+     *         not {@code true}.
+     */
+    public StatementConfiguration overrideWith(final InputStream input, final boolean ignoreMissing) {
+        if (input == null) {
+            if (ignoreMissing) {
+                return this;
+            } else {
+                throw new IllegalArgumentException("Missing input");
+            }
+        }
+
+        final Yaml yaml = createYamlParser();
+        /*
+         * we must load using "load(input)" not "loadAs(input, Map.class)", because the
+         * latter would require to construct a class (Map) by name, which we do not support.
+         */
+        final Map<String, Object> properties = yaml.load(input);
+        if (properties == null) {
+            // we could read the source, but it was empty
+            return this;
+        }
+        return overrideWith(properties);
+    }
+
+    private StatementConfiguration overrideWith(final Map<String, Object> properties) {
+
+        final Map<String, Statement> result = new HashMap<>(this.statements);
+
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            if (entry.getKey() == null) {
+                continue;
+            }
+
+            final String key = entry.getKey();
+
+            // if key is set, but not a string ...
+            if (entry.getValue() != null && (!(entry.getValue() instanceof String))) {
+                // ... fail
+                throw new IllegalArgumentException(String.format("Key '%s' is not of type string: %s", entry.getKey(), entry.getValue().getClass()));
+            }
+
+            final String value = entry.getValue() != null ? entry.getValue().toString() : null;
+            if (value == null || value.isBlank()) {
+                // remove key
+                result.remove(key);
+                continue;
+            }
+
+            final Statement s = Statement.statement(value, this.formatArguments);
+            result.put(key, s);
+        }
+
+        return new StatementConfiguration(result, this.formatArguments);
+    }
+
+    /**
+     * Optionally get a statement from the configuration.
+     *
+     * @param key The key of the statement.
+     * @return The optional statement. May be {@link Optional#empty()}, but never {@code null}.
+     */
+    public Optional<Statement> getStatement(final String key) {
+        return Optional.ofNullable(this.statements.get(key));
+    }
+
+    /**
+     * Get a statement from the configuration.
+     *
+     * @param key The key of the statement.
+     * @return The statement, never returns {@code null}.
+     * @throws IllegalArgumentException if the statement is not present in the configuration.
+     */
+    public Statement getRequiredStatment(final String key) {
+        return getStatement(key)
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Statement with key '%s' not found", key)));
+    }
+
+    /**
+     * And empty statment configuration.
+     * <p>
+     * This is intended to be use as a starting point, chaining several calls to the different
+     * "override" methods.
+     *
+     * @param formatArguments Arguments which will be used to replace positional
+     *        {@link String#format(String, Object...)} arguments in the SQL statement configuration.
+     *        This may be used to replace things like table names, which cannot be provided as SQL
+     *        statement parameters.
+     * @return A new, empty, statement configuration instance.
+     */
+    public static StatementConfiguration empty(final Object... formatArguments) {
+        return new StatementConfiguration(Collections.emptyMap(), formatArguments);
+    }
+
+    /**
+     * Default pattern of overriding configuration.
+     * <p>
+     * This will override the configuration from the following locations:
+     * <ul>
+     * <li>{@code classpath://package.to.clazz/<basename>.sql.yaml} (required)</li>
+     * <li>{@code classpath://package.to.clazz/<basename>.<dialect>.sql.yaml} (optional)</li>
+     * <li>{@code file://<path>/<basename>.<dialect>.sql.yaml} (optional)</li>
+     * </ul>
+     *
+     * @param basename The basename.
+     * @param dialect The SQL dialect.
+     * @param clazz The root location in the classpath.
+     * @param path The local file system path.
+     * @return An overridden configuration.
+     * @throws IOException In case of any IO error.
+     */
+    public StatementConfiguration overideWithDefaultPattern(final String basename, final String dialect, final Class<?> clazz, final Path path) throws IOException {
+
+        final String base = basename + ".sql.yaml";
+        final String dialected = basename + "." + dialect + ".sql.yaml";
+
+        try (
+                InputStream resource = clazz.getResourceAsStream(base);
+                InputStream dialectResource = clazz.getResourceAsStream(dialected);) {
+
+            final Path overridePath = path.resolve(basename + ".sql.yaml");
+
+            log.debug("Loading - class: {}, name: {}, input: {}", clazz, base, resource);
+            log.debug("Loading - class: {}, name: {}, input: {}", clazz, dialected, dialectResource);
+            log.debug("Loading - path: {}", overridePath);
+
+            return this
+                    .overrideWith(resource, false)
+                    .overrideWith(dialectResource, true)
+                    .overrideWith(overridePath, true);
+        }
+
+    }
+
+    /**
+     * Dump the configuration to a logger.
+     *
+     * @param logger The logger to dump to.
+     */
+    public void dump(final Logger logger) {
+
+        if (!logger.isInfoEnabled()) {
+            return;
+        }
+
+        logger.info("Dumping statement configuration");
+        logger.info("Format arguments: {}", this.formatArguments);
+
+        final String[] keys = this.statements.keySet().toArray(String[]::new);
+        Arrays.sort(keys);
+        logger.info("Statements:");
+        for (String key : keys) {
+            logger.info("{}\n{}", key, this.statements.get(key));
+        }
+
+    }
+
+    /**
+     * Create a YAML parser which reject creating arbitrary Java objects.
+     *
+     * @return A new YAML parser, never returns {@code null}.
+     */
+    static Yaml createYamlParser() {
+        return new Yaml(new Constructor() {
+            @Override
+            protected Class<?> getClassForName(final String name) throws ClassNotFoundException {
+                throw new IllegalArgumentException("Class instantiation is not supported");
+            }
+        });
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/devcon/DeviceState.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/devcon/DeviceState.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.devcon;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Data model for the device state.
+ */
+public class DeviceState {
+
+    private Optional<String> lastKnownGateway = Optional.empty();
+
+    /**
+     * Create a new instance.
+     */
+    public DeviceState() {
+    }
+
+    /**
+     * Set the last know gateway.
+     * @param lastKnownGateway The last known gateway.
+     */
+    public void setLastKnownGateway(final Optional<String> lastKnownGateway) {
+        Objects.requireNonNull(lastKnownGateway);
+        this.lastKnownGateway = lastKnownGateway;
+    }
+
+    public Optional<String> getLastKnownGateway() {
+        return lastKnownGateway;
+    }
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/devcon/Store.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/devcon/Store.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.devcon;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.hono.deviceregistry.service.deviceconnection.DeviceConnectionKey;
+import org.eclipse.hono.service.base.jdbc.store.AbstractStore;
+import org.eclipse.hono.service.base.jdbc.store.SQL;
+import org.eclipse.hono.service.base.jdbc.store.Statement;
+import org.eclipse.hono.service.base.jdbc.store.StatementConfiguration;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.ext.sql.SQLClient;
+import io.vertx.ext.sql.UpdateResult;
+
+/**
+ * A data store for device connection information.
+ */
+public class Store extends AbstractStore {
+
+    public static final String DEFAULT_TABLE_NAME = "device_states";
+
+    private static final Logger log = LoggerFactory.getLogger(Store.class);
+
+    private final SQLClient client;
+    private final Tracer tracer;
+
+    private final Statement readStatement;
+    private final Statement updateStatement;
+    private final Statement dropTenantStatement;
+
+    /**
+     * Create a new instance.
+     *
+     * @param client The SQL client to use.
+     * @param tracer The tracer to use.
+     * @param cfg The statement configuration to use.
+     */
+    public Store(final SQLClient client, final Tracer tracer, final StatementConfiguration cfg) {
+        super(client, tracer, cfg.getStatement("checkConnection"));
+        cfg.dump(log);
+
+        this.client = client;
+        this.tracer = tracer;
+
+        this.readStatement = cfg
+                .getRequiredStatment("read")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id");
+
+        this.updateStatement = cfg.getRequiredStatment("update")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "gateway_id");
+
+        this.dropTenantStatement = cfg.getRequiredStatment("dropTenant")
+                .validateParameters("tenant_id");
+
+    }
+
+    /**
+     * Create a device statement configuration for the device connection store.
+     *
+     * @param jdbcUrl The JDBC URL for detecting the database dialect.
+     * @param tableName The table name to use.
+     * @return The new configuration.
+     * @throws IOException in case an IO error occurs.
+     */
+    public static StatementConfiguration defaultStatementConfiguration(final String jdbcUrl, final Optional<String> tableName) throws IOException {
+
+        final String dialect = SQL.getDatabaseDialect(jdbcUrl);
+        final String tableNameString = tableName.orElse(DEFAULT_TABLE_NAME);
+
+        return StatementConfiguration
+                .empty(tableNameString)
+                .overideWithDefaultPattern("base", dialect, Store.class, StatementConfiguration.DEFAULT_PATH.resolve("devcon"));
+
+    }
+
+    /**
+     * Read the state of a device.
+     * <p>
+     * This will execute the {@code read} statement, read the column named {@code last_known_gateway},
+     * if there is exactly one entry.
+     * <p>
+     * If there are no entries, and empty result will be returned.
+     * <p>
+     * If more than one entry is being found, the result will be failed with an
+     * {@link IllegalStateException} exception.
+     *
+     * @param key The key to the device entry.
+     * @param spanContext The span to contribute to.
+     *
+     * @return The future, tracking the outcome of the operation.
+     */
+    public Future<Optional<DeviceState>> readDeviceState(final DeviceConnectionKey key, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "read device state", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .start();
+
+        final var expanded = this.readStatement.expand(map -> {
+            map.put("tenant_id", key.getTenantId());
+            map.put("device_id", key.getDeviceId());
+        });
+
+        log.debug("readDeviceState - statement: {}", expanded);
+        final var result = expanded.trace(this.tracer, span).query(this.client);
+
+        final var f = result
+                .<Optional<DeviceState>>flatMap(r -> {
+                    final var entries = r.getRows(true);
+                    span.log(Map.of(
+                            "event", "read result",
+                            "rows", entries.size()));
+                    switch (entries.size()) {
+                        case 0:
+                            return Future.succeededFuture(Optional.empty());
+                        case 1:
+                            final var entry = entries.get(0);
+                            final var state = new DeviceState();
+                            state.setLastKnownGateway(Optional.ofNullable(entry.getString("last_known_gateway")));
+                            return Future.succeededFuture(Optional.of(state));
+                        default:
+                            return Future.failedFuture(new IllegalStateException("Found multiple entries for a single device"));
+                    }
+                });
+
+        return f.onComplete(x -> span.finish());
+
+    }
+
+    /**
+     * Set the last known gateway information of the device state.
+     * <p>
+     * This will execute the {@code update} statement to update the entry.
+     *
+     * @param key The key to the device entry.
+     * @param spanContext The span to contribute to.
+     * @param gatewayId The value to set.
+     *
+     * @return The future, tracking the outcome of the operation.
+     */
+    public Future<UpdateResult> setLastKnownGateway(final DeviceConnectionKey key, final String gatewayId, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "update device state", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .withTag("gateway_id", gatewayId)
+                .start();
+
+        final var expanded = this.updateStatement.expand(params -> {
+            params.put("tenant_id", key.getTenantId());
+            params.put("device_id", key.getDeviceId());
+            params.put("gateway_id", gatewayId);
+        });
+
+        log.debug("setLastKnownGateway - statement: {}", expanded);
+        final var result = expanded.trace(this.tracer, span).update(this.client);
+
+        return result.onComplete(x -> span.finish());
+
+    }
+
+    /**
+     * Drop all entries for a tenant.
+     *
+     * @param tenantId The tenant to drop.
+     * @param spanContext The span to contribute to.
+     *
+     * @return The future, tracking the outcome of the operation.
+     */
+    public Future<UpdateResult> dropTenant(final String tenantId, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "drop tenant", getClass().getSimpleName())
+                .withTag("tenant_instance_id", tenantId)
+                .start();
+
+        final var expanded = this.dropTenantStatement.expand(params -> {
+            params.put("tenant_id", tenantId);
+        });
+
+        log.debug("dropTenant - statement: {}", expanded);
+        final var result = expanded.trace(this.tracer, span).update(this.client);
+
+        return result.onComplete(x -> span.finish());
+
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/AbstractDeviceAdapterStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/AbstractDeviceAdapterStore.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.util.Optional;
+
+import org.eclipse.hono.deviceregistry.service.credentials.CredentialKey;
+import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
+import org.eclipse.hono.service.base.jdbc.store.StatementConfiguration;
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.tracing.TracingHelper;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.json.Json;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLClient;
+
+/**
+ * Create a new abstract device registry store for the adapter side.
+ */
+public abstract class AbstractDeviceAdapterStore extends AbstractDeviceStore {
+
+    /**
+     * Create a new instance.
+     *
+     * @param client The SQL client to use.
+     * @param tracer The tracer to use.
+     * @param cfg The SQL statement configuration.
+     */
+    public AbstractDeviceAdapterStore(final SQLClient client, final Tracer tracer, final StatementConfiguration cfg) {
+        super(client, tracer, cfg);
+    }
+
+    /**
+     * Find credentials for a device.
+     *
+     * @param key The credentials key to look for.
+     * @param spanContext The span context.
+     *
+     * @return A future tracking the outcome of the operation.
+     */
+    public abstract Future<Optional<CredentialsReadResult>> findCredentials(CredentialKey key, SpanContext spanContext);
+
+    /**
+     * Read a device using {@link #readDevice(io.vertx.ext.sql.SQLOperations, DeviceKey, Span)} and the
+     * current SQL client.
+     *
+     * @param key The key of the device to read.
+     * @param span The span to contribute to.
+     *
+     * @return The result from {@link #readDevice(io.vertx.ext.sql.SQLOperations, DeviceKey, Span)}.
+     */
+    protected Future<ResultSet> readDevice(final DeviceKey key, final Span span) {
+        return readDevice(this.client, key, span);
+    }
+
+    /**
+     * Reads the device data.
+     * <p>
+     * This reads the device data using
+     * {@link #readDevice(io.vertx.ext.sql.SQLOperations, DeviceKey, Span)} and
+     * transforms the plain result into a {@link DeviceReadResult}.
+     * <p>
+     * If now rows where found, the result will be empty. If more than one row is found,
+     * the result will be failed with an {@link IllegalStateException}.
+     * <p>
+     * If there is exactly one row, it will read the device registration information from the column
+     * {@code data} and optionally current resource version from the column {@code version}.
+     *
+     * @param key The key of the device to read.
+     * @param spanContext The span to contribute to.
+     *
+     * @return A future, tracking the outcome of the operation.
+     */
+    public Future<Optional<DeviceReadResult>> readDevice(final DeviceKey key, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "read device", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .start();
+
+        return readDevice(this.client, key, span)
+
+                .<Optional<DeviceReadResult>>flatMap(r -> {
+                    final var entries = r.getRows(true);
+                    switch (entries.size()) {
+                        case 0:
+                            return Future.succeededFuture((Optional.empty()));
+                        case 1:
+                            final var entry = entries.get(0);
+                            final var device = Json.decodeValue(entry.getString("data"), Device.class);
+                            final var version = Optional.ofNullable(entry.getString("version"));
+                            return Future.succeededFuture(Optional.of(new DeviceReadResult(device, version)));
+                        default:
+                            return Future.failedFuture(new IllegalStateException("Found multiple entries for a single device"));
+                    }
+                })
+
+                .onComplete(x -> span.finish());
+
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/AbstractDeviceManagementStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/AbstractDeviceManagementStore.java
@@ -1,0 +1,401 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
+import org.eclipse.hono.service.base.jdbc.store.DuplicateKeyException;
+import org.eclipse.hono.service.base.jdbc.store.OptimisticLockingException;
+import org.eclipse.hono.service.base.jdbc.store.SQL;
+import org.eclipse.hono.service.base.jdbc.store.Statement;
+import org.eclipse.hono.service.base.jdbc.store.StatementConfiguration;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.json.Json;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLClient;
+import io.vertx.ext.sql.SQLOperations;
+import io.vertx.ext.sql.UpdateResult;
+
+/**
+ * Create a new abstract device registry store for the management side.
+ */
+public abstract class AbstractDeviceManagementStore extends AbstractDeviceStore {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractDeviceManagementStore.class);
+
+    private final Statement createStatement;
+
+    private final Statement updateRegistrationStatement;
+    private final Statement updateRegistrationVersionedStatement;
+    private final Statement deleteStatement;
+    private final Statement deleteVersionedStatement;
+    private final Statement dropTenantStatement;
+
+    /**
+     * Create a new instance.
+     *
+     * @param client The SQL client to use.
+     * @param tracer The tracer to use.
+     * @param cfg The SQL statement configuration.
+     */
+    public AbstractDeviceManagementStore(final SQLClient client, final Tracer tracer, final StatementConfiguration cfg) {
+        super(client, tracer, cfg);
+
+        this.createStatement = cfg
+                .getRequiredStatment("create")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "version",
+                        "data");
+
+        this.updateRegistrationStatement = cfg
+                .getRequiredStatment("updateRegistration")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "next_version",
+                        "data");
+
+        this.updateRegistrationVersionedStatement = cfg
+                .getRequiredStatment("updateRegistrationVersioned")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "next_version",
+                        "data",
+                        "expected_version");
+
+        this.deleteStatement = cfg
+                .getRequiredStatment("delete")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id");
+
+        this.deleteVersionedStatement = cfg
+                .getRequiredStatment("deleteVersioned")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "expected_version");
+
+        this.dropTenantStatement = cfg
+                .getRequiredStatment("dropTenant")
+                .validateParameters(
+                        "tenant_id");
+
+    }
+
+    /**
+     * Get all credentials for a device.
+     * <p>
+     * The gets the credentials of a device. If the device cannot be found, the
+     * result must be empty. If no credentials could be found for an existing device,
+     * the result must not be empty, but provide an empty {@link CredentialsReadResult}.
+     *
+     * @param key The key of the device.
+     * @param spanContext The span to contribute to.
+     *
+     * @return A future, tracking the outcome of the operation.
+     */
+    public abstract Future<Optional<CredentialsReadResult>> getCredentials(DeviceKey key, SpanContext spanContext);
+
+    /**
+     * Set all credentials for a device.
+     * <p>
+     * This will set/replace all credentials of the device. If the device does not exists, the result
+     * will be {@code false}. If the update was successful, then the result will be {@code true}.
+     * If the resource version was provided, but the provided version was no longer the current version,
+     * then the future will fail with a {@link OptimisticLockingException}.
+     *
+     * @param key The key of the device to update.
+     * @param credentials The credentials to set.
+     * @param resourceVersion The optional resource version to update.
+     * @param spanContext The span to contribute to.
+     *
+     * @return A future, tracking the outcome of the operation.
+     */
+    public abstract Future<Boolean> setCredentials(DeviceKey key, List<CommonCredential> credentials, Optional<String> resourceVersion, SpanContext spanContext);
+
+    /**
+     * Create a new device.
+     * <p>
+     * This method executes the {@code create} statement, providing the named parameters
+     * {@code tenant_id}, {@code device_id}, {@code version}, and {@code data}.
+     * <p>
+     * It returns the plain update result. In case a device with the same ID already
+     * exists, the underlying database must throw an {@link SQLException}, indicating
+     * a duplicate entity or constraint violation. This will be translated into a
+     * failed future with an {@link DuplicateKeyException}.
+     *
+     * @param key The key of the device to create.
+     * @param device The device data.
+     * @param spanContext The span to contribute to.
+     *
+     * @return A future, tracking the outcome of the operation.
+     */
+    public Future<UpdateResult> createDevice(final DeviceKey key, final Device device, final SpanContext spanContext) {
+
+        final String json = Json.encode(device);
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "create device", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .withTag("data", json)
+                .start();
+
+        final var expanded = this.createStatement.expand(params -> {
+            params.put("tenant_id", key.getTenantId());
+            params.put("device_id", key.getDeviceId());
+            params.put("version", UUID.randomUUID().toString());
+            params.put("data", json);
+        });
+
+        log.debug("createDevice - statement: {}", expanded);
+
+        return expanded
+                .trace(this.tracer, span)
+                .update(this.client)
+                .recover(SQL::translateException)
+                .onComplete(x -> span.finish());
+
+    }
+
+    /**
+     * Update a field of device information entry.
+     * <p>
+     * The method executes the provided statement, setting the named parameters
+     * {@code tenant_id}, {@code device_id}, {@code next_version} and {@code data}.
+     * Additionally it will provide the named parameter {@code expected_version}, if
+     * resource version is not empty.
+     * <p>
+     * The update must only be performed if the resource version is either empty
+     * or matches the current version.
+     * <p>
+     * It returns the plain update result, which includes the number of rows changes.
+     * This is one, if the device was updated. It may also be zero, if the device does
+     * not exists. If the device exists, but the resource version does not match, the result
+     * will fail with an {@link OptimisticLockingException}.
+     *
+     * @param key The key of the device to update.
+     * @param statement The statement to use for the update.
+     * @param jsonValue The value to set.
+     * @param resourceVersion The optional resource version.
+     * @param span The span to contribute to.
+     *
+     * @return A future, tracking the outcome of the operation.
+     */
+    protected Future<UpdateResult> updateJsonField(final DeviceKey key, final Statement statement, final String jsonValue, final Optional<String> resourceVersion,
+            final Span span) {
+
+        final var expanded = statement.expand(map -> {
+            map.put("tenant_id", key.getTenantId());
+            map.put("device_id", key.getDeviceId());
+            map.put("next_version", UUID.randomUUID().toString());
+            map.put("data", jsonValue);
+            resourceVersion.ifPresent(version -> map.put("expected_version", version));
+        });
+
+        log.debug("update - statement: {}", expanded);
+
+        // execute update
+        final var result = expanded.trace(this.tracer, span).update(this.client);
+
+        // process result, check optimistic lock
+        return checkOptimisticLock(
+                result, span,
+                resourceVersion,
+                checkSpan -> readDevice(this.client, key, checkSpan));
+    }
+
+    /**
+     * Update device registration information.
+     * <p>
+     * This called the {@link #updateJsonField(DeviceKey, Statement, String, Optional, Span)} method
+     * with either the {@code updateRegistration} or {@code updateRegistrationVersioned}
+     * statement.
+     *
+     * @param key The key of the device to update.
+     * @param device The device data to store.
+     * @param resourceVersion The optional resource version.
+     * @param spanContext The span to contribute to.
+     *
+     * @return A future, tracking the outcome of the operation.
+     */
+    public Future<UpdateResult> updateDevice(final DeviceKey key, final Device device, final Optional<String> resourceVersion, final SpanContext spanContext) {
+
+        final String json = Json.encode(device);
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "update device", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .withTag("data", json)
+                .start();
+
+        resourceVersion.ifPresent(version -> span.setTag("version", version));
+
+        final Statement statement = resourceVersion.isPresent() ? this.updateRegistrationVersionedStatement : this.updateRegistrationStatement;
+
+        return updateJsonField(key, statement, json, resourceVersion, span)
+                .onComplete(x -> span.finish());
+
+    }
+
+    @Override
+    protected Future<ResultSet> read(final SQLOperations operations, final DeviceKey key, final Optional<String> resourceVersion, final Statement statement, final Span span) {
+
+        final var expanded = statement.expand(params -> {
+            params.put("tenant_id", key.getTenantId());
+            params.put("device_id", key.getDeviceId());
+            resourceVersion.ifPresent(version -> params.put("expected_version", version));
+        });
+
+        log.debug("read - statement: {}", expanded);
+
+        return expanded
+                .trace(this.tracer, span)
+                .query(this.client);
+    }
+
+    /**
+     * Reads the device data.
+     * <p>
+     * This reads the device data using
+     * {@link #readDevice(io.vertx.ext.sql.SQLOperations, DeviceKey, Span)} and
+     * transforms the plain result into a {@link DeviceReadResult}.
+     * <p>
+     * If now rows where found, the result will be empty. If more than one row is found,
+     * the result will be failed with an {@link IllegalStateException}.
+     * <p>
+     * If there is exactly one row, it will read the device registration information from the column
+     * {@code data} and optionally current resource version from the column {@code version}.
+     *
+     * @param key The key of the device to read.
+     * @param spanContext The span to contribute to.
+     *
+     * @return A future, tracking the outcome of the operation.
+     */
+    public Future<Optional<DeviceReadResult>> readDevice(final DeviceKey key, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "read device", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .start();
+
+        return readDevice(this.client, key, span)
+
+                .<Optional<DeviceReadResult>>flatMap(r -> {
+                    final var entries = r.getRows(true);
+                    switch (entries.size()) {
+                        case 0:
+                            return Future.succeededFuture((Optional.empty()));
+                        case 1:
+                            final var entry = entries.get(0);
+                            final var device = Json.decodeValue(entry.getString("data"), Device.class);
+                            final var version = Optional.ofNullable(entry.getString("version"));
+                            return Future.succeededFuture(Optional.of(new DeviceReadResult(device, version)));
+                        default:
+                            return Future.failedFuture(new IllegalStateException("Found multiple entries for a single device"));
+                    }
+                })
+
+                .onComplete(x -> span.finish());
+
+    }
+
+    /**
+     * Delete a single device.
+     * <p>
+     * This will execute the {@code delete} or {@code deleteVersioned} SQL statement and provide
+     * the named parameters {@code tenant_id}, {@code device_id}, and {@code expected_version} (if set).
+     * It will return the plain update result of the operation.
+     *
+     * @param key The key of the device to delete.
+     * @param resourceVersion An optional resource version.
+     * @param spanContext The span to contribute to.
+     *
+     * @return A future, tracking the outcome of the operation.
+     */
+    public Future<UpdateResult> deleteDevice(final DeviceKey key, final Optional<String> resourceVersion, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "delete device", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .start();
+
+        resourceVersion.ifPresent(version -> span.setTag("version", version));
+
+        final Statement statement;
+        if (resourceVersion.isPresent()) {
+            statement = this.deleteVersionedStatement;
+        } else {
+            statement = this.deleteStatement;
+        }
+
+        final var expanded = statement.expand(map -> {
+            map.put("tenant_id", key.getTenantId());
+            map.put("device_id", key.getDeviceId());
+            resourceVersion.ifPresent(version -> map.put("expected_version", version));
+        });
+
+        log.debug("delete - statement: {}", expanded);
+
+        return expanded
+                .trace(this.tracer, span)
+                .update(this.client)
+                .onComplete(x -> span.finish());
+
+    }
+
+    /**
+     * Delete all devices belonging to the provided tenant.
+     *
+     * @param tenantId The tenant to clean up.
+     * @param spanContext The span to contribute to.
+     *
+     * @return A future tracking the outcome of the operation.
+     */
+    public Future<UpdateResult> dropTenant(final String tenantId, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "drop tenant", getClass().getSimpleName())
+                .withTag("tenant_instance_id", tenantId)
+                .start();
+
+        final var expanded = this.dropTenantStatement.expand(params -> {
+            params.put("tenant_id", tenantId);
+        });
+
+        log.debug("delete - statement: {}", expanded);
+
+        return expanded
+                .trace(this.tracer, span)
+                .update(this.client)
+                .onComplete(x -> span.finish());
+
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/AbstractDeviceStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/AbstractDeviceStore.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.util.Optional;
+
+import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
+import org.eclipse.hono.service.base.jdbc.store.AbstractStore;
+import org.eclipse.hono.service.base.jdbc.store.Statement;
+import org.eclipse.hono.service.base.jdbc.store.StatementConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLClient;
+import io.vertx.ext.sql.SQLOperations;
+
+/**
+ * An abstract base for implementing a device registration store.
+ */
+public abstract class AbstractDeviceStore extends AbstractStore {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractDeviceStore.class);
+
+    protected final SQLClient client;
+    protected final Tracer tracer;
+
+    private final Statement readRegistrationStatement;
+
+    /**
+     * Create a new instance.
+     *
+     * @param client The SQL client to use.
+     * @param tracer The tracer to use.
+     * @param cfg The SQL statement configuration.
+     */
+    public AbstractDeviceStore(final SQLClient client, final Tracer tracer, final StatementConfiguration cfg) {
+        super(client, tracer, cfg.getStatement("checkConnection"));
+
+        this.client = client;
+        this.tracer = tracer;
+
+        this.readRegistrationStatement = cfg
+                .getRequiredStatment("readRegistration")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id");
+
+    }
+
+    /**
+     * Read the registration data of a device.
+     * <p>
+     * This will execute the {@code readRegistration} statement and simply
+     * return the result set unprocessed.
+     *
+     * @param operations The SQL operations to use.
+     * @param key The key to the device entry.
+     * @param span The span to contribute to.
+     *
+     * @return The future, tracking the outcome of the operation.
+     */
+    protected Future<ResultSet> readDevice(final SQLOperations operations, final DeviceKey key, final Span span) {
+        return read(operations, key, this.readRegistrationStatement, span);
+    }
+
+    /**
+     * Read the registration data of a device.
+     * <p>
+     * This will execute the provided statement statement and simply
+     * return the result set unprocessed. The statement must accept the named
+     * parameters {@code tenant_id} and {@code device_id}.
+     *
+     * @param operations The SQL operations to use.
+     * @param key The key to the device entry.
+     * @param statement The statement to execute.
+     * @param span The span to contribute to.
+     *
+     * @return The future, tracking the outcome of the operation.
+     */
+    protected Future<ResultSet> read(final SQLOperations operations, final DeviceKey key, final Statement statement, final Span span) {
+        return read(operations, key, Optional.empty(), statement, span);
+    }
+
+    /**
+     * Read the registration data of a device.
+     * <p>
+     * This will execute the provided statement statement and simply
+     * return the result set unprocessed. The statement must accept the named
+     * parameters {@code tenant_id}, {@code device_id} and {@code expected_version} (if not empty).
+     *
+     * @param operations The SQL operations to use.
+     * @param key The key to the device entry.
+     * @param statement The statement to execute.
+     * @param resourceVersion An optional resource version to read.
+     * @param span The span to contribute to.
+     *
+     * @return The future, tracking the outcome of the operation.
+     */
+    protected Future<ResultSet> read(final SQLOperations operations, final DeviceKey key, final Optional<String> resourceVersion, final Statement statement, final Span span) {
+
+        final var expanded = statement.expand(params -> {
+            params.put("tenant_id", key.getTenantId());
+            params.put("device_id", key.getDeviceId());
+            resourceVersion.ifPresent(version -> params.put("expected_version", version));
+        });
+
+        log.debug("read - statement: {}", expanded);
+
+        return expanded.trace(this.tracer, span).query(this.client);
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/Configurations.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/Configurations.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.eclipse.hono.service.base.jdbc.store.SQL;
+import org.eclipse.hono.service.base.jdbc.store.StatementConfiguration;
+
+/**
+ * A class for configuring data stores.
+ */
+public final class Configurations {
+
+    /**
+     * Default table name, when using the JSON data model.
+     */
+    public static final String DEFAULT_TABLE_NAME_JSON = "devices";
+
+    /**
+     * Default table name of the credentials table, when using the flat table model.
+     */
+    public static final String DEFAULT_TABLE_NAME_CREDENTIALS = "device_credentials";
+
+    /**
+     * Default table name of the registrations table, when using the flat table model.
+     */
+    public static final String DEFAULT_TABLE_NAME_REGISTRATIONS = "device_registrations";
+
+    private Configurations() {
+    }
+
+    /**
+     * Create a new default table configuration.
+     *
+     * @param jdbcUrl The JDBC URL.
+     * @param tableNameCredentials The optional table name for the credentials table.
+     * @param tableNameRegistrations The optional table name for the registration table.
+     * @return The newly created configuration.
+     *
+     * @throws IOException in case an IO error occurs, when reading the statement configuration.
+     */
+    public static StatementConfiguration tableConfiguration(final String jdbcUrl, final Optional<String> tableNameCredentials, final Optional<String> tableNameRegistrations)
+            throws IOException {
+
+        final String dialect = SQL.getDatabaseDialect(jdbcUrl);
+
+        final String tableNameCredentialsString = tableNameCredentials.orElse(DEFAULT_TABLE_NAME_CREDENTIALS);
+        final String tableNameRegistrationsString = tableNameRegistrations.orElse(DEFAULT_TABLE_NAME_REGISTRATIONS);
+
+        final Path base = StatementConfiguration.DEFAULT_PATH.resolve("device");
+
+        return StatementConfiguration
+                .empty(tableNameRegistrationsString, tableNameCredentialsString)
+                .overideWithDefaultPattern("base", dialect, Configurations.class, base)
+                .overideWithDefaultPattern("table", dialect, Configurations.class, base);
+
+    }
+
+    /**
+     * Create a new default table configuration.
+     *
+     * @param jdbcUrl The JDBC URL.
+     * @param tableName The optional table name.
+     * @param hierarchical If the JSON store uses a hierarchical model for a flat one.
+     * @return The newly created configuration.
+     *
+     * @throws IOException in case an IO error occurs, when reading the statement configuration.
+     */
+    public static StatementConfiguration jsonConfiguration(final String jdbcUrl, final Optional<String> tableName, final boolean hierarchical) throws IOException {
+
+        final String dialect = SQL.getDatabaseDialect(jdbcUrl);
+        final String tableNameString = tableName.orElse(DEFAULT_TABLE_NAME_JSON);
+        final String jsonModel = hierarchical ? "json.tree" : "json.flat";
+
+        final Path base = StatementConfiguration.DEFAULT_PATH.resolve("device");
+
+        return StatementConfiguration
+                .empty(tableNameString)
+                .overideWithDefaultPattern("base", dialect, Configurations.class, base)
+                .overideWithDefaultPattern("json", dialect, Configurations.class, base)
+                .overideWithDefaultPattern(jsonModel, dialect, Configurations.class, base);
+
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/CredentialsReadResult.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/CredentialsReadResult.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * A read result for credentials information.
+ */
+public class CredentialsReadResult {
+
+    private String deviceId;
+    private List<CommonCredential> credentials;
+    private Optional<String> resourceVersion;
+
+    /**
+     * Create a new instance.
+     * @param deviceId The device ID.
+     * @param credentials The credentials.
+     * @param resourceVersion The optional resource version.
+     */
+    public CredentialsReadResult(final String deviceId, final List<CommonCredential> credentials, final Optional<String> resourceVersion) {
+        this.deviceId = Objects.requireNonNull(deviceId);
+        this.credentials = Objects.requireNonNull(credentials);
+        this.resourceVersion = Objects.requireNonNull(resourceVersion);
+    }
+
+    public String getDeviceId() {
+        return this.deviceId;
+    }
+
+    public List<CommonCredential> getCredentials() {
+        return this.credentials;
+    }
+
+    public Optional<String> getResourceVersion() {
+        return this.resourceVersion;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("deviceId", this.deviceId)
+                .add("resourceVersion", this.resourceVersion)
+                .add("credentials", this.credentials)
+                .toString();
+    }
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/DeviceReadResult.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/DeviceReadResult.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.service.management.device.Device;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * A read result for device information.
+ */
+public class DeviceReadResult {
+
+    private Device device;
+    private Optional<String> resourceVersion;
+
+    /**
+     * Create a new instance.
+     * @param device The device.
+     * @param resourceVersion The optional resource version.
+     */
+    public DeviceReadResult(final Device device, final Optional<String> resourceVersion) {
+        this.device = device;
+        this.resourceVersion = Objects.requireNonNull(resourceVersion);
+    }
+
+    public Device getDevice() {
+        return this.device;
+    }
+
+    public Optional<String> getResourceVersion() {
+        return this.resourceVersion;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("resourceVersion", this.resourceVersion)
+                .add("device", this.device)
+                .toString();
+    }
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/DeviceStores.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/DeviceStores.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.eclipse.hono.service.base.jdbc.config.JdbcDeviceProperties;
+import org.eclipse.hono.service.base.jdbc.config.JdbcProperties;
+
+import io.opentracing.Tracer;
+import io.vertx.core.Vertx;
+
+/**
+ * Helper class for device registry stores.
+ */
+public final class DeviceStores {
+
+    private DeviceStores() {
+    }
+
+    /**
+     * Store factory instance for adapter stores.
+     *
+     * @return A new instance for an adapter store.
+     */
+    public static StoreFactory<AbstractDeviceAdapterStore> adapterStoreFactory() {
+        return AdapterStoreFactory.INSTANCE;
+    }
+
+    /**
+     * Store factory instance for management stores.
+     *
+     * @return A new instance for an management store.
+     */
+    public static StoreFactory<AbstractDeviceManagementStore> managementStoreFactory() {
+        return ManagementStoreFactory.INSTANCE;
+    }
+
+    /**
+     * A store factory for creating adapter or management stores.
+     *
+     * @param <T> The type of store to create.
+     */
+    public interface StoreFactory<T extends AbstractDeviceStore> {
+        /**
+         * Create a new JSON store.
+         *
+         * @param vertx The vertx instance to use.
+         * @param tracer The tracer to use.
+         * @param properties The configuration properties.
+         * @param hierarchical If the JSON store uses a hierarchical model for a flat one.
+         * @return The new store.
+         *
+         * @throws IOException if any IO error occurs when reading the SQL statement configuration.
+         */
+        T createJson(Vertx vertx, Tracer tracer, JdbcProperties properties, boolean hierarchical) throws IOException;
+
+        /**
+         * Create a new flat table store.
+         *
+         * @param vertx The vertx instance to use.
+         * @param tracer The tracer to use.
+         * @param properties The configuration properties.
+         * @param credentials An optional table name for the credentials table.
+         * @param registrations An optional table name for the registrations table.
+         * @return The new store.
+         *
+         * @throws IOException if any IO error occurs when reading the SQL statement configuration.
+         */
+        T createTable(Vertx vertx, Tracer tracer, JdbcProperties properties,  Optional<String> credentials, Optional<String> registrations)
+                throws IOException;
+    }
+
+    private static final class AdapterStoreFactory implements StoreFactory<AbstractDeviceAdapterStore> {
+
+        private static final StoreFactory<AbstractDeviceAdapterStore> INSTANCE = new AdapterStoreFactory();
+
+        private AdapterStoreFactory() {
+        }
+
+        @Override
+        public AbstractDeviceAdapterStore createJson(final Vertx vertx, final Tracer tracer, final JdbcProperties properties, final boolean hierarchical) throws IOException {
+            return new JsonAdapterStore(
+                    JdbcProperties.dataSource(vertx, properties),
+                    tracer,
+                    hierarchical,
+                    Configurations.jsonConfiguration(properties.getUrl(), Optional.ofNullable(properties.getTableName()), hierarchical));
+        }
+
+        @Override
+        public AbstractDeviceAdapterStore createTable(final Vertx vertx, final Tracer tracer, final JdbcProperties properties, final Optional<String> credentials,
+                final Optional<String> registrations) throws IOException {
+            return new TableAdapterStore(
+                    JdbcProperties.dataSource(vertx, properties),
+                    tracer,
+                    Configurations.tableConfiguration(properties.getUrl(), credentials, registrations));
+        }
+    }
+
+    private static final class ManagementStoreFactory implements StoreFactory<AbstractDeviceManagementStore> {
+
+        private static final StoreFactory<AbstractDeviceManagementStore> INSTANCE = new ManagementStoreFactory();
+
+        private ManagementStoreFactory() {
+        }
+
+        @Override
+        public AbstractDeviceManagementStore createJson(final Vertx vertx, final Tracer tracer, final JdbcProperties properties, final boolean hierarchical) throws IOException {
+            return new JsonManagementStore(
+                    JdbcProperties.dataSource(vertx, properties),
+                    tracer,
+                    hierarchical,
+                    Configurations.jsonConfiguration(properties.getUrl(), Optional.ofNullable(properties.getTableName()), hierarchical));
+        }
+
+        @Override
+        public AbstractDeviceManagementStore createTable(final Vertx vertx, final Tracer tracer, final JdbcProperties properties, final Optional<String> credentials,
+                final Optional<String> registrations) throws IOException {
+            return new TableManagementStore(
+                    JdbcProperties.dataSource(vertx, properties),
+                    tracer,
+                    Configurations.tableConfiguration(properties.getUrl(), credentials, registrations));
+        }
+    }
+
+    /**
+     * Create a new data store for the device registry.
+     *
+     * @param <T> The type of the store.
+     * @param vertx The vertx instance to use.
+     * @param tracer The tracer to use.
+     * @param deviceProperties The configuration properties.
+     * @param extractor The extractor, for getting the {@link JdbcProperties} from the overall device
+     *        properties.
+     * @param factory The store factory.
+     *
+     * @return A new store factory.
+     * @throws IOException if any IO error occurs when reading the SQL statement configuration.
+     */
+    public static <T extends AbstractDeviceStore> T store(final Vertx vertx, final Tracer tracer, final JdbcDeviceProperties deviceProperties,
+            final Function<JdbcDeviceProperties, JdbcProperties> extractor, final StoreFactory<T> factory) throws IOException {
+
+        final var properties = extractor.apply(deviceProperties);
+
+        switch (deviceProperties.getMode()) {
+            case JSON_FLAT:
+                return factory.createJson(vertx, tracer, properties, false);
+            case JSON_TREE:
+                return factory.createJson(vertx, tracer, properties, true);
+            case TABLE:
+                final var prefix = Optional.ofNullable(properties.getTableName());
+                final var credentials = prefix.map(s -> s + "_credentials");
+                final var registrations = prefix.map(s -> s + "_registrations");
+                return factory.createTable(vertx, tracer, properties, credentials, registrations);
+            default:
+                throw new IllegalStateException(String.format("Unknown store type: %s", deviceProperties.getMode()));
+        }
+
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/JsonAdapterStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/JsonAdapterStore.java
@@ -1,0 +1,229 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.hono.deviceregistry.service.credentials.CredentialKey;
+import org.eclipse.hono.service.base.jdbc.store.Statement;
+import org.eclipse.hono.service.base.jdbc.store.StatementConfiguration;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.log.Fields;
+import io.vertx.core.Future;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
+
+/**
+ * A data store for devices and credentials, based on a JSON data model.
+ */
+public class JsonAdapterStore extends AbstractDeviceAdapterStore {
+
+    public static final String DEFAULT_TABLE_NAME_JSON = "devices";
+
+    private static final Logger log = LoggerFactory.getLogger(JsonAdapterStore.class);
+
+    private final Statement findCredentialsStatement;
+
+    private final boolean hierarchical;
+
+    /**
+     * Create a new instance.
+     *
+     * @param client The SQL client ot use.
+     * @param tracer The tracer to use.
+     * @param hierarchical If the JSON store uses a hierarchical model for a flat one.
+     * @param cfg The SQL statement configuration.
+     */
+    public JsonAdapterStore(final SQLClient client, final Tracer tracer, final boolean hierarchical, final StatementConfiguration cfg) {
+        super(client, tracer, cfg);
+        cfg.dump(log);
+
+        this.hierarchical = hierarchical;
+
+        this.findCredentialsStatement = cfg
+                .getRequiredStatment("findCredentials")
+                .validateParameters(
+                        "tenant_id",
+                        "type",
+                        "auth_id");
+
+    }
+
+    static String encodeCredentialsHierarchical(final List<CommonCredential> credentials) {
+        final JsonObject result = new JsonObject();
+
+        for (CommonCredential entry : credentials) {
+            final JsonObject c = JsonObject.mapFrom(entry);
+
+            final String type = c.getString(CredentialsConstants.FIELD_TYPE);
+            final String authId = c.getString(CredentialsConstants.FIELD_AUTH_ID);
+
+            final JsonObject target = lookupEntry(result, type, authId);
+            copyFields(c, target);
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Get credentials object from tree: {@code type->auth_id->}, validating duplicate entries.
+     *
+     * @param result The result to work on.
+     * @param type The type to look for.
+     * @param authId The auth id to look for.
+     * @return The object from the tree, never returns {@code null}, will create a new entry when
+     *         necessary.
+     */
+    private static JsonObject lookupEntry(final JsonObject result, final String type, final String authId) {
+        final JsonObject typeObject = result.getJsonObject(type, new JsonObject());
+        result.put(type, typeObject);
+
+        JsonObject authObject = typeObject.getJsonObject(authId);
+        if (authObject != null) {
+            throw new IllegalArgumentException(String.format("Duplicate entry for 'type'/'authId': '%s'/'%s'", type, authId));
+        }
+        authObject = new JsonObject();
+        typeObject.put(authId, authObject);
+        return authObject;
+    }
+
+    @Override
+    public Future<Optional<CredentialsReadResult>> findCredentials(final CredentialKey key, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "find credentials", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("auth_id", key.getAuthId())
+                .withTag("type", key.getType())
+                .start();
+
+        final var expanded = this.findCredentialsStatement.expand(params -> {
+            params.put("tenant_id", key.getTenantId());
+            params.put("type", key.getType());
+            params.put("auth_id", key.getAuthId());
+        });
+
+        log.debug("findCredentials - statement: {}", expanded);
+        return expanded
+
+                .trace(this.tracer, span)
+                .query(this.client)
+
+                .<Optional<CredentialsReadResult>>flatMap(r -> {
+                    final var entries = r.getRows(true);
+                    span.log(Map.of(
+                            Fields.EVENT, "read result",
+                            "rows", entries.size()));
+                    switch (entries.size()) {
+                        case 0:
+                            return Future.succeededFuture(Optional.empty());
+                        case 1:
+                            final var entry = entries.get(0);
+                            final var deviceId = entry.getString("device_id");
+                            final var credentials = decodeCredentials(entry.getString("credentials"));
+                            final var version = Optional.ofNullable(entry.getString("version"));
+                            return Future.succeededFuture(Optional.of(new CredentialsReadResult(deviceId, credentials, version)));
+                        default:
+                            TracingHelper.logError(span, "Found multiple entries for a single device");
+                            return Future.failedFuture(new IllegalStateException("Found multiple entries for a single device"));
+                    }
+                })
+
+                .onComplete(x -> span.finish());
+
+    }
+
+    private List<CommonCredential> decodeCredentials(final String credentials) {
+        if (credentials == null || credentials.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        if (this.hierarchical) {
+            return decodeCredentialsHierarchical(credentials);
+        } else {
+            return Arrays.asList(Json.decodeValue(credentials, CommonCredential[].class));
+        }
+    }
+
+    static List<CommonCredential> decodeCredentialsHierarchical(final String credentials) {
+        final JsonObject json = new JsonObject(credentials);
+
+        final List<CommonCredential> result = new ArrayList<>();
+
+        for (Map.Entry<String, Object> typeEntry : (Iterable<Map.Entry<String, Object>>) () -> json.iterator()) {
+            final Object value = typeEntry.getValue();
+            if (!(value instanceof JsonObject)) {
+                continue;
+            }
+            final JsonObject jsonValue = (JsonObject) value;
+            for (Map.Entry<String, Object> authEntry : (Iterable<Map.Entry<String, Object>>) () -> jsonValue.iterator()) {
+                final Object credentialValue = authEntry.getValue();
+                if (!(credentialValue instanceof JsonObject)) {
+                    continue;
+                }
+
+                final JsonObject credentialJsonValue = (JsonObject) credentialValue;
+                final JsonObject credentialEntry = new JsonObject();
+                credentialEntry.put(CredentialsConstants.FIELD_TYPE, typeEntry.getKey());
+                credentialEntry.put(CredentialsConstants.FIELD_AUTH_ID, authEntry.getKey());
+                copyFields(credentialJsonValue, credentialEntry);
+                result.add(credentialEntry.mapTo(CommonCredential.class));
+            }
+        }
+
+        return result;
+
+    }
+
+    /**
+     * Copy field from source to target object, if set.
+     *
+     * @param from Source to copy from.
+     * @param to Target to copy to.
+     * @param key The key of the field.
+     */
+    private static void copyField(final JsonObject from, final JsonObject to, final String key) {
+        final Object value = from.getValue(key);
+        if (value != null) {
+            to.put(key, value);
+        }
+    }
+
+    /**
+     * Copy all credential fields.
+     *
+     * @param from Source to copy from.
+     * @param to Target to copy to.
+     */
+    private static void copyFields(final JsonObject from, final JsonObject to) {
+        copyField(from, to, CredentialsConstants.FIELD_ENABLED);
+        copyField(from, to, CredentialsConstants.FIELD_SECRETS);
+        copyField(from, to, "comment");
+        copyField(from, to, "ext");
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/JsonManagementStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/JsonManagementStore.java
@@ -1,0 +1,274 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
+import org.eclipse.hono.service.base.jdbc.store.Statement;
+import org.eclipse.hono.service.base.jdbc.store.StatementConfiguration;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.SQLClient;
+
+/**
+ * A data store for devices and credentials, based on a JSON data model.
+ */
+public class JsonManagementStore extends AbstractDeviceManagementStore {
+
+    private static final Logger log = LoggerFactory.getLogger(JsonManagementStore.class);
+
+    private final Statement readCredentialsStatement;
+
+    private final Statement updateCredentialsStatement;
+    private final Statement updateCredentialsVersionedStatement;
+
+    private final boolean hierarchical;
+
+    /**
+     * Create a new instance.
+     *
+     * @param client The SQL client to use.
+     * @param tracer The tracer to use.
+     * @param hierarchical If the JSON store uses a hierarchical model for a flat one.
+     * @param cfg The SQL statement configuration.
+     */
+    public JsonManagementStore(final SQLClient client, final Tracer tracer, final boolean hierarchical, final StatementConfiguration cfg) {
+        super(client, tracer, cfg);
+        cfg.dump(log);
+
+        this.hierarchical = hierarchical;
+
+        this.readCredentialsStatement = cfg
+                .getRequiredStatment("readCredentials")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id");
+
+        this.updateCredentialsStatement = cfg
+                .getRequiredStatment("updateCredentials")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "next_version",
+                        "data");
+
+        this.updateCredentialsVersionedStatement = cfg
+                .getRequiredStatment("updateCredentialsVersioned")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "next_version",
+                        "data",
+                        "expected_version");
+
+    }
+
+    @Override
+    public Future<Boolean> setCredentials(final DeviceKey key, final List<CommonCredential> credentials, final Optional<String> resourceVersion,
+            final SpanContext spanContext) {
+
+        final String json = encodeCredentials(credentials);
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "set credentials", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .withTag("data", json)
+                .start();
+
+        resourceVersion.ifPresent(version -> span.setTag("version", version));
+
+        final Statement statement = resourceVersion.isPresent() ? this.updateCredentialsVersionedStatement : this.updateCredentialsStatement;
+
+        return updateJsonField(key, statement, json, resourceVersion, span)
+                .map(result -> result.getUpdated() > 0)
+                .onComplete(x -> span.finish());
+
+    }
+
+    private String encodeCredentials(final List<CommonCredential> credentials) {
+        if (this.hierarchical) {
+            return encodeCredentialsHierarchical(credentials);
+        } else {
+            return Json.encode(credentials.toArray(CommonCredential[]::new));
+        }
+    }
+
+    static String encodeCredentialsHierarchical(final List<CommonCredential> credentials) {
+        final JsonObject result = new JsonObject();
+
+        for (CommonCredential entry : credentials) {
+            final JsonObject c = JsonObject.mapFrom(entry);
+
+            final String type = c.getString(CredentialsConstants.FIELD_TYPE);
+            final String authId = c.getString(CredentialsConstants.FIELD_AUTH_ID);
+
+            final JsonObject target = lookupEntry(result, type, authId);
+            copyFields(c, target);
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Get credentials object from tree: {@code type->auth_id->}, validating duplicate entries.
+     *
+     * @param result The result to work on.
+     * @param type The type to look for.
+     * @param authId The auth id to look for.
+     * @return The object from the tree, never returns {@code null}, will create a new entry when
+     *         necessary.
+     */
+    private static JsonObject lookupEntry(final JsonObject result, final String type, final String authId) {
+
+        final JsonObject typeObject = result.getJsonObject(type, new JsonObject());
+        result.put(type, typeObject);
+
+        JsonObject authObject = typeObject.getJsonObject(authId);
+        if (authObject != null) {
+            throw new IllegalArgumentException(String.format("Duplicate entry for 'type'/'authId': '%s'/'%s'", type, authId));
+        }
+        authObject = new JsonObject();
+        typeObject.put(authId, authObject);
+        return authObject;
+
+    }
+
+    @Override
+    public Future<Optional<CredentialsReadResult>> getCredentials(final DeviceKey key, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "get credentials", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .start();
+
+        return read(this.client, key, this.readCredentialsStatement, span)
+                .<Optional<CredentialsReadResult>>flatMap(r -> {
+                    final var entries = r.getRows(true);
+                    span.log(Map.of(
+                            "event", "read result",
+                            "rows", entries.size()));
+                    switch (entries.size()) {
+                        case 0:
+                            return Future.succeededFuture(Optional.empty());
+                        case 1:
+                            try {
+                                final var entry = entries.get(0);
+                                final var deviceId = entry.getString("device_id");
+                                final var credentialsString = entry.getString("credentials");
+                                final var credentials = decodeCredentials(credentialsString);
+                                final var version = Optional.ofNullable(entry.getString("version"));
+                                log.debug("Converted - deviceId: {}, version: {}, credentials: {} -> {}", deviceId, version, credentialsString, credentials);
+                                return Future.succeededFuture(Optional.of(new CredentialsReadResult(deviceId, credentials, version)));
+                            } catch (Exception e) {
+                                log.info("Failed to convert result", e);
+                                return Future.failedFuture(e);
+                            }
+
+                        default:
+                            TracingHelper.logError(span, "Found multiple entries for a single device");
+                            return Future.failedFuture(new IllegalStateException("Found multiple entries for a single device"));
+                    }
+
+                })
+
+                .onComplete(x -> span.finish());
+
+    }
+
+    private List<CommonCredential> decodeCredentials(final String credentials) {
+        if (credentials == null || credentials.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        if (this.hierarchical) {
+            return decodeCredentialsHierarchical(credentials);
+        } else {
+            return Arrays.asList(Json.decodeValue(credentials, CommonCredential[].class));
+        }
+    }
+
+    static List<CommonCredential> decodeCredentialsHierarchical(final String credentials) {
+        final JsonObject json = new JsonObject(credentials);
+
+        final List<CommonCredential> result = new ArrayList<>();
+
+        for (Map.Entry<String, Object> typeEntry : (Iterable<Map.Entry<String, Object>>) () -> json.iterator()) {
+            final Object value = typeEntry.getValue();
+            if (!(value instanceof JsonObject)) {
+                continue;
+            }
+            final JsonObject jsonValue = (JsonObject) value;
+            for (Map.Entry<String, Object> authEntry : (Iterable<Map.Entry<String, Object>>) () -> jsonValue.iterator()) {
+                final Object credentialValue = authEntry.getValue();
+                if (!(credentialValue instanceof JsonObject)) {
+                    continue;
+                }
+
+                final JsonObject credentialJsonValue = (JsonObject) credentialValue;
+                final JsonObject credentialEntry = new JsonObject();
+                credentialEntry.put(CredentialsConstants.FIELD_TYPE, typeEntry.getKey());
+                credentialEntry.put(CredentialsConstants.FIELD_AUTH_ID, authEntry.getKey());
+                copyFields(credentialJsonValue, credentialEntry);
+                result.add(credentialEntry.mapTo(CommonCredential.class));
+            }
+        }
+
+        return result;
+
+    }
+
+    /**
+     * Copy field from source to target object, if set.
+     *
+     * @param from Source to copy from.
+     * @param to Target to copy to.
+     * @param key The key of the field.
+     */
+    private static void copyField(final JsonObject from, final JsonObject to, final String key) {
+        final Object value = from.getValue(key);
+        if (value != null) {
+            to.put(key, value);
+        }
+    }
+
+    /**
+     * Copy all credential fields.
+     *
+     * @param from Source to copy from.
+     * @param to Target to copy to.
+     */
+    private static void copyFields(final JsonObject from, final JsonObject to) {
+        copyField(from, to, CredentialsConstants.FIELD_ENABLED);
+        copyField(from, to, CredentialsConstants.FIELD_SECRETS);
+        copyField(from, to, "comment");
+        copyField(from, to, "ext");
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/TableAdapterStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/TableAdapterStore.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.hono.deviceregistry.service.credentials.CredentialKey;
+import org.eclipse.hono.service.base.jdbc.store.Statement;
+import org.eclipse.hono.service.base.jdbc.store.StatementConfiguration;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.json.Json;
+import io.vertx.ext.sql.SQLClient;
+
+/**
+ * A data store for devices and credentials, based on a table data model.
+ */
+public class TableAdapterStore extends AbstractDeviceAdapterStore {
+
+    private static final Logger log = LoggerFactory.getLogger(TableAdapterStore.class);
+
+    private final Statement findCredentialsStatement;
+
+    /**
+     * Create a new instance.
+     *
+     * @param client The SQL client ot use.
+     * @param tracer The tracer to use.
+     * @param cfg The SQL statement configuration.
+     */
+    public TableAdapterStore(final SQLClient client, final Tracer tracer, final StatementConfiguration cfg) {
+        super(client, tracer, cfg);
+        cfg.dump(log);
+
+        this.findCredentialsStatement = cfg
+                .getRequiredStatment("findCredentials")
+                .validateParameters(
+                        "tenant_id",
+                        "type",
+                        "auth_id");
+
+    }
+
+    @Override
+    public Future<Optional<CredentialsReadResult>> findCredentials(final CredentialKey key, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "find credentials", getClass().getSimpleName())
+                .withTag("auth_id", key.getAuthId())
+                .withTag("type", key.getType())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .start();
+
+        final var expanded = this.findCredentialsStatement.expand(params -> {
+            params.put("tenant_id", key.getTenantId());
+            params.put("type", key.getType());
+            params.put("auth_id", key.getAuthId());
+        });
+
+        log.debug("findCredentials - statement: {}", expanded);
+        return expanded.trace(this.tracer, span).query(this.client)
+                .<Optional<CredentialsReadResult>>flatMap(r -> {
+                    final var entries = r.getRows(true);
+                    span.log(Map.of(
+                            "event", "read result",
+                            "rows", entries.size()));
+
+                    final Set<String> deviceIds = entries.stream()
+                            .map(o -> o.getString("device_id"))
+                            .filter(o -> o != null)
+                            .collect(Collectors.toSet());
+
+                    final int num = deviceIds.size();
+                    if (num <= 0) {
+                        return Future.succeededFuture(Optional.empty());
+                    } else if (num > 1) {
+                        TracingHelper.logError(span, "Found multiple entries for a single device");
+                        return Future.failedFuture(new IllegalStateException("Found multiple entries for a single device"));
+                    }
+
+                    // we know now that we have exactly one entry
+                    final String deviceId = deviceIds.iterator().next();
+
+                    final List<CommonCredential> credentials = entries.stream()
+                            .map(o -> o.getString("data"))
+                            .map(s -> Json.decodeValue(s, CommonCredential.class))
+                            .collect(Collectors.toList());
+
+                    return Future.succeededFuture(Optional.of(new CredentialsReadResult(deviceId, credentials, Optional.empty())));
+                })
+
+                .onComplete(x -> span.finish());
+
+    }
+
+}

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/TableManagementStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/TableManagementStore.java
@@ -1,0 +1,307 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
+import org.eclipse.hono.service.base.jdbc.store.EntityNotFoundException;
+import org.eclipse.hono.service.base.jdbc.store.OptimisticLockingException;
+import org.eclipse.hono.service.base.jdbc.store.SQL;
+import org.eclipse.hono.service.base.jdbc.store.Statement;
+import org.eclipse.hono.service.base.jdbc.store.StatementConfiguration;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.log.Fields;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLClient;
+import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.sql.UpdateResult;
+
+/**
+ * A data store for devices and credentials, based on a table data model.
+ */
+public class TableManagementStore extends AbstractDeviceManagementStore {
+
+    private static final Logger log = LoggerFactory.getLogger(TableManagementStore.class);
+
+    private final Statement readForUpdateStatement;
+    private final Statement readForUpdateVersionedStatement;
+    private final Statement readCredentialsStatement;
+
+    private final Statement insertCredentialEntryStatement;
+    private final Statement deleteAllCredentialsStatement;
+    private final Statement updateDeviceVersionStatement;
+
+    /**
+     * Create a new instance.
+     *
+     * @param client The SQL client ot use.
+     * @param tracer The tracer to use.
+     * @param cfg The SQL statement configuration.
+     */
+    public TableManagementStore(final SQLClient client, final Tracer tracer, final StatementConfiguration cfg) {
+        super(client, tracer, cfg);
+        cfg.dump(log);
+
+        this.readForUpdateStatement = cfg.getRequiredStatment("readForUpdate")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id");
+        this.readForUpdateVersionedStatement = cfg.getRequiredStatment("readForUpdateVersioned")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "expected_version");
+
+        this.readCredentialsStatement = cfg
+                .getRequiredStatment("readCredentials")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id");
+
+        this.insertCredentialEntryStatement = cfg
+                .getRequiredStatment("insertCredentialEntry")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "type",
+                        "auth_id",
+                        "data");
+
+        this.deleteAllCredentialsStatement = cfg
+                .getRequiredStatment("deleteAllCredentials")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id");
+
+        this.updateDeviceVersionStatement = cfg
+                .getRequiredStatment("updateDeviceVersion")
+                .validateParameters(
+                        "tenant_id",
+                        "device_id",
+                        "next_version",
+                        "expected_version");
+
+    }
+
+    /**
+     * Read a device and lock it for updates.
+     * <p>
+     * This uses the {@code readForUpdate} or {@code readForUpdateVersioned} statement
+     * to read and lock the device entry for further updates (select for update).
+     * <p>
+     * It returns the plain result set from the query, which may also be empty.
+     *
+     * @param connection The connection to use.
+     * @param key The key of the device.
+     * @param resourceVersion An optional resource version.
+     * @param span The span to contribute to.
+     *
+     * @return A future tracking the outcome of the operation.
+     */
+    protected Future<ResultSet> readDeviceForUpdate(final SQLConnection connection, final DeviceKey key, final Optional<String> resourceVersion, final Span span) {
+
+        final Statement readStatement;
+
+        if (resourceVersion.isPresent()) {
+            readStatement = this.readForUpdateVersionedStatement;
+        } else {
+            readStatement = this.readForUpdateStatement;
+        }
+
+        return read(connection, key, resourceVersion, readStatement, span);
+
+    }
+
+    @Override
+    public Future<Boolean> setCredentials(final DeviceKey key, final List<CommonCredential> credentials, final Optional<String> resourceVersion,
+            final SpanContext spanContext) {
+
+        final String json = Json.encode(credentials.toArray(CommonCredential[]::new));
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "set credentials", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .withTag("data", json)
+                .start();
+
+        resourceVersion.ifPresent(version -> span.setTag("version", version));
+
+        final String nextVersion = UUID.randomUUID().toString();
+
+        final Promise<SQLConnection> promise = Promise.promise();
+        this.client.getConnection(promise);
+
+        return promise.future()
+
+                // disable autocommit, which is enabled by default
+                .flatMap(connection -> SQL.setAutoCommit(this.tracer, span.context(), connection, false))
+
+                // read the device "for update", locking the entry
+                .flatMap(connection -> readDeviceForUpdate(connection, key, resourceVersion, span)
+
+                        // check if we got back a result, if not this will abort early
+                        .flatMap(TableManagementStore::extractVersionForUpdate)
+
+                        // take the version and start processing on
+                        .flatMap(version -> this.deleteAllCredentialsStatement
+
+                                // delete the existing entries
+                                .expand(map -> {
+                                    map.put("tenant_id", key.getTenantId());
+                                    map.put("device_id", key.getDeviceId());
+                                })
+                                .trace(this.tracer, span).update(connection)
+
+                                // then create new entries
+                                .flatMap(x -> CompositeFuture.all(credentials.stream()
+                                        .map(JsonObject::mapFrom)
+                                        .filter(c -> c.containsKey("type") && c.containsKey("auth-id"))
+                                        .map(c -> this.insertCredentialEntryStatement
+                                                .expand(map -> {
+                                                    map.put("tenant_id", key.getTenantId());
+                                                    map.put("device_id", key.getDeviceId());
+                                                    map.put("type", c.getString("type"));
+                                                    map.put("auth_id", c.getString("auth-id"));
+                                                    map.put("data", c.toString());
+                                                })
+                                                .trace(this.tracer, span).update(connection))
+                                        .collect(Collectors.toList())).map(x))
+
+                                // update the version, this will release the lock
+                                .flatMap(x -> this.updateDeviceVersionStatement
+                                        .expand(map -> {
+                                            map.put("tenant_id", key.getTenantId());
+                                            map.put("device_id", key.getDeviceId());
+                                            map.put("expected_version", version);
+                                            map.put("next_version", nextVersion);
+                                        })
+                                        .trace(this.tracer, span).update(connection)
+
+                                        // check the update outcome
+                                        .flatMap(updateResult -> checkUpdateOutcome(updateResult)))
+
+                        )
+
+                        // commit or rollback ... return original result
+                        .flatMap(x -> SQL.commit(this.tracer, span.context(), connection).map(true))
+                        .recover(x -> SQL.rollback(this.tracer, span.context(), connection).flatMap(y -> Future.<Boolean>failedFuture(x))))
+
+                .recover(err -> recoverNotFound(span, err, () -> false))
+
+                .onComplete(x -> span.finish());
+
+    }
+
+    private <T> Future<T> recoverNotFound(final Span span, final Throwable err, final Supplier<T> orProvider) {
+        log.debug("Failed to update", err);
+        // map EntityNotFoundException to proper result
+        if (SQL.hasCauseOf(err, EntityNotFoundException.class)) {
+            TracingHelper.logError(span, "Entity not found");
+            return Future.succeededFuture(orProvider.get());
+        } else {
+            return Future.failedFuture(err);
+        }
+    }
+
+    private static Future<Object> checkUpdateOutcome(final UpdateResult updateResult) {
+        if (updateResult.getUpdated() < 0) {
+            // conflict
+            log.debug("Optimistic lock broke");
+            return Future.failedFuture(new OptimisticLockingException());
+        }
+
+        return Future.succeededFuture();
+    }
+
+    private static Future<String> extractVersionForUpdate(final ResultSet device) {
+        final Optional<String> version = device.getRows(true).stream().map(o -> o.getString("version")).findAny();
+
+        if (version.isEmpty()) {
+            log.debug("No version or no row found -> entity not found");
+            return Future.failedFuture(new EntityNotFoundException());
+        }
+
+        return Future.succeededFuture(version.get());
+    }
+
+    @Override
+    public Future<Optional<CredentialsReadResult>> getCredentials(final DeviceKey key, final SpanContext spanContext) {
+
+        final Span span = TracingHelper.buildChildSpan(this.tracer, spanContext, "get credentials", getClass().getSimpleName())
+                .withTag("tenant_instance_id", key.getTenantId())
+                .withTag("device_id", key.getDeviceId())
+                .start();
+
+        final Statement query = this.readCredentialsStatement;
+        final var expanded = query.expand(map -> {
+            map.put("tenant_id", key.getTenantId());
+            map.put("device_id", key.getDeviceId());
+        });
+
+        final Promise<SQLConnection> promise = Promise.promise();
+        this.client.getConnection(promise);
+
+        return promise.future()
+
+                .flatMap(connection -> readDevice(connection, key, span)
+
+                        // check if we got back a result, if not this will abort early
+
+                        .flatMap(TableManagementStore::extractVersionForUpdate)
+
+                        // read credentials
+
+                        .flatMap(version -> expanded.trace(this.tracer, span).query(connection)
+
+                                .flatMap(r -> {
+
+                                    final var entries = r.getRows(true);
+                                    span.log(Map.of(
+                                            Fields.EVENT, "read result",
+                                            "rows", entries.size()));
+
+                                    final List<CommonCredential> credentials = entries.stream()
+                                            .map(o -> o.getString("data"))
+                                            .map(s -> Json.decodeValue(s, CommonCredential.class))
+                                            .collect(Collectors.toList());
+
+                                    log.debug("Credentials: {}", credentials);
+
+                                    return Future.succeededFuture(Optional.of(new CredentialsReadResult(key.getDeviceId(), credentials, Optional.ofNullable(version))));
+                                })))
+                .recover(err -> recoverNotFound(span, err, () -> Optional.empty()))
+
+                .onComplete(x -> span.finish());
+
+    }
+
+}

--- a/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/QueryTest.java
+++ b/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/QueryTest.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.hono.service.base.jdbc.store.Statement.ExpandedStatement;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test parsing queries.
+ */
+public class QueryTest {
+
+    /**
+     * Test a statement with no parameters.
+     */
+    @Test
+    public void testNoParams() {
+        final ExpandedStatement expanded = Statement.statement("select 1").expand(Collections.emptyMap());
+        assertEquals("select 1", expanded.getSql());
+        assertArrayEquals(new Object[] {}, expanded.getParameters());
+    }
+
+    /**
+     * Test a statement with some simple named parameters.
+     */
+    @Test
+    public void testSimpleParams() {
+        final Map<String, Object> params = new HashMap<>();
+        params.put("foo", 1);
+        params.put("bar", "baz");
+
+        final ExpandedStatement expanded = Statement.statement("select * from table where foo=:foo and bar=:bar").expand(params);
+        assertEquals("select * from table where foo=? and bar=?", expanded.getSql());
+        assertArrayEquals(new Object[] {1, "baz"}, expanded.getParameters());
+    }
+
+    /**
+     * Test using the same named parameter multiple times.
+     */
+    @Test
+    public void testDoubleParams() {
+        final Map<String, Object> params = new HashMap<>();
+        params.put("foo", 1);
+        params.put("bar", "baz");
+
+        final ExpandedStatement expanded = Statement.statement("select * from table where foo=:foo and foo2=:foo and bar=:bar and barfoo=:foo and 1=1").expand(params);
+        assertEquals("select * from table where foo=? and foo2=? and bar=? and barfoo=? and 1=1", expanded.getSql());
+        assertArrayEquals(new Object[] {1, 1, "baz", 1}, expanded.getParameters());
+    }
+
+    /**
+     * Test providing additional named parameters, which are not referenced in the statement.
+     */
+    @Test
+    public void testExtraParams() {
+        final ExpandedStatement expanded = Statement.statement("select * from table where foo=:foo and bar=:bar")
+                .expand(params -> {
+                    params.put("foobarbaz", true); // not used
+                    params.put("foo", 1);
+                    params.put("bar", "baz");
+                });
+        assertEquals("select * from table where foo=? and bar=?", expanded.getSql());
+        assertArrayEquals(new Object[] {1, "baz"}, expanded.getParameters());
+    }
+
+    /**
+     * Test that a missing parameter throws an {@link IllegalArgumentException}.
+     */
+    @Test
+    public void testMissingParam() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Statement.statement("select * from table where foo=:foo and bar=:bar")
+                    .expand(params -> {
+                        params.put("bar", "baz");
+                    });
+        });
+    }
+
+    /**
+     * Test that a simple postgres JSON statement works.
+     */
+    @Test
+    public void testPostgresJson1() {
+        final ExpandedStatement expanded = Statement
+                .statement("SELECT device_id, version, credentials FROM table WHERE tenant_id=:tenant_id AND credentials @> jsonb_build_object('type', :type, 'auth-id', :auth_id)")
+                .expand(map -> {
+                    map.put("tenant_id", "tenant");
+                    map.put("type", "hashed-password");
+                    map.put("auth_id", "auth");
+                });
+
+        assertEquals("SELECT device_id, version, credentials FROM table WHERE tenant_id=? AND credentials @> jsonb_build_object('type', ?, 'auth-id', ?)", expanded.getSql());
+        assertArrayEquals(new Object[] {"tenant", "hashed-password", "auth"}, expanded.getParameters());
+    }
+
+    /**
+     * Test that a postgres type case (double colon) works.
+     */
+    @Test
+    public void testPostgresCast() {
+        final ExpandedStatement expanded =
+                Statement.statement("INSERT INTO %s (tenant_id, device_id, version, data) VALUES (:tenant_id, :device_id, :version, to_jsonb(:data::jsonb))", "table")
+                        .expand(map -> {
+                            map.put("tenant_id", "tenant");
+                            map.put("device_id", "device");
+                            map.put("version", "version");
+                            map.put("data", "{}");
+                        });
+
+        assertEquals("INSERT INTO table (tenant_id, device_id, version, data) VALUES (?, ?, ?, to_jsonb(?::jsonb))", expanded.getSql());
+        assertArrayEquals(new Object[] {"tenant", "device", "version", "{}"}, expanded.getParameters());
+    }
+
+
+}

--- a/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/SQLTest.java
+++ b/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/SQLTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link SQL}.
+ */
+public class SQLTest {
+
+    /**
+     * Provide values for {@link #testTypeDetector(String, String)}.
+     * @return Test values.
+     */
+    public static Stream<Arguments> typeDetectorValue() {
+        return Stream.of(
+                Arguments.of("jdbc:postgresql://localhost:1234/device-registry", "postgresql"),
+                Arguments.of("jdbc:h2:~/test;ACCESS_MODE_DATA=rws", "h2"));
+    }
+
+    /**
+     * Test if the correct database gets detected.
+     * @param url The JDBC URL.
+     * @param expected The expected database.
+     */
+    @ParameterizedTest
+    @MethodSource("typeDetectorValue")
+    public void testTypeDetector(final String url, final String expected) {
+        assertEquals(expected, SQL.getDatabaseDialect(url));
+    }
+
+}

--- a/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/StatementTest.java
+++ b/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/StatementTest.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.yaml.snakeyaml.constructor.ConstructorException;
+
+/**
+ * Testing {@link Statement}.
+ */
+public class StatementTest {
+
+    /**
+     * Test simple field validation.
+     */
+    @Test
+    public void testValidateFields() {
+        final Statement statement = Statement.statement("SELECT foo FROM bar WHERE baz=:baz");
+        statement.validateParameters("baz");
+    }
+
+    /**
+     * Test that validating a missing field works.
+     */
+    @Test
+    public void testValidateMissingField() {
+        final Statement statement = Statement.statement("SELECT foo FROM bar WHERE baz=:baz");
+        assertThrows(IllegalStateException.class, () -> {
+            statement.validateParameters("bar");
+        });
+    }
+
+    /**
+     * Test that validating additional fields does not cause an error.
+     */
+    @Test
+    public void testValidateAdditionalField() {
+        final Statement statement = Statement.statement("SELECT foo FROM bar WHERE baz=:baz");
+        statement.validateParameters("baz", "bar");
+    }
+
+    /**
+     * Test that a type cast does not get interpreted as named parameter, and fails the validation.
+     */
+    @Test
+    public void testValidateAdditionalField2() {
+        final Statement statement = Statement.statement("UPDATE devices\n" +
+                "SET\n" +
+                "   data=:data::jsonb,\n" +
+                "   version=:next_version\n" +
+                "WHERE\n" +
+                "   tenant_id=:tenant_id\n" +
+                "AND\n" +
+                "   device_id=:device_id");
+        statement.validateParameters("data", "device_id", "next_version", "tenant_id");
+    }
+
+    /**
+     * Test that we didn't break basic YAML with out override method.
+     */
+    @Test
+    public void testPlainYamlStillWorksForStatementConfig() {
+
+        final String yaml = "read: SELECT 1";
+
+        final var cfg = StatementConfiguration.empty()
+                .overrideWith(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)), false);
+
+        assertEquals("SELECT 1", cfg.getRequiredStatment("read").expand().getSql());
+
+    }
+
+    /**
+     * The creating a file via the value of a map item.
+     *
+     * @param tempDir A temporary directory.
+     */
+    @Test
+    public void testObjectCreationRejectedMapValue(@TempDir final Path tempDir) {
+        final Path markerFile = tempDir.resolve("testObjectCreationRejectedMapValue.marker");
+        final String yaml = "read: !!java.io.FileOutputStream [" + markerFile.toAbsolutePath().toString() + "]";
+
+        assertNoMarkerFile(markerFile, yaml);
+    }
+
+    /**
+     * The creating a file via a plain value.
+     *
+     * @param tempDir A temporary directory.
+     */
+    @Test
+    public void testObjectCreationRejectedPlainValue(@TempDir final Path tempDir) {
+        final Path markerFile = tempDir.resolve("testObjectCreationRejectedPlainValue.marker");
+        final String yaml = "!!java.io.FileOutputStream [" + markerFile.toAbsolutePath().toString() + "]";
+
+        assertNoMarkerFile(markerFile, yaml);
+    }
+
+    private void assertNoMarkerFile(final Path markerFile, final String yaml) {
+        Exception expected = null;
+        try {
+            final var cfg = StatementConfiguration.empty();
+            cfg.overrideWith(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)), false);
+        } catch (Exception e) {
+            // delay test for later
+            expected = e;
+        }
+
+        assertFalse(Files.isRegularFile(markerFile), "Marker file must not exist");
+        assertNotNull(expected);
+        assertThat(expected, IsInstanceOf.instanceOf(ConstructorException.class));
+    }
+
+}

--- a/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/device/JsonStoreTest.java
+++ b/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/device/JsonStoreTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.base.jdbc.store.device;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.service.management.credentials.PskCredential;
+import org.eclipse.hono.service.management.credentials.PskSecret;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.core.Is;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test {@link JsonAdapterStore} methods.
+ */
+public class JsonStoreTest {
+
+    private static PskCredential newPskCredential(final String authId) {
+
+        final PskSecret psk1 = new PskSecret();
+        psk1.setKey("foo".getBytes(StandardCharsets.UTF_8));
+
+        final PskCredential result = new PskCredential();
+        result.setAuthId(authId);
+        result.setSecrets(Arrays.asList(psk1));
+
+        return result;
+    }
+
+    /**
+     * Test converting hierarchical data structure.
+     */
+    @Test
+    public void testHierarchical() {
+
+        final PskCredential psk = newPskCredential("auth-1");
+        final String encoded = JsonAdapterStore.encodeCredentialsHierarchical(Arrays.asList(psk));
+
+        assertThat(encoded, Is.is("{\"psk\":{\"auth-1\":{\"secrets\":[{\"key\":\"Zm9v\"}]}}}"));
+
+        final List<CommonCredential> decoded = JsonAdapterStore.decodeCredentialsHierarchical(encoded);
+
+        assertThat(decoded, IsCollectionWithSize.hasSize(1));
+    }
+
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/DeviceConnectionKey.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/DeviceConnectionKey.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.service.deviceconnection;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Provides a unique key for a <em>Device Connection</em> entry of Hono's
+ * <a href="https://www.eclipse.org/hono/docs/api/device-connection/">Device Connection API</a>.
+ * It is used for storing and retrieving values from the backend storage and external systems.
+ */
+public final class DeviceConnectionKey {
+
+    protected String tenantId;
+    protected String deviceId;
+
+    /**
+     * Create a device connection key.
+     * @param tenantId The tenant to use.
+     * @param deviceId The device id to use.
+     */
+    public DeviceConnectionKey(final String tenantId, final String deviceId) {
+        this.tenantId = tenantId;
+        this.deviceId = deviceId;
+    }
+
+    public String getTenantId() {
+        return this.tenantId;
+    }
+
+    public void setTenantId(final String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getDeviceId() {
+        return this.deviceId;
+    }
+
+    public void setDeviceId(final String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.deviceId,
+                this.tenantId);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final DeviceConnectionKey other = (DeviceConnectionKey) obj;
+        return Objects.equals(this.deviceId, other.deviceId) &&
+                Objects.equals(this.tenantId, other.tenantId);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("tenantId", this.tenantId)
+                .add("deviceId", this.deviceId)
+                .toString();
+    }
+
+}

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -27,6 +27,7 @@
 
   <modules>
     <module>auth</module>
+    <module>base-jdbc</module>
     <module>device-connection</module>
     <module>device-registry-base</module>
     <module>device-registry-file</module>


### PR DESCRIPTION
This PR contains as base module for the JDBC based device registry. By itself this module isn't really useful, but splits up the whole JDBC device registry in smaller PRs to be easier to review.

The reason for a base module, aside from more modularity, is that it is being used by:
* the device registry
* the device connection service
* additional independent tasks, like a tenant cleanup process