### PR TITLE
Use Vert.x WebClient API in integration tests

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/CrudHttpClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/CrudHttpClient.java
@@ -25,20 +25,24 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 
 /**
  * A vert.x based HTTP client for invoking generic CRUD operations on HTTP APIs.
@@ -55,9 +59,9 @@ public final class CrudHttpClient {
     public static final String ORIGIN_URI = "http://hono.eclipse.org";
 
     private final Logger LOGGER = LoggerFactory.getLogger(getClass());
-    private final HttpClient client;
+    private final WebClient client;
     private final Context context;
-    private final HttpClientOptions options;
+    private final WebClientOptions options;
 
     /**
      * Creates a new client for a host and port.
@@ -79,16 +83,9 @@ public final class CrudHttpClient {
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public CrudHttpClient(final Vertx vertx, final HttpClientOptions options) {
-        this.options = Objects.requireNonNull(options);
-        this.client = vertx.createHttpClient(options);
+        this.options = new WebClientOptions(Objects.requireNonNull(options));
+        this.client = WebClient.create(vertx, this.options);
         this.context = vertx.getOrCreateContext();
-    }
-
-    private RequestOptions createRequestOptions() {
-        return new RequestOptions()
-                .setSsl(options.isSsl())
-                .setHost(options.getDefaultHost())
-                .setPort(options.getDefaultPort());
     }
 
     /**
@@ -131,20 +128,23 @@ public final class CrudHttpClient {
         final Promise<MultiMap> result = Promise.promise();
 
         context.runOnContext(go -> {
-            @SuppressWarnings("deprecation")
-            final HttpClientRequest req = client.options(requestOptions)
-                    .handler(response -> {
-                        if (successPredicate.test(response.statusCode())) {
-                            result.tryComplete(response.headers());
-                        } else {
-                            result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
-                        }
-                    }).exceptionHandler(result::tryFail);
-
-                if (requestHeaders != null) {
-                    req.headers().addAll(requestHeaders);
+            final HttpRequest<Buffer> req = client.request(HttpMethod.OPTIONS, requestOptions);
+            if (requestHeaders != null) {
+                req.headers().addAll(requestHeaders);
+            }
+            req.send(ar -> {
+                if (ar.failed()) {
+                    // problem at the network-level
+                    result.tryFail(ar.cause());
+                } else {
+                    final HttpResponse<Buffer> response = ar.result();
+                    if (successPredicate.test(response.statusCode())) {
+                        result.tryComplete(response.headers());
+                    } else {
+                        result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
+                    }
                 }
-                req.end();
+            });
         });
         return result.future();
     }
@@ -161,7 +161,7 @@ public final class CrudHttpClient {
      * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<MultiMap> create(final String uri, final JsonObject body,
-            final Predicate<HttpClientResponse> successPredicate) {
+            final Predicate<HttpResponse<Buffer>> successPredicate) {
         return create(uri, body, CONTENT_TYPE_JSON, successPredicate, false);
     }
 
@@ -177,7 +177,7 @@ public final class CrudHttpClient {
      * @throws NullPointerException if URI, content type or predicate are {@code null}.
      */
     public Future<MultiMap> create(final String uri, final JsonObject body, final String contentType,
-            final Predicate<HttpClientResponse> successPredicate, final boolean checkCorsHeaders) {
+            final Predicate<HttpResponse<Buffer>> successPredicate, final boolean checkCorsHeaders) {
 
         return create(uri,
                 Optional.ofNullable(body).map(json -> json.toBuffer()).orElse(null),
@@ -198,7 +198,7 @@ public final class CrudHttpClient {
      * @throws NullPointerException if URI or predicate are {@code null}.
      */
     public Future<MultiMap> create(final String uri, final Buffer body, final String contentType,
-            final Predicate<HttpClientResponse> successPredicate, final boolean checkCorsHeaders) {
+            final Predicate<HttpResponse<Buffer>> successPredicate, final boolean checkCorsHeaders) {
 
         final MultiMap requestHeaders = Optional.ofNullable(contentType)
                 .map(ct -> MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.CONTENT_TYPE, contentType))
@@ -226,7 +226,7 @@ public final class CrudHttpClient {
             final String uri,
             final Buffer body,
             final MultiMap requestHeaders,
-            final Predicate<HttpClientResponse> successPredicate) {
+            final Predicate<HttpResponse<Buffer>> successPredicate) {
 
         Objects.requireNonNull(uri);
         Objects.requireNonNull(successPredicate);
@@ -254,7 +254,7 @@ public final class CrudHttpClient {
             final RequestOptions requestOptions,
             final Buffer body,
             final MultiMap requestHeaders,
-            final Predicate<HttpClientResponse> successPredicate,
+            final Predicate<HttpResponse<Buffer>> successPredicate,
             final boolean checkCorsHeaders) {
 
         Objects.requireNonNull(requestOptions);
@@ -262,32 +262,36 @@ public final class CrudHttpClient {
 
         final Promise<MultiMap> result = Promise.promise();
 
-        context.runOnContext(go -> {
-            @SuppressWarnings("deprecation")
-            final HttpClientRequest req = client.post(requestOptions)
-                    .handler(response -> {
-                        LOGGER.trace("response status code {}", response.statusCode());
-                        if (successPredicate.test(response)) {
-                            if (checkCorsHeaders) {
-                                checkCorsHeaders(response, result);
-                            }
-                            result.tryComplete(response.headers());
-                        } else {
-                            result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
-                        }
-                    }).exceptionHandler(result::tryFail);
-
-                if (requestHeaders != null) {
-                    req.headers().addAll(requestHeaders);
-                }
-                if (checkCorsHeaders) {
-                    req.headers().add(HttpHeaders.ORIGIN, ORIGIN_URI);
-                }
-                if (body == null) {
-                    req.end();
+        final Handler<AsyncResult<HttpResponse<Buffer>>> handler = ar -> {
+            if (ar.failed()) {
+                result.tryFail(ar.cause());
+            } else {
+                final HttpResponse<Buffer> response = ar.result();
+                LOGGER.trace("response status code {}", response.statusCode());
+                if (successPredicate.test(response)) {
+                    if (checkCorsHeaders) {
+                        checkCorsHeaders(response, result);
+                    }
+                    result.tryComplete(response.headers());
                 } else {
-                    req.end(body);
+                    result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
                 }
+            }
+        };
+
+        context.runOnContext(go -> {
+            final HttpRequest<Buffer> req = client.request(HttpMethod.POST, requestOptions);
+            if (requestHeaders != null) {
+                req.headers().addAll(requestHeaders);
+            }
+            if (checkCorsHeaders) {
+                req.headers().add(HttpHeaders.ORIGIN, ORIGIN_URI);
+            }
+            if (body == null) {
+                req.send(handler);
+            } else {
+                req.sendBuffer(body, handler);
+            }
         });
         return result.future();
     }
@@ -454,31 +458,34 @@ public final class CrudHttpClient {
 
         final Promise<MultiMap> result = Promise.promise();
 
-        context.runOnContext(go -> {
-            @SuppressWarnings("deprecation")
-            final HttpClientRequest req = client.put(requestOptions)
-                    .handler(response -> {
-                        if (successPredicate.test(response.statusCode())) {
-                            if (checkCorsHeaders) {
-                                checkCorsHeaders(response, result);
-                            }
-                            result.tryComplete(response.headers());
-                        } else {
-                            result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
-                        }
-                    }).exceptionHandler(result::tryFail);
-
-                if (requestHeaders != null) {
-                    req.headers().addAll(requestHeaders);
-                }
-                if (checkCorsHeaders) {
-                    req.headers().add(HttpHeaders.ORIGIN, ORIGIN_URI);
-                }
-                if (body == null) {
-                    req.end();
+        final Handler<AsyncResult<HttpResponse<Buffer>>> handler = ar -> {
+            if (ar.failed()) {
+                result.tryFail(ar.cause());
+            } else {
+                final HttpResponse<Buffer> response = ar.result();
+                if (successPredicate.test(response.statusCode())) {
+                    if (checkCorsHeaders) {
+                        checkCorsHeaders(response, result);
+                    }
+                    result.tryComplete(response.headers());
                 } else {
-                    req.end(body);
+                    result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
                 }
+            }
+        };
+        context.runOnContext(go -> {
+            final HttpRequest<Buffer> req = client.request(HttpMethod.PUT, requestOptions);
+            if (requestHeaders != null) {
+                req.headers().addAll(requestHeaders);
+            }
+            if (checkCorsHeaders) {
+                req.headers().add(HttpHeaders.ORIGIN, ORIGIN_URI);
+            }
+            if (body == null) {
+                req.send(handler);
+            } else {
+                req.sendBuffer(body, handler);
+            }
         });
         return result.future();
     }
@@ -516,20 +523,23 @@ public final class CrudHttpClient {
         final Promise<Buffer> result = Promise.promise();
 
         context.runOnContext(go -> {
-            @SuppressWarnings("deprecation")
-            final HttpClientRequest req = client.get(requestOptions)
-            .handler(response -> {
-                if (successPredicate.test(response.statusCode())) {
-                    if (response.statusCode() < 400) {
-                        checkCorsHeaders(response, result);
-                    }
-                    response.bodyHandler(body -> result.tryComplete(body));
-                } else {
-                    result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
-                }
-            }).exceptionHandler(result::tryFail);
+            final HttpRequest<Buffer> req = client.request(HttpMethod.GET, requestOptions);
             req.headers().add(HttpHeaders.ORIGIN, ORIGIN_URI);
-            req.end();
+            req.send(ar -> {
+                if (ar.failed()) {
+                    result.tryFail(ar.cause());
+                } else {
+                    final HttpResponse<Buffer> response = ar.result();
+                    if (successPredicate.test(response.statusCode())) {
+                        if (response.statusCode() < 400) {
+                            checkCorsHeaders(response, result);
+                        }
+                        result.tryComplete(response.body());
+                    } else {
+                        result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
+                    }
+                }
+            });
         });
 
         return result.future();
@@ -567,19 +577,22 @@ public final class CrudHttpClient {
         final Promise<Void> result = Promise.promise();
 
         context.runOnContext(go -> {
-            @SuppressWarnings("deprecation")
-            final HttpClientRequest req = client.delete(requestOptions)
-            .handler(response -> {
-                LOGGER.debug("got response [status: {}]", response.statusCode());
-                if (successPredicate.test(response.statusCode())) {
-                    checkCorsHeaders(response, result);
-                    result.tryComplete();
-                } else {
-                    result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
-                }
-            }).exceptionHandler(result::tryFail);
+            final HttpRequest<Buffer> req = client.request(HttpMethod.DELETE, requestOptions);
             req.headers().add(HttpHeaders.ORIGIN, ORIGIN_URI);
-            req.end();
+            req.send(ar -> {
+                if (ar.failed()) {
+                    result.tryFail(ar.cause());
+                } else {
+                    final HttpResponse<Buffer> response = ar.result();
+                    LOGGER.debug("got response [status: {}]", response.statusCode());
+                    if (successPredicate.test(response.statusCode())) {
+                        checkCorsHeaders(response, result);
+                        result.tryComplete();
+                    } else {
+                        result.tryFail(newUnexpectedResponseStatusException(response.statusCode()));
+                    }
+                }
+            });
         });
 
         return result.future();
@@ -591,7 +604,7 @@ public final class CrudHttpClient {
      * @param response The response to check.
      * @param result the result will fail in case headers are not set
      */
-    private void checkCorsHeaders(final HttpClientResponse response, final Promise<?> result) {
+    private void checkCorsHeaders(final HttpResponse<?> response, final Promise<?> result) {
         final MultiMap headers = response.headers();
         if (!"*".equals(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))) {
             result.fail("Response does not contain proper Access-Control-Allow-Origin header");
@@ -607,6 +620,13 @@ public final class CrudHttpClient {
             return new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
                     "Unexpected response status " + statusCode);
         }
+    }
+
+    private RequestOptions createRequestOptions() {
+        return new RequestOptions()
+                .setSsl(options.isSsl())
+                .setHost(options.getDefaultHost())
+                .setPort(options.getDefaultPort());
     }
 
     @Override


### PR DESCRIPTION
The `HttpClient#handler` API has been deprecated and the deprecation warning suppressed in revision ed756f8f. This patch replaces the usage of the `HttpClient` in the integration tests module with the new `WebClient` API 

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>