### PR TITLE
Use VertxTestContext checkpoints consistently

### DIFF
--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -196,17 +196,19 @@ public class AbstractVertxBasedCoapAdapterTest {
 
         // GIVEN an adapter
         final CoapServer server = getCoapServer(false);
+        final Checkpoint startupDone = ctx.checkpoint();
         final Checkpoint onStartupSuccess = ctx.checkpoint();
 
-        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(server, true,
-                s -> onStartupSuccess.flag());
-
         // WHEN starting the adapter
+        final AbstractVertxBasedCoapAdapter<CoapAdapterProperties> adapter = getAdapter(
+                server,
+                true,
+                // THEN the onStartupSuccess method has been invoked
+                s -> onStartupSuccess.flag());
         final Promise<Void> startupTracker = Promise.promise();
-        startupTracker.future().onComplete(ctx.completing());
         adapter.start(startupTracker);
 
-        // THEN the onStartupSuccess method has been invoked
+        startupTracker.future().onComplete(ctx.succeeding(v -> startupDone.flag()));
     }
 
     /**

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -215,6 +215,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
 
         // GIVEN an adapter with a client provided http server
         final HttpServer server = getHttpServer(false);
+        final Checkpoint startupDone = ctx.checkpoint();
         final Checkpoint onStartupSuccess = ctx.checkpoint();
 
         // WHEN starting the adapter
@@ -224,8 +225,9 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
                 s -> onStartupSuccess.flag());
 
         final Promise<Void> startupTracker = Promise.promise();
-        startupTracker.future().onComplete(ctx.completing());
         adapter.start(startupTracker);
+
+        startupTracker.future().onComplete(ctx.succeeding(v -> startupDone.flag()));
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -299,6 +299,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
             return;
         }
 
+        final Checkpoint sendCommandsSucceeded = ctx.checkpoint();
         final CountDownLatch commandsSucceeded = new CountDownLatch(totalNoOfCommandsToSend);
         final AtomicInteger commandsSent = new AtomicInteger(0);
         final AtomicLong lastReceivedTimestamp = new AtomicLong(0);
@@ -340,7 +341,7 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         LOGGER.info("commands sent: {}, commands succeeded: {} after {} milliseconds",
                 commandsSent.get(), commandsCompleted, lastReceivedTimestamp.get() - start);
         if (commandsCompleted == commandsSent.get()) {
-            ctx.completeNow();
+            sendCommandsSucceeded.flag();
         } else {
             ctx.failNow(new IllegalStateException("did not complete all commands sent"));
         }


### PR DESCRIPTION
When using `vertxTestContext.checkpoint()`, tests should not rely on `vertxTestContext.completeNow()` to be called as the checkpoints already complete the context.

Otherwise the context might get completed prematurely, causing unexpected behaviour like `@AfterEach`/`@AfterAll` methods getting run before the test method is really finished.