### PR TITLE
[#2064] Make it configurable, if to close the MQTT connection in case of errors or not 

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -53,7 +53,6 @@ import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.AdapterConnectionsExceededException;
-import org.eclipse.hono.service.AdapterDisabledException;
 import org.eclipse.hono.service.auth.device.TenantServiceBasedX509Authentication;
 import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
 import org.eclipse.hono.service.auth.device.X509AuthProvider;
@@ -435,11 +434,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                         checkDeviceRegistration(authenticatedDevice, span.context()),
                         getTenantConfiguration(authenticatedDevice.getTenantId(), span.context())
                                 .compose(tenantConfig -> CompositeFuture.all(
-                                        isAdapterEnabled(tenantConfig).recover(t -> Future.failedFuture(
-                                                new AdapterDisabledException(
-                                                        authenticatedDevice.getTenantId(),
-                                                        "adapter is disabled for tenant",
-                                                        t))),
+                                        isAdapterEnabled(tenantConfig),
                                         checkConnectionLimit(tenantConfig, span.context()))))
                     .map(ok -> {
                         log.debug("{} is registered and enabled", authenticatedDevice);

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -40,6 +40,7 @@ import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.AdapterConnectionsExceededException;
 import org.eclipse.hono.service.AdapterDisabledException;
 import org.eclipse.hono.service.AuthorizationException;
+import org.eclipse.hono.service.RegistrationAssertionException;
 import org.eclipse.hono.service.TenantNotRegisteredException;
 import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.auth.device.AuthHandler;
@@ -905,8 +906,10 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                             // are due to the following reasons:
                             // - The tenant is not registered.
                             // - The tenant or adapter is disabled
+                            // - The device is disabled or not registered.
                             if (tenantObject.isCloseMqttConnectionOnError()
                                     || cause instanceof AdapterDisabledException
+                                    || cause instanceof RegistrationAssertionException
                                     || cause instanceof TenantNotRegisteredException) {
                                 span.log("closing connection to device");
                                 endpoint.close();
@@ -1642,7 +1645,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
 
         if (e instanceof MqttConnectionException) {
             return ((MqttConnectionException) e).code();
-        } else if (e instanceof AdapterDisabledException) {
+        } else if (e instanceof AdapterDisabledException || e instanceof RegistrationAssertionException) {
             return MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED;
         } else if (e instanceof AuthorizationException) {
             if (e instanceof AdapterConnectionsExceededException) {

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -224,6 +224,10 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
     // TENANTS
 
     /**
+     * The default value of the property indicating if a MQTT connection to be closed or not in case of errors.
+     */
+    public static final boolean DEFAULT_CLOSE_MQTT_CONNECTION_ON_ERROR = true;
+    /**
      * The default message size is set to 0, which implies no minimum size is defined.
      */
     public static final int DEFAULT_MINIMUM_MESSAGE_SIZE = 0;
@@ -241,6 +245,11 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      * all devices to authenticate.
      */
     public static final String FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED = "device-authentication-required";
+    /**
+     * The name of the property that contains a boolean indicating if a MQTT connection 
+     * to be closed or not in case of errors.
+     */
+    public static final String FIELD_CLOSE_MQTT_CONNECTION_ON_ERROR = "close-mqtt-connection-on-error";
     /**
      * The name of the property that contains the configuration options to limit 
      * the device connection duration of tenants.

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -67,6 +67,12 @@ public final class TenantConstants extends RequestResponseApiConstants {
     public static final String FIELD_AUTO_PROVISIONING_ENABLED = "auto-provisioning-enabled";
 
     /**
+     * The name of the property that contains a boolean indicating if a MQTT connection 
+     * to be closed or not in case of errors.
+     */
+    public static final String FIELD_CLOSE_MQTT_CONNECTION_ON_ERROR = "close-mqtt-connection-on-error";
+
+    /**
      * The name of the property that contains the configuration options to limit 
      * the device connection duration of tenants.
      */

--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -362,6 +362,17 @@ public final class TenantObject extends JsonBackedValueObject {
     }
 
     /**
+     * Checks whether the MQTT connection of a device belonging to this tenant should be closed in case of errors.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @return if MQTT connection to be closed or not in case of errors.
+     */
+    public boolean isCloseMqttConnectionOnError() {
+        return getProperty(TenantConstants.FIELD_CLOSE_MQTT_CONNECTION_ON_ERROR, Boolean.class, true);
+    }
+
+    /**
      * Gets the maximum number of seconds that a protocol adapter should wait for a command targeted at a device.
      * <p>
      * The returned value is determined as follows:

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -577,7 +577,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      *
      * @param tenantConfig The tenant to check for.
      * @return A succeeded future if this adapter is enabled for the tenant.
-     *         Otherwise the future will be failed with a {@link ClientErrorException}
+     *         Otherwise the future will be failed with a {@link AdapterDisabledException}
      *         containing the 403 Forbidden status code.
      * @throws NullPointerException if tenant config is {@code null}.
      */
@@ -592,8 +592,9 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         } else {
             log.debug("protocol adapter [{}] is disabled for tenant [{}]",
                     getTypeName(), tenantConfig.getTenantId());
-            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN,
-                    "adapter disabled for tenant"));
+            return Future.failedFuture(
+                    new AdapterDisabledException(tenantConfig.getTenantId(), HttpURLConnection.HTTP_FORBIDDEN,
+                            "adapter disabled for tenant"));
         }
     }
 
@@ -1670,10 +1671,9 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     public static ConnectionAttemptOutcome getOutcome(final Throwable e) {
 
-        if (e instanceof AuthorizationException) {
-            if (e instanceof AdapterDisabledException) {
-                return ConnectionAttemptOutcome.ADAPTER_DISABLED;
-            }
+        if (e instanceof AdapterDisabledException) {
+            return ConnectionAttemptOutcome.ADAPTER_DISABLED;
+        } else if (e instanceof AuthorizationException) {
             if (e instanceof AdapterConnectionsExceededException) {
                 return ConnectionAttemptOutcome.ADAPTER_CONNECTIONS_EXCEEDED;
             }

--- a/service-base/src/main/java/org/eclipse/hono/service/AdapterDisabledException.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AdapterDisabledException.java
@@ -14,33 +14,25 @@
 
 package org.eclipse.hono.service;
 
+import org.eclipse.hono.client.ClientErrorException;
+
 /**
  * An exception indicating that a protocol adapter is disabled for the tenant
  * that a device belongs to.
  *
  */
-public class AdapterDisabledException extends AuthorizationException {
+public class AdapterDisabledException extends ClientErrorException {
 
     private static final long serialVersionUID = 1L;
 
     /**
-     * Creates a new exception for a tenant and a detail message.
+     * Creates a new exception for a tenant, an error code and a detail message.
      *
      * @param tenant The tenant that the device belongs to or {@code null} if unknown.
+     * @param errorCode The code representing the erroneous outcome.
      * @param msg The detail message.
      */
-    public AdapterDisabledException(final String tenant, final String msg) {
-        this(tenant, msg, null);
-    }
-
-    /**
-     * Creates a new exception for a tenant, a detail message and a root cause.
-     *
-     * @param tenant The tenant that the device belongs to or {@code null} if unknown.
-     * @param msg The detail message.
-     * @param cause The root cause.
-     */
-    public AdapterDisabledException(final String tenant, final String msg, final Throwable cause) {
-        super(tenant, msg, cause);
+    public AdapterDisabledException(final String tenant, final int errorCode, final String msg) {
+        super(tenant, errorCode, msg);
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/RegistrationAssertionException.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/RegistrationAssertionException.java
@@ -14,33 +14,24 @@
 
 package org.eclipse.hono.service;
 
+import org.eclipse.hono.client.ClientErrorException;
+
 /**
- * An exception indicating that a device's attempt to establish a connection
- * with a protocol adapter has failed because the device is either unknown
+ * An exception indicating that the device is either unknown
  * or disabled.
  */
-public class RegistrationAssertionException extends AuthorizationException {
+public class RegistrationAssertionException extends ClientErrorException {
 
     private static final long serialVersionUID = 1L;
 
     /**
-     * Creates a new exception for tenant and a detail message.
+     * Creates a new exception for a tenant, an error code and a root cause.
      *
      * @param tenant The tenant that the device belongs to or {@code null} if unknown.
-     * @param msg The detail message.
-     */
-    public RegistrationAssertionException(final String tenant, final String msg) {
-        this(tenant, msg, null);
-    }
-
-    /**
-     * Creates a new exception for a tenant, a detail message and a root cause.
-     *
-     * @param tenant The tenant that the device belongs to or {@code null} if unknown.
-     * @param msg The detail message.
+     * @param errorCode The code representing the erroneous outcome.
      * @param cause The root cause.
      */
-    public RegistrationAssertionException(final String tenant, final String msg, final Throwable cause) {
-        super(tenant, msg, cause);
+    public RegistrationAssertionException(final String tenant, final int errorCode, final Throwable cause) {
+        super(tenant, errorCode, cause);
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/TenantNotRegisteredException.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/TenantNotRegisteredException.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.service;
+
+import org.eclipse.hono.client.ClientErrorException;
+
+/**
+ * An exception indicating that the tenant is not registered.
+ */
+public class TenantNotRegisteredException extends ClientErrorException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new exception for a tenant, an error code and a root cause.
+     *
+     * @param tenant The tenant that the device belongs to or {@code null} if unknown.
+     * @param errorCode The code representing the erroneous outcome.
+     * @param cause The root cause.
+     */
+    public TenantNotRegisteredException(final String tenant, final int errorCode, final Throwable cause) {
+        super(tenant, errorCode, cause);
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
@@ -59,6 +59,9 @@ public class Tenant {
     @JsonInclude(Include.NON_EMPTY)
     private List<Adapter> adapters = new LinkedList<>();
 
+    @JsonProperty(RegistryManagementConstants.FIELD_CLOSE_MQTT_CONNECTION_ON_ERROR)
+    private Boolean closeMqttConnectionOnError;
+
     @JsonProperty(RegistryManagementConstants.FIELD_MINIMUM_MESSAGE_SIZE)
     @JsonInclude(Include.NON_DEFAULT)
     private int minimumMessageSize = RegistryManagementConstants.DEFAULT_MINIMUM_MESSAGE_SIZE;
@@ -242,6 +245,33 @@ public class Tenant {
                     String.format("Already an adapter of the type [%s] exists", configuration.getType()));
         }
         adapters.add(configuration);
+        return this;
+    }
+
+    /**
+     * Checks whether the MQTT connection of a device belonging to this tenant should be closed in case of errors.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @return if MQTT connection to be closed or not in case of errors.
+     */
+    @JsonIgnore
+    public boolean isCloseMqttConnectionOnError() {
+        return Optional.ofNullable(closeMqttConnectionOnError)
+                .orElse(RegistryManagementConstants.DEFAULT_CLOSE_MQTT_CONNECTION_ON_ERROR);
+    }
+
+    /**
+     * Sets whether the MQTT connection of a device belonging to this tenant should be closed in case of errors.
+     * <p>
+     * The default value of this property is {@code true}.
+     *
+     * @param closeMqttConnectionOnError if MQTT connection to be closed or not in case of errors.
+     * @return This instance, to allow chained invocations.
+     */
+    @JsonIgnore
+    public Tenant setCloseMqttConnectionOnError(final boolean closeMqttConnectionOnError) {
+        this.closeMqttConnectionOnError = closeMqttConnectionOnError;
         return this;
     }
 

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
@@ -249,6 +249,31 @@ public class TenantTest {
     }
 
     /**
+     * Decode tenant with "close-mqtt-connection-on-error=false".
+     */
+    @Test
+    public void testDecodeWithCloseMqttConnectionOnError() {
+        final var tenant = new JsonObject()
+                .put(RegistryManagementConstants.FIELD_CLOSE_MQTT_CONNECTION_ON_ERROR, false)
+                .mapTo(Tenant.class);
+
+        assertNotNull(tenant);
+        assertEquals(false, tenant.isCloseMqttConnectionOnError());
+    }
+
+    /**
+     * Decode Tenant without setting "close-mqtt-connection-on-error".
+     */
+    @Test
+    public void testDecodeWithoutCloseMqttConnectionOnError() {
+        final var tenant = new JsonObject().mapTo(Tenant.class);
+
+        assertNotNull(tenant);
+        assertEquals(RegistryManagementConstants.DEFAULT_CLOSE_MQTT_CONNECTION_ON_ERROR,
+                tenant.isCloseMqttConnectionOnError());
+    }
+
+    /**
      * Decode tenant with "minimum-message-size=4096".
      */
     @Test
@@ -405,6 +430,19 @@ public class TenantTest {
         assertNotNull(json);
         assertFalse(json.getBoolean(RegistryManagementConstants.FIELD_ENABLED));
         assertNull(json.getJsonObject(RegistryManagementConstants.FIELD_EXT));
+    }
+
+    /**
+     * Encode tenant with "close-mqtt-connection-on-error=false".
+     */
+    @Test
+    public void testEncodeCloseMqttConnectionOnError() {
+        final var tenant = new Tenant();
+        tenant.setCloseMqttConnectionOnError(false);
+        final JsonObject json = JsonObject.mapFrom(tenant);
+
+        assertNotNull(json);
+        assertEquals(false, json.getBoolean(RegistryManagementConstants.FIELD_CLOSE_MQTT_CONNECTION_ON_ERROR));
     }
 
     /**


### PR DESCRIPTION
This PR introduces a new tenant level configuration property, which is used by the _MQTT_ adapter. When a message published by a device to the _MQTT_ adapter could not be processed, the adapter makes use of this property to decide if to close the _MQTT_ connection or not.

Irrespective of the property set to _true_ or _false_, the connection will be closed in case of the following situations.
- The tenant is not registered.
- The tenant or adapter is disabled.
- The device is disabled or not registered.