### PR TITLE
[#2135] Mark single-tenant mode methods as deprecated

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
@@ -87,7 +87,9 @@ public class ServiceConfigProperties extends ServerConfig {
      * {@link org.eclipse.hono.util.Constants#DEFAULT_TENANT} instead.
      *
      * @return {@code true} if the server is configured to run in single-tenant mode.
+     * @deprecated The single-tenant mode will be removed in Hono 1.5.
      */
+    @Deprecated
     public final boolean isSingleTenant() {
         return singleTenant;
     }
@@ -103,7 +105,9 @@ public class ServiceConfigProperties extends ServerConfig {
      *
      * @param singleTenant {@code true} if the server should support a single tenant only.
      * @return This instance for setter chaining.
+     * @deprecated The single-tenant mode will be removed in Hono 1.5.
      */
+    @Deprecated
     public final ServiceConfigProperties setSingleTenant(final boolean singleTenant) {
         this.singleTenant = singleTenant;
         return this;

--- a/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
@@ -185,7 +185,9 @@ public final class ResourceIdentifier {
      * @param resource the resource string to parse.
      * @return the resource identifier.
      * @throws NullPointerException if the given string is {@code null}.
+     * @deprecated This method will be removed in Hono 1.5.
      */
+    @Deprecated
     public static ResourceIdentifier fromStringAssumingDefaultTenant(final String resource) {
         Objects.requireNonNull(resource);
         return new ResourceIdentifier(resource, true);

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -16,6 +16,12 @@ title = "Release Notes"
 * The LoraWAN protocol adapter has been extended with support for the *Orbiwise* provider.
 * Added metrics for tracking the RTT between sending an AMQP message to receiving the disposition.
 
+### Deprecations
+ 
+ * The configuration property `singleTenant` of the protocol adapters and the device registry is now deprecated
+   and planned to be removed in a future release. The use case of a system with just a single tenant should be
+   realized by configuring just one tenant in the device registry.
+
 ## 1.3.0
 
 ### New Features


### PR DESCRIPTION
This is the first step for #2135.