### PR TITLE
Verify tenant from command target address

### DIFF
--- a/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
@@ -79,7 +79,6 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
     private String tenantCommandAddress;
     private String tenantId;
     private String deviceId;
-    private String gatewayId;
     private String adapterInstanceId;
 
     /**
@@ -100,7 +99,6 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
         when(vertx.eventBus()).thenReturn(eventBus);
 
         deviceId = "theDevice";
-        gatewayId = "theGateway";
         tenantId = "theTenant";
         adapterInstanceId = UUID.randomUUID().toString();
 


### PR DESCRIPTION
When mapping and delegating a command message, the tenant is now being
extracted from the message's address instead of using the (static)
tenant used for creating the tenant scoped command receiver link.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch.io>