### PR TITLE
Update monitoring-tracing-config.md

### DIFF
--- a/site/documentation/content/admin-guide/monitoring-tracing-config.md
+++ b/site/documentation/content/admin-guide/monitoring-tracing-config.md
@@ -82,7 +82,7 @@ The health check server can be configured by means of the following environment 
 
 
 {{% warning title="Failure to start" %}}
-The component/service will fail to start if neither the secure not the insecure server have been configured properly.
+The component/service will fail to start if neither the secure nor the insecure server have been configured properly.
 {{% /warning %}}
 
 ## Tracing


### PR DESCRIPTION
Spelling corrected in the "Failure to start" warning message - The component/service will fail to start if neither the secure not the insecure server have been configured properly.
Correction: "nor" instead of "not".