### PR TITLE
Fix sorting of devices during search devices operation in MongoDB device registry

### DIFF
--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/AbstractDeviceManagementSearchDevicesTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/AbstractDeviceManagementSearchDevicesTest.java
@@ -199,12 +199,12 @@ public abstract class AbstractDeviceManagementSearchDevicesTest {
         final int pageSize = 1;
         final int pageOffset = 0;
         final Filter filter = new Filter("/enabled", true);
-        final Sort sortOption = new Sort("/id");
+        final Sort sortOption = new Sort("/ext/id");
 
         sortOption.setDirection(Sort.Direction.desc);
         createDevices(tenantId, Map.of(
-                "testDevice1", new Device().setEnabled(true),
-                "testDevice2", new Device().setEnabled(true)))
+                "testDevice1", new Device().setEnabled(true).setExtensions(Map.of("id", "aaa")),
+                "testDevice2", new Device().setEnabled(true).setExtensions(Map.of("id", "bbb"))))
                         .compose(ok -> getDeviceManagementService()
                                 .searchDevices(tenantId, pageSize, pageOffset, List.of(filter), List.of(sortOption),
                                         NoopSpan.INSTANCE)

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/AbstractDeviceManagementSearchDevicesTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/AbstractDeviceManagementSearchDevicesTest.java
@@ -110,12 +110,13 @@ public abstract class AbstractDeviceManagementSearchDevicesTest {
         final int pageOffset = 0;
         final Filter filter1 = new Filter("/enabled", true);
         final Filter filter2 = new Filter("/via/0", "gw-1");
+        final Filter filter3 = new Filter("/id", "testDevice1");
 
         createDevices(tenantId, Map.of(
                 "testDevice1", new Device().setEnabled(true).setVia(List.of("gw-1")),
                 "testDevice2", new Device().setEnabled(false)))
                         .compose(ok -> getDeviceManagementService()
-                                .searchDevices(tenantId, pageSize, pageOffset, List.of(filter1, filter2),
+                                .searchDevices(tenantId, pageSize, pageOffset, List.of(filter1, filter2, filter3),
                                         List.of(), NoopSpan.INSTANCE)
                                 .onComplete(ctx.succeeding(s -> {
                                     ctx.verify(() -> {

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
@@ -143,12 +143,7 @@ public final class MongoDbDocumentBuilder {
 
         filters.forEach(filter -> {
             // TODO: To implement when filter values contain patterns such as * or %
-            if (FIELD_ID.equals(filter.getField())) {
-                document.put(RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID, filter.getValue());
-            } else {
-                document.put(MongoDbDeviceRegistryUtils.FIELD_DEVICE + filter.getField().toString().replace("/", "."),
-                        filter.getValue());
-            }
+            document.put(mapDeviceField(filter.getField()), filter.getValue());
         });
 
         return this;
@@ -162,16 +157,18 @@ public final class MongoDbDocumentBuilder {
      */
     public MongoDbDocumentBuilder withDeviceSortOptions(final List<Sort> sortOptions) {
 
-        sortOptions.forEach(sortOption -> {
-            if (FIELD_ID.equals(sortOption.getField())) {
-                document.put(RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID,
-                        mapSortingDirection(sortOption.getDirection()));
-            } else {
-                document.put(MongoDbDeviceRegistryUtils.FIELD_DEVICE + "." + sortOption.getField(),
-                        mapSortingDirection(sortOption.getDirection()));
-            }
-        });
+        sortOptions.forEach(sortOption -> document.put(mapDeviceField(sortOption.getField()),
+                mapSortingDirection(sortOption.getDirection())));
+
         return this;
+    }
+
+    private static String mapDeviceField(final JsonPointer field) {
+        if (FIELD_ID.equals(field)) {
+            return RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID;
+        } else {
+            return MongoDbDeviceRegistryUtils.FIELD_DEVICE + field.toString().replace("/", ".");
+        }
     }
 
     private static int mapSortingDirection(final Sort.Direction direction) {


### PR DESCRIPTION
The issue while converting the sorting field of type _JsonPointer_ to _MongoDB_ specific field in `MongoDbDocumentBuilder.withDeviceSortOptions(...)` is fixed with this PR. Also the corresponding test is updated.