### PR TITLE
[#2049] Adding AMQP application property "qos" for northbound consumers

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslResponseContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslResponseContext.java
@@ -17,14 +17,13 @@ import java.security.cert.Certificate;
 import java.util.Objects;
 
 import org.eclipse.hono.util.AuthenticationConstants;
-import org.eclipse.hono.util.MapBasedExecutionContext;
 
 import io.vertx.proton.ProtonConnection;
 
 /**
  * Keeps information about the SASL handshake.
  */
-public final class SaslResponseContext extends MapBasedExecutionContext {
+public final class SaslResponseContext {
 
     private final ProtonConnection protonConnection;
     private final Certificate[] peerCertificateChain;

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
@@ -20,6 +20,7 @@ import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.service.metric.MetricsTags.EndpointType;
 import org.eclipse.hono.util.MapBasedExecutionContext;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.ResourceIdentifier;
 
 import io.micrometer.core.instrument.Timer.Sample;
@@ -204,5 +205,10 @@ public class AmqpContext extends MapBasedExecutionContext {
      */
     final void setTraceSamplingPriority(final OptionalInt traceSamplingPriority) {
         this.traceSamplingPriority = Objects.requireNonNull(traceSamplingPriority);
+    }
+
+    @Override
+    public QoS getRequestedQos() {
+        return isRemotelySettled() ? QoS.AT_MOST_ONCE : QoS.AT_LEAST_ONCE;
     }
 }

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -1088,6 +1088,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                     final DownstreamSender sender = senderFuture.result();
                     final Message downstreamMessage = addProperties(
                             context.getMessage(),
+                            context.getRequestedQos(),
                             ResourceIdentifier.from(context.getEndpoint().getCanonicalName(), resource.getTenantId(), resource.getResourceId()),
                             context.getAddress().toString(),
                             tenantValidationTracker.result(),

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -747,6 +747,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                 final DownstreamSender sender = senderTracker.result();
                 final Integer ttd = ttdTracker.result();
                 final Message downstreamMessage = newMessage(
+                        context.getRequestedQos(),
                         ResourceIdentifier.from(endpoint.getCanonicalName(), device.getTenantId(),
                                 device.getDeviceId()),
                         "/" + context.getExchange().getRequestOptions().getUriPathString(),

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
@@ -306,5 +306,4 @@ public final class CoapContext extends MapBasedExecutionContext {
                 })
                 .orElse(null);
     }
-
 }

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
@@ -25,6 +25,7 @@ import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MapBasedExecutionContext;
+import org.eclipse.hono.util.QoS;
 
 import io.micrometer.core.instrument.Timer.Sample;
 import io.vertx.core.Vertx;
@@ -306,4 +307,10 @@ public final class CoapContext extends MapBasedExecutionContext {
                 })
                 .orElse(null);
     }
+
+    @Override
+    public QoS getRequestedQos() {
+        return isConfirmable() ? QoS.AT_LEAST_ONCE : QoS.AT_MOST_ONCE;
+    }
+
 }

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -672,6 +672,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                     .map(c -> ttdTracker.result())
                     .orElse(null);
             final Message downstreamMessage = newMessage(
+                    ctx.getRequestedQos(),
                     ResourceIdentifier.from(endpoint.getCanonicalName(), tenant, deviceId),
                     ctx.request().uri(),
                     contentType,

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
@@ -185,7 +185,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         // route for uploading telemetry data
         router.route(HttpMethod.PUT, String.format("/telemetry/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
-                .handler(ctx -> uploadTelemetryMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
+                .handler(ctx -> uploadTelemetryMessage(HttpContext.from(ctx), getTenantParam(ctx), getDeviceIdParam(ctx)));
     }
 
     private void addEventApiRoutes(final Router router, final Handler<RoutingContext> authHandler) {
@@ -226,7 +226,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         // route for sending event messages
         router.route(HttpMethod.PUT, String.format("/event/:%s/:%s", PARAM_TENANT, PARAM_DEVICE_ID))
-                .handler(ctx -> uploadEventMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx)));
+                .handler(ctx -> uploadEventMessage(HttpContext.from(ctx), getTenantParam(ctx), getDeviceIdParam(ctx)));
     }
 
     private void addCommandResponseRoutes(final String commandResponsePrefix, final Router router,
@@ -271,7 +271,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
         router.route(
                 HttpMethod.PUT,
                 String.format("/%s/res/:%s/:%s/:%s", commandResponsePrefix, PARAM_TENANT, PARAM_DEVICE_ID, PARAM_COMMAND_REQUEST_ID))
-            .handler(ctx -> uploadCommandResponseMessage(ctx, getTenantParam(ctx), getDeviceIdParam(ctx),
+            .handler(ctx -> uploadCommandResponseMessage(HttpContext.from(ctx), getTenantParam(ctx), getDeviceIdParam(ctx),
                     getCommandRequestIdParam(ctx), getCommandResponseStatusParam(ctx)));
     }
 
@@ -301,7 +301,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         if (Device.class.isInstance(ctx.user())) {
             final Device device = (Device) ctx.user();
-            uploadTelemetryMessage(ctx, device.getTenantId(), device.getDeviceId());
+            uploadTelemetryMessage(HttpContext.from(ctx), device.getTenantId(), device.getDeviceId());
         } else {
             handle401(ctx);
         }
@@ -311,7 +311,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         if (Device.class.isInstance(ctx.user())) {
             final Device device = (Device) ctx.user();
-            uploadEventMessage(ctx, device.getTenantId(), device.getDeviceId());
+            uploadEventMessage(HttpContext.from(ctx), device.getTenantId(), device.getDeviceId());
         } else {
             handle401(ctx);
         }
@@ -321,7 +321,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
         if (Device.class.isInstance(ctx.user())) {
             final Device device = (Device) ctx.user();
-            uploadCommandResponseMessage(ctx, device.getTenantId(), device.getDeviceId(),
+            uploadCommandResponseMessage(HttpContext.from(ctx), device.getTenantId(), device.getDeviceId(),
                     getCommandRequestIdParam(ctx), getCommandResponseStatusParam(ctx));
         } else {
             handle401(ctx);

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1135,6 +1135,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
 
             final DownstreamSender sender = senderTracker.result();
             final Message downstreamMessage = newMessage(
+                    ctx.getRequestedQos(),
                     ResourceIdentifier.from(endpoint.getCanonicalName(), tenantObject.getTenantId(), deviceId),
                     ctx.message().topicName(),
                     ctx.contentType(),

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.MapBasedExecutionContext;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.ResourceIdentifier;
 
 import io.micrometer.core.instrument.Timer.Sample;
@@ -43,6 +44,19 @@ public final class MqttContext extends MapBasedExecutionContext {
     private PropertyBag propertyBag;
 
     private MqttContext() {
+    }
+
+    @Override
+    public QoS getRequestedQos() {
+
+        switch (message.qosLevel()) {
+            case AT_LEAST_ONCE:
+                return QoS.AT_LEAST_ONCE;
+            case AT_MOST_ONCE:
+                return QoS.AT_MOST_ONCE;
+            default:
+                return QoS.UNKNOWN;
+        }
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/CommandContext.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandContext.java
@@ -24,6 +24,7 @@ import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.MapBasedExecutionContext;
+import org.eclipse.hono.util.QoS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -206,5 +207,10 @@ public class CommandContext extends MapBasedExecutionContext {
             TracingHelper.logError(currentSpan, "unexpected delivery state: " + deliveryState);
         }
         currentSpan.finish();
+    }
+
+    @Override
+    public QoS getRequestedQos() {
+        return delivery.remotelySettled() ? QoS.AT_MOST_ONCE : QoS.AT_LEAST_ONCE;
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
@@ -63,4 +63,11 @@ public interface ExecutionContext {
      * @return The context or {@code null} if no tracing context is set.
      */
     SpanContext getTracingContext();
+
+    /**
+     * Gets the QoS level as set in the request by the device.
+     *
+     * @return The QoS level requested by the device.
+     */
+    QoS getRequestedQos();
 }

--- a/core/src/main/java/org/eclipse/hono/util/MapBasedExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/MapBasedExecutionContext.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.hono.util;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -23,31 +22,10 @@ import io.opentracing.SpanContext;
  * An execution context that stores properties in a {@code Map}.
  *
  */
-public class MapBasedExecutionContext implements ExecutionContext {
+public abstract class MapBasedExecutionContext implements ExecutionContext {
 
     private Map<String, Object> data;
     private SpanContext spanContext;
-
-    /**
-     * Creates an empty execution context.
-     *
-     * @return The new context.
-     */
-    public static ExecutionContext empty() {
-        return new MapBasedExecutionContext();
-    }
-
-    /**
-     * Creates an execution context for given set of properties.
-     *
-     * @param props The properties to add to the new context.
-     * @return The new context.
-     */
-    public static ExecutionContext of(final Map<String, Object> props) {
-        final MapBasedExecutionContext result = new MapBasedExecutionContext();
-        result.data = new HashMap<>(props);
-        return result;
-    }
 
     @Override
     public final <T> T get(final String key) {
@@ -76,15 +54,6 @@ public class MapBasedExecutionContext implements ExecutionContext {
     @Override
     public void setTracingContext(final SpanContext spanContext) {
         this.spanContext = spanContext;
-    }
-
-    /**
-     * Gets the properties stored in this context.
-     *
-     * @return An unmodifiable view on this context's properties.
-     */
-    public final Map<String, Object> asMap() {
-        return Collections.unmodifiableMap(getData());
     }
 
     private Map<String, Object> getData() {

--- a/core/src/main/java/org/eclipse/hono/util/QoS.java
+++ b/core/src/main/java/org/eclipse/hono/util/QoS.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.util;
+
+/**
+ * Denotes the QoS level (in Hono's terms) with which a message was sent by the device.
+ */
+public enum QoS {
+
+    AT_MOST_ONCE,
+    AT_LEAST_ONCE,
+    /**
+     * Indicates that the device set a QoS level which is not known or supported.
+     */
+    UNKNOWN;
+}

--- a/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
@@ -167,6 +167,7 @@ public class MessageHelperTest {
         message.setAddress("telemetry/DEFAULT_TENANT/4711");
         MessageHelper.addProperties(
                 message,
+                QoS.AT_MOST_ONCE,
                 null,
                 null,
                 null,
@@ -218,6 +219,7 @@ public class MessageHelperTest {
 
         MessageHelper.addProperties(
                 message,
+                QoS.AT_LEAST_ONCE,
                 target,
                 null,
                 tenant,
@@ -267,6 +269,7 @@ public class MessageHelperTest {
         final JsonObject defaults = new JsonObject().put(MessageHelper.SYS_HEADER_PROPERTY_TTL, 15);
 
         final Message message = MessageHelper.newMessage(
+                QoS.AT_LEAST_ONCE,
                 target,
                 null,
                 "application/text",
@@ -297,6 +300,7 @@ public class MessageHelperTest {
         tenant.setResourceLimits(new ResourceLimits().setMaxTtl(15));
 
         final Message message = MessageHelper.newMessage(
+                QoS.AT_LEAST_ONCE,
                 target,
                 null,
                 "application/text",
@@ -324,6 +328,7 @@ public class MessageHelperTest {
 
         MessageHelper.addProperties(
                 message,
+                QoS.AT_MOST_ONCE,
                 ResourceIdentifier.fromString("telemetry/DEFAULT_TENANT/4711"),
                 null,
                 null,

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -60,6 +60,7 @@ import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.Strings;
@@ -1171,9 +1172,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * Subclasses are encouraged to use this method for creating {@code Message} instances to be sent downstream in
      * order to have required Hono specific properties being set on the message automatically.
      * <p>
-     * This method simply delegates to {@link #newMessage(ResourceIdentifier, String, String, Buffer, TenantObject,
+     * This method simply delegates to {@link #newMessage(QoS, ResourceIdentifier, String, String, Buffer, TenantObject,
      * JsonObject, Integer, Duration)}.
      *
+     * @param qos The QoS level with which the device sent the message to the protocol adapter or {@code null}
+     *            if the corresponding <em>qos</em> application property in the AMQP message should not be set.
      * @param target The target address of the message or {@code null} if the message's
      *               <em>to</em> property contains the target address. The target
      *               address is used to determine if the message represents an event or not.
@@ -1198,6 +1201,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @throws NullPointerException if target or registration info are {@code null}.
      */
     protected final Message newMessage(
+            final QoS qos,
             final ResourceIdentifier target,
             final String publishAddress,
             final String contentType,
@@ -1206,7 +1210,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             final JsonObject registrationInfo,
             final Integer timeUntilDisconnect) {
 
-        return newMessage(target, publishAddress, contentType, payload, tenant, registrationInfo, timeUntilDisconnect,
+        return newMessage(qos, target, publishAddress, contentType, payload, tenant, registrationInfo, timeUntilDisconnect,
                 null);
     }
 
@@ -1216,9 +1220,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * Subclasses are encouraged to use this method for creating {@code Message} instances to be sent downstream in
      * order to have required Hono specific properties being set on the message automatically.
      * <p>
-     * This method simply delegates to {@link MessageHelper#newMessage(ResourceIdentifier, String, String, Buffer,
+     * This method simply delegates to {@link MessageHelper#newMessage(QoS, ResourceIdentifier, String, String, Buffer,
      * TenantObject, JsonObject, Integer, Duration, String, boolean, boolean)}.
      *
+     * @param qos The QoS level with which the device sent the message to the protocol adapter or {@code null}
+     *            if the corresponding <em>qos</em> application property in the AMQP message should not be set.
      * @param target The target address of the message or {@code null} if the message's
      *               <em>to</em> property contains the target address. The target
      *               address is used to determine if the message represents an event or not.
@@ -1245,6 +1251,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @throws NullPointerException if registration info is {@code null}.
      */
     protected final Message newMessage(
+            final QoS qos,
             final ResourceIdentifier target,
             final String publishAddress,
             final String contentType,
@@ -1257,6 +1264,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         Objects.requireNonNull(registrationInfo);
 
         return MessageHelper.newMessage(
+                qos,
                 target,
                 publishAddress,
                 contentType,
@@ -1273,9 +1281,11 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     /**
      * Adds Hono specific properties to an AMQP 1.0 message.
      * <p>
-     * This method simply delegates to {@link #addProperties(Message, ResourceIdentifier, String, TenantObject, JsonObject, Integer, Duration)}.
+     * This method simply delegates to {@link #addProperties(Message, QoS, ResourceIdentifier, String, TenantObject, JsonObject, Integer, Duration)}.
      *
      * @param msg The message to add the properties to.
+     * @param qos The QoS level with which the device sent the message to the protocol adapter or {@code null}
+     *            if the corresponding <em>qos</em> application property in the AMQP message should not be set.
      * @param target The target address of the message or {@code null} if the message's
      *               <em>to</em> property contains the target address. The target
      *               address is used to determine if the message represents an event or not.
@@ -1298,22 +1308,25 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     protected final Message addProperties(
             final Message msg,
+            final QoS qos,
             final ResourceIdentifier target,
             final String publishAddress,
             final TenantObject tenant,
             final JsonObject registrationInfo,
             final Integer timeUntilDisconnect) {
 
-        return addProperties(msg, target, publishAddress, tenant, registrationInfo, timeUntilDisconnect, null);
+        return addProperties(msg, qos, target, publishAddress, tenant, registrationInfo, timeUntilDisconnect, null);
     }
 
     /**
      * Adds Hono specific properties to an AMQP 1.0 message.
      * <p>
-     * This method simply delegates to {@link MessageHelper#addProperties(Message, ResourceIdentifier,
+     * This method simply delegates to {@link MessageHelper#addProperties(Message, QoS, ResourceIdentifier,
      * String, TenantObject, JsonObject, Integer, Duration, String, boolean, boolean)}.
      *
      * @param msg The message to add the properties to.
+     * @param qos The QoS level with which the device sent the message to the protocol adapter or {@code null}
+     *            if the corresponding <em>qos</em> application property in the AMQP message should not be set.
      * @param target The target address of the message or {@code null} if the message's
      *               <em>to</em> property contains the target address. The target
      *               address is used to determine if the message represents an event or not.
@@ -1338,6 +1351,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     protected final Message addProperties(
             final Message msg,
+            final QoS qos,
             final ResourceIdentifier target,
             final String publishAddress,
             final TenantObject tenant,
@@ -1351,6 +1365,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
         return MessageHelper.addProperties(
                 msg,
+                qos,
                 target,
                 publishAddress,
                 tenant,
@@ -1513,6 +1528,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             if (tenantConfigTracker.result().isAdapterEnabled(getTypeName())) {
                 final DownstreamSender sender = senderTracker.result();
                 final Message msg = newMessage(
+                        QoS.AT_LEAST_ONCE,
                         ResourceIdentifier.from(EventConstants.EVENT_ENDPOINT, tenant, deviceId),
                         EventConstants.EVENT_ENDPOINT,
                         EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION,

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
@@ -14,7 +14,6 @@
 package org.eclipse.hono.service.http;
 
 import java.net.HttpURLConnection;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -25,7 +24,6 @@ import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.EventConstants;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
@@ -189,91 +187,6 @@ public final class HttpUtils {
                 }
             }
             ctx.fail(error);
-        }
-    }
-
-    /**
-     * Gets the value of the <em>Content-Type</em> HTTP header for a request.
-     *
-     * @param ctx The routing context containing the HTTP request.
-     * @return The content type or {@code null} if the request doesn't contain a
-     *         <em>Content-Type</em> header.
-     * @throws NullPointerException if context is {@code null}.
-     */
-    public static String getContentType(final RoutingContext ctx) {
-
-        return Objects.requireNonNull(ctx).parsedHeaders().contentType().value();
-    }
-
-    /**
-     * Checks if a given request contains an empty notification.
-     *
-     * @param ctx The routing context containing the HTTP request.
-     * @return {@code true} if the request contains an empty notification.
-     */
-    public static boolean isEmptyNotification(final RoutingContext ctx) {
-
-        return Optional.ofNullable(getContentType(ctx)).map(type -> EventConstants.isEmptyNotificationType(type))
-                .orElse(false);
-    }
-
-    /**
-     * Gets the value of the {@link org.eclipse.hono.util.Constants#HEADER_TIME_TILL_DISCONNECT} HTTP header for a request.
-     * If no such header can be found, the query is searched for containing a query parameter with the same key.
-     *
-     * @param ctx The routing context containing the HTTP request.
-     * @return The time til disconnect or {@code null} if
-     * <ul>
-     *     <li>the request doesn't contain a {@link org.eclipse.hono.util.Constants#HEADER_TIME_TILL_DISCONNECT} header or query parameter.</li>
-     *     <li>the contained value cannot be parsed as an Integer</li>
-     * </ul>
-     * @throws NullPointerException if context is {@code null}.
-     */
-    public static Integer getTimeTillDisconnect(final RoutingContext ctx) {
-        Objects.requireNonNull(ctx);
-
-        try {
-            Optional<String> timeTilDisconnectHeader = Optional.ofNullable(ctx.request().getHeader(Constants.HEADER_TIME_TILL_DISCONNECT));
-
-            if (timeTilDisconnectHeader.isEmpty()) {
-                timeTilDisconnectHeader = Optional.ofNullable(ctx.request().getParam(Constants.HEADER_TIME_TILL_DISCONNECT));
-            }
-
-            if (timeTilDisconnectHeader.isPresent()) {
-                return Integer.parseInt(timeTilDisconnectHeader.get());
-            }
-        } catch (final NumberFormatException e) {
-        }
-
-        return null;
-    }
-
-    /**
-     * Gets the value of the {@link org.eclipse.hono.util.Constants#HEADER_TIME_TO_LIVE} HTTP header for a request.
-     * If no such header can be found, the query is searched for containing a query parameter with the same key.
-     *
-     * @param ctx The routing context containing the HTTP request.
-     * @return The <em>time-to-live</em> duration or {@code null} if
-     * <ul>
-     *     <li>the request doesn't contain a {@link org.eclipse.hono.util.Constants#HEADER_TIME_TO_LIVE} header 
-     *     or query parameter.</li>
-     *     <li>the contained value cannot be parsed as a Long</li>
-     * </ul>
-     * @throws NullPointerException if context is {@code null}.
-     */
-    public static Duration getTimeToLive(final RoutingContext ctx) {
-        Objects.requireNonNull(ctx);
-
-        try {
-            return Optional.ofNullable(ctx.request().getHeader(Constants.HEADER_TIME_TO_LIVE))
-                    .map(ttlInHeader -> Long.parseLong(ttlInHeader))
-                    .map(ttl -> Duration.ofSeconds(ttl))
-                    .orElse(Optional.ofNullable(ctx.request().getParam(Constants.HEADER_TIME_TO_LIVE))
-                            .map(ttlInParam -> Long.parseLong(ttlInParam))
-                            .map(ttl -> Duration.ofSeconds(ttl))
-                            .orElse(null));
-        } catch (final NumberFormatException e) {
-            return null;
         }
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/http/TenantTraceSamplingHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/TenantTraceSamplingHandler.java
@@ -49,7 +49,7 @@ public class TenantTraceSamplingHandler implements Handler<RoutingContext> {
             return;
         }
         final Span span = getTracingHandlerServerSpan(ctx);
-        tenantObjectWithAuthIdProvider.get(new HttpContext(ctx), span.context())
+        tenantObjectWithAuthIdProvider.get(HttpContext.from(ctx), span.context())
                 .compose(tenantObjectWithAuthId -> {
                     TenantTraceSamplingHelper.applyTraceSamplingPriority(tenantObjectWithAuthId, span);
                     return Future.succeededFuture(tenantObjectWithAuthId);

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
@@ -110,7 +110,7 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                     final Duration timeToLive = Duration.ofSeconds(tenant.getResourceLimits().getMaxTtl());
 
                     return MessageHelper.newMessage(
-                            target, 
+                            target,
                             EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE, 
                             payload.toBuffer(), 
                             tenant, 

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
@@ -22,6 +22,7 @@ import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TenantObject;
 
@@ -110,8 +111,9 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                     final Duration timeToLive = Duration.ofSeconds(tenant.getResourceLimits().getMaxTtl());
 
                     return MessageHelper.newMessage(
+                            QoS.AT_LEAST_ONCE,
                             target,
-                            EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE, 
+                            EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE,
                             payload.toBuffer(), 
                             tenant, 
                             timeToLive,

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -57,6 +57,7 @@ import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.ResourceLimits;
@@ -282,7 +283,7 @@ public class AbstractProtocolAdapterBaseTest {
         final ResourceIdentifier target = ResourceIdentifier.from(TelemetryConstants.TELEMETRY_ENDPOINT, Constants.DEFAULT_TENANT, "4711");
         final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
 
-        adapter.addProperties(message, target, "/status", tenant, newRegistrationAssertionResult(), 15);
+        adapter.addProperties(message, QoS.AT_MOST_ONCE, target, "/status", tenant, newRegistrationAssertionResult(), 15);
 
         assertThat(
                 MessageHelper.getApplicationProperty(
@@ -317,7 +318,7 @@ public class AbstractProtocolAdapterBaseTest {
                     .put(MessageHelper.SYS_HEADER_PROPERTY_TTL, 30)
                     .put("custom-device", true));
 
-        adapter.addProperties(message, target, null, null, assertion, null);
+        adapter.addProperties(message, QoS.AT_LEAST_ONCE, target, null, null, assertion, null);
 
         assertThat(
                 MessageHelper.getApplicationProperty(message.getApplicationProperties(), "custom-device", Boolean.class),
@@ -338,7 +339,7 @@ public class AbstractProtocolAdapterBaseTest {
                 .setResourceLimits(new ResourceLimits().setMaxTtl(15L));
         final JsonObject assertion = newRegistrationAssertionResult();
 
-        adapter.addProperties(message, target, null, tenant, assertion, null);
+        adapter.addProperties(message, QoS.AT_LEAST_ONCE, target, null, tenant, assertion, null);
 
         assertThat(message.getTtl(), is(15000L));
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/http/HttpContextTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/http/HttpContextTest.java
@@ -27,9 +27,9 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 
 /**
- * Test verifying functionality of the {@link HttpUtils} class.
+ * Test verifying functionality of the {@link HttpContext} class.
  */
-public class HttpUtilsTest {
+public class HttpContextTest {
 
     @Mock
     private RoutingContext routingContext;
@@ -50,10 +50,11 @@ public class HttpUtilsTest {
 
     /**
      * Verifies that the {@link Constants#HEADER_TIME_TILL_DISCONNECT} header is used by
-     * the {@link HttpUtils#getTimeTillDisconnect(RoutingContext)} method.
+     * the {@link HttpContext#getTimeTillDisconnect()} method.
      */
     @Test
     public void testGetTimeTillDisconnectUsesHeader() {
+        final HttpContext httpContext = HttpContext.from(routingContext);
 
         // GIVEN a time till disconnect
         final Integer timeTillDisconnect = 60;
@@ -62,15 +63,16 @@ public class HttpUtilsTest {
                 .thenReturn(timeTillDisconnect.toString());
 
         // THEN the get method returns this value
-        assertEquals(timeTillDisconnect, HttpUtils.getTimeTillDisconnect(routingContext));
+        assertEquals(timeTillDisconnect, httpContext.getTimeTillDisconnect());
     }
 
     /**
      * Verifies that the {@link Constants#HEADER_TIME_TILL_DISCONNECT} query parameter is used by
-     * the {@link HttpUtils#getTimeTillDisconnect(RoutingContext)} method.
+     * the {@link HttpContext#getTimeTillDisconnect()} method.
      */
     @Test
     public void testGetTimeTillDisconnectUsesQueryParam() {
+        final HttpContext httpContext = HttpContext.from(routingContext);
 
         // GIVEN a time till disconnect
         final Integer timeTillDisconnect = 60;
@@ -79,26 +81,27 @@ public class HttpUtilsTest {
                 .thenReturn(timeTillDisconnect.toString());
 
         // THEN the get method returns this value
-        assertEquals(timeTillDisconnect, HttpUtils.getTimeTillDisconnect(routingContext));
+        assertEquals(timeTillDisconnect, httpContext.getTimeTillDisconnect());
     }
 
     /**
      * Verifies that
-     * the {@link HttpUtils#getTimeTillDisconnect(RoutingContext)} method returns {@code null} if
+     * the {@link HttpContext#getTimeTillDisconnect()} method returns {@code null} if
      * {@link Constants#HEADER_TIME_TILL_DISCONNECT} is neither provided as query parameter nor as requests header.
      */
     @Test
     public void testGetTimeTillDisconnectReturnsNullIfNotSpecified() {
-
-        assertNull(HttpUtils.getTimeTillDisconnect(routingContext));
+        final HttpContext httpContext = HttpContext.from(routingContext);
+        assertNull(httpContext.getTimeTillDisconnect());
     }
 
     /**
      * Verifies that the {@link Constants#HEADER_TIME_TO_LIVE} header is used by
-     * the {@link HttpUtils#getTimeToLive(RoutingContext)} method.
+     * the {@link HttpContext#getTimeToLive()} method.
      */
     @Test
     public void testGetTimeToLiveUsesHeader() {
+        final HttpContext httpContext = HttpContext.from(routingContext);
 
         // GIVEN a time to live in seconds
         final long timeToLive = 60L;
@@ -107,15 +110,16 @@ public class HttpUtilsTest {
                 .thenReturn(String.valueOf(timeToLive));
 
         // THEN the get method returns this value
-        assertEquals(timeToLive, HttpUtils.getTimeToLive(routingContext).toSeconds());
+        assertEquals(timeToLive, httpContext.getTimeToLive().toSeconds());
     }
 
     /**
      * Verifies that the {@link Constants#HEADER_TIME_TO_LIVE} query parameter is used by
-     * the {@link HttpUtils#getTimeToLive(RoutingContext)} method.
+     * the {@link HttpContext#getTimeToLive()} method.
      */
     @Test
     public void testGetTimeToLiveUsesQueryParam() {
+        final HttpContext httpContext = HttpContext.from(routingContext);
 
         // GIVEN a time to live in seconds
         final long timeToLive = 60L;
@@ -124,17 +128,17 @@ public class HttpUtilsTest {
                 .thenReturn(String.valueOf(timeToLive));
 
         // THEN the get method returns this value
-        assertEquals(timeToLive, HttpUtils.getTimeToLive(routingContext).toSeconds());
+        assertEquals(timeToLive, httpContext.getTimeToLive().toSeconds());
     }
 
     /**
-     * Verifies that the {@link HttpUtils#getTimeToLive(RoutingContext)} method 
+     * Verifies that the {@link HttpContext#getTimeToLive()} method
      * returns {@code null} if {@link Constants#HEADER_TIME_TO_LIVE} is neither
      * provided as query parameter nor as header.
      */
     @Test
     public void testGetTimeToLiveReturnsNullIfNotSpecified() {
-
-        assertNull(HttpUtils.getTimeToLive(routingContext));
+        final HttpContext httpContext = HttpContext.from(routingContext);
+        assertNull(httpContext.getTimeToLive());
     }
 }


### PR DESCRIPTION
I started to implement this and it became a bigger change than I initially thought. Hence I am opening this PR to ask for feedback / guidance 😃 :

1. In my opinion the right place for the QoS property are the subclasses of `ExecutionContext`. However the HTTP adapter didn't have one so far (although I found such a class in the code base). Hence I decided to adapt the HTTP adapter to make the adapter implementations more consistent. This is the main reason why the change came out a lot bigger than I thought.

2. Currently there are 2 QoS enums. I am tempted to refactor this as well, but the change will be bigger then. Hence I thought I will add this in a separate commit (if we agree on it) to make this a bit easier to digest.

3. The QoS enum I introduced also has a `NOT_APPLICABLE` (used for TTD and Notification events) and a `UNKNOWN` level (if a client sends a QoS level we do not know). Do you think we need those cases? What should we do in those cases? Omit the property? Also the validation of the property is not consistent (if I didn't miss something obvious): in the HTTP adapter a request with an unsupported QoS level will be rejected, in the MQTT adapter not as far as I can see.