### PR TITLE
Improve description of credentials resources

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericSecret.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,6 +15,7 @@ package org.eclipse.hono.service.management.credentials;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -34,5 +35,22 @@ public class GenericSecret extends CommonSecret {
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Sets this secret's additional properties to the value of the other secret's corresponding
+     * properties if this secret's additionalProperties map is empty.
+     */
+    @Override
+    protected void mergeProperties(final CommonSecret otherSecret) {
+
+        Objects.requireNonNull(otherSecret);
+
+        final GenericSecret otherGenericSecret = (GenericSecret) otherSecret;
+        if (this.additionalProperties.isEmpty()) {
+            this.additionalProperties.putAll(otherGenericSecret.additionalProperties);
+        }
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordSecret.java
@@ -131,8 +131,7 @@ public class PasswordSecret extends CommonSecret {
      * @throws IllegalStateException if the secret is not valid.
      */
     @Override
-    public void checkValidity() {
-        super.checkValidity();
+    protected void checkValidityOfSpecificProperties() {
         if (containsOnlySecretId()) {
             return;
         }
@@ -241,17 +240,22 @@ public class PasswordSecret extends CommonSecret {
 
     /**
      * {@inheritDoc}
+     * <p>
+     * Sets this secret's passwordPlain, passwordHash, hashFunction and salt properties
+     * to the values of the other secret's corresponding properties if this
+     * secret's {@link #containsOnlySecretId()} method returns {@code true}.
      */
     @Override
-    void merge(final CommonSecret secret) {
-        Objects.requireNonNull(secret);
+    protected void mergeProperties(final CommonSecret otherSecret) {
 
-        if (secret instanceof PasswordSecret && containsOnlySecretId()) {
-            final PasswordSecret passwordSecret = (PasswordSecret) secret;
-            passwordPlain = passwordSecret.getPasswordPlain();
-            passwordHash = passwordSecret.getPasswordHash();
-            hashFunction = passwordSecret.getHashFunction();
-            salt = passwordSecret.getSalt();
+        Objects.requireNonNull(otherSecret);
+
+        if (this.containsOnlySecretId()) {
+            final PasswordSecret otherPasswordSecret = (PasswordSecret) otherSecret;
+            this.passwordPlain = otherPasswordSecret.passwordPlain;
+            this.passwordHash = otherPasswordSecret.passwordHash;
+            this.hashFunction = otherPasswordSecret.hashFunction;
+            this.salt = otherPasswordSecret.salt;
         }
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskSecret.java
@@ -15,7 +15,6 @@ package org.eclipse.hono.service.management.credentials;
 import java.util.Objects;
 
 import org.eclipse.hono.util.RegistryManagementConstants;
-import org.eclipse.hono.util.Strings;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -52,8 +51,7 @@ public class PskSecret extends CommonSecret {
     }
 
     @Override
-    public void checkValidity() {
-        super.checkValidity();
+    public void checkValidityOfSpecificProperties() {
         if (this.key == null || this.key.length <= 0) {
             throw new IllegalStateException(String.format("'%s' must be set", RegistryManagementConstants.FIELD_SECRETS_KEY));
         }
@@ -61,16 +59,18 @@ public class PskSecret extends CommonSecret {
 
     /**
      * {@inheritDoc}
+     * <p>
+     * Sets this secret's key property to the value of the other secret's corresponding
+     * property if this secret's key property is @{@code null}.
      */
     @Override
-    void merge(final CommonSecret secret) {
-        Objects.requireNonNull(secret);
+    protected void mergeProperties(final CommonSecret otherSecret) {
 
-        if (secret instanceof PskSecret) {
-            if (!Strings.isNullOrEmpty(getId()) && Strings.isNullOrEmpty(key)) {
-                final PskSecret pskSecret = (PskSecret) secret;
-                key = pskSecret.getKey();
-            }
+        Objects.requireNonNull(otherSecret);
+
+        if (this.key == null) {
+            final PskSecret otherPskSecret = (PskSecret) otherSecret;
+            this.key = otherPskSecret.key;
         }
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/X509CertificateSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/X509CertificateSecret.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,4 +16,14 @@ package org.eclipse.hono.service.management.credentials;
  * This class encapsulates secret information for an X509 certificate credentials type.
  */
 public class X509CertificateSecret extends CommonSecret {
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method does nothing because this secret has no X.509 specific properties.
+     */
+    @Override
+    protected void mergeProperties(final CommonSecret otherSecret) {
+        // nothing to merge
+    }
 }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/credentials/CredentialsTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/credentials/CredentialsTest.java
@@ -13,11 +13,15 @@
 package org.eclipse.hono.service.management.credentials;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -28,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.util.RegistryManagementConstants;
 import org.junit.jupiter.api.Test;
 
@@ -83,12 +86,14 @@ public class CredentialsTest {
     @Test
     public void testEncodePskCredential() {
         final PskCredential credential = new PskCredential();
+                credential.setAuthId("psk-device");
+                credential.setSecrets(List.of(new PskSecret().setKey(new byte[] { 0x00, 0x01 })));
 
         final JsonObject json = JsonObject.mapFrom(credential);
+        System.out.println(json);
         assertNotNull(json);
-        assertNull(json.getJsonArray(RegistryManagementConstants.FIELD_SECRETS));
-
         assertEquals("psk", json.getString(RegistryManagementConstants.FIELD_TYPE));
+        assertThat(json.getJsonArray(RegistryManagementConstants.FIELD_SECRETS)).hasSize(1);
 
         final CommonCredential decodedCredential = json.mapTo(CommonCredential.class);
         assertTrue(decodedCredential instanceof PskCredential);
@@ -244,129 +249,62 @@ public class CredentialsTest {
     }
 
     /**
-     * Test merging of two password credentials.
+     * Verifies that merging other credentials fails if they are of a different
+     * type.
      */
     @Test
-    public void testMergingOfPasswordCredential() {
-        final String authId = "test-auth-1";
-        final String secretId = DeviceRegistryUtils.getUniqueIdentifier();
-        final Instant date = Instant.parse("2020-09-11T11:38:00.123456Z");
+    public void testMergeFailsForDifferentType() {
 
-        //Create password credential 1
-        final PasswordSecret secret1 = new PasswordSecret();
-        secret1.setId(secretId);
-        secret1.setPasswordHash("hash-1");
-        secret1.setSalt("salt-1");
-        secret1.setNotAfter(date);
-
-        final PasswordCredential credential1 = new PasswordCredential();
-        credential1.setAuthId(authId);
-        credential1.setSecrets(Arrays.asList(secret1));
-        credential1.setComment("Comment-1");
-
-        //Create PSK credential 2 with a secret having an id and another without id
-        final PasswordSecret secret2 = new PasswordSecret();
-        secret2.setId(secretId);
-
-        final PasswordSecret secret3 = new PasswordSecret();
-        secret3.setPasswordHash("hash-3");
-        secret3.setSalt("salt-3");
-        secret3.setNotBefore(date);
-
-        final PasswordCredential credential2 = new PasswordCredential();
-        credential2.setAuthId(authId);
-        credential2.setSecrets(Arrays.asList(secret2, secret3));
-        credential2.setComment("Comment-2");
-
-        //Merge those two credentials
-        final CommonCredential mergedCredential = credential2.merge(credential1);
-
-        //verify the result
-        assertEquals(2, mergedCredential.getSecrets().size());
-        assertEquals("Comment-2", mergedCredential.getComment());
-        final PasswordSecret mergedSecret = (PasswordSecret) mergedCredential.getSecrets().get(0);
-        assertEquals(secretId, mergedSecret.getId());
-        assertEquals("hash-1", mergedSecret.getPasswordHash());
-        assertEquals("salt-1", mergedSecret.getSalt());
-        assertNull(mergedSecret.getNotAfter());
+        final PasswordCredential pwdCredentials = new PasswordCredential();
+        assertThatThrownBy(() -> pwdCredentials.merge(new PskCredential()))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     /**
-     * Test merging of two PSK credentials.
+     * Verifies that merging other credentials fails if they do not contain
+     * secrets of matching IDs.
      */
     @Test
-    public void testMergingOfPskCredential() {
-        final String authId = "test-auth-1";
-        final String secretId = DeviceRegistryUtils.getUniqueIdentifier();
-        final Instant date = Instant.parse("1992-09-11T11:38:00.123456Z");
+    public void testMergeFailsForNonMatchingSecretId() {
 
-        //Create PSK credential 1
-        final PskSecret secret1 = new PskSecret();
-        secret1.setId(secretId);
-        secret1.setKey("key-1".getBytes(StandardCharsets.UTF_8));
-        secret1.setNotAfter(date);
+        final PasswordSecret existingSecret = spy(PasswordSecret.class);
+        existingSecret.setId("two");
+        final PasswordCredential existingCredentials = new PasswordCredential();
+        existingCredentials.setSecrets(List.of(existingSecret));
 
-        final PskCredential credential1 = new PskCredential();
-        credential1.setAuthId(authId);
-        credential1.setSecrets(Arrays.asList(secret1));
-        credential1.setComment("Comment-1");
+        final PasswordSecret newSecret = spy(PasswordSecret.class);
+        newSecret.setId("one");
+        final PasswordCredential newCredentials = new PasswordCredential();
+        newCredentials.setSecrets(List.of(newSecret));
 
-        //Create PSK credential 2 with a secret having an id and another without id
-        final PskSecret secret2 = new PskSecret();
-        secret2.setId(secretId);
-
-        final PskSecret secret3 = new PskSecret();
-        secret3.setKey("key-3".getBytes(StandardCharsets.UTF_8));
-        secret3.setNotBefore(date);
-
-        final PskCredential credential2 = new PskCredential();
-        credential2.setAuthId(authId);
-        credential2.setSecrets(Arrays.asList(secret2, secret3));
-        credential2.setComment("Comment-2");
-
-        //Merge those two credentials
-        final CommonCredential mergedCredential = credential2.merge(credential1);
-
-        //verify the result
-        assertEquals(2, mergedCredential.getSecrets().size());
-        assertEquals("Comment-2", mergedCredential.getComment());
-        final PskSecret mergedSecret = (PskSecret) mergedCredential.getSecrets().get(0);
-        assertEquals(secretId, mergedSecret.getId());
-        assertEquals("key-1", new String(mergedSecret.getKey()));
-        assertNull(mergedSecret.getNotBefore());
+        assertThatThrownBy(() -> newCredentials.merge(existingCredentials))
+            .isInstanceOf(IllegalArgumentException.class);
+        verify(existingSecret, never()).merge(any(PasswordSecret.class));
+        verify(newSecret, never()).merge(any(PasswordSecret.class));
     }
 
     /**
-     * Test merging two credentials of different types fails.
+     * Verifies that merging other credentials succeeds if they contain
+     * secrets of matching IDs.
      */
     @Test
-    public void testMergingCredentialsOfDifferentType() {
-        final String authId = "test-auth-1";
-        final String secretId = DeviceRegistryUtils.getUniqueIdentifier();
-        final Instant date = Instant.parse("2020-09-11T11:38:00.123456Z");
+    public void testMergeSucceedsForMatchingSecretIds() {
 
-        // Create password credential 1
-        final PasswordSecret secret1 = new PasswordSecret();
-        secret1.setId(secretId);
-        secret1.setPasswordHash("hash-1");
-        secret1.setSalt("salt-1");
-        secret1.setNotAfter(date);
+        final PskSecret existingSecret = spy(PskSecret.class);
+        existingSecret.setId("one");
+        final PskCredential existingCredentials = new PskCredential();
+        existingCredentials.setSecrets(List.of(existingSecret));
 
-        final PasswordCredential credential1 = new PasswordCredential();
-        credential1.setAuthId(authId);
-        credential1.setSecrets(Arrays.asList(secret1));
-        credential1.setComment("Comment-1");
+        final PskSecret updatedSecret = spy(PskSecret.class);
+        updatedSecret.setId("one");
+        final PskSecret newSecret = spy(PskSecret.class);
+        final PskCredential updatedCredentials = new PskCredential();
+        updatedCredentials.setSecrets(List.of(updatedSecret, newSecret));
 
-        // Create PSK credential 2
-        final PskSecret secret2 = new PskSecret();
-        secret2.setId(secretId);
-
-        final PskCredential credential2 = new PskCredential();
-        credential2.setAuthId(authId);
-        credential2.setSecrets(Arrays.asList(secret2));
-        credential2.setComment("Comment-2");
-
-        //Merge those two credentials and verify the result
-        assertThrows(IllegalArgumentException.class, () -> credential2.merge(credential1));
+        updatedCredentials.merge(existingCredentials);
+        verify(updatedSecret).merge(existingSecret);
+        verify(existingSecret, never()).merge(any(CommonSecret.class));
+        verify(newSecret, never()).merge(any(CommonSecret.class));
+        assertThat(updatedCredentials.getSecrets()).hasSize(2);
     }
 }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/credentials/CredentialsTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/credentials/CredentialsTest.java
@@ -90,7 +90,6 @@ public class CredentialsTest {
                 credential.setSecrets(List.of(new PskSecret().setKey(new byte[] { 0x00, 0x01 })));
 
         final JsonObject json = JsonObject.mapFrom(credential);
-        System.out.println(json);
         assertNotNull(json);
         assertEquals("psk", json.getString(RegistryManagementConstants.FIELD_TYPE));
         assertThat(json.getJsonArray(RegistryManagementConstants.FIELD_SECRETS)).hasSize(1);

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/credentials/SecretsTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/credentials/SecretsTest.java
@@ -13,23 +13,24 @@
 package org.eclipse.hono.service.management.credentials;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.spy;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
+import java.util.Map;
 
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.RegistryManagementConstants;
@@ -43,6 +44,25 @@ import io.vertx.core.json.JsonObject;
  */
 public class SecretsTest {
 
+    private <T extends CommonSecret> T addCommonProperties(final T secret) {
+
+        final LocalDateTime before = LocalDateTime.of(2017, 05, 01, 14, 00, 00);
+        final LocalDateTime after = LocalDateTime.of(2018, 01, 01, 00, 00, 00);
+
+        secret.setComment("a comment");
+        secret.setId("1234");
+        secret.setNotBefore(before.toInstant(ZoneOffset.of("+01:00")));
+        secret.setNotAfter(after.toInstant(ZoneOffset.UTC));
+        return secret;
+    }
+
+    private void assertCommonProperties(final JsonObject json) {
+        assertThat(json.getString(RegistryManagementConstants.FIELD_ID), is("1234"));
+        assertThat(json.getString(RegistryManagementConstants.FIELD_COMMENT), is("a comment"));
+        assertThat(json.getString(RegistryManagementConstants.FIELD_SECRETS_NOT_BEFORE), is("2017-05-01T13:00:00Z"));
+        assertThat(json.getString(RegistryManagementConstants.FIELD_SECRETS_NOT_AFTER), is("2018-01-01T00:00:00Z"));
+    }
+
     /**
      * Test encoding of a simple password secret.
      */
@@ -50,24 +70,18 @@ public class SecretsTest {
     public void testEncodePasswordSecret1() {
 
         final PasswordSecret secret = new PasswordSecret();
+        addCommonProperties(secret);
 
-        secret.setNotBefore(Instant.EPOCH.truncatedTo(ChronoUnit.SECONDS));
-        secret.setNotAfter(Instant.EPOCH.plusSeconds(1).truncatedTo(ChronoUnit.SECONDS));
-
-        secret.setComment("setec astronomy");
-
+        secret.setHashFunction(CredentialsConstants.HASH_FUNCTION_SHA256);
         secret.setPasswordHash("2a5d81942494986ce6e23aadfa18cd426a1d7ab90629a0814d244c4cd82cc81f");
         secret.setSalt("abc");
 
-        secret.setHashFunction(CredentialsConstants.HASH_FUNCTION_SHA256);
-
         final JsonObject json = JsonObject.mapFrom(secret);
-        assertNotNull(json);
-
+        assertCommonProperties(json);
+        assertEquals(CredentialsConstants.HASH_FUNCTION_SHA256, json.getString(RegistryManagementConstants.FIELD_SECRETS_HASH_FUNCTION));
         assertEquals("abc", json.getString(CredentialsConstants.FIELD_SECRETS_SALT));
         assertEquals("2a5d81942494986ce6e23aadfa18cd426a1d7ab90629a0814d244c4cd82cc81f",
                 json.getString(CredentialsConstants.FIELD_SECRETS_PWD_HASH));
-        assertEquals("setec astronomy", json.getString(RegistryManagementConstants.FIELD_SECRETS_COMMENT));
     }
 
     /**
@@ -76,42 +90,41 @@ public class SecretsTest {
     @Test
     public void testEncodePskSecret() {
 
-        final Instant notBefore = Instant.from(OffsetDateTime.of(2018, 1, 1, 00, 00, 00, 0, ZoneOffset.ofHours(-4)));
-        final Instant notAfter = Instant.from(OffsetDateTime.of(2019, 7, 22, 14, 30, 15, 0, ZoneOffset.ofHours(2)));
         final PskSecret secret = new PskSecret();
+        addCommonProperties(secret);
         secret.setKey(new byte[] { 1, 2, 3 });
-        secret.setNotBefore(notBefore);
-        secret.setNotAfter(notAfter);
 
         final JsonObject json = JsonObject.mapFrom(secret);
-        assertNotNull(json);
-
+        assertCommonProperties(json);
         assertArrayEquals(new byte[] { 1, 2, 3 }, json.getBinary(CredentialsConstants.FIELD_SECRETS_KEY));
-        assertThat(
-                DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(json.getString(RegistryManagementConstants.FIELD_SECRETS_NOT_BEFORE), OffsetDateTime::from).toInstant(),
-                is(notBefore));
-        assertThat(
-                DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(json.getString(RegistryManagementConstants.FIELD_SECRETS_NOT_AFTER), OffsetDateTime::from).toInstant(),
-                is(notAfter));
     }
 
     /**
      * Test encoding a x509 credential.
      */
     @Test
-    public void testEncodeX509Credential() {
+    public void testEncodeX509Secret() {
 
         final X509CertificateSecret secret = new X509CertificateSecret();
+        addCommonProperties(secret);
 
-        final X509CertificateCredential credential = new X509CertificateCredential();
-        credential.setAuthId("auth1");
+        final JsonObject json = JsonObject.mapFrom(secret);
+        assertCommonProperties(json);
+    }
 
-        credential.getSecrets().add(secret);
+    /**
+     * Test encoding a generic credential.
+     */
+    @Test
+    public void testEncodeGeneric() {
 
-        final JsonObject json = JsonObject.mapFrom(credential);
-        assertNotNull(json);
-        assertThat(json.getString(RegistryManagementConstants.FIELD_TYPE), is(CredentialsConstants.SECRETS_TYPE_X509_CERT));
-        assertThat(json.getJsonObject(RegistryManagementConstants.FIELD_EXT), nullValue());
+        final GenericSecret secret = new GenericSecret();
+        addCommonProperties(secret);
+        secret.setAdditionalProperties(Map.of("foo", "bar"));
+
+        final JsonObject json = JsonObject.mapFrom(secret);
+        assertCommonProperties(json);
+        assertThat(json.getString("foo"), is("bar"));
     }
 
     /**
@@ -153,7 +166,7 @@ public class SecretsTest {
     }
 
     /**
-     * Tests that secret dates are properly encoded and decoded.
+     * Tests that a secret's notBefore and notAfter instants are properly encoded and decoded.
      * Both formats with timezone offset and without the offset are supported for encoding.
      * For decoding the format without the offset is used.
      */
@@ -176,4 +189,175 @@ public class SecretsTest {
 
     }
 
+    /**
+     * Verifies that merging a secret of a different type but with same ID fails.
+     */
+    @Test
+    public void testMergeFailsForNonMatchingSecretTypes() {
+
+        final CommonSecret updatedSecret = spy(CommonSecret.class);
+        updatedSecret.setId("one");
+
+        final PasswordSecret otherSecret = new PasswordSecret();
+        otherSecret.setId("one");
+
+        assertThatThrownBy(() -> updatedSecret.merge(otherSecret)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /**
+     * Verifies that merging a secret of same type but with different IDs fails.
+     */
+    @Test
+    public void testMergeFailsForNonMatchingSecretIds() {
+
+        final CommonSecret updatedSecret = spy(CommonSecret.class);
+        updatedSecret.setId("one");
+
+        final CommonSecret otherSecret = spy(CommonSecret.class);
+        otherSecret.setId("two");
+
+        assertThatThrownBy(() -> updatedSecret.merge(otherSecret)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /**
+     * Verifies that the common properties of an updated secret have higher precendence
+     * than the corresponding properties of an existing secret that is being merged
+     * into the updated secret.
+     */
+    @Test
+    public void testMergeUsesNewCommonProperties() {
+
+        final Instant existingNotBefore = Instant.now().minus(Duration.ofDays(100));
+        final Instant existingNotAfter = Instant.now().plus(Duration.ofDays(100));
+        final CommonSecret existingSecret = spy(CommonSecret.class);
+        existingSecret.setId("one");
+        existingSecret.setComment("existing comment");
+        existingSecret.setNotBefore(existingNotBefore);
+        existingSecret.setNotAfter(existingNotAfter);
+
+        final Instant updatedNotAfter = Instant.now();
+        final CommonSecret updatedSecret = spy(CommonSecret.class);
+        updatedSecret.setId("one");
+        updatedSecret.setNotBefore(existingNotBefore);
+        updatedSecret.setNotAfter(updatedNotAfter);
+
+        updatedSecret.merge(existingSecret);
+        assertThat(updatedSecret.getComment()).isNull();
+        assertThat(updatedSecret.getNotBefore()).isEqualTo(existingNotBefore);
+        assertThat(updatedSecret.getNotAfter()).isEqualTo(updatedNotAfter);
+    }
+
+    /**
+     * Verifies that the password, hash function and salt of an existing secret
+     * are not merged into an updated secret if it contains a new (plaintext) password.
+     */
+    @Test
+    public void testMergePropertiesUsesNewPlaintextPassword() {
+
+        final PasswordSecret updatedSecret = new PasswordSecret();
+        updatedSecret.setId("one");
+        updatedSecret.setPasswordPlain("new-pwd");
+
+        final PasswordSecret existingSecret = new PasswordSecret();
+        existingSecret.setId("one");
+        existingSecret.setPasswordHash("hash-1");
+        existingSecret.setSalt("salt-1");
+        existingSecret.setHashFunction(CredentialsConstants.HASH_FUNCTION_SHA512);
+
+        updatedSecret.merge(existingSecret);
+
+        assertThat(updatedSecret.getPasswordPlain()).isEqualTo("new-pwd");
+        assertThat(updatedSecret.getPasswordHash()).isNull();
+        assertThat(updatedSecret.getHashFunction()).isNull();
+        assertThat(updatedSecret.getSalt()).isNull();
+    }
+
+    /**
+     * Verifies that the password, hash function and salt of an existing secret
+     * are not merged into an updated secret if it contains a new (hashed) password.
+     */
+    @Test
+    public void testMergePropertiesUsesNewHashedPassword() {
+
+        final PasswordSecret updatedSecret = new PasswordSecret();
+        updatedSecret.setId("one");
+        updatedSecret.setPasswordHash("new-hash");
+        updatedSecret.setHashFunction(CredentialsConstants.HASH_FUNCTION_BCRYPT);
+
+        final PasswordSecret existingSecret = new PasswordSecret();
+        existingSecret.setId("one");
+        existingSecret.setPasswordHash("hash-1");
+        existingSecret.setSalt("salt-1");
+        existingSecret.setHashFunction(CredentialsConstants.HASH_FUNCTION_SHA512);
+
+        updatedSecret.merge(existingSecret);
+
+        assertThat(updatedSecret.getPasswordHash()).isEqualTo("new-hash");
+        assertThat(updatedSecret.getPasswordPlain()).isNull();
+        assertThat(updatedSecret.getHashFunction()).isEqualTo(CredentialsConstants.HASH_FUNCTION_BCRYPT);
+        assertThat(updatedSecret.getSalt()).isNull();
+    }
+
+    /**
+     * Verifies that the password, hash function and salt of an existing secret
+     * are merged into an updated secret if it contains an ID only.
+     */
+    @Test
+    public void testMergePropertiesUsesExistingHashedPassword() {
+
+        final PasswordSecret updatedSecret = new PasswordSecret();
+        updatedSecret.setId("one");
+
+        final PasswordSecret existingSecret = new PasswordSecret();
+        existingSecret.setId("one");
+        existingSecret.setPasswordHash("hash-1");
+        existingSecret.setSalt("salt-1");
+        existingSecret.setHashFunction(CredentialsConstants.HASH_FUNCTION_SHA512);
+
+        updatedSecret.merge(existingSecret);
+
+        assertThat(updatedSecret.getPasswordHash()).isEqualTo("hash-1");
+        assertThat(updatedSecret.getPasswordPlain()).isNull();
+        assertThat(updatedSecret.getHashFunction()).isEqualTo(CredentialsConstants.HASH_FUNCTION_SHA512);
+        assertThat(updatedSecret.getSalt()).isEqualTo("salt-1");
+    }
+
+    /**
+     * Verifies that the key of an existing secret is not merged into an
+     * updated secret if it contains a new key.
+     */
+    @Test
+    public void testMergePropertiesUsesNewKey() {
+
+        final PskSecret updatedSecret = new PskSecret();
+        updatedSecret.setId("one");
+        updatedSecret.setKey(new byte[] { 0x03, 0x04 });
+
+        final PskSecret existingSecret = new PskSecret();
+        existingSecret.setId("one");
+        existingSecret.setKey(new byte[] { 0x01, 0x02 });
+
+        updatedSecret.merge(existingSecret);
+
+        assertThat(updatedSecret.getKey()).isEqualTo(new byte[] { 0x03, 0x04 });
+    }
+
+    /**
+     * Verifies that the shared key of an existing secret
+     * is merged into an updated secret if it contains an ID only.
+     */
+    @Test
+    public void testMergePropertiesUsesExistingKey() {
+
+        final PskSecret updatedSecret = new PskSecret();
+        updatedSecret.setId("one");
+
+        final PskSecret existingSecret = new PskSecret();
+        existingSecret.setId("one");
+        existingSecret.setKey(new byte[] { 0x01, 0x02 });
+
+        updatedSecret.merge(existingSecret);
+
+        assertThat(updatedSecret.getKey()).isEqualTo(new byte[] { 0x01, 0x02 });
+    }
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDto.java
@@ -161,15 +161,15 @@ public final class CredentialsDto extends BaseDto {
     /**
      * Merges the secrets of the given credential DTO with that of the current one.
      *
-     * @param credentialsDto The credential DTO to be merged.
+     * @param otherCredentialsDto The credential DTO to be merged.
      * @return  a reference to this for fluent use.
-     * @throws NullPointerException if the given credential DTO is {@code null}.
+     * @throws NullPointerException if the given credentials DTO is {@code null}.
      */
     @JsonIgnore
-    public CredentialsDto merge(final CredentialsDto credentialsDto) {
-        Objects.requireNonNull(credentialsDto);
+    public CredentialsDto merge(final CredentialsDto otherCredentialsDto) {
+        Objects.requireNonNull(otherCredentialsDto);
 
-        Optional.ofNullable(credentialsDto.getCredentials())
+        Optional.ofNullable(otherCredentialsDto.getCredentials())
                 .ifPresent(credentialsToMerge -> this.credentials
                         .forEach(credential -> findCredentialByIdAndType(credential.getAuthId(), credential.getType(),
                                 credentialsToMerge)

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -367,15 +367,19 @@ paths:
       get:
          tags:
             - credentials
-         summary: Get credentials set of a device.
+         summary: Gets a device's set of credentials.
          description: |
-            Get the credentials set of a device. As long as the device is
-            registered and the user has read access to it, this call should
-            never return "not found".
-            Depending on its implementation (or configuration), the device registry
-            can either return all credentials information including full secret details or
-            secret metadata along with the generated identifier (an `id` property).
-            The identifier can be used for the follow-up `update` operation).
+            Hono's protocol adapters use the credentials registered for a device in order to
+            authenticate the device when it connects to an adapter.
+            Implementors may return all of the credentials' data including all
+            details of its secrets like password hash and/or hash algortihm used.
+            This mode of operation is called *replace mode*. However, this behavior is
+            discouraged because it might disclose confidential information in plain text.
+            
+            Instead, implementors should remove all confidential information from the secrets
+            and include a (unique) identifier with each secret. Clients can then refer to
+            this identifier in order to update particular secrets. This mode of operation
+            is called *patch mode*.
          operationId: getAllCredentials
          responses:
             200:
@@ -402,10 +406,45 @@ paths:
       put:
          tags:
             - credentials
-         summary: Update credentials set for registered device
-         description: If the device registry is handling full secret details, the updated credential set
-                      will be an exact match of the provided content. If it is using secret metadata,
-                      data will be merged in based on the secret identities.
+         summary: Updates a device's credentials.
+         description: |
+            A client uses this operation to update a device's existing set of credentials
+            with the credentials contained in the request body.
+
+            A registry may run in one of two modes for updating credentials, *replace mode*
+            or *patch mode*. A client can determine the mode of operation by means of inspecting
+            any of the secrets returned by the *getAllCredentials* operation. If the secrets
+            do not contain an `id` property, then the registry uses *replace mode*, otherwise
+            it operates in *patch mode*.
+
+            In replace mode the registry simply replaces a device's existing set of credentials
+            with the credentials provided in the request body.
+
+            In patch mode the registry processes the set of updated credentials provided in the
+            request body as follows.
+            1. Start with an empty set `N` of new credentials.
+            1. For each updated credentials object `c-U` contained in the request body,
+               the registry looks up an existing credentials object `c-E` of the same device ID, type
+               and authentication identifier.
+               1. If no matching credentials object exists, `c-U` is added to the set of new
+                  credentials `N`.
+               1. Otherwise, `c-E` is patched over with `c-U` as follows. For each of `c-U`'s
+                  secrets `s-U` the registry does the following
+                  1. If `s-U` has no `id` property, the registry assigns a unique identifier to `s-U`.
+                  1. Otherwise, the registry tries to find a secret `s-E` with the same identifier as `s-U`
+                     among the secrets of `c-E`.
+                     1. If no matching secret exists, updating the credentials has failed and the registry
+                        returns a response with status 400 (Bad Request).
+                     1. Otherwise the confidential properties of `s-E` are merged into `s-U`
+                        with the property values of `s-U` taking precedence.
+               1. `c-U` is added to `N`.
+            1. The registry replaces the device's existing set of credentials with `N` and returns an
+               empty response with status code 204 (No Content) to indicate the successful outcome of the
+               operation.
+
+               Note that `N` does not contain any of the existing credentials objects `c-E` for which
+               no corresponding credentials object `c-U` with the same device ID, type and authentication
+               identifier exists. This way, existing credentials can be deleted.
          operationId: setAllCredentials
          parameters:
             - $ref: '#/components/parameters/resourceVersion'
@@ -1041,7 +1080,7 @@ components:
       NotFound:
          description: |
             Object not found. This may also be returned for some operations
-            if the user misses read access for the object.
+            if the user lacks authorization to read the subject of the operation.
          content:
             application/json:
                schema:


### PR DESCRIPTION
I have added more thorough descriptive text to the PUT credentials operation, specifying the behavior to be implemented in a registry.

Also improved code for merging credentials and secrets and added unit
tests.
