### PR TITLE
[#1607] Rename customize*Config methods to get*ConfigDefaults

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
@@ -13,8 +13,6 @@
 package org.eclipse.hono.adapter.amqp.impl;
 
 import org.eclipse.hono.adapter.amqp.AmqpAdapterProperties;
-import org.eclipse.hono.client.RequestResponseClientConfigProperties;
-import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
@@ -48,38 +46,8 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties config) {
-        if (config.getName() == null) {
-            config.setName(CONTAINER_ID_HONO_AMQP_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties config) {
-        if (config.getName() == null) {
-            config.setName(CONTAINER_ID_HONO_AMQP_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties config) {
-        if (config.getName() == null) {
-            config.setName(CONTAINER_ID_HONO_AMQP_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeTenantClientFactoryConfig(final RequestResponseClientConfigProperties config) {
-        if (config != null) {
-            config.setName(CONTAINER_ID_HONO_AMQP_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeDeviceConnectionClientFactoryConfig(final RequestResponseClientConfigProperties config) {
-        if (config != null) {
-            config.setName(CONTAINER_ID_HONO_AMQP_ADAPTER);
-        }
+    protected String getAdapterName() {
+        return CONTAINER_ID_HONO_AMQP_ADAPTER;
     }
 
     /**

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
@@ -14,8 +14,6 @@
 package org.eclipse.hono.adapter.coap.impl;
 
 import org.eclipse.hono.adapter.coap.CoapAdapterProperties;
-import org.eclipse.hono.client.RequestResponseClientConfigProperties;
-import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
@@ -60,41 +58,8 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeTenantClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeDeviceConnectionClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_COAP_ADAPTER);
-        }
+    protected String getAdapterName() {
+        return CONTAINER_ID_HONO_COAP_ADAPTER;
     }
 
     /**

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
@@ -14,8 +14,6 @@
 package org.eclipse.hono.adapter.http.impl;
 
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
-import org.eclipse.hono.client.RequestResponseClientConfigProperties;
-import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
@@ -49,54 +47,8 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeTenantClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeDeviceConnectionClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeCommandConsumerFactoryConfig(final ClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_HTTP_ADAPTER);
-        }
+    protected String getAdapterName() {
+        return CONTAINER_ID_HONO_HTTP_ADAPTER;
     }
 
     /**

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
@@ -15,8 +15,6 @@ package org.eclipse.hono.adapter.kura.impl;
 
 import org.eclipse.hono.adapter.mqtt.MicrometerBasedMqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.MqttAdapterMetrics;
-import org.eclipse.hono.client.RequestResponseClientConfigProperties;
-import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
@@ -50,44 +48,8 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_KURA_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_KURA_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_KURA_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeTenantClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_KURA_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeDeviceConnectionClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_KURA_ADAPTER);
-        }
+    protected String getAdapterName() {
+        return CONTAINER_ID_KURA_ADAPTER;
     }
 
     /**

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
@@ -17,8 +17,6 @@ import javax.annotation.PostConstruct;
 
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.lora.LoraProtocolAdapterProperties;
-import org.eclipse.hono.client.RequestResponseClientConfigProperties;
-import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
@@ -65,44 +63,8 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_LORA_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_LORA_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_LORA_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeTenantClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_LORA_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeDeviceConnectionClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_LORA_ADAPTER);
-        }
+    protected String getAdapterName() {
+        return CONTAINER_ID_HONO_LORA_ADAPTER;
     }
 
     /**

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
@@ -15,8 +15,6 @@ package org.eclipse.hono.adapter.mqtt.impl;
 
 import org.eclipse.hono.adapter.mqtt.MqttContext;
 import org.eclipse.hono.adapter.mqtt.MqttProtocolAdapterProperties;
-import org.eclipse.hono.client.RequestResponseClientConfigProperties;
-import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
@@ -51,44 +49,8 @@ public class Config extends AbstractAdapterConfig {
     }
 
     @Override
-    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
-        }
-    }
-
-    @Override
-    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeTenantClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeDeviceConnectionClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_MQTT_ADAPTER);
-        }
+    protected String getAdapterName() {
+        return CONTAINER_ID_HONO_MQTT_ADAPTER;
     }
 
     /**

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
@@ -15,8 +15,6 @@ package org.eclipse.hono.adapter.sigfox.impl;
 
 import javax.annotation.PostConstruct;
 
-import org.eclipse.hono.client.RequestResponseClientConfigProperties;
-import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
@@ -58,54 +56,9 @@ public class Config extends AbstractAdapterConfig {
         return new SigfoxProtocolAdapter();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_SIGFOX_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_SIGFOX_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_SIGFOX_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeTenantClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_SIGFOX_ADAPTER);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void customizeDeviceConnectionClientFactoryConfig(final RequestResponseClientConfigProperties props) {
-        if (props.getName() == null) {
-            props.setName(CONTAINER_ID_HONO_SIGFOX_ADAPTER);
-        }
+    protected String getAdapterName() {
+        return CONTAINER_ID_HONO_SIGFOX_ADAPTER;
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/config/AuthenticatingClientConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/AuthenticatingClientConfigProperties.java
@@ -27,12 +27,14 @@ import org.eclipse.hono.util.Constants;
  */
 public class AuthenticatingClientConfigProperties extends AbstractConfig {
 
+    public static final String SERVER_ROLE_UNKNOWN = "unknown";
+
     private String credentialsPath;
     private String host = "localhost";
     private boolean hostnameVerificationRequired = true;
     private char[] password;
     private int port;
-    private String serverRole = "unknown";
+    private String serverRole = SERVER_ROLE_UNKNOWN;
     private boolean tlsEnabled = false;
     private String username;
 
@@ -287,7 +289,7 @@ public class AuthenticatingClientConfigProperties extends AbstractConfig {
     /**
      * Sets the name of the role that the server plays from the client's perspective.
      * <p>
-     * The default value of this property is <em>unknown</em>.
+     * The default value of this property is {@link #SERVER_ROLE_UNKNOWN}.
      *
      * @param roleName The name.
      * @throws NullPointerException if name is {@code null}.
@@ -299,7 +301,7 @@ public class AuthenticatingClientConfigProperties extends AbstractConfig {
     /**
      * Gets the name of the role that the server plays from the client's perspective.
      * <p>
-     * The default value of this property is <em>unknown</em>.
+     * The default value of this property is {@link #SERVER_ROLE_UNKNOWN}.
      *
      * @return The name.
      */

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.config.ApplicationConfigProperties;
+import org.eclipse.hono.config.AuthenticatingClientConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ServerConfig;
 import org.eclipse.hono.config.VertxProperties;
@@ -98,6 +99,17 @@ public abstract class AbstractAdapterConfig {
     }
 
     /**
+     * Gets the name of this protocol adapter.
+     * <p>
+     * This name will be used as part of the <em>container-id</em> in the AMQP <em>Open</em> frame sent by the
+     * clients defined in this adapter config.
+     * <p>
+     *
+     * @return The protocol adapter name.
+     */
+    protected abstract String getAdapterName();
+
+    /**
      * Creates properties for configuring the Connection Event producer.
      *
      * @return The properties.
@@ -130,8 +142,8 @@ public abstract class AbstractAdapterConfig {
     /**
      * Exposes configuration properties for accessing the AMQP Messaging Network as a Spring bean.
      * <p>
-     * The properties can be customized in subclasses by means of overriding the
-     * {@link #customizeDownstreamSenderFactoryConfig(ClientConfigProperties)} method.
+     * A default set of properties, on top of which the configured properties will by loaded, can be set in subclasses
+     * by means of overriding the {@link #getDownstreamSenderFactoryConfigDefaults()} method.
      *
      * @return The properties.
      */
@@ -139,23 +151,24 @@ public abstract class AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.messaging")
     @Bean
     public ClientConfigProperties downstreamSenderFactoryConfig() {
-        final ClientConfigProperties config = new ClientConfigProperties();
-        config.setServerRole("AMQP Messaging Network");
-        customizeDownstreamSenderFactoryConfig(config);
+        final ClientConfigProperties config = Optional.ofNullable(getDownstreamSenderFactoryConfigDefaults())
+                .orElseGet(ClientConfigProperties::new);
+        setConfigServerRoleIfUnknown(config, "AMQP Messaging Network");
+        setDefaultConfigNameIfNotSet(config);
         return config;
     }
 
     /**
-     * Further customizes the client properties provided by the {@link #downstreamSenderFactoryConfig()}
-     * method.
+     * Gets the default client properties, on top of which the configured properties will be loaded, to be then provided
+     * via {@link #downstreamSenderFactoryConfig()}.
      * <p>
-     * This method does nothing by default. Subclasses may override this method to set additional
-     * properties programmatically.
+     * This method returns an empty set of properties by default. Subclasses may override this method to set specific
+     * properties.
      *
-     * @param config The client configuration to customize.
+     * @return The properties.
      */
-    protected void customizeDownstreamSenderFactoryConfig(final ClientConfigProperties config) {
-        // empty by default
+    protected ClientConfigProperties getDownstreamSenderFactoryConfigDefaults() {
+        return new ClientConfigProperties();
     }
 
     /**
@@ -188,8 +201,6 @@ public abstract class AbstractAdapterConfig {
 
     /**
      * Exposes configuration properties for accessing the registration service as a Spring bean.
-     * <p>
-     * Sets the <em>amqpHostname</em> to {@code hono-device-registry} if not set explicitly.
      *
      * @return The properties.
      */
@@ -197,23 +208,24 @@ public abstract class AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.registration")
     @Bean
     public RequestResponseClientConfigProperties registrationClientFactoryConfig() {
-        final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
-        config.setServerRole("Device Registration");
-        customizeRegistrationClientFactoryConfig(config);
+        final RequestResponseClientConfigProperties config = Optional.ofNullable(getRegistrationClientFactoryConfigDefaults())
+                .orElseGet(RequestResponseClientConfigProperties::new);
+        setConfigServerRoleIfUnknown(config, "Device Registration");
+        setDefaultConfigNameIfNotSet(config);
         return config;
     }
 
     /**
-     * Further customizes the properties provided by the {@link #registrationClientFactoryConfig()}
-     * method.
+     * Gets the default client properties, on top of which the configured properties will be loaded, to be then provided
+     * via {@link #registrationClientFactoryConfig()}.
      * <p>
-     * This method does nothing by default. Subclasses may override this method to set additional
-     * properties programmatically.
+     * This method returns an empty set of properties by default. Subclasses may override this method to set specific
+     * properties.
      *
-     * @param config The configuration to customize.
+     * @return The properties.
      */
-    protected void customizeRegistrationClientFactoryConfig(final RequestResponseClientConfigProperties config) {
-        // empty by default
+    protected RequestResponseClientConfigProperties getRegistrationClientFactoryConfigDefaults() {
+        return new RequestResponseClientConfigProperties();
     }
 
     /**
@@ -261,23 +273,24 @@ public abstract class AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.credentials")
     @Bean
     public RequestResponseClientConfigProperties credentialsClientFactoryConfig() {
-        final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
-        config.setServerRole("Credentials");
-        customizeCredentialsClientFactoryConfig(config);
+        final RequestResponseClientConfigProperties config = Optional.ofNullable(getCredentialsClientFactoryConfigDefaults())
+                .orElseGet(RequestResponseClientConfigProperties::new);
+        setConfigServerRoleIfUnknown(config, "Credentials");
+        setDefaultConfigNameIfNotSet(config);
         return config;
     }
 
     /**
-     * Further customizes the properties provided by the {@link #credentialsClientFactoryConfig()}
-     * method.
+     * Gets the default client properties, on top of which the configured properties will be loaded, to be then provided
+     * via {@link #credentialsClientFactoryConfig()}.
      * <p>
-     * This method does nothing by default. Subclasses may override this method to set additional
-     * properties programmatically.
+     * This method returns an empty set of properties by default. Subclasses may override this method to set specific
+     * properties.
      *
-     * @param config The configuration to customize.
+     * @return The properties.
      */
-    protected void customizeCredentialsClientFactoryConfig(final RequestResponseClientConfigProperties config) {
-        // empty by default
+    protected RequestResponseClientConfigProperties getCredentialsClientFactoryConfigDefaults() {
+        return new RequestResponseClientConfigProperties();
     }
 
     /**
@@ -325,23 +338,24 @@ public abstract class AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.tenant")
     @Bean
     public RequestResponseClientConfigProperties tenantServiceClientConfig() {
-        final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
-        config.setServerRole("Tenant");
-        customizeTenantClientFactoryConfig(config);
+        final RequestResponseClientConfigProperties config = Optional.ofNullable(getTenantClientFactoryConfigDefaults())
+                .orElseGet(RequestResponseClientConfigProperties::new);
+        setConfigServerRoleIfUnknown(config, "Tenant");
+        setDefaultConfigNameIfNotSet(config);
         return config;
     }
 
     /**
-     * Further customizes the properties provided by the {@link #tenantServiceClientConfig()}
-     * method.
+     * Gets the default client properties, on top of which the configured properties will be loaded, to be then provided
+     * via {@link #tenantServiceClientConfig()}.
      * <p>
-     * This method does nothing by default. Subclasses may override this method to set additional
-     * properties programmatically.
+     * This method returns an empty set of properties by default. Subclasses may override this method to set specific
+     * properties.
      *
-     * @param config The configuration to customize.
+     * @return The properties.
      */
-    protected void customizeTenantClientFactoryConfig(final RequestResponseClientConfigProperties config) {
-        // empty by default
+    protected RequestResponseClientConfigProperties getTenantClientFactoryConfigDefaults() {
+        return new RequestResponseClientConfigProperties();
     }
 
     /**
@@ -390,10 +404,24 @@ public abstract class AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.device-connection")
     @ConditionalOnProperty(prefix = "hono.device-connection", name = "host")
     public RequestResponseClientConfigProperties deviceConnectionServiceClientConfig() {
-        final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
-        config.setServerRole("Device Connection");
-        customizeDeviceConnectionClientFactoryConfig(config);
+        final RequestResponseClientConfigProperties config = Optional.ofNullable(getDeviceConnectionClientFactoryConfigDefaults())
+                .orElseGet(RequestResponseClientConfigProperties::new);
+        setConfigServerRoleIfUnknown(config, "Device Connection");
+        setDefaultConfigNameIfNotSet(config);
         return config;
+    }
+
+    /**
+     * Gets the default client properties, on top of which the configured properties will be loaded, to be then provided
+     * via {@link #deviceConnectionServiceClientConfig()}.
+     * <p>
+     * This method returns an empty set of properties by default. Subclasses may override this method to set specific
+     * properties.
+     *
+     * @return The properties.
+     */
+    protected RequestResponseClientConfigProperties getDeviceConnectionClientFactoryConfigDefaults() {
+        return new RequestResponseClientConfigProperties();
     }
 
     /**
@@ -423,19 +451,6 @@ public abstract class AbstractAdapterConfig {
     }
 
     /**
-     * Further customizes the properties provided by the {@link #deviceConnectionServiceClientConfig()}
-     * method.
-     * <p>
-     * This method does nothing by default. Subclasses may override this method to set additional
-     * properties programmatically.
-     *
-     * @param config The configuration to customize.
-     */
-    protected void customizeDeviceConnectionClientFactoryConfig(final RequestResponseClientConfigProperties config) {
-        // empty by default
-    }
-
-    /**
      * Exposes configuration properties for Command and Control.
      *
      * @return The Properties.
@@ -444,23 +459,24 @@ public abstract class AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.command")
     @Bean
     public ClientConfigProperties commandConsumerFactoryConfig() {
-        final ClientConfigProperties config = new ClientConfigProperties();
-        config.setServerRole("Command & Control");
-        customizeCommandConsumerFactoryConfig(config);
+        final ClientConfigProperties config = Optional.ofNullable(getCommandConsumerFactoryConfigDefaults())
+                .orElseGet(ClientConfigProperties::new);
+        setConfigServerRoleIfUnknown(config, "Command & Control");
+        setDefaultConfigNameIfNotSet(config);
         return config;
     }
 
     /**
-     * Further customizes the client properties provided by the {@link #commandConsumerFactoryConfig()}
-     * method.
+     * Gets the default client properties, on top of which the configured properties will be loaded, to be then provided
+     * via {@link #commandConsumerFactoryConfig()}.
      * <p>
-     * This method does nothing by default. Subclasses may override this method to set additional
-     * properties programmatically.
+     * This method returns an empty set of properties by default. Subclasses may override this method to set specific
+     * properties.
      *
-     * @param config The client configuration to customize.
+     * @return The properties.
      */
-    protected void customizeCommandConsumerFactoryConfig(final ClientConfigProperties config) {
-        // empty by default
+    protected ClientConfigProperties getCommandConsumerFactoryConfigDefaults() {
+        return new ClientConfigProperties();
     }
 
     /**
@@ -507,6 +523,19 @@ public abstract class AbstractAdapterConfig {
     @Bean
     public VertxProperties vertxProperties() {
         return new VertxProperties();
+    }
+
+    private static void setConfigServerRoleIfUnknown(final AuthenticatingClientConfigProperties config,
+            final String serverRole) {
+        if (config.getServerRole().equals(AuthenticatingClientConfigProperties.SERVER_ROLE_UNKNOWN)) {
+            config.setServerRole(serverRole);
+        }
+    }
+
+    private void setDefaultConfigNameIfNotSet(final ClientConfigProperties config) {
+        if (config.getName() == null && getAdapterName() != null) {
+            config.setName(getAdapterName());
+        }
     }
 
     /**

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -82,6 +82,12 @@ title = "Release Notes"
   because the Device Registration API does not define a corresponding operation.
   Consequently, the C&C functionality of the Kerlink Lora provider which relied on the *get*
   method has been removed.
+* Protocol adapters implementing the `org.eclipse.hono.service.AbstractAdapterConfig` class
+  now need to implement the `getAdapterName` method. The `customizeDownstreamSenderFactoryConfig`
+  method has been renamed to `getDownstreamSenderFactoryConfigDefaults`, while now returning
+  properties instead of working on given ones. The new method name now more accurately conveys
+  what the method is used for. The same change has been applied to the other `customize[*]Config`
+  methods in the `AbstractAdapterConfig` class.
  
 ### Deprecations
  


### PR DESCRIPTION
This fixes #1607.
Also introduce a new `getAdapterName` method, with which the default `config.name` on client configurations is set. This makes all of the currently used overridden `customize*Config` methods obsolete.