### PR TITLE
[#1679]  Add tests for the mongodb based device registration

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,6 +30,7 @@
   <properties>
     <artemis.image.name>quay.io/enmasse/artemis-base:2.10.1</artemis.image.name>
     <assertj-core.version>3.15.0</assertj-core.version>
+    <mockito-inline.version>2.7.13</mockito-inline.version>
     <californium.version>2.2.0</californium.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.10.0</dispatch-router.image.name>
     <guava.version>28.0-jre</guava.version>
@@ -259,6 +260,12 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj-core.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito-inline.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationServiceTests.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationServiceTests.java
@@ -61,6 +61,10 @@ public abstract class RegistrationServiceTests {
      * The gateway identifier used in the tests.
      */
     protected static final String GW = "gw-1";
+    /**
+     * The version identifier used in tests.
+     */
+    protected static final String VERSION = "dummy_version";
 
     /**
      * Gets registration service being tested.
@@ -577,6 +581,43 @@ public abstract class RegistrationServiceTests {
                     });
                     register.flag();
                 }));
+    }
+
+    /**
+     * Verify that deleting a device fails when the request contains a non existing device id and a resourceVersion
+     * parameter.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testDeleteFailsWithNonExistingDeviceAndResourceVersion(final VertxTestContext ctx) {
+
+        // GIVEN a device db without devices
+        // WHEN tenant is deleted with version provided
+        getDeviceManagementService().deleteDevice(TENANT, DEVICE, Optional.of(VERSION), NoopSpan.INSTANCE)
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN deletion should fail
+                    assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verify that deleting a device fails when the request contains a non existing device id.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testDeleteFailsWithNonExistingDevice(final VertxTestContext ctx) {
+
+        // GIVEN a device db without devices
+        // WHEN tenant is deleted
+        getDeviceManagementService().deleteDevice(TENANT, DEVICE, Optional.empty(), NoopSpan.INSTANCE)
+                .setHandler(ctx.succeeding(result -> ctx.verify(() -> {
+                    // THEN deletion should fail
+                    assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+                    ctx.completeNow();
+                })));
     }
 
     // updateDevice tests

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -33,8 +33,21 @@
             <artifactId>hono-service-device-registry-base</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-service-base</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-mongo-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/Application.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/Application.java
@@ -38,6 +38,7 @@ import io.vertx.core.Verticle;
  */
 @ComponentScan(basePackages = "org.eclipse.hono.service.auth", excludeFilters = @ComponentScan.Filter(Deprecated.class))
 @ComponentScan(basePackages = "org.eclipse.hono.service.metric", excludeFilters = @ComponentScan.Filter(Deprecated.class))
+@ComponentScan(basePackages = "org.eclipse.hono.deviceregistry", excludeFilters = @ComponentScan.Filter(Deprecated.class))
 @Import(ApplicationConfig.class)
 @EnableAutoConfiguration
 public class Application extends AbstractBaseApplication {

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedRegistrationS
 import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbCallExecutor;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryAmqpServer;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
+import org.eclipse.hono.deviceregistry.service.deviceconnection.MapBasedDeviceConnectionsConfigProperties;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.amqp.AmqpEndpoint;
@@ -116,6 +117,16 @@ public class ApplicationConfig {
 
         return r -> r.config().commonTags(MetricsTags.forService(Constants.SERVICE_NAME_DEVICE_REGISTRY));
 
+    }
+
+    /**
+     * Gets properties for configuring
+     * the {@link org.eclipse.hono.deviceregistry.service.deviceconnection.MapBasedDeviceConnectionService}.
+     * @return the properties.
+     */
+    @Bean
+    public MapBasedDeviceConnectionsConfigProperties serviceConnectionProperties() {
+        return new MapBasedDeviceConnectionsConfigProperties();
     }
 
     /**

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoClientMock.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoClientMock.java
@@ -1,0 +1,574 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.mongodb.service;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.mongodb.MongoException;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.ext.mongo.AggregateOptions;
+import io.vertx.ext.mongo.BulkOperation;
+import io.vertx.ext.mongo.BulkWriteOptions;
+import io.vertx.ext.mongo.FindOptions;
+import io.vertx.ext.mongo.IndexOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.MongoClientBulkWriteResult;
+import io.vertx.ext.mongo.MongoClientDeleteResult;
+import io.vertx.ext.mongo.MongoClientUpdateResult;
+import io.vertx.ext.mongo.UpdateOptions;
+import io.vertx.ext.mongo.WriteOption;
+
+/**
+ * A Mock implementation to the vertx mongoDbClient to ease the testing. Uses HashMaps to store the collections and
+ * indexes for unique collection properties.
+ */
+class MongoDbClientMock implements MongoClient {
+
+    /**
+     * The error code from {@link com.mongodb.ErrorCategory} to signal creation of a duplicate.
+     */
+    private static final int DUPLICATE_KEY_ERROR_CODES = 11000;
+
+    /**
+     * The mocked internal MongoDb ObjectId.
+     */
+    final String OBJECT_ID_FIELD = "DummyObjectId";
+
+    /**
+     * The map to hold created collections.
+     */
+    private final Map<String, List<JsonObject>> mongoDbData = new HashMap<>();
+
+    /**
+     * The map to hold property names of unique fields for each collection.
+     */
+    private final Map<String, List<String>> mongoDbIndexes = new HashMap<>();
+
+    /**
+     * Default constructor for serialisation/deserialization.
+     */
+    MongoDbClientMock() {
+    }
+
+    @Override
+    public MongoClient createIndexWithOptions(final String collection, final JsonObject key,
+            final IndexOptions options, final Handler<AsyncResult<Void>> resultHandler) {
+        // create new List for collection if not present
+        if (this.mongoDbData.containsKey(collection)) {
+            resultHandler.handle(Future.succeededFuture());
+            return this;
+        }
+        this.mongoDbData.put(collection, new ArrayList<>());
+        final ArrayList<String> indexes = new ArrayList<>(key.getMap().keySet());
+        this.mongoDbIndexes.put(collection, indexes);
+        resultHandler.handle(Future.succeededFuture());
+        return this;
+    }
+
+    @Override
+    public MongoClient find(final String collection, final JsonObject query,
+            final Handler<AsyncResult<List<JsonObject>>> resultHandler) {
+        final List<JsonObject> collectionList = this.mongoDbData.get(collection);
+        final List<JsonObject> foundDocuments = new ArrayList<>();
+        // get entity by comparing key-val-pairs, success if all match
+        for (JsonObject entity : collectionList) {
+            final Map<String, Object> entityAttr = entity.getMap();
+            if (query.getMap().entrySet().stream()
+                    .allMatch(queryAttr -> queryAttr.getValue().equals(entityAttr.get(queryAttr.getKey())))) {
+                foundDocuments.add(entity);
+            }
+        }
+        // special query mocks:
+        if (query.getMap().size() == 1 && query.getMap().values().toArray()[0].toString().contains("$eq")) {
+            // getByCa query
+            final List<JsonObject> documentsFoundGetByCa = findDocumentsByJsonPathEqSearch(collection, query);
+            if (!documentsFoundGetByCa.isEmpty()) {
+                foundDocuments.addAll(documentsFoundGetByCa);
+            }
+        }
+        resultHandler.handle(Future.succeededFuture(foundDocuments));
+        // nothing found
+        return this;
+    }
+
+    @Override
+    public MongoClient findOne(final String collection, final JsonObject query, @Nullable final JsonObject fields,
+            final Handler<AsyncResult<JsonObject>> resultHandler) {
+        final Promise<List<JsonObject>> documentFound = Promise.promise();
+        this.find(collection, query, documentFound);
+        documentFound.future()
+                .compose(documents -> {
+                    if (documents.isEmpty()) {
+                        return Future.succeededFuture(null);
+                    }
+                    return Future.succeededFuture(documents.get(0));
+                })
+                .setHandler(resultHandler);
+        return this;
+    }
+
+    /**
+     * Searches for {@code $eq}-MongoDb-query in a collection.
+     *
+     * @param collection the collection to search in.
+     * @param query the {@code $eq} query
+     * @return the documents if found.
+     */
+    private List<JsonObject> findDocumentsByJsonPathEqSearch(final String collection, final JsonObject query) {
+        final List<JsonObject> documentsFound = new ArrayList<>();
+        final String path = query.getMap().keySet().toArray()[0].toString();
+        final JsonObject searchObject = new JsonObject(query.getMap().values().toArray()[0].toString());
+        final String eqSearchValue = searchObject.getString("$eq");
+        final String[] pathElements = path.split("\\.");
+        final List<JsonObject> collectionList = this.mongoDbData.get(collection);
+        for (JsonObject doc : collectionList) {
+            if (findEntityByFindPropertyPath(doc, pathElements, eqSearchValue)) {
+                documentsFound.add(doc);
+            }
+        }
+        return documentsFound;
+    }
+
+    /**
+     * Checks if provided document contain a search string in the provided path.
+     *
+     * @param document the document to search in.
+     * @param path the path to traverse.
+     * @param eqSearchValue the search string to compare to after path traversing.
+     * @return {@code true } if search string can be found in provided path.
+     */
+    private Boolean findEntityByFindPropertyPath(final Object document, final String[] path,
+            final String eqSearchValue) {
+        if (path.length > 0) {
+            final Object pathElem = path[0];
+            if (document.getClass() == JsonObject.class) {
+                final Map<String, Object> currentNodeMap = ((JsonObject) document).getMap();
+                if (!currentNodeMap.containsKey(pathElem)) {
+                    return false;
+                }
+                return findEntityByFindPropertyPath(currentNodeMap.get(pathElem),
+                        Arrays.copyOfRange(path, 1, path.length), eqSearchValue);
+            } else if (document.getClass() == JsonArray.class) {
+                final JsonArray documentArray = ((JsonArray) document);
+                return documentArray.stream()
+                        .anyMatch(arrayElem -> findEntityByFindPropertyPath(arrayElem, path, eqSearchValue));
+            } else {
+                return false;
+            }
+        }
+        return document.equals(eqSearchValue);
+    }
+
+    @Override
+    public MongoClient insert(final String collection, final JsonObject document,
+            final Handler<AsyncResult<String>> resultHandler) {
+        final List<JsonObject> collectionList = this.mongoDbData.get(collection);
+        // extract indexed keys from provided document
+        final List<String> indexes = this.mongoDbIndexes.get(collection);
+        final Map<String, Object> indexesInDocument = indexes.stream().map(index -> {
+            if (!document.containsKey(index)) {
+                // provided document does not contain index
+                return null;
+            }
+            return new AbstractMap.SimpleEntry<String, Object>(index, document.getString(index));
+        }).filter(Objects::nonNull)
+                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+
+        // search for document with given unique keys
+        final Promise<JsonObject> existingDocumentFound = Promise.promise();
+        this.findOne(collection, new JsonObject(indexesInDocument), null, existingDocumentFound);
+
+        existingDocumentFound.future()
+                .compose(existingDocument -> {
+                    if (existingDocument != null) {
+                        return Future.failedFuture(new MongoException(DUPLICATE_KEY_ERROR_CODES,
+                                "Duplicate tenantId dummyException"));
+                    }
+                    final JsonObject documentWithId = document.copy().put(OBJECT_ID_FIELD,
+                            UUID.randomUUID().toString());
+                    collectionList.add(documentWithId);
+                    return Future.succeededFuture(documentWithId.getString(OBJECT_ID_FIELD));
+                })
+                .setHandler(resultHandler);
+
+        return this;
+    }
+
+    @Override
+    public MongoClient removeDocument(final String collection, final JsonObject query,
+            final Handler<AsyncResult<MongoClientDeleteResult>> resultHandler) {
+        final Promise<List<JsonObject>> documentFound = Promise.promise();
+        this.find(collection, query, documentFound);
+        documentFound.future()
+                .compose(docs -> {
+                    if (docs.isEmpty()) {
+                        return Future.succeededFuture(new MongoClientDeleteResult(0));
+                    } else {
+                        docs.forEach(d -> this.mongoDbData.get(collection).remove(d));
+                        return Future.succeededFuture(new MongoClientDeleteResult(docs.size()));
+                    }
+
+                }).setHandler(resultHandler);
+        return this;
+    }
+
+    @Override
+    public MongoClient findOneAndReplace(final String collection, final JsonObject query, final JsonObject replace,
+            final Handler<AsyncResult<JsonObject>> resultHandler) {
+
+        final Promise<MongoClientDeleteResult> documentRemoved = Promise.promise();
+        this.removeDocument(collection, query, documentRemoved);
+        documentRemoved.future()
+                .compose(document -> {
+                    if (document.getRemovedCount() == 0) {
+                        return Future.succeededFuture();
+                    }
+                    final Promise<String> recreateDocument = Promise.promise();
+                    this.insert(collection, replace, recreateDocument);
+                    return recreateDocument.future()
+                            .compose(createdDocumentId -> Future.succeededFuture(replace));
+                })
+                .setHandler(resultHandler);
+        return this;
+    }
+
+    @Override
+    public MongoClient findOneAndReplaceWithOptions(final String collection, final JsonObject query,
+            final JsonObject replace, final FindOptions findOptions, final UpdateOptions updateOptions,
+            final Handler<AsyncResult<JsonObject>> resultHandler) {
+        if (updateOptions.isReturningNewDocument()) {
+//            final Promise<JsonObject> updateDocument = Promise.promise();
+            findOneAndReplace(collection, query, replace, resultHandler);
+        } else {
+            throw new UnsupportedOperationException("Mock: UpdateOptions only accepts \"isReturningNewDocument\": true");
+        }
+        return this;
+    }
+
+    @Override
+    public MongoClient count(final String collection, final JsonObject query,
+            final Handler<AsyncResult<Long>> resultHandler) {
+        if (query.isEmpty()) {
+            resultHandler.handle(Future.succeededFuture((long) this.mongoDbData.get(collection).size()));
+            return this;
+        }
+        resultHandler.handle(Future.failedFuture("mongoClientMock: Not Implemented!"));
+        return this;
+    }
+
+    @Override
+    public MongoClient updateCollection(final String collection, final JsonObject query, final JsonObject update,
+            final Handler<AsyncResult<MongoClientUpdateResult>> resultHandler) {
+        if (!update.containsKey("$set")) {
+            resultHandler.handle(Future.failedFuture("mongoClientMock: No valid update expression."));
+            return this;
+        }
+        final JsonObject updateContent = update.getJsonObject("$set");
+        final Promise<List<JsonObject>> documentsToUpdate = Promise.promise();
+        this.find(collection, query, documentsToUpdate);
+        documentsToUpdate.future()
+                .compose(docs -> {
+                    for (JsonObject doc : docs) {
+                        doc.mergeIn(updateContent);
+                    }
+                    return Future.succeededFuture(
+                            new MongoClientUpdateResult(
+                                    new JsonObject().put(MongoClientUpdateResult.DOC_MATCHED, docs.size())));
+                })
+                .setHandler(resultHandler);
+        return this;
+
+    }
+
+    @Override
+    public MongoClient findOneAndDelete(final String collection, final JsonObject query,
+            final Handler<AsyncResult<JsonObject>> resultHandler) {
+
+        final Promise<JsonObject> foundAndDeletedDocument = Promise.promise();
+        findOne(collection, query, new JsonObject(), foundAndDeletedDocument);
+        foundAndDeletedDocument.future()
+                .compose( found -> {
+                    if (found == null) {
+                        return Future.succeededFuture();
+                    }
+                    final Promise<MongoClientDeleteResult> documentDeleted = Promise.promise();
+                    removeDocument(collection, query, documentDeleted);
+                    return documentDeleted.future()
+                                    .compose( ok -> Future.succeededFuture(found));
+
+                })
+                .setHandler(resultHandler);
+                return this;
+    }
+
+    // Not implemented methods
+
+    @Override
+    public MongoClient save(final String collection, final JsonObject document,
+            final Handler<AsyncResult<String>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient saveWithOptions(final String collection, final JsonObject document,
+            @Nullable final WriteOption writeOption, final Handler<AsyncResult<String>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient insertWithOptions(final String collection, final JsonObject document,
+            @Nullable final WriteOption writeOption, final Handler<AsyncResult<String>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient update(final String collection, final JsonObject query, final JsonObject update,
+            final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient updateWithOptions(final String collection, final JsonObject query, final JsonObject update,
+            final UpdateOptions options, final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient updateCollectionWithOptions(final String collection, final JsonObject query,
+            final JsonObject update, final UpdateOptions options,
+            final Handler<AsyncResult<MongoClientUpdateResult>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient replace(final String collection, final JsonObject query, final JsonObject replace,
+            final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient replaceDocuments(final String collection, final JsonObject query, final JsonObject replace,
+            final Handler<AsyncResult<MongoClientUpdateResult>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient replaceWithOptions(final String collection, final JsonObject query, final JsonObject replace,
+            final UpdateOptions options, final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient replaceDocumentsWithOptions(final String collection, final JsonObject query,
+            final JsonObject replace, final UpdateOptions options,
+            final Handler<AsyncResult<MongoClientUpdateResult>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient bulkWrite(final String collection, final List<BulkOperation> operations,
+            final Handler<AsyncResult<MongoClientBulkWriteResult>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient bulkWriteWithOptions(final String collection, final List<BulkOperation> operations,
+            final BulkWriteOptions bulkWriteOptions,
+            final Handler<AsyncResult<MongoClientBulkWriteResult>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public ReadStream<JsonObject> findBatch(final String collection, final JsonObject query) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient findWithOptions(final String collection, final JsonObject query, final FindOptions options,
+            final Handler<AsyncResult<List<JsonObject>>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public ReadStream<JsonObject> findBatchWithOptions(final String collection, final JsonObject query,
+            final FindOptions options) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient findOneAndUpdate(final String collection, final JsonObject query, final JsonObject update,
+            final Handler<AsyncResult<JsonObject>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient findOneAndUpdateWithOptions(final String collection, final JsonObject query,
+            final JsonObject update, final FindOptions findOptions, final UpdateOptions updateOptions,
+            final Handler<AsyncResult<JsonObject>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient findOneAndDeleteWithOptions(final String collection, final JsonObject query,
+            final FindOptions findOptions, final Handler<AsyncResult<JsonObject>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient remove(final String collection, final JsonObject query,
+            final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient removeDocuments(final String collection, final JsonObject query,
+            final Handler<AsyncResult<MongoClientDeleteResult>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient removeWithOptions(final String collection, final JsonObject query,
+            final WriteOption writeOption, final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient removeDocumentsWithOptions(final String collection, final JsonObject query,
+            @Nullable final WriteOption writeOption,
+            final Handler<AsyncResult<MongoClientDeleteResult>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient removeOne(final String collection, final JsonObject query,
+            final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient removeOneWithOptions(final String collection, final JsonObject query,
+            final WriteOption writeOption, final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient removeDocumentWithOptions(final String collection, final JsonObject query,
+            @Nullable final WriteOption writeOption,
+            final Handler<AsyncResult<MongoClientDeleteResult>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient createCollection(final String collectionName,
+            final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient getCollections(final Handler<AsyncResult<List<String>>> resultHandler) {
+        resultHandler.handle(Future.succeededFuture(new ArrayList<>(this.mongoDbData.keySet())));
+        return this;
+    }
+
+    @Override
+    public MongoClient dropCollection(final String collection, final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient createIndex(final String collection, final JsonObject key,
+            final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient listIndexes(final String collection, final Handler<AsyncResult<JsonArray>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient dropIndex(final String collection, final String indexName,
+            final Handler<AsyncResult<Void>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient runCommand(final String commandName, final JsonObject command,
+            final Handler<AsyncResult<JsonObject>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient distinct(final String collection, final String fieldName, final String resultClassname,
+            final Handler<AsyncResult<JsonArray>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public MongoClient distinctWithQuery(final String collection, final String fieldName,
+            final String resultClassname, final JsonObject query,
+            final Handler<AsyncResult<JsonArray>> resultHandler) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public ReadStream<JsonObject> distinctBatch(final String collection, final String fieldName,
+            final String resultClassname) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public ReadStream<JsonObject> distinctBatchWithQuery(final String collection, final String fieldName,
+            final String resultClassname, final JsonObject query) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public ReadStream<JsonObject> distinctBatchWithQuery(final String collection, final String fieldName,
+            final String resultClassname, final JsonObject query, final int batchSize) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public ReadStream<JsonObject> aggregate(final String collection, final JsonArray pipeline) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public ReadStream<JsonObject> aggregateWithOptions(final String collection, final JsonArray pipeline,
+            final AggregateOptions options) {
+        throw new UnsupportedOperationException("Mock: Not implemented");
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
@@ -48,13 +48,12 @@ class MongoDbBasedRegistrationServiceTest extends RegistrationServiceTests {
         final MongoDbBasedRegistrationConfigProperties config = new MongoDbBasedRegistrationConfigProperties();
         svc = spy(new MongoDbBasedRegistrationService());
         svc.setConfig(config);
-        svc.init(vertx, ctx);
 
         mongoDbCallExecutor = mock(MongoDbCallExecutor.class);
         mongoClient = new MongoDbClientMock();
         prepareMongoDbCallExecutorMock();
         svc.setExecutor(mongoDbCallExecutor);
-        svc.start(Promise.promise());
+        svc.start();
     }
 
     private void prepareMongoDbCallExecutorMock() {

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.service;
+
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbCallExecutor;
+import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.service.registration.RegistrationService;
+import org.eclipse.hono.service.registration.RegistrationServiceTests;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Context;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.IndexOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+
+@ExtendWith(VertxExtension.class)
+@Timeout(timeUnit = TimeUnit.SECONDS, value = 3)
+class MongoDbBasedRegistrationServiceTest extends RegistrationServiceTests {
+
+    private MongoDbCallExecutor mongoDbCallExecutor;
+    private MongoClient mongoClient;
+    private MongoDbBasedRegistrationService svc;
+
+    @BeforeEach
+    void setUp() {
+        final Context ctx = mock(Context.class);
+        final Vertx vertx = mock(Vertx.class);
+        final MongoDbBasedRegistrationConfigProperties config = new MongoDbBasedRegistrationConfigProperties();
+        svc = spy(new MongoDbBasedRegistrationService());
+        svc.setConfig(config);
+        svc.init(vertx, ctx);
+
+        mongoDbCallExecutor = mock(MongoDbCallExecutor.class);
+        mongoClient = new MongoDbClientMock();
+        prepareMongoDbCallExecutorMock();
+        svc.setExecutor(mongoDbCallExecutor);
+        svc.start(Promise.promise());
+    }
+
+    private void prepareMongoDbCallExecutorMock() {
+        when(mongoDbCallExecutor.getMongoClient()).thenReturn(mongoClient);
+        when(mongoDbCallExecutor.createCollectionIndex(anyString(), any(JsonObject.class), any(IndexOptions.class),
+                anyInt()))
+                        .then(invocation -> {
+                            final String collection = invocation.getArgument(0);
+                            final JsonObject key = invocation.getArgument(1);
+                            final IndexOptions options = invocation.getArgument(2);
+                            final Promise<Void> indexCreated = Promise.promise();
+                            mongoClient.createIndexWithOptions(collection, key, options, indexCreated);
+                            return indexCreated;
+                        });
+    }
+
+    @Override
+    public RegistrationService getRegistrationService() {
+        return svc;
+    }
+
+    @Override
+    public DeviceManagementService getDeviceManagementService() {
+        return svc;
+    }
+
+}


### PR DESCRIPTION
In addition to the tests of the mongodb based device registration, a mock of the `mongoDbClient` is necessary to emulate the database functions and access.

Summary of the contents:
- Add `mongoClientMock`
- Add tests for device registration