### PR TITLE
MQTT adapter: Fix NPE in case command payload is null

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1460,7 +1460,8 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         Tags.MESSAGE_BUS_DESTINATION.set(commandContext.getTracingSpan(), publishTopic);
         TracingHelper.TAG_QOS.set(commandContext.getTracingSpan(), subscription.getQos().name());
 
-        endpoint.publish(publishTopic, command.getPayload(), subscription.getQos(), false, false, sentHandler -> {
+        final Buffer payload = Optional.ofNullable(command.getPayload()).orElseGet(Buffer::buffer);
+        endpoint.publish(publishTopic, payload, subscription.getQos(), false, false, sentHandler -> {
             if (sentHandler.succeeded()) {
 
                 if (command.isTargetedAtGateway()) {


### PR DESCRIPTION
This fixes a potential NPE when sending a command with an empty (ie. unsupported) payload to an MQTT device.
(This NPE caused the command to be released via the exception handling.)
