### PR TITLE
[#2115] Add ExecutionContext#getTracingSpan

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslResponseContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslResponseContext.java
@@ -20,7 +20,6 @@ import org.eclipse.hono.util.AuthenticationConstants;
 import org.eclipse.hono.util.MapBasedExecutionContext;
 
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
 import io.vertx.proton.ProtonConnection;
 
 /**
@@ -32,15 +31,14 @@ public final class SaslResponseContext extends MapBasedExecutionContext {
     private final Certificate[] peerCertificateChain;
     private final String[] saslResponseFields;
     private final String remoteMechanism;
-    private final Span span;
 
     private SaslResponseContext(final ProtonConnection protonConnection, final String remoteMechanism,
             final String[] saslResponseFields, final Certificate[] peerCertificateChain, final Span span) {
+        super(span);
         this.protonConnection = Objects.requireNonNull(protonConnection);
         this.remoteMechanism = Objects.requireNonNull(remoteMechanism);
         this.saslResponseFields = saslResponseFields;
         this.peerCertificateChain = peerCertificateChain;
-        this.span = Objects.requireNonNull(span);
     }
 
     /**
@@ -76,17 +74,6 @@ public final class SaslResponseContext extends MapBasedExecutionContext {
         Objects.requireNonNull(span);
         return new SaslResponseContext(protonConnection, AuthenticationConstants.MECHANISM_EXTERNAL, null,
                 peerCertificateChain, span);
-    }
-
-    @Override
-    public SpanContext getTracingContext() {
-        return span.context();
-    }
-
-    @Override
-    public void setTracingContext(final SpanContext spanContext) {
-        // not supported
-        // TODO: this method shall get removed as part of adapting span handling in contexts
     }
 
     /**

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
@@ -30,6 +30,7 @@ import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.TenantObject;
 
 import io.micrometer.core.instrument.Timer.Sample;
+import io.opentracing.Span;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 
@@ -55,8 +56,9 @@ public final class CoapContext extends MapBasedTelemetryExecutionContext {
             final CoapExchange exchange,
             final Device originDevice,
             final Device authenticatedDevice,
-            final String authId) {
-        super(authenticatedDevice);
+            final String authId,
+            final Span span) {
+        super(span, authenticatedDevice);
         this.exchange = exchange;
         this.originDevice = originDevice;
         this.authId = authId;
@@ -70,18 +72,21 @@ public final class CoapContext extends MapBasedTelemetryExecutionContext {
      * @param authenticatedDevice The authenticated device that has uploaded the message or {@code null}
      *                            if the device has not been authenticated.
      * @param authId The authentication identifier of the request or {@code null} if the request is unauthenticated.
+     * @param span The <em>OpenTracing</em> root span that is used to track the processing of this context.
      * @return The context.
-     * @throws NullPointerException if request or origin device are {@code null}.
+     * @throws NullPointerException if request, originDevice or span are {@code null}.
      */
     public static CoapContext fromRequest(
             final CoapExchange request,
             final Device originDevice,
             final Device authenticatedDevice,
-            final String authId) {
+            final String authId,
+            final Span span) {
 
         Objects.requireNonNull(request);
         Objects.requireNonNull(originDevice);
-        return new CoapContext(request, originDevice, authenticatedDevice, authId);
+        Objects.requireNonNull(span);
+        return new CoapContext(request, originDevice, authenticatedDevice, authId, span);
     }
 
     /**
@@ -92,22 +97,25 @@ public final class CoapContext extends MapBasedTelemetryExecutionContext {
      * @param authenticatedDevice The authenticated device that has uploaded the message or {@code null}
      *                            if the device has not been authenticated.
      * @param authId The authentication identifier of the request or {@code null} if the request is unauthenticated.
+     * @param span The <em>OpenTracing</em> root span that is used to track the processing of this context.
      * @param timer The object to use for measuring the time it takes to process the request.
      * @return The context.
-     * @throws NullPointerException if request, origin device or timer are {@code null}.
+     * @throws NullPointerException if request, originDevice, span or timer are {@code null}.
      */
     public static CoapContext fromRequest(
             final CoapExchange request,
             final Device originDevice,
             final Device authenticatedDevice,
             final String authId,
+            final Span span,
             final Sample timer) {
 
         Objects.requireNonNull(request);
         Objects.requireNonNull(originDevice);
+        Objects.requireNonNull(span);
         Objects.requireNonNull(timer);
 
-        final CoapContext result = new CoapContext(request, originDevice, authenticatedDevice, authId);
+        final CoapContext result = new CoapContext(request, originDevice, authenticatedDevice, authId, span);
         result.timer = timer;
         return result;
     }

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResource.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResource.java
@@ -41,8 +41,8 @@ import io.vertx.core.Future;
  * <p>
  * This resource supports processing of {@code POST} and {@code PUT} requests only.
  * For each request, a new OpenTracing {@code Span} is created. The {@code Span} context is
- * associated with the {@link CoapContext} that is created via {@link #createCoapContextForPost(CoapExchange)}
- * or {@link #createCoapContextForPut(CoapExchange)}. The {@link CoapContext} is
+ * associated with the {@link CoapContext} that is created via {@link #createCoapContextForPost(CoapExchange, Span)}
+ * or {@link #createCoapContextForPut(CoapExchange, Span)}. The {@link CoapContext} is
  * then passed in to the {@link #handlePost(CoapContext)} or {@link #handlePut(CoapContext)}
  * method.
  * <p>
@@ -117,12 +117,12 @@ public abstract class TracingSupportingHonoResource extends CoapResource {
         final Future<ResponseCode> responseCode;
         switch (exchange.getRequest().getCode()) {
         case POST:
-            responseCode = createCoapContextForPost(coapExchange)
+            responseCode = createCoapContextForPost(coapExchange, currentSpan)
                     .compose(coapContext -> applyTraceSamplingPriority(coapContext, currentSpan))
                     .compose(this::handlePost);
             break;
         case PUT:
-            responseCode = createCoapContextForPut(coapExchange)
+            responseCode = createCoapContextForPut(coapExchange, currentSpan)
                     .compose(coapContext -> applyTraceSamplingPriority(coapContext, currentSpan))
                     .compose(this::handlePut);
             break;
@@ -150,21 +150,23 @@ public abstract class TracingSupportingHonoResource extends CoapResource {
      * Creates a CoAP context for an incoming POST request.
      *
      * @param coapExchange The CoAP exchange to process.
+     * @param span The <em>OpenTracing</em> root span that is used to track the processing of the created context.
      * @return A future indicating the outcome of processing the request.
      *         The future will be succeeded with the created CoAP context,
      *         otherwise the future will be failed with a {@link org.eclipse.hono.client.ClientErrorException}.
      */
-    protected abstract Future<CoapContext> createCoapContextForPost(CoapExchange coapExchange);
+    protected abstract Future<CoapContext> createCoapContextForPost(CoapExchange coapExchange, Span span);
 
     /**
      * Creates a CoAP context for an incoming PUT request.
      *
      * @param coapExchange The CoAP exchange to process.
+     * @param span The <em>OpenTracing</em> root span that is used to track the processing of the created context.
      * @return A future indicating the outcome of processing the request.
      *         The future will be succeeded with the created CoAP context,
      *         otherwise the future will be failed with a {@link org.eclipse.hono.client.ClientErrorException}.
      */
-    protected abstract Future<CoapContext> createCoapContextForPut(CoapExchange coapExchange);
+    protected abstract Future<CoapContext> createCoapContextForPut(CoapExchange coapExchange, Span span);
 
     /**
      * Applies the trace sampling priority configured for the tenant associated with the
@@ -180,11 +182,10 @@ public abstract class TracingSupportingHonoResource extends CoapResource {
         return tenantObjectWithAuthIdProvider.get(ctx, span.context())
                 .map(tenantObjectWithAuthId -> {
                     TenantTraceSamplingHelper.applyTraceSamplingPriority(tenantObjectWithAuthId, span);
-                    ctx.setTracingContext(span.context());
                     return ctx;
                 })
                 .recover(t -> {
-                    ctx.setTracingContext(span.context());
+                    // do not propagate error here
                     return Future.succeededFuture(ctx);
                 });
     }

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/impl/VertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/impl/VertxBasedCoapAdapter.java
@@ -36,6 +36,7 @@ import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TelemetryConstants;
 
+import io.opentracing.Span;
 import io.vertx.core.Future;
 
 /**
@@ -108,12 +109,13 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
                         authenticatedDevice));
     }
 
-    private CoapContext newContext(final CoapExchange exchange, final RequestDeviceAndAuth deviceAndAuth) {
+    private CoapContext newContext(final CoapExchange exchange, final RequestDeviceAndAuth deviceAndAuth, final Span span) {
         return CoapContext.fromRequest(
                 exchange,
                 deviceAndAuth.getOriginDevice(),
                 deviceAndAuth.getAuthenticatedDevice(),
                 deviceAndAuth.getAuthId(),
+                span,
                 getMetrics().startTimer());
     }
 
@@ -127,13 +129,13 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
         result.add(new TracingSupportingHonoResource(tracer, TelemetryConstants.TELEMETRY_ENDPOINT, getTypeName(), tenantObjectWithAuthIdProvider) {
 
             @Override
-            protected Future<CoapContext> createCoapContextForPost(final CoapExchange exchange) {
-                return getPostRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth));
+            protected Future<CoapContext> createCoapContextForPost(final CoapExchange exchange, final Span span) {
+                return getPostRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth, span));
             }
 
             @Override
-            protected Future<CoapContext> createCoapContextForPut(final CoapExchange exchange) {
-                return getPutRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth));
+            protected Future<CoapContext> createCoapContextForPut(final CoapExchange exchange, final Span span) {
+                return getPutRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth, span));
             }
 
             @Override
@@ -150,13 +152,13 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
         result.add(new TracingSupportingHonoResource(tracer, EventConstants.EVENT_ENDPOINT, getTypeName(), tenantObjectWithAuthIdProvider) {
 
             @Override
-            protected Future<CoapContext> createCoapContextForPost(final CoapExchange exchange) {
-                return getPostRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth));
+            protected Future<CoapContext> createCoapContextForPost(final CoapExchange exchange, final Span span) {
+                return getPostRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth, span));
             }
 
             @Override
-            protected Future<CoapContext> createCoapContextForPut(final CoapExchange exchange) {
-                return getPutRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth));
+            protected Future<CoapContext> createCoapContextForPut(final CoapExchange exchange, final Span span) {
+                return getPutRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth, span));
             }
 
             @Override
@@ -172,13 +174,13 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
         result.add(new TracingSupportingHonoResource(tracer, CommandConstants.COMMAND_RESPONSE_ENDPOINT, getTypeName(), tenantObjectWithAuthIdProvider) {
 
             @Override
-            protected Future<CoapContext> createCoapContextForPost(final CoapExchange exchange) {
-                return getPostRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth));
+            protected Future<CoapContext> createCoapContextForPost(final CoapExchange exchange, final Span span) {
+                return getPostRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth, span));
             }
 
             @Override
-            protected Future<CoapContext> createCoapContextForPut(final CoapExchange exchange) {
-                return getPutRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth));
+            protected Future<CoapContext> createCoapContextForPut(final CoapExchange exchange, final Span span) {
+                return getPutRequestDeviceAndAuth(exchange).map(deviceAndAuth -> newContext(exchange, deviceAndAuth, span));
             }
 
             @Override

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -122,6 +122,7 @@ public class AbstractVertxBasedCoapAdapterTest {
     private CommandTargetMapper commandTargetMapper;
     private ResourceLimitChecks resourceLimitChecks;
     private CoapAdapterMetrics metrics;
+    private Span span;
 
     /**
      * Sets up common fixture.
@@ -135,6 +136,10 @@ public class AbstractVertxBasedCoapAdapterTest {
         config.setAuthenticationRequired(false);
 
         metrics = mock(CoapAdapterMetrics.class);
+
+        span = mock(Span.class);
+        final SpanContext spanContext = mock(SpanContext.class);
+        when(span.context()).thenReturn(spanContext);
 
         regClient = mock(RegistrationClient.class);
         when(regClient.assertRegistration(anyString(), any(), any(SpanContext.class))).thenReturn(Future.succeededFuture(new JsonObject()));
@@ -355,7 +360,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.NON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("my-tenant", "the-device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "the-device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "the-device", span);
 
         adapter.uploadTelemetryMessage(context);
 
@@ -391,7 +396,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.NON, (Integer) null);
         final Device authenticatedDevice = new Device("my-tenant", "the-device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "the-device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "the-device", span);
 
         adapter.uploadTelemetryMessage(context);
 
@@ -427,7 +432,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         // a URI-query option
         final CoapExchange coapExchange = newCoapExchange(null, Type.NON, MediaTypeRegistry.UNDEFINED);
         final Device authenticatedDevice = new Device("my-tenant", "the-device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "the-device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "the-device", span);
 
         adapter.uploadTelemetryMessage(context);
 
@@ -463,7 +468,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         options.addUriQuery(CoapContext.PARAM_EMPTY_CONTENT);
         final CoapExchange coapExchange = newCoapExchange(null, Type.NON, options);
         final Device authenticatedDevice = new Device("my-tenant", "the-device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "the-device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "the-device", span);
 
         adapter.uploadTelemetryMessage(context);
 
@@ -500,7 +505,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.NON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
 
         adapter.uploadTelemetryMessage(context);
 
@@ -538,7 +543,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
 
         adapter.uploadTelemetryMessage(context);
 
@@ -579,7 +584,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
 
         adapter.uploadEventMessage(context);
 
@@ -621,7 +626,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext ctx = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
 
         adapter.uploadEventMessage(ctx);
         verify(sender).sendAndWaitForOutcome(any(Message.class), any(SpanContext.class));
@@ -674,7 +679,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         options.setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, options);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
 
         adapter.uploadTelemetryMessage(context);
 
@@ -724,7 +729,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         options.setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, options);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
 
         adapter.uploadCommandResponseMessage(context);
 
@@ -777,7 +782,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         options.setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, options);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
 
         adapter.uploadCommandResponseMessage(context);
         outcome.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "malformed message"));
@@ -822,7 +827,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         options.setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, options);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext context = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
 
         adapter.uploadCommandResponseMessage(context);
 
@@ -861,7 +866,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.NON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext ctx = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
         adapter.uploadTelemetryMessage(ctx);
 
         // THEN the message is not being forwarded downstream
@@ -901,7 +906,7 @@ public class AbstractVertxBasedCoapAdapterTest {
         final Buffer payload = Buffer.buffer("some payload");
         final CoapExchange coapExchange = newCoapExchange(payload, Type.CON, MediaTypeRegistry.TEXT_PLAIN);
         final Device authenticatedDevice = new Device("tenant", "device");
-        final CoapContext ctx = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device");
+        final CoapContext ctx = CoapContext.fromRequest(coapExchange, authenticatedDevice, authenticatedDevice, "device", span);
         adapter.uploadEventMessage(ctx);
 
         // THEN the message is not being forwarded downstream

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResourceTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResourceTest.java
@@ -89,24 +89,25 @@ public class TracingSupportingHonoResourceTest {
         resource = new TracingSupportingHonoResource(tracer, "test", "adapter", tenantObjectWithAuthIdProvider) {
 
             @Override
-            protected Future<CoapContext> createCoapContextForPost(final CoapExchange coapExchange) {
-                return Future.succeededFuture(createCoapContext(coapExchange));
+            protected Future<CoapContext> createCoapContextForPost(final CoapExchange coapExchange, final Span span) {
+                return Future.succeededFuture(createCoapContext(coapExchange, span));
             }
 
             @Override
-            protected Future<CoapContext> createCoapContextForPut(final CoapExchange coapExchange) {
-                return Future.succeededFuture(createCoapContext(coapExchange));
+            protected Future<CoapContext> createCoapContextForPut(final CoapExchange coapExchange, final Span span) {
+                return Future.succeededFuture(createCoapContext(coapExchange, span));
             }
 
-            @Override protected Future<ResponseCode> handlePost(final CoapContext coapContext) {
+            @Override
+            protected Future<ResponseCode> handlePost(final CoapContext coapContext) {
                 return Future.succeededFuture(ResponseCode.CHANGED);
             }
         };
     }
 
-    private CoapContext createCoapContext(final CoapExchange coapExchange) {
+    private CoapContext createCoapContext(final CoapExchange coapExchange, final Span span) {
         return CoapContext.fromRequest(coapExchange, new Device(TENANT_ID, DEVICE_ID),
-                new Device(TENANT_ID, AUTHENTICATED_DEVICE_ID), AUTH_ID);
+                new Device(TENANT_ID, AUTHENTICATED_DEVICE_ID), AUTH_ID, span);
     }
 
     /**

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -525,12 +525,9 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
     private Future<Device> handleEndpointConnectionWithAuthentication(final MqttEndpoint endpoint,
             final Span currentSpan) {
 
-        final MqttContext context = MqttContext.fromConnectPacket(endpoint);
+        final MqttContext context = MqttContext.fromConnectPacket(endpoint, currentSpan);
         final Future<OptionalInt> traceSamplingPriority = applyTenantTraceSamplingPriority(context, currentSpan);
-        final Future<DeviceUser> authAttempt = traceSamplingPriority.compose(v -> {
-            context.setTracingContext(currentSpan.context());
-            return authenticate(context);
-        });
+        final Future<DeviceUser> authAttempt = traceSamplingPriority.compose(v -> authenticate(context));
         return authAttempt
                 .compose(authenticatedDevice -> CompositeFuture.all(
                         getTenantConfiguration(authenticatedDevice.getTenantId(), currentSpan.context())
@@ -845,25 +842,28 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         }
     }
 
-    void handlePublishedMessage(final MqttContext context) {
+    void handlePublishedMessage(final MqttPublishMessage message, final MqttEndpoint endpoint, final Device authenticatedDevice) {
+
         // try to extract a SpanContext from the property bag of the message's topic (if set)
-        final SpanContext spanContext = Optional.ofNullable(context.propertyBag())
-                .map(propertyBag -> TracingHelper.extractSpanContext(tracer, propertyBag::getPropertiesIterator))
-                .orElse(null);
-        final MqttQoS qos = context.message().qosLevel();
+        final SpanContext spanContext = message.topicName() != null
+                ? Optional.ofNullable(PropertyBag.fromTopic(message.topicName()))
+                .map(propertyBag -> TracingHelper.extractSpanContext(tracer,
+                        propertyBag::getPropertiesIterator))
+                .orElse(null)
+                : null;
+        final MqttQoS qos = message.qosLevel();
         final Span span = TracingHelper.buildChildSpan(tracer, spanContext, "PUBLISH", getTypeName())
-            .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
-            .withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), context.message().topicName())
-            .withTag(TracingHelper.TAG_QOS.getKey(), qos.toString())
-            .withTag(TracingHelper.TAG_CLIENT_ID.getKey(), context.deviceEndpoint().clientIdentifier())
-            .start();
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                .withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), message.topicName())
+                .withTag(TracingHelper.TAG_QOS.getKey(), qos.toString())
+                .withTag(TracingHelper.TAG_CLIENT_ID.getKey(), endpoint.clientIdentifier())
+                .start();
+
+        final MqttContext context = MqttContext.fromPublishPacket(message, endpoint, span, authenticatedDevice);
         context.setTimer(getMetrics().startTimer());
 
         applyTenantTraceSamplingPriority(context, span)
-                .compose(v -> {
-                    context.setTracingContext(span.context());
-                    return checkTopic(context);
-                })
+                .compose(v -> checkTopic(context))
                 .compose(ok -> onPublishedMessage(context))
                 .onComplete(processing -> {
                     if (processing.succeeded()) {
@@ -1593,7 +1593,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         final CommandSubscriptionsManager<T> cmdSubscriptionsManager = new CommandSubscriptionsManager<>(vertx, getConfig());
         endpoint.closeHandler(v -> close(endpoint, authenticatedDevice, cmdSubscriptionsManager, traceSamplingPriority));
         endpoint.publishHandler(
-                message -> handlePublishedMessage(MqttContext.fromPublishPacket(message, endpoint, authenticatedDevice)));
+                message -> handlePublishedMessage(message, endpoint, authenticatedDevice));
         endpoint.publishAcknowledgeHandler(cmdSubscriptionsManager::handlePubAck);
         endpoint.subscribeHandler(subscribeMsg -> onSubscribe(endpoint, authenticatedDevice, subscribeMsg, cmdSubscriptionsManager,
                 traceSamplingPriority));

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/ConnectPacketAuthHandlerTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/ConnectPacketAuthHandlerTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.mqtt.MqttAuth;
@@ -41,6 +43,7 @@ public class ConnectPacketAuthHandlerTest {
 
     private ConnectPacketAuthHandler authHandler;
     private DeviceCredentialsAuthProvider<UsernamePasswordCredentials> authProvider;
+    private Span span;
 
     /**
      * Sets up the fixture.
@@ -50,6 +53,10 @@ public class ConnectPacketAuthHandlerTest {
     public void setUp() {
         authProvider = mock(DeviceCredentialsAuthProvider.class);
         authHandler = new ConnectPacketAuthHandler(authProvider);
+
+        span = mock(Span.class);
+        final SpanContext spanContext = mock(SpanContext.class);
+        when(span.context()).thenReturn(spanContext);
     }
 
     /**
@@ -73,7 +80,7 @@ public class ConnectPacketAuthHandlerTest {
         when(endpoint.auth()).thenReturn(auth);
         when(endpoint.clientIdentifier()).thenReturn("mqtt-device");
 
-        final MqttContext context = MqttContext.fromConnectPacket(endpoint);
+        final MqttContext context = MqttContext.fromConnectPacket(endpoint, span);
         authHandler.parseCredentials(context)
             // THEN the auth info is correctly retrieved from the client certificate
             .onComplete(ctx.succeeding(info -> {

--- a/core/src/main/java/org/eclipse/hono/tracing/SpanContextHolder.java
+++ b/core/src/main/java/org/eclipse/hono/tracing/SpanContextHolder.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tracing;
+
+import java.util.Map;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.tag.Tag;
+
+/**
+ * A {@link Span} implementation whose purpose it is to keep a {@link SpanContext} and provide it via the
+ * {@link #context()} method. All the other methods are no-ops.
+ *
+ */
+public class SpanContextHolder implements Span {
+
+    private final SpanContext spanContext;
+
+    /**
+     * Creates a new SpanContextHolder.
+     * @param spanContext The span context to be returned by the {@link #context()} method.
+     */
+    public SpanContextHolder(final SpanContext spanContext) {
+        this.spanContext = spanContext;
+    }
+
+    @Override
+    public SpanContext context() {
+        return spanContext;
+    }
+
+    // -----------------
+
+    @Override
+    public Span setTag(final String key, final String value) {
+        return this;
+    }
+
+    @Override
+    public Span setTag(final String key, final boolean value) {
+        return this;
+    }
+
+    @Override
+    public Span setTag(final String key, final Number value) {
+        return this;
+    }
+
+    @Override
+    public <T> Span setTag(final Tag<T> tag, final T value) {
+        return this;
+    }
+
+    @Override
+    public Span log(final Map<String, ?> fields) {
+        return this;
+    }
+
+    @Override
+    public Span log(final long timestampMicroseconds, final Map<String, ?> fields) {
+        return this;
+    }
+
+    @Override
+    public Span log(final String event) {
+        return this;
+    }
+
+    @Override
+    public Span log(final long timestampMicroseconds, final String event) {
+        return this;
+    }
+
+    @Override
+    public Span setBaggageItem(final String key, final String value) {
+        return this;
+    }
+
+    @Override
+    public String getBaggageItem(final String key) {
+        return null;
+    }
+
+    @Override
+    public Span setOperationName(final String operationName) {
+        return this;
+    }
+
+    @Override
+    public void finish() {
+        // do nothing
+    }
+
+    @Override
+    public void finish(final long finishMicros) {
+        // do nothing
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.util;
 
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 
 /**
@@ -50,19 +51,19 @@ public interface ExecutionContext {
     void put(String key, Object value);
 
     /**
-     * Sets the <em>OpenTracing</em> context to use for
-     * tracking the processing of this context.
-     *
-     * @param context The context.
-     */
-    void setTracingContext(SpanContext context);
-
-    /**
      * Gets the <em>OpenTracing</em> context that is used to
      * track the processing of this context.
      *
      * @return The context or {@code null} if no tracing context is set.
      */
     SpanContext getTracingContext();
+
+    /**
+     * Gets the <em>OpenTracing</em> root span that is used to
+     * track the processing of this context.
+     *
+     * @return The span or {@code null} if no span is set.
+     */
+    Span getTracingSpan();
 
 }

--- a/core/src/main/java/org/eclipse/hono/util/GenericExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/GenericExecutionContext.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.hono.util;
 
+import org.eclipse.hono.tracing.SpanContextHolder;
+
 import io.opentracing.SpanContext;
 
 /**
@@ -24,7 +26,7 @@ public class GenericExecutionContext extends MapBasedExecutionContext {
      * Creates a new execution context.
      */
     public GenericExecutionContext() {
-        //
+        super(new SpanContextHolder(null));
     }
 
     /**
@@ -33,6 +35,6 @@ public class GenericExecutionContext extends MapBasedExecutionContext {
      * @param spanContext The <em>OpenTracing</em> context to use for tracking the processing of this context.
      */
     public GenericExecutionContext(final SpanContext spanContext) {
-        setTracingContext(spanContext);
+        super(new SpanContextHolder(spanContext));
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/MapBasedTelemetryExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/MapBasedTelemetryExecutionContext.java
@@ -14,6 +14,8 @@ package org.eclipse.hono.util;
 
 import org.eclipse.hono.auth.Device;
 
+import io.opentracing.Span;
+
 /**
  * An execution context that stores properties in a {@code Map}.
  *
@@ -25,10 +27,13 @@ public abstract class MapBasedTelemetryExecutionContext extends MapBasedExecutio
     /**
      * Creates a new context for a message received from a device.
      *
-     * @param authenticatedDevice The authenticated device that has uploaded the message or {@code null}
-     *                            if the device has not been authenticated.
+     * @param span The <em>OpenTracing</em> root span that is used to track the processing of this context.
+     * @param authenticatedDevice The authenticated device that has uploaded the message or {@code null} if the device
+     *            has not been authenticated.
+     * @throws NullPointerException If span is {@code null}.
      */
-    public MapBasedTelemetryExecutionContext(final Device authenticatedDevice) {
+    public MapBasedTelemetryExecutionContext(final Span span, final Device authenticatedDevice) {
+        super(span);
         this.authenticatedDevice = authenticatedDevice;
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
@@ -26,6 +26,7 @@ import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TelemetryExecutionContext;
 
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -38,7 +39,6 @@ import io.vertx.ext.web.RoutingContext;
 public final class HttpContext implements TelemetryExecutionContext {
 
     private final RoutingContext routingContext;
-    private SpanContext spanContext;
 
     private HttpContext(final RoutingContext routingContext) {
         this.routingContext = Objects.requireNonNull(routingContext);
@@ -82,13 +82,14 @@ public final class HttpContext implements TelemetryExecutionContext {
     }
 
     @Override
-    public void setTracingContext(final SpanContext spanContext) {
-        this.spanContext = spanContext;
+    public SpanContext getTracingContext() {
+        return Optional.ofNullable(getTracingSpan()).map(Span::context).orElse(null);
     }
 
     @Override
-    public SpanContext getTracingContext() {
-        return spanContext;
+    public Span getTracingSpan() {
+        final Object spanObject = routingContext.get(TracingHandler.CURRENT_SPAN);
+        return spanObject instanceof Span ? (Span) spanObject : null;
     }
 
     @Override


### PR DESCRIPTION
This is for #2115:
Require the `MapBasedExecutionContext` classes to have a non-null `Span` object. This is a preparation for having the authentication handler classes apply a trace sampling priority on the span of the `ExecutionContext`.