### PR TITLE
[#2131] Check for tenant existence in device registration operations in MongoDB device registry

### DIFF
--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -31,6 +31,7 @@ import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedRegistrationS
 import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedTenantService;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryAmqpServer;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
+import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantInformationService;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.amqp.AmqpEndpoint;
@@ -296,7 +297,8 @@ public class ApplicationConfig {
         return new MongoDbBasedRegistrationService(
                 vertx(),
                 mongoClient(),
-                registrationServiceProperties());
+                registrationServiceProperties(),
+                tenantInformationService());
     }
 
     /**
@@ -328,6 +330,17 @@ public class ApplicationConfig {
                 mongoClient(),
                 tenantsServiceProperties()
         );
+    }
+
+    /**
+     * Exposes the autowired tenant information service as a Spring bean.
+     *
+     * @return The MongoDB tenant service.
+     */
+    @Bean
+    @Scope("prototype")
+    public AutowiredTenantInformationService tenantInformationService() {
+        return new AutowiredTenantInformationService();
     }
 
     /**

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedDeviceManagementSearchDevicesTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedDeviceManagementSearchDevicesTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
+import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
 import org.eclipse.hono.service.management.device.AbstractDeviceManagementSearchDevicesTest;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.junit.jupiter.api.AfterAll;
@@ -63,7 +64,8 @@ public final class MongoDBBasedDeviceManagementSearchDevicesTest implements Abst
         registrationService = new MongoDbBasedRegistrationService(
                 vertx,
                 mongoClient,
-                config);
+                config,
+                new NoopTenantInformationService());
         registrationService.start().onComplete(testContext.completing());
     }
 

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
+import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
 import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
@@ -79,7 +80,8 @@ public class MongoDbBasedCredentialServiceTest implements AbstractCredentialsSer
         registrationService = new MongoDbBasedRegistrationService(
                 vertx,
                 mongoClient,
-                registrationServiceConfig);
+                registrationServiceConfig,
+                new NoopTenantInformationService());
         deviceBackendService = new MongoDbBasedDeviceBackend(this.registrationService, this.credentialsService);
         credentialsService.start().onSuccess(ok -> started.flag());
         registrationService.start().onSuccess(ok -> started.flag());

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
+import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.registration.RegistrationService;
 import org.eclipse.hono.service.registration.RegistrationServiceTests;
@@ -65,7 +66,8 @@ public class MongoDbBasedRegistrationServiceTest implements RegistrationServiceT
         registrationService = new MongoDbBasedRegistrationService(
                 vertx,
                 mongoClient,
-                config);
+                config,
+                new NoopTenantInformationService());
         registrationService.start().onComplete(testContext.completing());
     }
 


### PR DESCRIPTION
With this PR, while registering devices, the existence of the tenant is now being verified using `TenantInformationService`.