### PR TITLE
Externalize opentracing by default

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -137,11 +137,8 @@
             <Include-Resource>
               META-INF=${project.build.outputDirectory}/META-INF
             </Include-Resource>
-            <Export-Package>
-              {local-packages}
-            </Export-Package>
             <Require-Capability>
-              osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=${java.level}))"
+              osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=${maven.compiler.target}))"
             </Require-Capability>
           </instructions>
         </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -186,22 +186,8 @@
             <Include-Resource>
               META-INF=${project.build.outputDirectory}/META-INF
             </Include-Resource>
-            <!--
-              The OpenTracing API artifact is not a bundle, so we inline
-              and export its packages.
-            -->
-            <Export-Package>
-              io.opentracing*;version=${opentracing.version},
-              org.springframework.security.crypto*;version=${spring-security-crypto.version},
-              {local-packages}
-            </Export-Package>
-            <Embed-Dependency>
-              opentracing-api;inline=true,
-              opentracing-noop;inline=true,
-              spring-security-crypto;inline=true
-            </Embed-Dependency>
             <Require-Capability>
-              osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=${java.level}))"
+              osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=${maven.compiler.target}))"
             </Require-Capability>
           </instructions>
         </configuration>
@@ -212,4 +198,38 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>embed-dependencies</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <extensions>true</extensions>
+            <configuration>
+              <instructions>
+                <!--
+                  The OpenTracing API and Spring Crypto artifacts are not an
+                  OSGi bundle, so we inline and export its packages.
+                -->
+                <Export-Package>
+                  io.opentracing*;version=${opentracing.version},
+                  org.springframework.security.crypto*;version=${spring-security-crypto.version},
+                  {local-packages}
+                </Export-Package>
+                <Embed-Dependency>
+                  opentracing-api;inline=true,
+                  opentracing-noop;inline=true,
+                  spring-security-crypto;inline=true
+                </Embed-Dependency>
+              </instructions>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -45,6 +45,11 @@ title = "Release Notes"
 * The *set command-handling protocol adapter instance* operation of the *Device Connection* API
   has been extended to support an additional parameter which can be used to indicate the
   maximum amount of time that the given information is to be considered valid.
+* The `hono-core` module no longer embeds any external classes by default.
+  This includes the *OpenTracing API* and *Spring Crypto* classes. You can still
+  embed the classes, as in Hono versions 1.2.x and before, by enabling the
+  Maven profile `embed-dependencies` (e.g using the command line switch
+  `-Pembed-dependencies`). By default this profile is not active.
 
 ## 1.2.2
 


### PR DESCRIPTION
This removes the embedded OpenTracing API dependencies and adds a new profile named `embed-opentracing` which brings back the original behavior. However, this profile is not enabled by default.

IIRC this was the plan I discussed with @sophokles73 during BCX, the make it possible not-include the opentracing API, but also keep the current behavior as an option.

Additionally this PR fixes the OSGi ExecutionEnvironment configuration, which was still using the `java.level` property, which was removed a while back.