### PR TITLE
Allow to use empty payloads with the TTN provider

### DIFF
--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -42,6 +42,7 @@ import org.eclipse.hono.service.http.TracingHandler;
 import org.eclipse.hono.service.http.X509AuthHandler;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -202,16 +203,21 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
                     final Buffer payload = uplinkMessage.getPayload();
 
                     Optional.ofNullable(uplinkMessage.getNormalizedData())
-                        .ifPresent(data -> ctx.put(LoraConstants.NORMALIZED_PROPERTIES, data));
+                            .ifPresent(data -> ctx.put(LoraConstants.NORMALIZED_PROPERTIES, data));
 
                     Optional.ofNullable(uplinkMessage.getAdditionalData())
-                        .ifPresent(data -> ctx.put(LoraConstants.ADDITIONAL_DATA, data));
+                            .ifPresent(data -> ctx.put(LoraConstants.ADDITIONAL_DATA, data));
 
-                    final String contentType = String.format(
-                            "%s%s%s",
-                            LoraConstants.CONTENT_TYPE_LORA_BASE,
-                            provider.getProviderName(),
-                            LoraConstants.CONTENT_TYPE_LORA_POST_FIX);
+                    final String contentType;
+                    if (payload.length() > 0) {
+                        contentType = String.format(
+                                "%s%s%s",
+                                LoraConstants.CONTENT_TYPE_LORA_BASE,
+                                provider.getProviderName(),
+                                LoraConstants.CONTENT_TYPE_LORA_POST_FIX);
+                    } else {
+                        contentType = EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION;
+                    }
 
                     uploadTelemetryMessage(ctx, gatewayDevice.getTenantId(), deviceId, payload, contentType);
                     break;

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProvider.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProvider.java
@@ -67,6 +67,12 @@ public class ThingsNetworkProvider extends BaseLoraProvider {
     protected Buffer extractPayload(final JsonObject loraMessage) {
 
         Objects.requireNonNull(loraMessage);
+
+        if (loraMessage.containsKey(FIELD_TTN_PAYLOAD_RAW) && loraMessage.getValue(FIELD_TTN_PAYLOAD_RAW) == null) {
+            // ... this is an empty payload message, still valid.
+            return Buffer.buffer();
+        }
+
         return LoraUtils.getChildObject(loraMessage, FIELD_TTN_PAYLOAD_RAW, String.class)
                 .map(s -> Buffer.buffer(Base64.getDecoder().decode(s)))
                 .orElseThrow(() -> new LoraProviderMalformedPayloadException("message does not contain Base64 encoded payload property"));

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraTestUtil.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraTestUtil.java
@@ -18,7 +18,10 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 
@@ -38,14 +41,21 @@ public final class LoraTestUtil {
      *
      * @param providerName The name of the provider to load the file for.
      * @param type The type of message to load.
+     * @param classifiers additional classifiers of the test file.
      * @return the contents of the file.
      * @throws IOException if the test file could not be loaded.
      * @throws URISyntaxException if the test file could not be loaded.
      */
-    public static Buffer loadTestFile(final String providerName, final LoraMessageType type) throws IOException, URISyntaxException {
+    public static Buffer loadTestFile(final String providerName, final LoraMessageType type, final String... classifiers) throws IOException, URISyntaxException {
         Objects.requireNonNull(providerName);
         Objects.requireNonNull(type);
-        final URL location = LoraTestUtil.class.getResource(String.format("/payload/%s.%s.json", providerName, type.name().toLowerCase()));
+        final String name = Stream
+                .<String>concat(
+                        Stream.of(providerName, type.name().toLowerCase()),
+                        Arrays.stream(classifiers))
+                .collect(Collectors.joining("."));
+        final URL location = LoraTestUtil.class.getResource(String.format("/payload/%s.json", name));
         return Buffer.buffer(Files.readAllBytes(Paths.get(location.toURI())));
     }
+
 }

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraUtilsTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/LoraUtilsTest.java
@@ -14,9 +14,10 @@
 package org.eclipse.hono.adapter.lora.providers;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.eclipse.hono.adapter.lora.providers.LoraUtils;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.JsonObject;
@@ -70,7 +71,7 @@ public class LoraUtilsTest {
     @Test
     public void testInvalidHexInput() {
         assertThatThrownBy(() -> LoraUtils.convertFromHexToBase64("68A5K9")).isInstanceOf(LoraProviderMalformedPayloadException.class);
-        ;
+
     }
 
     /**

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProviderTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProviderTest.java
@@ -13,6 +13,12 @@
 
 package org.eclipse.hono.adapter.lora.providers;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.hono.adapter.lora.LoraMessageType;
+import org.eclipse.hono.adapter.lora.UplinkLoraMessage;
+import org.junit.jupiter.api.Test;
+
 /**
  * Verifies behavior of {@link ThingsNetworkProvider}.
  */
@@ -25,6 +31,21 @@ public class ThingsNetworkProviderTest extends LoraProviderTestBase<ThingsNetwor
     @Override
     protected ThingsNetworkProvider newProvider() {
         return new ThingsNetworkProvider();
+    }
+
+    /**
+     * Test an uplink message with a null payload.
+     *
+     * @throws Exception if anything goes wrong.
+     */
+    @Test
+    public void testGetMessageParsesUplinkMessagePropertiesWithNullPayload() throws Exception {
+
+        final UplinkLoraMessage loraMessage = (UplinkLoraMessage) this.provider.getMessage(LoraTestUtil.loadTestFile(this.provider.getProviderName(), LoraMessageType.UPLINK, "with-null-payload"));
+
+        assertThat(loraMessage.getDevEUIAsString()).isEqualTo("0102030405060708");
+        assertThat(loraMessage.getPayload()).isNotNull();
+        assertThat(loraMessage.getPayload().length()).isEqualTo(0);
     }
 
 }

--- a/adapters/lora-vertx/src/test/resources/payload/ttn.uplink.with-null-payload.json
+++ b/adapters/lora-vertx/src/test/resources/payload/ttn.uplink.with-null-payload.json
@@ -1,0 +1,36 @@
+{
+  "app_id": "ttn-app-id",
+  "dev_id": "ttn-dev-id",
+  "hardware_serial": "0102030405060708",
+  "port": 1,
+  "counter": 9,
+  "is_retry": false,
+  "confirmed": false,
+  "payload_raw": null,
+  "metadata": {
+    "airtime": 32527000,
+    "time": "2019-03-03T04:20:04Z",
+    "frequency": 868.1,
+    "modulation": "LORA",
+    "data_rate": "SF7BW125",
+    "bit_rate": 50000,
+    "coding_rate": "4/5",
+    "gateways": [
+      {
+        "gtw_id": "ttn-test-gtw",
+        "timestamp": 12345,
+        "time": "2019-03-03T04:19:32Z",
+        "channel": 0,
+        "rssi": -25,
+        "snr": 5,
+        "rf_chain": 0,
+        "latitude": 53.1088,
+        "longitude": 9.1934,
+        "altitude": 90
+      }
+    ],
+    "latitude": 53.1088,
+    "longitude": 9.1934,
+    "altitude": 90
+  }
+}


### PR DESCRIPTION
The TTN provider allows to send an empty payload message. This is indicated by an explicit `null` value in the `payload_raw` field.

This PR adds support for properly parsing and testing the TTN provider for this type of payload and also corrects the content type for that case for all providers.