### PR TITLE
Fix a NPE in the TenantObject

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -140,7 +140,7 @@ public final class TenantObject extends JsonBackedValueObject {
      * @param subjectDn The CA's subject DN.
      * @param autoProvisioningEnabled A flag indicating whether this CA may be used for automatic provisioning.
      * @return This tenant for command chaining.
-     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws NullPointerException if the public key or subjectDN parameters is {@code null}.
      */
     @JsonIgnore
     public TenantObject addTrustAnchor(final PublicKey publicKey, final X500Principal subjectDn,
@@ -148,7 +148,6 @@ public final class TenantObject extends JsonBackedValueObject {
 
         Objects.requireNonNull(publicKey);
         Objects.requireNonNull(subjectDn);
-        Objects.requireNonNull(autoProvisioningEnabled);
 
         final JsonObject trustedCa = new JsonObject();
         trustedCa.put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, subjectDn.getName(X500Principal.RFC2253));
@@ -223,15 +222,17 @@ public final class TenantObject extends JsonBackedValueObject {
      * 
      * @param subjectDn The subject DN of the CA to check.
      * @return {@code true} if auto-provisioning is enabled.
+     * @throws NullPointerException if the parameter subjectDN is {@code null}.
      */
     @JsonIgnore
     public boolean isAutoProvisioningEnabled(final String subjectDn) {
+        Objects.requireNonNull(subjectDn);
         return getProperty(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, JsonArray.class, new JsonArray())
                 .stream()
-                .filter(obj -> obj instanceof JsonObject)
-                .map(obj -> (JsonObject) obj)
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
                 .filter(ca -> subjectDn.equals(getProperty(ca, TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, String.class)))
-                .map(caInUse -> getProperty(caInUse, TenantConstants.FIELD_AUTO_PROVISIONING_ENABLED, Boolean.class))
+                .map(caInUse -> getProperty(caInUse, TenantConstants.FIELD_AUTO_PROVISIONING_ENABLED, Boolean.class, false))
                 .findFirst().orElse(false);
     }
 

--- a/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
@@ -410,4 +410,23 @@ public class TenantObjectTest {
 
         assertThat(tenantObject.getMinimumMessageSize()).isEqualTo(TenantConstants.DEFAULT_MINIMUM_MESSAGE_SIZE);
     }
+
+    /**
+     * Test if the "auto provisioning enabled" field can be null.
+     * 
+     * @throws Exception in case the certificate generation fails.
+     */
+    @Test
+    public void testAcceptsNullAutoProvisioning() throws Exception {
+
+        final String caName = "eclipse.org";
+        final X509Certificate caCert = createCaCertificate(caName);
+
+        final TenantObject tenantObject = TenantObject.from(Constants.DEFAULT_TENANT, Boolean.TRUE)
+                .setTrustAnchor(trustedCaCert.getPublicKey(), trustedCaCert.getSubjectX500Principal())
+                .addTrustAnchor(caCert.getPublicKey(), caCert.getSubjectX500Principal(), null);
+
+        assertThat(tenantObject.isAutoProvisioningEnabled(caCert.getSubjectX500Principal().getName())).isFalse();
+
+    }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
@@ -173,7 +173,7 @@ public final class TenantServiceBasedX509Authentication implements X509Authentic
             span.finish();
             return authInfo;
         }).recover(t -> {
-            log.debug("verification of client certificate failed: {}", t.getMessage());
+            log.debug("verification of client certificate failed", t);
             TracingHelper.logError(span, t);
             span.finish();
             return Future.failedFuture(t);


### PR DESCRIPTION
According to the spec, the field "auto-provisioning-enabled" is not
mandatory. However the method TenantObject#addTrustAnchor throws a
NPE, while allowing a Boolean (vs boolean) parameter to be passed.

Additionally the method TenantObject#isAutoProvinsingEnabled() fails
with a NPE if the field is missing on the trust anchor.

This change also logs the full stack trace.

I think this should also be backported to 1.2.x.