### PR TITLE
[#1714] Set TTL for connection event messages.

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/DownstreamSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/DownstreamSender.java
@@ -133,6 +133,10 @@ public interface DownstreamSender extends MessageSender {
     /**
      * Sends a message for a given device to the endpoint configured for this client.
      *
+     * @param maxTtl   The maximum TTL value in seconds indicating the duration for which the message is to be considered live.
+     *                 <p>
+     *                 The value of this parameter will be contained in the message's <em>ttl</em> header.
+     *
      * @param deviceId The id of the device.
      *                 <p>
      *                 This parameter will be used as the value for the message's application property <em>device_id</em>.
@@ -162,6 +166,7 @@ public interface DownstreamSender extends MessageSender {
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      */
     Future<ProtonDelivery> send(
+            Long maxTtl,
             String deviceId,
             Map<String, ?> properties,
             byte[] payload,

--- a/client/src/main/java/org/eclipse/hono/client/DownstreamSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/DownstreamSender.java
@@ -133,10 +133,6 @@ public interface DownstreamSender extends MessageSender {
     /**
      * Sends a message for a given device to the endpoint configured for this client.
      *
-     * @param maxTtl   The maximum TTL value in seconds indicating the duration for which the message is to be considered live.
-     *                 <p>
-     *                 The value of this parameter will be contained in the message's <em>ttl</em> header.
-     *
      * @param deviceId The id of the device.
      *                 <p>
      *                 This parameter will be used as the value for the message's application property <em>device_id</em>.
@@ -166,7 +162,6 @@ public interface DownstreamSender extends MessageSender {
      * @throws IllegalArgumentException if the content type specifies an unsupported character set.
      */
     Future<ProtonDelivery> send(
-            Long maxTtl,
             String deviceId,
             Map<String, ?> properties,
             byte[] payload,

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractDownstreamSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractDownstreamSender.java
@@ -15,7 +15,6 @@ package org.eclipse.hono.client.impl;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
@@ -65,7 +64,7 @@ public abstract class AbstractDownstreamSender extends AbstractSender implements
 
     @Override
     public final Future<ProtonDelivery> send(final String deviceId, final byte[] payload, final String contentType) {
-        return send(null, deviceId, null, payload, contentType);
+        return send(deviceId, null, payload, contentType);
     }
 
     @Override
@@ -77,19 +76,16 @@ public abstract class AbstractDownstreamSender extends AbstractSender implements
     public final Future<ProtonDelivery> send(final String deviceId, final Map<String, ?> properties, final String payload, final String contentType) {
         Objects.requireNonNull(payload);
         final Charset charset = getCharsetForContentType(Objects.requireNonNull(contentType));
-        return send(null, deviceId, properties, payload.getBytes(charset), contentType);
+        return send(deviceId, properties, payload.getBytes(charset), contentType);
     }
 
     @Override
-    public final Future<ProtonDelivery> send(final Long maxTtl, final String deviceId, final Map<String, ?> properties, final byte[] payload, final String contentType) {
+    public final Future<ProtonDelivery> send(final String deviceId, final Map<String, ?> properties, final byte[] payload, final String contentType) {
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(payload);
         Objects.requireNonNull(contentType);
 
         final Message msg = ProtonHelper.message();
-        if (maxTtl != null) {
-            MessageHelper.setTimeToLive(msg, Duration.ofSeconds(maxTtl));
-        }
         msg.setAddress(getTo(deviceId));
         MessageHelper.setPayload(msg, contentType, payload);
         setApplicationProperties(msg, properties);

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -561,10 +561,10 @@ public final class MessageHelper {
     }
 
     /**
-     * Sets the <em>time-to-live</em> of the AMQP 1.0 message.
+     * Sets the <em>time-to-live</em> for the given AMQP 1.0 message.
      *
-     * @param message the message for that the <em>time-to-live</em> is set.
-     * @param timeToLive The <em>time-to-live</em> duration to be set in the message.
+     * @param message The message whose <em>time-to-live</em> is to be set.
+     * @param timeToLive The <em>time-to-live</em> duration to be set on the message.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public static void setTimeToLive(final Message message, final Duration timeToLive) {

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -924,6 +924,37 @@ public final class MessageHelper {
     }
 
     /**
+     * Creates an AMQP 1.0 message.
+     * <p>
+     * This method simply calls
+     * {@link #newMessage(ResourceIdentifier, String, String, Buffer, TenantObject, JsonObject, Integer, Duration, String, boolean, boolean)}
+     * to create the AMQP 1.0 message.
+     * 
+     * @param target       The target address of the message or {@code null} if the message's
+     *                     <em>to</em> property contains the target address.
+     * @param contentType  The content type describing the message's payload or {@code null} if no content type
+     *                     should be set.
+     * @param payload      The message payload or {@code null} if the message has no payload.
+     * @param tenant       The information registered for the tenant that the device belongs to or {@code null}
+     *                     if no information about the tenant is available.
+     * @param timeToLive   The message's <em>time-to-live</em> as provided by the device or {@code null} if the
+     *                     device did not provide any TTL.
+     * @param adapterName  The type name of the protocol adapter that the message has been published to.
+     * 
+     * @return  The AMQP 1.0 message.
+     */
+    public static Message newMessage(
+            final ResourceIdentifier target,
+            final String contentType,
+            final Buffer payload,
+            final TenantObject tenant,
+            final Duration timeToLive,
+            final String adapterName) {
+
+        return MessageHelper.newMessage(target, null, contentType, payload, tenant, null, null, timeToLive, adapterName, false,
+                false);
+    }
+    /**
      * Creates a new AMQP 1.0 message.
      * <p>
      * This method creates a new {@code Message} and sets
@@ -1139,7 +1170,7 @@ public final class MessageHelper {
             addJmsVendorProperties(message);
         }
 
-        // make sure that device provided TLL is capped at max TTL (if set)
+        // make sure that device provided TTL is capped at max TTL (if set)
         // AMQP spec defines TTL as milliseconds
         final long maxTtlMillis = maxTtl * 1000L;
         if (target.hasEventEndpoint() && maxTtl != TenantConstants.UNLIMITED_TTL) {

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -126,7 +126,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         }
 
         @Override
-        public TenantClientFactory getTenantClient() {
+        public TenantClientFactory getTenantClientFactory() {
             return AbstractProtocolAdapterBase.this.tenantClientFactory;
         }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -125,6 +125,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             return AbstractProtocolAdapterBase.this.downstreamSenderFactory;
         }
 
+        @Override
+        public TenantClientFactory getTenantClient() {
+            return AbstractProtocolAdapterBase.this.tenantClientFactory;
+        }
+
     };
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
@@ -94,7 +94,6 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                                 final JsonObject payload = new JsonObject();
                                 payload.put("cause", cause);
                                 payload.put("remote-id", remoteId);
-                                // TODO: can this be removed in favour of 'orig_dapter'?
                                 payload.put("source", protocolAdapter);
 
                                 if (data != null) {
@@ -106,9 +105,6 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                                 final ResourceIdentifier target = ResourceIdentifier.from(EventConstants.EVENT_ENDPOINT, tenantId, deviceId);
                                 final Duration timeToLive = Duration.ofSeconds(tenantObjectFuture.result().getResourceLimits().getMaxTtl());
 
-                                // the 'orig_adapter' will be added to the message's application
-                                // properties to contain the name of the protocol adapter
-                                // forwarding this connection event
                                 final Message msg = MessageHelper.newMessage(
                                         target, 
                                         EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE, 

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.service.monitoring;
 
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.DownstreamSenderFactory;
+import org.eclipse.hono.client.TenantClientFactory;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
@@ -52,6 +53,14 @@ public interface ConnectionEventProducer {
          *         use. This client has to be initialized and started.
          */
         DownstreamSenderFactory getMessageSenderClient();
+        /**
+         * Provides the tenant client which the {@link ConnectionEventProducer} should use to lookup the tenant
+         * that the device connecting to a protocol adapter belongs to.
+         * 
+         * @return The tenant client instance. This client has to be initialized and started.
+         */
+        TenantClientFactory getTenantClient();
+
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
@@ -59,7 +59,7 @@ public interface ConnectionEventProducer {
          * 
          * @return The tenant client instance. This client has to be initialized and started.
          */
-        TenantClientFactory getTenantClient();
+        TenantClientFactory getTenantClientFactory();
 
     }
 

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.HttpURLConnection;
+import java.time.Duration;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.auth.Device;
@@ -38,6 +39,7 @@ import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.DisconnectListener;
+import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
@@ -45,9 +47,12 @@ import org.eclipse.hono.client.ReconnectListener;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.http.HttpUtils;
+import org.eclipse.hono.service.monitoring.ConnectionEventProducer;
+import org.eclipse.hono.service.monitoring.HonoEventConnectionEventProducer;
 import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
@@ -90,13 +95,14 @@ public class AbstractProtocolAdapterBaseTest {
     private ProtocolAdapterProperties properties;
     private AbstractProtocolAdapterBase<ProtocolAdapterProperties> adapter;
     private RegistrationClient registrationClient;
-    private TenantClientFactory tenantService;
+    private TenantClientFactory tenantClientFactory;
     private RegistrationClientFactory registrationClientFactory;
     private CredentialsClientFactory credentialsClientFactory;
     private DownstreamSenderFactory downstreamSenderFactory;
     private ProtocolAdapterCommandConsumerFactory commandConsumerFactory;
     private DeviceConnectionClientFactory deviceConnectionClientFactory;
     private CommandTargetMapper commandTargetMapper;
+    private ConnectionEventProducer.Context connectionEventProducerContext;
 
     /**
      * Sets up the fixture.
@@ -105,8 +111,8 @@ public class AbstractProtocolAdapterBaseTest {
     @BeforeEach
     public void setup() {
 
-        tenantService = mock(TenantClientFactory.class);
-        when(tenantService.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+        tenantClientFactory = mock(TenantClientFactory.class);
+        when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
         registrationClientFactory = mock(RegistrationClientFactory.class);
         when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
@@ -126,11 +132,15 @@ public class AbstractProtocolAdapterBaseTest {
         deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
         when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
+        connectionEventProducerContext = mock(ConnectionEventProducer.Context.class);
+        when(connectionEventProducerContext.getMessageSenderClient()).thenReturn(downstreamSenderFactory);
+        when(connectionEventProducerContext.getTenantClientFactory()).thenReturn(tenantClientFactory);
+
         commandTargetMapper = mock(CommandTargetMapper.class);
 
         properties = new ProtocolAdapterProperties();
         adapter = newProtocolAdapter(properties);
-        adapter.setTenantClientFactory(tenantService);
+        adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setDownstreamSenderFactory(downstreamSenderFactory);
@@ -160,7 +170,7 @@ public class AbstractProtocolAdapterBaseTest {
 
         // GIVEN an adapter that does not define a type name
         adapter = newProtocolAdapter(properties, null);
-        adapter.setTenantClientFactory(tenantService);
+        adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setDownstreamSenderFactory(downstreamSenderFactory);
@@ -196,7 +206,7 @@ public class AbstractProtocolAdapterBaseTest {
         // WHEN starting the adapter
         adapter.startInternal().setHandler(ctx.succeeding(ok -> ctx.verify(() -> {
             // THEN the service clients have connected
-            verify(tenantService).connect();
+            verify(tenantClientFactory).connect();
             verify(registrationClientFactory).connect();
             verify(downstreamSenderFactory).connect();
             verify(credentialsClientFactory).connect();
@@ -256,7 +266,7 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.setCredentialsClientFactory(credentialsClientFactory);
         adapter.setDownstreamSenderFactory(downstreamSenderFactory);
         adapter.setRegistrationClientFactory(registrationClientFactory);
-        adapter.setTenantClientFactory(tenantService);
+        adapter.setTenantClientFactory(tenantClientFactory);
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
         adapter.setCommandTargetMapper(commandTargetMapper);
@@ -684,6 +694,44 @@ public class AbstractProtocolAdapterBaseTest {
                             is(HttpURLConnection.HTTP_FORBIDDEN)));
                     ctx.completeNow();
                 }));
+    }
+
+    /**
+     * Verifies that the (default) ConnectionEvent API configured for a protocol adapter
+     * sets the connection event message's TTL header value before forwarding the message
+     * to downstream aoplications.
+     * 
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void tesForwardedConnectionEventMessageHasTtlHeaderSet(final VertxTestContext ctx) {
+
+        // GIVEN a protocol adapter configured to send connection events
+        final ConnectionEventProducer connectionEventProducer = new HonoEventConnectionEventProducer();
+        adapter.setConnectionEventProducer(connectionEventProducer);
+        final DownstreamSender connectionEventSender = mock(DownstreamSender.class);
+        when(connectionEventSender.send(any(Message.class))).thenReturn(Future.succeededFuture());
+        when(downstreamSenderFactory.getOrCreateEventSender(Constants.DEFAULT_TENANT)).thenReturn(Future.succeededFuture(connectionEventSender));
+
+        // WHEN a device, belonging to a tenant for which a max TTL is configured, connects to such an adapter
+        final Device authenticatedDevice = new Device(Constants.DEFAULT_TENANT, "4711");
+        final TenantClient tenantClient = mock(TenantClient.class);
+        when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
+        final TenantObject tenantObject = TenantObject.from(Constants.DEFAULT_TENANT, true);
+        final ResourceLimits tenantLimits = mock(ResourceLimits.class);
+        when(tenantLimits.getMaxTtl()).thenReturn(5L);
+        tenantObject.setResourceLimits(tenantLimits);
+        when(tenantClient.get(Constants.DEFAULT_TENANT)).thenReturn(Future.succeededFuture(tenantObject));
+
+        // THEN the adapter forwards the connection event message downstream
+        adapter.sendConnectedEvent("remote-id", authenticatedDevice).setHandler(ctx.succeeding(result -> {
+            final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+            verify(connectionEventSender).send(messageCaptor.capture());
+
+            // AND the forwarded connection event message contains the TTL value (in milliseconds) in its header
+            ctx.verify(() -> assertThat(messageCaptor.getValue().getTtl(), is(Duration.ofSeconds(5L).toMillis())));
+            ctx.completeNow();
+        }));
     }
 
     private AbstractProtocolAdapterBase<ProtocolAdapterProperties> newProtocolAdapter(final ProtocolAdapterProperties props) {

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -699,12 +699,12 @@ public class AbstractProtocolAdapterBaseTest {
     /**
      * Verifies that the (default) ConnectionEvent API configured for a protocol adapter
      * sets the connection event message's TTL header value before forwarding the message
-     * to downstream aoplications.
+     * to downstream applications.
      * 
      * @param ctx The vert.x test context.
      */
     @Test
-    public void tesForwardedConnectionEventMessageHasTtlHeaderSet(final VertxTestContext ctx) {
+    public void testForwardedConnectionEventMessageHasTtlHeaderSet(final VertxTestContext ctx) {
 
         // GIVEN a protocol adapter configured to send connection events
         final ConnectionEventProducer connectionEventProducer = new HonoEventConnectionEventProducer();
@@ -718,8 +718,8 @@ public class AbstractProtocolAdapterBaseTest {
         final TenantClient tenantClient = mock(TenantClient.class);
         when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
         final TenantObject tenantObject = TenantObject.from(Constants.DEFAULT_TENANT, true);
-        final ResourceLimits tenantLimits = mock(ResourceLimits.class);
-        when(tenantLimits.getMaxTtl()).thenReturn(5L);
+        final ResourceLimits tenantLimits = new ResourceLimits();
+        tenantLimits.setMaxTtl(5L);
         tenantObject.setResourceLimits(tenantLimits);
         when(tenantClient.get(Constants.DEFAULT_TENANT)).thenReturn(Future.succeededFuture(tenantObject));
 


### PR DESCRIPTION
fixes #1714

-  I placed the TTL config parameter in the `ClientConfigProperties` since protocol adapters connect to the messaging network to forward the `connection event` downstream. 
- I  currently set a default TTL value of 5 secs. Users can change the default  value  to any non-negative value by changing the corresponding config property.

@sophokles73 I was thinking of allowing  the  option  to set the value to `-1` if  a connection event message should be  keep in the broker (forever) until  it is consumed. WDYT? maybe this value would make a more sensible default?

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>