### PR TITLE
Use parallel jobs to test both registry variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,16 @@ services:
 jdk:
 - openjdk11
 
-install: true # no need to call 'mvn install'
-
-script:
-- free -m
-- mvn verify -B -e -Dmsg.count=400 -Dtest.env=true -DcreateJavadoc=true -Ddocker.host=unix:///var/run/docker.sock -Dservice.startup.timeout=600000 -Dmax.event-loop.execute-time=20000 -Pbuild-docker-image,run-tests -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-
 env:
   global:
   - COMMIT=${TRAVIS_COMMIT::8}
+  - DOCKER_HOST=unix:///var/run/docker.sock
 
-after_script:
-- bash <(curl -s https://codecov.io/bash)
+install: true # no need to call 'mvn install'
+
+jobs:
+  include:
+  - script: mvn verify -B -e -DcreateJavadoc=true -Dservice.startup.timeout=600000 -Dmax.event-loop.execute-time=20000 -Dmsg.count=400 -Dtest.env=true -Pbuild-docker-image,run-tests -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+    name: "file based registry"
+  - script: mvn verify -B -e -DcreateJavadoc=true -Dservice.startup.timeout=600000 -Dmax.event-loop.execute-time=20000 -Dmsg.count=400 -Dtest.env=true -Pbuild-docker-image,run-tests,device-registry-mongodb -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+    name: "MongoDB based registry"


### PR DESCRIPTION
The Travis build now starts two jobs in parallel, one for building and
testing the file based registry and another for testing the MongoDB
based registry.
