### PR TITLE
Refactor MQTT "afterCommandPublished" handling, fix tracing, add test

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.qpid.proton.message.Message;
@@ -111,8 +109,6 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
     private MqttServer server;
     private MqttServer insecureServer;
     private AuthHandler<MqttContext> authHandler;
-    private final Function<TenantObject, BiConsumer<CommandSubscription, CommandContext>> afterCommandPublished = tenantObject -> (
-            subscription, commandContext) -> afterCommandPublished(tenantObject, subscription, commandContext);
     private ExecutionContextTenantAndAuthIdProvider<MqttContext> tenantObjectWithAuthIdProvider;
 
     /**
@@ -465,9 +461,10 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
      * the {@linkplain MqttProtocolAdapterProperties#isAuthenticationRequired() authentication required} configuration
      * property to {@code false}.
      * <p>
-     * Registers a close handler on the endpoint which invokes {@link #close(MqttEndpoint, Device, CommandHandler, OptionalInt)}. Registers a publish
-     * handler on the endpoint which invokes {@link #onPublishedMessage(MqttContext)} for each message being published
-     * by the client. Accepts the connection request.
+     * Registers a close handler on the endpoint which invokes
+     * {@link #close(MqttEndpoint, Device, CommandSubscriptionsManager, OptionalInt)}. Registers a publish handler on
+     * the endpoint which invokes {@link #onPublishedMessage(MqttContext)} for each message being published by the
+     * client. Accepts the connection request.
      * 
      * @param endpoint The MQTT endpoint representing the client.
      */
@@ -549,33 +546,33 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
      * @param authenticatedDevice The authenticated identity of the device or {@code null}
      *                            if the device has not been authenticated.
      * @param subscribeMsg The subscribe request received from the device.
-     * @param cmdHandler The commandHandler to track command subscriptions, unsubscriptions and handle PUBACKs.
+     * @param cmdSubscriptionsManager The CommandSubscriptionsManager to track command subscriptions, unsubscriptions
+     *                                and handle PUBACKs.
      * @param traceSamplingPriority The sampling priority to be applied on the <em>OpenTracing</em> span
      *                              created for this operation.
      * @throws NullPointerException if any of the parameters except authenticatedDevice is {@code null}.
      */
-    @SuppressWarnings("rawtypes")
     protected final void onSubscribe(
             final MqttEndpoint endpoint,
             final Device authenticatedDevice,
             final MqttSubscribeMessage subscribeMsg,
-            final CommandHandler<T> cmdHandler,
+            final CommandSubscriptionsManager<T> cmdSubscriptionsManager,
             final OptionalInt traceSamplingPriority) {
 
         Objects.requireNonNull(endpoint);
         Objects.requireNonNull(subscribeMsg);
-        Objects.requireNonNull(cmdHandler);
+        Objects.requireNonNull(cmdSubscriptionsManager);
         Objects.requireNonNull(traceSamplingPriority);
 
-        final Map<String, Future> topicFilters = new HashMap<>();
-        final Map<MqttTopicSubscription, Future> subscriptionOutcome = new LinkedHashMap<>(
+        final Map<String, Future<CommandSubscription>> topicFilters = new HashMap<>();
+        final Map<MqttTopicSubscription, Future<CommandSubscription>> subscriptionOutcome = new LinkedHashMap<>(
                 subscribeMsg.topicSubscriptions().size());
 
         final Span span = newSpan("SUBSCRIBE", endpoint, authenticatedDevice, traceSamplingPriority);
 
         subscribeMsg.topicSubscriptions().forEach(subscription -> {
 
-            Future result = topicFilters.get(subscription.topicName());
+            Future<CommandSubscription> result = topicFilters.get(subscription.topicName());
             if (result != null) {
 
                 // according to the MQTT 3.1.1 spec (section 3.8.4) we need to
@@ -598,7 +595,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     // we do not support subscribing to commands using QoS 2
                     result = Future.failedFuture(new IllegalArgumentException("QoS 2 not supported for command subscription"));
                 } else {
-                    result = createCommandConsumer(endpoint, cmdSub, cmdHandler, span).map(consumer -> {
+                    result = createCommandConsumer(endpoint, cmdSub, cmdSubscriptionsManager, span).map(consumer -> {
                         final Map<String, Object> items = new HashMap<>(4);
                         items.put(Fields.EVENT, "accepting subscription");
                         items.put(KEY_TOPIC_FILTER, subscription.topicName());
@@ -608,7 +605,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                         log.debug("created subscription [tenant: {}, device: {}, filter: {}, requested QoS: {}, granted QoS: {}]",
                                 cmdSub.getTenant(), cmdSub.getDeviceId(), subscription.topicName(),
                                 subscription.qualityOfService(), subscription.qualityOfService());
-                        cmdHandler.addSubscription(cmdSub, consumer);
+                        cmdSubscriptionsManager.addSubscription(cmdSub, consumer);
                         return cmdSub;
                     }).recover(t -> {
                         final Map<String, Object> items = new HashMap<>(4);
@@ -645,8 +642,8 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             // we can send empty notifications for succeeded command subscriptions
             // downstream
             topicFilters.values().forEach(f -> {
-                if (f.succeeded() && f.result() instanceof CommandSubscription) {
-                    final CommandSubscription s = (CommandSubscription) f.result();
+                if (f.succeeded() && f.result() != null) {
+                    final CommandSubscription s = f.result();
                     sendConnectedTtdEvent(s.getTenant(), s.getDeviceId(), authenticatedDevice, span.context());
                 }
             });
@@ -687,7 +684,8 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
      * @param authenticatedDevice The authenticated identity of the device or {@code null}
      *                            if the device has not been authenticated.
      * @param unsubscribeMsg The unsubscribe request received from the device.
-     * @param cmdHandler The commandHandler to track command subscriptions, unsubscriptions and handle PUBACKs.
+     * @param cmdSubscriptionsManager The CommandSubscriptionsManager to track command subscriptions, unsubscriptions
+     *                                and handle PUBACKs.
      * @param traceSamplingPriority The sampling priority to be applied on the <em>OpenTracing</em> span
      *                              created for this operation.
      * @throws NullPointerException if any of the parameters except authenticatedDevice is {@code null}.
@@ -696,12 +694,12 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             final MqttEndpoint endpoint,
             final Device authenticatedDevice,
             final MqttUnsubscribeMessage unsubscribeMsg,
-            final CommandHandler<T> cmdHandler,
+            final CommandSubscriptionsManager<T> cmdSubscriptionsManager,
             final OptionalInt traceSamplingPriority) {
 
         Objects.requireNonNull(endpoint);
         Objects.requireNonNull(unsubscribeMsg);
-        Objects.requireNonNull(cmdHandler);
+        Objects.requireNonNull(cmdSubscriptionsManager);
         Objects.requireNonNull(traceSamplingPriority);
 
         final Span span = newSpan("UNSUBSCRIBE", endpoint, authenticatedDevice, traceSamplingPriority);
@@ -725,12 +723,9 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                 span.log(items);
                 log.debug("unsubscribing device [tenant-id: {}, device-id: {}] from topic [{}]",
                         tenantId, deviceId, topic);
-                final Future<Void> removalDone = cmdHandler.removeSubscription(topic, (tenant, device) -> {
-                    final Span sendEventSpan = newChildSpan(span.context(), "Send Disconnected Event", endpoint,
-                            authenticatedDevice);
-                    return sendDisconnectedTtdEvent(tenant, device, authenticatedDevice, sendEventSpan.context())
-                            .onComplete(r -> sendEventSpan.finish()).mapEmpty();
-                }, span.context());
+                final Future<Void> removalDone = cmdSubscriptionsManager.removeSubscription(topic,
+                        (tenant, device) -> sendDisconnectedTtdEvent(tenant, device, authenticatedDevice, endpoint, span),
+                        span.context());
                 removalDoneFutures.add(removalDone);
             }
         });
@@ -741,7 +736,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
     }
 
     private Future<ProtocolAdapterCommandConsumer> createCommandConsumer(final MqttEndpoint mqttEndpoint,
-            final CommandSubscription sub, final CommandHandler<T> cmdHandler, final Span span) {
+            final CommandSubscription sub, final CommandSubscriptionsManager<T> cmdHandler, final Span span) {
 
         final Handler<CommandContext> commandHandler = commandContext -> {
 
@@ -1188,26 +1183,24 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
      * 
      * @param endpoint The connection to close.
      * @param authenticatedDevice Optional authenticated device information, may be {@code null}.
-     * @param cmdHandler The commandHandler to track command subscriptions, unsubscriptions and handle PUBACKs.
+     * @param cmdSubscriptionsManager The CommandSubscriptionsManager to track command subscriptions, unsubscriptions
+     *                                and handle PUBACKs.
      * @param traceSamplingPriority The sampling priority to be applied on the <em>OpenTracing</em> span
      *                              created for this operation.
      * @throws NullPointerException if any of the parameters except authenticatedDevice is {@code null}.
      */
     protected final void close(final MqttEndpoint endpoint, final Device authenticatedDevice,
-            final CommandHandler<T> cmdHandler, final OptionalInt traceSamplingPriority) {
+            final CommandSubscriptionsManager<T> cmdSubscriptionsManager, final OptionalInt traceSamplingPriority) {
 
         Objects.requireNonNull(endpoint);
-        Objects.requireNonNull(cmdHandler);
+        Objects.requireNonNull(cmdSubscriptionsManager);
         Objects.requireNonNull(traceSamplingPriority);
 
         final Span span = newSpan("CLOSE", endpoint, authenticatedDevice, traceSamplingPriority);
         onClose(endpoint);
-        final CompositeFuture removalDoneFuture = cmdHandler.removeAllSubscriptions((tenant, device) -> {
-            final Span sendEventSpan = newChildSpan(span.context(), "Send Disconnected Event", endpoint,
-                    authenticatedDevice);
-            return sendDisconnectedTtdEvent(tenant, device, authenticatedDevice, sendEventSpan.context())
-                    .onComplete(r -> sendEventSpan.finish()).mapEmpty();
-        }, span.context());
+        final CompositeFuture removalDoneFuture = cmdSubscriptionsManager.removeAllSubscriptions(
+                (tenant, device) -> sendDisconnectedTtdEvent(tenant, device, authenticatedDevice, endpoint, span),
+                span.context());
         sendDisconnectedEvent(endpoint.clientIdentifier(), authenticatedDevice);
         if (authenticatedDevice == null) {
             log.debug("connection to anonymous device [clientId: {}] closed", endpoint.clientIdentifier());
@@ -1221,9 +1214,17 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             log.debug("closing connection with client [client ID: {}]", endpoint.clientIdentifier());
             endpoint.close();
         } else {
-            log.trace("client has already closed connection");
+            log.trace("connection to client is already closed");
         }
         removalDoneFuture.onComplete(r -> span.finish());
+    }
+
+    private Future<Void> sendDisconnectedTtdEvent(final String tenant, final String device,
+            final Device authenticatedDevice, final MqttEndpoint endpoint, final Span span) {
+        final Span sendEventSpan = newChildSpan(span.context(), "Send Disconnected Event", endpoint,
+                authenticatedDevice);
+        return sendDisconnectedTtdEvent(tenant, device, authenticatedDevice, sendEventSpan.context())
+                .onComplete(r -> sendEventSpan.finish()).mapEmpty();
     }
 
     /**
@@ -1348,7 +1349,8 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
      * @param endpoint The device that the command should be delivered to.
      * @param subscription The device's command subscription.
      * @param commandContext The command to be delivered.
-     * @param cmdHandler The commandHandler to track command subscriptions, unsubscriptions and handle PUBACKs.
+     * @param cmdSubscriptionsManager The CommandSubscriptionsManager to track command subscriptions, unsubscriptions
+     *                                and handle PUBACKs.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     protected final void onCommandReceived(
@@ -1356,7 +1358,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             final MqttEndpoint endpoint,
             final CommandSubscription subscription,
             final CommandContext commandContext,
-            final CommandHandler<T> cmdHandler) {
+            final CommandSubscriptionsManager<T> cmdSubscriptionsManager) {
 
         Objects.requireNonNull(endpoint);
         Objects.requireNonNull(subscription);
@@ -1376,7 +1378,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                 : subscription.isAuthenticated() ? "" : subscription.getDeviceId();
         final String topicCommandRequestId = command.isOneWay() ? "" : command.getRequestId();
 
-        final String topic = String.format("%s/%s/%s/%s/%s/%s",
+        final String publishTopic = String.format("%s/%s/%s/%s/%s/%s",
                 subscription.getEndpoint(), topicTenantId, topicDeviceId, subscription.getRequestPart(),
                 topicCommandRequestId, command.getName());
 
@@ -1389,25 +1391,15 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     subscription.getTenant(), subscription.getDeviceId(), subscription.getClientId(),
                     subscription.getQos());
         }
-        final Map<String, String> items = new HashMap<>(3);
-        items.put(Fields.EVENT, "Publishing command to device");
-        items.put(TracingHelper.TAG_CLIENT_ID.getKey(), subscription.getClientId());
-        items.put(TracingHelper.TAG_QOS.getKey(), subscription.getQos().toString());
-        commandContext.getCurrentSpan().log(items);
+        logSubscriptionEventToSpan(commandContext.getCurrentSpan(), subscription, true,
+                "Publishing command to device");
 
-        endpoint.publish(topic, command.getPayload(), subscription.getQos(), false, false, sentHandler -> {
+        endpoint.publish(publishTopic, command.getPayload(), subscription.getQos(), false, false, sentHandler -> {
             if (sentHandler.succeeded()) {
-                if (MqttQoS.AT_LEAST_ONCE.equals(subscription.getQos())) {
-                    cmdHandler.addToWaitingForAcknowledgement(sentHandler.result(), tenantObject, subscription,
-                            commandContext);
-                } else {
-                    afterCommandPublished(tenantObject, subscription, commandContext);
-                }
+                afterCommandPublished(sentHandler.result(), commandContext, tenantObject, subscription, cmdSubscriptionsManager);
             } else {
-                log.debug(
-                        "Error publishing command to device [tenant-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}]",
-                        subscription.getTenant(), subscription.getDeviceId(), endpoint.clientIdentifier(),
-                        subscription.getQos(),
+                log.debug("Error publishing command to device [tenant-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}]",
+                        subscription.getTenant(), subscription.getDeviceId(), endpoint.clientIdentifier(), subscription.getQos(),
                         sentHandler.cause());
                 TracingHelper.logError(commandContext.getCurrentSpan(), sentHandler.cause());
                 metrics.reportCommand(
@@ -1420,6 +1412,69 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                 commandContext.release();
             }
         });
+    }
+
+    private void afterCommandPublished(
+            final Integer publishedMsgId,
+            final CommandContext commandContext,
+            final TenantObject tenantObject,
+            final CommandSubscription subscription,
+            final CommandSubscriptionsManager<T> cmdSubscriptionsManager) {
+
+        final boolean waitForAck = MqttQoS.AT_LEAST_ONCE.equals(subscription.getQos());
+
+        log.debug("Published command to device{} [tenant-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}]",
+                waitForAck ? ", waiting for ack" : "", subscription.getTenant(), subscription.getDeviceId(),
+                subscription.getClientId(), subscription.getQos());
+        logSubscriptionEventToSpan(commandContext.getCurrentSpan(), subscription, true,
+                waitForAck ? "Published command to device, waiting for ack" : "Published command to device");
+
+        if (waitForAck) {
+            final Handler<Integer> onAckHandler = msgId -> {
+                reportPublishedCommand(tenantObject, subscription, commandContext);
+                log.debug("Acknowledged [Msg-id: {}] command to device [tenant-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}]",
+                        msgId, subscription.getTenant(), subscription.getDeviceId(), subscription.getClientId(),
+                        subscription.getQos());
+                logSubscriptionEventToSpan(commandContext.getCurrentSpan(), subscription, false,
+                        "Published command has been acknowledged");
+                commandContext.accept();
+            };
+
+            final Handler<Void> onAckTimeoutHandler = v -> {
+                log.debug("Timed out waiting for acknowledgment for command sent to device [tenant-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}]",
+                        subscription.getTenant(), subscription.getDeviceId(), subscription.getClientId(), subscription.getQos());
+                logSubscriptionEventToSpan(commandContext.getCurrentSpan(), subscription, false,
+                        "Timed out waiting for acknowledgment for command sent to device");
+                commandContext.release();
+            };
+            cmdSubscriptionsManager.addToWaitingForAcknowledgement(publishedMsgId, onAckHandler, onAckTimeoutHandler);
+        } else {
+            reportPublishedCommand(tenantObject, subscription, commandContext);
+            commandContext.accept();
+        }
+    }
+
+    private void reportPublishedCommand(final TenantObject tenantObject, final CommandSubscription subscription,
+            final CommandContext commandContext) {
+        metrics.reportCommand(
+                commandContext.getCommand().isOneWay() ? Direction.ONE_WAY : Direction.REQUEST,
+                subscription.getTenant(),
+                tenantObject,
+                ProcessingOutcome.FORWARDED,
+                commandContext.getCommand().getPayloadSize(),
+                getMicrometerSample(commandContext));
+    }
+
+    private void logSubscriptionEventToSpan(final Span span, final CommandSubscription subscription,
+            final boolean includeDestination, final String eventMessage) {
+        final Map<String, String> items = new HashMap<>(4);
+        items.put(Fields.EVENT, eventMessage);
+        if (includeDestination) {
+            items.put(Tags.MESSAGE_BUS_DESTINATION.getKey(), subscription.getTopic());
+        }
+        items.put(TracingHelper.TAG_CLIENT_ID.getKey(), subscription.getClientId());
+        items.put(TracingHelper.TAG_QOS.getKey(), subscription.getQos().toString());
+        span.log(items);
     }
 
     /**
@@ -1444,30 +1499,6 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         } catch (final NumberFormatException e) {
             return null;
         }
-    }
-
-    private void afterCommandPublished(
-            final TenantObject tenantObject,
-            final CommandSubscription subscription,
-            final CommandContext commandContext) {
-
-        metrics.reportCommand(
-                commandContext.getCommand().isOneWay() ? Direction.ONE_WAY : Direction.REQUEST,
-                subscription.getTenant(),
-                tenantObject,
-                ProcessingOutcome.FORWARDED,
-                commandContext.getCommand().getPayloadSize(),
-                getMicrometerSample(commandContext));
-        log.debug("Published command to device [tenant-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}]",
-                subscription.getTenant(), subscription.getDeviceId(), subscription.getClientId(),
-                subscription.getQos());
-        final Map<String, String> items = new HashMap<>(4);
-        items.put(Fields.EVENT, "Published command to device");
-        items.put(Tags.MESSAGE_BUS_DESTINATION.getKey(), subscription.getTopic());
-        items.put(TracingHelper.TAG_CLIENT_ID.getKey(), subscription.getClientId());
-        items.put(TracingHelper.TAG_QOS.getKey(), subscription.getQos().toString());
-        commandContext.getCurrentSpan().log(items);
-        commandContext.accept();
     }
 
     private static void addRetainAnnotation(final MqttContext context, final Message downstreamMessage,
@@ -1498,15 +1529,15 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
 
     private Future<Device> registerHandlers(final MqttEndpoint endpoint, final Device authenticatedDevice,
             final OptionalInt traceSamplingPriority) {
-        final CommandHandler<T> cmdHandler = new CommandHandler<>(vertx, getConfig());
-        endpoint.closeHandler(v -> close(endpoint, authenticatedDevice, cmdHandler, traceSamplingPriority));
+        final CommandSubscriptionsManager<T> cmdSubscriptionsManager = new CommandSubscriptionsManager<>(vertx, getConfig());
+        endpoint.closeHandler(v -> close(endpoint, authenticatedDevice, cmdSubscriptionsManager, traceSamplingPriority));
         endpoint.publishHandler(
                 message -> handlePublishedMessage(MqttContext.fromPublishPacket(message, endpoint, authenticatedDevice)));
-        endpoint.publishAcknowledgeHandler(msgId -> cmdHandler.handlePubAck(msgId, afterCommandPublished));
-        endpoint.subscribeHandler(subscribeMsg -> onSubscribe(endpoint, authenticatedDevice, subscribeMsg, cmdHandler,
+        endpoint.publishAcknowledgeHandler(cmdSubscriptionsManager::handlePubAck);
+        endpoint.subscribeHandler(subscribeMsg -> onSubscribe(endpoint, authenticatedDevice, subscribeMsg, cmdSubscriptionsManager,
                 traceSamplingPriority));
         endpoint.unsubscribeHandler(unsubscribeMsg -> onUnsubscribe(endpoint, authenticatedDevice, unsubscribeMsg,
-                cmdHandler, traceSamplingPriority));
+                cmdSubscriptionsManager, traceSamplingPriority));
         if (authenticatedDevice == null) {
             metrics.incrementUnauthenticatedConnections();
         } else {

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -924,10 +924,10 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(msg.messageId()).thenReturn(15);
         when(msg.topicSubscriptions()).thenReturn(subscriptions);
 
-        final CommandHandler<MqttProtocolAdapterProperties> cmdHandler = new CommandHandler<>(vertx, config);
+        final CommandSubscriptionsManager<MqttProtocolAdapterProperties> cmdSubscriptionsManager = new CommandSubscriptionsManager<>(vertx, config);
         endpoint.closeHandler(
-                handler -> adapter.close(endpoint, new Device("tenant", "deviceId"), cmdHandler, OptionalInt.empty()));
-        adapter.onSubscribe(endpoint, null, msg, cmdHandler, OptionalInt.empty());
+                handler -> adapter.close(endpoint, new Device("tenant", "deviceId"), cmdSubscriptionsManager, OptionalInt.empty()));
+        adapter.onSubscribe(endpoint, null, msg, cmdSubscriptionsManager, OptionalInt.empty());
 
         // THEN the adapter creates a command consumer that is checked periodically
         verify(commandConsumerFactory).createCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class), any(), any());
@@ -978,7 +978,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
         when(msg.messageId()).thenReturn(15);
         when(msg.topicSubscriptions()).thenReturn(subscriptions);
 
-        adapter.onSubscribe(endpoint, null, msg, new CommandHandler<>(vertx, config), OptionalInt.empty());
+        adapter.onSubscribe(endpoint, null, msg, new CommandSubscriptionsManager<>(vertx, config), OptionalInt.empty());
 
         // THEN the adapter sends a SUBACK packet to the device
         // which contains a failure status code for each unsupported filter

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -15,9 +15,11 @@ package org.eclipse.hono.tests.mqtt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -31,6 +33,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.MessageSender;
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.CommandEndpointConfiguration.SubscriberRole;
 import org.eclipse.hono.tests.IntegrationTestSupport;
@@ -44,15 +47,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.mqtt.MqttPubAckMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.NetSocketInternal;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.mqtt.impl.MqttClientImpl;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import io.vertx.proton.ProtonHelper;
 
@@ -402,5 +411,152 @@ public class CommandAndControlMqttIT extends MqttTestBase {
             ctx.verify(() -> assertThat(t).isInstanceOf(ClientErrorException.class));
             failedAttempts.flag();
         }));
+    }
+
+    /**
+     * Verifies that the adapter forwards the <em>released</em> disposition back to the
+     * application if the device hasn't sent an acknowledgement for the command message
+     * published to the device.
+     *
+     * @param endpointConfig The endpoints to use for sending/receiving commands.
+     * @param ctx The vert.x test context.
+     * @throws InterruptedException if not all commands and responses are exchanged in time.
+     */
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("allCombinations")
+    @Timeout(timeUnit = TimeUnit.SECONDS, value = 20)
+    public void testSendCommandFailsForCommandNotAcknowledgedByDevice(
+            final MqttCommandEndpointConfiguration endpointConfig,
+            final VertxTestContext ctx) throws InterruptedException {
+
+        final MqttQoS subscribeQos = MqttQoS.AT_LEAST_ONCE;
+
+        final VertxTestContext setup = new VertxTestContext();
+        final Checkpoint ready = setup.checkpoint(2);
+
+        final String commandTargetDeviceId = endpointConfig.isSubscribeAsGateway()
+                ? helper.setupGatewayDeviceBlocking(tenantId, deviceId, 5)
+                : deviceId;
+
+        final int totalNoOfCommandsToSend = 2;
+        final CountDownLatch commandsFailed = new CountDownLatch(totalNoOfCommandsToSend);
+        final AtomicInteger receivedMessagesCounter = new AtomicInteger(0);
+        final AtomicInteger counter = new AtomicInteger();
+        final Handler<MqttPublishMessage> commandConsumer = msg -> {
+            LOGGER.trace("received command [{}] - no response sent here", msg.topicName());
+            final ResourceIdentifier topic = ResourceIdentifier.fromString(msg.topicName());
+            ctx.verify(() -> {
+                endpointConfig.assertCommandPublishTopicStructure(topic, commandTargetDeviceId, false, "setValue");
+            });
+            receivedMessagesCounter.incrementAndGet();
+        };
+        final Function<Buffer, Future<?>> commandSender = payload -> {
+            return helper.sendCommand(tenantId, commandTargetDeviceId, "setValue", "text/plain", payload,
+                    // set "forceCommandRerouting" message property so that half the command are rerouted via the AMQP network
+                    IntegrationTestSupport.newCommandMessageProperties(() -> counter.getAndIncrement() >= COMMANDS_TO_SEND / 2),
+                    200);
+        };
+
+        helper.registry
+                .addDeviceForTenant(tenantId, tenant, deviceId, password)
+                .compose(ok -> connectToAdapter(IntegrationTestSupport.getUsername(deviceId, tenantId), password))
+                // let the MqttClient skip sending the PubAck messages
+                .compose(ok -> injectMqttClientPubAckBlocker(new AtomicBoolean(true)))
+                .compose(ok -> createConsumer(tenantId, msg -> {
+                    // expect empty notification with TTD -1
+                    setup.verify(() -> assertThat(msg.getContentType()).isEqualTo(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION));
+                    final TimeUntilDisconnectNotification notification = TimeUntilDisconnectNotification.fromMessage(msg).orElse(null);
+                    LOGGER.info("received notification [{}]", notification);
+                    setup.verify(() -> assertThat(notification).isNotNull());
+                    if (notification.getTtd() == -1) {
+                        ready.flag();
+                    }
+                }))
+                .compose(conAck -> subscribeToCommands(commandTargetDeviceId, commandConsumer, endpointConfig, subscribeQos))
+                .setHandler(setup.succeeding(ok -> ready.flag()));
+
+        assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
+        if (setup.failed()) {
+            ctx.failNow(setup.causeOfFailure());
+        }
+
+        final AtomicInteger commandsSent = new AtomicInteger(0);
+        final AtomicLong lastReceivedTimestamp = new AtomicLong(0);
+        final long start = System.currentTimeMillis();
+
+        while (commandsSent.get() < totalNoOfCommandsToSend) {
+            final CountDownLatch commandSent = new CountDownLatch(1);
+            context.runOnContext(go -> {
+                final Buffer msg = Buffer.buffer("value: " + commandsSent.getAndIncrement());
+                commandSender.apply(msg).setHandler(sendAttempt -> {
+                    if (sendAttempt.succeeded()) {
+                        LOGGER.debug("sending command {} succeeded unexpectedly", commandsSent.get());
+                    } else {
+                        if (sendAttempt.cause() instanceof ServerErrorException
+                                && ((ServerErrorException) sendAttempt.cause()).getErrorCode() == HttpURLConnection.HTTP_UNAVAILABLE) {
+                            LOGGER.debug("sending command {} failed as expected: {}", commandsSent.get(),
+                                    sendAttempt.cause().toString());
+                            lastReceivedTimestamp.set(System.currentTimeMillis());
+                            commandsFailed.countDown();
+                            if (commandsFailed.getCount() % 20 == 0) {
+                                LOGGER.info("commands failed as expected: {}",
+                                        totalNoOfCommandsToSend - commandsFailed.getCount());
+                            }
+                        } else {
+                            LOGGER.debug("sending command {} failed with an unexpected error", commandsSent.get(),
+                                    sendAttempt.cause());
+                        }
+                    }
+                    if (commandsSent.get() % 20 == 0) {
+                        LOGGER.info("commands sent: " + commandsSent.get());
+                    }
+                    commandSent.countDown();
+                });
+            });
+
+            commandSent.await();
+        }
+
+        // have to wait an extra MqttAdapterProperties.DEFAULT_COMMAND_ACK_TIMEOUT (100ms) for each command message
+        final long timeToWait = totalNoOfCommandsToSend * 300;
+        if (!commandsFailed.await(timeToWait, TimeUnit.MILLISECONDS)) {
+            LOGGER.info("Timeout of {} milliseconds reached, stop waiting for commands", timeToWait);
+        }
+        assertThat(receivedMessagesCounter.get()).isEqualTo(totalNoOfCommandsToSend);
+        final long commandsCompleted = totalNoOfCommandsToSend - commandsFailed.getCount();
+        LOGGER.info("commands sent: {}, commands failed: {} after {} milliseconds",
+                commandsSent.get(), commandsCompleted, lastReceivedTimestamp.get() - start);
+        if (commandsCompleted == commandsSent.get()) {
+            ctx.completeNow();
+        } else {
+            ctx.failNow(new java.lang.IllegalStateException("did not complete all commands sent"));
+        }
+    }
+
+    private Future<Void> injectMqttClientPubAckBlocker(final AtomicBoolean outboundPubAckBlocked) {
+        // The vert.x MqttClient automatically sends a PubAck after having received a Qos 1 Publish message,
+        // as of now, there is no configuration option to prevent this (see https://github.com/vert-x3/vertx-mqtt/issues/120).
+        // Therefore the underlying NetSocket pipeline is used here to filter out the outbound PubAck messages.
+        try {
+            final Method connectionMethod = MqttClientImpl.class.getDeclaredMethod("connection");
+            connectionMethod.setAccessible(true);
+            final NetSocketInternal connection = (NetSocketInternal) connectionMethod.invoke(mqttClient);
+            connection.channelHandlerContext().pipeline().addBefore("handler", "OutboundPubAckBlocker",
+                    new ChannelOutboundHandlerAdapter() {
+                @Override
+                public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise)
+                        throws Exception {
+                    if (outboundPubAckBlocked.get() && msg instanceof io.netty.handler.codec.mqtt.MqttPubAckMessage) {
+                        LOGGER.debug("suppressing PubAck, message id: {}", ((MqttPubAckMessage) msg).variableHeader().messageId());
+                    } else {
+                        super.write(ctx, msg, promise);
+                    }
+                }
+            });
+            return Future.succeededFuture();
+        } catch (final Exception e) {
+            LOGGER.error("failed to inject PubAck blocking handler");
+            return Future.failedFuture(new Exception("failed to inject PubAck blocking handler", e));
+        }
     }
 }


### PR DESCRIPTION
This takes over the refactorings and tracing fixes done in https://github.com/eclipse/hono/pull/1941, but keeps the behaviour in case of a command ack timeout (i.e. the MQTT connection is kept open).