### PR TITLE
[#2095] Restore links to device registry user guide and admin guide.

### DIFF
--- a/site/documentation/content/admin-guide/device-registry-config.md
+++ b/site/documentation/content/admin-guide/device-registry-config.md
@@ -1,0 +1,10 @@
++++
+title = "Device Registry Configurations"
+hidden = true # does not show up in the menu, but shows up in the version selector and can be accessed from links
+weight = 0
++++
+
+The configuration of Eclipse Hono&trade;s Device Registry implementations for the 
+[File Based Device Registry]({{< relref "/admin-guide/file-based-device-registry-config" >}})
+and for the
+[MongoDB Based Device Registry]({{< relref "/admin-guide/mongodb-device-registry-config" >}}).

--- a/site/documentation/content/user-guide/device-registry.md
+++ b/site/documentation/content/user-guide/device-registry.md
@@ -1,0 +1,11 @@
++++
+title = "Device Registries"
+hidden = true # does not show up in the menu, but shows up in the version selector and can be accessed from links
+weight = 0
++++
+
+Eclipse Hono&trade; provides these device registry implementations:
+
+[File Based Device Registry]({{< relref "/user-guide/file-based-device-registry" >}})
+
+[MongoDB Based Device Registry]({{< relref "/user-guide/mongodb-based-device-registry" >}}).


### PR DESCRIPTION
Fixes #2095. 

Needs to be cherrypicked into the docfix branch for version 1.3.