### PR TITLE
[#1858] Remove 'updateOnly' param in setCommandHandlingAdapterInstance

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/BasicCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/BasicCache.java
@@ -232,30 +232,6 @@ public abstract class BasicCache<K, V> implements Cache<K, V>, ConnectionLifecyc
     }
 
     /**
-     * Replaces the entry for a key only if currently mapped to a given value.
-     *
-     * @param key The key.
-     * @param oldValue The value to overwrite.
-     * @param newValue The value to store.
-     * @param lifespan The lifespan of the entry. A negative value is interpreted as an unlimited lifespan.
-     * @param lifespanUnit The time unit for the lifespan.
-     * @return A succeeded future containing a boolean, indicating whether the value was replaced or not.
-     *         A failed future if the value could not be stored in the cache.
-     * @throws NullPointerException if any of the parameters is {@code null}.
-     */
-    @Override
-    public Future<Boolean> replace(final K key, final V oldValue, final V newValue, final long lifespan,
-            final TimeUnit lifespanUnit) {
-        Objects.requireNonNull(key);
-        Objects.requireNonNull(oldValue);
-        Objects.requireNonNull(newValue);
-        Objects.requireNonNull(lifespanUnit);
-
-        return withCache(cache -> cache.replaceAsync(key, oldValue, newValue, lifespan, lifespanUnit));
-
-    }
-
-    /**
      * Remove a key/value mapping from the cache.
      *
      * @param key The key.

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Cache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Cache.java
@@ -64,20 +64,6 @@ public interface Cache<K, V> {
     Future<V> put(K key, V value, long lifespan, TimeUnit lifespanUnit);
 
     /**
-     * Replaces the entry for a key only if currently mapped to a given value.
-     *
-     * @param key The key.
-     * @param oldValue The value to overwrite.
-     * @param newValue The value to store.
-     * @param lifespan The lifespan of the entry. A negative value is interpreted as an unlimited lifespan.
-     * @param lifespanUnit The time unit for the lifespan.
-     * @return A succeeded future containing a boolean, indicating whether the value was replaced or not.
-     *         A failed future if the value could not be stored in the cache.
-     * @throws NullPointerException if any of the parameters is {@code null}.
-     */
-    Future<Boolean> replace(K key, V oldValue, V newValue, long lifespan, TimeUnit lifespanUnit);
-
-    /**
      * Gets a value from the cache.
      *
      * @param key The key.

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
@@ -117,8 +117,8 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
 
     @Override
     public Future<Void> setCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
-            final Duration lifespan, final boolean updateOnly, final SpanContext context) {
-        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, updateOnly, context);
+            final Duration lifespan, final SpanContext context) {
+        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, context);
     }
 
     @Override

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
@@ -76,8 +76,6 @@ public interface DeviceConnectionInfo {
      * @param adapterInstanceId The protocol adapter instance id.
      * @param lifespan The lifespan of the mapping entry. Using a negative duration or {@code null} here is
      *                 interpreted as an unlimited lifespan.
-     * @param updateOnly If {@code true}, this operation will only update an existing mapping entry with the given
-     *                   lifespan, provided such an entry with the given device id and adapter instance id exists.
      * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            Implementing classes should use this as the parent for any span they create for tracing
      *            the execution of this operation.
@@ -88,7 +86,7 @@ public interface DeviceConnectionInfo {
      * @throws NullPointerException if any of the parameters except context is {@code null}.
      */
     Future<Void> setCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId,
-            Duration lifespan, boolean updateOnly, SpanContext context);
+            Duration lifespan, SpanContext context);
 
     /**
      * Removes the mapping information that associates the given device with the given protocol adapter instance

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
@@ -226,8 +226,7 @@ class CacheBasedDeviceConnectionInfoTest {
     public void testSetCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, spanContext)
                 .onComplete(ctx.succeeding(result -> ctx.completeNow()));
     }
 
@@ -241,52 +240,8 @@ class CacheBasedDeviceConnectionInfoTest {
     public void testSetCommandHandlingAdapterInstanceWithLifespanSucceeds(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, Duration.ofSeconds(10),
-                false, spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, Duration.ofSeconds(10), spanContext)
                 .onComplete(ctx.succeeding(result -> ctx.completeNow()));
-    }
-
-    /**
-     * Verifies that the <em>setCommandHandlingAdapterInstance</em> operation with <em>updateOnly</em> set to
-     * {@code true} succeeds.
-     *
-     * @param ctx The vert.x context.
-     */
-    @Test
-    public void testSetCommandHandlingAdapterInstanceWithUpdateOnlyTrueSucceeds(final VertxTestContext ctx) {
-        final String deviceId = "testDevice";
-        final String adapterInstance = "adapterInstance";
-        // first invocation initially adds the entry
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false,
-                spanContext)
-        // now update the entry
-        .compose(v -> info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null,
-                true, spanContext))
-        .onComplete(ctx.succeeding(result -> ctx.completeNow()));
-    }
-
-    /**
-     * Verifies that the <em>setCommandHandlingAdapterInstance</em> operation with <em>updateOnly</em> set to
-     * {@code true} fails with a PRECON_FAILED status if the given adapter instance parameter doesn't match the one of
-     * the entry registered for the given device.
-     *
-     * @param ctx The vert.x context.
-     */
-    @Test
-    public void testSetCommandHandlingAdapterInstanceWithUpdateOnlyTrueFails(final VertxTestContext ctx) {
-        final String deviceId = "testDevice";
-        final String adapterInstance = "adapterInstance";
-        // first invocation initially adds the entry
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false,
-                spanContext)
-        // now try to update the entry, but with another adapter instance
-        .compose(v -> info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, "otherAdapterInstance",
-                null, true, spanContext))
-        .onComplete(ctx.failing(t -> ctx.verify(() -> {
-            assertThat(t).isInstanceOf(ServiceInvocationException.class);
-            assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
-            ctx.completeNow();
-        })));
     }
 
     /**
@@ -298,8 +253,7 @@ class CacheBasedDeviceConnectionInfoTest {
     public void testRemoveCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, spanContext)
         .compose(v -> info.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId,
                 adapterInstance, spanContext))
         .onComplete(ctx.succeeding(result -> ctx.verify(() -> {
@@ -319,8 +273,7 @@ class CacheBasedDeviceConnectionInfoTest {
     public void testRemoveCommandHandlingAdapterInstanceFailsForOtherDevice(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, spanContext)
         .compose(v -> {
             return info.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, "otherDevice", adapterInstance, spanContext);
         }).onComplete(ctx.succeeding(result -> ctx.verify(() -> {
@@ -339,8 +292,7 @@ class CacheBasedDeviceConnectionInfoTest {
     public void testRemoveCommandHandlingAdapterInstanceFailsForOtherAdapterInstance(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, spanContext)
         .compose(v -> {
             return info.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, "otherAdapterInstance", spanContext);
         }).onComplete(ctx.succeeding(result -> ctx.verify(() -> {
@@ -359,8 +311,7 @@ class CacheBasedDeviceConnectionInfoTest {
     public void testGetCommandHandlingAdapterInstancesForDevice(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, spanContext)
         .compose(v -> {
             return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, Collections.emptySet(), spanContext);
         }).onComplete(ctx.succeeding(result -> ctx.verify(() -> {
@@ -385,8 +336,7 @@ class CacheBasedDeviceConnectionInfoTest {
 
         final Cache<String, String> mockedCache = spy(cache);
         info = new CacheBasedDeviceConnectionInfo(mockedCache, tracer);
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, Duration.ofMillis(1),
-                false, spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, Duration.ofMillis(1), spanContext)
         .compose(v -> {
             final Promise<JsonObject> instancesPromise = Promise.promise();
             // wait 2ms to make sure entry has expired after that
@@ -439,12 +389,10 @@ class CacheBasedDeviceConnectionInfoTest {
         final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId));
         viaGateways.addAll(extraUnusedViaGateways);
         // set command handling adapter instance for gateway
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, spanContext)
         .compose(v -> {
             // set command handling adapter instance for other gateway
-            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, null,
-                    false, spanContext);
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, null, spanContext);
         }).compose(deviceConnectionResult -> {
             return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, spanContext);
         }).compose(u -> {
@@ -478,12 +426,10 @@ class CacheBasedDeviceConnectionInfoTest {
         final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId));
         viaGateways.addAll(extraUnusedViaGateways);
         // set command handling adapter instance for gateway
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, spanContext)
         .compose(v -> {
             // set command handling adapter instance for other gateway
-            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, null,
-                    false, spanContext);
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, null, spanContext);
         }).compose(deviceConnectionResult -> {
             return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayIdNotInVia, spanContext);
         }).compose(u -> {
@@ -518,13 +464,11 @@ class CacheBasedDeviceConnectionInfoTest {
         final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId, gatewayWithNoAdapterInstance));
         viaGateways.addAll(extraUnusedViaGateways);
         // set command handling adapter instance for gateway
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false,
-                spanContext)
-        .compose(v -> {
-            // set command handling adapter instance for other gateway
-            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, null,
-                    false, spanContext);
-        }).compose(deviceConnectionResult -> {
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, spanContext)
+                .compose(v -> {
+                    // set command handling adapter instance for other gateway
+                    return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, null, spanContext);
+                }).compose(deviceConnectionResult -> {
             return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayWithNoAdapterInstance, spanContext);
         }).compose(u -> {
             return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
@@ -555,8 +499,7 @@ class CacheBasedDeviceConnectionInfoTest {
         final Set<String> viaGateways = new HashSet<>(Set.of("otherGatewayId"));
         viaGateways.addAll(extraUnusedViaGateways);
         // set command handling adapter instance for gateway
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, spanContext)
         .compose(deviceConnectionResult -> {
             return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, spanContext);
         }).compose(u -> {
@@ -586,12 +529,10 @@ class CacheBasedDeviceConnectionInfoTest {
         final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId));
         viaGateways.addAll(extraUnusedViaGateways);
         // set command handling adapter instance for device
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, spanContext)
         .compose(v -> {
             // set command handling adapter instance for other gateway
-            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, otherAdapterInstance, null,
-                    false, spanContext);
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, otherAdapterInstance, null, spanContext);
         }).compose(u -> {
             return info.setLastKnownGatewayForDevice(Constants.DEFAULT_TENANT, deviceId, gatewayId, spanContext);
         }).compose(w -> {
@@ -623,12 +564,10 @@ class CacheBasedDeviceConnectionInfoTest {
         final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId));
         viaGateways.addAll(extraUnusedViaGateways);
         // set command handling adapter instance for device
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, spanContext)
         .compose(v -> {
             // set command handling adapter instance for other gateway
-            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, otherAdapterInstance, null,
-                    false, spanContext);
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, otherAdapterInstance, null, spanContext);
         }).compose(w -> {
             return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
         }).onComplete(ctx.succeeding(result -> ctx.verify(() -> {
@@ -657,8 +596,7 @@ class CacheBasedDeviceConnectionInfoTest {
         final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId));
         viaGateways.addAll(extraUnusedViaGateways);
         // set command handling adapter instance for gateway
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, spanContext)
         .compose(v -> {
             return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
         }).onComplete(ctx.succeeding(result -> ctx.verify(() -> {
@@ -687,12 +625,10 @@ class CacheBasedDeviceConnectionInfoTest {
         final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId, otherGatewayId));
         viaGateways.addAll(extraUnusedViaGateways);
         // set command handling adapter instance for gateway
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, spanContext)
         .compose(v -> {
             // set command handling adapter instance for other gateway
-            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, null,
-                    false, spanContext);
+            return info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, otherAdapterInstance, null, spanContext);
         }).compose(u -> {
             return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
         }).onComplete(ctx.succeeding(result -> ctx.verify(() -> {
@@ -743,8 +679,7 @@ class CacheBasedDeviceConnectionInfoTest {
         final Set<String> viaGateways = new HashSet<>(Set.of(gatewayId));
         viaGateways.addAll(extraUnusedViaGateways);
         // set command handling adapter instance for other gateway
-        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, adapterInstance, null, false,
-                spanContext)
+        info.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, adapterInstance, null, spanContext)
         .compose(v -> {
             return info.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId, viaGateways, spanContext);
         }).onComplete(ctx.failing(t -> ctx.verify(() -> {

--- a/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
@@ -76,8 +76,6 @@ public interface DeviceConnectionClient extends RequestResponseClient {
      * @param lifespan The lifespan of the mapping entry. Using a negative duration or {@code null} here is
      *                 interpreted as an unlimited lifespan. Only the number of seconds in the given duration
      *                 will be taken into account.
-     * @param updateOnly If {@code true}, this operation will only update an existing mapping entry with the given
-     *                   lifespan, provided such an entry with the given device id and adapter instance id exists.
      * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            An implementation should use this as the parent for any span it creates for tracing
      *            the execution of this operation.
@@ -85,7 +83,7 @@ public interface DeviceConnectionClient extends RequestResponseClient {
      * @throws NullPointerException if device id or adapter instance id is {@code null}.
      */
     Future<Void> setCommandHandlingAdapterInstance(String deviceId, String adapterInstanceId, Duration lifespan,
-            boolean updateOnly, SpanContext context);
+            SpanContext context);
 
     /**
      * Removes the mapping information that associates the given device with the given protocol adapter instance

--- a/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientImpl.java
@@ -270,7 +270,7 @@ public class DeviceConnectionClientImpl extends AbstractRequestResponseClient<De
 
     @Override
     public Future<Void> setCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
-            final Duration lifespan, final boolean updateOnly, final SpanContext context) {
+            final Duration lifespan, final SpanContext context) {
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(adapterInstanceId);
 
@@ -278,7 +278,6 @@ public class DeviceConnectionClientImpl extends AbstractRequestResponseClient<De
         final Map<String, Object> properties = createDeviceIdProperties(deviceId);
         properties.put(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId);
         properties.put(MessageHelper.APP_PROPERTY_LIFESPAN, lifespanSeconds);
-        properties.put(MessageHelper.APP_PROPERTY_UPDATE_ONLY, updateOnly);
 
         final Span currentSpan = newChildSpan(context, "set command handling adapter instance");
         TracingHelper.setDeviceTags(currentSpan, getTenantId(), deviceId);

--- a/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -183,8 +183,7 @@ public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClien
     private Future<Void> setCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
             final Duration lifespan, final SpanContext context) {
         return deviceConnectionClientFactory.getOrCreateDeviceConnectionClient(tenantId)
-                .compose(client -> client.setCommandHandlingAdapterInstance(deviceId, adapterInstanceId, lifespan,
-                        false, context))
+                .compose(client -> client.setCommandHandlingAdapterInstance(deviceId, adapterInstanceId, lifespan, context))
                 .recover(thr -> {
                     log.info("error setting command handling adapter instance [tenant: {}, device: {}]", tenantId,
                             deviceId, thr);

--- a/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
@@ -161,7 +161,7 @@ public class DeviceConnectionClientImplTest {
     public void testSetCommandHandlingAdapterInstance(final VertxTestContext ctx) {
 
         // WHEN setting the command handling adapter instance
-        client.setCommandHandlingAdapterInstance("deviceId", "adapterInstanceId", null, false, span.context())
+        client.setCommandHandlingAdapterInstance("deviceId", "adapterInstanceId", null, span.context())
                 .onComplete(ctx.succeeding(r -> {
                     ctx.verify(() -> {
                         // THEN the response has been handled and the span is finished
@@ -302,7 +302,7 @@ public class DeviceConnectionClientImplTest {
         when(sender.sendQueueFull()).thenReturn(true);
 
         // WHEN setting the command handling adapter instance
-        client.setCommandHandlingAdapterInstance("deviceId", "adapterInstanceId", null, false, span.context())
+        client.setCommandHandlingAdapterInstance("deviceId", "adapterInstanceId", null, span.context())
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {
                         // THEN the invocation fails and the span is marked as erroneous
@@ -478,7 +478,7 @@ public class DeviceConnectionClientImplTest {
         });
 
         // WHEN setting the command handling adapter instance
-        client.setCommandHandlingAdapterInstance("deviceId", "adapterInstanceId", null, false, span.context())
+        client.setCommandHandlingAdapterInstance("deviceId", "adapterInstanceId", null, span.context())
                 .onComplete(ctx.failing(t -> {
                     assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                     ctx.verify(() -> {
@@ -611,7 +611,7 @@ public class DeviceConnectionClientImplTest {
         final String deviceId = "deviceId";
 
         // WHEN setting the command handling adapter instance
-        client.setCommandHandlingAdapterInstance(deviceId, "adapterInstanceId", null, false, span.context());
+        client.setCommandHandlingAdapterInstance(deviceId, "adapterInstanceId", null, span.context());
 
         // THEN the message being sent contains the device ID in its properties
         final Message sentMessage = verifySenderSend();
@@ -622,9 +622,6 @@ public class DeviceConnectionClientImplTest {
         assertThat(MessageHelper.getApplicationProperty(sentMessage.getApplicationProperties(),
                 MessageHelper.APP_PROPERTY_LIFESPAN, Integer.class))
                         .isEqualTo(Integer.valueOf(-1));
-        assertThat(MessageHelper.getApplicationProperty(sentMessage.getApplicationProperties(),
-                MessageHelper.APP_PROPERTY_UPDATE_ONLY, Boolean.class))
-                        .isFalse();
         assertThat(sentMessage.getMessageId()).isNotNull();
         assertThat(sentMessage.getSubject()).isEqualTo(DeviceConnectionConstants.DeviceConnectionAction.SET_CMD_HANDLING_ADAPTER_INSTANCE.getSubject());
         assertThat(MessageHelper.getJsonPayload(sentMessage)).isNull();
@@ -642,7 +639,7 @@ public class DeviceConnectionClientImplTest {
 
         // WHEN setting the command handling adapter instance
         client.setCommandHandlingAdapterInstance(deviceId, "adapterInstanceId",
-                Duration.ofSeconds(lifespanSeconds), true, span.context());
+                Duration.ofSeconds(lifespanSeconds), span.context());
 
         // THEN the message being sent contains the device ID in its properties
         final Message sentMessage = verifySenderSend();
@@ -653,9 +650,6 @@ public class DeviceConnectionClientImplTest {
         assertThat(MessageHelper.getApplicationProperty(sentMessage.getApplicationProperties(),
                 MessageHelper.APP_PROPERTY_LIFESPAN, Integer.class))
                 .isEqualTo(lifespanSeconds);
-        assertThat(MessageHelper.getApplicationProperty(sentMessage.getApplicationProperties(),
-                MessageHelper.APP_PROPERTY_UPDATE_ONLY, Boolean.class))
-                .isTrue();
         assertThat(sentMessage.getMessageId()).isNotNull();
         assertThat(sentMessage.getSubject()).isEqualTo(DeviceConnectionConstants.DeviceConnectionAction.SET_CMD_HANDLING_ADAPTER_INSTANCE.getSubject());
         assertThat(MessageHelper.getJsonPayload(sentMessage)).isNull();

--- a/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
@@ -133,7 +133,7 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
         when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
         when(deviceConnectionClientFactory.getOrCreateDeviceConnectionClient(anyString()))
                 .thenReturn(Future.succeededFuture(devConClient));
-        when(devConClient.setCommandHandlingAdapterInstance(anyString(), anyString(), any(), anyBoolean(), any()))
+        when(devConClient.setCommandHandlingAdapterInstance(anyString(), anyString(), any(), any()))
                 .thenReturn(Future.succeededFuture());
         when(devConClient.removeCommandHandlingAdapterInstance(anyString(), anyString(), any()))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
@@ -185,7 +185,7 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
                 ctx.verify(() -> {
                     verify(connection).createReceiver(eq(tenantCommandAddress), eq(ProtonQoS.AT_LEAST_ONCE), any(), anyInt(),
                             eq(false), any());
-                    verify(devConClient).setCommandHandlingAdapterInstance(eq(deviceId), anyString(), any(), eq(false), any());
+                    verify(devConClient).setCommandHandlingAdapterInstance(eq(deviceId), anyString(), any(), any());
                 });
                 ctx.completeNow();
             }));
@@ -209,7 +209,7 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
             ctx.verify(() -> {
                 verify(connection).createReceiver(eq(tenantCommandAddress), eq(ProtonQoS.AT_LEAST_ONCE), any(), anyInt(),
                         eq(false), any());
-                verify(devConClient).setCommandHandlingAdapterInstance(eq(deviceId), anyString(), any(), eq(false), any());
+                verify(devConClient).setCommandHandlingAdapterInstance(eq(deviceId), anyString(), any(), any());
                 // verify closing the consumer is successful
                 consumer.close(any()).onComplete(ctx.succeeding(v -> {
                     ctx.verify(() -> {

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -81,11 +81,6 @@ public final class MessageHelper {
      */
     public static final String APP_PROPERTY_LIFESPAN = "lifespan";
     /**
-     * The name of the AMQP 1.0 message application property defining whether the operation should only
-     * update an existing value or not.
-     */
-    public static final String APP_PROPERTY_UPDATE_ONLY = "update_only";
-    /**
      * The name of the AMQP 1.0 application property that is used to convey the address that a message has been
      * originally published to by a device.
      */

--- a/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DelegatingDeviceConnectionAmqpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DelegatingDeviceConnectionAmqpEndpoint.java
@@ -16,7 +16,6 @@ import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
@@ -242,9 +241,6 @@ public class DelegatingDeviceConnectionAmqpEndpoint<S extends DeviceConnectionSe
         final String deviceId = MessageHelper.getDeviceId(request);
         final String adapterInstanceId = MessageHelper.getApplicationProperty(request.getApplicationProperties(), MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, String.class);
         final Integer lifespanSecondsOrNull = MessageHelper.getApplicationProperty(request.getApplicationProperties(), MessageHelper.APP_PROPERTY_LIFESPAN, Integer.class);
-        final boolean updateOnly = Optional
-                .ofNullable(MessageHelper.getApplicationProperty(request.getApplicationProperties(), MessageHelper.APP_PROPERTY_UPDATE_ONLY, Boolean.class))
-                .orElse(false);
 
         final Span span = TracingHelper.buildServerChildSpan(
                 tracer,
@@ -263,12 +259,10 @@ public class DelegatingDeviceConnectionAmqpEndpoint<S extends DeviceConnectionSe
             TracingHelper.TAG_DEVICE_ID.set(span, deviceId);
             span.setTag(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId);
             span.setTag(MessageHelper.APP_PROPERTY_LIFESPAN, lifespan.getSeconds());
-            span.setTag(MessageHelper.APP_PROPERTY_UPDATE_ONLY, updateOnly);
-            log.debug("setting command handling adapter instance for tenant [{}], device [{}] to {} (lifespan: {}s, updateOnly: {})",
-                    tenantId, deviceId, adapterInstanceId, lifespan.getSeconds(), updateOnly);
+            log.debug("setting command handling adapter instance for tenant [{}], device [{}] to {} (lifespan: {}s)",
+                    tenantId, deviceId, adapterInstanceId, lifespan.getSeconds());
 
-            resultFuture = getService().setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan,
-                    updateOnly, span)
+            resultFuture = getService().setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, span)
                     .map(res -> DeviceConnectionConstants.getAmqpReply(
                             DeviceConnectionConstants.DEVICE_CONNECTION_ENDPOINT,
                             tenantId,

--- a/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DeviceConnectionService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DeviceConnectionService.java
@@ -83,8 +83,6 @@ public interface DeviceConnectionService {
      * @param lifespan The lifespan of the mapping entry. Using a negative duration or {@code null} here is
      *                 interpreted as an unlimited lifespan. The guaranteed granularity taken into account
      *                 here is seconds.
-     * @param updateOnly If {@code true}, this operation will only update an existing mapping entry with the given
-     *                   lifespan, provided such an entry with the given device id and adapter instance id exists.
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
      *            implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
@@ -93,7 +91,7 @@ public interface DeviceConnectionService {
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     Future<DeviceConnectionResult> setCommandHandlingAdapterInstance(String tenantId, String deviceId,
-            String adapterInstanceId, Duration lifespan, boolean updateOnly, Span span);
+            String adapterInstanceId, Duration lifespan, Span span);
 
     /**
      * Removes the mapping information that associates the given device with the given protocol adapter instance

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
@@ -80,8 +80,8 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
     @Override
     public Future<DeviceConnectionResult> setCommandHandlingAdapterInstance(final String tenantId,
             final String deviceId, final String adapterInstanceId, final Duration lifespan,
-            final boolean updateOnly, final Span span) {
-        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, updateOnly, span.context())
+            final Span span) {
+        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, span.context())
                 .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }

--- a/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
+++ b/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
@@ -15,7 +15,6 @@ package org.eclipse.hono.deviceconnection.infinispan;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -156,18 +155,17 @@ public class CacheBasedDeviceConnectionServiceTest {
 
         final String deviceId = "testDevice";
         final String adapterInstanceId = "adapterInstanceId";
-        final boolean updateOnly = true;
-        when(cache.setCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(), anyBoolean(), any(SpanContext.class)))
+        when(cache.setCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture());
 
         givenAStartedService()
         .compose(ok -> svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstanceId, null,
-                updateOnly, span))
+                 span))
         .onComplete(ctx.succeeding(result -> {
             ctx.verify(() -> {
                 assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
                 verify(cache).setCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(),
-                        eq(updateOnly), any(SpanContext.class));
+                        any(SpanContext.class));
             });
             ctx.completeNow();
         }));

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionServiceTest.java
@@ -169,7 +169,7 @@ public class MapBasedDeviceConnectionServiceTest {
     public void testSetCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, span)
                 .onComplete(ctx.succeeding(result -> ctx.verify(() -> {
                     assertEquals(HttpURLConnection.HTTP_NO_CONTENT, result.getStatus());
                     ctx.completeNow();
@@ -187,70 +187,17 @@ public class MapBasedDeviceConnectionServiceTest {
         props.setMaxDevicesPerTenant(1);
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
                     });
                     // set another entry
                     return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, "testDevice2",
-                            adapterInstance, null, false, span);
+                            adapterInstance, null, span);
                 }).onComplete(ctx.succeeding(deviceConnectionResult -> ctx.verify(() -> {
                     assertEquals(HttpURLConnection.HTTP_FORBIDDEN, deviceConnectionResult.getStatus());
                     assertNull(deviceConnectionResult.getPayload());
-                    ctx.completeNow();
-                })));
-    }
-
-    /**
-     * Verifies that the <em>setCommandHandlingAdapterInstance</em> operation with <em>updateOnly</em> set to
-     * {@code true} succeeds.
-     *
-     * @param ctx The vert.x context.
-     */
-    @Test
-    public void testSetCommandHandlingAdapterInstanceWithUpdateOnlyTrueSucceeds(final VertxTestContext ctx) {
-        final String deviceId = "testDevice";
-        final String adapterInstance = "adapterInstance";
-        // first invocation initially adds the entry
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
-                .compose(deviceConnectionResult -> {
-                    ctx.verify(() -> {
-                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
-                    });
-                    // now update the entry
-                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance,
-                            null, true, span);
-                }).onComplete(ctx.succeeding(result -> ctx.verify(() -> {
-                    assertEquals(HttpURLConnection.HTTP_NO_CONTENT, result.getStatus());
-                    assertNull(result.getPayload());
-                    ctx.completeNow();
-                })));
-    }
-
-    /**
-     * Verifies that the <em>setCommandHandlingAdapterInstance</em> operation with <em>updateOnly</em> set to
-     * {@code true} fails with a PRECON_FAILED status if the given adapter instance parameter doesn't match the one of
-     * the entry registered for the given device.
-     *
-     * @param ctx The vert.x context.
-     */
-    @Test
-    public void testSetCommandHandlingAdapterInstanceWithUpdateOnlyTrueFails(final VertxTestContext ctx) {
-        final String deviceId = "testDevice";
-        final String adapterInstance = "adapterInstance";
-        // first invocation initially adds the entry
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
-                .compose(deviceConnectionResult -> {
-                    ctx.verify(() -> {
-                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
-                    });
-                    // now try to update the entry, but with another adapter instance
-                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId,
-                            "otherAdapterInstance", null, true, span);
-                }).onComplete(ctx.succeeding(result -> ctx.verify(() -> {
-                    assertEquals(HttpURLConnection.HTTP_PRECON_FAILED, result.getStatus());
-                    assertNull(result.getPayload());
                     ctx.completeNow();
                 })));
     }
@@ -265,7 +212,7 @@ public class MapBasedDeviceConnectionServiceTest {
     public void testRemoveCommandHandlingAdapterInstanceSucceeds(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -289,7 +236,7 @@ public class MapBasedDeviceConnectionServiceTest {
     public void testRemoveCommandHandlingAdapterInstanceFailsForOtherDevice(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -313,7 +260,7 @@ public class MapBasedDeviceConnectionServiceTest {
     public void testRemoveCommandHandlingAdapterInstanceFailsForOtherAdapterInstance(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -340,7 +287,7 @@ public class MapBasedDeviceConnectionServiceTest {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
         final Duration lifespan = Duration.ofMillis(1);
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, lifespan, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, lifespan, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -369,7 +316,7 @@ public class MapBasedDeviceConnectionServiceTest {
     public void testGetCommandHandlingAdapterInstancesForDevice(final VertxTestContext ctx) {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -397,48 +344,8 @@ public class MapBasedDeviceConnectionServiceTest {
         final String deviceId = "testDevice";
         final String adapterInstance = "adapterInstance";
         final Duration lifespan = Duration.ofMillis(1);
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, lifespan, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, lifespan, span)
                 .compose(deviceConnectionResult -> {
-                    ctx.verify(() -> {
-                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
-                    });
-                    final Promise<DeviceConnectionResult> instancesPromise = Promise.promise();
-                    // wait 2ms so that the lifespan has elapsed
-                    vertx.setTimer(2, tid -> {
-                        svc.getCommandHandlingAdapterInstances(Constants.DEFAULT_TENANT, deviceId,
-                                Collections.emptyList(), span)
-                                .onComplete(instancesPromise.future());
-                    });
-                    return instancesPromise.future();
-                }).onComplete(ctx.succeeding(result -> ctx.verify(() -> {
-                    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
-                    ctx.completeNow();
-                })));
-    }
-
-    /**
-     * Verifies that the <em>getCommandHandlingAdapterInstances</em> operation fails if the adapter instance
-     * entry has expired after having been updated with a short lifespan.
-     *
-     * @param vertx The vert.x instance.
-     * @param ctx The vert.x context.
-     */
-    @Test
-    public void testGetCommandHandlingAdapterInstancesForUpdatedExpiredEntry(final Vertx vertx, final VertxTestContext ctx) {
-        final String deviceId = "testDevice";
-        final String adapterInstance = "adapterInstance";
-        final Duration firstLongLifespan = Duration.ofSeconds(300);
-        final Duration secondShortLifespan = Duration.ofMillis(1);
-        // create entry with a long lifespan first
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, firstLongLifespan, false, span)
-                .compose(deviceConnectionResult -> {
-                    ctx.verify(() -> {
-                        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
-                    });
-                    // now invoke with "updateOnly" and use the short lifespan
-                    return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance,
-                            secondShortLifespan, true, span);
-                }).compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
                     });
@@ -488,14 +395,14 @@ public class MapBasedDeviceConnectionServiceTest {
         final String otherGatewayId = "gw-2";
         final List<String> viaGateways = List.of(gatewayId, otherGatewayId);
         // set command handling adapter instance for gateway
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
                     });
                     // set command handling adapter instance for other gateway
                     return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId,
-                            otherAdapterInstance, null, false, span);
+                            otherAdapterInstance, null, span);
                 }).compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -536,14 +443,14 @@ public class MapBasedDeviceConnectionServiceTest {
         final String gatewayIdNotInVia = "gw-old";
         final List<String> viaGateways = List.of(gatewayId, otherGatewayId);
         // set command handling adapter instance for gateway
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
                     });
                     // set command handling adapter instance for other gateway
                     return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId,
-                            otherAdapterInstance, null, false, span);
+                            otherAdapterInstance, null, span);
                 }).compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -585,14 +492,14 @@ public class MapBasedDeviceConnectionServiceTest {
         final String gatewayWithNoAdapterInstance = "gw-other";
         final List<String> viaGateways = List.of(gatewayId, otherGatewayId, gatewayWithNoAdapterInstance);
         // set command handling adapter instance for gateway
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
                     });
                     // set command handling adapter instance for other gateway
                     return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId,
-                            otherAdapterInstance, null, false, span);
+                            otherAdapterInstance, null, span);
                 }).compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -630,7 +537,7 @@ public class MapBasedDeviceConnectionServiceTest {
         final String gatewayId = "gw-1";
         final List<String> viaGateways = Collections.singletonList("otherGatewayId");
         // set command handling adapter instance for gateway
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -664,14 +571,14 @@ public class MapBasedDeviceConnectionServiceTest {
         final String gatewayId = "gw-1";
         final List<String> viaGateways = List.of(gatewayId);
         // set command handling adapter instance for device
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
                     });
                     // set command handling adapter instance for other gateway
                     return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId,
-                            otherAdapterInstance, null, false, span);
+                            otherAdapterInstance, null, span);
                 }).compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -709,14 +616,14 @@ public class MapBasedDeviceConnectionServiceTest {
         final String gatewayId = "gw-1";
         final List<String> viaGateways = List.of(gatewayId);
         // set command handling adapter instance for device
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
                     });
                     // set command handling adapter instance for other gateway
                     return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId,
-                            otherAdapterInstance, null, false, span);
+                            otherAdapterInstance, null, span);
                 }).compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -747,7 +654,7 @@ public class MapBasedDeviceConnectionServiceTest {
         final String otherGatewayId = "gw-2";
         final List<String> viaGateways = List.of(gatewayId, otherGatewayId);
         // set command handling adapter instance for gateway
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -778,14 +685,14 @@ public class MapBasedDeviceConnectionServiceTest {
         final String otherGatewayId = "gw-2";
         final List<String> viaGateways = List.of(gatewayId, otherGatewayId);
         // set command handling adapter instance for gateway
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, false, span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, gatewayId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
                     });
                     // set command handling adapter instance for other gateway
                     return svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId,
-                            otherAdapterInstance, null, false, span);
+                            otherAdapterInstance, null, span);
                 }).compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());
@@ -834,8 +741,7 @@ public class MapBasedDeviceConnectionServiceTest {
         final String otherGatewayId = "gw-2";
         final List<String> viaGateways = List.of(gatewayId);
         // set command handling adapter instance for other gateway
-        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, adapterInstance, null, false,
-                span)
+        svc.setCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, otherGatewayId, adapterInstance, null, span)
                 .compose(deviceConnectionResult -> {
                     ctx.verify(() -> {
                         assertEquals(HttpURLConnection.HTTP_NO_CONTENT, deviceConnectionResult.getStatus());

--- a/site/documentation/content/api/device-connection/index.md
+++ b/site/documentation/content/api/device-connection/index.md
@@ -129,7 +129,6 @@ The following table provides an overview of the properties a client needs to set
 | *subject*             | yes       | *properties*             | *string*  | MUST be set to `set-cmd-handling-adapter-instance`. |
 | *adapter_instance_id* | yes       | *application-properties* | *string*  | The identifier of the protocol adapter instance that currently handles commands for the device or gateway identified by the *device_id* property. |
 | *lifespan*            | no        | *application-properties* | *int*     | The lifespan of the mapping entry in seconds. After that period, the mapping entry shall be treated as non-existent by the *Device Registration API* methods. A negative value, as well as an omitted property, is interpreted as an unlimited lifespan. |
-| *update_only*         | no        | *application-properties* | *boolean* | If set to `true`, the command will only update an existing mapping entry with the given lifespan, provided such an entry with the given device id and adapter instance id exists. If the property is omitted or set to `false`, the mapping entry will be set regardless whether an entry with the given adapter instance id exists or not. |
 
 The body of the message SHOULD be empty and will be ignored if it is not.
 
@@ -143,7 +142,6 @@ The response message's *status* property may contain the following codes:
 | :---- | :---------- |
 | *204* | OK, the command-handling adapter instance for the device has been updated. |
 | *400* | Bad Request, the adapter instance for the device has not been set or updated due to invalid or missing data in the request. |
-| *412* | Precondition failed, the adapter instance for the device has not been set or updated. This status is returned if the *update_only* property is set to `true` but no matching entry for the given device ID and adapter instance value exists. |
 
 Implementors of this API may return a *404* status code in order to indicate that no device with the given identifier exists for the given tenant. However, performing such a check is optional.
 

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedDeviceConnectionClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedDeviceConnectionClient.java
@@ -115,7 +115,6 @@ public class JmsBasedDeviceConnectionClient extends JmsBasedRequestResponseClien
             final String deviceId,
             final String adapterInstanceId,
             final Duration lifespan,
-            final boolean updateOnly,
             final SpanContext context) {
 
         final int lifespanSeconds = lifespan != null && lifespan.getSeconds() <= Integer.MAX_VALUE ? (int) lifespan.getSeconds() : -1;
@@ -123,8 +122,7 @@ public class JmsBasedDeviceConnectionClient extends JmsBasedRequestResponseClien
                 DeviceConnectionAction.SET_CMD_HANDLING_ADAPTER_INSTANCE.getSubject(),
                 Map.of(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId,
                         MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId,
-                        MessageHelper.APP_PROPERTY_LIFESPAN, lifespanSeconds,
-                        MessageHelper.APP_PROPERTY_UPDATE_ONLY, updateOnly),
+                        MessageHelper.APP_PROPERTY_LIFESPAN, lifespanSeconds),
                 null)
                 .onSuccess(payload -> LOGGER.debug("successfully set command-handling adapter instance"))
                 .onFailure(t -> LOGGER.error("failed to set command-handling adapter instance", t))


### PR DESCRIPTION
This is for #1858.
The `updateOnly` parameter won't be needed anymore.