### PR TITLE
[#2017] Fix reconnect-handling concerning command_internal links

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
@@ -223,20 +223,20 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
      *
      * @param con The connection to the AMQP network.
      * @param adapterInstanceId The protocol adapter instance id.
-     * @param closeHook A handler to invoke if the peer closes the link unexpectedly (may be {@code null}).
+     * @param remoteCloseHook A handler to invoke if the peer closes the link unexpectedly (may be {@code null}).
      * @return A future indicating the result of the creation attempt.
      * @throws NullPointerException if con or adapterInstanceId is {@code null}.
      */
     public static Future<DelegatedCommandSender> create(
             final HonoConnection con,
             final String adapterInstanceId,
-            final Handler<String> closeHook) {
+            final Handler<String> remoteCloseHook) {
 
         Objects.requireNonNull(con);
         Objects.requireNonNull(adapterInstanceId);
 
         final String targetAddress = getTargetAddress(adapterInstanceId);
-        return con.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, closeHook)
+        return con.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, remoteCloseHook)
                 .map(sender -> new DelegatedCommandSenderImpl(con, sender));
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -115,9 +115,7 @@ public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClien
 
     @Override
     protected void onDisconnect() {
-        if (adapterSpecificConsumer != null) {
-            connection.closeAndFree(adapterSpecificConsumer, v -> {});
-        }
+        adapterSpecificConsumer = null;
         mappingAndDelegatingCommandConsumerFactory.clearState();
     }
 


### PR DESCRIPTION
This fixes #2017.
The sender links on the "command_internal/[adapterId]" address didn't get removed from the cache on connection close, so that these then invalid links still got used on the new proton connection, causing timeout exceptions.

Also the receiver on the "command_internal/[adapterId]" address might not have been recreated on connection close (if the link was still marked as "open" locally).