### PR TITLE
[#2175] Accept underscore in auth-id property

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
@@ -120,7 +120,7 @@ public final class CredentialsConstants extends RequestResponseApiConstants {
     /**
      * The regular expression to validate that the auth-id field supplied in credentials is legal.
      */
-    public static final Pattern PATTERN_AUTH_ID_VALUE = Pattern.compile("^[a-zA-Z0-9-=.]+$");
+    public static final Pattern PATTERN_AUTH_ID_VALUE = Pattern.compile("^[a-zA-Z0-9-_=.]+$");
     /**
      * The regular expression to validate that the type field supplied in credentials is legal.
      */

--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -31,6 +31,10 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/X509CertificateCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/X509CertificateCredential.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.hono.util.RegistryManagementConstants;
+import org.eclipse.hono.util.Strings;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -59,6 +60,9 @@ public class X509CertificateCredential extends CommonCredential {
     @Override
     protected Predicate<String> getAuthIdValidator() {
         return authId -> {
+            if (Strings.isNullOrEmpty(authId)) {
+                return false;
+            }
             final X500Principal distinguishedName = new X500Principal(authId);
             return distinguishedName.getName(X500Principal.RFC2253).equals(authId);
         };

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
@@ -63,7 +63,7 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(CredentialsManagementIT.class);
 
-    private static final String PREFIX_AUTH_ID = "sensor20";
+    private static final String PREFIX_AUTH_ID = "my_sensor.20=ext";
     private static final String ORIG_BCRYPT_PWD;
 
     private DeviceRegistryHttpClient registry;


### PR DESCRIPTION
The Device Registry Management API allows the underscore character to be
used in the auth-id property of credentials. The corresponding pattern
used for validating the authId property in the CommonCredential class
has been updated accordingly.