### PR TITLE
Fix missing password encoder for the file based device registry

### DIFF
--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -119,6 +119,7 @@ public class FileBasedServiceConfig {
 
         final FileBasedCredentialsService credentialsService = new FileBasedCredentialsService(vertx);
         credentialsService.setConfig(credentialsProperties());
+        credentialsService.setPasswordEncoder(passwordEncoder());
 
         return new FileBasedDeviceBackend(registrationService, credentialsService);
     }


### PR DESCRIPTION
The password encoder has not been set for the file based credentials service, which leads to error while updating credentials. This has been fixed in this PR. 