### PR TITLE
Exit tests after vertxTestContext.failNow(t)

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -298,6 +298,9 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
 
         connectAndSubscribe(ctx, commandTargetDeviceId, endpointConfig,
                 (cmdReceiver, cmdResponseSender) -> createCommandConsumer(ctx, cmdReceiver, cmdResponseSender));
+        if (ctx.failed()) {
+            return;
+        }
 
         final String replyId = "reply-id";
         final int totalNoOfCommandsToSend = 60;
@@ -325,6 +328,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
+            return;
         }
 
         final long start = System.currentTimeMillis();
@@ -425,6 +429,9 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             final int totalNoOfCommandsToSend) throws InterruptedException {
 
         connectAndSubscribe(ctx, commandTargetDeviceId, endpointConfig, commandConsumerFactory);
+        if (ctx.failed()) {
+            return;
+        }
 
         final CountDownLatch commandsSucceeded = new CountDownLatch(totalNoOfCommandsToSend);
         final AtomicInteger commandsSent = new AtomicInteger(0);
@@ -523,6 +530,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
+            return;
         }
 
         final Checkpoint expectedFailures = ctx.checkpoint(2);
@@ -596,6 +604,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
+            return;
         }
 
         final Checkpoint expectedSteps = ctx.checkpoint(2);
@@ -650,6 +659,9 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
 
         connectAndSubscribe(ctx, commandTargetDeviceId, endpointConfig,
                 (cmdReceiver, cmdResponseSender) -> createRejectingCommandConsumer(ctx, cmdReceiver));
+        if (ctx.failed()) {
+            return;
+        }
 
         final int totalNoOfCommandsToSend = 3;
         final CountDownLatch commandsFailed = new CountDownLatch(totalNoOfCommandsToSend);
@@ -665,6 +677,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         assertThat(commandClientCreation.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
         if (commandClientCreation.failed()) {
             ctx.failNow(commandClientCreation.causeOfFailure());
+            return;
         }
 
         while (commandsSent.get() < totalNoOfCommandsToSend) {
@@ -739,6 +752,9 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         // command handler won't send a disposition update
         connectAndSubscribe(ctx, commandTargetDeviceId, endpointConfig,
                 (cmdReceiver, cmdResponseSender) -> createNotSendingDeliveryUpdateCommandConsumer(ctx, cmdReceiver, receivedMessagesCounter));
+        if (ctx.failed()) {
+            return;
+        }
 
         final int totalNoOfCommandsToSend = 2;
         final CountDownLatch commandsFailed = new CountDownLatch(totalNoOfCommandsToSend);
@@ -754,6 +770,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         assertThat(commandClientCreation.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
         if (commandClientCreation.failed()) {
             ctx.failNow(commandClientCreation.causeOfFailure());
+            return;
         }
 
         while (commandsSent.get() < totalNoOfCommandsToSend) {

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -529,7 +529,7 @@ public abstract class HttpTestBase {
         final long start = System.currentTimeMillis();
         int messageCount = 0;
 
-        while (messageCount < numberOfMessages) {
+        while (messageCount < numberOfMessages && !messageSending.failed()) {
 
             messageCount++;
             final int currentMessage = messageCount;

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -287,6 +287,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
+            return;
         }
 
         final CountDownLatch commandsSucceeded = new CountDownLatch(totalNoOfCommandsToSend);
@@ -389,6 +390,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         assertThat(setup.awaitCompletion(15, TimeUnit.SECONDS)).isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
+            return;
         }
 
         final Checkpoint failedAttempts = ctx.checkpoint(2);
@@ -480,6 +482,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
+            return;
         }
 
         final AtomicInteger commandsSent = new AtomicInteger(0);

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -114,6 +114,7 @@ public class EventMqttIT extends MqttPublishTestBase {
         assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
+            return;
         }
 
         // WHEN a device that belongs to the tenant publishes an event


### PR DESCRIPTION
Exit test methods when `vertxTestContext.failNow(t)` has been called.
Otherwise a subsequent exception in the following code might hide the original exception.

Happened in a recent integration test run:
The original error
````
20:33:51.417 [main] INFO  o.e.h.t.amqp.CommandAndControlAmqpIT - running testSendOneWayCommandSucceeds(AmqpCommandEndpointConfiguration, VertxTestContext) [1]; parameters: subscribe as: DEVICE, southbound endpoint: command, northbound endpoint: command
20:33:52.250 [vert.x-eventloop-thread-2] ERROR o.e.h.t.amqp.CommandAndControlAmqpIT - failed to establish connection to AMQP adapter [host: localhost, port: 32785]
javax.security.sasl.AuthenticationException: Failed to authenticate
	at io.vertx.proton.impl.ProtonSaslClientAuthenticatorImpl.handleSaslFail(ProtonSaslClientAuthenticatorImpl.java:173)
	at io.vertx.proton.impl.ProtonSaslClientAuthenticatorImpl.process(ProtonSaslClientAuthenticatorImpl.java:111)
````
was concealed by a follow-up NPE:
````
[ERROR] Tests run: 19, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 22.946 s <<< FAILURE! - in org.eclipse.hono.tests.amqp.CommandAndControlAmqpIT
[ERROR] testSendOneWayCommandSucceeds{AmqpCommandEndpointConfiguration, VertxTestContext}[1]  Time elapsed: 0.873 s  <<< ERROR!
java.lang.NullPointerException
	at org.eclipse.hono.tests.amqp.CommandAndControlAmqpIT.testSendCommandSucceeds(CommandAndControlAmqpIT.java:437)
	at org.eclipse.hono.tests.amqp.CommandAndControlAmqpIT.testSendOneWayCommandSucceeds(CommandAndControlAmqpIT.java:255)
````