### PR TITLE
[#2017] 1.2.x: Fix reconnect-handling concerning command_internal links

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
@@ -223,20 +223,20 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
      *
      * @param con The connection to the AMQP network.
      * @param adapterInstanceId The protocol adapter instance id.
-     * @param closeHook A handler to invoke if the peer closes the link unexpectedly (may be {@code null}).
+     * @param remoteCloseHook A handler to invoke if the peer closes the link unexpectedly (may be {@code null}).
      * @return A future indicating the result of the creation attempt.
      * @throws NullPointerException if con or adapterInstanceId is {@code null}.
      */
     public static Future<DelegatedCommandSender> create(
             final HonoConnection con,
             final String adapterInstanceId,
-            final Handler<String> closeHook) {
+            final Handler<String> remoteCloseHook) {
 
         Objects.requireNonNull(con);
         Objects.requireNonNull(adapterInstanceId);
 
         final String targetAddress = getTargetAddress(adapterInstanceId);
-        return con.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, closeHook)
+        return con.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, remoteCloseHook)
                 .map(sender -> new DelegatedCommandSenderImpl(con, sender));
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/MappingAndDelegatingCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/MappingAndDelegatingCommandHandler.java
@@ -93,6 +93,7 @@ public class MappingAndDelegatingCommandHandler {
         this.adapterInstanceId = Objects.requireNonNull(adapterInstanceId);
 
         this.delegatedCommandSenderFactory = new CachingClientFactory<>(connection.getVertx(), s -> s.isOpen());
+        this.connection.addDisconnectListener(con -> delegatedCommandSenderFactory.clearState());
     }
 
     /**
@@ -279,7 +280,9 @@ public class MappingAndDelegatingCommandHandler {
     private Future<DelegatedCommandSender> getOrCreateDelegatedCommandSender(final String protocolAdapterInstanceId) {
         return connection.executeOnContext(result -> {
             delegatedCommandSenderFactory.getOrCreateClient(protocolAdapterInstanceId,
-                    () -> DelegatedCommandSenderImpl.create(connection, protocolAdapterInstanceId, null), result);
+                    () -> DelegatedCommandSenderImpl.create(connection, protocolAdapterInstanceId,
+                            onSenderClosed -> delegatedCommandSenderFactory.removeClient(protocolAdapterInstanceId)),
+                    result);
         });
     }
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -108,9 +108,7 @@ public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClien
 
     @Override
     protected void onDisconnect() {
-        if (adapterSpecificConsumer != null) {
-            connection.closeAndFree(adapterSpecificConsumer, v -> {});
-        }
+        adapterSpecificConsumer = null;
         mappingAndDelegatingCommandConsumerFactory.clearState();
     }
 


### PR DESCRIPTION
This fixes #2017.

Adopting changes from #2018 in 1.2.x.