### PR TITLE
[#1858] Don't treat removeCmdHandlingAdapterInstance 404 as error

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
@@ -122,7 +122,7 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
     }
 
     @Override
-    public Future<Void> removeCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
+    public Future<Boolean> removeCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
             final SpanContext context) {
         return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, context);
     }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfo.java
@@ -162,7 +162,7 @@ public final class CacheBasedDeviceConnectionInfo implements DeviceConnectionInf
     }
 
     @Override
-    public Future<Void> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
+    public Future<Boolean> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
             final String adapterInstanceId, final SpanContext context) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
@@ -177,16 +177,15 @@ public final class CacheBasedDeviceConnectionInfo implements DeviceConnectionInf
                             tenantId, deviceId, adapterInstanceId, t);
                     return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, t));
                 })
-                .compose(removed -> {
+                .map(removed -> {
                     if (!removed) {
                         LOG.debug("command handling adapter instance was not removed, key not mapped or value didn't match [tenant: {}, device-id: {}, adapter-instance: {}]",
                                 tenantId, deviceId, adapterInstanceId);
-                        return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
                     } else {
                         LOG.debug("removed command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}]",
                                 tenantId, deviceId, adapterInstanceId);
-                        return Future.succeededFuture();
                     }
+                    return removed;
                 });
 
     }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
@@ -99,13 +99,14 @@ public interface DeviceConnectionInfo {
      * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            Implementing classes should use this as the parent for any span they create for tracing
      *            the execution of this operation.
-     * @return A future indicating the outcome of the operation.
+     * @return A future indicating the outcome of the operation, with its value indicating whether the protocol
+     *         adapter instance value was removed or not.
      *         <p>
-     *         The future will be succeeded if the entry was successfully removed.
-     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     *         The future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} if there
+     *         was an error removing the value.
      * @throws NullPointerException if any of the parameters except context is {@code null}.
      */
-    Future<Void> removeCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId, SpanContext context);
+    Future<Boolean> removeCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId, SpanContext context);
 
     /**
      * Gets information about the adapter instances that can handle a command for the given device.

--- a/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
@@ -95,13 +95,14 @@ public interface DeviceConnectionClient extends RequestResponseClient {
      * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            An implementation should use this as the parent for any span it creates for tracing
      *            the execution of this operation.
-     * @return A future indicating the outcome of the operation.
+     * @return A future indicating the outcome of the operation, with its value indicating whether the protocol
+     *         adapter instance value was removed or not.
      *         <p>
-     *         The future will be succeeded if the entry was successfully removed.
-     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     *         The future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} if there
+     *         was an error removing the value.
      * @throws NullPointerException if device id or adapter instance id is {@code null}.
      */
-    Future<Void> removeCommandHandlingAdapterInstance(String deviceId, String adapterInstanceId, SpanContext context);
+    Future<Boolean> removeCommandHandlingAdapterInstance(String deviceId, String adapterInstanceId, SpanContext context);
 
     /**
      * Gets information about the adapter instances that can handle a command for the given device.

--- a/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientImpl.java
@@ -232,7 +232,7 @@ public class DeviceConnectionClientImpl extends AbstractRequestResponseClient<De
     }
 
     @Override
-    public Future<Void> removeCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId, final SpanContext context) {
+    public Future<Boolean> removeCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId, final SpanContext context) {
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(adapterInstanceId);
 
@@ -252,7 +252,9 @@ public class DeviceConnectionClientImpl extends AbstractRequestResponseClient<De
         return mapResultAndFinishSpan(resultTracker.future(), result -> {
             switch (result.getStatus()) {
                 case HttpURLConnection.HTTP_NO_CONTENT:
-                    return null;
+                    return Boolean.TRUE;
+                case HttpURLConnection.HTTP_NOT_FOUND:
+                    return Boolean.FALSE;
                 default:
                     throw StatusCodeMapper.from(result);
             }

--- a/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
@@ -135,8 +135,10 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
         when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
         when(deviceConnectionClientFactory.getOrCreateDeviceConnectionClient(anyString()))
                 .thenReturn(Future.succeededFuture(devConClient));
-        when(devConClient.setCommandHandlingAdapterInstance(anyString(), anyString(), any(), any())).thenReturn(Future.succeededFuture());
-        when(devConClient.removeCommandHandlingAdapterInstance(anyString(), anyString(), any())).thenReturn(Future.succeededFuture());
+        when(devConClient.setCommandHandlingAdapterInstance(anyString(), anyString(), any(), any()))
+                .thenReturn(Future.succeededFuture());
+        when(devConClient.removeCommandHandlingAdapterInstance(anyString(), anyString(), any()))
+                .thenReturn(Future.succeededFuture(Boolean.TRUE));
 
         commandConsumerFactory = new ProtocolAdapterCommandConsumerFactoryImpl(connection);
         commandConsumerFactory.initialize(commandTargetMapper, deviceConnectionClientFactory);

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
@@ -187,8 +187,8 @@ abstract class DeviceConnectionApiTests extends DeviceRegistryTestBase {
     }
 
     /**
-     * Verifies that a request to remove the command-handling adapter instance for a device fails if no
-     * adapter is registered for the device.
+     * Verifies that a request to remove the command-handling adapter instance for a device succeeds with
+     * a <em>false</em> value if no adapter is registered for the device.
      *
      * @param ctx The vert.x test context.
      */
@@ -200,8 +200,8 @@ abstract class DeviceConnectionApiTests extends DeviceRegistryTestBase {
 
         getClient(Constants.DEFAULT_TENANT)
             .compose(client -> client.removeCommandHandlingAdapterInstance(deviceId, "", null))
-            .setHandler(ctx.failing(t -> {
-                ctx.verify(() -> assertErrorCode(t, HttpURLConnection.HTTP_NOT_FOUND));
+            .setHandler(ctx.succeeding(result -> {
+                ctx.verify(() -> assertThat(result).isFalse());
                 ctx.completeNow();
             }));
     }


### PR DESCRIPTION
This is for #1858 and replaces #1922:
"Command handling adapter instance" entries may expire.
Therefore, getting a NOT FOUND result when invoking `removeCommandHandlingAdapterInstance()` shouldn't be treated as an error.

For that, the `DeviceConnectionClient.removeCommandHandlingAdapterInstance` method has been changed to return a `Future<Boolean>` now (instead of `Future<Void>`), with a `false` value returned if a NOT FOUND was received from the server.

When a command consumer is closed, the `removeCommandHandlingAdapterInstance` method is still called every time - just to be on the safe side, even though the entry might have been already deleted because it has expired.