### PR TITLE
[#1679] Part 3: Add tests for mongo db based credentials services

### DIFF
--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
@@ -353,27 +353,24 @@ public abstract class AbstractCredentialsServiceTest {
         final var authId = UUID.randomUUID().toString();
         final var secret = createPasswordCredential(authId, "bar");
 
+        //create device and set credentials.
         assertGetMissing(ctx, tenantId, deviceId, authId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD,
-                () -> getCredentialsManagementService()
-                        .updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
-                                Optional.empty(), NoopSpan.INSTANCE)
-                        .onComplete(ctx.succeeding(s2 -> ctx.verify(() -> {
+                () -> getDeviceManagementService()
+                        .createDevice(tenantId, Optional.of(deviceId), new Device(), NoopSpan.INSTANCE)
+                        .onComplete(ctx.succeeding(s -> getCredentialsManagementService()
+                                .updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
+                                        Optional.empty(), NoopSpan.INSTANCE)
+                                .onComplete(ctx.succeeding(s2 -> ctx.verify(() -> {
 
-                            assertEquals(HttpURLConnection.HTTP_NO_CONTENT, s2.getStatus());
-                            assertResourceVersion(s2);
+                                    assertEquals(HttpURLConnection.HTTP_NO_CONTENT, s2.getStatus());
+                                    assertResourceVersion(s2);
 
-                            assertGet(ctx, tenantId, deviceId, authId,
-                                    CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD,
-                                    r -> {
-                                        assertEquals(HttpURLConnection.HTTP_OK, r.getStatus());
-                                    },
-                                    r -> {
-                                        assertEquals(HttpURLConnection.HTTP_OK, r.getStatus());
-                                    },
-                                    ctx::completeNow);
-
-                        }))));
-
+                                    assertGet(ctx, tenantId, deviceId, authId,
+                                            CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD,
+                                            r -> assertEquals(HttpURLConnection.HTTP_OK, r.getStatus()),
+                                            r -> assertEquals(HttpURLConnection.HTTP_OK, r.getStatus()),
+                                            ctx::completeNow);
+                                }))))));
     }
 
     /**
@@ -390,36 +387,35 @@ public abstract class AbstractCredentialsServiceTest {
         final var password = "bar";
         final var secret = createPlainPasswordCredential(authId, password);
 
+        //create device and set credentials.
         assertGetMissing(ctx, tenantId, deviceId, authId, CredentialsConstants.FIELD_SECRETS_PWD_PLAIN,
-                () -> getCredentialsManagementService()
-                        .updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
-                                Optional.empty(), NoopSpan.INSTANCE)
-                        .onComplete(ctx.succeeding(s2 -> ctx.verify(() -> {
+                () -> getDeviceManagementService()
+                        .createDevice(tenantId, Optional.of(deviceId), new Device(), NoopSpan.INSTANCE)
+                        .onComplete(ctx.succeeding(s -> getCredentialsManagementService()
+                                .updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
+                                        Optional.empty(), NoopSpan.INSTANCE)
+                                .onComplete(ctx.succeeding(s2 -> ctx.verify(() -> {
 
-                            assertEquals(HttpURLConnection.HTTP_NO_CONTENT, s2.getStatus());
-                            assertResourceVersion(s2);
+                                    assertEquals(HttpURLConnection.HTTP_NO_CONTENT, s2.getStatus());
+                                    assertResourceVersion(s2);
 
-                            assertGet(ctx, tenantId, deviceId, authId,
-                                    CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD,
-                                    r -> {
-                                        final List<CommonCredential> credentials = r.getPayload();
-                                        assertEquals(1, credentials.size());
-                                        final List<PasswordSecret> secrets = ((PasswordCredential) credentials.get(0))
-                                                .getSecrets();
-                                        assertEquals(1, secrets.size());
-                                        assertNotNull(JsonObject.mapFrom(secrets.get(0))
-                                                .getString(RegistryManagementConstants.FIELD_ID));
-                                        assertPasswordSecretDoesNotContainPasswordDetails(secrets.get(0));
-                                        assertNull(secrets.get(0).getPasswordPlain());
-                                        assertEquals(HttpURLConnection.HTTP_OK, r.getStatus());
-                                    },
-                                    r -> {
-                                        assertEquals(HttpURLConnection.HTTP_OK, r.getStatus());
-                                    },
-                                    ctx::completeNow);
-
-                        }))));
-
+                                    assertGet(ctx, tenantId, deviceId, authId,
+                                            CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD,
+                                            r -> {
+                                                final List<CommonCredential> credentials = r.getPayload();
+                                                assertEquals(1, credentials.size());
+                                                final List<PasswordSecret> secrets = ((PasswordCredential) credentials
+                                                        .get(0)).getSecrets();
+                                                assertEquals(1, secrets.size());
+                                                assertNotNull(JsonObject.mapFrom(secrets.get(0))
+                                                        .getString(RegistryManagementConstants.FIELD_ID));
+                                                assertPasswordSecretDoesNotContainPasswordDetails(secrets.get(0));
+                                                assertNull(secrets.get(0).getPasswordPlain());
+                                                assertEquals(HttpURLConnection.HTTP_OK, r.getStatus());
+                                            },
+                                            r -> assertEquals(HttpURLConnection.HTTP_OK, r.getStatus()),
+                                            ctx::completeNow);
+                                }))))));
     }
 
     private void assertResourceVersion(final OperationResult<?> result) {
@@ -456,30 +452,26 @@ public abstract class AbstractCredentialsServiceTest {
 
         final Promise<?> phase1 = Promise.promise();
 
-        // phase 1 - initially set credentials
+        // phase 1 - initially create device and set credentials
 
-        assertGetMissing(ctx, tenantId, deviceId, authId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, () -> {
+        assertGetMissing(ctx, tenantId, deviceId, authId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD,
+                () -> getDeviceManagementService()
+                        .createDevice(tenantId, Optional.of(deviceId), new Device(), NoopSpan.INSTANCE)
+                        .onComplete(ctx.succeeding(s -> getCredentialsManagementService()
+                                .updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
+                                        Optional.empty(), NoopSpan.INSTANCE)
+                                .onComplete(ctx.succeeding(s2 -> ctx.verify(() -> {
 
-            getCredentialsManagementService().updateCredentials(tenantId, deviceId, Collections.singletonList(secret),
-                    Optional.empty(), NoopSpan.INSTANCE)
-                    .onComplete(ctx.succeeding(s2 -> ctx.verify(() -> {
+                                    assertResourceVersion(s2);
+                                    assertEquals(HttpURLConnection.HTTP_NO_CONTENT, s2.getStatus());
 
-                        assertResourceVersion(s2);
-                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, s2.getStatus());
+                                    assertGet(ctx, tenantId, deviceId, authId,
+                                            CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD,
+                                            r -> assertEquals(HttpURLConnection.HTTP_OK, r.getStatus()),
+                                            r -> assertEquals(HttpURLConnection.HTTP_OK, r.getStatus()),
+                                            phase1::complete);
 
-                        assertGet(ctx, tenantId, deviceId, authId,
-                                CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD,
-                                r -> {
-                                    assertEquals(HttpURLConnection.HTTP_OK, r.getStatus());
-                                },
-                                r -> {
-                                    assertEquals(HttpURLConnection.HTTP_OK, r.getStatus());
-                                },
-                                phase1::complete);
-
-                    })));
-
-        });
+                                }))))));
 
         // phase 2 - try to update
 
@@ -917,7 +909,7 @@ public abstract class AbstractCredentialsServiceTest {
                         .updateCredentials(tenantId, deviceId, Collections.singletonList(credential),
                                 Optional.empty(),
                                 NoopSpan.INSTANCE)
-                            .onComplete(ctx.succeeding(s -> phase1.complete()))));
+                        .onComplete(ctx.succeeding(s -> phase1.complete()))));
 
         // Retrieve credentials IDs
 
@@ -949,19 +941,21 @@ public abstract class AbstractCredentialsServiceTest {
         // re-set credentials
         final Promise<?> phase3 = Promise.promise();
 
-        // create a credential object with only one of the ID.
-        final PasswordCredential credentialWithOnlyId = new PasswordCredential();
-        credentialWithOnlyId.setAuthId(authId);
+        phase2.future().onComplete(ctx.succeeding(n -> {
+            // create a credential object with only one of the ID.
+            final PasswordCredential credentialWithOnlyId = new PasswordCredential();
+            credentialWithOnlyId.setAuthId(authId);
 
-        final PasswordSecret secretWithOnlyId = new PasswordSecret();
-        secretWithOnlyId.setId(secretIDs.get(0));
+            final PasswordSecret secretWithOnlyId = new PasswordSecret();
+            secretWithOnlyId.setId(secretIDs.get(0));
 
-        credentialWithOnlyId.setSecrets(Collections.singletonList(secretWithOnlyId));
+            credentialWithOnlyId.setSecrets(Collections.singletonList(secretWithOnlyId));
 
-        phase2.future().onComplete(ctx.succeeding(n -> getCredentialsManagementService()
-                .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithOnlyId),
-                        Optional.empty(), NoopSpan.INSTANCE)
-                .onComplete(ctx.succeeding(s -> phase3.complete()))));
+            getCredentialsManagementService()
+                    .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithOnlyId),
+                            Optional.empty(), NoopSpan.INSTANCE)
+                    .onComplete(ctx.succeeding(s -> phase3.complete()));
+        }));
 
 
         // Retrieve credentials again, one should be deleted.
@@ -1141,21 +1135,23 @@ public abstract class AbstractCredentialsServiceTest {
         // re-set credentials
         final Promise<?> phase3 = Promise.promise();
 
-        // Add some metadata to the secret
-        final PasswordCredential credentialWithMetadataUpdate = new PasswordCredential();
-        credentialWithMetadataUpdate.setAuthId(authId);
+        phase2.future().onComplete(ctx.succeeding(n -> {
+            // Add some metadata to the secret
+            final PasswordCredential credentialWithMetadataUpdate = new PasswordCredential();
+            credentialWithMetadataUpdate.setAuthId(authId);
 
-        final PasswordSecret secretWithOnlyIdAndMetadata = new PasswordSecret();
-        secretWithOnlyIdAndMetadata.setId(secretIDs.get(0));
-        secretWithOnlyIdAndMetadata.setComment("secret comment");
+            final PasswordSecret secretWithOnlyIdAndMetadata = new PasswordSecret();
+            secretWithOnlyIdAndMetadata.setId(secretIDs.get(0));
+            secretWithOnlyIdAndMetadata.setComment("secret comment");
 
 
-        credentialWithMetadataUpdate.setSecrets(Collections.singletonList(secretWithOnlyIdAndMetadata));
+            credentialWithMetadataUpdate.setSecrets(Collections.singletonList(secretWithOnlyIdAndMetadata));
 
-        phase2.future().onComplete(ctx.succeeding(n -> getCredentialsManagementService()
-                .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithMetadataUpdate),
-                        Optional.empty(), NoopSpan.INSTANCE)
-                .onComplete(ctx.succeeding(s -> phase3.complete()))));
+            getCredentialsManagementService()
+                    .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithMetadataUpdate),
+                            Optional.empty(), NoopSpan.INSTANCE)
+                    .onComplete(ctx.succeeding(s -> phase3.complete()));
+        }));
 
 
         // Retrieve credentials again, the ID should not have changed.
@@ -1250,21 +1246,21 @@ public abstract class AbstractCredentialsServiceTest {
         // re-set credentials
         final Promise<?> phase3 = Promise.promise();
 
-        // Add some other metadata to the secret
-        final PasswordCredential credentialWithMetadataUpdate = new PasswordCredential();
-        credentialWithMetadataUpdate.setAuthId(authId);
+        phase2.future().onComplete(ctx.succeeding(n -> {
+            // Add some other metadata to the secret
+            final PasswordCredential credentialWithMetadataUpdate = new PasswordCredential();
+            credentialWithMetadataUpdate.setAuthId(authId);
 
-        final PasswordSecret secretWithOnlyIdAndMetadata = new PasswordSecret();
-        secretWithOnlyIdAndMetadata.setId(secretIDs.get(0));
-        secretWithOnlyIdAndMetadata.setComment("secret comment");
+            final PasswordSecret secretWithOnlyIdAndMetadata = new PasswordSecret();
+            secretWithOnlyIdAndMetadata.setId(secretIDs.get(0));
+            secretWithOnlyIdAndMetadata.setComment("secret comment");
+            credentialWithMetadataUpdate.setSecrets(Collections.singletonList(secretWithOnlyIdAndMetadata));
 
-        credentialWithMetadataUpdate.setSecrets(Collections.singletonList(secretWithOnlyIdAndMetadata));
-
-
-        phase2.future().onComplete(ctx.succeeding(n -> getCredentialsManagementService()
-                .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithMetadataUpdate),
-                        Optional.empty(), NoopSpan.INSTANCE)
-                .onComplete(ctx.succeeding(s -> phase3.complete()))));
+            getCredentialsManagementService()
+                    .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithMetadataUpdate),
+                            Optional.empty(), NoopSpan.INSTANCE)
+                    .onComplete(ctx.succeeding(s -> phase3.complete()));
+        }));
 
 
         // Retrieve credentials again, both metadata should be there

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
@@ -1,0 +1,131 @@
+/*****************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.service;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbConfigProperties;
+import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
+import org.eclipse.hono.service.credentials.CredentialsService;
+import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
+import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import de.flapdoodle.embed.process.runtime.Network;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests for {@link MongoDbBasedCredentialsService}.
+ */
+@ExtendWith(VertxExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class MongoDbBasedCredentialServiceTest extends AbstractCredentialsServiceTest {
+
+    private final MongoDbTestUtils mongoDbTestUtils = new MongoDbTestUtils();
+    private MongoClient mongoClient;
+    private final MongoDbBasedCredentialsConfigProperties credentialsServiceConfig = new MongoDbBasedCredentialsConfigProperties();
+    private MongoDbBasedCredentialsService credentialsService;
+    private MongoDbBasedRegistrationService registrationService;
+    private MongoDbBasedDeviceBackend deviceBackendService;
+    private Vertx vertx;
+
+    /**
+     * Sets up static fixture.
+     *
+     * @param testContext The test context to use for running asynchronous tests.
+     * @throws IOException if the embedded mongo db could not be started on the available port.
+     */
+    @BeforeAll
+    public void setup(final VertxTestContext testContext) throws IOException {
+        final String mongoDbHost = "127.0.0.1";
+        final int mongoDbPort = Network.getFreeServerPort();
+        final MongoDbConfigProperties mongoDbConfig = new MongoDbConfigProperties()
+                .setHost(mongoDbHost)
+                .setPort(mongoDbPort)
+                .setDbName("hono-credentials-test");
+
+        mongoDbTestUtils.startEmbeddedMongoDb(mongoDbHost, mongoDbPort);
+        vertx = Vertx.vertx();
+        mongoClient = MongoClient.createShared(vertx, mongoDbConfig.getMongoClientConfig());
+        credentialsService = new MongoDbBasedCredentialsService(
+                vertx,
+                mongoClient,
+                credentialsServiceConfig,
+                new SpringBasedHonoPasswordEncoder());
+        registrationService = new MongoDbBasedRegistrationService(
+                vertx,
+                mongoClient,
+                new MongoDbBasedRegistrationConfigProperties());
+        credentialsService.start().onComplete(testContext.completing());
+        registrationService.start().onComplete(testContext.completing());
+        deviceBackendService = new MongoDbBasedDeviceBackend(this.registrationService, this.credentialsService);
+    }
+
+    /**
+     * Cleans up fixture.
+     *
+     * @param testContext The test context to use for running asynchronous tests.
+     */
+    @AfterAll
+    public void finishTest(final VertxTestContext testContext) {
+        final Checkpoint shutdown = testContext.checkpoint(4);
+
+        credentialsService.stop().onComplete(s -> shutdown.flag());
+        registrationService.stop().onComplete(s -> shutdown.flag());
+        mongoClient.close();
+        vertx.close(s -> shutdown.flag());
+        mongoDbTestUtils.stopEmbeddedMongoDb();
+        shutdown.flag();
+    }
+
+    /**
+     * Cleans up the collection after tests.
+     *
+     * @param testContext The test context to use for running asynchronous tests.
+     */
+    @AfterEach
+    public void cleanCollection(final VertxTestContext testContext) {
+        mongoClient.removeDocuments(credentialsServiceConfig.getCollectionName(), new JsonObject(),
+                testContext.completing());
+    }
+
+    @Override
+    public CredentialsService getCredentialsService() {
+        return this.credentialsService;
+    }
+
+    @Override
+    public CredentialsManagementService getCredentialsManagementService() {
+        return this.credentialsService;
+    }
+
+    @Override
+    public DeviceManagementService getDeviceManagementService() {
+        return this.deviceBackendService;
+    }
+}


### PR DESCRIPTION
This PR contains unit tests for the MongoDB based implementation of credentials service and management APIs. 

It also contains the below fixes in the `AbstractCredentialsServiceTest` class which are required for the for the above unit tests.
1. Now the test devices are created first before adding credentials to those devices.
2. The values being set during the _Future_ completion are being used even before that Future completes. This has been fixed.