### PR TITLE
[#1858] Describe 'lifespan' as mandatory for API implementations

### DIFF
--- a/site/documentation/content/api/device-connection/index.md
+++ b/site/documentation/content/api/device-connection/index.md
@@ -111,6 +111,8 @@ For status codes indicating an error (codes in the `400 - 499` range) the messag
 
 Clients use this command to *set* the protocol adapter instance that currently handles command & control messages for a given device.
 
+Clients can provide an optional `lifespan` parameter to make the protocol adapter instance entry expire after the given number of seconds. Note that implementations of this API have to support this feature, otherwise protocol adapters, as the clients of this API, might fail to correctly route command messages.
+
 This API doesn't mandate checks on the validity of the given device in order not to introduce a dependency on the *Device Registration API*. However, implementations of this API may choose to perform such checks or impose a restriction on the overall amount of data that can be stored per tenant in order to protect against malicious requests.
 
 **Message Flow**
@@ -126,7 +128,7 @@ The following table provides an overview of the properties a client needs to set
 | :-------------------- | :-------: | :----------------------- | :-------- | :---------- |
 | *subject*             | yes       | *properties*             | *string*  | MUST be set to `set-cmd-handling-adapter-instance`. |
 | *adapter_instance_id* | yes       | *application-properties* | *string*  | The identifier of the protocol adapter instance that currently handles commands for the device or gateway identified by the *device_id* property. |
-| *lifespan*            | no        | *application-properties* | *int*     | The desired lifespan of the mapping entry in seconds. If the *Device Registration API* implementation supports this property, the mapping entry shall be treated as non-existent after that period has elapsed. A negative value, as well as an omitted property, is interpreted as an unlimited lifespan. A *Device Registration API* implementation may not support this property, meaning that a client can't rely on the given lifespan to be applied. |
+| *lifespan*            | no        | *application-properties* | *int*     | The lifespan of the mapping entry in seconds. After that period, the mapping entry shall be treated as non-existent by the *Device Registration API* methods. A negative value, as well as an omitted property, is interpreted as an unlimited lifespan. |
 
 The body of the message SHOULD be empty and will be ignored if it is not.
 


### PR DESCRIPTION
This is for #1858:
See discussion here:
https://github.com/eclipse/hono/pull/1908#discussion_r412792617
