### PR TITLE
[#2020] Reject unknown properties in Device Management HTTP endpoint

### DIFF
--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/DeviceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/DeviceTest.java
@@ -14,12 +14,14 @@
 package org.eclipse.hono.service.management.device;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 
@@ -38,6 +40,14 @@ public class DeviceTest {
         assertThat(device.isEnabled());
     }
 
+    /**
+     * Decode device with unknown property succeeds.
+     */
+    @Test
+    public void testDecodeFailsForUnknownProperties() {
+        assertThatThrownBy(() -> Json.decodeValue("{\"unexpected\": \"property\"}", Device.class))
+            .isInstanceOf(DecodeException.class);
+    }
 
     /**
      * Decode device with "enabled=false".

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -672,6 +672,18 @@ public final class IntegrationTestSupport {
     }
 
     /**
+     * Adds a device identifier to the list
+     * of devices to be deleted after the current test has finished.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device's identifier.
+     * @see #deleteObjects(VertxTestContext)
+     */
+    public void addDeviceIdForRemoval(final String tenantId, final String deviceId) {
+        devicesToDelete.computeIfAbsent(tenantId, t -> new HashSet<>()).add(deviceId);
+    }
+
+    /**
      * Gets a random device identifier and adds it to the list
      * of devices to be deleted after the current test has finished.
      *


### PR DESCRIPTION
Added explicit error handling in case of failure to process requests.
Removed obsolete request payload parsing/modification.
Improved integration tests.
