### PR TITLE
Fix command delivery not getting released, improve tracing

### DIFF
--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -742,7 +742,8 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                             responseReady,
                             currentSpan));
 
-            return CompositeFuture.join(senderTracker, commandConsumerTracker).compose(ok -> {
+            return CompositeFuture.join(senderTracker, commandConsumerTracker)
+            .compose(ok -> {
                 final DownstreamSender sender = senderTracker.result();
                 final Integer ttd = ttdTracker.result();
                 final Message downstreamMessage = newMessage(
@@ -822,6 +823,10 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
             }).recover(t -> {
                 log.debug("cannot process message for device [tenantId: {}, deviceId: {}, endpoint: {}]",
                         context.getOriginDevice().getTenantId(), context.getOriginDevice().getDeviceId(), endpoint.getCanonicalName(), t);
+                final CommandContext commandContext = context.get(CommandContext.KEY_COMMAND_CONTEXT);
+                if (commandContext != null) {
+                    commandContext.release();
+                }
                 metrics.reportTelemetry(
                         endpoint,
                         context.getOriginDevice().getTenantId(),


### PR DESCRIPTION
This fixes #2155.

The first commit fixes the command delivery potentially not getting updated in the CoAP adapter.
The second commit improves the overall Command & Control related tracing in the CoAP adapter by adopting the corresponding changes done for the HTTP adapter (#2153).