### PR TITLE
[#2112] Part 1: Extend device registry base classes for search devices operation

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -104,6 +104,46 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_MEMBER_OF = "memberOf";
 
+    /**
+     * The name of the field that contains the JSON pointer corresponding to the field used for filtering devices.
+     */
+    public static final String FIELD_FILTER_FIELD = "field";
+
+    /**
+     * The name of the field that contains the filter JSON object for search devices operation.
+     */
+    public static final String FIELD_FILTER_JSON = "filterJson";
+
+    /**
+     * The name of the field that contains the operator used for filtering devices.
+     */
+    public static final String FIELD_FILTER_OPERATOR = "op";
+
+    /**
+     * The name of the field that contains the value used for filtering devices.
+     */
+    public static final String FIELD_FILTER_VALUE = "value";
+
+    /**
+     * The name of the field that contains the page offset for search devices operation.
+     */
+    public static final String FIELD_PAGE_OFFSET = "pageOffset";
+
+    /**
+     * The name of the field that contains the page size for search devices operation.
+     */
+    public static final String FIELD_PAGE_SIZE = "pageSize";
+
+    /**
+     * The name of the field that contains sort direction used by search devices operation to sort the result set.
+     */
+    public static final String FIELD_SORT_DIRECTION = "direction";
+
+    /**
+     * The name of the field that contains the sort JSON object used by search devices operation to sort the result set.
+     */
+    public static final String FIELD_SORT_JSON = "sortJson";
+
     // CREDENTIALS
 
     /**

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -110,9 +110,9 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
     public static final String FIELD_FILTER_FIELD = "field";
 
     /**
-     * The name of the field that contains the filter JSON object for search devices operation.
+     * The name of the query parameter that contains the filter JSON object for search devices operation.
      */
-    public static final String FIELD_FILTER_JSON = "filterJson";
+    public static final String PARAM_FILTER_JSON = "filterJson";
 
     /**
      * The name of the field that contains the operator used for filtering devices.
@@ -125,14 +125,14 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
     public static final String FIELD_FILTER_VALUE = "value";
 
     /**
-     * The name of the field that contains the page offset for search devices operation.
+     * The name of the query parameter that contains the page offset for search devices operation.
      */
-    public static final String FIELD_PAGE_OFFSET = "pageOffset";
+    public static final String PARAM_PAGE_OFFSET = "pageOffset";
 
     /**
-     * The name of the field that contains the page size for search devices operation.
+     * The name of the query parameter that contains the page size for search devices operation.
      */
-    public static final String FIELD_PAGE_SIZE = "pageSize";
+    public static final String PARAM_PAGE_SIZE = "pageSize";
 
     /**
      * The name of the field that contains sort direction used by search devices operation to sort the result set.
@@ -140,9 +140,10 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
     public static final String FIELD_SORT_DIRECTION = "direction";
 
     /**
-     * The name of the field that contains the sort JSON object used by search devices operation to sort the result set.
+     * The name of the query parameter that contains the sort JSON object used by search devices operation to sort the
+     * result set.
      */
-    public static final String FIELD_SORT_JSON = "sortJson";
+    public static final String PARAM_SORT_JSON = "sortJson";
 
     // CREDENTIALS
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpoint.java
@@ -15,8 +15,10 @@ package org.eclipse.hono.service.management.device;
 
 import java.net.HttpURLConnection;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.config.ServiceConfigProperties;
@@ -34,6 +36,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -52,6 +55,7 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
 
     private static final String SPAN_NAME_CREATE_DEVICE = "create Device from management API";
     private static final String SPAN_NAME_GET_DEVICE = "get Device from management API";
+    private static final String SPAN_NAME_SEARCH_DEVICES = "search Devices from management API";
     private static final String SPAN_NAME_UPDATE_DEVICE = "update Device from management API";
     private static final String SPAN_NAME_REMOVE_DEVICE = "remove Device from management API";
 
@@ -101,6 +105,10 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
         router.get(pathWithTenantAndDeviceId)
                 .handler(this::doGetDevice);
 
+        // SEARCH devices
+        router.get(pathWithTenant)
+                .handler(this::doSearchDevices);
+
         // UPDATE existing device
         router.put(pathWithTenantAndDeviceId)
                 .handler(this::extractRequiredJsonPayload)
@@ -133,6 +141,39 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
             .onSuccess(operationResult -> writeResponse(ctx, operationResult, span))
             .onFailure(t -> failRequest(ctx, t, span))
             .onComplete(s -> span.finish());
+    }
+
+    private void doSearchDevices(final RoutingContext ctx) {
+        final Span span = TracingHelper.buildServerChildSpan(
+                tracer,
+                TracingHandler.serverSpanContext(ctx),
+                SPAN_NAME_SEARCH_DEVICES,
+                getClass().getSimpleName()).start();
+
+        final Future<String> tenantId = getRequestParameter(ctx, PARAM_TENANT_ID,
+                getPredicate(config.getTenantIdPattern(), false));
+        final Optional<Integer> pageSize = Optional
+                .ofNullable(ctx.request().getParam(RegistryManagementConstants.FIELD_PAGE_SIZE))
+                .map(Integer::parseInt);
+        final Optional<Integer> pageOffset = Optional
+                .ofNullable(ctx.request().getParam(RegistryManagementConstants.FIELD_PAGE_OFFSET))
+                .map(Integer::parseInt);
+        final Future<Optional<List<Filter>>> filters = decodeJsonFromRequestParameter(ctx,
+                RegistryManagementConstants.FIELD_FILTER_JSON, Filter.class);
+        final Future<Optional<List<Sort>>> sortOptions = decodeJsonFromRequestParameter(ctx,
+                RegistryManagementConstants.FIELD_SORT_JSON, Sort.class);
+
+        CompositeFuture.all(tenantId, filters, sortOptions)
+                .compose(ok -> getService().searchDevices(
+                        tenantId.result(),
+                        pageSize,
+                        pageOffset,
+                        filters.result(),
+                        sortOptions.result(),
+                        span))
+                .onSuccess(operationResult -> writeResponse(ctx, operationResult, span))
+                .onFailure(t -> failRequest(ctx, t, span))
+                .onComplete(s -> span.finish());
     }
 
     private void doCreateDevice(final RoutingContext ctx) {
@@ -242,6 +283,25 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
                     },
                     // payload was empty
                     () -> result.complete(new Device()));
+        return result.future();
+    }
+
+    private <T> Future<Optional<List<T>>> decodeJsonFromRequestParameter(final RoutingContext ctx,
+            final String paramKey, final Class<T> clazz) {
+
+        Objects.requireNonNull(ctx);
+        Objects.requireNonNull(paramKey);
+        Objects.requireNonNull(clazz);
+
+        final Promise<Optional<List<T>>> result = Promise.promise();
+        final Optional<List<T>> values = Optional.ofNullable(ctx.request().params()
+                .getAll(paramKey))
+                .map(jsons -> jsons
+                        .stream()
+                        .map(json -> Json.decodeValue(json, clazz))
+                        .collect(Collectors.toList()));
+        result.complete(values);
+
         return result.future();
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
@@ -96,15 +96,13 @@ public interface DeviceManagementService {
      */
     default Future<OperationResult<List<DeviceWithId>>> searchDevices(
             final String tenantId,
-            final Optional<Integer> pageSize,
-            final Optional<Integer> pageOffset,
+            final int pageSize,
+            final int pageOffset,
             final Optional<List<Filter>> filters,
             final Optional<List<Sort>> sortOptions,
             final Span span) {
 
         Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(pageSize);
-        Objects.requireNonNull(pageOffset);
         Objects.requireNonNull(filters);
         Objects.requireNonNull(sortOptions);
         Objects.requireNonNull(span);

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
@@ -24,7 +24,6 @@ import org.eclipse.hono.service.management.Result;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 
 /**
  * A service for managing device registration information.
@@ -72,7 +71,7 @@ public interface DeviceManagementService {
     Future<OperationResult<Device>> readDevice(String tenantId, String deviceId, Span span);
 
     /**
-     * Search devices belonging to the given tenant with optional filters, paging and sorting options.
+     * Finds devices belonging to the given tenant with optional filters, paging and sorting options.
      * <p>
      * This search operation is considered as optional since it is not required for the normal functioning of Hono and
      * is more of a convenient operation. Hence here it is declared as a default method which returns
@@ -110,10 +109,7 @@ public interface DeviceManagementService {
         Objects.requireNonNull(sortOptions);
         Objects.requireNonNull(span);
 
-        final Promise<OperationResult<List<DeviceWithId>>> defaultSearchDevicesResult = Promise.promise();
-        defaultSearchDevicesResult.complete(OperationResult.empty(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
-
-        return defaultSearchDevicesResult.future();
+        return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
     }
 
     /**

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.hono.service.management.device;
 
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.hono.service.management.Id;
@@ -21,6 +24,7 @@ import org.eclipse.hono.service.management.Result;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * A service for managing device registration information.
@@ -66,6 +70,51 @@ public interface DeviceManagementService {
      *      Device Registry Management API - Get Device Registration</a>
      */
     Future<OperationResult<Device>> readDevice(String tenantId, String deviceId, Span span);
+
+    /**
+     * Search devices belonging to the given tenant with optional filters, paging and sorting options.
+     * <p>
+     * This search operation is considered as optional since it is not required for the normal functioning of Hono and
+     * is more of a convenient operation. Hence here it is declared as a default method which returns
+     * {@link HttpURLConnection#HTTP_NOT_IMPLEMENTED}. It is upto the implementors of this interface to offer an
+     * implementation of this service or not.
+     *
+     * @param tenantId The tenant that the devices belong to.
+     * @param pageSize The maximum number of results to include in a response.
+     * @param pageOffset The offset into the result set from which to include objects in the response. This allows to
+     *                   retrieve the whole result set page by page.
+     * @param filters A list of filters. The filters are predicates that objects in the result set must match.
+     * @param sortOptions A list of sort options. The sortOptions specify properties to sort the result set by.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
+     *            implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation. The <em>status code</em> is set as specified in the
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/searchDevicesForTenant"> Device
+     *         Registry Management API - Search Devices</a>
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/searchDevicesForTenant"> Device Registry
+     *      Management API - Search Devices</a>
+     */
+    default Future<OperationResult<List<DeviceWithId>>> searchDevices(
+            final String tenantId,
+            final Optional<Integer> pageSize,
+            final Optional<Integer> pageOffset,
+            final Optional<List<Filter>> filters,
+            final Optional<List<Sort>> sortOptions,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(pageSize);
+        Objects.requireNonNull(pageOffset);
+        Objects.requireNonNull(filters);
+        Objects.requireNonNull(sortOptions);
+        Objects.requireNonNull(span);
+
+        final Promise<OperationResult<List<DeviceWithId>>> defaultSearchDevicesResult = Promise.promise();
+        defaultSearchDevicesResult.complete(OperationResult.empty(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
+
+        return defaultSearchDevicesResult.future();
+    }
 
     /**
      * Updates device registration data.

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceWithId.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceWithId.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.management.device;
+
+import java.util.Objects;
+
+import org.eclipse.hono.util.RegistryManagementConstants;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Device information which also includes device identifier.
+ */
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+public final class DeviceWithId extends Device {
+
+    @JsonProperty(RegistryManagementConstants.FIELD_ID)
+    private String id;
+
+    private DeviceWithId(final String id, final Device device) {
+        super(device);
+        this.id = id;
+    }
+
+    /**
+     * Creates an instance of {@link DeviceWithId} from the given device identifier and
+     * {@link Device} instance.
+     *
+     * @param id The device identifier.
+     * @param device The device information.
+     *
+     * @return an instance of {@link DeviceWithId}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static DeviceWithId from(final String id, final Device device) {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(device);
+
+        return new DeviceWithId(id, device);
+    }
+
+    /**
+     * Returns the device identifier.
+     *
+     * @return the device identifier.
+     */
+    public String getId() {
+        return id;
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Filter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Filter.java
@@ -30,20 +30,35 @@ import io.vertx.core.json.pointer.JsonPointer;
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class Filter<T> {
 
-    @JsonProperty(RegistryManagementConstants.FIELD_FILTER_FIELD)
-    private JsonPointer field;
+    private final JsonPointer field;
 
-    @JsonProperty(RegistryManagementConstants.FIELD_FILTER_VALUE)
-    private T value;
+    private final T value;
 
     @JsonProperty(RegistryManagementConstants.FIELD_FILTER_OPERATOR)
-    private OPERATOR operator = OPERATOR.eq;
+    private Operator operator = Operator.eq;
 
     /**
      * An enum defining supported filter operators.
      */
-    public enum OPERATOR {
+    public enum Operator {
         eq
+    }
+
+    /**
+     * Creates an instance of {@link Filter}.
+     *
+     * @param field The field to use for filtering.
+     * @param value The value corresponding to the field to use for filtering.
+     * @throws IllegalArgumentException if the field is not a valid pointer.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public Filter(@JsonProperty(RegistryManagementConstants.FIELD_FILTER_FIELD) final String field,
+            @JsonProperty(RegistryManagementConstants.FIELD_FILTER_VALUE) final T value) {
+        Objects.requireNonNull(field);
+        Objects.requireNonNull(value);
+
+        this.field = JsonPointer.from(field);
+        this.value = value;
     }
 
     /**
@@ -56,18 +71,6 @@ public final class Filter<T> {
     }
 
     /**
-     * Sets the field to use for filtering.
-     *
-     * @param field The field to use for filtering.
-     * @throws IllegalArgumentException if the field is not a valid pointer.
-     * @throws NullPointerException if the field is {@code null}.
-     */
-    public void setField(final String field) {
-        Objects.requireNonNull(field);
-        this.field = JsonPointer.from(field);
-    }
-
-    /**
      * Gets the value corresponding to the field to use for filtering.
      *
      * @return The value corresponding to the field to use for filtering.
@@ -77,32 +80,22 @@ public final class Filter<T> {
     }
 
     /**
-     * Sets the value corresponding to the field to use for filtering.
-     *
-     * @param value The value corresponding to the field to use for filtering.
-     * @throws NullPointerException if the value is {@code null}.
-     */
-    public void setValue(final T value) {
-        this.value = Objects.requireNonNull(value);
-    }
-
-    /**
      * Gets the operator to use for filtering.
      *
      * @return The operator to use for filtering.
      */
-    public OPERATOR getOperator() {
+    public Operator getOperator() {
         return operator;
     }
 
     /**
      * Sets the operator to use for filtering.
      * <p>
-     * The default value is {@link OPERATOR#eq}
+     * The default value is {@link Operator#eq}
      *
      * @param operator The operator to use for filtering.
      */
-    public void setOperator(final OPERATOR operator) {
+    public void setOperator(final Operator operator) {
         Optional.ofNullable(operator)
                 .ifPresent(opr -> this.operator = opr);
     }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Filter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Filter.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.management.device;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.util.RegistryManagementConstants;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.vertx.core.json.pointer.JsonPointer;
+
+/**
+ * Filter to apply during search operation in Device Registry Management API.
+ *
+ * @param <T> The filter value type.
+ */
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+public final class Filter<T> {
+
+    @JsonProperty(RegistryManagementConstants.FIELD_FILTER_FIELD)
+    private JsonPointer field;
+
+    @JsonProperty(RegistryManagementConstants.FIELD_FILTER_VALUE)
+    private T value;
+
+    @JsonProperty(RegistryManagementConstants.FIELD_FILTER_OPERATOR)
+    private OPERATOR operator = OPERATOR.eq;
+
+    /**
+     * An enum defining supported filter operators.
+     */
+    public enum OPERATOR {
+        eq
+    }
+
+    /**
+     * Gets the field to use for filtering.
+     *
+     * @return The field to use for filtering.
+     */
+    public JsonPointer getField() {
+        return field;
+    }
+
+    /**
+     * Sets the field to use for filtering.
+     *
+     * @param field The field to use for filtering.
+     * @throws IllegalArgumentException if the field is not a valid pointer.
+     * @throws NullPointerException if the field is {@code null}.
+     */
+    public void setField(final String field) {
+        Objects.requireNonNull(field);
+        this.field = JsonPointer.from(field);
+    }
+
+    /**
+     * Gets the value corresponding to the field to use for filtering.
+     *
+     * @return The value corresponding to the field to use for filtering.
+     */
+    public T getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the value corresponding to the field to use for filtering.
+     *
+     * @param value The value corresponding to the field to use for filtering.
+     * @throws NullPointerException if the value is {@code null}.
+     */
+    public void setValue(final T value) {
+        this.value = Objects.requireNonNull(value);
+    }
+
+    /**
+     * Gets the operator to use for filtering.
+     *
+     * @return The operator to use for filtering.
+     */
+    public OPERATOR getOperator() {
+        return operator;
+    }
+
+    /**
+     * Sets the operator to use for filtering.
+     * <p>
+     * The default value is {@link OPERATOR#eq}
+     *
+     * @param operator The operator to use for filtering.
+     */
+    public void setOperator(final OPERATOR operator) {
+        Optional.ofNullable(operator)
+                .ifPresent(opr -> this.operator = opr);
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Sort.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Sort.java
@@ -26,18 +26,29 @@ import io.vertx.core.json.pointer.JsonPointer;
  */
 public final class Sort {
 
-    @JsonProperty(RegistryManagementConstants.FIELD_FILTER_FIELD)
-    private JsonPointer field;
+    private final JsonPointer field;
 
     @JsonProperty(RegistryManagementConstants.FIELD_SORT_DIRECTION)
-    private DIRECTION direction = DIRECTION.asc;
+    private Direction direction = Direction.asc;
 
     /**
      * An enum defining the sort directions.
      */
-    public enum DIRECTION {
+    public enum Direction {
         asc,
         desc
+    }
+
+    /**
+     * Creates an instance of {@link Sort}.
+     *
+     * @param field The field to be used for sorting.
+     * @throws IllegalArgumentException if the field is not a valid pointer.
+     * @throws NullPointerException if the field is {@code null}.
+     */
+    public Sort(@JsonProperty(RegistryManagementConstants.FIELD_FILTER_FIELD) final String field) {
+        Objects.requireNonNull(field);
+        this.field = JsonPointer.from(field);
     }
 
     /**
@@ -50,34 +61,22 @@ public final class Sort {
     }
 
     /**
-     * Sets the JSON pointer identifying the field to sort by.
-     *
-     * @param field The field to be used for sorting.
-     * @throws IllegalArgumentException if the field is not a valid pointer.
-     * @throws NullPointerException if the field is {@code null}.
-     */
-    public void setField(final String field) {
-        Objects.requireNonNull(field);
-        this.field = JsonPointer.from(field);
-    }
-
-    /**
      * Gets the sort direction.
      *
      * @return The sort direction.
      */
-    public DIRECTION getDirection() {
+    public Direction getDirection() {
         return direction;
     }
 
     /**
      * Sets the sort direction.
      * <p>
-     * The default value is {@link DIRECTION#asc}
+     * The default value is {@link Direction#asc}
      *
      * @param direction The sort direction.
      */
-    public void setDirection(final DIRECTION direction) {
+    public void setDirection(final Direction direction) {
         this.direction = direction;
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Sort.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/Sort.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.service.management.device;
+
+import java.util.Objects;
+
+import org.eclipse.hono.util.RegistryManagementConstants;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.vertx.core.json.pointer.JsonPointer;
+
+/**
+ * It specifies properties to sort the result set during search operation
+ * in Device Registry Management API.
+ */
+public final class Sort {
+
+    @JsonProperty(RegistryManagementConstants.FIELD_FILTER_FIELD)
+    private JsonPointer field;
+
+    @JsonProperty(RegistryManagementConstants.FIELD_SORT_DIRECTION)
+    private DIRECTION direction = DIRECTION.asc;
+
+    /**
+     * An enum defining the sort directions.
+     */
+    public enum DIRECTION {
+        asc,
+        desc
+    }
+
+    /**
+     * Gets the JSON pointer identifying the field to sort by.
+     *
+     * @return The JSON pointer identifying the field to sort by.
+     */
+    public JsonPointer getField() {
+        return field;
+    }
+
+    /**
+     * Sets the JSON pointer identifying the field to sort by.
+     *
+     * @param field The field to be used for sorting.
+     * @throws IllegalArgumentException if the field is not a valid pointer.
+     * @throws NullPointerException if the field is {@code null}.
+     */
+    public void setField(final String field) {
+        Objects.requireNonNull(field);
+        this.field = JsonPointer.from(field);
+    }
+
+    /**
+     * Gets the sort direction.
+     *
+     * @return The sort direction.
+     */
+    public DIRECTION getDirection() {
+        return direction;
+    }
+
+    /**
+     * Sets the sort direction.
+     * <p>
+     * The default value is {@link DIRECTION#asc}
+     *
+     * @param direction The sort direction.
+     */
+    public void setDirection(final DIRECTION direction) {
+        this.direction = direction;
+    }
+}


### PR DESCRIPTION
This PR focuses on extending the device registry base classes to support the implementation of the search devices operation in the _MongoDB_ based device registry.