### PR TITLE
Fix return codes of Device Connection service implementations

### DIFF
--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
@@ -91,7 +91,7 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
             final String adapterInstanceId, final Span span) {
         return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span)
                 .map(removed -> removed ? DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT)
-                        : DeviceConnectionResult.from(HttpURLConnection.HTTP_PRECON_FAILED))
+                        : DeviceConnectionResult.from(HttpURLConnection.HTTP_NOT_FOUND))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
 

--- a/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
+++ b/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
@@ -216,7 +216,7 @@ public class CacheBasedDeviceConnectionServiceTest {
                 .compose(ok -> svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstanceId, span))
                 .onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
-                        assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
+                        assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
                         verify(cache).removeCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(Span.class));
                     });
                     ctx.completeNow();

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
@@ -222,10 +222,29 @@ abstract class DeviceConnectionApiTests extends DeviceRegistryTestBase {
     @Test
     public void testRemoveCommandHandlingAdapterInstanceFailsForNonExistingEntry(final VertxTestContext ctx) {
 
+        getClient(Constants.DEFAULT_TENANT)
+            .compose(client -> client.removeCommandHandlingAdapterInstance("non-existing-device", "adapterOne", null))
+            .onComplete(ctx.succeeding(result -> {
+                ctx.verify(() -> assertThat(result).isFalse());
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that a request to remove the command-handling adapter instance for a device succeeds with
+     * a <em>false</em> value if the device is mapped to a different adapter instance ID.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    @Test
+    public void testRemoveCommandHandlingAdapterInstanceFailsForNonMatchingAdapterInstanceId(final VertxTestContext ctx) {
+
         final String deviceId = randomId();
 
         getClient(Constants.DEFAULT_TENANT)
-            .compose(client -> client.removeCommandHandlingAdapterInstance(deviceId, "", null))
+            .compose(client -> client.setCommandHandlingAdapterInstance(deviceId, "adapterOne", Duration.ofMinutes(5), null).map(client))
+            .compose(client -> client.removeCommandHandlingAdapterInstance(deviceId, "notAdapterOne", null))
             .onComplete(ctx.succeeding(result -> {
                 ctx.verify(() -> assertThat(result).isFalse());
                 ctx.completeNow();


### PR DESCRIPTION
The status codes returned by the "Remove command-handling protocol
adapter instance for device" operation did not match the ones specified
by the API.

The API defines 404 to be the status code to be returned in case of
non-existing/non-matching entries and 412 being allowed in case of
non-matching entries only.

