### PR TITLE
Improve LoraProvider implementations

### DIFF
--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraMessage.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraMessage.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.lora;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A message exchanged between a Lora device and Hono's Lora adapter.
+ *
+ */
+public interface LoraMessage {
+
+    /**
+     * Gets the global end-device ID in IEEE EUI64 address space that uniquely identifies the
+     * end-device.
+     * <p>
+     * This property corresponds to the <em>DevEUI</em> defined in section 6.1.1.2 of the
+     * LoRaWAN 1.1 Specification.
+     *
+     * @return The identifier.
+     */
+    byte[] getDevEUI();
+
+    /**
+     * Gets the global end-device ID in IEEE EUI64 address space that uniquely identifies the
+     * end-device.
+     * <p>
+     * This property corresponds to the <em>DevEUI</em> defined in section 6.1.1.2 of the
+     * LoRaWAN 1.1 Specification.
+     *
+     * @return The base16 (hex) encoded identifier.
+     */
+    String getDevEUIAsString();
+
+    /**
+     * Gets this message's type.
+     *
+     * @return The type.
+     */
+    LoraMessageType getType();
+
+    /**
+     * Gets the payload.
+     *
+     * @return The payload as raw bytes.
+     */
+    Buffer getPayload();
+}

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/UplinkLoraMessage.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/UplinkLoraMessage.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.lora;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.io.BaseEncoding;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+
+
+/**
+ * A Lora message that contains data sent from an end-device to a Network Server.
+ *
+ */
+public class UplinkLoraMessage implements LoraMessage {
+
+    private final byte[] devEui;
+    private final String devEuiAsString;
+    private Buffer payload;
+    private Map<String, Object> normalizedData = new HashMap<>();
+    private JsonObject additionalData;
+
+    /**
+     * Creates a new message for a device identifier.
+     *
+     * @param devEui The identifier.
+     * @throws NullPointerException if devEui is {@code null}.
+     */
+    public UplinkLoraMessage(final byte[] devEui) {
+        Objects.requireNonNull(devEui);
+        if (devEui.length != 8) {
+            throw new IllegalArgumentException("devEUI must be 64 bits long");
+        }
+        this.devEui = devEui;
+        this.devEuiAsString = BaseEncoding.base16().encode(devEui);
+    }
+
+    /**
+     * Creates a new message for a device identifier.
+     *
+     * @param devEui The identifier.
+     * @throws NullPointerException if devEui is {@code null}.
+     * @throws IllegalArgumentException if devEui is not base16 encoded.
+     */
+    public UplinkLoraMessage(final String devEui) {
+        Objects.requireNonNull(devEui);
+        if (devEui.length() != 16) {
+            throw new IllegalArgumentException("devEUI must be 64 bits long");
+        }
+        this.devEuiAsString = devEui;
+        this.devEui = BaseEncoding.base16().decode(devEui.toUpperCase());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final byte[] getDevEUI() {
+        return devEui;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getDevEUIAsString() {
+        return devEuiAsString;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final LoraMessageType getType() {
+        return LoraMessageType.UPLINK;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final Buffer getPayload() {
+        return payload;
+    }
+
+    /**
+     * Sets the message payload.
+     *
+     * @param payload The raw data bytes.
+     */
+    public final void setPayload(final Buffer payload) {
+        this.payload = Objects.requireNonNull(payload);
+    }
+
+    /**
+     * Gets the normalized data contained in this message.
+     *
+     * @return The normalized data.
+     */
+    public final Map<String, Object> getNormalizedData() {
+        return Collections.unmodifiableMap(normalizedData);
+    }
+
+    /**
+     * Sets the normalized data contained in this message.
+     *
+     * @param data The normalized data.
+     * @throws NullPointerException if data is {@code null}.
+     */
+    public final void setNormalizedData(final Map<String, Object> data) {
+        Objects.requireNonNull(data);
+        synchronized (normalizedData) {
+            normalizedData.clear();
+            normalizedData.putAll(data);
+        }
+    }
+
+    /**
+     * Gets additional data contained in this message.
+     * <p>
+     * The data returned might be included as application properties in the
+     * downstream AMQP message.
+     *
+     * @return The additional data or {@code null}.
+     */
+    public final JsonObject getAdditionalData() {
+        return additionalData;
+    }
+
+    /**
+     * Sets additional data contained in this message.
+     *
+     * @param data The additional data or {@code null}.
+     */
+    public final void setAdditionalData(final JsonObject data) {
+        this.additionalData = data;
+    }
+}

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/BaseLoraProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/BaseLoraProvider.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.lora.providers;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.lora.LoraMessage;
+import org.eclipse.hono.adapter.lora.LoraMessageType;
+import org.eclipse.hono.adapter.lora.UplinkLoraMessage;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A base class for implementing {@link LoraProvider}s.
+ *
+ */
+abstract class BaseLoraProvider implements LoraProvider {
+
+    @Override
+    public LoraMessage getMessage(final Buffer body) {
+        Objects.requireNonNull(body);
+        try {
+            final JsonObject requestBody = body.toJsonObject();
+            final LoraMessageType type = extractMessageType(requestBody);
+            switch (type) {
+            case UPLINK:
+                return createUplinkMessage(requestBody);
+            default:
+                throw new LoraProviderMalformedPayloadException(String.format("unsupported message type [%s]", type));
+            }
+        } catch (final DecodeException | IllegalArgumentException e) {
+            throw new LoraProviderMalformedPayloadException("failed to decode request body", e);
+        }
+    }
+
+    protected UplinkLoraMessage createUplinkMessage(final JsonObject requestBody) {
+        final String devEui = extractDevEui(requestBody);
+        final UplinkLoraMessage message = new UplinkLoraMessage(devEui);
+        message.setPayload(extractPayload(requestBody));
+        message.setNormalizedData(extractNormalizedData(requestBody));
+        message.setAdditionalData(extractAdditionalData(requestBody));
+        return message;
+    }
+
+    protected abstract String extractDevEui(JsonObject loraMessage);
+    protected abstract Buffer extractPayload( JsonObject loraMessage);
+    protected abstract LoraMessageType extractMessageType(JsonObject loraMessage);
+    protected Map<String, Object> extractNormalizedData(final JsonObject loraMessage) {
+        return Map.of();
+    };
+    protected JsonObject extractAdditionalData(final JsonObject loraMessage) {
+        return null;
+    };
+}

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProvider.java
@@ -13,13 +13,11 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
-import java.util.Map;
-
-import org.eclipse.hono.adapter.lora.LoraMessageType;
+import org.eclipse.hono.adapter.lora.LoraMessage;
 import org.eclipse.hono.service.http.HttpUtils;
 
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.JsonObject;
 
 /**
  * A LoraWAN provider which can send and receive messages from and to LoRa devices.
@@ -27,7 +25,7 @@ import io.vertx.core.json.JsonObject;
 public interface LoraProvider {
 
     /**
-     * The name of this LoRaWAN provider. Will be used e.g. as an AMQP 1.0 message application property indicating the
+     * The name of this LoRaWAN provider. Will be used e.g. as an AMQP 1.0 message application property indicating
      * the source provider of a LoRa Message.
      *
      * @return The name of this LoRaWAN provider.
@@ -42,68 +40,31 @@ public interface LoraProvider {
     String pathPrefix();
 
     /**
-     * Extracts the type from the incoming message of the LoRa Provider.
+     * Gets the content type that this provider accepts.
      *
-     * @param loraMessage from which the type should be extracted.
-     * @return LoraMessageType the type of this message
-     */
-    default LoraMessageType extractMessageType(final JsonObject loraMessage) {
-        return LoraMessageType.UPLINK;
-    }
-
-    /**
-     * The content type this provider will accept.
-     *
-     * @return MIME Content Type. E.g. "application/json"
+     * @return The accepted MIME type. This default implementation returns <em>application/json</em>.
      */
     default String acceptedContentType() {
         return HttpUtils.CONTENT_TYPE_JSON;
     }
 
     /**
-     * The HTTP method this provider will accept incoming data.
+     * Gets the HTTP method that this provider requires for uplink data.
      *
-     * @return MIME Content Type. E.g. "application/json"
+     * @return The HTTP method. This default implementation returns <em>POST</em>.
      */
     default HttpMethod acceptedHttpMethod() {
         return HttpMethod.POST;
     }
 
     /**
-     * Extracts the device id from an incoming message of the LoRa Provider.
+     * Gets the object representation of a message payload sent by
+     * the provider.
      *
-     * @param loraMessage from which the device id should be extracted.
-     * @return Device ID of the concerned device
-     * @throws LoraProviderMalformedPayloadException if device Id cannot be extracted.
+     * @param body The raw request body.
+     * @return The request object.
+     * @throws NullPointerException if body is {@code null}.
+     * @throws LoraProviderMalformedPayloadException if the body cannot be decoded.
      */
-    String extractDeviceId(JsonObject loraMessage);
-
-    /**
-     * Extracts the payload from an incoming message of the LoRa Provider.
-     *
-     * @param loraMessage from which the payload should be extracted.
-     * @return Payload
-     * @throws LoraProviderMalformedPayloadException if payload cannot be extracted.
-     */
-    String extractPayload(JsonObject loraMessage);
-
-    /**
-     * Extracts the normalizable data from an incoming message of the LoRa Provider.
-     *
-     * @param loraMessage from which the payload should be extracted.
-     * @return Normalized data map.
-     */
-    default Map<String, Object> extractNormalizedData(JsonObject loraMessage) {
-        return null;
-    }
-
-    /**
-     * Extracts the payload from an incoming message of the LoRa Provider.
-     *
-     * @param loraMessage from which the payload should be extracted.
-     * @return Data which could not be normalized as a JsonObject.
-     */
-    default JsonObject extractAdditionalData(JsonObject loraMessage) {
-        return null;
-    }
+    LoraMessage getMessage(Buffer body);
 }

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProviderMalformedPayloadException.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/LoraProviderMalformedPayloadException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,10 +21,21 @@ public class LoraProviderMalformedPayloadException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Create the Exception with the given message and cause.
+     * Creates a new exception for a message.
      *
-     * @param message the Exception message
-     * @param cause the Exception cause
+     * @param message The message describing the error.
+     */
+    public LoraProviderMalformedPayloadException(final String message) {
+        this(message, null);
+    }
+
+    /**
+     * Creates a new exception for a message and root cause.
+     *
+     * @param message The message describing the error.
+     * @param cause The root cause for the error. (A {@code null} value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
      */
     public LoraProviderMalformedPayloadException(final String message, final Exception cause) {
         super(message, cause);

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/EverynetProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/EverynetProviderTest.java
@@ -13,60 +13,16 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.eclipse.hono.adapter.lora.LoraMessageType;
-import org.junit.jupiter.api.Test;
-
-import io.vertx.core.json.JsonObject;
-
 /**
  * Verifies behavior of {@link EverynetProvider}.
  */
-public class EverynetProviderTest {
-
-    private final EverynetProvider providerPost = new EverynetProvider();
+public class EverynetProviderTest extends LoraProviderTestBase<EverynetProvider> {
 
     /**
-     * Verifies that the extraction of the device id from a message is successful.
+     * {@inheritDoc}
      */
-    @Test
-    public void extractDeviceIdFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("everynet.uplink");
-        final String deviceId = this.providerPost.extractDeviceId(loraMessage);
-
-        assertEquals("85f5ab9ebc636142", deviceId);
-    }
-
-    /**
-     * Verifies the extraction of a payload from a message is successful.
-     */
-    @Test
-    public void extractPayloadFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("everynet.uplink");
-        final String payload = this.providerPost.extractPayload(loraMessage);
-
-        assertEquals("YnVtbHV4", payload);
-    }
-
-    /**
-     * Verifies that the extracted message type matches uplink.
-     */
-    @Test
-    public void extractTypeFromLoraUplinkMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("everynet.uplink");
-        final LoraMessageType type = this.providerPost.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UPLINK, type);
-    }
-
-    /**
-     * Verifies that an unknown message type defaults to the {@link LoraMessageType#UNKNOWN} type.
-     */
-    @Test
-    public void extractTypeFromLoraUnknownMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("everynet.uplink");
-        loraMessage.put("type", "bumlux");
-        final LoraMessageType type = this.providerPost.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UNKNOWN, type);
+    @Override
+    protected EverynetProvider newProvider() {
+        return new EverynetProvider();
     }
 }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/FireflyProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/FireflyProviderTest.java
@@ -13,75 +13,36 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
 import org.eclipse.hono.adapter.lora.LoraConstants;
-import org.eclipse.hono.adapter.lora.LoraMessageType;
+import org.eclipse.hono.adapter.lora.UplinkLoraMessage;
 import org.junit.jupiter.api.Test;
-
-import io.vertx.core.json.JsonObject;
 
 /**
  * Verifies behavior of {@link FireflyProvider}.
  */
-public class FireflyProviderTest {
-
-    private final FireflyProvider provider = new FireflyProvider();
+public class FireflyProviderTest extends LoraProviderTestBase<FireflyProvider> {
 
     /**
-     * Verifies that the extraction of the device id from a message is successful.
+     * {@inheritDoc}
      */
-    @Test
-    public void extractDeviceIdFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("firefly.uplink");
-        final String deviceId = provider.extractDeviceId(loraMessage);
-
-        assertEquals("firefly-device", deviceId);
+    @Override
+    protected FireflyProvider newProvider() {
+        return new FireflyProvider();
     }
 
     /**
-     * Verifies the extraction of a payload from a message is successful.
+     * Verifies that properties are parsed correctly from the lora message.
      */
     @Test
-    public void extractPayloadFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("firefly.uplink");
-        final String payload = provider.extractPayload(loraMessage);
+    public void testGetMessageParsesNormalizedData() {
 
-        assertEquals("payload", payload);
-    }
+        final UplinkLoraMessage loraMessage = (UplinkLoraMessage) provider.getMessage(uplinkMessageBuffer);
 
-    /**
-     * Verifies that the extracted message type matches uplink.
-     */
-    @Test
-    public void extractTypeFromLoraUplinkMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("firefly.uplink");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UPLINK, type);
-    }
-
-    /**
-     * Verifies that the extracted mic is true.
-     */
-    @Test
-    public void extractMicFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("firefly.uplink");
-        final Map<String, Object> map = provider.extractNormalizedData(loraMessage);
-        assertTrue(map.containsKey(LoraConstants.APP_PROPERTY_MIC));
-        assertTrue((boolean) map.getOrDefault(LoraConstants.APP_PROPERTY_MIC, null));
-    }
-
-    /**
-     * Verifies that an unknown message type defaults to the {@link LoraMessageType#UNKNOWN} type.
-     */
-    @Test
-    public void extractTypeFromLoraUnknownMessage() {
-        final JsonObject loraMessage = new JsonObject();
-        loraMessage.put("bumlux", "bumlux");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UNKNOWN, type);
+        final Map<String, Object> map = loraMessage.getNormalizedData();
+        assertThat(map.get(LoraConstants.APP_PROPERTY_MIC)).isEqualTo(Boolean.TRUE);
     }
 }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderTest.java
@@ -13,70 +13,21 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.eclipse.hono.adapter.lora.LoraMessageType;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 
 /**
  * Verifies the behavior of {@link KerlinkProvider}.
  */
 @ExtendWith(VertxExtension.class)
-public class KerlinkProviderTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(KerlinkProviderTest.class);
-
-    private KerlinkProvider provider;
+public class KerlinkProviderTest extends LoraProviderTestBase<KerlinkProvider> {
 
     /**
-     * Sets up the fixture.
-     *
-     * @param testInfo The test meta data.
+     * {@inheritDoc}
      */
-    @BeforeEach
-    public void before(final TestInfo testInfo) {
-
-        LOG.info("running test: {}", testInfo.getDisplayName());
-        provider = new KerlinkProvider();
-    }
-
-    /**
-     * Verifies that the extraction of the device id from a message is successful.
-     */
-    @Test
-    public void extractDeviceIdFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("kerlink.uplink");
-        final String deviceId = provider.extractDeviceId(loraMessage);
-
-        assertEquals("myBumluxDevice", deviceId);
-    }
-
-    /**
-     * Verifies the extraction of a payload from a message is successful.
-     */
-    @Test
-    public void extractPayloadFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("kerlink.uplink");
-        final String payload = provider.extractPayload(loraMessage);
-
-        assertEquals("YnVtbHV4", payload);
-    }
-
-    /**
-     * Verifies that the extracted message type matches uplink.
-     */
-    @Test
-    public void extractTypeFromLoraUplinkMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("kerlink.uplink");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UPLINK, type);
+    @Override
+    protected KerlinkProvider newProvider() {
+        return new KerlinkProvider();
     }
 }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraProviderTestBase.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraProviderTestBase.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.lora.providers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.hono.adapter.lora.LoraMessageType;
+import org.eclipse.hono.adapter.lora.UplinkLoraMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * Base class for implementing tests for {@link LoraProvider} implementations.
+ *
+ * @param <T> The type of provider to test.
+ */
+public abstract class LoraProviderTestBase<T extends LoraProvider> {
+
+    /**
+     * The provider under test.
+     */
+    protected T provider;
+
+    /**
+     * The buffer containing the uplink message to use for testing.
+     */
+    protected Buffer uplinkMessageBuffer;
+
+    /**
+     * Creates a new instance of the provider under test.
+     *
+     * @return The instance to run tests against.
+     */
+    protected abstract T newProvider();
+
+    /**
+     * Sets up the fixture.
+     *
+     * @throws Exception if the example message file(s) cannot be read.
+     */
+    @BeforeEach
+    public void setUp() throws Exception {
+        provider = newProvider();
+        uplinkMessageBuffer = LoraTestUtil.loadTestFile(provider.getProviderName(), LoraMessageType.UPLINK);
+    }
+
+    /**
+     * Verifies that common properties are parsed correctly from the lora message.
+     */
+    @Test
+    public void testGetMessageParsesCommonUplinkMessageProperties() {
+
+        final UplinkLoraMessage loraMessage = (UplinkLoraMessage) provider.getMessage(uplinkMessageBuffer);
+
+        assertThat(loraMessage.getDevEUIAsString()).isEqualTo("0102030405060708");
+        assertThat(loraMessage.getPayload().getBytes()).isEqualTo("bumlux".getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraTestUtil.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraTestUtil.java
@@ -13,36 +13,39 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.util.List;
+import java.nio.file.Paths;
+import java.util.Objects;
 
-import io.vertx.core.json.JsonObject;
+import org.eclipse.hono.adapter.lora.LoraMessageType;
+
+import io.vertx.core.buffer.Buffer;
 
 /**
  * Utility methods for testing functionality of LoRa providers.
  */
-public class LoraTestUtil {
+public final class LoraTestUtil {
 
     private LoraTestUtil() {
         // Prevent instantiation
     }
 
     /**
-     * Loads a json test file from the payload directory.
+     * Loads a test file from the payload directory.
      *
-     * @param name the test file name to load
-     * @return the contents of the Json
-     * @throws RuntimeException if the test file could not be loaded
+     * @param providerName The name of the provider to load the file for.
+     * @param type The type of message to load.
+     * @return the contents of the file.
+     * @throws IOException if the test file could not be loaded.
+     * @throws URISyntaxException if the test file could not be loaded.
      */
-    public static JsonObject loadTestFile(final String name) throws RuntimeException {
-        try {
-            final URL url = LoraTestUtil.class.getResource("/payload/" + name + ".json");
-            final List<String> lines = Files.readAllLines(java.nio.file.Paths.get(url.toURI()));
-            final String fullJson = String.join("", lines);
-            return new JsonObject(fullJson);
-        } catch (final Exception e) {
-            throw new RuntimeException(e);
-        }
+    public static Buffer loadTestFile(final String providerName, final LoraMessageType type) throws IOException, URISyntaxException {
+        Objects.requireNonNull(providerName);
+        Objects.requireNonNull(type);
+        final URL location = LoraTestUtil.class.getResource(String.format("/payload/%s.%s.json", providerName, type.name().toLowerCase()));
+        return Buffer.buffer(Files.readAllBytes(Paths.get(location.toURI())));
     }
 }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoriotProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoriotProviderTest.java
@@ -13,61 +13,16 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.eclipse.hono.adapter.lora.LoraMessageType;
-import org.junit.jupiter.api.Test;
-
-import io.vertx.core.json.JsonObject;
-
 /**
  * Verifies behavior of {@link LoriotProvider}.
  */
-public class LoriotProviderTest {
-
-    private final LoriotProvider provider = new LoriotProvider();
+public class LoriotProviderTest extends LoraProviderTestBase<LoriotProvider> {
 
     /**
-     * Verifies that the extraction of the device id from a message is successful.
+     * {@inheritDoc}
      */
-    @Test
-    public void extractDeviceIdFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("loriot.uplink");
-        final String deviceId = provider.extractDeviceId(loraMessage);
-
-        assertEquals("loriot-device", deviceId);
+    @Override
+    protected LoriotProvider newProvider() {
+        return new LoriotProvider();
     }
-
-    /**
-     * Verifies the extraction of a payload from a message is successful.
-     */
-    @Test
-    public void extractPayloadFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("loriot.uplink");
-        final String payload = provider.extractPayload(loraMessage);
-
-        assertEquals("payload", payload);
-    }
-
-    /**
-     * Verifies that the extracted message type matches uplink.
-     */
-    @Test
-    public void extractTypeFromLoraUplinkMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("loriot.uplink");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UPLINK, type);
-    }
-
-    /**
-     * Verifies that an unknown message type defaults to the {@link LoraMessageType#UNKNOWN} type.
-     */
-    @Test
-    public void extractTypeFromLoraUnknownMessage() {
-        final JsonObject loraMessage = new JsonObject();
-        loraMessage.put("bumlux", "bumlux");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UNKNOWN, type);
-    }
-
 }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ObjeniousProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ObjeniousProviderTest.java
@@ -13,80 +13,17 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.eclipse.hono.adapter.lora.LoraMessageType;
-import org.junit.jupiter.api.Test;
-
-import io.vertx.core.json.JsonObject;
-
 /**
  * Verifies behavior of {@link ObjeniousProvider}.
  */
-public class ObjeniousProviderTest {
+public class ObjeniousProviderTest extends LoraProviderTestBase<ObjeniousProvider> {
 
-    private final ObjeniousProvider provider = new ObjeniousProvider();
-
-    /**
-     * Verifies that the extraction of the device id from a message is successful.
-     */
-    @Test
-    public void extractDeviceIdFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("objenious.uplink");
-        final String deviceId = provider.extractDeviceId(loraMessage);
-
-        assertEquals("2032e013597bde6b", deviceId);
-    }
 
     /**
-     * Verifies the extraction of a payload from a message is successful.
+     * {@inheritDoc}
      */
-    @Test
-    public void extractPayloadFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("objenious.uplink");
-        final String payload = provider.extractPayload(loraMessage);
-
-        assertEquals("00000000004000000000000000000000000000000000000000000000000000000000", payload);
-    }
-
-    /**
-     * Verifies that the extracted message type matches uplink.
-     */
-    @Test
-    public void extractTypeFromLoraUplinkMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("objenious.uplink");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UPLINK, type);
-    }
-
-    /**
-     * Verifies that the extracted message type matches join.
-     */
-    @Test
-    public void extractTypeFromLoraJoinMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("objenious.join");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.JOIN, type);
-    }
-
-    /**
-     * Verifies that the extracted message type matches downlink.
-     */
-    @Test
-    public void extractTypeFromLoraDownlinkMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("objenious.downlink");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.DOWNLINK, type);
-    }
-
-    /**
-     * Verifies that an unknown message type defaults to the {@link LoraMessageType#UNKNOWN} type.
-     */
-    @Test
-    public void extractTypeFromLoraUnknownMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("objenious.uplink");
-        loraMessage.put("type", "bumlux");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UNKNOWN, type);
+    @Override
+    protected ObjeniousProvider newProvider() {
+        return new ObjeniousProvider();
     }
 }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ProximusProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ProximusProviderTest.java
@@ -13,49 +13,16 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.eclipse.hono.adapter.lora.LoraMessageType;
-import org.junit.jupiter.api.Test;
-
-import io.vertx.core.json.JsonObject;
-
 /**
  * Verifies behavior of {@link ProximusProvider}.
  */
-public class ProximusProviderTest {
-
-    private final ProximusProvider provider = new ProximusProvider();
+public class ProximusProviderTest extends LoraProviderTestBase<ProximusProvider> {
 
     /**
-     * Verifies that the extraction of the device id from a message is successful.
+     * {@inheritDoc}
      */
-    @Test
-    public void extractDeviceIdFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("proximus.uplink");
-        final String deviceId = this.provider.extractDeviceId(loraMessage);
-
-        assertEquals("56FDB2B433873F4C", deviceId);
-    }
-
-    /**
-     * Verifies the extraction of a payload from a message is successful.
-     */
-    @Test
-    public void extractPayloadFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("proximus.uplink");
-        final String payload = this.provider.extractPayload(loraMessage);
-
-        assertEquals("2205630000328c", payload);
-    }
-
-    /**
-     * Verifies that the extracted message type matches uplink.
-     */
-    @Test
-    public void extractTypeFromLoraUplinkMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("proximus.uplink");
-        final LoraMessageType type = this.provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UPLINK, type);
+    @Override
+    protected ProximusProvider newProvider() {
+        return new ProximusProvider();
     }
 }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProviderTest.java
@@ -13,49 +13,18 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.eclipse.hono.adapter.lora.LoraMessageType;
-import org.junit.jupiter.api.Test;
-
-import io.vertx.core.json.JsonObject;
-
 /**
  * Verifies behavior of {@link ThingsNetworkProvider}.
  */
-public class ThingsNetworkProviderTest {
+public class ThingsNetworkProviderTest extends LoraProviderTestBase<ThingsNetworkProvider> {
 
-    private final ThingsNetworkProvider provider = new ThingsNetworkProvider();
-
-    /**
-     * Verifies that the extraction of the device id from a message is successful.
-     */
-    @Test
-    public void extractDeviceIdFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("ttn.uplink");
-        final String deviceId = provider.extractDeviceId(loraMessage);
-
-        assertEquals("0352828610682633", deviceId);
-    }
 
     /**
-     * Verifies the extraction of a payload from a message is successful.
+     * {@inheritDoc}
      */
-    @Test
-    public void extractPayloadFromLoraMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("ttn.uplink");
-        final String payload = provider.extractPayload(loraMessage);
-
-        assertEquals("YnVtbHV4", payload);
+    @Override
+    protected ThingsNetworkProvider newProvider() {
+        return new ThingsNetworkProvider();
     }
 
-    /**
-     * Verifies that the extracted message type matches uplink.
-     */
-    @Test
-    public void extractTypeFromLoraUplinkMessage() {
-        final JsonObject loraMessage = LoraTestUtil.loadTestFile("ttn.uplink");
-        final LoraMessageType type = provider.extractMessageType(loraMessage);
-        assertEquals(LoraMessageType.UPLINK, type);
-    }
 }

--- a/adapters/lora-vertx/src/test/resources/payload/actility.uplink.json
+++ b/adapters/lora-vertx/src/test/resources/payload/actility.uplink.json
@@ -1,13 +1,13 @@
 {
   "DevEUI_uplink": {
     "Time": "2019-02-27T14:48:35.544+01:00",
-    "DevEUI": "actility-device",
+    "DevEUI": "0102030405060708",
     "FPort": "1",
     "FCntUp": "548",
     "ADRbit": "1",
     "MType": "2",
     "FCntDn": "43",
-    "payload_hex": "00",
+    "payload_hex": "62756D6C7578",
     "mic_hex": "922d4454",
     "Lrcid": "00000119",
     "LrrRSSI": "-48.000000",

--- a/adapters/lora-vertx/src/test/resources/payload/chirpStack.uplink.json
+++ b/adapters/lora-vertx/src/test/resources/payload/chirpStack.uplink.json
@@ -2,7 +2,7 @@
   "applicationID": "123",
   "applicationName": "temperature-sensor",
   "deviceName": "garden-sensor",
-  "devEUI": "AgICAgICAgI=",
+  "devEUI": "AQIDBAUGBwg=",
   "rxInfo": [
     {
       "gatewayID": "AwMDAwMDAwM=",
@@ -38,7 +38,7 @@
   "dr": 1,
   "fCnt": 10,
   "fPort": 5,
-  "data": "data",
+  "data": "YnVtbHV4",
   "objectJSON": "{\"temperatureSensor\":25,\"humiditySensor\":32}",
   "tags": {
     "key": "value"

--- a/adapters/lora-vertx/src/test/resources/payload/everynet.uplink.json
+++ b/adapters/lora-vertx/src/test/resources/payload/everynet.uplink.json
@@ -13,7 +13,7 @@
     "application": "1081ea3923ad1408",
     "device_addr": "02711f49",
     "time": 1559072813.337497,
-    "device": "85f5ab9ebc636142",
+    "device": "0102030405060708",
     "packet_id": "de3fb2303a20bd8a1dd0ecbc959e55ff",
     "gateway": "88145c9c8db9e552"
   },

--- a/adapters/lora-vertx/src/test/resources/payload/firefly.uplink.json
+++ b/adapters/lora-vertx/src/test/resources/payload/firefly.uplink.json
@@ -44,10 +44,10 @@
     "datr":"SF7BW125",
     "codr":"4/5"
   },
-  "raw_payload":"raw_payload",
+  "raw_payload":"62756D6C7578",
   "port":2,
   "payload_encrypted":false,
-  "payload":"payload",
+  "payload":"62756D6C7578",
   "parsed_packet":{
     "port":2,
     "pending":false,
@@ -80,7 +80,7 @@
     "organization_id":7021,
     "name":"firefly-device",
     "id":7869,
-    "eui":"firefly-device",
+    "eui":"0102030405060708",
     "device_class_id":null,
     "address":"298BF69D"
   },

--- a/adapters/lora-vertx/src/test/resources/payload/kerlink.uplink.json
+++ b/adapters/lora-vertx/src/test/resources/payload/kerlink.uplink.json
@@ -1,5 +1,5 @@
 {
-  "devEui": "myBumluxDevice",
+  "devEui": "0102030405060708",
   "userdata": {
     "payload": "YnVtbHV4"
   }

--- a/adapters/lora-vertx/src/test/resources/payload/loriot.uplink.json
+++ b/adapters/lora-vertx/src/test/resources/payload/loriot.uplink.json
@@ -1,7 +1,7 @@
 {
   "cmd": "gw",
   "seqno": 136,
-  "EUI": "loriot-device",
+  "EUI": "0102030405060708",
   "ts": 1573574479110,
   "fcnt": 135,
   "port": 2,
@@ -20,5 +20,5 @@
     }
   ],
   "bat": 255,
-  "data": "payload"
+  "data": "62756D6C7578"
 }

--- a/adapters/lora-vertx/src/test/resources/payload/objenious.uplink.json
+++ b/adapters/lora-vertx/src/test/resources/payload/objenious.uplink.json
@@ -9,10 +9,10 @@
   "timestamp": "2019-02-27T14:48:35.544Z",
   "count": 7,
   "payload_encrypted": "4b503954fe7a25629aa9d18b3dc4daa97635c4f5e391e6b7471d4e31d04958b156aa",
-  "payload_cleartext": "00000000004000000000000000000000000000000000000000000000000000000000",
+  "payload_cleartext": "62756D6C7578",
   "device_properties": {
     "appeui": "be4800dfcb4f4333",
-    "deveui": "2032e013597bde6b",
+    "deveui": "0102030405060708",
     "external_id": ""
   },
   "protocol_data": {

--- a/adapters/lora-vertx/src/test/resources/payload/proximus.uplink.json
+++ b/adapters/lora-vertx/src/test/resources/payload/proximus.uplink.json
@@ -14,7 +14,7 @@
   "value": "12.45",
   "postfix": "°",
   "timestamp": "1551278360",
-  "DevEUI": "56FDB2B433873F4C",
+  "DevEUI": "0102030405060708",
   "DevAddr": "158205C6",
   "FPort": "6",
   "Fcntup": "23",
@@ -35,5 +35,5 @@
   "Batterylevel": "",
   "Batterytime": "",
   "margin": "",
-  "payload": "2205630000328c"
+  "payload": "62756D6C7578"
 }

--- a/adapters/lora-vertx/src/test/resources/payload/ttn.uplink.json
+++ b/adapters/lora-vertx/src/test/resources/payload/ttn.uplink.json
@@ -1,7 +1,7 @@
 {
   "app_id": "ttn-app-id",
   "dev_id": "ttn-dev-id",
-  "hardware_serial": "0352828610682633",
+  "hardware_serial": "0102030405060708",
   "port": 1,
   "counter": 9,
   "is_retry": false,


### PR DESCRIPTION
Added type checks when accessing message properties.
Changed *getPayload* method to return Buffer of unencoded bytes so that
downstream consumers can more easily process the raw data sent by
devices.
