### PR TITLE
[#2075] Check adapter connection limit for unauthenticated devices

### DIFF
--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -371,12 +371,12 @@ public class AbstractVertxBasedMqttProtocolAdapterTest {
     }
 
     /**
-     * Verifies that an adapter rejects connections when the connection limit is exceeded.
+     * Verifies that an adapter rejects connections when the adapter's connection limit is exceeded.
      *
      * @param ctx The helper to use for running async tests on vertx.
      */
     @Test
-    public void testEndpointHandlerRejectsConnectionsAboveLimit(final VertxTestContext ctx) {
+    public void testEndpointHandlerRejectsConnectionsExceedingAdapterLimit(final VertxTestContext ctx) {
 
         // GIVEN an adapter
         final MqttServer server = getMqttServer(false);


### PR DESCRIPTION
The AMQP adapter now always checks the adapter's connection limit
regardless of whether the device is authenticated or not.
