### PR TITLE
Use 'eclipse-hono' prefixed service names in the docs and try to get h…

### DIFF
--- a/site/documentation/content/deployment/helm-based-deployment.md
+++ b/site/documentation/content/deployment/helm-based-deployment.md
@@ -124,7 +124,7 @@ The following command can then be used to return the IP address with which the J
 browser (ensure `minikube tunnel` is running when using minikube):
 
 ~~~sh
-kubectl get service hono-jaeger-query --output='jsonpath={.status.loadBalancer.ingress[0].ip}' -n hono
+kubectl get service eclipse-hono-jaeger-query --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono
 ~~~
 
 If no example Jaeger back end should be deployed but instead an existing Jaeger installation should be used,

--- a/site/homepage/content/getting-started/index.md
+++ b/site/homepage/content/getting-started/index.md
@@ -84,9 +84,9 @@ For evaluation purposes a single node *Minikube* cluster is sufficient to deploy
 Once Hono has been deployed to your local cluster, run the following commands to set some environment variables which will be used during the guide
 
 ~~~sh
-export REGISTRY_IP=$(kubectl get service hono-service-device-registry-ext --output='jsonpath={.status.loadBalancer.ingress[0].ip}' -n hono)
-export HTTP_ADAPTER_IP=$(kubectl get service hono-adapter-http-vertx --output='jsonpath={.status.loadBalancer.ingress[0].ip}' -n hono)
-export MQTT_ADAPTER_IP=$(kubectl get service hono-adapter-mqtt-vertx --output='jsonpath={.status.loadBalancer.ingress[0].ip}' -n hono)
+export REGISTRY_IP=$(kubectl get service eclipse-hono-service-device-registry-ext --output=jsonpath="{.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)
+export HTTP_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-http-vertx --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)
+export MQTT_ADAPTER_IP=$(kubectl get service eclipse-hono-adapter-mqtt-vertx --output="jsonpath="{.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)
 ~~~
 
 Verify the last step with
@@ -213,7 +213,7 @@ export AMQP_NETWORK_IP=hono.eclipseprojects.io
 Otherwise, if you are using a local Minikube cluster:
 
 ~~~sh
-export AMQP_NETWORK_IP=$(kubectl get service hono-dispatch-router-ext --output='jsonpath={.status.loadBalancer.ingress[0].ip}' -n hono)
+export AMQP_NETWORK_IP=$(kubectl get service eclipse-hono-dispatch-router-ext --output="jsonpath={.status.loadBalancer.ingress[0]['hostname','ip']}" -n hono)
 ~~~
 
 The client can then be started from the command line as follows (make sure to replace `my-tenant` with your tenant identifier):


### PR DESCRIPTION
Our helm deployment uses 'eclipse-hono' prefix for release (and hence services), while the rest of the docs still uses just 'hono'. Also, on some systems 'hostname' is set on ingress instead of 'ip', so this should take either one.