### PR TITLE
[#2197] Remove carousel from adopters list.

### DIFF
--- a/site/homepage/layouts/partials/scripts.html
+++ b/site/homepage/layouts/partials/scripts.html
@@ -35,7 +35,6 @@
     eclipseFdnAdopters.getList({
         project_id: "iot.hono",
         selector: ".eclipsefdn-adopters",
-        ul_classes: "owl-carousel customers",
         logo_white: true
     });
 </script>

--- a/site/homepage/static/css/custom.css
+++ b/site/homepage/static/css/custom.css
@@ -121,9 +121,11 @@ pre {
 }
 
 .eclipsefdn-adopters ul li {
-  display: block;
-  float: left;
-  width: 80%;
-  max-width: 400px;
-  margin: 20px;
+  display: inline-block;
+  padding: 2%;
+  width: 50%;
+}
+
+.eclipsefdn-adopters ul li a img {
+  width: 100%;
 }

--- a/site/homepage/static/css/custom.css
+++ b/site/homepage/static/css/custom.css
@@ -118,14 +118,16 @@ pre {
 
 .eclipsefdn-adopters ul {
   list-style: none;
+  padding-left: 0;
 }
 
 .eclipsefdn-adopters ul li {
   display: inline-block;
   padding: 2%;
   width: 50%;
+  text-align: center;
 }
 
 .eclipsefdn-adopters ul li a img {
-  width: 100%;
+  width: 80%;
 }

--- a/site/homepage/static/css/custom.css
+++ b/site/homepage/static/css/custom.css
@@ -116,8 +116,14 @@ pre {
   font-size: 0.9rem;
 }
 
-/*Vertically align adopter logos */
-.customers .owl-wrapper-outer .owl-wrapper {
-  display: flex !important;
-  align-items: center;
+.eclipsefdn-adopters ul {
+  list-style: none;
+}
+
+.eclipsefdn-adopters ul li {
+  display: block;
+  float: left;
+  width: 80%;
+  max-width: 400px;
+  margin: 20px;
 }


### PR DESCRIPTION
This removes the carousel from the adopter's section on the homepage to increase the stability. The logos are now simply displayed as a vertical list with automatically adjusts to small window sizes.