### PR TITLE
Remove obsolete ComponentScan

### DIFF
--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Application.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Application.java
@@ -23,7 +23,6 @@ import org.springframework.context.annotation.Configuration;
  * The Kura adapter main application class.
  */
 @ComponentScan("org.eclipse.hono.adapter.kura.impl")
-@ComponentScan("org.eclipse.hono.service.credentials")
 @ComponentScan("org.eclipse.hono.service.metric")
 @ComponentScan("org.eclipse.hono.deviceconnection.infinispan.client")
 @Configuration


### PR DESCRIPTION
The package `org.eclipse.hono.service.credentials` can't be resolved here because it got moved from `service-base` to `device-registry-base` (which isn't used as a dependency here). Furthermore, the corresponding `Application` class from the MQTT adapter (as an adapter using the same base classes) also doesn't have this ComponentScan.