### PR TITLE
Use peers based deduplicator for coap-adapter

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -449,6 +449,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
         networkConfig.setInt(Keys.MAX_RESOURCE_BODY_SIZE, getConfig().getMaxPayloadSize());
         networkConfig.setInt(Keys.EXCHANGE_LIFETIME, getConfig().getExchangeLifetime());
         networkConfig.setBoolean(Keys.USE_MESSAGE_OFFLOADING, getConfig().isMessageOffloadingEnabled());
+        networkConfig.setString(Keys.DEDUPLICATOR, Keys.DEDUPLICATOR_PEERS_MARK_AND_SWEEP);
         final int maxConnections = getConfig().getMaxConnections();
         if (maxConnections == 0) {
             final MemoryBasedConnectionLimitStrategy limits = new MemoryBasedConnectionLimitStrategy(MINIMAL_MEMORY, MEMORY_PER_CONNECTION);

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <artemis.image.name>quay.io/enmasse/artemis-base:2.10.1</artemis.image.name>
     <assertj-core.version>3.15.0</assertj-core.version>
-    <californium.version>2.2.2</californium.version>
+    <californium.version>2.3.0</californium.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.12.0</dispatch-router.image.name>
     <flapdoodle.version>2.2.0</flapdoodle.version>
     <guava.version>28.0-jre</guava.version>


### PR DESCRIPTION
Requires Californium 2.3.0 release, scheduled for 16.06.2020.
So, on hold, as preview.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>
