### PR TITLE
[Not to merge] Make use of already downloaded flapdoodle mongo db artifacts

### DIFF
--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbTestUtils.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbTestUtils.java
@@ -13,28 +13,23 @@
 package org.eclipse.hono.deviceregistry.mongodb.service;
 
 import java.io.IOException;
-import java.util.UUID;
 
-import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.DownloadConfigBuilder;
-import de.flapdoodle.embed.mongo.config.ExtractedArtifactStoreBuilder;
 import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.config.IRuntimeConfig;
-import de.flapdoodle.embed.process.extract.UUIDTempNaming;
-import de.flapdoodle.embed.process.io.directories.FixedPath;
-import de.flapdoodle.embed.process.io.directories.IDirectory;
 import de.flapdoodle.embed.process.runtime.Network;
 
 /**
  * Utility class to initialize and tear down embedded mongodb.
  */
 public final class MongoDbTestUtils {
+    //The documentation suggests to make the MongodStarter instance static to
+    // cache the extracted executables and library files.
+    // For more info https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo
+    private static final MongodStarter DEFAULT_MONGOD_STARTER = MongodStarter.getDefaultInstance();
 
     private MongodExecutable mongodExecutable;
     private MongodProcess mongodProcess;
@@ -47,25 +42,11 @@ public final class MongoDbTestUtils {
      * @throws IOException if the embedded mongodb cannot be initialised.
      */
     public void startEmbeddedMongoDb(final String host, final int port) throws IOException {
-        final IDirectory artifactStorePath = new FixedPath(
-                "target/embeddedMongodbCustomPath-" + UUID.randomUUID().toString());
-        final IDirectory extractDir = new FixedPath("target/extractMongodbCustomPath-" + UUID.randomUUID().toString());
-        final Command command = Command.MongoD;
-        final IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder()
-                .defaults(command)
-                .artifactStore(new ExtractedArtifactStoreBuilder()
-                        .defaults(command)
-                        .download(new DownloadConfigBuilder()
-                                .defaultsForCommand(command)
-                                .artifactStorePath(artifactStorePath).build())
-                        .extractDir(extractDir)
-                        .executableNaming(new UUIDTempNaming()))
-                .build();
-        mongodExecutable = MongodStarter.getInstance(runtimeConfig)
-                .prepare(new MongodConfigBuilder()
-                        .version(Version.Main.PRODUCTION)
-                        .net(new Net(host, port, Network.localhostIsIPv6()))
-                        .build());
+
+        mongodExecutable = DEFAULT_MONGOD_STARTER.prepare(new MongodConfigBuilder()
+                .version(Version.Main.PRODUCTION)
+                .net(new Net(host, port, Network.localhostIsIPv6()))
+                .build());
         mongodProcess = mongodExecutable.start();
     }
 


### PR DESCRIPTION
An Embedded Mongo DB(_de.flapdoodle.embed.mongo_) instance is being used for the _mongo db based device registry_ unit tests. This gets downloaded during every build. The flapdoodle documentation talks about a static approach which caches the extracted executables and library files. But the problem with this approach is, that it doesn't work with _travis_ and the _travis_ build fails. 

The tests in this approach work fine in a local environment. But the travis build fails. This PR is to investigate that.