### PR TITLE
[#2180] Fix NPE if ResourceIdentifier string is empty

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
@@ -22,6 +22,7 @@ import org.eclipse.hono.util.MapBasedTelemetryExecutionContext;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.Strings;
 
 import io.micrometer.core.instrument.Timer.Sample;
 import io.opentracing.Span;
@@ -73,7 +74,7 @@ public class AmqpContext extends MapBasedTelemetryExecutionContext {
         ctx.delivery = delivery;
         ctx.message = message;
         ctx.payload = MessageHelper.getPayload(message);
-        if (message.getAddress() != null) {
+        if (!Strings.isNullOrEmpty(message.getAddress())) {
             ctx.address = ResourceIdentifier.fromString(message.getAddress());
             ctx.endpoint = EndpointType.fromString(ctx.address.getEndpoint());
         }

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -1249,21 +1249,10 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
 
     private static Future<ResourceIdentifier> getResourceIdentifier(final Source source) {
 
-        if (source == null) {
+        if (source == null || Strings.isNullOrEmpty(source.getAddress())) {
             return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND, "no such node"));
         } else {
-            final Promise<ResourceIdentifier> result = Promise.promise();
-            try {
-                if (Strings.isNullOrEmpty(source.getAddress())) {
-                    result.fail(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND,
-                            "no such node"));
-                } else {
-                    result.complete(ResourceIdentifier.fromString(source.getAddress()));
-                }
-            } catch (Throwable e) {
-                result.fail(e);
-            }
-            return result.future();
+            return Future.succeededFuture(ResourceIdentifier.fromString(source.getAddress()));
         }
     }
 

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -641,6 +641,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     result = Future.failedFuture(new IllegalArgumentException("unsupported topic filter"));
                 } else if (MqttQoS.EXACTLY_ONCE.equals(subscription.qualityOfService())) {
                     // we do not support subscribing to commands using QoS 2
+                    span.log("ignoring command subscription with unsupported QoS 2");
                     result = Future.failedFuture(new IllegalArgumentException("QoS 2 not supported for command subscription"));
                 } else {
                     result = createCommandConsumer(endpoint, cmdSub, cmdSubscriptionsManager, span).map(consumer -> {

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
@@ -54,6 +54,9 @@ public final class CommandSubscription {
 
     private CommandSubscription(final String topic, final Device authenticatedDevice) {
         this.topic = Objects.requireNonNull(topic);
+        if (topic.isEmpty()) {
+            throw new IllegalArgumentException("topic filter must not be empty");
+        }
         final ResourceIdentifier resource = ResourceIdentifier.fromString(topic);
 
         if (resource.length() != 5 || !"#".equals(resource.elementAt(4))) {

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
@@ -21,6 +21,7 @@ import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.MapBasedTelemetryExecutionContext;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.Strings;
 
 import io.micrometer.core.instrument.Timer.Sample;
 import io.netty.handler.codec.mqtt.MqttQoS;
@@ -104,7 +105,7 @@ public final class MqttContext extends MapBasedTelemetryExecutionContext {
         result.message = publishedMessage;
         result.deviceEndpoint = deviceEndpoint;
         result.authenticatedDevice = authenticatedDevice;
-        if (publishedMessage.topicName() != null) {
+        if (!Strings.isNullOrEmpty(publishedMessage.topicName())) {
             Optional.ofNullable(PropertyBag.fromTopic(publishedMessage.topicName()))
                     .ifPresentOrElse(propertyBag -> {
                         result.topic = ResourceIdentifier.fromString(propertyBag.topicWithoutPropertyBag());

--- a/client/src/main/java/org/eclipse/hono/client/Command.java
+++ b/client/src/main/java/org/eclipse/hono/client/Command.java
@@ -22,6 +22,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.Strings;
 
 import io.vertx.core.buffer.Buffer;
 
@@ -104,7 +105,7 @@ public final class Command {
 
         final StringJoiner validationErrorJoiner = new StringJoiner(", ");
         String originalDeviceId = deviceId;
-        if (message.getAddress() == null) {
+        if (Strings.isNullOrEmpty(message.getAddress())) {
             validationErrorJoiner.add("address is not set");
         } else {
             final ResourceIdentifier addressIdentifier = ResourceIdentifier.fromString(message.getAddress());

--- a/client/src/main/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandler.java
@@ -28,6 +28,7 @@ import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,8 @@ public final class AdapterInstanceCommandHandler {
         Objects.requireNonNull(msg);
         Objects.requireNonNull(delivery);
         // command could have been mapped to a gateway, but the original address stays the same in the message address in that case
-        final ResourceIdentifier resourceIdentifier = msg.getAddress() != null ? ResourceIdentifier.fromString(msg.getAddress()) : null;
+        final ResourceIdentifier resourceIdentifier = Strings.isNullOrEmpty(msg.getAddress()) ? null
+                : ResourceIdentifier.fromString(msg.getAddress());
         if (resourceIdentifier == null || resourceIdentifier.getResourceId() == null) {
             LOG.debug("address of command message is invalid: {}", msg.getAddress());
             final Rejected rejected = new Rejected();

--- a/client/src/main/java/org/eclipse/hono/client/impl/MappingAndDelegatingCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/MappingAndDelegatingCommandHandler.java
@@ -34,6 +34,7 @@ import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,7 +128,7 @@ public class MappingAndDelegatingCommandHandler {
         Objects.requireNonNull(message);
 
         // this is the place where a command message on the "command/${tenant}" address arrives *first*
-        if (message.getAddress() == null) {
+        if (Strings.isNullOrEmpty(message.getAddress())) {
             LOG.debug("command message has no address");
             final Rejected rejected = new Rejected();
             rejected.setError(new ErrorCondition(Constants.AMQP_BAD_REQUEST, "missing command target address"));

--- a/client/src/test/java/org/eclipse/hono/client/CommandResponseTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandResponseTest.java
@@ -14,8 +14,6 @@
 package org.eclipse.hono.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.net.HttpURLConnection;
 
@@ -52,8 +50,8 @@ public class CommandResponseTest {
                 null,
                 null,
                 HttpURLConnection.HTTP_OK);
-        assertNotNull(resp);
-        assertNotNull(resp.toMessage());
+        assertThat(resp).isNotNull();
+        assertThat(resp.toMessage()).isNotNull();
         assertThat(resp.toMessage().getCorrelationId()).isEqualTo(CORRELATION_ID);
         assertThat(resp.getReplyToId()).isEqualTo(REPLY_TO_ID);
     }
@@ -73,11 +71,13 @@ public class CommandResponseTest {
                 null,
                 null,
                 HttpURLConnection.HTTP_OK);
-        assertNotNull(resp.toMessage());
+        assertThat(resp).isNotNull();
+        assertThat(resp.toMessage()).isNotNull();
         assertThat(resp.toMessage().getCorrelationId()).isEqualTo("any");
         assertThat(resp.getReplyToId()).isEqualTo("String");
 
-        assertNull(CommandResponse.from("0ZZanyString", TENANT_ID, DEVICE_ID, null, null, HttpURLConnection.HTTP_OK));
+        assertThat(CommandResponse.from("0ZZanyString", TENANT_ID, DEVICE_ID, null, null, HttpURLConnection.HTTP_OK))
+                .isNull();
     }
 
     /**
@@ -95,11 +95,13 @@ public class CommandResponseTest {
                 null,
                 null,
                 HttpURLConnection.HTTP_OK);
-        assertNotNull(resp.toMessage());
+        assertThat(resp).isNotNull();
+        assertThat(resp.toMessage()).isNotNull();
         assertThat(resp.toMessage().getCorrelationId()).isEqualTo("any");
         assertThat(resp.getReplyToId()).isEqualTo("String");
 
-        assertNull(CommandResponse.from("Z03anyString", TENANT_ID, DEVICE_ID, null, null, HttpURLConnection.HTTP_OK));
+        assertThat(CommandResponse.from("Z03anyString", TENANT_ID, DEVICE_ID, null, null, HttpURLConnection.HTTP_OK))
+                .isNull();
     }
 
     /**
@@ -111,18 +113,19 @@ public class CommandResponseTest {
         // make sure we succeed with a valid status code
         final CommandResponse resp = CommandResponse.from(
                 "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 200);
-        assertNotNull(resp.toMessage());
+        assertThat(resp).isNotNull();
+        assertThat(resp.toMessage()).isNotNull();
         assertThat(resp.toMessage().getCorrelationId()).isEqualTo("one");
         assertThat(resp.getReplyToId()).isEqualTo(DEVICE_ID + "/Two");
 
-        assertNull(CommandResponse.from(
-                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 100));
-        assertNull(CommandResponse.from(
-                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 310));
-        assertNull(CommandResponse.from(
-                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 600));
-        assertNull(CommandResponse.from(
-                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, null));
+        assertThat(CommandResponse.from(
+                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 100)).isNull();
+        assertThat(CommandResponse.from(
+                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 310)).isNull();
+        assertThat(CommandResponse.from(
+                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 600)).isNull();
+        assertThat(CommandResponse.from(
+                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, null)).isNull();
     }
 
     /**
@@ -136,17 +139,18 @@ public class CommandResponseTest {
         // make sure we succeed with valid length
         final CommandResponse resp = CommandResponse.from(
                 String.format("0%02x%s", 4, id), TENANT_ID, DEVICE_ID, null, null, 200);
-        assertNotNull(resp.toMessage());
+        assertThat(resp).isNotNull();
+        assertThat(resp.toMessage()).isNotNull();
         assertThat(resp.toMessage().getCorrelationId()).isEqualTo("this");
         assertThat(resp.getReplyToId()).isEqualTo("IsLessThan255Characters");
 
-        assertNull(CommandResponse.from(
+        assertThat(CommandResponse.from(
                 "1FFthisIsLessThan255Characters",
                 TENANT_ID,
                 DEVICE_ID,
                 null,
                 null,
-                HttpURLConnection.HTTP_OK));
+                HttpURLConnection.HTTP_OK)).isNull();
     }
 
     /**
@@ -162,6 +166,7 @@ public class CommandResponseTest {
                 null,
                 null,
                 HttpURLConnection.HTTP_OK);
+        assertThat(resp).isNotNull();
         assertThat(resp.getReplyToId()).isEqualTo(REPLY_TO_ID_WITH_DEVICE);
     }
 
@@ -178,6 +183,7 @@ public class CommandResponseTest {
                 null,
                 null,
                 HttpURLConnection.HTTP_OK);
+        assertThat(resp).isNotNull();
         assertThat(resp.getReplyToId()).isEqualTo(REPLY_TO_ID);
     }
 
@@ -349,7 +355,8 @@ public class CommandResponseTest {
                 null,
                 null,
                 HttpURLConnection.HTTP_OK);
-        assertNotNull(response.toMessage());
+        assertThat(response).isNotNull();
+        assertThat(response.toMessage()).isNotNull();
         assertThat(MessageHelper.getTenantId(response.toMessage())).isEqualTo(TENANT_ID);
         assertThat(MessageHelper.getDeviceId(response.toMessage())).isEqualTo(DEVICE_ID);
     }

--- a/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
+++ b/core/src/main/java/org/eclipse/hono/util/ResourceIdentifier.java
@@ -165,9 +165,13 @@ public final class ResourceIdentifier {
      * @param resource the resource string to parse.
      * @return the resource identifier.
      * @throws NullPointerException if the given string is {@code null}.
+     * @throws IllegalArgumentException if the given string is empty.
      */
     public static ResourceIdentifier fromString(final String resource) {
         Objects.requireNonNull(resource);
+        if (resource.isEmpty()) {
+            throw new IllegalArgumentException("resource must not be empty");
+        }
         return new ResourceIdentifier(resource);
     }
 

--- a/core/src/test/java/org/eclipse/hono/util/ResourceIdentifierTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/ResourceIdentifierTest.java
@@ -211,4 +211,14 @@ public class ResourceIdentifierTest {
         assertThatThrownBy(() -> ResourceIdentifier.fromPath(new String[]{null, "second", "last"}))
             .isInstanceOf(IllegalArgumentException.class);
     }
+
+    /**
+     * Verifies that a resource identifier cannot be created from
+     * an empty string.
+     */
+    @Test
+    public void testFromStringFailsForEmptyString() {
+        assertThatThrownBy(() -> ResourceIdentifier.fromString(""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -1197,12 +1197,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      *
      * @param qos The QoS level with which the device sent the message to the protocol adapter or {@code null}
      *            if the corresponding <em>qos</em> application property in the AMQP message should not be set.
-     * @param target The target address of the message or {@code null} if the message's
-     *               <em>to</em> property contains the target address. The target
-     *               address is used to determine if the message represents an event or not.
-     *               Determining this information from the <em>to</em> property
-     *               requires additional parsing which can be prevented by passing in the
-     *               target address as a {@code ResourceIdentifier} instead.
+     * @param target The target address of the message. The target address is used to determine if the message
+     *               represents an event or not.
      * @param publishAddress The address that the message has been published to originally by the device or
      *            {@code null} if unknown.
      *            <p>
@@ -1218,7 +1214,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @param timeUntilDisconnect The number of seconds until the device that has published the message will disconnect
      *            from the protocol adapter or {@code null} if unknown.
      * @return The newly created message.
-     * @throws NullPointerException if target or registration info are {@code null}.
+     * @throws NullPointerException if target or registration info is {@code null}.
      */
     protected final Message newMessage(
             final QoS qos,
@@ -1245,12 +1241,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      *
      * @param qos The QoS level with which the device sent the message to the protocol adapter or {@code null}
      *            if the corresponding <em>qos</em> application property in the AMQP message should not be set.
-     * @param target The target address of the message or {@code null} if the message's
-     *               <em>to</em> property contains the target address. The target
-     *               address is used to determine if the message represents an event or not.
-     *               Determining this information from the <em>to</em> property
-     *               requires additional parsing which can be prevented by passing in the
-     *               target address as a {@code ResourceIdentifier} instead.
+     * @param target The target address of the message. The target address is used to determine if the message
+     *               represents an event or not.
      * @param publishAddress The address that the message has been published to originally by the device or
      *            {@code null} if unknown.
      *            <p>
@@ -1268,7 +1260,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @param timeToLive The message's <em>time-to-live</em> as provided by the device or {@code null} if the
      *                   device did not provide any TTL.
      * @return The newly created message.
-     * @throws NullPointerException if registration info is {@code null}.
+     * @throws NullPointerException if target or registration info is {@code null}.
      */
     protected final Message newMessage(
             final QoS qos,
@@ -1368,6 +1360,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      *                   device did not provide any TTL.
      * @return The message with its properties set.
      * @throws NullPointerException if message or registration info are {@code null}.
+     * @throws IllegalArgumentException if target is {@code null} and the message does not have an address set.
      */
     protected final Message addProperties(
             final Message msg,
@@ -1380,7 +1373,6 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             final Duration timeToLive) {
 
         Objects.requireNonNull(msg);
-        Objects.requireNonNull(target);
         Objects.requireNonNull(registrationInfo);
 
         return MessageHelper.addProperties(


### PR DESCRIPTION
This fixes #2180.
Improve error handling by explicitly checking for an empty string when creating a `ResourceIdentifier`.
Fix exception handling and javadoc comments concerning resource addresses.