### PR TITLE
[#1679] Avoid conversion from Device to JsonObject in MongoDB based assertRegistration

### DIFF
--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDeviceRegistryUtils.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDeviceRegistryUtils.java
@@ -36,6 +36,10 @@ import io.vertx.core.Future;
 public final class MongoDbDeviceRegistryUtils {
 
     /**
+     * The name of the JSON property containing the device data.
+     */
+    public static final String FIELD_DEVICE = "device";
+    /**
      * The name of the JSON property containing the last modification date and time.
      */
     public static final String FIELD_UPDATED_ON = "updatedOn";
@@ -43,10 +47,6 @@ public final class MongoDbDeviceRegistryUtils {
      * The name of the JSON property containing the version of the tenant or device or credentials information.
      */
     public static final String FIELD_VERSION = "version";
-    /**
-     * The name of the JSON property containing the device identifier.
-     */
-    public static final String FIELD_DEVICE = "device";
     private static final Logger LOG = LoggerFactory.getLogger(MongoDbDeviceRegistryUtils.class);
 
     private MongoDbDeviceRegistryUtils() {


### PR DESCRIPTION
In the existing  `processAssertRegistration(...)` implementation of the device registry, the retrieved _device_ is first mapped to a `JsonObject`  before creating a `RegistrationResult`. In this PR, this device mapping to `JsonObject` has been avoided considering the potential performance setback. @sophokles73 Would you mind taking a look?
