### PR TITLE
[#2112] Add search devices operation in MongoDB based device registry

### DIFF
--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
@@ -24,6 +24,9 @@ import org.eclipse.hono.service.management.Result;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.device.AutoProvisioningEnabledDeviceBackend;
 import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.device.DeviceWithId;
+import org.eclipse.hono.service.management.device.Filter;
+import org.eclipse.hono.service.management.device.Sort;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsResult;
@@ -75,6 +78,16 @@ public class MongoDbBasedDeviceBackend implements AutoProvisioningEnabledDeviceB
     @Override
     public Future<OperationResult<Device>> readDevice(final String tenantId, final String deviceId, final Span span) {
         return registrationService.readDevice(tenantId, deviceId, span);
+    }
+
+    @Override
+    public Future<OperationResult<List<DeviceWithId>>> searchDevices(final String tenantId,
+            final int pageSize,
+            final int pageOffset,
+            final List<Filter> filters,
+            final List<Sort> sortOptions,
+            final Span span) {
+        return registrationService.searchDevices(tenantId, pageSize, pageOffset, filters, sortOptions, span);
     }
 
     @Override

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
@@ -374,8 +374,10 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
         final Promise<List<JsonObject>> searchDevicesPromise = Promise.promise();
 
         searchDevicesOptions.setSort(sortDocument);
-        LOG.trace("pageSize: [{}], pageOffset: [{}], searchDevicesQuery: [{}], sortOptions: [{}]", pageSize, pageOffset,
-                searchDevicesQuery.encodePrettily(), sortDocument.encodePrettily());
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("pageSize: [{}], pageOffset: [{}], searchDevicesQuery: [{}], sortOptions: [{}]", pageSize,
+                    pageOffset, searchDevicesQuery.encodePrettily(), sortDocument.encodePrettily());
+        }
         mongoClient.findWithOptions(
                 config.getCollectionName(),
                 searchDevicesQuery,

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
@@ -34,6 +34,9 @@ import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.service.management.device.DeviceWithId;
+import org.eclipse.hono.service.management.device.Filter;
+import org.eclipse.hono.service.management.device.Sort;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.RegistrationResult;
@@ -146,6 +149,24 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
         Objects.requireNonNull(span);
 
         return processReadDevice(tenantId, deviceId)
+                .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
+    }
+
+    @Override
+    public Future<OperationResult<List<DeviceWithId>>> searchDevices(
+            final String tenantId,
+            final int pageSize,
+            final int pageOffset,
+            final List<Filter> filters,
+            final List<Sort> sortOptions,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(filters);
+        Objects.requireNonNull(sortOptions);
+        Objects.requireNonNull(span);
+
+        return processSearchDevices(tenantId, pageSize, pageOffset, filters, sortOptions)
                 .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
     }
 
@@ -330,6 +351,53 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
                             .orElse(new JsonArray());
                     span.log("successfully resolved group members");
                     return deviceIds;
+                });
+    }
+
+    private Future<OperationResult<List<DeviceWithId>>> processSearchDevices(
+            final String tenantId,
+            final int pageSize,
+            final int pageOffset,
+            final List<Filter> filters,
+            final List<Sort> sortOptions) {
+
+        final FindOptions searchDevicesOptions = new FindOptions()
+                .setLimit(pageSize)
+                .setSkip(pageOffset);
+        final JsonObject searchDevicesQuery = MongoDbDocumentBuilder.builder()
+                .withTenantId(tenantId)
+                .withDeviceFilters(filters)
+                .document();
+        final JsonObject sortDocument = MongoDbDocumentBuilder.builder()
+                .withDeviceSortOptions(sortOptions)
+                .document();
+        final Promise<List<JsonObject>> searchDevicesPromise = Promise.promise();
+
+        searchDevicesOptions.setSort(sortDocument);
+        LOG.trace("pageSize: [{}], pageOffset: [{}], searchDevicesQuery: [{}], sortOptions: [{}]", pageSize, pageOffset,
+                searchDevicesQuery.encodePrettily(), sortDocument.encodePrettily());
+        mongoClient.findWithOptions(
+                config.getCollectionName(),
+                searchDevicesQuery,
+                searchDevicesOptions,
+                searchDevicesPromise);
+
+        return searchDevicesPromise.future()
+                .map(result -> {
+                    final List<DeviceWithId> devicesWithId = Optional.ofNullable(result)
+                            .map(devices -> devices.stream()
+                                    .map(json -> json.mapTo(DeviceDto.class))
+                                    .map(deviceDto -> DeviceWithId.from(deviceDto.getDeviceId(), deviceDto.getDevice()))
+                                    .collect(Collectors.toList()))
+                            .map(devices -> devices.isEmpty() ? null : devices)
+                            .orElseThrow(() -> new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+
+                    return OperationResult.ok(
+                            HttpURLConnection.HTTP_OK,
+                            devicesWithId,
+                            Optional.ofNullable(
+                                    DeviceRegistryUtils.getCacheDirective(config.getCacheMaxAge())),
+                            Optional.empty());
                 });
     }
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
@@ -174,7 +174,7 @@ public final class MongoDbDocumentBuilder {
         return this;
     }
 
-    private int mapSortingDirection(final Sort.Direction direction) {
+    private static int mapSortingDirection(final Sort.Direction direction) {
         if (direction == Sort.Direction.asc) {
             return 1;
         } else {


### PR DESCRIPTION
With this PR, the _MongoDB based device registry_ supports search devices operation as specified in the OpenAPI spec by #1958. The tests are in progress.