### PR TITLE
Add option to run integration tests with Jaeger

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -39,6 +39,7 @@
     <infinispan.version>9.4.17.Final</infinispan.version>
     <infinispan.image.name>jboss/infinispan-server:9.4.11.Final</infinispan.image.name>
     <jackson.version>2.10.3</jackson.version>
+    <jaeger.image.name>jaegertracing/all-in-one:1.17</jaeger.image.name>
     <jaeger.version>1.2.0</jaeger.version>
     <java-base-image.name>docker.io/openjdk:11-jre-slim</java-base-image.name>
     <jaxb.api.version>2.2.12</jaxb.api.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -58,6 +58,9 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <!-- logging profile: either prod, dev or trace -->
     <logging.profile>prod</logging.profile>
     <trace.frames>0</trace.frames>
+    <jaeger.disabled>true</jaeger.disabled>
+    <jaeger.host>hono-jaeger.hono</jaeger.host>
+    <jaeger.query.port>18080</jaeger.query.port>
   </properties>
 
   <dependencies>
@@ -207,6 +210,60 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
               <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
               <startParallel>false</startParallel>
               <images>
+                <!-- ##### Jaeger tracing component ##### -->
+                <image>
+                  <name>${docker.image.org-name}/hono-jaeger-all-in-one-test</name>
+                  <alias>jaeger</alias>
+                  <build>
+                    <imagePullPolicy>IfNotPresent</imagePullPolicy>
+                    <from>${jaeger.image.name}</from>
+                    <ports>
+                      <port>8088</port><!-- admin-http -->
+                      <port>16686</port><!-- query-http -->
+                      <port>6831/udp</port><!-- agent (compact thrift protocol) -->
+                    </ports>
+                  </build>
+                  <run>
+                    <skip>${jaeger.disabled}</skip>
+                    <ports>
+                      <port>+jaeger.ip:jaeger.health.port:8088</port>
+                      <port>+jaeger.ip:jaeger.query.port:16686</port>
+                    </ports>
+                    <portPropertyFile>${project.build.directory}/docker/jaeger.port.properties</portPropertyFile>
+                    <network>
+                      <mode>custom</mode>
+                      <name>hono</name>
+                      <alias>hono-jaeger.hono</alias>
+                    </network>
+                    <!--
+                      Setting the swap property to the same value as the memory property effectively
+                      prevents the container from swapping at all.
+                      This way we can force the same behavior for running the integration
+                      tests on both a local machine (which usually has swap space available) as
+                      well as on Travis where there is no swap space available on the build job VMs.
+                      We can thus detect OOM problems when running locally as opposed to only
+                      later on Travis.
+                     -->
+                    <memorySwap>205520896</memorySwap>
+                    <memory>205520896</memory>
+                    <env>
+                      <ADMIN_HTTP_PORT>8088</ADMIN_HTTP_PORT>
+                      <MEMORY_MAX_TRACES>100000</MEMORY_MAX_TRACES>
+                    </env>
+                    <log>
+                      <prefix>JAEGER</prefix>
+                      <color>green</color>
+                    </log>
+                    <wait>
+                      <time>${service.startup.timeout}</time>
+                      <http>
+                        <method>GET</method>
+                        <url>http://${jaeger.ip}:${jaeger.health.port}/health</url>
+                        <status>200..299</status>
+                      </http>
+                    </wait>
+                  </run>
+                </image>
                 <!-- ##### Authentication service ##### -->
                 <image>
                   <name>${docker.image.org-name}/hono-service-auth-test</name>
@@ -334,6 +391,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${default.java.options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
+                      <JAEGER_SERVICE_NAME>device-registry</JAEGER_SERVICE_NAME>
+                      <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
+                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
+                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
+                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
                     </env>
                     <log>
                       <prefix>REGISTRY</prefix>
@@ -543,6 +605,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${default.java.options} ${http.java.options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
+                      <JAEGER_SERVICE_NAME>hono-adapter-http</JAEGER_SERVICE_NAME>
+                      <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
+                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
+                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
+                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
                     </env>
                     <log>
                       <prefix>HTTP</prefix>
@@ -617,6 +684,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${default.java.options} ${mqtt.java.options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
+                      <JAEGER_SERVICE_NAME>hono-adapter-mqtt</JAEGER_SERVICE_NAME>
+                      <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
+                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
+                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
+                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
                     </env>
                     <log>
                       <prefix>MQTT</prefix>
@@ -683,6 +755,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${default.java.options} ${amqp.java.options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
+                      <JAEGER_SERVICE_NAME>hono-adapter-amqp</JAEGER_SERVICE_NAME>
+                      <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
+                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
+                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
+                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
                     </env>
                     <log>
                       <prefix>AMQP</prefix>
@@ -750,6 +827,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${default.java.options} ${coap.java.options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
+                      <JAEGER_SERVICE_NAME>hono-adapter-lora</JAEGER_SERVICE_NAME>
+                      <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
+                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
+                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
+                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
                     </env>
                     <log>
                       <prefix>COAP</prefix>
@@ -871,6 +953,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 </goals>
                 <configuration>
                   <files>
+                    <file>${project.build.directory}/docker/jaeger.port.properties</file>
                     <file>${project.build.directory}/docker/auth.port.properties</file>
                     <file>${project.build.directory}/docker/deviceregistry.port.properties</file>
                     <file>${project.build.directory}/docker/broker.port.properties</file>
@@ -943,6 +1026,12 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jaeger</id>
+      <properties>
+        <jaeger.disabled>false</jaeger.disabled>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -27,9 +27,10 @@ This starts the following Docker containers and runs the test cases against them
 * Hono AMQP adapter
 * Hono CoAP adapter
 
-To run a single test, set the `it.test` property:
+To run all tests of a certain class, or to run an individual test, set the `it.test` property:
 
     $ mvn verify -Prun-tests -Dit.test=TelemetryHttpIT
+    $ mvn verify -Prun-tests -Dit.test=TelemetryHttpIT#testUploadUsingQoS1
 
 The `logging.profile` property with a value of either `prod`, `dev` or `trace` can be used to set the log level in the Hono Docker containers:
 
@@ -46,6 +47,42 @@ Subsequent test runs can use the running containers and will thereby finish much
     $ mvn verify -Prun-tests,useRunningContainers
 
 With that profile, the Docker containers will be kept running as well.
+
+In order to stop and remove the Docker containers started by a test run, use:
+
+    $ mvn verify -PstopContainers
+
+### Running the Tests with the Jaeger tracing component
+
+The tests can be run in such a way, that the OpenTracing trace spans created in the Hono components as part of a test run can be inspected later on. The OpenTracing component used for this is Jaeger.
+ 
+To include the Jaeger client, build the Hono Docker images using the `jaeger` maven profile:
+
+    # in the "hono" folder containing the source code
+    $ mvn clean install -Pbuild-docker-image,metrics-prometheus,jaeger
+
+(Add a `-Ddocker.host` property definition if needed, as described in the [Developer Guide](https://www.eclipse.org/hono/docs/dev-guide/building_hono/).)
+
+Then run the tests using the `jaeger` maven profile:
+
+    # in directory: hono/tests/
+    $ mvn verify -Prun-tests,jaeger -Ddocker.keepRunning
+
+To run a single test instead, use e.g.:
+
+    $ mvn verify -Prun-tests,jaeger -Ddocker.keepRunning -Dit.test=TelemetryHttpIT#testUploadUsingQoS1
+
+Note that in order to be able to view the traces after a test run, the `docker.keepRunning` property has to be used as well, as shown above.  
+
+The Jaeger UI, showing the traces of the test run, can be accessed at
+
+    http://localhost:18080
+
+if the Docker engine is running on `localhost`, otherwise the appropriate Docker host has to be used in the above URL. To choose a different port for the Jaeger UI, set the `jaeger.query.port` maven property to the desired port when running the tests. 
+
+Start subsequent test runs using the running containers with the `useRunningContainers` maven profile, e.g.:
+
+    $ mvn verify -Prun-tests,jaeger,useRunningContainers -Dit.test=TelemetryHttpIT#testUploadUsingQoS1
 
 In order to stop and remove the Docker containers started by a test run, use:
 


### PR DESCRIPTION
This adds an option to run the integration tests in such a way that the created traces can later on be viewed in the Jaeger UI.