### PR TITLE
Prevent usage of Java > 11 language features

### DIFF
--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -41,6 +41,10 @@
   <name>Hono Protocol Adapters</name>
   <description>An arbitrary collection of example protocol adapters for Hono. These adapters are mainly intended to be used for demonstration or PoCs. </description>
 
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -11,124 +11,125 @@
    
     SPDX-License-Identifier: EPL-2.0
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.eclipse.hono</groupId>
-        <artifactId>hono-bom</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
-        <relativePath>../bom</relativePath>
-    </parent>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-bom</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+    <relativePath>../bom</relativePath>
+  </parent>
 
-    <artifactId>hono-cli</artifactId>
-    <name>Hono command-line interface</name>
-    <url>https://www.eclipse.org/hono</url>
+  <artifactId>hono-cli</artifactId>
+  <name>Hono command-line interface</name>
+  <url>https://www.eclipse.org/hono</url>
 
-    <description>Hono Command line Interface</description>
+  <description>Hono Command line Interface</description>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.eclipse.hono</groupId>
-            <artifactId>hono-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.hono</groupId>
-            <artifactId>hono-legal</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.hono</groupId>
-            <artifactId>hono-demo-certs</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring-boot.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-junit5</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-        </dependency>
-    </dependencies>
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-legal</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-demo-certs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring-boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+  </dependencies>
 
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <!--
-                  Copy legal documents from "legal" module to "target/classes" folder
-                  so that we make sure to include legal docs in all modules.
-                 -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <!--
-                          Execution and configuration for copying certificates from related module
-                          to "target/classes" folder so that we can include them in the image.
-                         -->
-                        <id>copy_demo_certs</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeArtifactIds>
-                                hono-demo-certs
-                            </includeArtifactIds>
-                            <outputDirectory>${project.build.directory}/config</outputDirectory>
-                            <includes>
-                                *.pem,
-                                *.jks,
-                                *.p12
-                            </includes>
-                            <useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
-                            <stripClassifier>true</stripClassifier>
-                            <stripVersion>true</stripVersion>
-                            <excludeTransitive>true</excludeTransitive>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <!-- Copy legal documents from "legal" module to "target/classes" folder so that we make sure to include 
+          legal docs in all modules. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Execution and configuration for copying certificates from related module to "target/classes" folder 
+              so that we can include them in the image. -->
+            <id>copy_demo_certs</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeArtifactIds>
+                hono-demo-certs
+              </includeArtifactIds>
+              <outputDirectory>${project.build.directory}/config</outputDirectory>
+              <includes>
+                *.pem,
+                *.jks,
+                *.p12
+              </includes>
+              <useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
+              <stripClassifier>true</stripClassifier>
+              <stripVersion>true</stripVersion>
+              <excludeTransitive>true</excludeTransitive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -30,7 +30,8 @@
   <url>https://www.eclipse.org/hono</url>
 
   <properties>
-    <java.level>1.8</java.level>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -105,15 +106,6 @@
       </plugins>
     </pluginManagement>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.level}</source>
-          <target>${java.level}</target>
-          <encoding>UTF-8</encoding>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,7 +30,8 @@
   <url>https://www.eclipse.org/hono</url>
 
   <properties>
-    <java.level>1.8</java.level>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -136,15 +137,6 @@
       </plugins>
     </pluginManagement>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.level}</source>
-          <target>${java.level}</target>
-          <encoding>UTF-8</encoding>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -23,8 +23,9 @@
   </parent>
 
   <artifactId>hono-example</artifactId>
+  <packaging>pom</packaging>
   <name>Hono Examples</name>
-  <description>A collection of examples code for Hono.</description>
+  <description>Example code for Hono.</description>
   <url>https://www.eclipse.org/hono</url>
 
   <modules>
@@ -32,8 +33,7 @@
     <module>protocol-gateway-example</module>
   </modules>
 
-  <packaging>pom</packaging>
-
-
-
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+
     <classifier.spring.boot.artifact>exec</classifier.spring.boot.artifact>
 
     <!-- configure timestamp format to be injected into legal docs -->
@@ -262,12 +265,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-          <configuration>
-            <source>11</source>
-            <target>11</target>
-            <encoding>UTF-8</encoding>
-          </configuration>
+          <version>3.8.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -38,6 +38,10 @@
   <description>Micro services implementing APIs that Hono depends on only and which are therefore not part of the Hono server process itself.
   The service components included here can be replaced by other (custom) components as long as they implement the required API(s).</description>
 
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.hono</groupId>


### PR DESCRIPTION
For the `core` and `client` modules we use the *animal-sniffer-maven-plugin* in order to detect (and prevent) usage of language features that are not available on the target platform (Java 8).
The *maven-compiler-plugin* supports specifying the Java compiler's *release* option which serves the same purpose for for Java >= 9.