### PR TITLE
Use DeviceConnectionService with embedded cache for ITs

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -43,6 +43,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <!-- should be set to false if testing against a registry that doesn't support GW mode -->
     <deviceregistry.supportsGatewayMode>true</deviceregistry.supportsGatewayMode>
     <hono.amqp-network.host>hono-dispatch-router.hono</hono.amqp-network.host>
+    <hono.device-connection.host>hono-service-device-connection.hono</hono.device-connection.host>
     <hono.registration.host>hono-service-device-registry.hono</hono.registration.host>
     <hono.auth.host>hono-service-auth.hono</hono.auth.host>
     <default.java.options>
@@ -338,7 +339,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </env>
                     <log>
                       <prefix>AUTH</prefix>
-                      <color>cyan</color>
+                      <color>yellow</color>
                     </log>
                     <wait>
                       <time>${service.startup.timeout}</time>
@@ -411,7 +412,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </env>
                     <log>
                       <prefix>REGISTRY</prefix>
-                      <color>yellow</color>
+                      <color>green</color>
                     </log>
                     <wait>
                       <time>${service.startup.timeout}</time>
@@ -546,7 +547,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <memory>268435456</memory>
                     <log>
                       <prefix>QPID</prefix>
-                      <color>blue</color>
+                      <color>magenta</color>
                     </log>
                     <wait>
                       <time>${service.startup.timeout}</time>
@@ -555,6 +556,78 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <env>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
                     </env>
+                  </run>
+                </image>
+                <!-- ##### Device Connection service ##### -->
+                <image>
+                  <name>${docker.image.org-name}/hono-service-device-connection-test</name>
+                  <alias>device-connection</alias>
+                  <build>
+                    <imagePullPolicy>IfNotPresent</imagePullPolicy>
+                    <from>${docker.image.org-name}/hono-service-device-connection:${project.version}</from>
+                    <assembly>
+                      <mode>dir</mode>
+                      <basedir>/</basedir>
+                      <inline>
+                        <id>config</id>
+                        <fileSets>
+                          <fileSet>
+                            <directory>${project.build.directory}/resources/deviceconnection</directory>
+                            <outputDirectory>etc/hono</outputDirectory>
+                            <includes>
+                              <include>*</include>
+                            </includes>
+                          </fileSet>
+                          <fileSet>
+                            <directory>${project.build.directory}/certs</directory>
+                            <outputDirectory>etc/hono/certs</outputDirectory>
+                            <includes>
+                              <include>device-connection-*.pem</include>
+                              <include>auth-server-cert.pem</include>
+                              <include>trusted-certs.pem</include>
+                            </includes>
+                          </fileSet>
+                        </fileSets>
+                      </inline>
+                    </assembly>
+                  </build>
+                  <run>
+                    <ports>
+                      <port>+deviceconnection.ip:deviceconnection.amqp.port:5672</port>
+                      <port>+deviceconnection.ip:deviceconnection.health.port:${vertx.health.port}</port>
+                    </ports>
+                    <portPropertyFile>${project.build.directory}/docker/deviceconnection.port.properties</portPropertyFile>
+                    <network>
+                      <mode>custom</mode>
+                      <name>hono</name>
+                      <alias>hono-service-device-connection.hono</alias>
+                    </network>
+                    <memorySwap>205520896</memorySwap>
+                    <memory>205520896</memory>
+                    <env>
+                      <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SPRING_PROFILES_ACTIVE>${logging.profile},embedded-cache</SPRING_PROFILES_ACTIVE>
+                      <JDK_JAVA_OPTIONS>${default.java.options}</JDK_JAVA_OPTIONS>
+                      <PN_TRACE_FRM>0</PN_TRACE_FRM>
+                      <JAEGER_SERVICE_NAME>device-connection</JAEGER_SERVICE_NAME>
+                      <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
+                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
+                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
+                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
+                    </env>
+                    <log>
+                      <prefix>DEVCON</prefix>
+                      <color>yellow</color>
+                    </log>
+                    <wait>
+                      <time>${service.startup.timeout}</time>
+                      <http>
+                        <method>GET</method>
+                        <url>http://${deviceconnection.ip}:${deviceconnection.health.port}/readiness</url>
+                        <status>200..299</status>
+                      </http>
+                    </wait>
                   </run>
                 </image>
                 <!-- ##### HTTP adapter ##### -->
@@ -626,6 +699,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </env>
                     <log>
                       <prefix>HTTP</prefix>
+                      <color>red</color>
                     </log>
                     <wait>
                       <time>${service.startup.timeout}</time>
@@ -706,6 +780,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </env>
                     <log>
                       <prefix>MQTT</prefix>
+                      <color>red</color>
                     </log>
                     <wait>
                       <time>${service.startup.timeout}</time>
@@ -777,7 +852,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </env>
                     <log>
                       <prefix>AMQP</prefix>
-                      <color>RED</color>
+                      <color>red</color>
                     </log>
                     <wait>
                       <time>${service.startup.timeout}</time>
@@ -849,6 +924,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </env>
                     <log>
                       <prefix>COAP</prefix>
+                      <color>red</color>
                     </log>
                     <wait>
                       <time>${service.startup.timeout}</time>

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -54,7 +54,7 @@ hono:
     requestTimeout: ${request.timeout}
   deviceConnection:
     name: 'Hono AMQP Adapter'
-    host: ${hono.registration.host}
+    host: ${hono.device-connection.host}
     port: 5672 # AMQP port of the device registry
     username: amqp-adapter@HONO
     password: amqp-secret

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -54,7 +54,7 @@ hono:
     requestTimeout: ${request.timeout}
   deviceConnection:
     name: 'Hono CoAP Adapter'
-    host: ${hono.registration.host}
+    host: ${hono.device-connection.host}
     port: 5672
     username: coap-adapter@HONO
     password: coap-secret

--- a/tests/src/test/resources/deviceconnection/application.yml
+++ b/tests/src/test/resources/deviceconnection/application.yml
@@ -1,0 +1,23 @@
+hono:
+  app:
+    maxInstances: 1
+    startupTimeout: 90
+  healthCheck:
+    insecurePortBindAddress: 0.0.0.0
+    insecurePort: ${vertx.health.port}
+  auth:
+    host: ${hono.auth.host}
+    port: 5672
+    name: device-connection
+    validation:
+      certPath: /etc/hono/certs/auth-server-cert.pem
+  deviceConnection:
+    amqp:
+      insecurePortEnabled: true
+      insecurePortBindAddress: 0.0.0.0
+  vertx:
+    maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+
+spring:
+  jmx:
+    enabled: false

--- a/tests/src/test/resources/deviceconnection/cache-config.xml
+++ b/tests/src/test/resources/deviceconnection/cache-config.xml
@@ -1,0 +1,21 @@
+<!-- 
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<infinispan>
+  <cache-container default-cache="device-connection">
+    <local-cache name="device-connection" simple-cache="true">
+      <memory>
+        <object size="100" strategy="REMOVE" />
+      </memory>
+    </local-cache>
+  </cache-container>
+</infinispan>

--- a/tests/src/test/resources/deviceconnection/logback-spring.xml
+++ b/tests/src/test/resources/deviceconnection/logback-spring.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+
+  <!-- 
+    This is the logging configuration that is used by the
+    Hono Device Connection Docker image while executing the integration tests.
+
+    Any changes made here will be reflected on the next start
+    of the Hono Device Connection Docker image only, i.e. the next time
+
+    mvn -Prun-tests verify
+
+    is invoked.
+   -->
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <springProfile name="dev">
+    <logger name="org.eclipse.hono" level="DEBUG"/>
+
+    <logger name="io.netty.handler.logging.LoggingHandler" level="DEBUG"/>
+
+    <logger name="io.vertx.proton.impl" level="INFO"/>
+    <logger name="io.vertx.core.net.impl" level="INFO"/>
+  </springProfile>
+
+  <springProfile name="prod">
+    <logger name="org.eclipse.hono" level="INFO"/>
+
+    <logger name="io.netty.handler.logging.LoggingHandler" level="INFO"/>
+
+    <logger name="io.vertx.proton.impl" level="INFO"/>
+    <logger name="io.vertx.core.net.impl" level="INFO"/>
+  </springProfile>
+
+</configuration>

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -55,7 +55,7 @@ hono:
     requestTimeout: ${request.timeout}
   deviceConnection:
     name: 'Hono HTTP Adapter'
-    host: ${hono.registration.host}
+    host: ${hono.device-connection.host}
     port: 5672
     username: http-adapter@HONO
     password: http-secret

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -54,7 +54,7 @@ hono:
     requestTimeout: ${request.timeout}
   deviceConnection:
     name: 'Hono MQTT Adapter'
-    host: ${hono.registration.host}
+    host: ${hono.device-connection.host}
     port: 5672
     username: mqtt-adapter@HONO
     password: mqtt-secret


### PR DESCRIPTION
The integration tests are now run with the DeviceConnectionService
configured with an embedded cache instead of the Map based
implementation provided by the example registry.
This will make it easier to run the ITs with other registry
implementations once they are available.

Signed-off-by: Kai Hudalla <kai.hudalla@bosch.io>