### PR TITLE
[#1679] Part 2: Support updating credentials with secret ids

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
@@ -187,23 +187,18 @@ public abstract class CommonCredential {
 
         getSecrets()
                 .forEach(secret -> Optional.ofNullable(secret.getId())
-                        .ifPresent(secretId -> findSecretById(credential, secretId)
-                                .map(result -> {
-                                    if (secret instanceof PasswordSecret) {
-                                        ((PasswordSecret) secret).merge((PasswordSecret) result);
-                                    } else if (secret instanceof PskSecret) {
-                                        ((PskSecret) secret).merge((PskSecret) result);
-                                    }
-                                    return result;
-                                }).orElseThrow(() -> new IllegalArgumentException(
-                                        String.format("secret [id: %s] not found", secret.getId())))));
+                        .ifPresent(secretId -> credential.findSecretById(secretId)
+                                .ifPresentOrElse(secret::merge, () -> {
+                                    throw new IllegalArgumentException(
+                                            String.format("secret [id: %s] not found", secret.getId()));
+                                })));
 
         return this;
     }
 
 
-    private Optional<? extends CommonSecret> findSecretById(final CommonCredential credential, final String secretId) {
-        return credential.getSecrets()
+    private Optional<? extends CommonSecret> findSecretById(final String secretId) {
+        return getSecrets()
                 .stream()
                 .filter(secret -> secret.getId() != null)
                 .filter(secret -> secret.getId().equals(secretId))

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
@@ -15,9 +15,12 @@ package org.eclipse.hono.service.management.credentials;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.hono.util.RegistryManagementConstants;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -163,5 +166,47 @@ public abstract class CommonCredential {
      */
     public CommonCredential stripPrivateInfo() {
         return this;
+    }
+
+    /**
+     * Merges the secrets of the given credential with that of the current one based on the secret ids.
+     *
+     * @param credential The credential to be merged.
+     * @return a reference to this for fluent use.
+     * @throws IllegalArgumentException if the given credential is invalid and cannot be merged.
+     * @throws NullPointerException if the given credential is {@code null}.
+     */
+    @JsonIgnore
+    public CommonCredential merge(final CommonCredential credential) {
+
+        Objects.requireNonNull(credential);
+
+        if (!getType().equals(credential.getType())) {
+            throw new IllegalArgumentException("credential to be merged must be of the same type");
+        }
+
+        getSecrets()
+                .forEach(secret -> Optional.ofNullable(secret.getId())
+                        .ifPresent(secretId -> findSecretById(credential, secretId)
+                                .map(result -> {
+                                    if (secret instanceof PasswordSecret) {
+                                        ((PasswordSecret) secret).merge((PasswordSecret) result);
+                                    } else if (secret instanceof PskSecret) {
+                                        ((PskSecret) secret).merge((PskSecret) result);
+                                    }
+                                    return result;
+                                }).orElseThrow(() -> new IllegalArgumentException(
+                                        String.format("secret [id: %s] not found", secret.getId())))));
+
+        return this;
+    }
+
+
+    private Optional<? extends CommonSecret> findSecretById(final CommonCredential credential, final String secretId) {
+        return credential.getSecrets()
+                .stream()
+                .filter(secret -> secret.getId() != null)
+                .filter(secret -> secret.getId().equals(secretId))
+                .findFirst();
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
@@ -161,6 +161,14 @@ public abstract class CommonSecret {
         }
     }
 
+    /**
+     * Merges the given secret with that of the current one.
+     * <p>
+     * The default implementation in {@link CommonSecret} does nothing.
+     *
+     * @param secret The secret to be merged.
+     * @throws NullPointerException if the given secret is {@code null}.
+     */
     void merge(final CommonSecret secret) {
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
@@ -160,4 +160,7 @@ public abstract class CommonSecret {
             }
         }
     }
+
+    void merge(final CommonSecret secret) {
+    }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
@@ -238,4 +238,15 @@ public class PasswordSecret extends CommonSecret {
         passwordHash = null;
         salt = null;
     }
+
+    void merge(final PasswordSecret passwordSecret) {
+        Objects.requireNonNull(passwordSecret);
+
+        if (containsOnlySecretId()) {
+            passwordPlain = passwordSecret.getPasswordPlain();
+            passwordHash = passwordSecret.getPasswordHash();
+            hashFunction = passwordSecret.getHashFunction();
+            salt = passwordSecret.getSalt();
+        }
+    }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
@@ -239,6 +239,9 @@ public class PasswordSecret extends CommonSecret {
         salt = null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     void merge(final CommonSecret secret) {
         Objects.requireNonNull(secret);

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
@@ -239,10 +239,12 @@ public class PasswordSecret extends CommonSecret {
         salt = null;
     }
 
-    void merge(final PasswordSecret passwordSecret) {
-        Objects.requireNonNull(passwordSecret);
+    @Override
+    void merge(final CommonSecret secret) {
+        Objects.requireNonNull(secret);
 
-        if (containsOnlySecretId()) {
+        if (secret instanceof PasswordSecret && containsOnlySecretId()) {
+            final PasswordSecret passwordSecret = (PasswordSecret) secret;
             passwordPlain = passwordSecret.getPasswordPlain();
             passwordHash = passwordSecret.getPasswordHash();
             hashFunction = passwordSecret.getHashFunction();

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskSecret.java
@@ -12,7 +12,10 @@
  *******************************************************************************/
 package org.eclipse.hono.service.management.credentials;
 
+import java.util.Objects;
+
 import org.eclipse.hono.util.RegistryManagementConstants;
+import org.eclipse.hono.util.Strings;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -56,4 +59,12 @@ public class PskSecret extends CommonSecret {
         }
     }
 
+
+    void merge(final PskSecret pskSecret) {
+        Objects.requireNonNull(pskSecret);
+
+        if (!Strings.isNullOrEmpty(getId()) && Strings.isNullOrEmpty(key)) {
+            this.key = pskSecret.getKey();
+        }
+    }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskSecret.java
@@ -59,12 +59,15 @@ public class PskSecret extends CommonSecret {
         }
     }
 
+    @Override
+    void merge(final CommonSecret secret) {
+        Objects.requireNonNull(secret);
 
-    void merge(final PskSecret pskSecret) {
-        Objects.requireNonNull(pskSecret);
-
-        if (!Strings.isNullOrEmpty(getId()) && Strings.isNullOrEmpty(key)) {
-            this.key = pskSecret.getKey();
+        if (secret instanceof PskSecret) {
+            if (!Strings.isNullOrEmpty(getId()) && Strings.isNullOrEmpty(key)) {
+                final PskSecret pskSecret = (PskSecret) secret;
+                key = pskSecret.getKey();
+            }
         }
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskSecret.java
@@ -59,6 +59,9 @@ public class PskSecret extends CommonSecret {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     void merge(final CommonSecret secret) {
         Objects.requireNonNull(secret);

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDeviceRegistryUtils.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDeviceRegistryUtils.java
@@ -100,9 +100,15 @@ public final class MongoDbDeviceRegistryUtils {
 
         LOG.debug(error.getMessage(), error);
         TracingHelper.logError(span, error.getMessage(), error);
+
         if (error instanceof ClientErrorException) {
             return OperationResult.empty(((ClientErrorException) error).getErrorCode());
         }
+
+        if (error instanceof IllegalArgumentException) {
+            return OperationResult.empty(HttpURLConnection.HTTP_BAD_REQUEST);
+        }
+
         return OperationResult.empty(HttpURLConnection.HTTP_INTERNAL_ERROR);
     }
 


### PR DESCRIPTION
With this PR, the Mongo DB based device registry extends support for updating the credentials with existing secret identifiers.

This PR needs to merged after the #1947.