### PR TITLE
Do not enforce values to be returned from remote cache

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -35,8 +35,7 @@
     <guava.version>28.0-jre</guava.version>
     <caffeine.version>2.8.0</caffeine.version>
     <hamcrest-core.version>2.2</hamcrest-core.version>
-    <infinispan.version>9.4.17.Final</infinispan.version>
-    <infinispan.image.name>jboss/infinispan-server:9.4.11.Final</infinispan.image.name>
+    <infinispan.version>9.4.19.Final</infinispan.version>
     <jackson.version>2.10.3</jackson.version>
     <jaeger.version>0.35.2</jaeger.version>
     <jaeger-agent.image.name>jaegertracing/jaeger-agent:1.16.0</jaeger-agent.image.name>

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCache.java
@@ -28,7 +28,6 @@ import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.ReconnectListener;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.util.Futures;
-import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCacheContainer;
 import org.infinispan.commons.api.BasicCache;
 import org.slf4j.Logger;
@@ -173,11 +172,7 @@ public final class HotrodCache<K, V> implements RemoteCache<K, V>, ConnectionLif
 
         } else {
 
-            return Futures.create(() -> {
-                return cache
-                    .withFlags(Flag.FORCE_RETURN_VALUE)
-                    .putAsync(key, value);
-            });
+            return Futures.create(() -> cache.putAsync(key, value));
 
         }
 
@@ -207,11 +202,7 @@ public final class HotrodCache<K, V> implements RemoteCache<K, V>, ConnectionLif
 
         } else {
 
-            return Futures.create(() -> {
-                return cache
-                        .withFlags(Flag.FORCE_RETURN_VALUE)
-                        .putAsync(key, value, lifespan, lifespanUnit);
-            });
+            return Futures.create(() -> cache.putAsync(key, value, lifespan, lifespanUnit));
 
         }
 
@@ -227,11 +218,7 @@ public final class HotrodCache<K, V> implements RemoteCache<K, V>, ConnectionLif
 
         } else {
 
-            return Futures.create(() -> {
-                return cache
-                    .withFlags(Flag.FORCE_RETURN_VALUE)
-                    .removeWithVersionAsync(key, version);
-            });
+            return Futures.create(() -> cache.removeWithVersionAsync(key, version));
 
         }
 

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCacheConfig.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCacheConfig.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.eclipse.hono.client.BasicDeviceConnectionClientFactory;
 import org.eclipse.hono.util.DeviceConnectionConstants;
@@ -74,7 +75,7 @@ public class HotrodCacheConfig {
                 vertx,
                 remoteCacheManager(),
                 DeviceConnectionConstants.CACHE_NAME,
-                "KEY_CHECK_CONNECTION",
+                UUID.randomUUID().toString(),
                 "VALUE_CHECK_CONNECTION");
     }
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -10,6 +10,8 @@ title = "Release Notes"
   a certain number of reconnnect attempts (58 with the default configuration) had already
   failed. This has been fixed.
 * An error when freeing Command & Control related resources of an idle tenant has been fixed.
+* The Hotrod based DeviceConnectionClientFactory has been improved to prevent locking of
+  objects in a clustered cache.
 
 ## 1.2.3
 


### PR DESCRIPTION
The Hotrod client does no longer enforce (previous) values being
returned from the remote cache in the put and removeWithVersion methods
as in the former case the returned value isn't used anyway and in the
latter case the flag should not have any impact at all.