### PR TITLE
[#1998] Set lifespan for lastKnownGateway cache entries

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfo.java
@@ -51,6 +51,11 @@ import io.vertx.ext.healthchecks.Status;
 public final class CacheBasedDeviceConnectionInfo implements DeviceConnectionInfo, HealthCheckProvider {
 
     /**
+     * Lifespan for last-known-gateway cache entries.
+     */
+    static final Duration LAST_KNOWN_GATEWAY_CACHE_ENTRY_LIFESPAN = Duration.ofDays(28);
+
+    /**
      * For <em>viaGateways</em> parameter value lower or equal to this value, the {@link #getCommandHandlingAdapterInstances(String, String, Set, SpanContext)}
      * method will use an optimized approach, potentially saving additional cache requests.
      */
@@ -97,7 +102,8 @@ public final class CacheBasedDeviceConnectionInfo implements DeviceConnectionInf
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(gatewayId);
 
-        return cache.put(getGatewayEntryKey(tenantId, deviceId), gatewayId)
+        final long lifespanMillis = LAST_KNOWN_GATEWAY_CACHE_ENTRY_LIFESPAN.toMillis();
+        return cache.put(getGatewayEntryKey(tenantId, deviceId), gatewayId, lifespanMillis, TimeUnit.MILLISECONDS)
             .map(replacedValue -> {
                 LOG.debug("set last known gateway [tenant: {}, device-id: {}, gateway: {}]", tenantId, deviceId,
                         gatewayId);

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -133,7 +134,7 @@ class CacheBasedDeviceConnectionInfoTest {
     void testSetLastKnownGatewaySucceeds(final VertxTestContext ctx) {
         final Cache<String, String> mockedCache = mockCache();
         info = new CacheBasedDeviceConnectionInfo(mockedCache, tracer);
-        when(mockedCache.put(anyString(), anyString())).thenReturn(Future.succeededFuture("oldValue"));
+        when(mockedCache.put(anyString(), anyString(), anyLong(), any())).thenReturn(Future.succeededFuture("oldValue"));
         info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, "device-id", "gw-id", null)
             .onComplete(ctx.completing());
     }
@@ -147,7 +148,7 @@ class CacheBasedDeviceConnectionInfoTest {
     void testSetLastKnownGatewayFails(final VertxTestContext ctx) {
         final Cache<String, String> mockedCache = mockCache();
         info = new CacheBasedDeviceConnectionInfo(mockedCache, tracer);
-        when(mockedCache.put(anyString(), anyString())).thenReturn(Future.failedFuture(new IOException("not available")));
+        when(mockedCache.put(anyString(), anyString(), anyLong(), any())).thenReturn(Future.failedFuture(new IOException("not available")));
         info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, "device-id", "gw-id", mock(SpanContext.class))
             .onComplete(ctx.failing(t -> {
                 ctx.verify(() -> assertThat(t).isInstanceOf(ServiceInvocationException.class));


### PR DESCRIPTION
This fixes #1998.

Applies a fixed lifespan for the `lastKnownGateway` cache entries. This is a minimalistic sotution for #1998. We should probably make this lifespan configurable. This can be done in a subsequent PR (possibly along with renaming `CommonCacheConfig` for that).