### PR TITLE
Let removeCommandHandlingAdapterInstance() return 412 if not removed

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientImpl.java
@@ -254,6 +254,7 @@ public class DeviceConnectionClientImpl extends AbstractRequestResponseClient<De
                 case HttpURLConnection.HTTP_NO_CONTENT:
                     return Boolean.TRUE;
                 case HttpURLConnection.HTTP_NOT_FOUND:
+                case HttpURLConnection.HTTP_PRECON_FAILED:
                     return Boolean.FALSE;
                 default:
                     throw StatusCodeMapper.from(result);

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
@@ -90,7 +90,8 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
     public Future<DeviceConnectionResult> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
             final String adapterInstanceId, final Span span) {
         return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span.context())
-                .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
+                .map(removed -> removed ? DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT)
+                        : DeviceConnectionResult.from(HttpURLConnection.HTTP_PRECON_FAILED))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
 

--- a/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
+++ b/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
@@ -52,7 +52,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
-public class RemoteCacheBasedDeviceConnectionServiceTest {
+public class CacheBasedDeviceConnectionServiceTest {
 
     private CacheBasedDeviceConnectionService svc;
     private Span span;
@@ -171,5 +171,57 @@ public class RemoteCacheBasedDeviceConnectionServiceTest {
             });
             ctx.completeNow();
         }));
+    }
+
+    /**
+     * Verifies that the <em>removeCommandHandlingAdapterInstance</em> operation succeeds, invokes the
+     * corresponding method on the {@link DeviceConnectionInfo} instance, and returns the correct status code.
+     * This test uses a {@code true} return value of <em>removeCommandHandlingAdapterInstance</em>.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceReturningTrue(final VertxTestContext ctx) {
+
+        final String deviceId = "testDevice";
+        final String adapterInstanceId = "adapterInstanceId";
+        when(cache.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(SpanContext.class)))
+                .thenReturn(Future.succeededFuture(true));
+
+        givenAStartedService()
+                .compose(ok -> svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstanceId, span))
+                .setHandler(ctx.succeeding(result -> {
+                    ctx.verify(() -> {
+                        assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
+                        verify(cache).removeCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(SpanContext.class));
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that the <em>removeCommandHandlingAdapterInstance</em> operation succeeds, invokes the
+     * corresponding method on the {@link DeviceConnectionInfo} instance, and returns the correct status code.
+     * This test uses a {@code false} return value of <em>removeCommandHandlingAdapterInstance</em>.
+     *
+     * @param ctx The vert.x context.
+     */
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceReturningFalse(final VertxTestContext ctx) {
+
+        final String deviceId = "testDevice";
+        final String adapterInstanceId = "adapterInstanceId";
+        when(cache.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(SpanContext.class)))
+                .thenReturn(Future.succeededFuture(false));
+
+        givenAStartedService()
+                .compose(ok -> svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstanceId, span))
+                .setHandler(ctx.succeeding(result -> {
+                    ctx.verify(() -> {
+                        assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
+                        verify(cache).removeCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(SpanContext.class));
+                    });
+                    ctx.completeNow();
+                }));
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionService.java
@@ -203,7 +203,7 @@ public class MapBasedDeviceConnectionService implements DeviceConnectionService 
                 resultFuture = Future.succeededFuture(DeviceConnectionResult.from(HttpURLConnection.HTTP_PRECON_FAILED));
             }
         } else {
-            resultFuture = Future.succeededFuture(DeviceConnectionResult.from(HttpURLConnection.HTTP_NOT_FOUND));
+            resultFuture = Future.succeededFuture(DeviceConnectionResult.from(HttpURLConnection.HTTP_PRECON_FAILED));
         }
         return resultFuture;
     }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionServiceTest.java
@@ -297,7 +297,7 @@ public class MapBasedDeviceConnectionServiceTest {
                     return svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, "otherDevice",
                             adapterInstance, span);
                 }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
-                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    assertEquals(HttpURLConnection.HTTP_PRECON_FAILED, result.getStatus());
                     assertNull(result.getPayload());
                     ctx.completeNow();
                 })));
@@ -353,7 +353,7 @@ public class MapBasedDeviceConnectionServiceTest {
                     });
                     return instancesPromise.future();
                 }).setHandler(ctx.succeeding(result -> ctx.verify(() -> {
-                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                    assertEquals(HttpURLConnection.HTTP_PRECON_FAILED, result.getStatus());
                     assertNull(result.getPayload());
                     ctx.completeNow();
                 })));

--- a/site/documentation/content/api/device-connection/index.md
+++ b/site/documentation/content/api/device-connection/index.md
@@ -181,10 +181,9 @@ The response message's *status* property may contain the following codes:
 | :---- | :---------- |
 | *204* | OK, the adapter instance mapping information for the device has been removed. |
 | *400* | Bad Request, the request message does not contain all required properties. |
-| *404* | Not Found, there is no matching command-handling adapter instance assigned to the device. |
+| *412* | Precondition failed, the adapter instance for the device has not been removed because there is no matching command-handling adapter instance assigned to the device. |
 
 Implementors of this API may return a *404* status code in order to indicate that no device with the given identifier exists for the given tenant. However, performing such a check is optional.
-In case the currently mapped adapter instance doesn't match the given adapter instance id, a *412* status code may also be returned instead of *404*.
 
 For status codes indicating an error (codes in the `400 - 499` range) the message body MAY contain a detailed description of the error that occurred.
 

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
@@ -249,6 +249,32 @@ abstract class DeviceConnectionApiTests extends DeviceRegistryTestBase {
 
     /**
      * Verifies that a request to remove the command-handling adapter instance for a device succeeds with
+     * a <em>true</em> value if there was a matching adapter instance entry.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
+
+        final String deviceId = randomId();
+        final String adapterInstance = randomId();
+
+        getClient(Constants.DEFAULT_TENANT)
+                // add the entry
+                .compose(client -> client
+                        .setCommandHandlingAdapterInstance(deviceId, adapterInstance, null, false, null)
+                        .map(client))
+                // then remove it
+                .compose(client -> client.removeCommandHandlingAdapterInstance(deviceId, adapterInstance, null))
+                .setHandler(ctx.succeeding(result -> {
+                    ctx.verify(() -> assertThat(result).isTrue());
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that a request to remove the command-handling adapter instance for a device succeeds with
      * a <em>false</em> value if no adapter is registered for the device.
      *
      * @param ctx The vert.x test context.


### PR DESCRIPTION
This is based on the discussion in https://github.com/eclipse/hono/pull/1936#discussion_r419448211:

The Device Connection API method `removeCommandHandlingAdapterInstance` now returns a `412` status code if no entry has been removed.
Previously, a return status code of `404` was documented, with `412` being an optional alternative.
Now using `412` aligns the definition with the one from the `setCommandHandlingAdapterInstance` method (see #1936).

This PR also fixes a bug in `CacheBasedDeviceConnectionService.removeCommandHandlingAdapterInstance()` where a "not found" result wasn't propagated in the `DeviceConnectionResult` (relates to https://github.com/eclipse/hono/pull/1926).
