### PR TITLE
[#1958]  implementation of the search devices operation for the file-based registry

### DIFF
--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
@@ -31,6 +31,9 @@ import org.eclipse.hono.service.management.Result;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.device.AutoProvisioningEnabledDeviceBackend;
 import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.device.Filter;
+import org.eclipse.hono.service.management.device.SearchDevicesResult;
+import org.eclipse.hono.service.management.device.Sort;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsResult;
@@ -170,6 +173,11 @@ public class FileBasedDeviceBackend implements AutoProvisioningEnabledDeviceBack
     public Future<OperationResult<Id>> updateDevice(final String tenantId, final String deviceId, final Device device,
             final Optional<String> resourceVersion, final Span span) {
         return registrationService.updateDevice(tenantId, deviceId, device, resourceVersion, span);
+    }
+
+    @Override
+    public Future<OperationResult<SearchDevicesResult>> searchDevices(final String tenantId, final int pageSize, final int pageOffset, final List<Filter> filters, final List<Sort> sortOptions, final Span span) {
+    return registrationService.searchDevices(tenantId, pageSize, pageOffset, filters, sortOptions, span);
     }
 
     // CREDENTIALS

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceManagementSearchDevicesTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceManagementSearchDevicesTest.java
@@ -1,0 +1,132 @@
+/*****************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
+import org.eclipse.hono.service.management.device.AbstractDeviceManagementSearchDevicesTest;
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.service.management.device.Filter;
+import org.eclipse.hono.service.management.device.SearchDevicesResult;
+import org.eclipse.hono.service.management.device.Sort;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Vertx;
+import io.vertx.core.file.FileSystem;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests for {@link FileBasedRegistrationService#searchDevices(String, int, int, List, List, Span)}.
+ */
+@ExtendWith(VertxExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public final class FileBasedDeviceManagementSearchDevicesTest implements AbstractDeviceManagementSearchDevicesTest {
+
+    private static final String FILE_NAME = "/device-identities.json";
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileBasedDeviceManagementSearchDevicesTest.class);
+    private Vertx vertx;
+    private FileBasedRegistrationService registrationService;
+    private FileBasedRegistrationConfigProperties registrationConfig;
+    private FileSystem fileSystem;
+
+    /**
+     * Sets up static fixture.
+     */
+    @BeforeAll
+    public void setup() {
+
+        fileSystem = mock(FileSystem.class);
+        vertx = mock(Vertx.class);
+        when(vertx.fileSystem()).thenReturn(fileSystem);
+
+        registrationConfig = new FileBasedRegistrationConfigProperties();
+        registrationConfig.setFilename(FILE_NAME);
+
+        registrationService = new FileBasedRegistrationService(vertx);
+        registrationService.setConfig(registrationConfig);
+    }
+
+    /**
+     * Prints the test name.
+     *
+     * @param testInfo Test case meta information.
+     */
+    @BeforeEach
+    public void setup(final TestInfo testInfo) {
+        LOG.info("running {}", testInfo.getDisplayName());
+    }
+
+
+    @Override
+    public DeviceManagementService getDeviceManagementService() {
+        return this.registrationService;
+    }
+
+    /**
+     * Verifies that a request to search devices with valid page offset succeeds and the result is in accordance with
+     * the specified page offset.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Override
+    @Test
+    // Overridden test because the order of entries in the in-memory store is not consistent.
+    public void testSearchDevicesWithPageOffset(final VertxTestContext ctx) {
+        final String tenantId = DeviceRegistryUtils.getUniqueIdentifier();
+        final int pageSize = 1;
+        final int pageOffset = 1;
+        final Filter filter = new Filter("/enabled", true);
+        final Sort sortOption = new Sort("/id");
+
+        sortOption.setDirection(Sort.Direction.desc);
+        createDevices(tenantId, Map.of(
+                "testDevice1", new Device().setEnabled(true),
+                "testDevice2", new Device().setEnabled(true)))
+                .compose(ok -> getDeviceManagementService()
+                        .searchDevices(tenantId, pageSize, pageOffset, List.of(filter),
+                                List.of(sortOption),
+                                NoopSpan.INSTANCE)
+                        .onComplete(ctx.succeeding(s -> {
+                            ctx.verify(() -> {
+                                assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_OK);
+
+                                final SearchDevicesResult searchResult = s.getPayload();
+                                assertThat(searchResult.getTotal()).isEqualTo(2);
+                                assertThat(searchResult.getResult()).hasSize(1);
+                            });
+                            ctx.completeNow();
+                        })));
+    }
+}

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
@@ -53,7 +53,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -69,7 +68,6 @@ public class FileBasedRegistrationServiceTest implements RegistrationServiceTest
     private FileBasedRegistrationService registrationService;
     private FileBasedRegistrationConfigProperties registrationConfig;
     private Vertx vertx;
-    private EventBus eventBus;
     private FileSystem fileSystem;
 
     /**
@@ -78,9 +76,7 @@ public class FileBasedRegistrationServiceTest implements RegistrationServiceTest
     @BeforeEach
     public void setUp() {
         fileSystem = mock(FileSystem.class);
-        eventBus = mock(EventBus.class);
         vertx = mock(Vertx.class);
-        when(vertx.eventBus()).thenReturn(eventBus);
         when(vertx.fileSystem()).thenReturn(fileSystem);
 
         registrationConfig = new FileBasedRegistrationConfigProperties();

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -38,14 +38,14 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <flow.latency>1000</flow.latency>
     <request.timeout>500</request.timeout>
     <adapter.sendMessageToDeviceTimeout>1000</adapter.sendMessageToDeviceTimeout>
-    <!-- use minimum cost factor in order to speed up test execution --> 
+    <!-- use minimum cost factor in order to speed up test execution -->
     <max.bcrypt.costFactor>4</max.bcrypt.costFactor>
     <max.event-loop.execute-time>5000</max.event-loop.execute-time>
     <!-- should be set to false if testing against a registry that doesn't support GW mode -->
     <deviceregistry.supportsGatewayMode>true</deviceregistry.supportsGatewayMode>
     <deviceregistry.credentials.supportsClientContext>true</deviceregistry.credentials.supportsClientContext>
     <!-- should be set to true if testing against a registry that supports search devices operation -->
-    <deviceregistry.supportsSearchDevices>false</deviceregistry.supportsSearchDevices>
+    <deviceregistry.supportsSearchDevices>true</deviceregistry.supportsSearchDevices>
     <hono.amqp-network.host>hono-dispatch-router.hono</hono.amqp-network.host>
     <hono.device-connection.host>hono-service-device-connection.hono</hono.device-connection.host>
     <hono.registration.host>hono-service-device-registry.hono</hono.registration.host>


### PR DESCRIPTION
Follow up of issue #1995. This implementation on the search devices operations only support paging ( and it may not be consistent).
Filtering and sorting should be implemented using databases features.

This is a draft PR to make sure we agree on the shape of things while I write a few integration tests :smiley: 

Signed-off-by: Jean-Baptiste Trystram <jbtrystram@redhat.com>