### PR TITLE
Add metrics sending messages downstream

### DIFF
--- a/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/Application.java
+++ b/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/Application.java
@@ -151,12 +151,13 @@ public class Application {
     CredentialsClientFactory credentialsClientFactory() {
         return CredentialsClientFactory.create(
                 HonoConnection.newConnection(vertx, config.credentials),
-                newCaffeineCache(config.credentials.getResponseCacheMinSize(), config.credentials.getResponseCacheMaxSize()));
+                newCaffeineCache(config.credentials.getResponseCacheMinSize(), config.credentials.getResponseCacheMaxSize()),
+                metrics);
     }
 
     @Produces
     DeviceConnectionClientFactory deviceConnectionClientFactory() {
-        return DeviceConnectionClientFactory.create(HonoConnection.newConnection(vertx, config.deviceConnection));
+        return DeviceConnectionClientFactory.create(HonoConnection.newConnection(vertx, config.deviceConnection), metrics);
     }
 
     @Produces
@@ -175,14 +176,16 @@ public class Application {
     RegistrationClientFactory registrationClientFactory() {
         return RegistrationClientFactory.create(
                 HonoConnection.newConnection(vertx, config.registration),
-                newCaffeineCache(config.registration.getResponseCacheMinSize(), config.registration.getResponseCacheMaxSize()));
+                newCaffeineCache(config.registration.getResponseCacheMinSize(), config.registration.getResponseCacheMaxSize()),
+                metrics);
     }
 
     @Produces
     TenantClientFactory tenantClientFactory() {
         return TenantClientFactory.create(
                 HonoConnection.newConnection(vertx, config.tenant),
-                newCaffeineCache(config.tenant.getResponseCacheMinSize(), config.tenant.getResponseCacheMaxSize()));
+                newCaffeineCache(config.tenant.getResponseCacheMinSize(), config.tenant.getResponseCacheMaxSize()),
+                metrics);
     }
 
     /**

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>hono-legal</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
@@ -11,7 +11,6 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-
 package org.eclipse.hono.client;
 
 import java.util.function.BiConsumer;
@@ -26,7 +25,6 @@ import io.vertx.proton.ProtonDelivery;
 
 /**
  * A factory for creating clients for Hono's north bound APIs.
- *
  */
 public interface ApplicationClientFactory extends ConnectionLifecycle<HonoConnection> {
 
@@ -38,7 +36,19 @@ public interface ApplicationClientFactory extends ConnectionLifecycle<HonoConnec
      * @throws NullPointerException if connection is {@code null}
      */
     static ApplicationClientFactory create(final HonoConnection connection) {
-        return new ApplicationClientFactoryImpl(connection);
+        return create(connection, SendMessageSampler.Factory.noop());
+    }
+
+    /**
+     * Creates a new factory for an existing connection.
+     *
+     * @param connection The connection to use.
+     * @param samplerFactory The sampler to use.
+     * @return The factory.
+     * @throws NullPointerException if connection is {@code null}
+     */
+    static ApplicationClientFactory create(final HonoConnection connection, final SendMessageSampler.Factory samplerFactory) {
+        return new ApplicationClientFactoryImpl(connection, samplerFactory);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/CredentialsClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/CredentialsClientFactory.java
@@ -33,7 +33,7 @@ public interface CredentialsClientFactory extends ConnectionLifecycle<HonoConnec
      * @throws NullPointerException if connection is {@code null}
      */
     static CredentialsClientFactory create(final HonoConnection connection) {
-        return new CredentialsClientFactoryImpl(connection, null);
+        return new CredentialsClientFactoryImpl(connection, null, SendMessageSampler.Factory.noop());
     }
 
     /**
@@ -42,11 +42,12 @@ public interface CredentialsClientFactory extends ConnectionLifecycle<HonoConnec
      * @param connection The connection to use.
      * @param cacheProvider The cache provider to use for creating caches for credential objects
      *                      or {@code null} if credential objects should not be cached.
+     * @param samplerFactory The sampler factory to use.
      * @return The factory.
      * @throws NullPointerException if connection is {@code null}
      */
-    static CredentialsClientFactory create(final HonoConnection connection, final CacheProvider cacheProvider) {
-        return new CredentialsClientFactoryImpl(connection, cacheProvider);
+    static CredentialsClientFactory create(final HonoConnection connection, final CacheProvider cacheProvider, final SendMessageSampler.Factory samplerFactory) {
+        return new CredentialsClientFactoryImpl(connection, cacheProvider, samplerFactory);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClientFactory.java
@@ -26,10 +26,11 @@ public interface DeviceConnectionClientFactory extends BasicDeviceConnectionClie
      * Creates a new factory for an existing connection.
      *
      * @param connection The connection to use.
+     * @param samplerFactory The sampler factory to use.
      * @return The factory.
      * @throws NullPointerException if connection is {@code null}
      */
-    static DeviceConnectionClientFactory create(final HonoConnection connection) {
-        return new DeviceConnectionClientFactoryImpl(connection);
+    static DeviceConnectionClientFactory create(final HonoConnection connection, final SendMessageSampler.Factory samplerFactory) {
+        return new DeviceConnectionClientFactoryImpl(connection, samplerFactory);
     }
 }

--- a/client/src/main/java/org/eclipse/hono/client/DownstreamSenderFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/DownstreamSenderFactory.java
@@ -11,7 +11,6 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-
 package org.eclipse.hono.client;
 
 import org.eclipse.hono.client.impl.DownstreamSenderFactoryImpl;
@@ -32,7 +31,19 @@ public interface DownstreamSenderFactory extends ConnectionLifecycle<HonoConnect
      * @throws NullPointerException if connection is {@code null}
      */
     static DownstreamSenderFactory create(final HonoConnection connection) {
-        return new DownstreamSenderFactoryImpl(connection);
+        return new DownstreamSenderFactoryImpl(connection, SendMessageSampler.Factory.noop());
+    }
+
+    /**
+     * Creates a new factory for an existing connection.
+     *
+     * @param connection The connection to use.
+     * @param samplerFactory The sampler factory to use.
+     * @return The factory.
+     * @throws NullPointerException if connection is {@code null}
+     */
+    static DownstreamSenderFactory create(final HonoConnection connection, final SendMessageSampler.Factory samplerFactory) {
+        return new DownstreamSenderFactoryImpl(connection, samplerFactory);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/ProtocolAdapterCommandConsumerFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/ProtocolAdapterCommandConsumerFactory.java
@@ -35,7 +35,19 @@ public interface ProtocolAdapterCommandConsumerFactory extends ConnectionLifecyc
      * @throws NullPointerException if connection or gatewayMapper is {@code null}.
      */
     static ProtocolAdapterCommandConsumerFactory create(final HonoConnection connection) {
-        return new ProtocolAdapterCommandConsumerFactoryImpl(connection);
+        return create(connection, SendMessageSampler.Factory.noop());
+    }
+
+    /**
+     * Creates a new factory for an existing connection.
+     *
+     * @param connection The connection to the AMQP network.
+     * @param samplerFactory The sampler factory to use.
+     * @return The factory.
+     * @throws NullPointerException if connection or gatewayMapper is {@code null}.
+     */
+    static ProtocolAdapterCommandConsumerFactory create(final HonoConnection connection, final SendMessageSampler.Factory samplerFactory) {
+        return new ProtocolAdapterCommandConsumerFactoryImpl(connection, samplerFactory);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/RegistrationClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/RegistrationClientFactory.java
@@ -33,7 +33,7 @@ public interface RegistrationClientFactory extends ConnectionLifecycle<HonoConne
      * @throws NullPointerException if connection is {@code null}
      */
     static RegistrationClientFactory create(final HonoConnection connection) {
-        return new RegistrationClientFactoryImpl(connection, null);
+        return new RegistrationClientFactoryImpl(connection, null, SendMessageSampler.Factory.noop());
     }
 
     /**
@@ -42,11 +42,12 @@ public interface RegistrationClientFactory extends ConnectionLifecycle<HonoConne
      * @param connection The connection to use.
      * @param cacheProvider The cache provider to use for creating caches for tenant objects
      *                      or {@code null} if tenant objects should not be cached.
+     * @param samplerFactory The sampler factory to use.
      * @return The factory.
      * @throws NullPointerException if connection is {@code null}
      */
-    static RegistrationClientFactory create(final HonoConnection connection, final CacheProvider cacheProvider) {
-        return new RegistrationClientFactoryImpl(connection, cacheProvider);
+    static RegistrationClientFactory create(final HonoConnection connection, final CacheProvider cacheProvider, final SendMessageSampler.Factory samplerFactory) {
+        return new RegistrationClientFactoryImpl(connection, cacheProvider, samplerFactory);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/SendMessageSampler.java
+++ b/client/src/main/java/org/eclipse/hono/client/SendMessageSampler.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client;
+
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
+
+/**
+ * An interface for sampling <em>send message</em> operations.
+ */
+public interface SendMessageSampler {
+
+    /**
+     * A factory for creating samplers.
+     */
+    interface Factory {
+
+        /**
+         * Create a new sampler.
+         *
+         * @param messageType The message type to create a sampler for.
+         * @return A new sampler.
+         */
+        SendMessageSampler create(String messageType);
+
+        /**
+         * Get a default, no-op implementation.
+         *
+         * @return A no-op implementation, never returns {@code null}.
+         */
+        static SendMessageSampler.Factory noop() {
+            return Noop.FACTORY;
+        }
+
+    }
+
+    /**
+     * Get a default, no-op implementation.
+     *
+     * @return A no-op implementation, never returns {@code null}.
+     */
+    static SendMessageSampler noop() {
+        return Noop.SAMPLER;
+    }
+
+    /**
+     * A default no-op implementations.
+     */
+    class Noop {
+
+        private static final Sample SAMPLE = new Sample() {
+
+            @Override
+            public void completed(final String outcome) {
+            }
+
+            @Override
+            public void timeout() {
+            }
+
+        };
+
+        private static final SendMessageSampler SAMPLER = new SendMessageSampler() {
+
+            @Override
+            public Sample start(final String tenantId) {
+                return SAMPLE;
+            }
+
+            @Override
+            public void queueFull(final String tenantId) {
+            }
+
+        };
+
+        private static final Factory FACTORY = new Factory() {
+
+            @Override
+            public SendMessageSampler create(final String messageType) {
+                return SAMPLER;
+            }
+
+        };
+
+        private Noop() {
+        }
+
+    }
+
+    /**
+     * An active sample instance.
+     */
+    interface Sample {
+
+        String OUTCOME_ABORTED = "aborted";
+
+        /**
+         * Call when the message was processed by the remote peer.
+         *
+         * @param outcome The outcome of the message. This is expected to be one of AMQP dispositions.
+         */
+        void completed(String outcome);
+
+        /**
+         * Call when the message was processed by the remote peer.
+         * <p>
+         * This method will use the <em>simple class name</em> of the delivery state parameter. If the
+         * parameter is {@code null} the operating is considered <em>aborted</em> and the value {@link #OUTCOME_ABORTED}
+         * will be used instead.
+         *
+         * @param remoteState The remote state.
+         */
+        default void completed(final DeliveryState remoteState) {
+            if (remoteState == null) {
+                completed(OUTCOME_ABORTED);
+            } else {
+                completed(remoteState.getClass().getSimpleName().toLowerCase());
+            }
+        }
+
+        /**
+         * Call when the operation timed out.
+         */
+        void timeout();
+
+    }
+
+    /**
+     * Start operation.
+     *
+     * @param tenantId The tenant ID to sample for.
+     * @return A sample instance.
+     */
+    Sample start(String tenantId);
+
+    /**
+     * Record a case of "queue full".
+     *
+     * @param tenantId The tenant ID to sample for.
+     */
+    void queueFull(String tenantId);
+
+}

--- a/client/src/main/java/org/eclipse/hono/client/TenantClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/TenantClientFactory.java
@@ -33,7 +33,7 @@ public interface TenantClientFactory extends ConnectionLifecycle<HonoConnection>
      * @throws NullPointerException if connection is {@code null}
      */
     static TenantClientFactory create(final HonoConnection connection) {
-        return new TenantClientFactoryImpl(connection, null);
+        return new TenantClientFactoryImpl(connection, null, SendMessageSampler.Factory.noop());
     }
 
     /**
@@ -42,11 +42,12 @@ public interface TenantClientFactory extends ConnectionLifecycle<HonoConnection>
      * @param connection The connection to use.
      * @param cacheProvider The provider to use for creating caches for tenant objects
      *                      or {@code null} if tenant objects should not be cached.
+     * @param samplerFactory The sampler factory to use.
      * @return The factory.
      * @throws NullPointerException if connection is {@code null}
      */
-    static TenantClientFactory create(final HonoConnection connection, final CacheProvider cacheProvider) {
-        return new TenantClientFactoryImpl(connection, cacheProvider);
+    static TenantClientFactory create(final HonoConnection connection, final CacheProvider cacheProvider, final SendMessageSampler.Factory samplerFactory) {
+        return new TenantClientFactoryImpl(connection, cacheProvider, samplerFactory);
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/device/amqp/AmqpAdapterClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/device/amqp/AmqpAdapterClientFactory.java
@@ -19,6 +19,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ConnectionLifecycle;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.impl.AmqpAdapterClientFactoryImpl;
 
 import io.vertx.core.Future;
@@ -33,11 +34,24 @@ public interface AmqpAdapterClientFactory extends ConnectionLifecycle<HonoConnec
      *
      * @param connection The connection to use.
      * @param tenantId The ID of the tenant for which the connection is authenticated.
+     * @param samplerFactory The sampler factory to use.
+     * @return The factory.
+     * @throws NullPointerException if any of the parameters is {@code null}
+     */
+    static AmqpAdapterClientFactory create(final HonoConnection connection, final String tenantId, final SendMessageSampler.Factory samplerFactory) {
+        return new AmqpAdapterClientFactoryImpl(connection, tenantId, samplerFactory);
+    }
+
+    /**
+     * Creates a new factory for an existing connection.
+     *
+     * @param connection The connection to use.
+     * @param tenantId The ID of the tenant for which the connection is authenticated.
      * @return The factory.
      * @throws NullPointerException if any of the parameters is {@code null}
      */
     static AmqpAdapterClientFactory create(final HonoConnection connection, final String tenantId) {
-        return new AmqpAdapterClientFactoryImpl(connection, tenantId);
+        return new AmqpAdapterClientFactoryImpl(connection, tenantId, SendMessageSampler.Factory.noop());
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/device/amqp/internal/AmqpAdapterClientCommandResponseSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/device/amqp/internal/AmqpAdapterClientCommandResponseSender.java
@@ -20,6 +20,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.device.amqp.CommandResponder;
 import org.eclipse.hono.client.device.amqp.TraceableCommandResponder;
 import org.eclipse.hono.client.impl.CommandResponseSenderImpl;
@@ -41,7 +42,7 @@ public class AmqpAdapterClientCommandResponseSender extends CommandResponseSende
 
     AmqpAdapterClientCommandResponseSender(final HonoConnection connection, final ProtonSender sender,
             final String tenantId) {
-        super(connection, sender, tenantId, null);
+        super(connection, sender, tenantId, null, SendMessageSampler.noop());
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/device/amqp/internal/AmqpAdapterClientEventSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/device/amqp/internal/AmqpAdapterClientEventSenderImpl.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.device.amqp.EventSender;
 import org.eclipse.hono.client.device.amqp.TraceableEventSender;
 import org.eclipse.hono.client.impl.EventSenderImpl;
@@ -39,7 +40,7 @@ public class AmqpAdapterClientEventSenderImpl extends EventSenderImpl implements
 
     AmqpAdapterClientEventSenderImpl(final HonoConnection con, final ProtonSender sender, final String tenantId,
             final String targetAddress) {
-        super(con, sender, tenantId, targetAddress);
+        super(con, sender, tenantId, targetAddress, SendMessageSampler.noop());
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/device/amqp/internal/AmqpAdapterClientTelemetrySenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/device/amqp/internal/AmqpAdapterClientTelemetrySenderImpl.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.device.amqp.TelemetrySender;
 import org.eclipse.hono.client.device.amqp.TraceableTelemetrySender;
 import org.eclipse.hono.client.impl.TelemetrySenderImpl;
@@ -40,7 +41,7 @@ public class AmqpAdapterClientTelemetrySenderImpl extends TelemetrySenderImpl
 
     AmqpAdapterClientTelemetrySenderImpl(final HonoConnection con, final ProtonSender sender, final String tenantId,
             final String targetAddress) {
-        super(con, sender, tenantId, targetAddress);
+        super(con, sender, tenantId, targetAddress, SendMessageSampler.noop());
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractDownstreamSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractDownstreamSender.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.util.MessageHelper;
 
 import io.vertx.core.Future;
@@ -51,15 +52,17 @@ public abstract class AbstractDownstreamSender extends AbstractSender implements
      * @param tenantId The identifier of the tenant that the
      *           devices belong to which have published the messages
      *           that this sender is used to send downstream.
+     * @param sampler The sampler for sending messages.
      * @param targetAddress The target address to send the messages to.
      */
     protected AbstractDownstreamSender(
             final HonoConnection connection,
             final ProtonSender sender,
             final String tenantId,
-            final String targetAddress) {
+            final String targetAddress,
+            final SendMessageSampler sampler) {
 
-        super(connection, sender, tenantId, targetAddress);
+        super(connection, sender, tenantId, targetAddress, sampler);
     }
 
     @Override

--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractHonoClientFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.hono.client.ConnectionLifecycle;
 import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ReconnectListener;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.slf4j.Logger;
@@ -42,14 +43,19 @@ abstract class AbstractHonoClientFactory implements ConnectionLifecycle<HonoConn
      * The connection to use for interacting with Hono.
      */
     protected final HonoConnection connection;
+    /**
+     * The factory for creating <em>send message</em> samplers.
+     */
+    protected final SendMessageSampler.Factory samplerFactory;
 
     /**
      * @param connection The connection to use.
      * @throws NullPointerException if connection is {@code null}.
      */
-    AbstractHonoClientFactory(final HonoConnection connection) {
+    AbstractHonoClientFactory(final HonoConnection connection, final SendMessageSampler.Factory samplerFactory) {
         this.connection = Objects.requireNonNull(connection);
         this.connection.addDisconnectListener(con -> onDisconnect());
+        this.samplerFactory = samplerFactory;
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/AmqpAdapterClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AmqpAdapterClientFactoryImpl.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
 import org.eclipse.hono.client.device.amqp.AmqpSenderLink;
 import org.eclipse.hono.client.device.amqp.CommandResponder;
@@ -53,10 +54,11 @@ public final class AmqpAdapterClientFactoryImpl extends AbstractHonoClientFactor
      *
      * @param connection The connection to use.
      * @param tenantId The ID of the tenant to be used for the clients created by this factory.
+     * @param samplerFactory The sampler factory to use.
      * @throws NullPointerException if any of the parameters is {@code null}
      */
-    public AmqpAdapterClientFactoryImpl(final HonoConnection connection, final String tenantId) {
-        super(connection);
+    public AmqpAdapterClientFactoryImpl(final HonoConnection connection, final String tenantId, final SendMessageSampler.Factory samplerFactory) {
+        super(connection, samplerFactory);
         Objects.requireNonNull(tenantId);
 
         telemetrySenderClientFactory = new CachingClientFactory<>(connection.getVertx(), AmqpSenderLink::isOpen);

--- a/client/src/main/java/org/eclipse/hono/client/impl/ApplicationClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ApplicationClientFactoryImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.hono.client.AsyncCommandClient;
 import org.eclipse.hono.client.CommandClient;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.util.CommandConstants;
 
 import io.vertx.core.Future;
@@ -46,9 +47,10 @@ public class ApplicationClientFactoryImpl extends AbstractHonoClientFactory impl
      * Creates a new factory for an existing connection.
      *
      * @param connection The connection to use.
+     * @param samplerFactory The sampler factory to use.
      */
-    public ApplicationClientFactoryImpl(final HonoConnection connection) {
-        super(connection);
+    public ApplicationClientFactoryImpl(final HonoConnection connection, final SendMessageSampler.Factory samplerFactory) {
+        super(connection, samplerFactory);
         consumerFactory = new ClientFactory<>();
         commandClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
         asyncCommandClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
@@ -139,6 +141,7 @@ public class ApplicationClientFactoryImpl extends AbstractHonoClientFactory impl
                             connection,
                             tenantId,
                             replyId,
+                            samplerFactory.create(CommandConstants.COMMAND_ENDPOINT),
                             s -> removeCommandClient(cacheKey),
                             s -> removeCommandClient(cacheKey)),
                     result);
@@ -167,6 +170,7 @@ public class ApplicationClientFactoryImpl extends AbstractHonoClientFactory impl
                     () -> AsyncCommandClientImpl.create(
                             connection,
                             tenantId,
+                            samplerFactory.create(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT),
                             s -> removeAsyncCommandClient(key)),
                     result);
         });

--- a/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandClientImpl.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.AsyncCommandClient;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
 
@@ -42,8 +43,9 @@ public class AsyncCommandClientImpl extends AbstractSender implements AsyncComma
             final HonoConnection con,
             final ProtonSender sender,
             final String tenantId,
-            final String targetAddress) {
-        super(con, sender, tenantId, targetAddress);
+            final String targetAddress,
+            final SendMessageSampler sampler) {
+        super(con, sender, tenantId, targetAddress, sampler);
     }
 
     @Override
@@ -144,12 +146,14 @@ public class AsyncCommandClientImpl extends AbstractSender implements AsyncComma
      * @param con The connection to the Hono server.
      * @param tenantId The tenant that the device belongs to.
      * @param closeHook A handler to invoke if the peer closes the sender link unexpectedly.
+     * @param sampler The sampler to use.
      * @return A future indicating the outcome.
      * @throws NullPointerException if any of connection, tenantId or deviceId are {@code null}.
      */
     public static Future<AsyncCommandClient> create(
             final HonoConnection con,
             final String tenantId,
+            final SendMessageSampler sampler,
             final Handler<String> closeHook) {
 
         Objects.requireNonNull(con);
@@ -157,6 +161,6 @@ public class AsyncCommandClientImpl extends AbstractSender implements AsyncComma
 
         final String linkTargetAddress = AsyncCommandClientImpl.getLinkTargetAddress(tenantId);
         return con.createSender(linkTargetAddress, ProtonQoS.AT_LEAST_ONCE, closeHook)
-                .compose(sender -> Future.succeededFuture(new AsyncCommandClientImpl(con, sender, tenantId, linkTargetAddress)));
+                .compose(sender -> Future.succeededFuture(new AsyncCommandClientImpl(con, sender, tenantId, linkTargetAddress, sampler)));
     }
 }

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
@@ -21,6 +21,7 @@ import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.CommandClient;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
@@ -62,14 +63,16 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
      * @param connection The connection to Hono.
      * @param tenantId The tenant that the device belongs to.
      * @param replyId The replyId to use in the reply-to address.
+     * @param sampler The sampler to use.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     CommandClientImpl(
             final HonoConnection connection,
             final String tenantId,
-            final String replyId) {
+            final String replyId,
+            final SendMessageSampler sampler) {
 
-        super(connection, tenantId, replyId);
+        super(connection, tenantId, replyId, sampler);
     }
 
     /**
@@ -80,6 +83,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
      * @param replyId The replyId to use in the reply-to address.
      * @param sender The link to use for sending command requests.
      * @param receiver The link to use for receiving command responses.
+     * @param sampler The sampler to use.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     CommandClientImpl(
@@ -87,9 +91,10 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
             final String tenantId,
             final String replyId,
             final ProtonSender sender,
-            final ProtonReceiver receiver) {
+            final ProtonReceiver receiver,
+            final SendMessageSampler sampler) {
 
-        this(connection, tenantId, replyId);
+        this(connection, tenantId, replyId, sampler);
         this.sender = Objects.requireNonNull(sender);
         this.receiver = Objects.requireNonNull(receiver);
     }
@@ -244,6 +249,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
      * @param con The connection to Hono.
      * @param tenantId The tenant that the device belongs to.
      * @param replyId The replyId to use in the reply-to address.
+     * @param sampler The sampler to use
      * @param senderCloseHook A handler to invoke if the peer closes the sender link unexpectedly.
      * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly.
      * @return A future indicating the outcome.
@@ -253,10 +259,11 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
             final HonoConnection con,
             final String tenantId,
             final String replyId,
+            final SendMessageSampler sampler,
             final Handler<String> senderCloseHook,
             final Handler<String> receiverCloseHook) {
 
-        final CommandClientImpl client = new CommandClientImpl(con, tenantId, replyId);
+        final CommandClientImpl client = new CommandClientImpl(con, tenantId, replyId, sampler);
         return client.createLinks(senderCloseHook, receiverCloseHook)
                 .map(ok -> {
                     LOG.debug("successfully created command client for [{}]", tenantId);

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandResponseSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandResponseSenderImpl.java
@@ -18,6 +18,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.AddressHelper;
 import org.eclipse.hono.util.CommandConstants;
@@ -50,14 +51,16 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
      * @param sender The sender link to send command response messages over.
      * @param tenantId The tenant that the messages will be published for.
      * @param targetAddress The target address to send the messages to.
+     * @param sampler The sampler to use.
      */
     protected CommandResponseSenderImpl(
             final HonoConnection connection,
             final ProtonSender sender,
             final String tenantId,
-            final String targetAddress) {
+            final String targetAddress,
+            final SendMessageSampler sampler) {
 
-        super(connection, sender, tenantId, targetAddress);
+        super(connection, sender, tenantId, targetAddress, sampler);
     }
 
     @Override
@@ -111,6 +114,7 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
      * @param con The connection to the AMQP network.
      * @param tenantId The tenant that the command response will be send for and the device belongs to.
      * @param replyId The reply id as the unique postfix of the replyTo address.
+     * @param sampler The sampler to use.
      * @param closeHook A handler to invoke if the peer closes the link unexpectedly.
      * @return A future indicating the result of the creation attempt.
      * @throws NullPointerException if any of con, tenantId or replyId are {@code null}.
@@ -119,6 +123,7 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
             final HonoConnection con,
             final String tenantId,
             final String replyId,
+            final SendMessageSampler sampler,
             final Handler<String> closeHook) {
 
         Objects.requireNonNull(con);
@@ -133,7 +138,7 @@ public class CommandResponseSenderImpl extends AbstractSender implements Command
 
         return con.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, closeHook)
                 .map(sender -> (CommandResponseSender) new CommandResponseSenderImpl(con, sender, tenantId,
-                        targetAddress));
+                        targetAddress, sampler));
     }
 
     @Override

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientFactoryImpl.java
@@ -20,7 +20,9 @@ import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.CredentialsClient;
 import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.CredentialsConstants;
 
 import io.vertx.core.Future;
 import io.vertx.core.eventbus.Message;
@@ -42,9 +44,10 @@ public class CredentialsClientFactoryImpl extends AbstractHonoClientFactory impl
      * @param connection The connection to use.
      * @param cacheProvider The cache provider to use for creating caches for credential objects
      *                      or {@code null} if credentials objects should not be cached.
+     * @param samplerFactory The sampler factory to use.
      */
-    public CredentialsClientFactoryImpl(final HonoConnection connection, final CacheProvider cacheProvider) {
-        super(connection);
+    public CredentialsClientFactoryImpl(final HonoConnection connection, final CacheProvider cacheProvider, final SendMessageSampler.Factory samplerFactory) {
+        super(connection, samplerFactory);
         credentialsClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
         this.cacheProvider = cacheProvider;
         connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
@@ -75,6 +78,7 @@ public class CredentialsClientFactoryImpl extends AbstractHonoClientFactory impl
                                     cacheProvider,
                                     connection,
                                     tenantId,
+                                    samplerFactory.create(CredentialsConstants.CREDENTIALS_ENDPOINT),
                                     this::removeCredentialsClient,
                                     this::removeCredentialsClient),
                             result);

--- a/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CredentialsClientImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CredentialsClient;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CredentialsConstants;
@@ -66,9 +67,10 @@ public class CredentialsClientImpl extends AbstractRequestResponseClient<Credent
      *
      * @param connection The connection to Hono.
      * @param tenantId The identifier of the tenant for which the client should be created.
+     * @param sampler The sampler to use.
      */
-    CredentialsClientImpl(final HonoConnection connection, final String tenantId) {
-        super(connection, tenantId);
+    CredentialsClientImpl(final HonoConnection connection, final String tenantId, final SendMessageSampler sampler) {
+        super(connection, tenantId, sampler);
     }
 
     /**
@@ -78,10 +80,15 @@ public class CredentialsClientImpl extends AbstractRequestResponseClient<Credent
      * @param tenantId The identifier of the tenant for which the client should be created.
      * @param sender The AMQP link to use for sending requests to the service.
      * @param receiver The AMQP link to use for receiving responses from the service.
+     * @param sampler The sampler to use.
      */
-    CredentialsClientImpl(final HonoConnection connection, final String tenantId, final ProtonSender sender,
-            final ProtonReceiver receiver) {
-        super(connection, tenantId, sender, receiver);
+    CredentialsClientImpl(
+            final HonoConnection connection,
+            final String tenantId,
+            final ProtonSender sender,
+            final ProtonReceiver receiver,
+            final SendMessageSampler sampler) {
+        super(connection, tenantId, sender, receiver, sampler);
     }
 
     @Override
@@ -138,6 +145,7 @@ public class CredentialsClientImpl extends AbstractRequestResponseClient<Credent
      *                      or {@code null} if credential objects should not be cached.
      * @param con The connection to the server.
      * @param tenantId The tenant for which credentials are handled.
+     * @param sampler The sampler to use.
      * @param senderCloseHook A handler to invoke if the peer closes the sender link unexpectedly.
      * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly.
      * @return A future indicating the outcome of the creation attempt.
@@ -147,11 +155,12 @@ public class CredentialsClientImpl extends AbstractRequestResponseClient<Credent
             final CacheProvider cacheProvider,
             final HonoConnection con,
             final String tenantId,
+            final SendMessageSampler sampler,
             final Handler<String> senderCloseHook,
             final Handler<String> receiverCloseHook) {
 
         LOG.debug("creating new credentials client for [{}]", tenantId);
-        final CredentialsClientImpl client = new CredentialsClientImpl(con, tenantId);
+        final CredentialsClientImpl client = new CredentialsClientImpl(con, tenantId, sampler);
         if (cacheProvider != null) {
             client.setResponseCache(cacheProvider.getCache(CredentialsClientImpl.getTargetAddress(tenantId)));
         }

--- a/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientFactoryImpl.java
@@ -19,7 +19,9 @@ import java.util.Objects;
 import org.eclipse.hono.client.DeviceConnectionClient;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.DeviceConnectionConstants;
 
 import io.vertx.core.Future;
 import io.vertx.core.eventbus.Message;
@@ -38,10 +40,11 @@ public class DeviceConnectionClientFactoryImpl extends AbstractHonoClientFactory
      * Creates a new factory for an existing connection.
      *
      * @param connection The connection to use.
+     * @param samplerFactory The sampler factory to use.
      * @throws NullPointerException if connection is {@code null}
      */
-    public DeviceConnectionClientFactoryImpl(final HonoConnection connection) {
-        super(connection);
+    public DeviceConnectionClientFactoryImpl(final HonoConnection connection, final SendMessageSampler.Factory samplerFactory) {
+        super(connection, samplerFactory);
         this.deviceConnectionClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
         connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
                 this::handleTenantTimeout);
@@ -69,6 +72,7 @@ public class DeviceConnectionClientFactoryImpl extends AbstractHonoClientFactory
                             () -> DeviceConnectionClientImpl.create(
                                     connection,
                                     tenantId,
+                                    samplerFactory.create(DeviceConnectionConstants.DEVICE_CONNECTION_ENDPOINT),
                                     this::removeDeviceConnectionClient,
                                     this::removeDeviceConnectionClient),
                             result);

--- a/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DeviceConnectionClientImpl.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.eclipse.hono.client.DeviceConnectionClient;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
@@ -62,9 +63,10 @@ public class DeviceConnectionClientImpl extends AbstractRequestResponseClient<De
      *
      * @param connection The connection to the Device Connection service.
      * @param tenantId The identifier of the tenant for which the client should be created.
+     * @param sampler The sampler to use.
      */
-    protected DeviceConnectionClientImpl(final HonoConnection connection, final String tenantId) {
-        super(connection, tenantId);
+    protected DeviceConnectionClientImpl(final HonoConnection connection, final String tenantId, final SendMessageSampler sampler) {
+        super(connection, tenantId, sampler);
     }
 
     /**
@@ -74,14 +76,16 @@ public class DeviceConnectionClientImpl extends AbstractRequestResponseClient<De
      * @param tenantId The identifier of the tenant for which the client should be created.
      * @param sender The AMQP link to use for sending requests to the service.
      * @param receiver The AMQP link to use for receiving responses from the service.
+     * @param sampler The sampler to use.
      */
     protected DeviceConnectionClientImpl(
             final HonoConnection connection,
             final String tenantId,
             final ProtonSender sender,
-            final ProtonReceiver receiver) {
+            final ProtonReceiver receiver,
+            final SendMessageSampler sampler) {
 
-        super(connection, tenantId, sender, receiver);
+        super(connection, tenantId, sender, receiver, sampler);
     }
 
     /**
@@ -133,6 +137,7 @@ public class DeviceConnectionClientImpl extends AbstractRequestResponseClient<De
      *
      * @param con The connection to the server.
      * @param tenantId The tenant to consumer events for.
+     * @param sampler The sampler to use.
      * @param senderCloseHook A handler to invoke if the peer closes the sender link unexpectedly.
      * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly.
      * @return A future indicating the outcome of the creation attempt.
@@ -141,11 +146,12 @@ public class DeviceConnectionClientImpl extends AbstractRequestResponseClient<De
     public static final Future<DeviceConnectionClient> create(
             final HonoConnection con,
             final String tenantId,
+            final SendMessageSampler sampler,
             final Handler<String> senderCloseHook,
             final Handler<String> receiverCloseHook) {
 
         LOG.debug("creating new device connection client for [{}]", tenantId);
-        final DeviceConnectionClientImpl client = new DeviceConnectionClientImpl(con, tenantId);
+        final DeviceConnectionClientImpl client = new DeviceConnectionClientImpl(con, tenantId, sampler);
         // no response cache being set on client here - device connection results shall not be cached
         return client.createLinks(senderCloseHook, receiverCloseHook)
                 .map(ok -> {

--- a/client/src/main/java/org/eclipse/hono/client/impl/EventSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/EventSenderImpl.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.AddressHelper;
@@ -44,14 +45,16 @@ public class EventSenderImpl extends AbstractDownstreamSender {
      * @param sender The sender link to send events over.
      * @param tenantId The tenant that the events will be published for.
      * @param targetAddress The target address to send the events to.
+     * @param sampler The sampler to use.
      */
     protected EventSenderImpl(
             final HonoConnection con,
             final ProtonSender sender,
             final String tenantId,
-            final String targetAddress) {
+            final String targetAddress,
+            final SendMessageSampler sampler) {
 
-        super(con, sender, tenantId, targetAddress);
+        super(con, sender, tenantId, targetAddress, sampler);
     }
 
     @Override
@@ -69,6 +72,7 @@ public class EventSenderImpl extends AbstractDownstreamSender {
      *
      * @param con The connection to the Hono server.
      * @param tenantId The tenant that the events will be published for.
+     * @param sampler The sampler to use.
      * @param remoteCloseHook The handler to invoke when the link is closed by the peer (may be {@code null}). The
      *            sender's target address is provided as an argument to the handler.
      * @return A future indicating the outcome.
@@ -77,6 +81,7 @@ public class EventSenderImpl extends AbstractDownstreamSender {
     public static Future<DownstreamSender> create(
             final HonoConnection con,
             final String tenantId,
+            final SendMessageSampler sampler,
             final Handler<String> remoteCloseHook) {
 
         Objects.requireNonNull(con);
@@ -84,7 +89,7 @@ public class EventSenderImpl extends AbstractDownstreamSender {
 
         final String targetAddress = AddressHelper.getTargetAddress(EventConstants.EVENT_ENDPOINT, tenantId, null, con.getConfig());
         return con.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, remoteCloseHook)
-                .compose(sender -> Future.succeededFuture(new EventSenderImpl(con, sender, tenantId, targetAddress)));
+                .compose(sender -> Future.succeededFuture(new EventSenderImpl(con, sender, tenantId, targetAddress, sampler)));
     }
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientFactoryImpl.java
@@ -20,7 +20,9 @@ import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RegistrationClient;
 import org.eclipse.hono.client.RegistrationClientFactory;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.RegistrationConstants;
 
 import io.vertx.core.Future;
 import io.vertx.core.eventbus.Message;
@@ -42,10 +44,11 @@ public class RegistrationClientFactoryImpl extends AbstractHonoClientFactory imp
      * @param connection The connection to use.
      * @param cacheProvider The cache provider to use for creating caches for tenant objects
      *                      or {@code null} if tenant objects should not be cached.
+     * @param samplerFactory The sampler factory to use.
      * @throws NullPointerException if connection is {@code null}
      */
-    public RegistrationClientFactoryImpl(final HonoConnection connection, final CacheProvider cacheProvider) {
-        super(connection);
+    public RegistrationClientFactoryImpl(final HonoConnection connection, final CacheProvider cacheProvider, final SendMessageSampler.Factory samplerFactory) {
+        super(connection, samplerFactory);
         this.registrationClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
         this.cacheProvider = cacheProvider;
         connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
@@ -76,6 +79,7 @@ public class RegistrationClientFactoryImpl extends AbstractHonoClientFactory imp
                                     cacheProvider,
                                     connection,
                                     tenantId,
+                                    samplerFactory.create(RegistrationConstants.REGISTRATION_ENDPOINT),
                                     this::removeRegistrationClient,
                                     this::removeRegistrationClient),
                             result);

--- a/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/RegistrationClientImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
@@ -61,9 +62,10 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
      *
      * @param connection The connection to Hono.
      * @param tenantId The identifier of the tenant for which the client should be created.
+     * @param sampler The sampler to use.
      */
-    protected RegistrationClientImpl(final HonoConnection connection, final String tenantId) {
-        super(connection, tenantId);
+    protected RegistrationClientImpl(final HonoConnection connection, final String tenantId, final SendMessageSampler sampler) {
+        super(connection, tenantId, sampler);
     }
 
     /**
@@ -73,14 +75,16 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
      * @param tenantId The identifier of the tenant for which the client should be created.
      * @param sender The AMQP link to use for sending requests to the service.
      * @param receiver The AMQP link to use for receiving responses from the service.
+     * @param sampler The sampler to use.
      */
     protected RegistrationClientImpl(
             final HonoConnection connection,
             final String tenantId,
             final ProtonSender sender,
-            final ProtonReceiver receiver) {
+            final ProtonReceiver receiver,
+            final SendMessageSampler sampler) {
 
-        super(connection, tenantId, sender, receiver);
+        super(connection, tenantId, sender, receiver, sampler);
     }
 
     /**
@@ -133,6 +137,7 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
      *                     the client will not cache any results from the Device Registration service.
      * @param con The connection to the server.
      * @param tenantId The tenant to consumer events for.
+     * @param sampler The sampler to use.
      * @param senderCloseHook A handler to invoke if the peer closes the sender link unexpectedly.
      * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly.
      * @return A future indicating the outcome of the creation attempt.
@@ -142,11 +147,12 @@ public class RegistrationClientImpl extends AbstractRequestResponseClient<Regist
             final CacheProvider cacheProvider,
             final HonoConnection con,
             final String tenantId,
+            final SendMessageSampler sampler,
             final Handler<String> senderCloseHook,
             final Handler<String> receiverCloseHook) {
 
         LOG.debug("creating new registration client for [{}]", tenantId);
-        final RegistrationClientImpl client = new RegistrationClientImpl(con, tenantId);
+        final RegistrationClientImpl client = new RegistrationClientImpl(con, tenantId, sampler);
         if (cacheProvider != null) {
             client.setResponseCache(cacheProvider.getCache(RegistrationClientImpl.getTargetAddress(tenantId)));
         }

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantClientFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantClientFactoryImpl.java
@@ -16,8 +16,10 @@ package org.eclipse.hono.client.impl;
 
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.client.TenantClientFactory;
+import org.eclipse.hono.util.TenantConstants;
 
 import io.vertx.core.Future;
 
@@ -37,10 +39,11 @@ public class TenantClientFactoryImpl extends AbstractHonoClientFactory implement
      * @param connection The connection to use.
      * @param cacheProvider The cache provider to use for creating caches for tenant objects
      *                      or {@code null} if tenant objects should not be cached.
+     * @param samplerFactory The sampler factory to use.
      * @throws NullPointerException if connection is {@code null}
      */
-    public TenantClientFactoryImpl(final HonoConnection connection, final CacheProvider cacheProvider) {
-        super(connection);
+    public TenantClientFactoryImpl(final HonoConnection connection, final CacheProvider cacheProvider, final SendMessageSampler.Factory samplerFactory) {
+        super(connection, samplerFactory);
         this.tenantClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
         this.cacheProvider = cacheProvider;
     }
@@ -66,6 +69,7 @@ public class TenantClientFactoryImpl extends AbstractHonoClientFactory implement
                             () -> TenantClientImpl.create(
                                     cacheProvider,
                                     connection,
+                                    samplerFactory.create(TenantConstants.TENANT_ENDPOINT),
                                     this::removeTenantClient,
                                     this::removeTenantClient),
                             result);

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
@@ -26,6 +26,7 @@ import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.TenantClient;
 import org.eclipse.hono.util.CacheDirective;
@@ -70,10 +71,11 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
      * {@link #createLinks(Handler, Handler)} only.
      *
      * @param connection The connection to Hono.
+     * @param sampler The sampler to use.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
-    protected TenantClientImpl(final HonoConnection connection) {
-        super(connection, null);
+    protected TenantClientImpl(final HonoConnection connection, final SendMessageSampler sampler) {
+        super(connection, null, sampler);
     }
 
     /**
@@ -82,14 +84,16 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
      * @param connection The connection to Hono.
      * @param sender The AMQP 1.0 link to use for sending requests to the peer.
      * @param receiver The AMQP 1.0 link to use for receiving responses from the peer.
+     * @param sampler The sampler to use.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     protected TenantClientImpl(
             final HonoConnection connection,
             final ProtonSender sender,
-            final ProtonReceiver receiver) {
+            final ProtonReceiver receiver,
+            final SendMessageSampler sampler) {
 
-        super(connection, null, sender, receiver);
+        super(connection, null, sender, receiver, sampler);
     }
 
     @Override
@@ -142,7 +146,8 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
      *
      * @param cacheProvider A factory for cache instances for tenant configuration results. If {@code null}
      *                     the client will not cache any results from the Tenant service.
-     * @param con The connection to the server.
+     * @param connection The connection to the server.
+     * @param sampler The sampler to use.
      * @param senderCloseHook A handler to invoke if the peer closes the sender link unexpectedly.
      * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly.
      * @return A future indicating the outcome of the creation attempt.
@@ -150,12 +155,13 @@ public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult
      */
     public static final Future<TenantClient> create(
             final CacheProvider cacheProvider,
-            final HonoConnection con,
+            final HonoConnection connection,
+            final SendMessageSampler sampler,
             final Handler<String> senderCloseHook,
             final Handler<String> receiverCloseHook) {
 
         LOG.debug("creating new tenant client");
-        final TenantClientImpl client = new TenantClientImpl(con);
+        final TenantClientImpl client = new TenantClientImpl(connection, sampler);
         if (cacheProvider != null) {
             client.setResponseCache(cacheProvider.getCache(TenantClientImpl.getTargetAddress()));
         }

--- a/client/src/test/java/org/eclipse/hono/client/device/amqp/AmqpAdapterClientFactoryTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/device/amqp/AmqpAdapterClientFactoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.impl.HonoClientUnitTestHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -54,7 +55,7 @@ public class AmqpAdapterClientFactoryTest {
         final ProtonReceiver receiver = HonoClientUnitTestHelper.mockProtonReceiver();
         when(connection.createReceiver(anyString(), any(), any(), any())).thenReturn(Future.succeededFuture(receiver));
 
-        factory = AmqpAdapterClientFactory.create(connection, "my-tenant");
+        factory = AmqpAdapterClientFactory.create(connection, "my-tenant", SendMessageSampler.Factory.noop());
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
@@ -40,6 +40,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.CacheDirective;
@@ -482,7 +483,7 @@ public class AbstractRequestResponseClientTest  {
     private AbstractRequestResponseClient<SimpleRequestResponseResult> getClient(final String tenant, final ProtonSender sender, final ProtonReceiver receiver) {
 
         final HonoConnection connection = HonoClientUnitTestHelper.mockHonoConnection(vertx);
-        return new AbstractRequestResponseClient<SimpleRequestResponseResult>(connection, tenant, sender, receiver) {
+        return new AbstractRequestResponseClient<SimpleRequestResponseResult>(connection, tenant, sender, receiver, SendMessageSampler.noop()) {
 
             @Override
             protected String getName() {

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
@@ -29,6 +29,7 @@ import java.net.HttpURLConnection;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.BeforeEach;
@@ -158,7 +159,8 @@ public class AbstractSenderTest {
                 connection,
                 protonSender,
                 tenantId,
-                targetAddress) {
+                targetAddress,
+                SendMessageSampler.noop()) {
 
             @Override
             public String getEndpoint() {

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.Constants;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +70,8 @@ public class CommandClientImplTest {
                 Constants.DEFAULT_TENANT,
                 REPLY_ID,
                 sender,
-                receiver);
+                receiver,
+                SendMessageSampler.noop());
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/impl/CredentialsClientFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CredentialsClientFactoryImplTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.impl;
 
 import org.eclipse.hono.client.CredentialsClient;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 
 import io.vertx.core.Future;
 
@@ -25,6 +26,7 @@ public class CredentialsClientFactoryImplTest extends AbstractTenantTimeoutRelat
 
     @Override
     protected Future<CredentialsClient> getClientFuture(final HonoConnection connection, final String tenantId) {
-        return new CredentialsClientFactoryImpl(connection, null).getOrCreateCredentialsClient(tenantId);
+        return new CredentialsClientFactoryImpl(connection, null, SendMessageSampler.Factory.noop())
+                .getOrCreateCredentialsClient(tenantId);
     }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/CredentialsClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CredentialsClientImplTest.java
@@ -30,6 +30,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CredentialsConstants;
@@ -92,7 +93,7 @@ public class CredentialsClientImplTest {
 
         sender = HonoClientUnitTestHelper.mockProtonSender();
         cache = mock(ExpiringValueCache.class);
-        client = new CredentialsClientImpl(connection, "tenant", sender, HonoClientUnitTestHelper.mockProtonReceiver());
+        client = new CredentialsClientImpl(connection, "tenant", sender, HonoClientUnitTestHelper.mockProtonReceiver(), SendMessageSampler.noop());
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientFactoryImplTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.impl;
 
 import org.eclipse.hono.client.DeviceConnectionClient;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 
 import io.vertx.core.Future;
 
@@ -26,6 +27,7 @@ public class DeviceConnectionClientFactoryImplTest
 
     @Override
     protected Future<DeviceConnectionClient> getClientFuture(final HonoConnection connection, final String tenantId) {
-        return new DeviceConnectionClientFactoryImpl(connection).getOrCreateDeviceConnectionClient(tenantId);
+        return new DeviceConnectionClientFactoryImpl(connection, SendMessageSampler.Factory.noop())
+                .getOrCreateDeviceConnectionClient(tenantId);
     }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
@@ -29,6 +29,7 @@ import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
@@ -90,7 +91,7 @@ public class DeviceConnectionClientImplTest {
         final HonoConnection connection = HonoClientUnitTestHelper.mockHonoConnection(vertx, config);
         when(connection.getTracer()).thenReturn(tracer);
 
-        client = new DeviceConnectionClientImpl(connection, Constants.DEFAULT_TENANT, sender, receiver);
+        client = new DeviceConnectionClientImpl(connection, Constants.DEFAULT_TENANT, sender, receiver, SendMessageSampler.noop());
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplEventTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplEventTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.impl;
 
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 
 import io.vertx.core.Future;
 
@@ -26,6 +27,6 @@ public class DownstreamSenderFactoryImplEventTest
 
     @Override
     protected Future<DownstreamSender> getClientFuture(final HonoConnection connection, final String tenantId) {
-        return new DownstreamSenderFactoryImpl(connection).getOrCreateEventSender(tenantId);
+        return new DownstreamSenderFactoryImpl(connection, SendMessageSampler.Factory.noop()).getOrCreateEventSender(tenantId);
     }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplTelemetryTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplTelemetryTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.impl;
 
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 
 import io.vertx.core.Future;
 
@@ -26,6 +27,6 @@ public class DownstreamSenderFactoryImplTelemetryTest
 
     @Override
     protected Future<DownstreamSender> getClientFuture(final HonoConnection connection, final String tenantId) {
-        return new DownstreamSenderFactoryImpl(connection).getOrCreateTelemetrySender(tenantId);
+        return new DownstreamSenderFactoryImpl(connection, SendMessageSampler.Factory.noop()).getOrCreateTelemetrySender(tenantId);
     }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,7 +72,7 @@ public class DownstreamSenderFactoryImplTest {
         when(connection.isConnected()).thenReturn(Future.succeededFuture());
         when(connection.isConnected(anyLong())).thenReturn(Future.succeededFuture());
         when(vertx.eventBus()).thenReturn(mock(EventBus.class));
-        factory = new DownstreamSenderFactoryImpl(connection);
+        factory = new DownstreamSenderFactoryImpl(connection, SendMessageSampler.Factory.noop());
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/impl/EventSenderImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/EventSenderImplTest.java
@@ -29,6 +29,7 @@ import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -72,7 +73,7 @@ public class EventSenderImplTest {
 
         // GIVEN a sender that has credit
         when(sender.sendQueueFull()).thenReturn(Boolean.FALSE);
-        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "telemetry/tenant");
+        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "telemetry/tenant", SendMessageSampler.noop());
         final AtomicReference<Handler<ProtonDelivery>> handlerRef = new AtomicReference<>();
         doAnswer(invocation -> {
             handlerRef.set(invocation.getArgument(1));
@@ -104,7 +105,7 @@ public class EventSenderImplTest {
 
         // GIVEN a sender that has credit
         when(sender.sendQueueFull()).thenReturn(Boolean.FALSE);
-        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "telemetry/tenant");
+        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "telemetry/tenant", SendMessageSampler.noop());
         final AtomicReference<Handler<ProtonDelivery>> handlerRef = new AtomicReference<>();
         doAnswer(invocation -> {
             handlerRef.set(invocation.getArgument(1));
@@ -136,7 +137,7 @@ public class EventSenderImplTest {
 
         // GIVEN a sender that has credit
         when(sender.sendQueueFull()).thenReturn(Boolean.TRUE);
-        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "event/tenant");
+        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "event/tenant", SendMessageSampler.noop());
 
         // WHEN trying to send a message
         final Message event = ProtonHelper.message("event/tenant", "hello");
@@ -155,7 +156,7 @@ public class EventSenderImplTest {
 
         // GIVEN a sender that has credit
         when(sender.sendQueueFull()).thenReturn(Boolean.FALSE);
-        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "telemetry/tenant");
+        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "telemetry/tenant", SendMessageSampler.noop());
         when(sender.send(any(Message.class), VertxMockSupport.anyHandler())).thenReturn(mock(ProtonDelivery.class));
 
         // WHEN trying to send a message
@@ -176,7 +177,7 @@ public class EventSenderImplTest {
 
         // GIVEN a sender that has credit
         when(sender.sendQueueFull()).thenReturn(Boolean.FALSE);
-        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "telemetry/tenant");
+        final DownstreamSender messageSender = new EventSenderImpl(connection, sender, "tenant", "telemetry/tenant", SendMessageSampler.noop());
         when(sender.send(any(Message.class), VertxMockSupport.anyHandler())).thenReturn(mock(ProtonDelivery.class));
 
         // WHEN trying to send a message

--- a/client/src/test/java/org/eclipse/hono/client/impl/MappingAndDelegatingCommandHandlerTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/MappingAndDelegatingCommandHandlerTest.java
@@ -40,6 +40,7 @@ import org.eclipse.hono.client.Command;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
@@ -109,7 +110,7 @@ public class MappingAndDelegatingCommandHandlerTest {
         commandTargetMapper = mock(CommandTargetMapper.class);
 
         mappingAndDelegatingCommandHandler = new MappingAndDelegatingCommandHandler(
-                connection, commandTargetMapper, adapterInstanceCommandHandler, adapterInstanceId);
+                connection, commandTargetMapper, adapterInstanceCommandHandler, adapterInstanceId, SendMessageSampler.noop());
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
@@ -36,6 +36,7 @@ import org.eclipse.hono.client.DeviceConnectionClient;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumer;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
@@ -138,7 +139,7 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
         when(devConClient.removeCommandHandlingAdapterInstance(anyString(), anyString(), any()))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
 
-        commandConsumerFactory = new ProtocolAdapterCommandConsumerFactoryImpl(connection);
+        commandConsumerFactory = new ProtocolAdapterCommandConsumerFactoryImpl(connection, SendMessageSampler.Factory.noop());
         commandConsumerFactory.initialize(commandTargetMapper, deviceConnectionClientFactory);
     }
 

--- a/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientFactoryImplTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.impl;
 
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.SendMessageSampler;
 
 import io.vertx.core.Future;
 
@@ -26,6 +27,7 @@ public class RegistrationClientFactoryImplTest
 
     @Override
     protected Future<RegistrationClient> getClientFuture(final HonoConnection connection, final String tenantId) {
-        return new RegistrationClientFactoryImpl(connection, null).getOrCreateRegistrationClient(tenantId);
+        return new RegistrationClientFactoryImpl(connection, null, SendMessageSampler.Factory.noop())
+                .getOrCreateRegistrationClient(tenantId);
     }
 }

--- a/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/RegistrationClientImplTest.java
@@ -30,6 +30,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationConstants;
@@ -94,7 +95,7 @@ public class RegistrationClientImplTest {
         connection = HonoClientUnitTestHelper.mockHonoConnection(vertx, config);
         when(connection.getTracer()).thenReturn(tracer);
 
-        client = new RegistrationClientImpl(connection, "tenant", sender, receiver);
+        client = new RegistrationClientImpl(connection, "tenant", sender, receiver, SendMessageSampler.noop());
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/impl/TelemetrySenderImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/TelemetrySenderImplTest.java
@@ -29,6 +29,7 @@ import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,7 +74,7 @@ public class TelemetrySenderImplTest {
 
         // GIVEN a sender that has credit
         when(sender.sendQueueFull()).thenReturn(Boolean.FALSE);
-        final DownstreamSender messageSender = new TelemetrySenderImpl(connection, sender, "tenant", "telemetry/tenant");
+        final DownstreamSender messageSender = new TelemetrySenderImpl(connection, sender, "tenant", "telemetry/tenant", SendMessageSampler.noop());
         final AtomicReference<Handler<ProtonDelivery>> handlerRef = new AtomicReference<>();
         doAnswer(invocation -> {
             handlerRef.set(invocation.getArgument(1));
@@ -102,7 +103,7 @@ public class TelemetrySenderImplTest {
 
         // GIVEN a sender that has credit
         when(sender.sendQueueFull()).thenReturn(Boolean.TRUE);
-        final DownstreamSender messageSender = new TelemetrySenderImpl(connection, sender, "tenant", "telemetry/tenant");
+        final DownstreamSender messageSender = new TelemetrySenderImpl(connection, sender, "tenant", "telemetry/tenant", SendMessageSampler.noop());
 
         // WHEN trying to send a message
         final Message event = ProtonHelper.message("telemetry/tenant", "hello");
@@ -129,7 +130,7 @@ public class TelemetrySenderImplTest {
             handler.handle(timerId);
             return timerId;
         });
-        final DownstreamSender messageSender = new TelemetrySenderImpl(connection, sender, "tenant", "telemetry/tenant");
+        final DownstreamSender messageSender = new TelemetrySenderImpl(connection, sender, "tenant", "telemetry/tenant", SendMessageSampler.noop());
 
         // WHEN sending a message
         final Message message = mock(Message.class);

--- a/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/TenantClientImplTest.java
@@ -34,6 +34,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.MessageHelper;
@@ -103,7 +104,7 @@ public class TenantClientImplTest {
         when(connection.getTracer()).thenReturn(tracer);
 
         cache = mock(ExpiringValueCache.class);
-        client = new TenantClientImpl(connection, sender, receiver);
+        client = new TenantClientImpl(connection, sender, receiver, SendMessageSampler.noop());
     }
 
     /**

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/devices/AmqpExampleDevice.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/devices/AmqpExampleDevice.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
 import org.eclipse.hono.config.ClientConfigProperties;
@@ -95,7 +96,7 @@ public class AmqpExampleDevice {
     }
 
     private void startDevice(final HonoConnection connection) {
-        factory = AmqpAdapterClientFactory.create(connection, TENANT_ID);
+        factory = AmqpAdapterClientFactory.create(connection, TENANT_ID, SendMessageSampler.Factory.noop());
 
         sendTelemetryMessageWithQos1();
 

--- a/examples/protocol-gateway-example/src/main/java/org/eclipse/hono/example/protocolgateway/Application.java
+++ b/examples/protocol-gateway-example/src/main/java/org/eclipse/hono/example/protocolgateway/Application.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.example.protocolgateway;
 import java.util.Optional;
 
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ServerConfig;
@@ -101,11 +102,13 @@ public class Application {
     /**
      * Exposes a factory for clients for the AMQP adapter as a Spring bean.
      *
+     * @param samplerFactory The sampler factory to use, may be {@link SendMessageSampler.Factory#noop()}
+     * it you don't want sampling.
      * @return The factory.
      */
     @Bean
     @Scope("prototype")
-    public AmqpAdapterClientFactory amqpAdapterClientFactory() {
-        return AmqpAdapterClientFactory.create(amqpAdapterConnection(), amqpAdapterTenant());
+    public AmqpAdapterClientFactory amqpAdapterClientFactory(final SendMessageSampler.Factory samplerFactory) {
+        return AmqpAdapterClientFactory.create(amqpAdapterConnection(), amqpAdapterTenant(), samplerFactory);
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
 import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.AuthenticatingClientConfigProperties;
@@ -82,7 +83,6 @@ public abstract class AbstractAdapterConfig {
      */
     @Bean
     public Tracer getTracer() {
-
         return Optional.ofNullable(TracerResolver.resolveTracer())
                 .orElse(NoopTracerFactory.create());
     }
@@ -179,13 +179,15 @@ public abstract class AbstractAdapterConfig {
      * <p>
      * The factory is initialized with the connection provided by {@link #downstreamConnection()}.
      *
+     * @param samplerFactory The sampler factory to use. Can re-use adapter metrics, based on {@link org.eclipse.hono.service.metric.MicrometerBasedMetrics}
+     * out of the box.
      * @return The factory.
      */
     @Qualifier(Constants.QUALIFIER_MESSAGING)
     @Bean
     @Scope("prototype")
-    public DownstreamSenderFactory downstreamSenderFactory() {
-        return DownstreamSenderFactory.create(downstreamConnection());
+    public DownstreamSenderFactory downstreamSenderFactory(final SendMessageSampler.Factory samplerFactory) {
+        return DownstreamSenderFactory.create(downstreamConnection(), samplerFactory);
     }
 
     /**
@@ -234,13 +236,14 @@ public abstract class AbstractAdapterConfig {
     /**
      * Exposes a factory for creating clients for the <em>Device Registration</em> API as a Spring bean.
      *
+     * @param samplerFactory The sampler factory to use.
      * @return The factory.
      */
     @Bean
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
-    public RegistrationClientFactory registrationClientFactory() {
-        return RegistrationClientFactory.create(registrationServiceConnection(), registrationCacheProvider());
+    public RegistrationClientFactory registrationClientFactory(final SendMessageSampler.Factory samplerFactory) {
+        return RegistrationClientFactory.create(registrationServiceConnection(), registrationCacheProvider(), samplerFactory);
     }
 
     /**
@@ -299,13 +302,14 @@ public abstract class AbstractAdapterConfig {
     /**
      * Exposes a factory for creating clients for the <em>Credentials</em> API as a Spring bean.
      *
+     * @param samplerFactory The sampler factory to use.
      * @return The factory.
      */
     @Bean
     @Qualifier(CredentialsConstants.CREDENTIALS_ENDPOINT)
     @Scope("prototype")
-    public CredentialsClientFactory credentialsClientFactory() {
-        return CredentialsClientFactory.create(credentialsServiceConnection(), credentialsCacheProvider());
+    public CredentialsClientFactory credentialsClientFactory(final SendMessageSampler.Factory samplerFactory) {
+        return CredentialsClientFactory.create(credentialsServiceConnection(), credentialsCacheProvider(), samplerFactory);
     }
 
     /**
@@ -364,13 +368,14 @@ public abstract class AbstractAdapterConfig {
     /**
      * Exposes a factory for creating clients for the <em>Tenant</em> API as a Spring bean.
      *
+     * @param samplerFactory The sampler factory to use.
      * @return The factory.
      */
     @Bean
     @Qualifier(TenantConstants.TENANT_ENDPOINT)
     @Scope("prototype")
-    public TenantClientFactory tenantClientFactory() {
-        return TenantClientFactory.create(tenantServiceConnection(), tenantCacheProvider());
+    public TenantClientFactory tenantClientFactory(final SendMessageSampler.Factory samplerFactory) {
+        return TenantClientFactory.create(tenantServiceConnection(), tenantCacheProvider(), samplerFactory);
     }
 
     /**
@@ -443,14 +448,15 @@ public abstract class AbstractAdapterConfig {
     /**
      * Exposes a factory for creating clients for the <em>Device Connection</em> API as a Spring bean.
      *
+     * @param samplerFactory The sampler factory to use.
      * @return The factory.
      */
     @Bean
     @Qualifier(DeviceConnectionConstants.DEVICE_CONNECTION_ENDPOINT)
     @Scope("prototype")
     @ConditionalOnProperty(prefix = "hono.device-connection", name = "host")
-    public BasicDeviceConnectionClientFactory deviceConnectionClientFactory() {
-        return DeviceConnectionClientFactory.create(deviceConnectionServiceConnection());
+    public BasicDeviceConnectionClientFactory deviceConnectionClientFactory(final SendMessageSampler.Factory samplerFactory) {
+        return DeviceConnectionClientFactory.create(deviceConnectionServiceConnection(), samplerFactory);
     }
 
     /**

--- a/site/documentation/content/admin-guide/monitoring-tracing-config.md
+++ b/site/documentation/content/admin-guide/monitoring-tracing-config.md
@@ -32,7 +32,7 @@ of Maven profiles. The following build profiles are currently supported:
 * `metrics-graphite` – Enables the Graphite backend.
 * `metrics-influxdb` – Enables the InfluxDB backend.
 
-Additionally to selecting a metrics back end, you may need to configure the
+Additionally, to selecting a metrics back end, you may need to configure the
 back end using Spring configuration options. See the documentation mentioned
 above for more information.
 

--- a/site/documentation/content/api/Metrics.md
+++ b/site/documentation/content/api/Metrics.md
@@ -65,7 +65,18 @@ Additional tags for protocol adapters are:
 | *tenant*    | *string*                                           | The identifier of the tenant that the metric is being reported for |
 | *ttd*       | `command`, `expired`, `none`                    | A status indicating the outcome of processing a TTD value contained in a message received from a device.<br>`command` indicates that a command for the device has been included in the response to the device's request for uploading the message.<br>`expired` indicates that a response without a command has been sent to the device.<br>`none` indicates that either no TTD value has been specified by the device or that the protocol adapter does not support it. |
 | *type*      | `telemetry`, `event`                             | The type of (downstream) message that the metric is being reported for. |
+
+Additional tags for *hono.connections.attempts*:
+
+| Name        | Value                                              | Description |
+| ----------- | -------------------------------------------------- | ----------- |
 | *outcome*   | `adapter-disabled`, `connection-duration-exceeded`,<br/>`data-volume-exceeded`, `registration-assertion-failure`,<br/>`succeeded`, `tenant-connections-exceeded`,<br/>`unauthorized`, `unavailable`, `unknown` | The outcome of a device's connection attempt.<br/>`adapter-connections-exceeded` indicates that the maximum number of connections that the adapter instance can handle are exceeded<br/>`adapter-disabled` indicates that the protocol adapter is not enabled for the device's tenant<br/>`connection-duration-exceeded` indicates that the overall amount of time that a tenant's devices may be connected to an adapter has exceeded<br/>`data-volume-exceeded` indicates that the overall amount of data that a tenant's device may transfer per time period has exceeded<br/>`registration-assertion-failure` indicates that the device is either unknown or disabled<br/>`succeeded` indicates a successfully established connection<br/>`tenant-connections-exceeded` indicates that the maximum number of devices that may be connected simultaneously for a tenant has been exceeded<br/>`unauthorized` indicates that the device failed to authenticate<br/>`unavailable` indicates that some of Hono's (required) services are not available<br/>`unknown` indicates an unknown reason. |
+
+Additional tags for *hono.downstream.sent*:
+
+| Name        | Value                                              | Description |
+| ----------- | -------------------------------------------------- | ----------- |
+| *outcome*   | `received`, `accepted`, `rejected`, `released`, `modified`, `declared`, `transactionalState`, and `aborted` | Any of the AMQP 1.0 disposition states, as well as `aborted`, in the case the connection/link was closed before the disposition could be read. | 
 
 Metrics provided by the protocol adapters are:
 
@@ -77,6 +88,9 @@ Metrics provided by the protocol adapters are:
 | *hono.connections.unauthenticated* | Gauge               | *host*, *component-type*, *component-name*                                                   | Current number of connected, unauthenticated devices. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
 | *hono.connections.authenticated.duration* | Timer        | *host*, *component-type*, *component-name*, *tenant*                                         | The overall amount of time that authenticated devices have been connected to protocol adapters. <br/> **NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
 | *hono.connections.attempts*        | Counter             | *host*, *component-type*, *component-name*, *tenant*, *outcome*                              | The number of attempts made by devices to connect to a protocol adapter. The *outcome* tag's value determines if the attempt was successful or not. In the latter case the outcome also indicates the reason for the failure to connect.<br/>**NB** This metric is only supported by protocol adapters that maintain *connection state* with authenticated devices. In particular, the HTTP adapter does not support this metric. |
+| *hono.downstream.full*             | Counter             | *host*, *component-type*, *component-name*, *tenant*, *type*                                 | The number of times a message should be sent, but could not because the sender was out of credit. |
+| *hono.downstream.sent*             | Timer               | *host*, *component-type*, *component-name*, *tenant*, *type*, *outcome*                      | The time it took to send a message and receive the remote peers disposition. |
+| *hono.downstream.timeout*          | Counter             | *host*, *component-type*, *component-name*, *tenant*, *type*                                 | The number of times a message timed out, meaning that no disposition was received in the appropriate amount of time. |
 | *hono.messages.received*           | Timer               | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*, *qos*, *ttd*         | The time it took to process a message conveying telemetry data or an event. |
 | *hono.messages.payload*            | DistributionSummary | *host*, *component-type*, *component-name*, *tenant*, *type*, *status*                       | The number of bytes conveyed in the payload of a telemetry or event message. |
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -14,6 +14,7 @@ title = "Release Notes"
   startup times comparing to the existing one.
 * The LoraWAN protocol adapter has been extended with support for the *Actility Enterprise* provider.
 * The LoraWAN protocol adapter has been extended with support for the *Orbiwise* provider.
+* Added metrics for tracking the RTT between sending an AMQP message to receiving the disposition.
 
 ## 1.3.0
 

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestApplicationClientFactoryImpl.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestApplicationClientFactoryImpl.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.MessageSender;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.impl.ApplicationClientFactoryImpl;
 
 import io.vertx.core.Future;
@@ -35,7 +36,7 @@ public class IntegrationTestApplicationClientFactoryImpl extends ApplicationClie
      * @param connection The connection to Hono.
      */
     public IntegrationTestApplicationClientFactoryImpl(final HonoConnection connection) {
-        super(connection);
+        super(connection, SendMessageSampler.Factory.noop());
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionAmqpIT.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.tests.registry;
 import org.eclipse.hono.client.DeviceConnectionClient;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -51,7 +52,8 @@ public class DeviceConnectionAmqpIT extends DeviceConnectionApiTests {
                         vertx,
                         IntegrationTestSupport.getDeviceConnectionServiceProperties(
                                 IntegrationTestSupport.HONO_USER,
-                                IntegrationTestSupport.HONO_PWD)));
+                                IntegrationTestSupport.HONO_PWD)),
+                SendMessageSampler.Factory.noop());
 
         client.connect().onComplete(ctx.completing());
     }


### PR DESCRIPTION
This change adds functionality to capture the duration of "send message" operations. Focusing on the downstream channel. It captures the times from sending the message, to receiving the message disposition.

It also records "timeout" and "queue full" conditions.