### PR TITLE
Update spec. Add missing information.

### DIFF
--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -323,6 +323,8 @@ paths:
                $ref: '#/components/responses/Unauthorized'
             403:
                $ref: '#/components/responses/NotAllowed'
+            404:
+               $ref: '#/components/responses/TenantNotFound'
 
       get:
          tags:
@@ -359,7 +361,8 @@ paths:
             - devices
          summary: Create a new device registration
          description: |
-            Clients use this operation to register a new device with a given identifier.
+            Clients use this operation to register a new device for an existing tenant with
+            a given identifier
          operationId: createDeviceRegistrationWithId
          requestBody:
             description: The configuration properties to register for the device.
@@ -384,6 +387,8 @@ paths:
                $ref: '#/components/responses/NotAllowed'
             409:
                $ref: '#/components/responses/AlreadyExists'
+            404:
+               $ref: '#/components/responses/TenantNotFound'
 
       get:
          tags:
@@ -550,7 +555,7 @@ paths:
             401:
                $ref: '#/components/responses/Unauthorized'
             404:
-               $ref: '#/components/responses/NotFound'
+               $ref: '#/components/responses/DeviceNotFound'
 
       put:
          tags:
@@ -618,7 +623,7 @@ paths:
             403:
                $ref: '#/components/responses/NotAllowed'
             404:
-               $ref: '#/components/responses/NotFound'
+               $ref: '#/components/responses/DeviceNotFound'
             412:
                $ref: '#/components/responses/ResourceVersionMismatch'
 
@@ -1426,6 +1431,28 @@ components:
          description: |
             Object not found. This may also be returned for some operations
             if the user lacks authorization to read the subject of the operation.
+         content:
+            application/json:
+               schema:
+                  $ref: '#/components/schemas/Error'
+
+      TenantNotFound:
+         description: |
+            The referenced tenant could not be found.
+
+            This may also be returned for some operations
+            if the user lacks authorization to read the tenant.
+         content:
+            application/json:
+               schema:
+                  $ref: '#/components/schemas/Error'
+
+      DeviceNotFound:
+         description: |
+            The referenced device could not be found.
+
+            This may also be returned for some operations
+            if the user lacks authorization to read the device.
          content:
             application/json:
                schema:

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -270,8 +270,9 @@ paths:
          summary: Delete tenant
          description: |
             Clients use this operation to remove an existing tenant from the registry.
-            Registry implementations may optionally perform a *cascading* delete of all
-            the tenant's devices and credentials as well.
+
+            When the operation succeeds, the data owned by this tenant (including devices and their
+            credentials) must no longer be accessible. These entities should be reported as *not found*.
          operationId: deleteTenant
          parameters:
             - $ref: '#/components/parameters/resourceVersion'
@@ -494,8 +495,9 @@ paths:
          summary: Delete an existing device registration
          description: |
             Clients use this operation to remove an existing device from the registry.
-            Registry implementations may optionally perform a *cascading* delete of all
-            the device's credentials as well.
+
+            When the operation succeeds, the data owned by this device (including its credentials)
+            must no longer be accessible. These entities should be reported as *not found*.
          operationId: deleteRegistration
          parameters:
             - $ref: '#/components/parameters/resourceVersion'


### PR DESCRIPTION
This corrects a note, making it more explicit that a tenant must exist
when creating a device. It also lists the error code to report in such
cases.