### PR TITLE
Pass on execution context from Hono AuthHandler to AuthProvider

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterSaslAuthenticatorFactory.java
@@ -50,6 +50,8 @@ import org.eclipse.hono.service.metric.MetricsTags.ConnectionAttemptOutcome;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.AuthenticationConstants;
 import org.eclipse.hono.util.CredentialsConstants;
+import org.eclipse.hono.util.ExecutionContext;
+import org.eclipse.hono.util.GenericExecutionContext;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.TenantObject;
 import org.slf4j.Logger;
@@ -312,7 +314,8 @@ public class AmqpAdapterSaslAuthenticatorFactory implements ProtonSaslAuthentica
             currentSpan.log(items);
 
             final Promise<DeviceUser> authResult = Promise.promise();
-            usernamePasswordAuthProvider.authenticate(credentials, currentSpan.context(), authResult);
+            final ExecutionContext executionContext = new GenericExecutionContext(currentSpan.context());
+            usernamePasswordAuthProvider.authenticate(credentials, executionContext, authResult);
             return authResult.future()
                     .recover(t -> Future.failedFuture(new AuthorizationException(
                             credentials.getTenantId(),
@@ -361,7 +364,8 @@ public class AmqpAdapterSaslAuthenticatorFactory implements ProtonSaslAuthentica
                         final Promise<DeviceUser> authResult = Promise.promise();
                         final SubjectDnCredentials credentials = SubjectDnCredentials.create(tenant.getTenantId(),
                                 deviceCert.getSubjectX500Principal(), clientContext);
-                        clientCertAuthProvider.authenticate(credentials, currentSpan.context(), authResult);
+                        final ExecutionContext executionContext = new GenericExecutionContext(currentSpan.context());
+                        clientCertAuthProvider.authenticate(credentials, executionContext, authResult);
                         return authResult.future()
                                 .recover(t -> Future.failedFuture(new AuthorizationException(
                                         credentials.getTenantId(),

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/ConnectPacketAuthHandler.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/ConnectPacketAuthHandler.java
@@ -22,7 +22,6 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.auth.device.ExecutionContextAuthHandler;
 import org.eclipse.hono.service.auth.device.HonoClientBasedAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
-import org.eclipse.hono.tracing.TracingHelper;
 
 import io.opentracing.Tracer;
 import io.vertx.core.Future;
@@ -98,7 +97,8 @@ public class ConnectPacketAuthHandler extends ExecutionContextAuthHandler<MqttCo
                     .put("username", auth.getUsername())
                     .put("password", auth.getPassword())
                     .put(PROPERTY_CLIENT_IDENTIFIER, context.deviceEndpoint().clientIdentifier());
-            TracingHelper.injectSpanContext(tracer, context.getTracingContext(), credentialsJSON);
+            // spanContext of MqttContext not injected into json here since authenticateDevice(mqttContext) will
+            // pass on the MqttContext as well as the json into authProvider.authenticate()
             result.complete(credentialsJSON);
         }
 

--- a/client/src/main/java/org/eclipse/hono/client/CommandContext.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandContext.java
@@ -24,7 +24,6 @@ import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.MapBasedExecutionContext;
-import org.eclipse.hono.util.QoS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,10 +206,5 @@ public class CommandContext extends MapBasedExecutionContext {
             TracingHelper.logError(currentSpan, "unexpected delivery state: " + deliveryState);
         }
         currentSpan.finish();
-    }
-
-    @Override
-    public QoS getRequestedQos() {
-        return delivery.remotelySettled() ? QoS.AT_MOST_ONCE : QoS.AT_LEAST_ONCE;
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
@@ -65,10 +65,4 @@ public interface ExecutionContext {
      */
     SpanContext getTracingContext();
 
-    /**
-     * Gets the QoS level as set in the request by the device.
-     *
-     * @return The QoS level requested by the device.
-     */
-    QoS getRequestedQos();
 }

--- a/core/src/main/java/org/eclipse/hono/util/GenericExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/GenericExecutionContext.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.util;
+
+import io.opentracing.SpanContext;
+
+/**
+ * A generic execution context that stores properties in a {@code Map}.
+ *
+ */
+public class GenericExecutionContext extends MapBasedExecutionContext {
+
+    /**
+     * Creates a new execution context.
+     */
+    public GenericExecutionContext() {
+        //
+    }
+
+    /**
+     * Creates a new execution context.
+     *
+     * @param spanContext The <em>OpenTracing</em> context to use for tracking the processing of this context.
+     */
+    public GenericExecutionContext(final SpanContext spanContext) {
+        setTracingContext(spanContext);
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/TelemetryExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/TelemetryExecutionContext.java
@@ -38,4 +38,11 @@ public interface TelemetryExecutionContext extends ExecutionContext {
     default boolean isDeviceAuthenticated() {
         return getAuthenticatedDevice() != null;
     }
+
+    /**
+     * Gets the QoS level as set in the request by the device.
+     *
+     * @return The QoS level requested by the device.
+     */
+    QoS getRequestedQos();
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/AuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/AuthHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.hono.util.ExecutionContext;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.AuthProvider;
 
 
 /**
@@ -56,5 +55,5 @@ public interface AuthHandler<T extends ExecutionContext> {
      *
      * @return The provider.
      */
-    AuthProvider getAuthProvider();
+    HonoClientBasedAuthProvider<?> getAuthProvider();
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoClientBasedAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/HonoClientBasedAuthProvider.java
@@ -14,16 +14,15 @@
 package org.eclipse.hono.service.auth.device;
 
 import org.eclipse.hono.service.auth.DeviceUser;
+import org.eclipse.hono.util.ExecutionContext;
 
-import io.opentracing.SpanContext;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AuthProvider;
 
-
 /**
- * An authentication provider for verifying credentials that also supports monitoring by
- * means of health checks.
+ * An authentication provider for verifying credentials.
  *
  * @param <T> The type of credentials that this provider can validate.
  */
@@ -37,10 +36,35 @@ public interface HonoClientBasedAuthProvider<T extends AbstractDeviceCredentials
      *  <a href="https://www.eclipse.org/hono/docs/api/credentials/">Credentials API</a>.
      *
      * @param credentials The credentials provided by the device.
-     * @param spanContext The SpanContext (may be null).
+     * @param executionContext The execution context concerning the request of the device.
      * @param resultHandler The handler to notify about the outcome of the validation. If validation succeeds,
      *                      the result contains an object representing the authenticated device.
-     * @throws NullPointerException if credentials or result handler are {@code null}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    void authenticate(T credentials, SpanContext spanContext, Handler<AsyncResult<DeviceUser>> resultHandler);
+    void authenticate(T credentials, ExecutionContext executionContext, Handler<AsyncResult<DeviceUser>> resultHandler);
+
+    /**
+     * Authenticates a device.
+     * <p>
+     * The first argument is a JSON object containing information for authenticating the device. What this actually
+     * contains depends on the specific implementation. In the case of a simple username/password based authentication
+     * it is likely to contain a JSON object with the following structure:
+     * <pre>
+     *   {
+     *     "username": "tim",
+     *     "password": "mypassword"
+     *   }
+     * </pre>
+     * For other types of authentication it contain different information - for example a JWT token or OAuth bearer
+     * token.
+     * <p>
+     * If the device is successfully authenticated a {@link DeviceUser} object is passed to the handler in an
+     * {@link io.vertx.core.AsyncResult}.
+     *
+     * @param authInfo The auth information.
+     * @param executionContext The execution context concerning the request of the device.
+     * @param resultHandler The result handler.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    void authenticate(JsonObject authInfo, ExecutionContext executionContext, Handler<AsyncResult<DeviceUser>> resultHandler);
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/device/CredentialsApiAuthProviderTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/device/CredentialsApiAuthProviderTest.java
@@ -30,6 +30,7 @@ import org.eclipse.hono.client.CredentialsClient;
 import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.util.CredentialsObject;
+import org.eclipse.hono.util.GenericExecutionContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -138,7 +139,7 @@ public class CredentialsApiAuthProviderTest {
                 .addSecret(CredentialsObject.emptySecret(Instant.now().minusSeconds(120), null));
         when(credentialsClient.get(eq("type"), eq("identity"), any(JsonObject.class), any()))
         .thenReturn(Future.succeededFuture(credentialsOnRecord));
-        provider.authenticate(creds, null, ctx.failing(t -> {
+        provider.authenticate(creds, new GenericExecutionContext(), ctx.failing(t -> {
             // THEN authentication fails with a 401 client error
             ctx.verify(() -> assertThat(((ClientErrorException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED));
             ctx.completeNow();

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProviderTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProviderTest.java
@@ -35,6 +35,7 @@ import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsObject;
+import org.eclipse.hono.util.GenericExecutionContext;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -101,7 +102,7 @@ public class UsernamePasswordAuthProviderTest {
     @Test
     public void testAuthenticateRequiresVertxContext(final VertxTestContext ctx) {
 
-        provider.authenticate(deviceCredentials, null, ctx.failing(e -> {
+        provider.authenticate(deviceCredentials, new GenericExecutionContext(), ctx.failing(e -> {
             ctx.verify(() -> assertThat(e).isInstanceOf(IllegalStateException.class));
             ctx.completeNow();
         }));
@@ -118,7 +119,7 @@ public class UsernamePasswordAuthProviderTest {
 
         final Promise<DeviceUser> result = Promise.promise();
         vertx.runOnContext(go -> {
-            provider.authenticate(deviceCredentials, null, result);
+            provider.authenticate(deviceCredentials, new GenericExecutionContext(), result);
         });
         result.future().onComplete(ctx.succeeding(device -> {
             ctx.verify(() -> {
@@ -142,7 +143,7 @@ public class UsernamePasswordAuthProviderTest {
 
         deviceCredentials = UsernamePasswordCredentials.create("device@DEFAULT_TENANT", "wrong_pwd", false);
         vertx.runOnContext(go -> {
-            provider.authenticate(deviceCredentials, null, result);
+            provider.authenticate(deviceCredentials, new GenericExecutionContext(), result);
         });
         result.future().onComplete(ctx.failing(e -> {
             ctx.verify(() -> assertThat(((ClientErrorException) e).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED));
@@ -162,7 +163,7 @@ public class UsernamePasswordAuthProviderTest {
         givenCredentialsOnRecord(CredentialsObject.fromClearTextPassword("4711", "device", PWD, null, Instant.now().minusSeconds(120)));
         final Promise<DeviceUser> result = Promise.promise();
         vertx.runOnContext(go -> {
-            provider.authenticate(deviceCredentials, null, result);
+            provider.authenticate(deviceCredentials, new GenericExecutionContext(), result);
         });
         result.future().onComplete(ctx.failing(t -> {
             // THEN authentication fails with a 401 client error
@@ -183,7 +184,7 @@ public class UsernamePasswordAuthProviderTest {
         givenCredentialsOnRecord(CredentialsObject.fromClearTextPassword("4711", "device", PWD, Instant.now().plusSeconds(120), null));
         final Promise<DeviceUser> result = Promise.promise();
         vertx.runOnContext(go -> {
-            provider.authenticate(deviceCredentials, null, result);
+            provider.authenticate(deviceCredentials, new GenericExecutionContext(), result);
         });
         result.future().onComplete(ctx.failing(t -> {
             // THEN authentication fails with a 401 client error


### PR DESCRIPTION
The Hono `AuthHandler` (in package `org.eclipse.hono.service.auth.device`) now uses an AuthProvider that also supports working with an `ExecutionContext`. This makes `TraceContext` serialization/deserialization unnecessary in scenarios where a
`HonoClientBasedAuthProvider` is used with such a Hono `AuthHandler`.

This is a preparation for #2115.

As a next step, `HonoClientBasedAuthProvider<T>` should better be renamed to the more generic `DeviceCredentialsAuthProvider<T>` (`ExecutionContextDeviceCredentialsAuthProvider<T>` would be more specific but a bit long).