### PR TITLE
Let removeCommandHandlingAdapterInstance return 412 again

### DIFF
--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
@@ -91,7 +91,7 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
             final String adapterInstanceId, final Span span) {
         return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span)
                 .map(removed -> removed ? DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT)
-                        : DeviceConnectionResult.from(HttpURLConnection.HTTP_NOT_FOUND))
+                        : DeviceConnectionResult.from(HttpURLConnection.HTTP_PRECON_FAILED))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
 

--- a/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
+++ b/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
@@ -216,7 +216,7 @@ public class CacheBasedDeviceConnectionServiceTest {
                 .compose(ok -> svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstanceId, span))
                 .onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
-                        assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+                        assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
                         verify(cache).removeCommandHandlingAdapterInstance(eq(Constants.DEFAULT_TENANT), eq(deviceId), eq(adapterInstanceId), any(Span.class));
                     });
                     ctx.completeNow();

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionService.java
@@ -185,7 +185,7 @@ public class MapBasedDeviceConnectionService implements DeviceConnectionService 
         final ExpiringValue<JsonObject> adapterInstanceIdJsonHolder = adapterInstancesForTenantMap.get(deviceId);
         final Promise<DeviceConnectionResult> result = Promise.promise();
         if (adapterInstanceIdJsonHolder == null) {
-            result.complete(DeviceConnectionResult.from(HttpURLConnection.HTTP_NOT_FOUND));
+            result.complete(DeviceConnectionResult.from(HttpURLConnection.HTTP_PRECON_FAILED));
         } else {
             // remove entry only if existing value contains matching adapterInstanceId
             final boolean removed = adapterInstanceId.equals(getAdapterInstanceIdFromJson(adapterInstanceIdJsonHolder.getValue()))

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/deviceconnection/MapBasedDeviceConnectionServiceTest.java
@@ -241,7 +241,7 @@ public class MapBasedDeviceConnectionServiceTest {
         svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, "non-existing", "adapterInstance", span)
                 .onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
-                        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                        assertEquals(HttpURLConnection.HTTP_PRECON_FAILED, result.getStatus());
                         assertNull(result.getPayload());
                     });
                     ctx.completeNow();
@@ -301,7 +301,7 @@ public class MapBasedDeviceConnectionServiceTest {
                     return instancesPromise.future();
                 }).onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
-                        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, result.getStatus());
+                        assertEquals(HttpURLConnection.HTTP_PRECON_FAILED, result.getStatus());
                         assertNull(result.getPayload());
                     });
                     ctx.completeNow();


### PR DESCRIPTION
The recent change towards returning 404 for the "Remove command-handling adapter instance" operation (see #2066) didn't
match the most recent API definition as introduced in #1940. Therefore reverting that change here and again returning 412 instead of 404.

See the corresponding comment in #2066.