### PR TITLE
[#1632] Keep link open on cmd disposition update timeout

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -788,7 +788,7 @@ public class VertxBasedAmqpProtocolAdapterTest {
         final CommandContext context = CommandContext.from(command, commandDelivery, mock(Span.class));
         final ProtocolAdapterCommandConsumer commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        adapter.onCommandReceived(tenantObject, deviceLink, commandConsumer, context);
+        adapter.onCommandReceived(tenantObject, deviceLink, context);
         // and the device settles it
         final ArgumentCaptor<Handler<ProtonDelivery>> deliveryUpdateHandler = ArgumentCaptor.forClass(Handler.class);
         verify(deviceLink).send(any(Message.class), deliveryUpdateHandler.capture());
@@ -1102,13 +1102,9 @@ public class VertxBasedAmqpProtocolAdapterTest {
             return 1L;
         }).when(vertx).setTimer(anyLong(), any(Handler.class));
 
-        adapter.onCommandReceived(tenantObject, deviceLink, commandConsumer, context);
-        // THEN the adapter closes the device link
-        verify(deviceLink).close();
-        // AND notifies the application by sending back a RELEASED disposition
+        adapter.onCommandReceived(tenantObject, deviceLink, context);
+        // THEN the adapter notifies the application by sending back a RELEASED disposition
         verify(commandDelivery).disposition(any(Released.class), eq(true));
-        // AND the command consumer is closed
-        verify(commandConsumer).close(any());
     }
 
     /**

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -20,7 +20,7 @@ title = "Release Notes"
   for additional information.
 * When sending a command message to a device, the AMQP adapter now waits for a
   configurable period of time (default is 1 second) for the acknowledgement from the device.
-  If none is received, the AMQP link to the device for sending commands is being closed.
+  If none is received, the downstream command sender gets back a `released` outcome.
   Please refer to the `sendMessageToDeviceTimeout` property description in the
   AMQP Adapter admin guide for additional information.
 * The client for storing device connection information to a data grid now supports configuring


### PR DESCRIPTION
Based on the discussion in #1632, the command link to the device is now kept open when the device hasn't sent a disposition update in time.