### PR TITLE
Removes the usage of setHandler()

### DIFF
--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -724,7 +724,7 @@ public class AbstractProtocolAdapterBaseTest {
         when(tenantClient.get(Constants.DEFAULT_TENANT)).thenReturn(Future.succeededFuture(tenantObject));
 
         // THEN the adapter forwards the connection event message downstream
-        adapter.sendConnectedEvent("remote-id", authenticatedDevice).setHandler(ctx.succeeding(result -> {
+        adapter.sendConnectedEvent("remote-id", authenticatedDevice).onComplete(ctx.succeeding(result -> {
             final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
             verify(connectionEventSender).send(messageCaptor.capture());
 


### PR DESCRIPTION
Revision c2819c3 removes usage of the deprecate `setHandler()` API with `onComplete()`. This affects the recently merged #1923 pull request.

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>