### PR TITLE
CoAP adapter: Skip 'PSK-getDeviceIdentityInfo' span if no lookup is done

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/PreSharedKeyDeviceIdentity.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/PreSharedKeyDeviceIdentity.java
@@ -57,17 +57,20 @@ public class PreSharedKeyDeviceIdentity implements DeviceCredentials {
     /**
      * Creates a new instance.
      *
-     * @param span The current open tracing span.
      * @param identity The identity provided by the device using the pre shared key handshake.
      * @param separateRegex The regular expression to split identity for multi tenant.
+     * @param span The current open tracing span or {@code null}.
      * @return The instance of the created object. Will be null if the identity is null, or the identity does not comply
      *         to the structure defined by the separateRegex.
      */
-    public static final PreSharedKeyDeviceIdentity create(final Span span, final String identity, final String separateRegex) {
+    public static final PreSharedKeyDeviceIdentity create(final String identity, final String separateRegex,
+            final Span span) {
 
         if (identity == null) {
             LOG.trace("username must not be null");
-            span.log("PSK identity must not be null");
+            if (span != null) {
+                span.log("PSK identity must not be null");
+            }
             return null;
         }
 
@@ -78,8 +81,10 @@ public class PreSharedKeyDeviceIdentity implements DeviceCredentials {
             final String[] userComponents = identity.split(separateRegex, 2);
             if (userComponents.length != 2) {
                 LOG.trace("username [{}] does not comply with expected pattern [<authId>@<tenantId>]", identity);
-                span.log("PSK identity [" + identity + "] does not comply with expected pattern [<authId>"
-                        + separateRegex + "<tenantId>]");
+                if (span != null) {
+                    span.log("PSK identity [" + identity + "] does not comply with expected pattern [<authId>"
+                            + separateRegex + "<tenantId>]");
+                }
                 return null;
             }
             return new PreSharedKeyDeviceIdentity(userComponents[1], userComponents[0]);


### PR DESCRIPTION
The top level `PSK-getDeviceIdentityInfo` trace span (created as part of the TLS handshake handling) will be a 0ms operation with no child spans if the device id is taken from a previous lookup. Therefore the creation of such a span should better be skipped in that case, so that the span is only created if an actual device id lookup is done (in case of a session resumption).

With this PR, instead of the two `PSK-getSecretKey` and `PSK-getDeviceIdentityInfo` spans, there will only be one `PSK-getDeviceSecretKeyAndIdentityInfo` span.