### PR TITLE
Release and settle delivery when waiting for update timed out

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractSender.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.Modified;
@@ -53,6 +54,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
 import io.vertx.proton.ProtonSender;
 
 /**
@@ -267,6 +269,7 @@ public abstract class AbstractSender extends AbstractHonoClient implements Messa
         Objects.requireNonNull(message);
         Objects.requireNonNull(currentSpan);
 
+        final AtomicReference<ProtonDelivery> deliveryRef = new AtomicReference<>();
         final Promise<ProtonDelivery> result = Promise.promise();
         final String messageId = String.format("%s-%d", getClass().getSimpleName(), MESSAGE_COUNTER.getAndIncrement());
         message.setMessageId(messageId);
@@ -282,13 +285,18 @@ public abstract class AbstractSender extends AbstractHonoClient implements Messa
                                         + connection.getConfig().getSendMessageTimeout() + "ms");
                         logMessageSendingError("waiting for delivery update timed out for message [ID: {}, address: {}] after {}ms",
                                 messageId, getMessageAddress(message), connection.getConfig().getSendMessageTimeout());
+                        // settle and release the delivery - this ensures that the message isn't considered "in flight"
+                        // anymore in the AMQP messaging network and that it doesn't count towards the link capacity
+                        // (it would be enough to just settle the delivery without an outcome but that cannot be done with proton-j as of now)
+                        Optional.ofNullable(deliveryRef.get())
+                                .ifPresent(delivery -> ProtonHelper.released(delivery, true));
                         result.fail(exception);
                         sample.timeout();
                     }
                 })
                 : null;
 
-        sender.send(message, deliveryUpdated -> {
+        deliveryRef.set(sender.send(message, deliveryUpdated -> {
             if (timerId != null) {
                 connection.getVertx().cancelTimer(timerId);
             }
@@ -328,7 +336,7 @@ public abstract class AbstractSender extends AbstractHonoClient implements Messa
                         "peer did not settle message, failing delivery");
                 result.fail(e);
             }
-        });
+        }));
         log.trace("sent message [ID: {}, address: {}], remaining credit: {}, queued messages: {}", messageId,
                 getMessageAddress(message), sender.getCredit(), sender.getQueued());
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TelemetrySenderImpl.java
@@ -15,7 +15,9 @@ package org.eclipse.hono.client.impl;
 
 import java.net.HttpURLConnection;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.message.Message;
@@ -38,6 +40,7 @@ import io.opentracing.tag.Tags;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
 import io.vertx.proton.ProtonQoS;
 import io.vertx.proton.ProtonSender;
 
@@ -170,6 +173,7 @@ public class TelemetrySenderImpl extends AbstractDownstreamSender {
 
         final SendMessageSampler.Sample sample = this.sampler.start(this.tenantId);
 
+        final AtomicReference<ProtonDelivery> deliveryRef = new AtomicReference<>();
         final ClientConfigProperties config = connection.getConfig();
         final AtomicBoolean timeoutReached = new AtomicBoolean(false);
         final Long timerId = config.getSendMessageTimeout() > 0
@@ -180,6 +184,11 @@ public class TelemetrySenderImpl extends AbstractDownstreamSender {
                         logMessageSendingError(
                                 "waiting for delivery update timed out for message [ID: {}, address: {}] after {}ms",
                                 messageId, getMessageAddress(message), connection.getConfig().getSendMessageTimeout());
+                        // settle and release the delivery - this ensures that the message isn't considered "in flight"
+                        // anymore in the AMQP messaging network and that it doesn't count towards the link capacity
+                        // (it would be enough to just settle the delivery without an outcome but that cannot be done with proton-j as of now)
+                        Optional.ofNullable(deliveryRef.get())
+                                .ifPresent(delivery -> ProtonHelper.released(delivery, true));
                         TracingHelper.logError(currentSpan, exception.getMessage());
                         Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_UNAVAILABLE);
                         currentSpan.finish();
@@ -188,7 +197,7 @@ public class TelemetrySenderImpl extends AbstractDownstreamSender {
                 })
                 : null;
 
-        final ProtonDelivery result = sender.send(message, deliveryUpdated -> {
+        final ProtonDelivery delivery = sender.send(message, deliveryUpdated -> {
             if (timerId != null) {
                 connection.getVertx().cancelTimer(timerId);
             }
@@ -208,10 +217,11 @@ public class TelemetrySenderImpl extends AbstractDownstreamSender {
             }
             currentSpan.finish();
         });
+        deliveryRef.set(delivery);
         log.trace("sent message [ID: {}, address: {}], remaining credit: {}, queued messages: {}", messageId,
                 getMessageAddress(message), sender.getCredit(), sender.getQueued());
 
-        return Future.succeededFuture(result);
+        return Future.succeededFuture(delivery);
     }
 
     @Override


### PR DESCRIPTION
This should free up some resources.

EDIT:
When a telemetry message with Qos1 gets sent and the northbound consumer doesn't acknowledge the message by sending a delivery update, a timeout will occur in the protocol adapter after some time. 

The problem here is, that the message is considered as "in flight" still, most notably from the point of view of the AMQP messaging network (e.g. the Qpid dispatch router). This message counts towards the link capacity configured in the router.

This all means that if one sends as many messages as configured as the router link capacity to the north bound application, and if the northbound application doesn't send a delivery update for any of these, then any further messages will result in a "no credit" error when the adapter tries to send them to the router.
This will be the case irrespective of the northbound application having sent new credits to the router.

I think we should consider releasing/settling the message from the *sender* side (i.e. the protocol adapter) in this case, in order to free up resources in the router.
