### PR TITLE
Remove IllegalArgumentException where it isn't thrown

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
@@ -66,12 +66,8 @@ public class AmqpContext extends MapBasedTelemetryExecutionContext {
         ctx.message = message;
         ctx.payload = MessageHelper.getPayload(message);
         if (message.getAddress() != null) {
-            try {
-                ctx.address = ResourceIdentifier.fromString(message.getAddress());
-                ctx.endpoint = EndpointType.fromString(ctx.address.getEndpoint());
-            } catch (final IllegalArgumentException e) {
-                // malformed address
-            }
+            ctx.address = ResourceIdentifier.fromString(message.getAddress());
+            ctx.endpoint = EndpointType.fromString(ctx.address.getEndpoint());
         }
         return ctx;
     }

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
@@ -99,16 +99,12 @@ public final class MqttContext extends MapBasedTelemetryExecutionContext {
         result.deviceEndpoint = deviceEndpoint;
         result.authenticatedDevice = authenticatedDevice;
         if (publishedMessage.topicName() != null) {
-            try {
-                Optional.ofNullable(PropertyBag.fromTopic(publishedMessage.topicName()))
-                        .ifPresentOrElse(propertyBag -> {
-                            result.topic = ResourceIdentifier.fromString(propertyBag.topicWithoutPropertyBag());
-                            result.propertyBag = propertyBag;
-                        }, () -> result.topic = ResourceIdentifier.fromString(publishedMessage.topicName()));
-                result.endpoint = MetricsTags.EndpointType.fromString(result.topic.getEndpoint());
-            } catch (final IllegalArgumentException e) {
-                // malformed topic
-            }
+            Optional.ofNullable(PropertyBag.fromTopic(publishedMessage.topicName()))
+                    .ifPresentOrElse(propertyBag -> {
+                        result.topic = ResourceIdentifier.fromString(propertyBag.topicWithoutPropertyBag());
+                        result.propertyBag = propertyBag;
+                    }, () -> result.topic = ResourceIdentifier.fromString(publishedMessage.topicName()));
+            result.endpoint = MetricsTags.EndpointType.fromString(result.topic.getEndpoint());
         }
         return result;
     }

--- a/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
@@ -168,7 +168,6 @@ public final class ResourceIdentifier {
      * @param resource the resource string to parse.
      * @return the resource identifier.
      * @throws NullPointerException if the given string is {@code null}.
-     * @throws IllegalArgumentException if the given string does not represent a valid resource identifier.
      */
     public static ResourceIdentifier fromString(final String resource) {
         Objects.requireNonNull(resource);
@@ -186,7 +185,6 @@ public final class ResourceIdentifier {
      * @param resource the resource string to parse.
      * @return the resource identifier.
      * @throws NullPointerException if the given string is {@code null}.
-     * @throws IllegalArgumentException if the given string does not represent a valid resource identifier.
      */
     public static ResourceIdentifier fromStringAssumingDefaultTenant(final String resource) {
         Objects.requireNonNull(resource);


### PR DESCRIPTION
Removed `IllegalArgumentException` handling concerning `ResourceIdentifier` objects where that exception isn't actually thrown.