### PR TITLE
[#1864] Add basic authentication support for the MongoDB based device registry

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -422,6 +422,11 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
+        <artifactId>vertx-auth-mongo</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
         <artifactId>vertx-health-check</artifactId>
         <version>${vertx.version}</version>
       </dependency>

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceConfigProperties.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpServiceConfigProperties.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.http;
+
+import java.util.Objects;
+
+import org.eclipse.hono.config.ServiceConfigProperties;
+
+/**
+ * Common configuration properties for the HTTP endpoint.
+ *
+ */
+public class HttpServiceConfigProperties extends ServiceConfigProperties {
+    /**
+     * The default name of the realm that clients need to authenticate to.
+     */
+    public static final String DEFAULT_REALM = "Hono";
+
+    private boolean authenticationRequired = true;
+    private String realm = DEFAULT_REALM;
+
+    /**
+     * Checks whether the HTTP endpoint requires clients to authenticate.
+     * <p>
+     * If this property is {@code false} then clients are always allowed to access the HTTP endpoint
+     * without authentication.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @return {@code true} if the HTTP endpoint should require clients to authenticate.
+     */
+    public final boolean isAuthenticationRequired() {
+        return authenticationRequired;
+    }
+
+    /**
+     * Sets whether the HTTP endpoint requires clients to authenticate.
+     * <p>
+     * If this property is {@code false} then clients are always allowed to access the HTTP endpoint
+     * without authentication.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @param authenticationRequired {@code true} if the HTTP endpoint should require clients to authenticate.
+     */
+    public final void setAuthenticationRequired(final boolean authenticationRequired) {
+        this.authenticationRequired = authenticationRequired;
+    }
+
+    /**
+     * Gets the name of the realm to be used in the <em>WWW-Authenticate</em> header.
+     * <p>
+     * The realm is used in the <em>WWW-Authenticate</em> header.
+     * <p>
+     * The default value is {@link #DEFAULT_REALM}.
+     *
+     * @return The realm name.
+     */
+    public final String getRealm() {
+        return realm;
+    }
+
+    /**
+     * Sets the name of the realm to be used in the <em>WWW-Authenticate</em> header.
+     * <p>
+     * The realm is used in the <em>WWW-Authenticate</em> header.
+     * <p>
+     * The default value is {@link #DEFAULT_REALM}.
+     *
+     * @param realm The realm name.
+     * @throws NullPointerException if the realm is {@code null}.
+     */
+    public final void setRealm(final String realm) {
+        this.realm = Objects.requireNonNull(realm);
+    }
+}

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>vertx-mongo-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-auth-mongo</artifactId>
+        </dependency>
+        <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <scope>test</scope>

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -60,6 +60,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.mongo.MongoAuth;
+import io.vertx.ext.mongo.MongoClient;
 import io.vertx.ext.web.handler.AuthHandler;
 
 /**
@@ -168,6 +169,17 @@ public class ApplicationConfig {
     }
 
     /**
+     * Gets a {@link MongoClient} instance for MongoDB interaction.
+     *
+     * @return An instance of the {@link MongoClient}.
+     */
+    @Bean
+    @Scope("prototype")
+    public MongoClient mongoClient() {
+        return MongoClient.createShared(vertx(), mongoDbConfigProperties().getMongoClientConfig());
+    }
+
+    /**
      * Gets a {@link MongoDbCallExecutor} instance containing helper methods for mongodb interaction.
      *
      * @return An instance of the helper class {@link MongoDbCallExecutor}.
@@ -175,7 +187,7 @@ public class ApplicationConfig {
     @Bean
     @Scope("prototype")
     public MongoDbCallExecutor mongoDBCallExecutor() {
-        return new MongoDbCallExecutor(vertx(), mongoDbConfigProperties());
+        return new MongoDbCallExecutor(vertx(), mongoClient());
     }
 
     //
@@ -344,7 +356,7 @@ public class ApplicationConfig {
     @ConditionalOnProperty(name = "hono.registry.http.authenticationRequired", havingValue = "true", matchIfMissing = true)
     public AuthHandler createAuthHandler() {
         return new HonoBasicAuthHandler(
-                MongoAuth.create(mongoDBCallExecutor().getMongoClient(), new JsonObject()),
+                MongoAuth.create(mongoClient(), new JsonObject()),
                 MongoDbDeviceRegistryUtils.DEFAULT_REALM,
                 getTracer());
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
@@ -85,7 +85,17 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
     @Autowired
     public void setExecutor(final MongoDbCallExecutor mongoDbCallExecutor) {
         this.mongoDbCallExecutor = Objects.requireNonNull(mongoDbCallExecutor);
-        this.mongoClient = this.mongoDbCallExecutor.getMongoClient();
+    }
+
+    /**
+     * Sets an instance of the {@link MongoClient}.
+     *
+     * @param mongoClient An instance of the mongo client.
+     * @throws NullPointerException if the mongoClient is {@code null}.
+     */
+    @Autowired
+    public void setMongoClient(final MongoClient mongoClient) {
+        this.mongoClient = Objects.requireNonNull(mongoClient);
     }
 
     /**

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
@@ -34,6 +34,7 @@ import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
 import io.vertx.core.Vertx;
+import io.vertx.ext.mongo.MongoClient;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -70,11 +71,15 @@ public class MongoDbBasedRegistrationServiceTest extends RegistrationServiceTest
 
         registrationService = new MongoDbBasedRegistrationService();
         registrationService.setConfig(new MongoDbBasedRegistrationConfigProperties());
-        registrationService.setExecutor(new MongoDbCallExecutor(vertx,
-                new MongoDbConfigProperties()
-                        .setHost(mongoDbHost)
-                        .setPort(mongoDbPort)
-                        .setDbName("mongoDBTestDeviceRegistry")));
+
+        final MongoClient mongoClient = MongoClient.createShared(vertx, new MongoDbConfigProperties()
+                .setHost(mongoDbHost)
+                .setPort(mongoDbPort)
+                .setDbName("mongoDBTestDeviceRegistry")
+                .getMongoClientConfig());
+        registrationService.setMongoClient(mongoClient);
+        registrationService.setExecutor(new MongoDbCallExecutor(vertx, mongoClient));
+
         registrationService.start().onComplete(testContext.completing());
     }
 


### PR DESCRIPTION
This PR provides _basic authentication_ support for the _MongoDB_ based device registry. _Vert.x MongodB Auth Provider_ is used in this implementation. It makes use of the user credentials stored in a _MongoDB_ collection to authenticate client credentials.