### PR TITLE
[#2020] Reject unknown properties in Credentials Management endpoint

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
@@ -14,6 +14,7 @@ package org.eclipse.hono.util;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import io.vertx.core.json.JsonObject;
 
@@ -119,11 +120,11 @@ public final class CredentialsConstants extends RequestResponseApiConstants {
     /**
      * The regular expression to validate that the auth-id field supplied in credentials is legal.
      */
-    public static final String AUTH_ID_VALUE_REGEX = "^[a-zA-Z0-9-=.]+$";
+    public static final Pattern PATTERN_AUTH_ID_VALUE = Pattern.compile("^[a-zA-Z0-9-=.]+$");
     /**
      * The regular expression to validate that the type field supplied in credentials is legal.
      */
-    public static final String TYPE_VALUE_REGEX = "^[a-z0-9-]+$";
+    public static final Pattern PATTERN_TYPE_VALUE = Pattern.compile("^[a-z0-9-]+$");
 
     /**
      * Request actions that belong to the Credentials API.

--- a/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/device/JsonStoreTest.java
+++ b/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/device/JsonStoreTest.java
@@ -36,8 +36,7 @@ public class JsonStoreTest {
         final PskSecret psk1 = new PskSecret();
         psk1.setKey("foo".getBytes(StandardCharsets.UTF_8));
 
-        final PskCredential result = new PskCredential();
-        result.setAuthId(authId);
+        final PskCredential result = new PskCredential(authId);
         result.setSecrets(Arrays.asList(psk1));
 
         return result;

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/AbstractDelegatingRegistryHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/AbstractDelegatingRegistryHttpEndpoint.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.hono.service.management;
 
-import java.net.HttpURLConnection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -28,12 +27,12 @@ import org.eclipse.hono.service.http.HttpUtils;
 
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
-import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 
 
@@ -134,74 +133,17 @@ public abstract class AbstractDelegatingRegistryHttpEndpoint<S, T extends Servic
             customHandler.accept(response.headers(), status);
         }
         // once the body has been written, the response headers can no longer be changed
-        HttpUtils.setResponseBody(response, asJson(result.getPayload()));
+        HttpUtils.setResponseBody(response, asJson(result.getPayload()), HttpUtils.CONTENT_TYPE_JSON_UTF8);
         Tags.HTTP_STATUS.set(span, status);
         response.end();
     }
 
-    private JsonObject asJson(final Object obj) {
+    private Buffer asJson(final Object obj) {
         try {
-            return JsonObject.mapFrom(obj);
+            return Json.encodeToBuffer(obj);
         } catch (final IllegalArgumentException e) {
             logger.debug("error serializing result object [type: {}] to JSON", obj.getClass().getName(), e);
             return null;
         }
-    }
-
-    /**
-     * Writes a response based on generic result.
-     * <p>
-     * The behavior is as follows:
-     * <ol>
-     * <li>Set the status code on the response.</li>
-     * <li>If the status code represents an error condition (i.e. the code is &gt;= 400),
-     * then the JSON object passed in the result is written to the response body.</li>
-     * <li>If the result is created (the code is = 201), the JSON object is written to the response body and the given custom handler is
-     * invoked (if not {@code null}).</li>
-     * <li>Sets the status of the tracing span and finishes it.</li>
-     * <li>Ends a response.</li>
-     * </ol>
-     *
-     * @param ctx The routing context of the request.
-     * @param result The generic result of the operation.
-     * @param customHandler An (optional) handler for post processing successful HTTP response, e.g. to set any additional HTTP
-     *                      headers. The handler <em>must not</em> write to response body. May be {@code null}.
-     * @param span The active OpenTracing span for this operation. The status of the response is logged and span is finished.
-     * @deprecated Use {@link #writeResponse(RoutingContext, Result, BiConsumer, Span)} instead.
-     */
-    @Deprecated
-    protected final void writeResponse(final RoutingContext ctx, final Result<?> result, final Handler<HttpServerResponse> customHandler, final Span span) {
-        final int status = result.getStatus();
-        final HttpServerResponse response = ctx.response();
-        response.setStatusCode(status);
-        if (status >= 400) {
-            HttpUtils.setResponseBody(response, JsonObject.mapFrom(result.getPayload()));
-        } else if (status == HttpURLConnection.HTTP_CREATED) {
-            if (customHandler != null) {
-                customHandler.handle(response);
-            }
-            HttpUtils.setResponseBody(response, JsonObject.mapFrom(result.getPayload()));
-        }
-        Tags.HTTP_STATUS.set(span, status);
-        span.finish();
-        response.end();
-    }
-
-    /**
-     * Writes a response based on operation result (including the resource version).
-     * <p>
-     * Sets ETAG header and then calls {@link #writeResponse}
-     *
-     * @param ctx The routing context of the request.
-     * @param result The operation result of the operation.
-     * @param customHandler An (optional) handler for post processing successful HTTP response, e.g. to set any additional HTTP
-     *                      headers. The handler <em>must not</em> write to response body. May be {@code null}.
-     * @param span The active OpenTracing span for this operation. The status of the response is logged and span is finished.
-     * @deprecated Use {@link #writeResponse(RoutingContext, Result, BiConsumer, Span)} instead.
-     */
-    @Deprecated
-    protected final void writeOperationResponse(final RoutingContext ctx, final OperationResult<?> result, final Handler<HttpServerResponse> customHandler, final Span span) {
-        result.getResourceVersion().ifPresent(v -> ctx.response().putHeader(HttpHeaders.ETAG, v));
-        writeResponse(ctx, result, customHandler, span);
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericCredential.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,16 +17,25 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.eclipse.hono.util.CredentialsConstants;
+import org.eclipse.hono.util.RegistryManagementConstants;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A generic credentials implementation.
  */
 public class GenericCredential extends CommonCredential {
 
+    private static final Predicate<String> typeValidator = CredentialsConstants.PATTERN_TYPE_VALUE.asMatchPredicate();
+
+    @JsonProperty(value = RegistryManagementConstants.FIELD_TYPE)
     private String type;
 
     @JsonAnySetter
@@ -36,26 +45,34 @@ public class GenericCredential extends CommonCredential {
     private List<GenericSecret> secrets = new LinkedList<>();
 
     /**
-     * Sets the credentials type name reflecting the type of authentication mechanism a device will use
-     * when authenticating to protocol adapters.
+     * Creates a new credentials object for a type and authentication identifier.
      *
-     * @param type  The credential name type to set.
-     * @return      a reference to this for fluent use.
-     *
-     * @see <a href="https://www.eclipse.org/hono/docs/api/credentials/#standard-credential-types">Standard Credential Types</a>
+     * @param type The credentials type to set.
+     * @param authId The authentication identifier.
+     * @throws NullPointerException if type or auth ID are {@code null}.
+     * @throws IllegalArgumentException if type does not match {@link CredentialsConstants#PATTERN_TYPE_VALUE}
+     *         or if auth ID does not match {@link CredentialsConstants#PATTERN_AUTH_ID_VALUE}.
      */
-    public GenericCredential setType(final String type) {
-        this.type = type;
-        return this;
+    public GenericCredential(
+            @JsonProperty(value = RegistryManagementConstants.FIELD_TYPE, required = true) final String type,
+            @JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String authId) {
+        super(authId);
+        Objects.requireNonNull(type);
+        if (typeValidator.test(type)) {
+            this.type = type;
+        } else {
+            throw new IllegalArgumentException("type name must match pattern "
+                    + CredentialsConstants.PATTERN_TYPE_VALUE.pattern());
+        }
     }
 
     @Override
-    public String getType() {
+    public final String getType() {
         return type;
     }
 
     @Override
-    public List<GenericSecret> getSecrets() {
+    public final List<GenericSecret> getSecrets() {
         return this.secrets;
     }
 
@@ -68,7 +85,7 @@ public class GenericCredential extends CommonCredential {
      * @return        a reference to this for fluent use.
      * @throws IllegalArgumentException if the list of secrets is empty.
      */
-    public GenericCredential setSecrets(final List<GenericSecret> secrets) {
+    public final GenericCredential setSecrets(final List<GenericSecret> secrets) {
         if (secrets != null && secrets.isEmpty()) {
             throw new IllegalArgumentException("Secrets cannot be empty");
         }
@@ -82,13 +99,13 @@ public class GenericCredential extends CommonCredential {
      * @param additionalProperties  The additional properties for this credential.
      * @return                      a reference to this for fluent use.
      */
-    public GenericCredential setAdditionalProperties(final Map<String, Object> additionalProperties) {
+    public final GenericCredential setAdditionalProperties(final Map<String, Object> additionalProperties) {
         this.additionalProperties = additionalProperties;
         return this;
     }
 
     @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
+    public final Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordCredential.java
@@ -37,6 +37,17 @@ public class PasswordCredential extends CommonCredential {
     private List<PasswordSecret> secrets = new LinkedList<>();
 
     /**
+     * Creates a new credentials object for an authentication identifier.
+     *
+     * @param authId The authentication identifier.
+     * @throws NullPointerException if the auth ID is {@code null}.
+     * @throws IllegalArgumentException if auth ID does not match {@link org.eclipse.hono.util.CredentialsConstants#PATTERN_AUTH_ID_VALUE}.
+     */
+    public PasswordCredential(@JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String authId) {
+        super(authId);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
@@ -32,9 +32,20 @@ public class PskCredential extends CommonCredential {
 
     static final String TYPE = RegistryManagementConstants.SECRETS_TYPE_PRESHARED_KEY;
 
-    @JsonProperty
+    @JsonProperty(value = RegistryManagementConstants.FIELD_SECRETS)
     @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
     private List<PskSecret> secrets = new LinkedList<>();
+
+    /**
+     * Creates a new credentials object for an authentication identifier.
+     *
+     * @param authId The authentication identifier.
+     * @throws NullPointerException if the auth ID is {@code null}.
+     * @throws IllegalArgumentException if auth ID does not match {@link org.eclipse.hono.util.CredentialsConstants#PATTERN_AUTH_ID_VALUE}.
+     */
+    public PskCredential(@JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String authId) {
+        super(authId);
+    }
 
     /**
      * {@inheritDoc}
@@ -46,7 +57,7 @@ public class PskCredential extends CommonCredential {
     }
 
     @Override
-    public List<PskSecret> getSecrets() {
+    public final List<PskSecret> getSecrets() {
         return secrets;
     }
 
@@ -59,7 +70,7 @@ public class PskCredential extends CommonCredential {
      * @return        a reference to this for fluent use.
      * @throws IllegalArgumentException if the list of secrets is empty.
      */
-    public PskCredential setSecrets(final List<PskSecret> secrets) {
+    public final PskCredential setSecrets(final List<PskSecret> secrets) {
         if (secrets != null && secrets.isEmpty()) {
             throw new IllegalArgumentException("secrets cannot be empty");
         }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/X509CertificateCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/X509CertificateCredential.java
@@ -14,6 +14,9 @@ package org.eclipse.hono.service.management.credentials;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Predicate;
+
+import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.hono.util.RegistryManagementConstants;
 
@@ -38,6 +41,30 @@ public class X509CertificateCredential extends CommonCredential {
     private List<X509CertificateSecret> secrets = new LinkedList<>();
 
     /**
+     * Creates a new credentials object for a an X.500 Distinguished Name.
+     * <p>
+     * The given distinguished name will be normalized to RFC 2253 format.
+     *
+     * @param distinguishedName The DN to use as the authentication identifier.
+     * @throws NullPointerException if the DN is {@code null}.
+     * @throws IllegalArgumentException if the given string is not a valid X.500 distinguished name.
+     */
+    public X509CertificateCredential(@JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String distinguishedName) {
+        super(new X500Principal(distinguishedName).getName(X500Principal.RFC2253));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Predicate<String> getAuthIdValidator() {
+        return authId -> {
+            final X500Principal distinguishedName = new X500Principal(authId);
+            return distinguishedName.getName(X500Principal.RFC2253).equals(authId);
+        };
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -47,7 +74,7 @@ public class X509CertificateCredential extends CommonCredential {
     }
 
     @Override
-    public List<X509CertificateSecret> getSecrets() {
+    public final List<X509CertificateSecret> getSecrets() {
         return secrets;
     }
 
@@ -60,7 +87,7 @@ public class X509CertificateCredential extends CommonCredential {
      * @return        a reference to this for fluent use.
      * @throws IllegalArgumentException if the list of secrets is empty.
      */
-    public X509CertificateCredential setSecrets(final List<X509CertificateSecret> secrets) {
+    public final X509CertificateCredential setSecrets(final List<X509CertificateSecret> secrets) {
         if (secrets != null && secrets.isEmpty()) {
             throw new IllegalArgumentException("secrets cannot be empty");
         }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackend.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioningEnabledDeviceBackend.java
@@ -76,10 +76,10 @@ public interface AutoProvisioningEnabledDeviceBackend extends DeviceBackend {
                     }
 
                     // 2. set the certificate credential
-                    final X509CertificateCredential certCredential = new X509CertificateCredential()
+                    final String authId = clientCertificate.getSubjectX500Principal().getName(X500Principal.RFC2253);
+                    final X509CertificateCredential certCredential = new X509CertificateCredential(authId)
                             .setSecrets(List.of(new X509CertificateSecret()));
-                    certCredential.setEnabled(true).setComment(comment)
-                            .setAuthId(clientCertificate.getSubjectX500Principal().getName(X500Principal.RFC2253));
+                    certCredential.setEnabled(true).setComment(comment);
 
                     final String deviceId = r.getPayload().getId();
 

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
@@ -164,8 +164,7 @@ public abstract class AbstractCredentialsServiceTest {
      * @return The fully populated secret.
      */
     public static PskCredential createPSKCredential(final String authId, final String psk) {
-        final PskCredential p = new PskCredential();
-        p.setAuthId(authId);
+        final PskCredential p = new PskCredential(authId);
 
         final PskSecret s = new PskSecret();
         s.setKey(psk.getBytes());
@@ -185,8 +184,7 @@ public abstract class AbstractCredentialsServiceTest {
      */
     public static PasswordCredential createPasswordCredential(final String authId, final String password,
             final OptionalInt maxBcryptIterations) {
-        final PasswordCredential p = new PasswordCredential();
-        p.setAuthId(authId);
+        final PasswordCredential p = new PasswordCredential(authId);
 
         p.setSecrets(Collections.singletonList(createPasswordSecret(password, maxBcryptIterations)));
 
@@ -201,8 +199,7 @@ public abstract class AbstractCredentialsServiceTest {
      * @return The fully populated credential.
      */
     public static PasswordCredential createPlainPasswordCredential(final String authId, final String password) {
-        final PasswordCredential p = new PasswordCredential();
-        p.setAuthId(authId);
+        final PasswordCredential p = new PasswordCredential(authId);
 
         final PasswordSecret secret = new PasswordSecret();
         secret.setPasswordPlain(password);
@@ -892,8 +889,7 @@ public abstract class AbstractCredentialsServiceTest {
         final String deviceId = UUID.randomUUID().toString();
         final String authId = UUID.randomUUID().toString();
 
-        final PasswordCredential credential = new PasswordCredential();
-        credential.setAuthId(authId);
+        final PasswordCredential credential = new PasswordCredential(authId);
         final PasswordSecret sec1 = new PasswordSecret().setPasswordPlain("bar");
         final PasswordSecret sec2 = new PasswordSecret().setPasswordPlain("foo");
 
@@ -943,8 +939,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase2.future().onComplete(ctx.succeeding(n -> {
             // create a credential object with only one of the ID.
-            final PasswordCredential credentialWithOnlyId = new PasswordCredential();
-            credentialWithOnlyId.setAuthId(authId);
+            final PasswordCredential credentialWithOnlyId = new PasswordCredential(authId);
 
             final PasswordSecret secretWithOnlyId = new PasswordSecret();
             secretWithOnlyId.setId(secretIDs.get(0));
@@ -1137,8 +1132,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase2.future().onComplete(ctx.succeeding(n -> {
             // Add some metadata to the secret
-            final PasswordCredential credentialWithMetadataUpdate = new PasswordCredential();
-            credentialWithMetadataUpdate.setAuthId(authId);
+            final PasswordCredential credentialWithMetadataUpdate = new PasswordCredential(authId);
 
             final PasswordSecret secretWithOnlyIdAndMetadata = new PasswordSecret();
             secretWithOnlyIdAndMetadata.setId(secretIDs.get(0));
@@ -1248,8 +1242,7 @@ public abstract class AbstractCredentialsServiceTest {
 
         phase2.future().onComplete(ctx.succeeding(n -> {
             // Add some other metadata to the secret
-            final PasswordCredential credentialWithMetadataUpdate = new PasswordCredential();
-            credentialWithMetadataUpdate.setAuthId(authId);
+            final PasswordCredential credentialWithMetadataUpdate = new PasswordCredential(authId);
 
             final PasswordSecret secretWithOnlyIdAndMetadata = new PasswordSecret();
             secretWithOnlyIdAndMetadata.setId(secretIDs.get(0));

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
@@ -370,8 +370,7 @@ public class FileBasedCredentialsServiceTest extends AbstractCredentialsServiceT
         when(fileSystem.existsBlocking(credentialsConfig.getFilename())).thenReturn(Boolean.TRUE);
 
         // 4700
-        final PasswordCredential passwordCredential = new PasswordCredential();
-        passwordCredential.setAuthId("bumlux");
+        final PasswordCredential passwordCredential = new PasswordCredential("bumlux");
 
         final PasswordSecret hashedPassword = new PasswordSecret();
         hashedPassword.setPasswordHash("$2a$10$UK9lmSMlYmeXqABkTrDRsu1nlZRnAmGnBdPIWZoDajtjyxX18Dry.");
@@ -379,8 +378,7 @@ public class FileBasedCredentialsServiceTest extends AbstractCredentialsServiceT
         passwordCredential.setSecrets(Collections.singletonList(hashedPassword));
 
         // 4711RegistryManagementConstants.FIELD_ID
-        final PskCredential pskCredential = new PskCredential();
-        pskCredential.setAuthId("sensor1");
+        final PskCredential pskCredential = new PskCredential("sensor1");
 
         final PskSecret pskSecret = new PskSecret();
         pskSecret.setKey("sharedkey".getBytes(StandardCharsets.UTF_8));
@@ -525,8 +523,7 @@ public class FileBasedCredentialsServiceTest extends AbstractCredentialsServiceT
         credentialsConfig.setHashAlgorithmsWhitelist(whitelist);
 
         // 4700
-        final PasswordCredential passwordCredential = new PasswordCredential();
-        passwordCredential.setAuthId("bumlux");
+        final PasswordCredential passwordCredential = new PasswordCredential("bumlux");
 
         final PasswordSecret hashedPassword = new PasswordSecret();
         hashedPassword.setPasswordHash("$2a$10$UK9lmSMlYmeXqABkTrDRsu1nlZRnAmGnBdPIWZoDajtjyxX18Dry.");
@@ -564,8 +561,7 @@ public class FileBasedCredentialsServiceTest extends AbstractCredentialsServiceT
         final PskSecret pskSecret = new PskSecret();
         pskSecret.setKey("sharedkey".getBytes(StandardCharsets.UTF_8));
 
-        final PskCredential pskCredential = new PskCredential();
-        pskCredential.setAuthId(authId);
+        final PskCredential pskCredential = new PskCredential(authId);
         pskCredential.setExtensions(Map.of("property-to-match", expectedContextValue));
         pskCredential.setSecrets(Collections.singletonList(pskSecret));
 

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
@@ -237,8 +237,8 @@ public class MqttConnectionIT extends MqttTestBase {
                     return helper.registry.addTenant(tenantId, tenant);
                 }).compose(ok -> helper.registry.registerDevice(tenantId, deviceId))
                 .compose(ok -> {
-                    final X509CertificateCredential credential = new X509CertificateCredential();
-                    credential.setAuthId(new X500Principal("CN=4711").getName(X500Principal.RFC2253));
+                    final String authId = new X500Principal("CN=4711").getName(X500Principal.RFC2253);
+                    final X509CertificateCredential credential = new X509CertificateCredential(authId);
                     credential.getSecrets().add(new X509CertificateSecret());
                     return helper.registry.addCredentials(tenantId, deviceId, Collections.singleton(credential));
                 })

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
@@ -299,8 +299,7 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
         final var secret2 = AbstractCredentialsServiceTest.createPasswordSecret("hono-password",
                 OptionalInt.of(IntegrationTestSupport.MAX_BCRYPT_ITERATIONS));
 
-        final var credential = new PasswordCredential();
-        credential.setAuthId(authId);
+        final var credential = new PasswordCredential(authId);
         credential.setSecrets(Arrays.asList(secret1, secret2));
 
         return credential;


### PR DESCRIPTION
Added explicit error handling in case of failure to process requests.
Improved integration tests.
Improved credentials and secret data objects to implicitly check
constraints on property values during de-serialization/instantiation.
