### PR TITLE
Add tracing in CacheBasedDeviceConnectionClient

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
@@ -11,40 +11,55 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
+import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.hono.client.DeviceConnectionClient;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.MessageHelper;
 
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-
 
 /**
  * A client for accessing device connection information in a data grid.
  */
 public final class CacheBasedDeviceConnectionClient implements DeviceConnectionClient {
 
+    private static final String SPAN_NAME_GET_LAST_GATEWAY = "get last known gateway";
+    private static final String SPAN_NAME_SET_LAST_GATEWAY = "set last known gateway";
+    private static final String SPAN_NAME_GET_CMD_HANDLING_ADAPTER_INSTANCES = "get command handling adapter instances";
+    private static final String SPAN_NAME_SET_CMD_HANDLING_ADAPTER_INSTANCE = "set command handling adapter instance";
+    private static final String SPAN_NAME_REMOVE_CMD_HANDLING_ADAPTER_INSTANCE = "remove command handling adapter instance";
+
     final String tenantId;
     final DeviceConnectionInfo cache;
+    private final Tracer tracer;
 
     /**
      * Creates a client for accessing device connection information.
      *
      * @param tenantId The tenant that this client is scoped to.
      * @param cache The remote cache that contains the data.
+     * @param tracer The OpenTracing {@code Tracer} to use for tracking requests done by this client.
+     * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    public CacheBasedDeviceConnectionClient(final String tenantId, final DeviceConnectionInfo cache) {
+    public CacheBasedDeviceConnectionClient(final String tenantId, final DeviceConnectionInfo cache, final Tracer tracer) {
         this.tenantId = Objects.requireNonNull(tenantId);
         this.cache = Objects.requireNonNull(cache);
+        this.tracer = Objects.requireNonNull(tracer);
     }
 
     /**
@@ -104,7 +119,10 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
      */
     @Override
     public Future<Void> setLastKnownGatewayForDevice(final String deviceId, final String gatewayId, final SpanContext context) {
-        return cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, context);
+        final Span span = newSpan(context, SPAN_NAME_SET_LAST_GATEWAY);
+        TracingHelper.setDeviceTags(span, tenantId, deviceId);
+        TracingHelper.TAG_GATEWAY_ID.set(span, gatewayId);
+        return finishSpan(cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, span), span);
     }
 
     /**
@@ -112,24 +130,55 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
      */
     @Override
     public Future<JsonObject> getLastKnownGatewayForDevice(final String deviceId, final SpanContext context) {
-        return cache.getLastKnownGatewayForDevice(tenantId, deviceId, context);
+        final Span span = newSpan(context, SPAN_NAME_GET_LAST_GATEWAY);
+        TracingHelper.setDeviceTags(span, tenantId, deviceId);
+        return finishSpan(cache.getLastKnownGatewayForDevice(tenantId, deviceId, span), span);
     }
 
     @Override
     public Future<Void> setCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
             final Duration lifespan, final SpanContext context) {
-        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, context);
+        final Span span = newSpan(context, SPAN_NAME_SET_CMD_HANDLING_ADAPTER_INSTANCE);
+        TracingHelper.setDeviceTags(span, tenantId, deviceId);
+        span.setTag(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId);
+        final int lifespanSeconds = lifespan != null && lifespan.getSeconds() <= Integer.MAX_VALUE ? (int) lifespan.getSeconds() : -1;
+        span.setTag(MessageHelper.APP_PROPERTY_LIFESPAN, lifespanSeconds);
+        return finishSpan(cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, span), span);
     }
 
     @Override
     public Future<Boolean> removeCommandHandlingAdapterInstance(final String deviceId, final String adapterInstanceId,
             final SpanContext context) {
-        return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, context);
+        final Span span = newSpan(context, SPAN_NAME_REMOVE_CMD_HANDLING_ADAPTER_INSTANCE);
+        TracingHelper.setDeviceTags(span, tenantId, deviceId);
+        span.setTag(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId);
+        return finishSpan(cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span), span);
     }
 
     @Override
     public Future<JsonObject> getCommandHandlingAdapterInstances(final String deviceId, final List<String> viaGateways,
             final SpanContext context) {
-        return cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), context);
+        final Span span = newSpan(context, SPAN_NAME_GET_CMD_HANDLING_ADAPTER_INSTANCES);
+        TracingHelper.setDeviceTags(span, tenantId, deviceId);
+        return finishSpan(cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), span), span);
+    }
+
+    private Span newSpan(final SpanContext parent, final String operationName) {
+        return TracingHelper.buildChildSpan(tracer, parent, operationName, getClass().getSimpleName())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+                .start();
+    }
+
+    private <T> Future<T> finishSpan(final Future<T> result, final Span span) {
+        return result.recover(t -> {
+            Tags.HTTP_STATUS.set(span, ServiceInvocationException.extractStatusCode(t));
+            TracingHelper.logError(span, t);
+            span.finish();
+            return Future.failedFuture(t);
+        }).map(resultValue -> {
+            Tags.HTTP_STATUS.set(span, resultValue != null ? HttpURLConnection.HTTP_OK : HttpURLConnection.HTTP_ACCEPTED);
+            span.finish();
+            return resultValue;
+        });
     }
 }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClientFactory.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClientFactory.java
@@ -110,7 +110,7 @@ public final class CacheBasedDeviceConnectionClientFactory implements BasicDevic
     public Future<DeviceConnectionClient> getOrCreateDeviceConnectionClient(final String tenantId) {
         final DeviceConnectionClient result = clients.get(tenantId, key -> {
             final DeviceConnectionInfo info = new CacheBasedDeviceConnectionInfo(cache, tracer);
-            return new CacheBasedDeviceConnectionClient(key, info);
+            return new CacheBasedDeviceConnectionClient(key, info, tracer);
         });
         return Future.succeededFuture(result);
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DeviceConnectionService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/deviceconnection/DeviceConnectionService.java
@@ -88,7 +88,7 @@ public interface DeviceConnectionService {
      *            parent for any spans created in this method.
      * @return A future indicating the outcome of the operation.
      *         The <em>status</em> will be <em>204 No Content</em> if the operation completed successfully.
-     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws NullPointerException if any of the parameters except lifespan is {@code null}.
      */
     Future<DeviceConnectionResult> setCommandHandlingAdapterInstance(String tenantId, String deviceId,
             String adapterInstanceId, Duration lifespan, Span span);
@@ -132,7 +132,7 @@ public interface DeviceConnectionService {
      *         to adapter instance id.</li>
      *         <li><em>404 Not Found</em> if no instances were found.</li>
      *         </ul>
-     * @throws NullPointerException if any of the parameters except context is {@code null}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
      */
     Future<DeviceConnectionResult> getCommandHandlingAdapterInstances(String tenantId, String deviceId, List<String> viaGateways, Span span);
 }

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
@@ -59,7 +59,7 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
             final String gatewayId,
             final Span span) {
 
-        return cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, span.context())
+        return cache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, span)
                 .map(ok -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT));
     }
 
@@ -72,7 +72,7 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
             final String deviceId,
             final Span span) {
 
-        return cache.getLastKnownGatewayForDevice(tenantId, deviceId, span.context())
+        return cache.getLastKnownGatewayForDevice(tenantId, deviceId, span)
                 .map(json -> DeviceConnectionResult.from(HttpURLConnection.HTTP_OK, json))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
@@ -81,7 +81,7 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
     public Future<DeviceConnectionResult> setCommandHandlingAdapterInstance(final String tenantId,
             final String deviceId, final String adapterInstanceId, final Duration lifespan,
             final Span span) {
-        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, span.context())
+        return cache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, span)
                 .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
@@ -89,7 +89,7 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
     @Override
     public Future<DeviceConnectionResult> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
             final String adapterInstanceId, final Span span) {
-        return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span.context())
+        return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span)
                 .map(removed -> removed ? DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT)
                         : DeviceConnectionResult.from(HttpURLConnection.HTTP_PRECON_FAILED))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
@@ -98,7 +98,7 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
     @Override
     public Future<DeviceConnectionResult> getCommandHandlingAdapterInstances(final String tenantId, final String deviceId,
             final List<String> viaGateways, final Span span) {
-        return cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), span.context())
+        return cache.getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), span)
                 .map(json -> DeviceConnectionResult.from(HttpURLConnection.HTTP_OK, json))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }

--- a/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
+++ b/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
@@ -106,7 +106,7 @@ public class CacheBasedDeviceConnectionServiceTest {
 
         final String deviceId = "testDevice";
         final String gatewayId = "testGateway";
-        when(cache.setLastKnownGatewayForDevice(anyString(), anyString(), anyString(), any(SpanContext.class)))
+        when(cache.setLastKnownGatewayForDevice(anyString(), anyString(), anyString(), any(Span.class)))
             .thenReturn(Future.succeededFuture());
 
         givenAStartedService()
@@ -114,7 +114,7 @@ public class CacheBasedDeviceConnectionServiceTest {
         .onComplete(ctx.succeeding(result -> {
             ctx.verify(() -> {
                 assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
-                verify(cache).setLastKnownGatewayForDevice(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(gatewayId), any(SpanContext.class));
+                verify(cache).setLastKnownGatewayForDevice(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(gatewayId), any(Span.class));
             });
             ctx.completeNow();
         }));
@@ -130,7 +130,7 @@ public class CacheBasedDeviceConnectionServiceTest {
     public void testGetLastKnownGatewayForDeviceNotFound(final VertxTestContext ctx) {
 
         final String deviceId = "testDevice";
-        when(cache.getLastKnownGatewayForDevice(anyString(), anyString(), any(SpanContext.class)))
+        when(cache.getLastKnownGatewayForDevice(anyString(), anyString(), any(Span.class)))
             .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
 
         givenAStartedService()
@@ -155,7 +155,7 @@ public class CacheBasedDeviceConnectionServiceTest {
 
         final String deviceId = "testDevice";
         final String adapterInstanceId = "adapterInstanceId";
-        when(cache.setCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(), any(SpanContext.class)))
+        when(cache.setCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(), any(Span.class)))
                 .thenReturn(Future.succeededFuture());
 
         givenAStartedService()
@@ -165,7 +165,7 @@ public class CacheBasedDeviceConnectionServiceTest {
             ctx.verify(() -> {
                 assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
                 verify(cache).setCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(),
-                        any(SpanContext.class));
+                        any(Span.class));
             });
             ctx.completeNow();
         }));
@@ -183,7 +183,7 @@ public class CacheBasedDeviceConnectionServiceTest {
 
         final String deviceId = "testDevice";
         final String adapterInstanceId = "adapterInstanceId";
-        when(cache.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(SpanContext.class)))
+        when(cache.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(Span.class)))
                 .thenReturn(Future.succeededFuture(true));
 
         givenAStartedService()
@@ -191,7 +191,7 @@ public class CacheBasedDeviceConnectionServiceTest {
                 .onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
                         assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
-                        verify(cache).removeCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(SpanContext.class));
+                        verify(cache).removeCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(Span.class));
                     });
                     ctx.completeNow();
                 }));
@@ -209,7 +209,7 @@ public class CacheBasedDeviceConnectionServiceTest {
 
         final String deviceId = "testDevice";
         final String adapterInstanceId = "adapterInstanceId";
-        when(cache.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(SpanContext.class)))
+        when(cache.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(Span.class)))
                 .thenReturn(Future.succeededFuture(false));
 
         givenAStartedService()
@@ -217,7 +217,7 @@ public class CacheBasedDeviceConnectionServiceTest {
                 .onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
                         assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
-                        verify(cache).removeCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(SpanContext.class));
+                        verify(cache).removeCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(Span.class));
                     });
                     ctx.completeNow();
                 }));


### PR DESCRIPTION
Currently device connection requests only get traced when using the `DelegatingDeviceConnectionAmqpEndpoint`, i.e. when using a separate device connection service component.
This PR adds the corresponding trace spans also for the Hotrod client based device connection client.

Furthermore, when using `DelegatingDeviceConnectionAmqpEndpoint`, there are now no duplicate "getCommandHandlingAdapterInstances" spans anymore.