### PR TITLE
Allow setting the name of the cache, explicitly mention sasl realm

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CommonCacheConfig.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CommonCacheConfig.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceconnection.infinispan.client;
+
+import org.eclipse.hono.util.DeviceConnectionConstants;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Common cache configuration options.
+ */
+public class CommonCacheConfig {
+
+    private String cacheName = DeviceConnectionConstants.DEFAULT_CACHE_NAME;
+
+    private String checkKey = "KEY_CONNECTION_CHECK";
+    private String checkValue = "VALUE_CONNECTION_CHECK";
+
+    public void setCacheName(final String cacheName) {
+        this.cacheName = cacheName;
+    }
+
+    public String getCacheName() {
+        return cacheName;
+    }
+
+    public void setCheckKey(final String checkKey) {
+        this.checkKey = checkKey;
+    }
+
+    public String getCheckKey() {
+        return checkKey;
+    }
+
+    public void setCheckValue(final String checkValue) {
+        this.checkValue = checkValue;
+    }
+
+    public String getCheckValue() {
+        return checkValue;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects
+                .toStringHelper(this)
+                .add("cacheName", this.cacheName)
+                .add("checkKey", this.checkKey)
+                .add("checkValue", this.checkValue)
+                .toString();
+    }
+}

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCacheConfig.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCacheConfig.java
@@ -37,7 +37,7 @@ public class HotrodCacheConfig {
     /**
      * Gets properties for configuring the connection to the Infinispan
      * data grid that contains device connection information.
-     * 
+     *
      * @return The properties.
      */
     @Bean
@@ -50,7 +50,7 @@ public class HotrodCacheConfig {
     /**
      * Exposes the Infinispan data grid that contains device connection information
      * as a remote cache manager.
-     * 
+     *
      * @return The newly created cache manager. The manager will not be started.
      */
     @Bean
@@ -65,17 +65,18 @@ public class HotrodCacheConfig {
      * connection information.
      *
      * @param vertx The vert.x instance to run on.
+     * @param cacheConfig Common cache configuration options.
      * @return The cache.
      */
     @Bean
     @ConditionalOnProperty(prefix = "hono.device-connection", name = "server-list")
-    public HotrodCache<String, String> remoteCache(final Vertx vertx) {
+    public HotrodCache<String, String> remoteCache(final Vertx vertx, final CommonCacheConfig cacheConfig) {
         return new HotrodCache<>(
                 vertx,
                 remoteCacheManager(),
-                DeviceConnectionConstants.CACHE_NAME,
-                "KEY_CHECK_CONNECTION",
-                "VALUE_CHECK_CONNECTION");
+                cacheConfig.getCacheName(),
+                cacheConfig.getCheckKey(),
+                cacheConfig.getCheckValue());
     }
 
     /**
@@ -93,5 +94,17 @@ public class HotrodCacheConfig {
     public BasicDeviceConnectionClientFactory hotrodBasedDeviceConnectionClientFactory(
             final HotrodCache<String, String> cache, final Optional<Tracer> tracer) {
         return new CacheBasedDeviceConnectionClientFactory(cache, tracer.orElse(NoopTracerFactory.create()));
+    }
+
+    /**
+     * Gets properties for configuring the service's common cache aspects.
+     *
+     * @return The properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.device-connection.common")
+    @ConditionalOnProperty(prefix = "hono.device-connection", name = "server-list")
+    public CommonCacheConfig commonCacheConfig() {
+        return new CommonCacheConfig();
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/DeviceConnectionConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/DeviceConnectionConstants.java
@@ -20,10 +20,10 @@ package org.eclipse.hono.util;
 public final class DeviceConnectionConstants extends RequestResponseApiConstants {
 
     /**
-     * The name of the (remote) cache in the data grid that is use for
+     * The default name of the (remote) cache in the data grid that is use for
      * storing device connection information.
      */
-    public static final String CACHE_NAME = "device-connection";
+    public static final String DEFAULT_CACHE_NAME = "device-connection";
 
     /**
      * The name of the field that contains the identifier of a gateway.
@@ -98,7 +98,7 @@ public final class DeviceConnectionConstants extends RequestResponseApiConstants
 
         /**
          * Gets the AMQP message subject corresponding to this action.
-         * 
+         *
          * @return The subject.
          */
         public String getSubject() {

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/ApplicationConfig.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/ApplicationConfig.java
@@ -21,6 +21,7 @@ import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.config.VertxProperties;
 import org.eclipse.hono.deviceconnection.infinispan.client.BasicCache;
 import org.eclipse.hono.deviceconnection.infinispan.client.CacheBasedDeviceConnectionInfo;
+import org.eclipse.hono.deviceconnection.infinispan.client.CommonCacheConfig;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.amqp.AmqpEndpoint;
@@ -153,7 +154,7 @@ public class ApplicationConfig {
     @Bean
     @Scope("prototype")
     public AmqpEndpoint deviceConnectionAmqpEndpoint(final DeviceConnectionService service) {
-        return new DelegatingDeviceConnectionAmqpEndpoint<DeviceConnectionService>(vertx(), service);
+        return new DelegatingDeviceConnectionAmqpEndpoint<>(vertx(), service);
     }
 
     /**
@@ -202,4 +203,16 @@ public class ApplicationConfig {
     public HealthCheckServer healthCheckServer() {
         return new VertxBasedHealthCheckServer(vertx(), healthCheckProperties());
     }
+
+    /**
+     * Gets properties for configuring the service's common cache aspects.
+     *
+     * @return The properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.device-connection.common")
+    public CommonCacheConfig commonCacheConfig() {
+        return new CommonCacheConfig();
+    }
+
 }

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheConfig.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/RemoteCacheConfig.java
@@ -14,10 +14,12 @@
 package org.eclipse.hono.deviceconnection.infinispan;
 
 import org.eclipse.hono.deviceconnection.infinispan.client.BasicCache;
+import org.eclipse.hono.deviceconnection.infinispan.client.CommonCacheConfig;
 import org.eclipse.hono.deviceconnection.infinispan.client.HotrodCache;
 import org.eclipse.hono.deviceconnection.infinispan.client.InfinispanRemoteConfigurationProperties;
-import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,13 +34,15 @@ import io.vertx.core.Vertx;
 @Profile("!" + ApplicationConfig.PROFILE_EMBEDDED_CACHE)
 public class RemoteCacheConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(RemoteCacheConfig.class);
+
     /**
      * Gets properties for configuring the connection to the remote cache.
      *
      * @return The properties.
      */
     @Bean
-    @ConfigurationProperties(prefix = "hono.device-connection.remote")
+    @ConfigurationProperties("hono.device-connection.remote")
     public InfinispanRemoteConfigurationProperties remoteCacheProperties() {
         return new InfinispanRemoteConfigurationProperties();
     }
@@ -59,16 +63,18 @@ public class RemoteCacheConfig {
      * connection information.
      *
      * @param vertx The vert.x instance to run on.
+     * @param cacheConfig Common cache configuration options.
      * @return The cache.
      */
     @Bean
-    public BasicCache<String, String> remoteCache(final Vertx vertx) {
+    public BasicCache<String, String> remoteCache(final Vertx vertx, final CommonCacheConfig cacheConfig) {
+        log.info("Common Config: {}", cacheConfig);
         return new HotrodCache<>(
                 vertx,
                 remoteCacheManager(),
-                DeviceConnectionConstants.CACHE_NAME,
-                "KEY_CONNECTION_CHECK",
-                "VALUE_CONNECTION_CHECK");
+                cacheConfig.getCacheName(),
+                cacheConfig.getCheckKey(),
+                cacheConfig.getCheckValue());
     }
 
 }

--- a/site/documentation/content/admin-guide/device-connection-config.md
+++ b/site/documentation/content/admin-guide/device-connection-config.md
@@ -90,18 +90,44 @@ The server may be configured to open both a secure and a non-secure port at the 
 
 ## Data Grid Connection Configuration
 
-The Device Connection component requires a connection to a remote data grid using the Infinispan Hotrod protocol to store device connection information in.
+The Device Connection component requires either an embedded cache or a remote
+data grid, using the Infinispan Hotrod protocol to store device information.
+
+The following table provides an overview of the configuration variables and corresponding command line options for configuring the common aspects of the service:
+
+| Environment Variable<br>Command Line Option | Mandatory | Default | Description                                                             |
+| :------------------------------------------ | :-------: | :------ | :-----------------------------------------------------------------------|
+| `HONO_DEVICECONNECTION_COMMON_CACHENAME`<br>`--hono.deviceConnection.common.cacheName` | no | `device-connection` | The name of the cache |
+| `HONO_DEVICECONNECTION_COMMON_CHECKKEY`<br>`--hono.deviceConnection.common.checkKey` | no | `KEY_CONNECTION_CHECK` | The key used to check the health of the cache. |
+| `HONO_DEVICECONNECTION_COMMON_CHECKVALUE`<br>`--hono.deviceConnection.common.checkValue` | no | `VALUE_CONNECTION_CHECK` | The value used to check the health of the cache. |
+
+The type of the cache is selected on startup by enabling or disabling the
+profile `embedded-cache`. If the profile is enabled the embedded cache is
+used, otherwise the remote cache is being used. The remote cache is the default.
+
+### Remote cache
 
 The following table provides an overview of the configuration variables and corresponding command line options for configuring the connection to the data grid:
 
 | Environment Variable<br>Command Line Option | Mandatory | Default | Description                                                             |
 | :------------------------------------------ | :-------: | :------ | :-----------------------------------------------------------------------|
-| `HONO_DEVICECONNECTION_REMOTE_SERVER_LIST`<br>`--hono.deviceConnection.remote.serverList` | yes | - | A list of remote servers in the form: `host1[:port][;host2[:port]]....`. |
-| `HONO_DEVICECONNECTION_REMOTE_AUTH_SERVER_NAME`<br>`--hono.deviceConnection.remote.authServerName` | yes | - | The server name to indicate in the SASL handshake when authenticating to the server. |
-| `HONO_DEVICECONNECTION_REMOTE_AUTH_USERNAME`<br>`--hono.deviceConnection.remote.authUsername` | yes | - | The username to use for authenticating to the server. |
-| `HONO_DEVICECONNECTION_REMOTE_AUTH_PASSWORD`<br>`--hono.deviceConnection.remote.authPassword` | yes | - | The password to use for authenticating to the server. |
+| `HONO_DEVICECONNECTION_REMOTE_SERVERLIST`<br>`--hono.deviceConnection.remote.serverList` | yes | - | A list of remote servers in the form: `host1[:port][;host2[:port]]....`. |
+| `HONO_DEVICECONNECTION_REMOTE_AUTHSERVERNAME`<br>`--hono.deviceConnection.remote.authServerName` | yes | - | The server name to indicate in the SASL handshake when authenticating to the server. |
+| `HONO_DEVICECONNECTION_REMOTE_AUTHREALM`<br>`--hono.deviceConnection.remote.authRealm` | yes | - | The authentication realm for the SASL handshake when authenticating to the server. |
+| `HONO_DEVICECONNECTION_REMOTE_AUTHUSERNAME`<br>`--hono.deviceConnection.remote.authUsername` | yes | - | The username to use for authenticating to the server. |
+| `HONO_DEVICECONNECTION_REMOTE_AUTHPASSWORD`<br>`--hono.deviceConnection.remote.authPassword` | yes | - | The password to use for authenticating to the server. |
 
 In general, the service supports all configuration properties of the [Infinispan Hotrod client](https://docs.jboss.org/infinispan/9.4/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html#package.description) using `hono.deviceConnection.remote` instead of the `infinispan.client.hotrod` prefix.
+
+### Embedded cache
+
+The following table provides an overview of the configuration variables and corresponding command line options for configuring the embedded cache:
+
+hono.device-connection.embedded.configuration-file
+
+| Environment Variable<br>Command Line Option | Mandatory | Default | Description                                                             |
+| :------------------------------------------ | :-------: | :------ | :-----------------------------------------------------------------------|
+| `HONO_DEVICECONNECTION_EMBEDDED_CONFIGURATIONFILE`<br>`--hono.deviceConnection.embedded.configurationFile` | yes | - | The absolute path to an Infinispan configuration file. Also see the [Infinispan Configuration Schema](https://docs.jboss.org/infinispan/9.4/configdocs/). |
 
 ## Authentication Service Connection Configuration
 


### PR DESCRIPTION
This allows providing a cache name for the Infinispan backend.

Additionally it mentions the *SASL realm* explicitly in the documentation.