### PR TITLE
[#2115] Add PreCredentialsValidationHandler (obsolete)

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslExternalAuthHandler.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.ExecutionContextAuthHandler;
+import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
 import org.eclipse.hono.service.auth.device.SubjectDnCredentials;
 import org.eclipse.hono.service.auth.device.X509Authentication;
 
@@ -49,7 +50,26 @@ public class SaslExternalAuthHandler extends ExecutionContextAuthHandler<SaslRes
     public SaslExternalAuthHandler(
             final X509Authentication clientAuth,
             final DeviceCredentialsAuthProvider<SubjectDnCredentials> authProvider) {
-        super(authProvider);
+        this(clientAuth, authProvider, null);
+    }
+
+    /**
+     * Creates a new handler.
+     *
+     * @param clientAuth The service to use for validating the client's certificate path.
+     * @param authProvider The authentication provider to use for verifying
+     *              the device identity.
+     * @param preCredentialsValidationHandler An optional handler to invoke after the credentials got determined and
+     *            before they get validated. Can be used to perform checks using the credentials and tenant information
+     *            before the potentially expensive credentials validation is done. A failed future returned by the
+     *            handler will fail the corresponding authentication attempt.
+     * @throws NullPointerException if client auth is {@code null}.
+     */
+    public SaslExternalAuthHandler(
+            final X509Authentication clientAuth,
+            final DeviceCredentialsAuthProvider<SubjectDnCredentials> authProvider,
+            final PreCredentialsValidationHandler<SaslResponseContext> preCredentialsValidationHandler) {
+        super(authProvider, preCredentialsValidationHandler);
         this.auth = Objects.requireNonNull(clientAuth);
     }
 

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslPlainAuthHandler.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/SaslPlainAuthHandler.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.ExecutionContextAuthHandler;
+import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
 
 import io.vertx.core.Future;
@@ -36,7 +37,23 @@ public class SaslPlainAuthHandler extends ExecutionContextAuthHandler<SaslRespon
      *            ({@code auth-id@TENANT}).
      */
     public SaslPlainAuthHandler(final DeviceCredentialsAuthProvider<UsernamePasswordCredentials> authProvider) {
-        super(authProvider);
+        this(authProvider, null);
+    }
+
+    /**
+     * Creates a new handler for a given auth provider.
+     *
+     * @param authProvider The authentication provider to use for validating device credentials. The given provider
+     *            should support validation of credentials with a username containing the device's tenant
+     *            ({@code auth-id@TENANT}).
+     * @param preCredentialsValidationHandler An optional handler to invoke after the credentials got determined and
+     *            before they get validated. Can be used to perform checks using the credentials and tenant information
+     *            before the potentially expensive credentials validation is done. A failed future returned by the
+     *            handler will fail the corresponding authentication attempt.
+     */
+    public SaslPlainAuthHandler(final DeviceCredentialsAuthProvider<UsernamePasswordCredentials> authProvider,
+            final PreCredentialsValidationHandler<SaslResponseContext> preCredentialsValidationHandler) {
+        super(authProvider, preCredentialsValidationHandler);
     }
 
     /**

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -184,10 +184,11 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                                 .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
                                 .withTag(Tags.COMPONENT.getKey(), getTypeName())
                                 .start(),
-                        new SaslPlainAuthHandler(new UsernamePasswordAuthProvider(getCredentialsClientFactory(), tracer)),
+                        new SaslPlainAuthHandler(new UsernamePasswordAuthProvider(getCredentialsClientFactory(),
+                                getTenantClientFactory(), tracer)),
                         new SaslExternalAuthHandler(
                                 new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
-                                new X509AuthProvider(getCredentialsClientFactory(), tracer)),
+                                new X509AuthProvider(getCredentialsClientFactory(), getTenantClientFactory(), tracer)),
                         (saslResponseContext, span) -> applyTenantTraceSamplingPriority(saslResponseContext, span));
             }
             return Future.succeededFuture();

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
@@ -127,10 +127,10 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
             authHandler.append(new X509AuthHandler(
                     new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
                     Optional.ofNullable(clientCertAuthProvider).orElse(
-                            new X509AuthProvider(getCredentialsClientFactory(), tracer)), tracer));
+                            new X509AuthProvider(getCredentialsClientFactory(), getTenantClientFactory(), tracer)), tracer));
             authHandler.append(new HonoBasicAuthHandler(
                     Optional.ofNullable(usernamePasswordAuthProvider).orElse(
-                            new UsernamePasswordAuthProvider(getCredentialsClientFactory(), tracer)),
+                            new UsernamePasswordAuthProvider(getCredentialsClientFactory(), getTenantClientFactory(), tracer)),
                     getConfig().getRealm(), tracer));
             addTelemetryApiRoutes(router, authHandler);
             addEventApiRoutes(router, authHandler);

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -151,10 +151,10 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
         authHandler.append(new X509AuthHandler(
                 new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
                 Optional.ofNullable(clientCertAuthProvider).orElse(
-                        new X509AuthProvider(getCredentialsClientFactory(), tracer)), tracer));
+                        new X509AuthProvider(getCredentialsClientFactory(), getTenantClientFactory(), tracer)), tracer));
         authHandler.append(new HonoBasicAuthHandler(
                 Optional.ofNullable(usernamePasswordAuthProvider).orElse(
-                        new UsernamePasswordAuthProvider(getCredentialsClientFactory(), tracer)),
+                        new UsernamePasswordAuthProvider(getCredentialsClientFactory(), getTenantClientFactory(), tracer)),
                 getConfig().getRealm(), tracer));
 
         router.route().handler(authHandler);

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -193,10 +193,11 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         return new ChainAuthHandler<MqttContext>()
                 .append(new X509AuthHandler(
                         new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
-                        new X509AuthProvider(getCredentialsClientFactory(), tracer)))
+                        new X509AuthProvider(getCredentialsClientFactory(), getTenantClientFactory(), tracer)))
                 .append(new ConnectPacketAuthHandler(
                         new UsernamePasswordAuthProvider(
                                 getCredentialsClientFactory(),
+                                getTenantClientFactory(),
                                 tracer)));
     }
 

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/ConnectPacketAuthHandler.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/ConnectPacketAuthHandler.java
@@ -20,13 +20,13 @@ import java.util.Objects;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.ExecutionContextAuthHandler;
+import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.mqtt.MqttAuth;
-
 
 /**
  * An auth handler for extracting a username and password from an MQTT CONNECT packet.
@@ -40,7 +40,22 @@ public class ConnectPacketAuthHandler extends ExecutionContextAuthHandler<MqttCo
      * @param authProvider The provider to use for verifying a device's credentials.
      */
     public ConnectPacketAuthHandler(final DeviceCredentialsAuthProvider<UsernamePasswordCredentials> authProvider) {
-        super(authProvider);
+        this(authProvider, null);
+    }
+
+    /**
+     * Creates a new handler for a Hono client based auth provider.
+     *
+     * @param authProvider The provider to use for verifying a device's credentials.
+     * @param preCredentialsValidationHandler An optional handler to invoke after the credentials got determined and
+     *            before they get validated. Can be used to perform checks using the credentials and tenant information
+     *            before the potentially expensive credentials validation is done. A failed future returned by the
+     *            handler will fail the corresponding authentication attempt.
+     */
+    public ConnectPacketAuthHandler(
+            final DeviceCredentialsAuthProvider<UsernamePasswordCredentials> authProvider,
+            final PreCredentialsValidationHandler<MqttContext> preCredentialsValidationHandler) {
+        super(authProvider, preCredentialsValidationHandler);
     }
 
     /**

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/X509AuthHandler.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/X509AuthHandler.java
@@ -23,13 +23,13 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.ExecutionContextAuthHandler;
+import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
 import org.eclipse.hono.service.auth.device.SubjectDnCredentials;
 import org.eclipse.hono.service.auth.device.X509Authentication;
 
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-
 
 /**
  * A handler for authenticating an MQTT client using an X.509 client certificate.
@@ -55,7 +55,26 @@ public class X509AuthHandler extends ExecutionContextAuthHandler<MqttContext> {
     public X509AuthHandler(
             final X509Authentication clientAuth,
             final DeviceCredentialsAuthProvider<SubjectDnCredentials> authProvider) {
-        super(authProvider);
+        this(clientAuth, authProvider, null);
+    }
+
+    /**
+     * Creates a new handler.
+     *
+     * @param clientAuth The service to use for validating the client's certificate path.
+     * @param authProvider The authentication provider to use for verifying
+     *              the device identity.
+     * @param preCredentialsValidationHandler An optional handler to invoke after the credentials got determined and
+     *            before they get validated. Can be used to perform checks using the credentials and tenant information
+     *            before the potentially expensive credentials validation is done. A failed future returned by the
+     *            handler will fail the corresponding authentication attempt.
+     * @throws NullPointerException if client auth is {@code null}.
+     */
+    public X509AuthHandler(
+            final X509Authentication clientAuth,
+            final DeviceCredentialsAuthProvider<SubjectDnCredentials> authProvider,
+            final PreCredentialsValidationHandler<MqttContext> preCredentialsValidationHandler) {
+        super(authProvider, preCredentialsValidationHandler);
         this.auth = Objects.requireNonNull(clientAuth);
     }
 

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -124,7 +124,7 @@ public final class SigfoxProtocolAdapter
 
         authHandler.append(new HonoBasicAuthHandler(
                 Optional.ofNullable(this.usernamePasswordAuthProvider).orElse(
-                        new UsernamePasswordAuthProvider(getCredentialsClientFactory(), this.tracer)),
+                        new UsernamePasswordAuthProvider(getCredentialsClientFactory(), getTenantClientFactory(), this.tracer)),
                 getConfig().getRealm(), this.tracer));
 
         router.route().handler(authHandler);

--- a/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/ExecutionContext.java
@@ -51,6 +51,20 @@ public interface ExecutionContext {
     void put(String key, Object value);
 
     /**
+     * Gets the tenant associated with the device that sent the message.
+     *
+     * @return The tenant object or {@code null} if not set.
+     */
+    TenantObject getTenantObject();
+
+    /**
+     * Sets the tenant associated with the device that sent the message.
+     *
+     * @param tenantObject The tenant object.
+     */
+    void setTenantObject(TenantObject tenantObject);
+
+    /**
      * Gets the <em>OpenTracing</em> context that is used to
      * track the processing of this context.
      *

--- a/core/src/main/java/org/eclipse/hono/util/MapBasedExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/MapBasedExecutionContext.java
@@ -28,6 +28,7 @@ public abstract class MapBasedExecutionContext implements ExecutionContext {
 
     private Map<String, Object> data;
     private final Span span;
+    private TenantObject tenantObject;
 
     /**
      * Creates a new MapBasedExecutionContext instance.
@@ -55,6 +56,16 @@ public abstract class MapBasedExecutionContext implements ExecutionContext {
     @Override
     public final void put(final String key, final Object value) {
         getData().put(key, value);
+    }
+
+    @Override
+    public final TenantObject getTenantObject() {
+        return tenantObject;
+    }
+
+    @Override
+    public final void setTenantObject(final TenantObject tenantObject) {
+        this.tenantObject = tenantObject;
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/ChainAuthHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/ChainAuthHandler.java
@@ -40,11 +40,27 @@ public class ChainAuthHandler<T extends ExecutionContext> extends ExecutionConte
      * Creates a new handler with an empty list of chained handlers.
      */
     public ChainAuthHandler() {
-        super(null);
+        this(null);
+    }
+
+    /**
+     * Creates a new handler with an empty list of chained handlers.
+     *
+     * @param preCredentialsValidationHandler An optional handler to invoke after the credentials got determined and
+     *            before they get validated. Can be used to perform checks using the credentials and tenant information
+     *            before the potentially expensive credentials validation is done. A failed future returned by the
+     *            handler will fail the corresponding authentication attempt.
+     */
+    public ChainAuthHandler(final PreCredentialsValidationHandler<T> preCredentialsValidationHandler) {
+        super(null, preCredentialsValidationHandler);
     }
 
     /**
      * Appends a handler implementing a specific authentication mechanism.
+     * <p>
+     * The {@link #parseCredentials(ExecutionContext)} method and the auth provider of the given handler
+     * will be used in this ChainAuthHandler. Note that the {@link #authenticateDevice(ExecutionContext)} method of
+     * the given handler won't be invoked.
      *
      * @param handler The handler to append.
      * @return This handler for command chaining.

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/CredentialsApiAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/CredentialsApiAuthProvider.java
@@ -22,6 +22,8 @@ import org.eclipse.hono.client.CredentialsClient;
 import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.TenantClient;
+import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CredentialsObject;
@@ -56,17 +58,23 @@ public abstract class CredentialsApiAuthProvider<T extends AbstractDeviceCredent
      */
     protected final Logger log = LoggerFactory.getLogger(getClass());
     private final CredentialsClientFactory credentialsClientFactory;
+    private final TenantClientFactory tenantClientFactory;
     private final Tracer tracer;
 
     /**
-     * Creates a new authentication provider for a credentials client factory.
+     * Creates a new authentication provider for a credentials and tenant client factory.
      *
-     * @param credentialsClientFactory The factory.
+     * @param credentialsClientFactory The credentials client factory.
+     * @param tenantClientFactory The tenant client factory.
      * @param tracer The tracer instance.
-     * @throws NullPointerException if the factory or the tracer are {@code null}
+     * @throws NullPointerException if any of the parameters is null {@code null}
      */
-    public CredentialsApiAuthProvider(final CredentialsClientFactory credentialsClientFactory, final Tracer tracer) {
+    public CredentialsApiAuthProvider(
+            final CredentialsClientFactory credentialsClientFactory,
+            final TenantClientFactory tenantClientFactory,
+            final Tracer tracer) {
         this.credentialsClientFactory = Objects.requireNonNull(credentialsClientFactory);
+        this.tenantClientFactory = Objects.requireNonNull(tenantClientFactory);
         this.tracer = Objects.requireNonNull(tracer);
     }
 
@@ -78,6 +86,15 @@ public abstract class CredentialsApiAuthProvider<T extends AbstractDeviceCredent
      */
     protected final Future<CredentialsClient> getCredentialsClient(final String tenantId) {
         return credentialsClientFactory.getOrCreateCredentialsClient(tenantId);
+    }
+
+    /**
+     * Gets a client for the Tenant service.
+     *
+     * @return A future containing the client.
+     */
+    protected final Future<TenantClient> getTenantClient() {
+        return tenantClientFactory.getOrCreateTenantClient();
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/DeviceCredentialsAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/DeviceCredentialsAuthProvider.java
@@ -66,5 +66,44 @@ public interface DeviceCredentialsAuthProvider<T extends AbstractDeviceCredentia
      * @param resultHandler The result handler.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    void authenticate(JsonObject authInfo, ExecutionContext executionContext, Handler<AsyncResult<DeviceUser>> resultHandler);
+    default void authenticate(
+            final JsonObject authInfo,
+            final ExecutionContext executionContext,
+            final Handler<AsyncResult<DeviceUser>> resultHandler) {
+        authenticate(authInfo, executionContext, resultHandler, null);
+    }
+
+    /**
+     * Authenticates a device.
+     * <p>
+     * The first argument is a JSON object containing information for authenticating the device. What this actually
+     * contains depends on the specific implementation. In the case of a simple username/password based authentication
+     * it is likely to contain a JSON object with the following structure:
+     * <pre>
+     *   {
+     *     "username": "tim",
+     *     "password": "mypassword"
+     *   }
+     * </pre>
+     * For other types of authentication it contain different information - for example a JWT token or OAuth bearer
+     * token.
+     * <p>
+     * If the device is successfully authenticated a {@link DeviceUser} object is passed to the handler in an
+     * {@link io.vertx.core.AsyncResult}.
+     *
+     * @param <S> The ExecutionContext type.
+     * @param authInfo The auth information.
+     * @param executionContext The execution context concerning the request of the device.
+     * @param resultHandler The result handler.
+     * @param preCredentialsValidationHandler An optional handler to invoke after the credentials got determined and
+     *            before they get validated. Can be used to perform checks using the credentials and tenant information
+     *            before the potentially expensive credentials validation is done. A failed future returned by the
+     *            handler will fail the given resultHandler.
+     * @throws NullPointerException if any of the parameters except preCredentialsValidationHandler is {@code null}.
+     */
+    <S extends ExecutionContext> void authenticate(
+            JsonObject authInfo,
+            S executionContext,
+            Handler<AsyncResult<DeviceUser>> resultHandler,
+            PreCredentialsValidationHandler<S> preCredentialsValidationHandler);
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/PreCredentialsValidationHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/PreCredentialsValidationHandler.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.auth.device;
+
+import org.eclipse.hono.util.ExecutionContext;
+
+import io.vertx.core.Future;
+
+/**
+ * Handler to be invoked after credentials got determined and before they get validated.
+ *
+ * @param <T> The type of execution context this handler works with.
+ */
+@FunctionalInterface
+public interface PreCredentialsValidationHandler<T extends ExecutionContext> {
+
+    /**
+     * Invokes the handler.
+     *
+     * @param credentials The credentials
+     * @param executionContext The execution context. It has to be ensured that invoking
+     *              {@link ExecutionContext#getTenantObject()} on the given context doesn't return {@code null}.
+     * @return A future indicating the outcome of the operation.
+     * @throws NullPointerException If any of the parameters is {@code null}.
+     * @throws IllegalArgumentException If the tenant of the executionContext is {@code null}.
+     */
+    Future<Void> handle(DeviceCredentials credentials, T executionContext);
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
@@ -22,6 +22,7 @@ import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.util.CredentialsObject;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -44,18 +45,21 @@ public final class UsernamePasswordAuthProvider extends CredentialsApiAuthProvid
      * Creates a new provider for a given configuration.
      *
      * @param credentialsClientFactory The factory to use for creating a Credentials service client.
+     * @param tenantClientFactory The factory to use for creating a Tenant service client.
      * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
-    public UsernamePasswordAuthProvider(final CredentialsClientFactory credentialsClientFactory, final Tracer tracer) {
-        this(credentialsClientFactory, new SpringBasedHonoPasswordEncoder(), tracer);
+    public UsernamePasswordAuthProvider(final CredentialsClientFactory credentialsClientFactory,
+            final TenantClientFactory tenantClientFactory, final Tracer tracer) {
+        this(credentialsClientFactory, tenantClientFactory, new SpringBasedHonoPasswordEncoder(), tracer);
     }
 
     /**
      * Creates a new provider for a given configuration.
      *
      * @param credentialsClientFactory The factory to use for creating a Credentials service client.
+     * @param tenantClientFactory The factory to use for creating a Tenant service client.
      * @param pwdEncoder The object to use for validating hashed passwords.
      * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
@@ -63,10 +67,11 @@ public final class UsernamePasswordAuthProvider extends CredentialsApiAuthProvid
     @Autowired
     public UsernamePasswordAuthProvider(
             final CredentialsClientFactory credentialsClientFactory,
+            final TenantClientFactory tenantClientFactory,
             final HonoPasswordEncoder pwdEncoder,
             final Tracer tracer) {
 
-        super(credentialsClientFactory, tracer);
+        super(credentialsClientFactory, tenantClientFactory, tracer);
         this.pwdEncoder = Objects.requireNonNull(pwdEncoder);
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,12 +38,16 @@ public class X509AuthProvider extends CredentialsApiAuthProvider<SubjectDnCreden
      * Creates a new provider for a given configuration.
      *
      * @param credentialsClientFactory The factory to use for creating a Credentials service client.
+     * @param tenantClientFactory The factory to use for creating a Tenant service client.
      * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
-    public X509AuthProvider(final CredentialsClientFactory credentialsClientFactory, final Tracer tracer) {
-        super(credentialsClientFactory, tracer);
+    public X509AuthProvider(
+            final CredentialsClientFactory credentialsClientFactory,
+            final TenantClientFactory tenantClientFactory,
+            final Tracer tracer) {
+        super(credentialsClientFactory, tenantClientFactory, tracer);
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
@@ -25,6 +25,7 @@ import org.eclipse.hono.util.ExecutionContext;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TelemetryExecutionContext;
+import org.eclipse.hono.util.TenantObject;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -39,6 +40,7 @@ import io.vertx.ext.web.RoutingContext;
 public final class HttpContext implements TelemetryExecutionContext {
 
     private final RoutingContext routingContext;
+    private TenantObject tenantObject;
 
     private HttpContext(final RoutingContext routingContext) {
         this.routingContext = Objects.requireNonNull(routingContext);
@@ -79,6 +81,16 @@ public final class HttpContext implements TelemetryExecutionContext {
     @Override
     public void put(final String key, final Object value) {
         routingContext.put(key, value);
+    }
+
+    @Override
+    public TenantObject getTenantObject() {
+        return tenantObject;
+    }
+
+    @Override
+    public void setTenantObject(final TenantObject tenantObject) {
+        this.tenantObject = tenantObject;
     }
 
     @Override

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/device/X509AuthProviderTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/device/X509AuthProviderTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.TenantClientFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +40,9 @@ class X509AuthProviderTest {
     @BeforeAll
     static void setUp() {
         final CredentialsClientFactory credentialsClientFactory = mock(CredentialsClientFactory.class);
-        provider = new X509AuthProvider(credentialsClientFactory, NoopTracerFactory.create());
+        final TenantClientFactory tenantClientFactory = mock(TenantClientFactory.class);
+
+        provider = new X509AuthProvider(credentialsClientFactory, tenantClientFactory, NoopTracerFactory.create());
 
     }
 


### PR DESCRIPTION
This is for #2115.

Adds an optional handler to the AuthHandler classes that is invoked before the actual (possibly expensive) credentials validation is performed. This handler can do checks using credentials and TenantObject obtained from the authentication data.