### PR TITLE
Add authenticated device to execution context

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/impl/VertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/impl/VertxBasedCoapAdapter.java
@@ -107,8 +107,12 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
                 .map(authenticatedDevice -> new RequestDeviceAndAuth(authenticatedDevice, authenticatedDevice));
     }
 
-    private CoapContext newContext(final CoapExchange exchange) {
-        return CoapContext.fromRequest(exchange, getMetrics().startTimer());
+    private CoapContext newContext(final CoapExchange exchange, final RequestDeviceAndAuth deviceAndAuth) {
+        return CoapContext.fromRequest(
+                exchange,
+                deviceAndAuth.getOriginDevice(),
+                deviceAndAuth.getAuthenticatedDevice(),
+                getMetrics().startTimer());
     }
 
     @Override
@@ -131,9 +135,9 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
 
             private Future<ResponseCode> upload(final CoapExchange exchange, final RequestDeviceAndAuth deviceAndAuth,
                     final Span currentSpan) {
-                final CoapContext ctx = newContext(exchange);
+                final CoapContext ctx = newContext(exchange, deviceAndAuth);
                 ctx.setTracingContext(currentSpan.context());
-                return uploadTelemetryMessage(ctx, deviceAndAuth.getOriginDevice(), deviceAndAuth.getAuthenticatedDevice());
+                return uploadTelemetryMessage(ctx);
             }
         });
 
@@ -153,9 +157,9 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
 
             private Future<ResponseCode> upload(final CoapExchange exchange, final RequestDeviceAndAuth deviceAndAuth,
                     final Span currentSpan) {
-                final CoapContext ctx = newContext(exchange);
+                final CoapContext ctx = newContext(exchange, deviceAndAuth);
                 ctx.setTracingContext(currentSpan.context());
-                return uploadEventMessage(ctx, deviceAndAuth.getOriginDevice(), deviceAndAuth.getAuthenticatedDevice());
+                return uploadEventMessage(ctx);
             }
         });
         result.add(new TracingSupportingHonoResource(tracer, CommandConstants.COMMAND_RESPONSE_ENDPOINT, getTypeName()) {
@@ -174,7 +178,7 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
 
             private Future<ResponseCode> upload(final CoapExchange exchange, final RequestDeviceAndAuth deviceAndAuth,
                     final Span currentSpan) {
-                final CoapContext ctx = newContext(exchange);
+                final CoapContext ctx = newContext(exchange, deviceAndAuth);
                 ctx.setTracingContext(currentSpan.context());
                 return uploadCommandResponseMessage(ctx, deviceAndAuth.getOriginDevice(), deviceAndAuth.getAuthenticatedDevice());
             }

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -351,9 +351,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.NON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("my-tenant", "the-device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
-        adapter.uploadTelemetryMessage(context, authenticatedDevice, authenticatedDevice);
+        adapter.uploadTelemetryMessage(context);
 
         // THEN the device gets a response with code 4.03
         verify(coapExchange).respond(argThat((Response res) -> ResponseCode.FORBIDDEN.equals(res.getCode())));
@@ -387,9 +387,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.NON, (Integer) null);
         final Device authenticatedDevice = new Device("my-tenant", "the-device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
-        adapter.uploadTelemetryMessage(context, authenticatedDevice, authenticatedDevice);
+        adapter.uploadTelemetryMessage(context);
 
         // THEN the device gets a response with code 4.00
         verify(coapExchange).respond(argThat((Response res) -> ResponseCode.BAD_REQUEST.equals(res.getCode())));
@@ -423,9 +423,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         // a URI-query option
         final CoapExchange coapExchange = newCoapExchange(null, Type.NON, MediaTypeRegistry.UNDEFINED);
         final Device authenticatedDevice = new Device("my-tenant", "the-device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
-        adapter.uploadTelemetryMessage(context, authenticatedDevice, authenticatedDevice);
+        adapter.uploadTelemetryMessage(context);
 
         // THEN the device gets a response with code 4.00
         verify(coapExchange).respond(argThat((Response res) -> ResponseCode.BAD_REQUEST.equals(res.getCode())));
@@ -459,9 +459,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         options.addUriQuery(CoapContext.PARAM_EMPTY_CONTENT);
         final CoapExchange coapExchange = newCoapExchange(null, Type.NON, options);
         final Device authenticatedDevice = new Device("my-tenant", "the-device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
-        adapter.uploadTelemetryMessage(context, authenticatedDevice, authenticatedDevice);
+        adapter.uploadTelemetryMessage(context);
 
         // THEN the device gets a response indicating success
         verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED.equals(res.getCode())));
@@ -496,9 +496,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.NON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
-        adapter.uploadTelemetryMessage(context, authenticatedDevice, authenticatedDevice);
+        adapter.uploadTelemetryMessage(context);
 
         // THEN the device gets a response indicating success
         verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED.equals(res.getCode())));
@@ -533,10 +533,10 @@ public class AbstractVertxBasedCoapAdapterTest {
         // WHEN a device publishes an telemetry message with QoS 1
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, MediaTypeRegistry.TEXT_PLAIN);
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
         final Device authenticatedDevice = new Device("tenant", "device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
-        adapter.uploadTelemetryMessage(context, authenticatedDevice, authenticatedDevice);
+        adapter.uploadTelemetryMessage(context);
 
         // THEN the message is being forwarded downstream
         verify(sender).sendAndWaitForOutcome(any(Message.class), any(SpanContext.class));
@@ -575,9 +575,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
-        adapter.uploadEventMessage(context, authenticatedDevice, authenticatedDevice);
+        adapter.uploadEventMessage(context);
 
         // THEN the message is being forwarded downstream
         verify(sender).sendAndWaitForOutcome(any(Message.class), any(SpanContext.class));
@@ -617,9 +617,9 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext ctx = CoapContext.fromRequest(coapExchange);
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
-        adapter.uploadEventMessage(ctx, authenticatedDevice, authenticatedDevice);
+        adapter.uploadEventMessage(ctx);
         verify(sender).sendAndWaitForOutcome(any(Message.class), any(SpanContext.class));
         outcome.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "malformed message"));
 
@@ -659,7 +659,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         options.setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, options);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
         adapter.uploadCommandResponseMessage(context, authenticatedDevice, authenticatedDevice);
 
@@ -712,7 +712,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         options.setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, options);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
         adapter.uploadCommandResponseMessage(context, authenticatedDevice, authenticatedDevice);
         outcome.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "malformed message"));
@@ -757,7 +757,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         options.setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, options);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange);
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
 
         adapter.uploadCommandResponseMessage(context, authenticatedDevice, authenticatedDevice);
 
@@ -796,8 +796,8 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.NON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext ctx = CoapContext.fromRequest(coapExchange);
-        adapter.uploadTelemetryMessage(ctx, authenticatedDevice, authenticatedDevice);
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
+        adapter.uploadTelemetryMessage(ctx);
 
         // THEN the message is not being forwarded downstream
         verify(sender, never()).send(any(Message.class), any(SpanContext.class));
@@ -836,8 +836,8 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext ctx = CoapContext.fromRequest(coapExchange);
-        adapter.uploadEventMessage(ctx, authenticatedDevice, authenticatedDevice);
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice);
+        adapter.uploadEventMessage(ctx);
 
         // THEN the message is not being forwarded downstream
         verify(sender, never()).sendAndWaitForOutcome(any(Message.class), any(SpanContext.class));

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -191,8 +191,8 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
         TAG_LORA_PROVIDER.set(currentSpan, provider.getProviderName());
         ctx.put(LoraConstants.APP_PROPERTY_ORIG_LORA_PROVIDER, provider.getProviderName());
 
-        if (ctx.getRoutingContext().user() instanceof Device) {
-            final Device gatewayDevice = (Device) ctx.getRoutingContext().user();
+        if (ctx.isDeviceAuthenticated()) {
+            final Device gatewayDevice = ctx.getAuthenticatedDevice();
             TracingHelper.setDeviceTags(currentSpan, gatewayDevice.getTenantId(), gatewayDevice.getDeviceId());
 
             try {

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.service.metric.MetricsTags;
-import org.eclipse.hono.util.MapBasedExecutionContext;
+import org.eclipse.hono.util.MapBasedTelemetryExecutionContext;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.ResourceIdentifier;
 
@@ -32,7 +32,7 @@ import io.vertx.mqtt.messages.MqttPublishMessage;
  * processing of an MQTT message published by a device.
  *
  */
-public final class MqttContext extends MapBasedExecutionContext {
+public final class MqttContext extends MapBasedTelemetryExecutionContext {
 
     private MqttPublishMessage message;
     private MqttEndpoint deviceEndpoint;
@@ -43,7 +43,8 @@ public final class MqttContext extends MapBasedExecutionContext {
     private MetricsTags.EndpointType endpoint;
     private PropertyBag propertyBag;
 
-    private MqttContext() {
+    private MqttContext(final Device authenticatedDevice) {
+        super(authenticatedDevice);
     }
 
     @Override
@@ -93,7 +94,7 @@ public final class MqttContext extends MapBasedExecutionContext {
         Objects.requireNonNull(publishedMessage);
         Objects.requireNonNull(deviceEndpoint);
 
-        final MqttContext result = new MqttContext();
+        final MqttContext result = new MqttContext(authenticatedDevice);
         result.message = publishedMessage;
         result.deviceEndpoint = deviceEndpoint;
         result.authenticatedDevice = authenticatedDevice;
@@ -120,7 +121,7 @@ public final class MqttContext extends MapBasedExecutionContext {
      * @throws NullPointerException if endpoint is {@code null}.
      */
     public static MqttContext fromConnectPacket(final MqttEndpoint endpoint) {
-        final MqttContext result = new MqttContext();
+        final MqttContext result = new MqttContext(null);
         result.deviceEndpoint = endpoint;
         return result;
     }

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -173,12 +173,12 @@ public final class SigfoxProtocolAdapter
 
     private void dataHandler(final HttpContext ctx, final UploadHandler uploadHandler) {
 
-        if (!(ctx.getRoutingContext().user() instanceof Device)) {
+        if (!ctx.isDeviceAuthenticated()) {
             LOG.warn("Not a device");
             return;
         }
 
-        final Device gatewayDevice = (Device) ctx.getRoutingContext().user();
+        final Device gatewayDevice = ctx.getAuthenticatedDevice();
 
         final String deviceTenant = gatewayDevice.getTenantId();
         final String requestTenant = ctx.getRoutingContext().pathParam(SIGFOX_PARAM_TENANT);

--- a/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,8 +16,9 @@ package org.eclipse.hono.util;
 import io.opentracing.SpanContext;
 
 /**
- * A context that can be used to pass around arbitrary key/value pairs.
- *
+ * A container for information relevant for processing a message sent by a device.
+ * <p>
+ * Provides means to store arbitrary key/value pairs.
  */
 public interface ExecutionContext {
 

--- a/core/src/main/java/org/eclipse/hono/util/MapBasedTelemetryExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/MapBasedTelemetryExecutionContext.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.util;
+
+import org.eclipse.hono.auth.Device;
+
+/**
+ * An execution context that stores properties in a {@code Map}.
+ *
+ */
+public abstract class MapBasedTelemetryExecutionContext extends MapBasedExecutionContext implements TelemetryExecutionContext {
+
+    private final Device authenticatedDevice;
+
+    /**
+     * Creates a new context for a message received from a device.
+     *
+     * @param authenticatedDevice The authenticated device that has uploaded the message or {@code null}
+     *                            if the device has not been authenticated.
+     */
+    public MapBasedTelemetryExecutionContext(final Device authenticatedDevice) {
+        this.authenticatedDevice = authenticatedDevice;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final Device getAuthenticatedDevice() {
+        return authenticatedDevice;
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/TelemetryExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/TelemetryExecutionContext.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.util;
+
+import org.eclipse.hono.auth.Device;
+
+/**
+ * A container for information relevant for processing a message sent by a device
+ * which contains telemetry data or an event.
+ */
+public interface TelemetryExecutionContext extends ExecutionContext {
+
+    /**
+     * Gets the verified identity of the device that the message has been
+     * received from which is processed in this context.
+     *
+     * @return The device or {@code null} if the device has not been authenticated.
+     */
+    Device getAuthenticatedDevice();
+
+    /**
+     * Determines if the message that is processed in this context has been received from
+     * a device whose identity has been verified.
+     *
+     * @return {@code true} if the device has been authenticated or {@code false} otherwise.
+     */
+    default boolean isDeviceAuthenticated() {
+        return getAuthenticatedDevice() != null;
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.ExecutionContext;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.Strings;
+import org.eclipse.hono.util.TelemetryExecutionContext;
 
 import io.opentracing.SpanContext;
 import io.vertx.core.http.HttpServerRequest;
@@ -34,7 +35,7 @@ import io.vertx.ext.web.RoutingContext;
  * Represents the context for the handling of a Vert.x HTTP request, wrapping the Vert.x {@link RoutingContext} as well
  * as implementing the {@link ExecutionContext} interface.
  */
-public final class HttpContext implements ExecutionContext {
+public final class HttpContext implements TelemetryExecutionContext {
 
     private final RoutingContext routingContext;
     private SpanContext spanContext;
@@ -180,10 +181,9 @@ public final class HttpContext implements ExecutionContext {
     }
 
     /**
-     * Gets the authenticated device identity from the routing context.
-     *
-     * @return The device or {@code null} if the device has not been authenticated.
+     * {@inheritDoc}
      */
+    @Override
     public Device getAuthenticatedDevice() {
 
         return Optional.ofNullable(routingContext.user()).map(user -> {


### PR DESCRIPTION
All protocol adapters now consistently retrieve the authenticated device
from the ExecutionContext used for processing a message from a device.
