### PR TITLE
[#1679] Part 1: Add mongo db based implementation of credentials service and management APIs

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementService.java
@@ -48,14 +48,16 @@ public abstract class AbstractCredentialsManagementService implements Credential
     private final Vertx vertx;
 
     /**
-     * Creates a service for a Vertx instance.
+     * Creates a service for the given Vertx and password encoder instances.
      *
      * @param vertx The Vertx instance to use.
-     * @throws NullPointerException if vertx is {@code null};
+     * @param passwordEncoder The password encoder.
+     * @throws NullPointerException if any of the parameters is {@code null};
      */
     @Autowired
-    public AbstractCredentialsManagementService(final Vertx vertx) {
+    public AbstractCredentialsManagementService(final Vertx vertx, final HonoPasswordEncoder passwordEncoder) {
         this.vertx = Objects.requireNonNull(vertx);
+        this.passwordEncoder = Objects.requireNonNull(passwordEncoder);
     }
 
     /**
@@ -69,17 +71,6 @@ public abstract class AbstractCredentialsManagementService implements Credential
     @Autowired(required = false)
     public void setTenantInformationService(final TenantInformationService tenantInformationService) {
         this.tenantInformationService = Objects.requireNonNull(tenantInformationService);
-    }
-
-    /**
-     * Set password encoder.
-     *
-     * @param passwordEncoder The password encoder.
-     * @throws NullPointerException if encoder is {@code null};
-     */
-    @Autowired
-    public void setPasswordEncoder(final HonoPasswordEncoder passwordEncoder) {
-        this.passwordEncoder = Objects.requireNonNull(passwordEncoder);
     }
 
     /**

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedCredentialsConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedCredentialsConfigProperties.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.config;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Configuration properties for Hono's credentials service and management APIs.
+ */
+public class MongoDbBasedCredentialsConfigProperties extends AbstractMongoDbBasedRegistryConfigProperties {
+
+    /**
+     * The name of the mongodb collection where devices information are stored.
+     */
+    private static final String DEFAULT_CREDENTIALS_COLLECTION_NAME = "credentials";
+
+    private final Set<String> hashAlgorithmsWhitelist = new HashSet<>();
+
+    private int maxBcryptIterations = 10;
+
+    @Override
+    protected String getDefaultCollectionName() {
+        return DEFAULT_CREDENTIALS_COLLECTION_NAME;
+    }
+
+    /**
+     * Gets the maximum number of iterations to use for bcrypt
+     * password hashes.
+     * <p>
+     * The default value of this property is 10.
+     *
+     * @return The maximum number.
+     */
+    public int getMaxBcryptIterations() {
+        return maxBcryptIterations;
+    }
+
+    /**
+     * Sets the maximum number of iterations to use for bcrypt
+     * password hashes.
+     * <p>
+     * The default value of this property is 10.
+     *
+     * @param iterations The maximum number.
+     * @throws IllegalArgumentException if iterations is &lt; 4 or &gt; 31.
+     */
+    public void setMaxBcryptIterations(final int iterations) {
+        if (iterations < 4 || iterations > 31) {
+            throw new IllegalArgumentException("iterations must be > 3 and < 32");
+        } else {
+            maxBcryptIterations = iterations;
+        }
+    }
+
+
+    /**
+     * Gets the list of supported hashing algorithms for pre-hashed passwords.
+     * <p>
+     * The device registry will not accept credentials using a hashing
+     * algorithm that is not contained in this list.
+     * If the list is empty, the device registry will accept any hashing algorithm.
+     * <p>
+     * Default value is an empty list.
+     *
+     * @return The supported algorithms.
+     */
+    public Set<String> getHashAlgorithmsWhitelist() {
+        return Collections.unmodifiableSet(hashAlgorithmsWhitelist);
+    }
+
+    /**
+     * Sets the list of supported hashing algorithms for pre-hashed passwords.
+     * <p>
+     * The device registry will not accept credentials using a hashing
+     * algorithm that is not contained in this list.
+     * If the list is empty, the device registry will accept any hashing algorithm.
+     * <p>
+     * Default value is an empty list.
+     *
+     * @param hashAlgorithmsWhitelist The algorithms to support.
+     * @throws NullPointerException if the list is {@code null}.
+     */
+    public void setHashAlgorithmsWhitelist(final String[] hashAlgorithmsWhitelist) {
+
+        Objects.requireNonNull(hashAlgorithmsWhitelist);
+        this.hashAlgorithmsWhitelist.clear();
+        this.hashAlgorithmsWhitelist.addAll(Arrays.asList(hashAlgorithmsWhitelist));
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedCredentialsConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedCredentialsConfigProperties.java
@@ -21,7 +21,7 @@ import java.util.Set;
 /**
  * Configuration properties for Hono's credentials service and management APIs.
  */
-public class MongoDbBasedCredentialsConfigProperties extends AbstractMongoDbBasedRegistryConfigProperties {
+public final class MongoDbBasedCredentialsConfigProperties extends AbstractMongoDbBasedRegistryConfigProperties {
 
     /**
      * The name of the mongodb collection where devices information are stored.

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDto.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.model;
+
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDeviceRegistryUtils;
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.service.management.credentials.CommonSecret;
+import org.eclipse.hono.service.management.credentials.GenericCredential;
+import org.eclipse.hono.service.management.credentials.PasswordCredential;
+import org.eclipse.hono.service.management.credentials.PskCredential;
+import org.eclipse.hono.service.management.credentials.X509CertificateCredential;
+import org.eclipse.hono.util.RegistryManagementConstants;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A DTO (Data Transfer Object) class to store credentials information in mongodb.
+ */
+public class CredentialsDto extends BaseDto {
+
+    @JsonProperty(value = RegistryManagementConstants.FIELD_PAYLOAD_TENANT_ID, required = true)
+    private String tenantId;
+
+    @JsonProperty(value = RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID, required = true)
+    private String deviceId;
+
+    @JsonProperty(value = MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS, required = true)
+    private List<CommonCredential> credentials;
+    private boolean hasSecretIds;
+
+    /**
+     * Default constructor for serialisation/deserialization.
+     */
+    public CredentialsDto() {
+        // Explicit default constructor.
+    }
+
+    /**
+     * Creates a new data transfer object to store credentials information in mongodb.
+     *
+     * @param tenantId The tenant identifier.
+     * @param deviceId The device identifier.
+     * @param credentials The list of credentials.
+     * @param version The version of tenant to be sent as request header.
+     * @throws NullPointerException if any of the parameters except the secrets are {@code null}
+     * @throws IllegalArgumentException if validation of the given credentials fail.
+     */
+    public CredentialsDto(
+            final String tenantId,
+            final String deviceId,
+            final List<CommonCredential> credentials,
+            final String version) {
+
+        setTenantId(tenantId);
+        setDeviceId(deviceId);
+
+        //Validate the given credentials, secrets and generate secret ids if not available.
+        Optional.ofNullable(credentials)
+                .ifPresent(ok -> {
+                    validateForUniqueAuthIdAndType(credentials);
+                    validateSecretsAndGenerateIds(credentials);
+                });
+        setCredentials(credentials);
+
+        setVersion(version);
+        setUpdatedOn(Instant.now());
+    }
+
+    /**
+     * Gets the identifier of the tenant.
+     *
+     * @return The identifier of the tenant.
+     */
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Sets the identifier of the tenant.
+     *
+     * @param tenantId The tenant's identifier.
+     * @throws NullPointerException if the tenantId is {@code null}.
+     */
+    public void setTenantId(final String tenantId) {
+        this.tenantId = Objects.requireNonNull(tenantId);
+    }
+
+    /**
+     * Gets the identifier of the device.
+     *
+     * @return The identifier of the device.
+     */
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    /**
+     * Sets the identifier of the device.
+     *
+     * @param deviceId The identifier of the device.
+     * @throws NullPointerException if the deviceId is {@code null}.
+     */
+    public void setDeviceId(final String deviceId) {
+        this.deviceId = Objects.requireNonNull(deviceId);
+    }
+
+    /**
+     * Gets the list of credentials.
+     *
+     * @return The list of credentials.
+     */
+    public List<CommonCredential> getCredentials() {
+        return credentials;
+    }
+
+    /**
+     * Sets the list of credentials.
+     *
+     * @param credentials A list of credentials.
+     */
+    public void setCredentials(final List<CommonCredential> credentials) {
+        this.credentials = credentials;
+    }
+
+    /**
+     * Checks whether the credentials to be updated already have secret ids.
+     *
+     * @return hasSecretIds {@code true} if any credential already has a secret identifier,
+     *                      otherwise {@code false}
+     */
+    @JsonIgnore
+    public boolean hasSecretIds() {
+        return hasSecretIds;
+    }
+
+    /**
+     * Sets whether the credentials to be updated already have secret ids.
+     *
+     * @param hasSecretIds {@code true} if any credential already has a secret identifier,
+     *                         otherwise {@code false}
+     */
+    @JsonIgnore
+    public void setHasSecretIds(final boolean hasSecretIds) {
+        this.hasSecretIds = hasSecretIds;
+    }
+
+    @JsonIgnore
+    private List<? extends CommonSecret> getSecrets(final CommonCredential credential) {
+        if (credential instanceof PasswordCredential) {
+            return ((PasswordCredential) credential).getSecrets();
+        } else if (credential instanceof X509CertificateCredential) {
+            return ((X509CertificateCredential) credential).getSecrets();
+        } else if (credential instanceof PskCredential) {
+            return ((PskCredential) credential).getSecrets();
+        } else {
+            return ((GenericCredential) credential).getSecrets();
+        }
+    }
+
+    @JsonIgnore
+    private <T extends CommonSecret> T generateSecretId(final T secret) {
+        if (secret.getId() == null) {
+            secret.setId(DeviceRegistryUtils.getUniqueIdentifier());
+        } else {
+            this.setHasSecretIds(true);
+        }
+        return secret;
+    }
+
+    @JsonIgnore
+    private void validateForUniqueAuthIdAndType(final List<? extends CommonCredential> credentials) {
+            final long uniqueAuthIdAndTypeCount = credentials.stream()
+                    .map(credential -> credential.getAuthId() + credential.getClass().getSimpleName())
+                    .distinct()
+                    .count();
+
+            if (credentials.size() != uniqueAuthIdAndTypeCount) {
+                throw new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
+                        "the composite key of auth-id and type must be unique");
+            }
+    }
+
+    @JsonIgnore
+    private void validateSecretsAndGenerateIds(final List<? extends CommonCredential> credentials) {
+
+        credentials.stream()
+                .map(this::getSecrets)
+                .filter(secrets -> secrets != null && !secrets.isEmpty())
+                .forEach(secrets -> {
+                    final long uniqueIdsCount = secrets.stream()
+                            .map(this::generateSecretId)
+                            .map(CommonSecret::getId)
+                            .distinct()
+                            .count();
+                    if (secrets.size() != uniqueIdsCount) {
+                        throw new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
+                                "secret ids must be unique for the secrets belonging to the same auth-id and type");
+                    }
+                });
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDto.java
@@ -60,8 +60,8 @@ public class CredentialsDto extends BaseDto {
      * @param tenantId The tenant identifier.
      * @param deviceId The device identifier.
      * @param credentials The list of credentials.
-     * @param version The version of tenant to be sent as request header.
-     * @throws NullPointerException if any of the parameters except the secrets are {@code null}
+     * @param version The version of the credentials to be sent as request header.
+     * @throws NullPointerException if any of the parameters except credentials is {@code null}
      * @throws IllegalArgumentException if validation of the given credentials fail.
      */
     public CredentialsDto(
@@ -164,6 +164,20 @@ public class CredentialsDto extends BaseDto {
     }
 
     @JsonIgnore
+    private String getAuthType(final CommonCredential credential) {
+        if (credential instanceof GenericCredential) {
+            return ((GenericCredential) credential).getType();
+        } else if (credential instanceof PasswordCredential) {
+            return RegistryManagementConstants.SECRETS_TYPE_HASHED_PASSWORD;
+        } else if (credential instanceof PskCredential) {
+            return RegistryManagementConstants.SECRETS_TYPE_PRESHARED_KEY;
+        } else if (credential instanceof X509CertificateCredential) {
+            return RegistryManagementConstants.SECRETS_TYPE_X509_CERT;
+        }
+        return null;
+    }
+
+    @JsonIgnore
     private List<? extends CommonSecret> getSecrets(final CommonCredential credential) {
         if (credential instanceof PasswordCredential) {
             return ((PasswordCredential) credential).getSecrets();
@@ -189,7 +203,7 @@ public class CredentialsDto extends BaseDto {
     @JsonIgnore
     private void validateForUniqueAuthIdAndType(final List<? extends CommonCredential> credentials) {
             final long uniqueAuthIdAndTypeCount = credentials.stream()
-                    .map(credential -> credential.getAuthId() + credential.getClass().getSimpleName())
+                    .map(credential -> credential.getAuthId() + getAuthType(credential))
                     .distinct()
                     .count();
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialsService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialsService.java
@@ -16,18 +16,44 @@ import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import org.eclipse.hono.auth.HonoPasswordEncoder;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.model.CredentialsDto;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbCallExecutor;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDeviceRegistryUtils;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDocumentBuilder;
+import org.eclipse.hono.deviceregistry.service.credentials.AbstractCredentialsManagementService;
+import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.service.Lifecycle;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
-import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsResult;
+import org.eclipse.hono.util.RegistryManagementConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoException;
 
 import io.opentracing.Span;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.FindOptions;
+import io.vertx.ext.mongo.IndexOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.UpdateOptions;
 
 /**
  * This is an implementation of the credentials service and the credentials management service where data is 
@@ -36,14 +62,54 @@ import io.vertx.core.json.JsonObject;
  * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/">Credentials API</a>
  * @see <a href="https://www.eclipse.org/hono/docs/api/management/">Device Registry Management API</a>
  */
-public class MongoDbBasedCredentialsService implements CredentialsManagementService, CredentialsService, Lifecycle {
+public final class MongoDbBasedCredentialsService extends AbstractCredentialsManagementService
+        implements CredentialsService, Lifecycle {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDbBasedCredentialsService.class);
+
+    private static final String CREDENTIALS_FILTERED_POSITIONAL_OPERATOR = String.format("%s.$",
+            MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS);
+    private static final int INDEX_CREATION_MAX_RETRIES = 3;
+
+    private final MongoDbBasedCredentialsConfigProperties config;
+    private final MongoClient mongoClient;
+    private final MongoDbCallExecutor mongoDbCallExecutor;
+
+    /**
+     * Creates a new service for configuration properties.
+     *
+     * @param vertx The vert.x instance to run on.
+     * @param mongoClient The client for accessing the Mongo DB instance.
+     * @param config The properties for configuring this service.
+     * @param passwordEncoder The password encoder.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public MongoDbBasedCredentialsService(
+            final Vertx vertx,
+            final MongoClient mongoClient,
+            final MongoDbBasedCredentialsConfigProperties config,
+            final HonoPasswordEncoder passwordEncoder) {
+
+        super(Objects.requireNonNull(vertx), Objects.requireNonNull(passwordEncoder));
+
+        Objects.requireNonNull(mongoClient);
+        Objects.requireNonNull(config);
+
+        this.mongoClient = mongoClient;
+        this.config = config;
+        this.mongoDbCallExecutor = new MongoDbCallExecutor(vertx, mongoClient);
+    }
 
     /**
      * {@inheritDoc}
      */
     @Override
     public Future<Void> start() {
-        return Future.succeededFuture();
+        return createIndices()
+                .map(ok -> {
+                    LOG.debug("MongoDB credentials service started.");
+                    return null;
+                });
     }
 
     /**
@@ -51,55 +117,401 @@ public class MongoDbBasedCredentialsService implements CredentialsManagementServ
      */
     @Override
     public Future<Void> stop() {
+        mongoClient.close();
         return Future.succeededFuture();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type,
-            final String authId, final Span span) {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type,
+    public Future<CredentialsResult<JsonObject>> get(
+            final String tenantId,
+            final String type,
             final String authId,
-            final JsonObject clientContext, final Span span) {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public Future<OperationResult<Void>> updateCredentials(final String tenantId, final String deviceId,
-            final List<CommonCredential> credentials, final Optional<String> resourceVersion, final Span span) {
-        // TODO
-        return Future.succeededFuture(
-                OperationResult.ok(HttpURLConnection.HTTP_NO_CONTENT, null, Optional.empty(), Optional.empty()));
-    }
-
-    @Override
-    public Future<OperationResult<List<CommonCredential>>> readCredentials(final String tenantId,
-            final String deviceId,
             final Span span) {
-        // TODO
-        return null;
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(authId);
+        Objects.requireNonNull(span);
+
+        return processGetCredential(tenantId, type, authId, null);
     }
 
     /**
-     * Remove all the credentials for the given device ID.
-     *
-     * @param tenantId the Id of the tenant which the device belongs to.
-     * @param deviceId the id of the device that is deleted.
-     * @param span The active OpenTracing span for this operation.
-     * @return A future indicating the outcome of the operation.
-     *         The <em>status</em> will be <em>204 No Content</em> 
-     *         if the operation completed successfully.
-     * @throws NullPointerException if any of the parameters except span is {@code null}.
+     * {@inheritDoc}
      */
-    public Future<Result<Void>> removeCredentials(final String tenantId, final String deviceId, final Span span) {
+    @Override
+    public Future<CredentialsResult<JsonObject>> get(
+            final String tenantId,
+            final String type,
+            final String authId,
+            final JsonObject clientContext,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(authId);
+        Objects.requireNonNull(clientContext);
+        Objects.requireNonNull(span);
+
+        return processGetCredential(tenantId, type, authId, clientContext);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Future<OperationResult<Void>> processUpdateCredentials(
+            final DeviceKey deviceKey,
+            final Optional<String> resourceVersion,
+            final List<CommonCredential> credentials,
+            final Span span) {
+
+        Objects.requireNonNull(deviceKey);
+        Objects.requireNonNull(resourceVersion);
+        Objects.requireNonNull(span);
+
+        TracingHelper.TAG_DEVICE_ID.set(span, deviceKey.getDeviceId());
+
+        return MongoDbDeviceRegistryUtils.isModificationEnabled(config)
+                .compose(ok -> updateCredentials(deviceKey, resourceVersion, credentials, span))
+                .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override protected Future<OperationResult<List<CommonCredential>>> processReadCredentials(
+            final DeviceKey deviceKey,
+            final Span span) {
+
+        Objects.requireNonNull(deviceKey);
+        Objects.requireNonNull(span);
+
+        return findCredentials(deviceKey)
+                .map(result -> {
+                    final List<CommonCredential> credentialsList = result
+                            .getJsonArray(MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS)
+                            .stream()
+                            .map(credential -> removePasswordDetailsFromCredential((JsonObject) credential))
+                            .map(credential -> credential.mapTo(CommonCredential.class))
+                            .collect(Collectors.toList());
+
+                    return OperationResult.ok(
+                            HttpURLConnection.HTTP_OK,
+                            credentialsList,
+                            Optional.empty(),
+                            Optional.of(result.getString(MongoDbDeviceRegistryUtils.FIELD_VERSION)));
+                })
+                .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
+    }
+
+    /**
+     * Adds credentials for the given device.
+     *
+     * @param tenantId the id of the tenant which the device belongs to.
+     * @param deviceId the id of the device that is deleted.
+     * @param credentials A list of credentials.
+     * @param resourceVersion The identifier of the resource version to update.
+     * @param span The active OpenTracing span for this operation.
+     * @return A future indicating the outcome of the operation. The <em>status</em> will be
+     *         <ul>
+     *         <li><em>201 No Content</em> if the credentials have been created successfully.</li>
+     *         </ul>
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public Future<Result<Void>> addCredentials(
+            final String tenantId,
+            final String deviceId,
+            final List<CommonCredential> credentials,
+            final Optional<String> resourceVersion,
+            final Span span) {
+
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
-        // TODO
-        return Future.succeededFuture(Result.from(HttpURLConnection.HTTP_NO_CONTENT));
+        Objects.requireNonNull(credentials);
+        Objects.requireNonNull(resourceVersion);
+        Objects.requireNonNull(span);
+
+        TracingHelper.TAG_DEVICE_ID.set(span, deviceId);
+
+        return processAddCredentials(tenantId, deviceId, credentials, resourceVersion, span)
+                .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
+    }
+
+    /**
+     * Removes all the credentials for the given device.
+     *
+     * @param tenantId the id of the tenant which the device belongs to.
+     * @param deviceId the id of the device that is deleted.
+     * @param span The active OpenTracing span for this operation.
+     * @return A future indicating the outcome of the operation. The <em>status</em> will be
+     *         <ul>
+     *         <li><em>204 No Content</em> if the credentials have been removed successfully.</li>
+     *         <li><em>404 Not Found</em> if no credentials are available for the given device.</li>
+     *         </ul>
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public Future<Result<Void>> removeCredentials(
+            final String tenantId,
+            final String deviceId,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(span);
+
+        TracingHelper.TAG_DEVICE_ID.set(span, deviceId);
+
+        return processRemoveCredentials(tenantId, deviceId, span)
+                .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
+    }
+
+    private CompositeFuture createIndices() {
+        final String authIdKey = String.format("%s.%s", MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS,
+                RegistryManagementConstants.FIELD_AUTH_ID);
+        final String credentialsTypeKey = String.format("%s.%s", MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS,
+                RegistryManagementConstants.FIELD_TYPE);
+
+        return CompositeFuture.all(
+                // index based on tenantId & deviceId
+                mongoDbCallExecutor.createCollectionIndex(
+                        config.getCollectionName(),
+                        new JsonObject()
+                                .put(RegistryManagementConstants.FIELD_PAYLOAD_TENANT_ID, 1)
+                                .put(RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID, 1),
+                        new IndexOptions().unique(true),
+                        INDEX_CREATION_MAX_RETRIES),
+                // index based on tenantId, authId & type
+                mongoDbCallExecutor.createCollectionIndex(
+                        config.getCollectionName(),
+                        new JsonObject()
+                                .put(RegistryManagementConstants.FIELD_PAYLOAD_TENANT_ID, 1)
+                                .put(authIdKey, 1)
+                                .put(credentialsTypeKey, 1),
+                        new IndexOptions().unique(true)
+                                .partialFilterExpression(new JsonObject()
+                                        .put(authIdKey, new JsonObject().put("$exists", true))
+                                        .put(credentialsTypeKey, new JsonObject().put("$exists", true))),
+                        INDEX_CREATION_MAX_RETRIES));
+    }
+
+    private Future<JsonObject> findCredentials(final DeviceKey deviceKey) {
+        final JsonObject findCredentialsQuery = MongoDbDocumentBuilder.builder()
+                .withTenantId(deviceKey.getTenantId())
+                .withDeviceId(deviceKey.getDeviceId())
+                .document();
+        final Promise<JsonObject> findCredentialsPromise = Promise.promise();
+
+        mongoClient.findOne(config.getCollectionName(), findCredentialsQuery, null, findCredentialsPromise);
+
+        return findCredentialsPromise.future()
+                .compose(result -> Optional.ofNullable(result)
+                        .map(Future::succeededFuture)
+                        .orElseGet(() -> Future.failedFuture(
+                                new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND))));
+    }
+
+    private Future<CredentialsResult<JsonObject>> findCredentials(
+            final String tenantId,
+            final String authId,
+            final String type) {
+        final JsonObject findCredentialsQuery = MongoDbDocumentBuilder.builder()
+                .withTenantId(tenantId)
+                .withAuthId(authId)
+                .withType(type)
+                .document();
+        final Promise<JsonObject> findCredentialsPromise = Promise.promise();
+
+        mongoClient.findOne(
+                config.getCollectionName(),
+                findCredentialsQuery,
+                new JsonObject().put(RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID, 1)
+                        .put(CREDENTIALS_FILTERED_POSITIONAL_OPERATOR, 1)
+                        .put("_id", 0),
+                findCredentialsPromise);
+
+        return findCredentialsPromise.future()
+                .map(result -> Optional.ofNullable(result)
+                        .flatMap(ok -> Optional
+                                .ofNullable(result.getJsonArray(MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS))
+                                .map(credential -> credential.getJsonObject(0))
+                                .map(credential -> credential.put(RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID,
+                                        result.getString(RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID))))
+                        .filter(this::isCredentialEnabled)
+                        .map(credential -> CredentialsResult.from(
+                                HttpURLConnection.HTTP_OK,
+                                credential,
+                                getCacheDirective(type)))
+                        .orElse(CredentialsResult.from(HttpURLConnection.HTTP_NOT_FOUND)));
+    }
+
+    private Future<CredentialsDto> getCredentialsDto(final DeviceKey deviceKey) {
+
+        return findCredentials(deviceKey)
+                .map(result -> result.mapTo(CredentialsDto.class));
+    }
+
+    private CacheDirective getCacheDirective(final String type) {
+
+        if (config.getCacheMaxAge() > 0) {
+            switch (type) {
+            case CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD:
+            case CredentialsConstants.SECRETS_TYPE_X509_CERT:
+                return CacheDirective.maxAgeDirective(config.getCacheMaxAge());
+            default:
+                return CacheDirective.noCacheDirective();
+            }
+        } else {
+            return CacheDirective.noCacheDirective();
+        }
+    }
+
+    private boolean isCredentialEnabled(final JsonObject credential) {
+        return Optional.ofNullable(credential.getBoolean(CredentialsConstants.FIELD_ENABLED))
+                .orElse(true);
+    }
+
+    private boolean isDuplicateKeyError(final Throwable throwable) {
+
+        if (throwable instanceof MongoException) {
+            final MongoException mongoException = (MongoException) throwable;
+            return ErrorCategory.fromErrorCode(mongoException.getCode()) == ErrorCategory.DUPLICATE_KEY;
+        }
+
+        return false;
+    }
+
+    private Future<CredentialsResult<JsonObject>> processGetCredential(
+            final String tenantId,
+            final String type,
+            final String authId,
+            final JsonObject clientContext) {
+
+        //TODO: To implement to make use of the client context.
+        return findCredentials(tenantId, authId, type);
+    }
+
+    private Future<Result<Void>> processAddCredentials(
+            final String tenantId,
+            final String deviceId,
+            final List<CommonCredential> credentials,
+            final Optional<String> resourceVersion, final Span span) {
+        final Promise<String> addCredentialsPromise = Promise.promise();
+        mongoClient.insert(
+                config.getCollectionName(),
+                JsonObject.mapFrom(new CredentialsDto(
+                        tenantId,
+                        deviceId,
+                        credentials,
+                        resourceVersion.orElse(DeviceRegistryUtils.getUniqueIdentifier()))),
+                addCredentialsPromise);
+
+        return addCredentialsPromise.future()
+                .map(added -> {
+                    span.log("successfully added credentials");
+                    LOG.debug("successfully added credentials for the device [[{}]]", deviceId);
+                    return Result.from(HttpURLConnection.HTTP_NO_CONTENT);
+                });
+    }
+
+    private Future<Result<Void>> processRemoveCredentials(
+            final String tenantId,
+            final String deviceId,
+            final Span span) {
+        final JsonObject removeCredentialsQuery = MongoDbDocumentBuilder.builder()
+                .withTenantId(tenantId)
+                .withDeviceId(deviceId)
+                .document();
+        final Promise<JsonObject> removeCredentialsPromise = Promise.promise();
+
+        mongoClient.findOneAndDelete(config.getCollectionName(), removeCredentialsQuery, removeCredentialsPromise);
+
+        return removeCredentialsPromise.future()
+                .compose(result -> Optional.ofNullable(result)
+                        .map(removed -> {
+                            span.log("successfully removed credentials");
+                            LOG.debug("successfully removed credentials for the device [[{}]]", deviceId);
+                            return Future.succeededFuture(Result.<Void> from(HttpURLConnection.HTTP_NO_CONTENT));
+                        })
+                        .orElse(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND))));
+    }
+
+    private Future<OperationResult<Void>> updateCredentials(
+            final DeviceKey deviceKey,
+            final Optional<String> resourceVersion,
+            final List<CommonCredential> credentials,
+            final Span span) {
+        final JsonObject updateCredentialsQuery = MongoDbDocumentBuilder.builder()
+                .withVersion(resourceVersion)
+                .withTenantId(deviceKey.getTenantId())
+                .withDeviceId(deviceKey.getDeviceId())
+                .document();
+        final Promise<JsonObject> updateCredentialsPromise = Promise.promise();
+        final CredentialsDto credentialsDto = new CredentialsDto(deviceKey.getTenantId(), deviceKey.getDeviceId(),
+                credentials, DeviceRegistryUtils.getUniqueIdentifier());
+
+        //If the credentials to be updated do not have any existing secret ids, the credentials document is replaced.
+        //Else the document is to be merged based on the secret ids and it is yet to be implemented.
+        if (!credentialsDto.hasSecretIds()) {
+            mongoClient.findOneAndReplaceWithOptions(config.getCollectionName(),
+                    updateCredentialsQuery,
+                    JsonObject.mapFrom(credentialsDto),
+                    new FindOptions(),
+                    new UpdateOptions().setReturningNewDocument(true),
+                    updateCredentialsPromise);
+        } else {
+            // TODO: To implement - if secret meta data already exists.
+            LOG.warn("merging of secret data based on the given secret ids is not implemented");
+            TracingHelper.logError(span, "merging of secret data based on the given secret ids is not implemented");
+            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
+        }
+
+        return updateCredentialsPromise.future()
+                .compose(result -> {
+                    if (result == null) {
+                        return MongoDbDeviceRegistryUtils.checkForVersionMismatchAndFail(
+                                deviceKey.getDeviceId(), resourceVersion,
+                                getCredentialsDto(deviceKey));
+                    } else {
+                        LOG.debug("successfully updated credentials for the device [{}}]", deviceKey.getDeviceId());
+                        span.log("successfully updated credentials");
+                        return Future.succeededFuture(
+                                OperationResult.ok(
+                                        HttpURLConnection.HTTP_NO_CONTENT,
+                                        (Void) null,
+                                        Optional.empty(),
+                                        Optional.of(result.getString(MongoDbDeviceRegistryUtils.FIELD_VERSION))));
+                    }
+                })
+                .recover(error -> {
+                    if (isDuplicateKeyError(error)) {
+                        LOG.debug("the composite key of auth-id and type for the given tenant[{}] must be unique",
+                                deviceKey.getTenantId(), error);
+                        TracingHelper.logError(span,
+                                "the composite key of auth-id and type for the given tenant must be unique");
+                        return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_CONFLICT));
+                    }
+                    return Future.failedFuture(error);
+                });
+    }
+
+    private JsonObject removePasswordDetailsFromCredential(final JsonObject credential) {
+
+        if (credential.getString(CredentialsConstants.FIELD_TYPE)
+                .equals(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD)) {
+            credential.getJsonArray(CredentialsConstants.FIELD_SECRETS)
+                    .forEach(secret -> removePasswordDetailsFromSecret((JsonObject) secret));
+        }
+        return credential;
+    }
+
+    private void removePasswordDetailsFromSecret(final JsonObject secret) {
+        secret.remove(CredentialsConstants.FIELD_SECRETS_HASH_FUNCTION);
+        secret.remove(CredentialsConstants.FIELD_SECRETS_PWD_HASH);
+        secret.remove(CredentialsConstants.FIELD_SECRETS_SALT);
+        secret.remove(CredentialsConstants.FIELD_SECRETS_PWD_PLAIN);
     }
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialsService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialsService.java
@@ -41,9 +41,6 @@ import org.eclipse.hono.util.RegistryManagementConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.mongodb.ErrorCategory;
-import com.mongodb.MongoException;
-
 import io.opentracing.Span;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -107,7 +104,7 @@ public final class MongoDbBasedCredentialsService extends AbstractCredentialsMan
     public Future<Void> start() {
         return createIndices()
                 .map(ok -> {
-                    LOG.debug("MongoDB credentials service started.");
+                    LOG.debug("MongoDB credentials service started");
                     return null;
                 });
     }
@@ -374,16 +371,6 @@ public final class MongoDbBasedCredentialsService extends AbstractCredentialsMan
                 .orElse(true);
     }
 
-    private boolean isDuplicateKeyError(final Throwable throwable) {
-
-        if (throwable instanceof MongoException) {
-            final MongoException mongoException = (MongoException) throwable;
-            return ErrorCategory.fromErrorCode(mongoException.getCode()) == ErrorCategory.DUPLICATE_KEY;
-        }
-
-        return false;
-    }
-
     private Future<CredentialsResult<JsonObject>> processGetCredential(
             final String tenantId,
             final String type,
@@ -487,7 +474,7 @@ public final class MongoDbBasedCredentialsService extends AbstractCredentialsMan
                     }
                 })
                 .recover(error -> {
-                    if (isDuplicateKeyError(error)) {
+                    if (MongoDbDeviceRegistryUtils.isDuplicateKeyError(error)) {
                         LOG.debug("the composite key of auth-id and type for the given tenant[{}] must be unique",
                                 deviceKey.getTenantId(), error);
                         TracingHelper.logError(span,

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
@@ -109,7 +109,7 @@ public class MongoDbBasedDeviceBackend implements AutoProvisioningEnabledDeviceB
                         return Future.succeededFuture(result);
                     }
                     // now create the empty credentials set and pass on the original result
-                    return credentialsService.updateCredentials(
+                    return credentialsService.addCredentials(
                             tenantId,
                             result.getPayload().getId(),
                             Collections.emptyList(),

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDeviceRegistryUtils.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDeviceRegistryUtils.java
@@ -39,6 +39,10 @@ import io.vertx.core.Future;
 public final class MongoDbDeviceRegistryUtils {
 
     /**
+     * The name of the JSON property containing the credentials.
+     */
+    public static final String FIELD_CREDENTIALS = "credentials";
+    /**
      * The name of the JSON property containing the device data.
      */
     public static final String FIELD_DEVICE = "device";

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
@@ -27,9 +27,9 @@ import io.vertx.core.json.JsonObject;
  */
 public final class MongoDbDocumentBuilder {
 
-    private static final String FILED_CREDENTIALS_AUTH_ID_KEY = String.format("%s.%s",
+    private static final String FIELD_CREDENTIALS_AUTH_ID_KEY = String.format("%s.%s",
             MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS, RegistryManagementConstants.FIELD_AUTH_ID);
-    private static final String FILED_CREDENTIALS_TYPE_KEY = String.format("%s.%s",
+    private static final String FIELD_CREDENTIALS_TYPE_KEY = String.format("%s.%s",
             MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS, RegistryManagementConstants.FIELD_TYPE);
     private static final String TENANT_TRUSTED_CA_SUBJECT_PATH = String.format("%s.%s.%s",
             RegistryManagementConstants.FIELD_TENANT,
@@ -112,7 +112,7 @@ public final class MongoDbDocumentBuilder {
      * @return a reference to this for fluent use.
      */
     public MongoDbDocumentBuilder withType(final String type) {
-        document.put(FILED_CREDENTIALS_TYPE_KEY, type);
+        document.put(FIELD_CREDENTIALS_TYPE_KEY, type);
         return this;
     }
 
@@ -123,7 +123,7 @@ public final class MongoDbDocumentBuilder {
      * @return a reference to this for fluent use.
      */
     public MongoDbDocumentBuilder withAuthId(final String authId) {
-        document.put(FILED_CREDENTIALS_AUTH_ID_KEY, authId);
+        document.put(FIELD_CREDENTIALS_AUTH_ID_KEY, authId);
         return this;
     }
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
@@ -27,6 +27,10 @@ import io.vertx.core.json.JsonObject;
  */
 public final class MongoDbDocumentBuilder {
 
+    private static final String FILED_CREDENTIALS_AUTH_ID_KEY = String.format("%s.%s",
+            MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS, RegistryManagementConstants.FIELD_AUTH_ID);
+    private static final String FILED_CREDENTIALS_TYPE_KEY = String.format("%s.%s",
+            MongoDbDeviceRegistryUtils.FIELD_CREDENTIALS, RegistryManagementConstants.FIELD_TYPE);
     private static final String TENANT_TRUSTED_CA_SUBJECT_PATH = String.format("%s.%s.%s",
             RegistryManagementConstants.FIELD_TENANT,
             RegistryManagementConstants.FIELD_PAYLOAD_TRUSTED_CA,
@@ -99,5 +103,27 @@ public final class MongoDbDocumentBuilder {
      */
     public JsonObject document() {
         return document;
+    }
+
+    /**
+     * Sets the json object with the given credentials type.
+     *
+     * @param type The credentials type.
+     * @return a reference to this for fluent use.
+     */
+    public MongoDbDocumentBuilder withType(final String type) {
+        document.put(FILED_CREDENTIALS_TYPE_KEY, type);
+        return this;
+    }
+
+    /**
+     * Sets the json object with the given auth id.
+     *
+     * @param authId The auth id.
+     * @return a reference to this for fluent use.
+     */
+    public MongoDbDocumentBuilder withAuthId(final String authId) {
+        document.put(FILED_CREDENTIALS_AUTH_ID_KEY, authId);
+        return this;
     }
 }


### PR DESCRIPTION
This PR provides a mongo db based implementation of the credentials service and management APIs.

Some of the features such as merging of the secrets based on the secret ids, making use of the _ClientContext_ during _get_ operation are to be implemented incrementally. There are some more scope for improvements such as moving few validations and configurations to the abstract classes which will be implemented in next iterations.