### PR TITLE
Fix content type of the LoRaWAN adapter

### DIFF
--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraConstants.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/LoraConstants.java
@@ -36,7 +36,6 @@ public class LoraConstants {
     public static final String FIELD_LORA_DEVICE_PORT = "lora-port";
     public static final String FIELD_LORA_DOWNLINK_PAYLOAD = "payload";
     public static final String EMPTY = "";
-    public static final String CONTENT_TYPE_LORA_POST_FIX = "+json";
     public static final String CONTENT_TYPE_LORA_BASE = "application/vnd.eclipse-hono.lora.";
     public static final String META_DATA = "meta_data";
     public static final String ADDITIONAL_DATA = "additional_data";

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -213,10 +213,9 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
                     final String contentType;
                     if (payload.length() > 0) {
                         contentType = String.format(
-                                "%s%s%s",
+                                "%s%s",
                                 LoraConstants.CONTENT_TYPE_LORA_BASE,
-                                provider.getProviderName(),
-                                LoraConstants.CONTENT_TYPE_LORA_POST_FIX);
+                                provider.getProviderName());
                     } else {
                         contentType = EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION;
                     }


### PR DESCRIPTION
This changes the content type of the telemetry messages sent by the LoRaWAN adapter to drop the `+json` suffix.

The payload wasn't JSON before the refactoring, but also currently it is not JSON. So that is a bug IMHO. And it causes problems with JMS clients.

In the past this wasn't a big deal, because the payload contained an actual string (base 64 encoded payload). So the message could be decoded as a JMS text message.

Now the payload is a BLOB/byte array and decoding as a String will not always work. If the decoding as a string doesn't work, JMS libraries fail to decode the message into a JMS text message, and you cannot process them.

Dropping the `+json` suffix seems to be the right cause of action IMHO, as the payload never did contain a JSON structure.