### PR TITLE
[#1790] Add documentation

### DIFF
--- a/site/documentation/content/admin-guide/mqtt-adapter-config.md
+++ b/site/documentation/content/admin-guide/mqtt-adapter-config.md
@@ -34,9 +34,6 @@ The following table provides an overview of the configuration variables and corr
 | `HONO_MQTT_KEY_PATH`<br>`--hono.mqtt.keyPath` | no | - | The absolute path to the (PKCS8) PEM file containing the private key that the protocol adapter should use for authenticating to clients. This option must be used in conjunction with `HONO_MQTT_CERT_PATH`. Alternatively, the `HONO_MQTT_KEY_STORE_PATH` option can be used to configure a key store containing both the key as well as the certificate. |
 | `HONO_MQTT_KEY_STORE_PASSWORD`<br>`--hono.mqtt.keyStorePassword` | no | - | The password required to read the contents of the key store. |
 | `HONO_MQTT_KEY_STORE_PATH`<br>`--hono.mqtt.keyStorePath` | no | - | The absolute path to the Java key store containing the private key and certificate that the protocol adapter should use for authenticating to clients. Either this option or the `HONO_MQTT_KEY_PATH` and `HONO_MQTT_CERT_PATH` options need to be set in order to enable TLS secured connections with clients. The key store format can be either `JKS` or `PKCS12` indicated by a `.jks` or `.p12` file suffix respectively. |
-| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_HOST`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.host` | no | - | The host to which the adapter should connect to call the custom mapper. Replace `<mapperName>` with the name of the mapper to configure. |
-| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_PORT`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.port` | no | - | The port to which the adapter should connect to call the custom mapper. Replace `<mapperName>` with the name of the mapper to configure. |
-| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_URI`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.uri` | no | - | The used uri to append to the host to call the mapping method on the mapping server. Replace `<mapperName>` with the name of the mapper to configure. |
 | `HONO_MQTT_SNI`<br>`--hono.mqtt.sni` | no | `false` | Set whether the server supports Server Name Indication. By default, the server will not support SNI and the option is `false`. However, if set to `true` then the key store format , `HONO_MQTT_KEY_STORE_PATH`,  should be either `JKS` or `PKCS12` indicated by a `.jks` or `.p12` file suffix respectively. |
 | `HONO_MQTT_MAX_CONNECTIONS`<br>`--hono.mqtt.maxConnections` | no | `0` | The maximum number of concurrent connections that the protocol adapter should accept. If not set (or set to `0`), the protocol adapter determines a reasonable value based on the available resources like memory and CPU. |
 | `HONO_MQTT_MAX_PAYLOAD_SIZE`<br>`--hono.mqtt.maxPayloadSize` | no | `2048` | The maximum allowed size of an incoming MQTT message's payload in bytes. When a client sends a message with a larger payload, the message is discarded and the connection to the client gets closed. |
@@ -91,3 +88,22 @@ The protocol adapter may be configured to open both a secure and a non-secure po
 ### Ephemeral Ports
 
 Both the secure as well as the insecure port numbers may be explicitly set to `0`. The protocol adapter will then use arbitrary (unused) port numbers determined by the operating system during startup.
+
+## Custom Message Mapping
+
+This protocol adapter supports transformation of messages that have been uploaded by devices before forwarding them to downstream consumers.
+
+{{% note title="Experimental" %}}
+This is an experimental feature. The names of the configuration properties, potential values and the overall functionality are therefore
+subject to change without prior notice.
+{{% /note %}}
+
+The following table provides an overview of the configuration variables and corresponding command line options for configuring the external
+service endpoint(s) for transforming messages:
+
+| Environment Variable<br>Command Line Option | Mandatory | Default Value | Description  |
+| :------------------------------------------ | :-------: | :------------ | :------------|
+| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_HOST`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.host` | no | - | The host name or IP address of the service to invoke for transforming uploaded messages. The `<mapperName>` needs to contain the logical service name as set in the *mapper* property of the device's registration information. |
+| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_PORT`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.port` | no | - | The port of the service to invoke for transforming uploaded messages. The `<mapperName>` needs to contain the logical service name as set in the *mapper* property of the device's registration information. |
+| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_URI`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.uri` | no | - | The URI of the service to invoke for transforming uploaded messages. The `<mapperName>` needs to contain the logical service name as set in the *mapper* property of the device's registration information. |
+

--- a/site/documentation/content/admin-guide/mqtt-adapter-config.md
+++ b/site/documentation/content/admin-guide/mqtt-adapter-config.md
@@ -103,7 +103,7 @@ service endpoint(s) for transforming messages:
 
 | Environment Variable<br>Command Line Option | Mandatory | Default Value | Description  |
 | :------------------------------------------ | :-------: | :------------ | :------------|
-| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_HOST`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.host` | no | - | The host name or IP address of the service to invoke for transforming uploaded messages. The `<mapperName>` needs to contain the logical service name as set in the *mapper* property of the device's registration information. |
-| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_PORT`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.port` | no | - | The port of the service to invoke for transforming uploaded messages. The `<mapperName>` needs to contain the logical service name as set in the *mapper* property of the device's registration information. |
-| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_URI`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.uri` | no | - | The URI of the service to invoke for transforming uploaded messages. The `<mapperName>` needs to contain the logical service name as set in the *mapper* property of the device's registration information. |
+| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_HOST`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.host` | no | - | The host name or IP address of the service to invoke for transforming uploaded messages. The `<mapperName>` needs to contain the service name as set in the *mapper* property of the device's registration information. |
+| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_PORT`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.port` | no | - | The port of the service to invoke for transforming uploaded messages. The `<mapperName>` needs to contain the service name as set in the *mapper* property of the device's registration information. |
+| `HONO_MQTT_MAPPERENDPOINTS_<mapperName>_URI`<br>`--hono.mqtt.mapperEndpoints.<mapperName>.uri` | no | - | The URI of the service to invoke for transforming uploaded messages. The `<mapperName>` needs to contain the service name as set in the *mapper* property of the device's registration information. |
 

--- a/site/documentation/content/api/device-registration/index.md
+++ b/site/documentation/content/api/device-registration/index.md
@@ -62,6 +62,7 @@ In case of a successful invocation of the operation, the body of the response me
 | *device-id*      | *yes*     | *string*      | The ID of the device that is subject of the assertion. |
 | *via*            | *no*      | *array*       | The IDs (JSON strings) of gateways which may act on behalf of the device. This property MUST be set if any gateways are registered for the device. If the assertion request contained a *gateway_id* property and the response's *status* property has value `200` (indicating a successful assertion) then the array MUST at least contain the gateway ID from the request. |
 | *defaults*       | *no*      | *object*      | Default values to be used by protocol adapters for augmenting messages from devices with missing information like a *content type*. It is up to the discretion of a protocol adapter if and how to use the given default values when processing messages published by the device. |
+| *mapper*         | *no*      | *string*      | The (logical) name of a service that can be used to transform messages uploaded by the device before they are forwarded to downstream consumers. The client needs to map this name to the particular service to invoke. |
 
 Below is an example for a payload of a response to an *assert* request for device `4711` which also includes a default *content-type*:
 ~~~json

--- a/site/documentation/content/api/device-registration/index.md
+++ b/site/documentation/content/api/device-registration/index.md
@@ -62,16 +62,17 @@ In case of a successful invocation of the operation, the body of the response me
 | *device-id*      | *yes*     | *string*      | The ID of the device that is subject of the assertion. |
 | *via*            | *no*      | *array*       | The IDs (JSON strings) of gateways which may act on behalf of the device. This property MUST be set if any gateways are registered for the device. If the assertion request contained a *gateway_id* property and the response's *status* property has value `200` (indicating a successful assertion) then the array MUST at least contain the gateway ID from the request. |
 | *defaults*       | *no*      | *object*      | Default values to be used by protocol adapters for augmenting messages from devices with missing information like a *content type*. It is up to the discretion of a protocol adapter if and how to use the given default values when processing messages published by the device. |
-| *mapper*         | *no*      | *string*      | The (logical) name of a service that can be used to transform messages uploaded by the device before they are forwarded to downstream consumers. The client needs to map this name to the particular service to invoke. |
+| *mapper*         | *no*      | *string*      | The name of a service that can be used to transform messages uploaded by the device before they are forwarded to downstream consumers. The client needs to map this name to the particular service to invoke. |
 
-Below is an example for a payload of a response to an *assert* request for device `4711` which also includes a default *content-type*:
+Below is an example for a payload of a response to an *assert* request for device `4711` which also includes a default *content-type* and a mapper service:
 ~~~json
 {
   "device-id": "4711",
   "via": ["4712"],
   "defaults": {
     "content-type": "application/vnd.acme+json"
-  }
+  },
+  "mapper": "my-payload-transformation"
 }
 ~~~
 

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -785,7 +785,7 @@ components:
             "mapper":
                type: string
                description: |
-                  The (logical) name of a service that can be used by protocol adapters to transform messages
+                  The name of a service that can be used by protocol adapters to transform messages
                   uploaded by devices before sending them to downstream consumers.
                   The protocol adapter needs to map this name to the particular service to invoke.
                   NB: This is an experimental feature and thus this property is subject to change without

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -36,7 +36,7 @@ info:
    license:
       name: EPL-2.0
       url: https://www.eclipse.org/legal/epl-2.0/
-   version: 1.1.0
+   version: 1.2.0
 
 externalDocs:
    description: Eclipse Hono™ web page
@@ -765,17 +765,31 @@ components:
                type: array
                items:
                   type: string
-               description: The device IDs of the gateways that are registered to act on behalf of this device. Note that "via" and "memberOf" must not be set at the same time.
+               description: |
+                  The device IDs of the gateways that are registered to act on behalf of this device.
+                  Note that "via" and "memberOf" must not be set at the same time.
             "viaGroups":
                type: array
                items:
                   type: string
-               description: The IDs of the gateway groups that are registered to act on behalf of this device. Note that "viaGroups" and "memberOf" must not be set at the same time.
+               description: |
+                  The IDs of the gateway groups that are registered to act on behalf of this device.
+                  Note that "viaGroups" and "memberOf" must not be set at the same time.
             "memberOf":
                type: array
                items:
                   type: string
-               description: The IDs of the gateway groups that this device is a member of. Note that "via" and "memberOf" must not be set at the same time. The same applies for "viaGroups" and "memberOf" which must be set at the same time too. The reason is that Eclipse Hono does not support groups of gateway groups.
+               description: |
+                  The IDs of the gateway groups that this device is a member of.
+                  Note that neither "via" nor "viaGroups" must be set if "memberOf" is set.
+            "mapper":
+               type: string
+               description: |
+                  The (logical) name of a service that can be used by protocol adapters to transform messages
+                  uploaded by devices before sending them to downstream consumers.
+                  The protocol adapter needs to map this name to the particular service to invoke.
+                  NB: This is an experimental feature and thus this property is subject to change without
+                  notice.
             "ext":
                $ref: '#/components/schemas/Extensions'
 


### PR DESCRIPTION
Added documentation of the MQTT adapter's experimental "custom message
mapping" feature to Device Registry Management API, Device Registration
API, MQTT adapter user and admin guides.
