### PR TITLE
[#1632] Close MQTT connection when ack timeout has occurred

### DIFF
--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -924,10 +924,10 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(msg.messageId()).thenReturn(15);
         when(msg.topicSubscriptions()).thenReturn(subscriptions);
 
-        final CommandHandler<MqttProtocolAdapterProperties> cmdHandler = new CommandHandler<>(vertx, config);
+        final CommandSubscriptionsManager<MqttProtocolAdapterProperties> cmdSubscriptionsManager = new CommandSubscriptionsManager<>(vertx, config);
         endpoint.closeHandler(
-                handler -> adapter.close(endpoint, new Device("tenant", "deviceId"), cmdHandler, OptionalInt.empty()));
-        adapter.onSubscribe(endpoint, null, msg, cmdHandler, OptionalInt.empty());
+                handler -> adapter.close(endpoint, new Device("tenant", "deviceId"), cmdSubscriptionsManager, OptionalInt.empty()));
+        adapter.onSubscribe(endpoint, null, msg, cmdSubscriptionsManager, OptionalInt.empty());
 
         // THEN the adapter creates a command consumer that is checked periodically
         verify(commandConsumerFactory).createCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class), any(), any());
@@ -978,7 +978,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(msg.messageId()).thenReturn(15);
         when(msg.topicSubscriptions()).thenReturn(subscriptions);
 
-        adapter.onSubscribe(endpoint, null, msg, new CommandHandler<>(vertx, config), OptionalInt.empty());
+        adapter.onSubscribe(endpoint, null, msg, new CommandSubscriptionsManager<>(vertx, config), OptionalInt.empty());
 
         // THEN the adapter sends a SUBACK packet to the device
         // which contains a failure status code for each unsupported filter

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -15,9 +15,11 @@ package org.eclipse.hono.tests.mqtt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -31,6 +33,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.MessageSender;
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.CommandEndpointConfiguration.SubscriberRole;
 import org.eclipse.hono.tests.IntegrationTestSupport;
@@ -44,15 +47,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.mqtt.MqttPubAckMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.NetSocketInternal;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.mqtt.impl.MqttClientImpl;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import io.vertx.proton.ProtonHelper;
 
@@ -402,5 +411,155 @@ public class CommandAndControlMqttIT extends MqttTestBase {
             ctx.verify(() -> assertThat(t).isInstanceOf(ClientErrorException.class));
             failedAttempts.flag();
         }));
+    }
+
+    /**
+     * Verifies that the adapter forwards the <em>released</em> disposition back to the
+     * application if the device hasn't sent an acknowledgement for the command message
+     * published to the device.
+     *
+     * @param endpointConfig The endpoints to use for sending/receiving commands.
+     * @param ctx The vert.x test context.
+     * @throws InterruptedException if not all commands and responses are exchanged in time.
+     */
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("allCombinations")
+    @Timeout(timeUnit = TimeUnit.SECONDS, value = 20)
+    public void testSendCommandFailsForCommandNotAcknowledgedByDevice(
+            final MqttCommandEndpointConfiguration endpointConfig,
+            final VertxTestContext ctx) throws InterruptedException {
+
+        final MqttQoS subscribeQos = MqttQoS.AT_LEAST_ONCE;
+
+        final VertxTestContext setup = new VertxTestContext();
+        final Checkpoint ready = setup.checkpoint(2);
+
+        final String commandTargetDeviceId = endpointConfig.isSubscribeAsGateway()
+                ? helper.setupGatewayDeviceBlocking(tenantId, deviceId, 5)
+                : deviceId;
+
+        final int totalNoOfCommandsToSend = 3;
+        final CountDownLatch commandsFailed = new CountDownLatch(totalNoOfCommandsToSend);
+        final AtomicInteger receivedMessagesCounter = new AtomicInteger(0);
+        final AtomicInteger counter = new AtomicInteger();
+        final Handler<MqttPublishMessage> commandConsumer = msg -> {
+            LOGGER.trace("received command [{}] - no response sent here", msg.topicName());
+            final ResourceIdentifier topic = ResourceIdentifier.fromString(msg.topicName());
+            ctx.verify(() -> {
+                endpointConfig.assertCommandPublishTopicStructure(topic, commandTargetDeviceId, false, "setValue");
+            });
+            receivedMessagesCounter.incrementAndGet();
+        };
+        final Function<Buffer, Future<?>> commandSender = payload -> {
+            return helper.sendCommand(tenantId, commandTargetDeviceId, "setValue", "text/plain", payload,
+                    // set "forceCommandRerouting" message property so that half the command are rerouted via the AMQP network
+                    IntegrationTestSupport.newCommandMessageProperties(() -> counter.getAndIncrement() >= COMMANDS_TO_SEND / 2),
+                    200);
+        };
+
+        helper.registry
+                .addDeviceForTenant(tenantId, tenant, deviceId, password)
+                .compose(ok -> connectToAdapter(IntegrationTestSupport.getUsername(deviceId, tenantId), password))
+                // let the MqttClient skip sending the PubAck messages
+                .compose(ok -> injectMqttClientPubAckBlocker(new AtomicBoolean(true)))
+                .compose(ok -> createConsumer(tenantId, msg -> {
+                    // expect empty notification with TTD -1
+                    setup.verify(() -> assertThat(msg.getContentType()).isEqualTo(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION));
+                    final TimeUntilDisconnectNotification notification = TimeUntilDisconnectNotification.fromMessage(msg).orElse(null);
+                    LOGGER.info("received notification [{}]", notification);
+                    setup.verify(() -> assertThat(notification).isNotNull());
+                    if (notification.getTtd() == -1) {
+                        ready.flag();
+                    }
+                }))
+                .compose(conAck -> subscribeToCommands(commandTargetDeviceId, commandConsumer, endpointConfig, subscribeQos))
+                .setHandler(setup.succeeding(ok -> ready.flag()));
+
+        assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
+        if (setup.failed()) {
+            ctx.failNow(setup.causeOfFailure());
+        }
+
+        final AtomicInteger commandsSent = new AtomicInteger(0);
+        final AtomicLong lastReceivedTimestamp = new AtomicLong(0);
+        final long start = System.currentTimeMillis();
+
+        while (commandsSent.get() < totalNoOfCommandsToSend) {
+            final CountDownLatch commandSent = new CountDownLatch(1);
+            context.runOnContext(go -> {
+                final Buffer msg = Buffer.buffer("value: " + commandsSent.getAndIncrement());
+                commandSender.apply(msg).setHandler(sendAttempt -> {
+                    if (sendAttempt.succeeded()) {
+                        LOGGER.debug("sending command {} succeeded unexpectedly", commandsSent.get());
+                    } else {
+                        if (sendAttempt.cause() instanceof ServerErrorException
+                                && ((ServerErrorException) sendAttempt.cause()).getErrorCode() == HttpURLConnection.HTTP_UNAVAILABLE) {
+                            LOGGER.debug("sending command {} failed as expected: {}", commandsSent.get(),
+                                    sendAttempt.cause().toString());
+                            lastReceivedTimestamp.set(System.currentTimeMillis());
+                            commandsFailed.countDown();
+                            if (commandsFailed.getCount() % 20 == 0) {
+                                LOGGER.info("commands failed as expected: {}",
+                                        totalNoOfCommandsToSend - commandsFailed.getCount());
+                            }
+                        } else {
+                            LOGGER.debug("sending command {} failed with an unexpected error", commandsSent.get(),
+                                    sendAttempt.cause());
+                        }
+                    }
+                    if (commandsSent.get() % 20 == 0) {
+                        LOGGER.info("commands sent: " + commandsSent.get());
+                    }
+                    commandSent.countDown();
+                });
+            });
+
+            commandSent.await();
+        }
+
+        // have to wait more than MqttAdapterProperties.DEFAULT_COMMAND_ACK_TIMEOUT (100ms) for the first command message
+        final long timeToWait = 130 + ((totalNoOfCommandsToSend - 1) * 300);
+        if (!commandsFailed.await(timeToWait, TimeUnit.MILLISECONDS)) {
+            LOGGER.info("Timeout of {} milliseconds reached, stop waiting for commands", timeToWait);
+        }
+        // assert that only the first command message has reached the device,
+        // subsequent command messages shouldn't have come so far because the adapter has closed device connection and command consumer
+        // after it didn't get the PubAck for the first command
+        assertThat(receivedMessagesCounter.get()).isEqualTo(1);
+        final long commandsCompleted = totalNoOfCommandsToSend - commandsFailed.getCount();
+        LOGGER.info("commands sent: {}, commands failed: {} after {} milliseconds",
+                commandsSent.get(), commandsCompleted, lastReceivedTimestamp.get() - start);
+        if (commandsCompleted == commandsSent.get()) {
+            ctx.completeNow();
+        } else {
+            ctx.failNow(new java.lang.IllegalStateException("did not complete all commands sent"));
+        }
+    }
+
+    private Future<Void> injectMqttClientPubAckBlocker(final AtomicBoolean outboundPubAckBlocked) {
+        // The vert.x MqttClient automatically sends a PubAck after having received a Qos 1 Publish message,
+        // as of now, there is no configuration option to prevent this (see https://github.com/vert-x3/vertx-mqtt/issues/120).
+        // Therefore the underlying NetSocket pipeline is used here to filter out the outbound PubAck messages.
+        try {
+            final Method connectionMethod = MqttClientImpl.class.getDeclaredMethod("connection");
+            connectionMethod.setAccessible(true);
+            final NetSocketInternal connection = (NetSocketInternal) connectionMethod.invoke(mqttClient);
+            connection.channelHandlerContext().pipeline().addBefore("handler", "OutboundPubAckBlocker",
+                    new ChannelOutboundHandlerAdapter() {
+                @Override
+                public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise)
+                        throws Exception {
+                    if (outboundPubAckBlocked.get() && msg instanceof io.netty.handler.codec.mqtt.MqttPubAckMessage) {
+                        LOGGER.debug("suppressing PubAck, message id: {}", ((MqttPubAckMessage) msg).variableHeader().messageId());
+                    } else {
+                        super.write(ctx, msg, promise);
+                    }
+                }
+            });
+            return Future.succeededFuture();
+        } catch (final Exception e) {
+            LOGGER.error("failed to inject PubAck blocking handler");
+            return Future.failedFuture(new Exception("failed to inject PubAck blocking handler", e));
+        }
     }
 }


### PR DESCRIPTION
This is for #1632:
When the MQTT adapter sends a command (with Qos 1) to the device and doesn't receive an acknowledgement in time, the MQTT connection is now closed, a disconnect notification is sent downstream and the command consumer is closed.

I've done some refactoring here regarding the place where the `ackTimeout` and also `handlePubAck()` logic is located:
Previously, some parts were in `CommandHandler`, others in `AbstractVertxBasedMqttProtocolAdapter`, with the needed objects for the logic being passed between the two. The `ackTimeout` was handled in `CommandHandler.startTimer()`.
I found that somewhat confusing. 

Now, the `ackTimeout` and `handlePubAck()` logic is defined in two Handlers in `AbstractVertxBasedMqttProtocolAdapter.afterCommandPublished`, with these Handlers passed along to the `CommandSubscriptionsManager` (renamed from `CommandHandler`) which will invoke the Handlers when needed.
(Along the way, trace handling in `handlePubAck()` was also fixed (`span.log()` had been called after  the span was already finished).)

The main new behaviour is, that in the `ackTimeout` handling, the MQTT connection with the device is disconnected now.
The needed followup-actions (removal of subscription and command consumer) are done in the `close` method of the adapter, triggered by the lost connection.