### PR TITLE
Use AuthHandlers for AMQP adapter authentication

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.amqp;
+
+import java.net.HttpURLConnection;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
+import org.eclipse.hono.service.auth.device.ExecutionContextAuthHandler;
+import org.eclipse.hono.service.auth.device.SubjectDnCredentials;
+import org.eclipse.hono.service.auth.device.X509Authentication;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A handler for authenticating an AMQP client using an X.509 client certificate.
+ * <p>
+ * On successful validation of the certificate, its subject DN is used to retrieve
+ * X.509 credentials for the device in order to determine the corresponding device identifier.
+ *
+ */
+public class SaslExternalAuthHandler extends ExecutionContextAuthHandler<SaslResponseContext> {
+
+    private final X509Authentication auth;
+
+    /**
+     * Creates a new handler.
+     *
+     * @param clientAuth The service to use for validating the client's certificate path.
+     * @param authProvider The authentication provider to use for verifying
+     *              the device identity.
+     * @throws NullPointerException if client auth is {@code null}.
+     */
+    public SaslExternalAuthHandler(
+            final X509Authentication clientAuth,
+            final DeviceCredentialsAuthProvider<SubjectDnCredentials> authProvider) {
+        super(authProvider);
+        this.auth = Objects.requireNonNull(clientAuth);
+    }
+
+    /**
+     * Validates a client certificate and extracts credentials from it.
+     * <p>
+     * The JSON object returned will contain
+     * <ul>
+     * <li>the subject DN of the validated client certificate in the
+     * {@link org.eclipse.hono.util.RequestResponseApiConstants#FIELD_PAYLOAD_SUBJECT_DN} property,</li>
+     * <li>the tenant that the device belongs to in the {@link org.eclipse.hono.util.RequestResponseApiConstants#FIELD_PAYLOAD_TENANT_ID}
+     * property</li>
+     * </ul>
+     *
+     * @param context The context containing the SASL response.
+     * @return A future indicating the outcome of the operation.
+     *         The future will succeed with the client's credentials extracted from context
+     *         or it will fail with a {@link org.eclipse.hono.client.ServiceInvocationException} indicating
+     *         the cause of the failure.
+     * @throws NullPointerException if the context is {@code null}.
+     */
+    @Override
+    public Future<JsonObject> parseCredentials(final SaslResponseContext context) {
+
+        Objects.requireNonNull(context);
+
+        final Certificate[] peerCertificateChain = context.getPeerCertificateChain();
+        if (peerCertificateChain == null) {
+            return Future.failedFuture(
+                    new ClientErrorException(HttpURLConnection.HTTP_UNAUTHORIZED, "Missing client certificate"));
+
+        } else if (!(peerCertificateChain[0] instanceof X509Certificate)) {
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_UNAUTHORIZED,
+                    "Only X.509 certificates are supported"));
+        }
+        return auth.validateClientCertificate(peerCertificateChain, context.getTracingContext());
+    }
+}

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslPlainAuthHandler.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslPlainAuthHandler.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.amqp;
+
+import java.util.Objects;
+
+import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
+import org.eclipse.hono.service.auth.device.ExecutionContextAuthHandler;
+import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A handler for authenticating an AMQP client using username and password from the SASL PLAIN response fields.
+ *
+ */
+public class SaslPlainAuthHandler extends ExecutionContextAuthHandler<SaslResponseContext> {
+
+    /**
+     * Creates a new handler for a given auth provider.
+     *
+     * @param authProvider The authentication provider to use for validating device credentials. The given provider
+     *            should support validation of credentials with a username containing the device's tenant
+     *            ({@code auth-id@TENANT}).
+     */
+    public SaslPlainAuthHandler(final DeviceCredentialsAuthProvider<UsernamePasswordCredentials> authProvider) {
+        super(authProvider);
+    }
+
+    /**
+     * Extracts credentials from the SASL PLAIN response fields.
+     * <p>
+     * The JSON object returned will contain
+     * <ul>
+     * <li>a <em>username</em> property containing the value from the <em>authcid</em> field,</li>
+     * <li>a <em>password</em> property containing the value from the <em>passwd</em> field.</li>
+     * </ul>
+     *
+     * @param context The context containing the SASL response.
+     * @return A future indicating the outcome of the operation. The future will succeed with the client's credentials
+     *         extracted from context.
+     * @throws NullPointerException if the context is {@code null}.
+     * @throws IllegalArgumentException if the context does not the response fields.
+     */
+    @Override
+    public Future<JsonObject> parseCredentials(final SaslResponseContext context) {
+        Objects.requireNonNull(context);
+        final String[] saslResponseFields = context.getSaslResponseFields();
+        if (saslResponseFields == null) {
+            throw new IllegalArgumentException("no sasl response fields");
+        }
+        return Future.succeededFuture(new JsonObject()
+                .put("username", saslResponseFields[1]) // represents authcid field
+                .put("password", saslResponseFields[2])); // represents passwd field
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/AuthenticationConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/AuthenticationConstants.java
@@ -131,13 +131,14 @@ public final class AuthenticationConstants {
     /**
      * Parses the SASL response and extracts the authzid, authcid and pwd from the response.
      * <p>
-     * <a href="https://tools.ietf.org/html/rfc4616">The specification for the SASL PLAIN mechanism</a> mandates the format
-     * of the credentials to be of the form: {@code [authzid] UTF8NUL authcid UTF8NUL passwd}.
+     * <a href="https://tools.ietf.org/html/rfc4616">The specification for the SASL PLAIN mechanism</a> mandates the
+     * format of the credentials to be of the form: {@code [authzid] UTF8NUL authcid UTF8NUL passwd}.
      *
      * @param saslResponse The SASL response to parse.
      * @return A String array containing the elements in the SASL response.
      *
-     * @throws CredentialException If one the elements (authzid, authcid and pwd) is missing from the SASL response.
+     * @throws CredentialException If one of the elements (authzid, authcid and pwd) is missing from the SASL response
+     *             or if the authcid or passwd element is empty.
      */
     public static String[] parseSaslResponse(final byte[] saslResponse) throws CredentialException {
         final List<String> fields = new ArrayList<>();

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509Authentication.java
@@ -113,7 +113,7 @@ public final class TenantServiceBasedX509Authentication implements X509Authentic
      * the Tenant service.
      *
      * @param path The certificate path to validate.
-     * @param currentSpan The <em>OpenTracing</em> context in which the
+     * @param spanContext The <em>OpenTracing</em> context in which the
      *                    validation should be executed, or {@code null}
      *                    if no context exists (yet).
      * @return A future indicating the outcome of the validation.
@@ -138,11 +138,11 @@ public final class TenantServiceBasedX509Authentication implements X509Authentic
     @Override
     public Future<JsonObject> validateClientCertificate(
             final Certificate[] path,
-            final SpanContext currentSpan) {
+            final SpanContext spanContext) {
 
         Objects.requireNonNull(path);
 
-        final Span span = TracingHelper.buildChildSpan(tracer, currentSpan, "verify device certificate", getClass().getSimpleName())
+        final Span span = TracingHelper.buildChildSpan(tracer, spanContext, "verify device certificate", getClass().getSimpleName())
                 .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
                 .start();
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509Authentication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509Authentication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -31,7 +31,7 @@ public interface X509Authentication {
      * Validates a certificate path.
      *
      * @param path The certificate path to validate.
-     * @param currentSpan The <em>OpenTracing</em> context in which the
+     * @param spanContext The <em>OpenTracing</em> context in which the
      *                    validation should be executed, or {@code null}
      *                    if no context exists (yet).
      * @return A future indicating the outcome of the validation.
@@ -49,5 +49,5 @@ public interface X509Authentication {
      */
     Future<JsonObject> validateClientCertificate(
             Certificate[] path,
-            SpanContext currentSpan);
+            SpanContext spanContext);
 }


### PR DESCRIPTION
The AMQP adapter authentication handling has been refactored to use `ExecutionContextAuthHandler` instances.
This allows removing duplicate code concerning the parsing of credentials, now done using the existing `CredentialsApiAuthProvider#getCredentials` implementations.

This is a preparation for #2115.