### PR TITLE
[#2215] Make secrets array mandatory

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <artemis.image.name>quay.io/enmasse/artemis-base:2.10.1</artemis.image.name>
-    <assertj-core.version>3.15.0</assertj-core.version>
+    <assertj-core.version>3.17.2</assertj-core.version>
     <c3p0.version>0.9.5.4</c3p0.version>
     <caffeine.version>2.8.4</caffeine.version>
     <californium.version>2.3.1</californium.version>

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
@@ -81,9 +81,9 @@ public abstract class CommonCredential {
     }
 
     /**
-     * Get a list of secrets for this credential.
+     * Gets the secrets for this credential.
      *
-     * @return The list of credentials, must not be {@code null}.
+     * @return The credentials (never {@code null}).
      */
     public abstract List<? extends CommonSecret> getSecrets();
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordCredential.java
@@ -12,8 +12,10 @@
  *******************************************************************************/
 package org.eclipse.hono.service.management.credentials;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.hono.util.RegistryManagementConstants;
 
@@ -32,19 +34,23 @@ public class PasswordCredential extends CommonCredential {
 
     static final String TYPE = RegistryManagementConstants.SECRETS_TYPE_HASHED_PASSWORD;
 
-    @JsonProperty
-    @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
-    private List<PasswordSecret> secrets = new LinkedList<>();
+    private final List<PasswordSecret> secrets = new LinkedList<>();
 
     /**
      * Creates a new credentials object for an authentication identifier.
      *
      * @param authId The authentication identifier.
-     * @throws NullPointerException if the auth ID is {@code null}.
-     * @throws IllegalArgumentException if auth ID does not match {@link org.eclipse.hono.util.CredentialsConstants#PATTERN_AUTH_ID_VALUE}.
+     * @param secrets The credential's secret password(s).
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @throws IllegalArgumentException if auth ID does not match {@link org.eclipse.hono.util.CredentialsConstants#PATTERN_AUTH_ID_VALUE}
+     *                                  or if secrets is empty.
      */
-    public PasswordCredential(@JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String authId) {
+    public PasswordCredential(
+            @JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String authId,
+            @JsonProperty(value = RegistryManagementConstants.FIELD_SECRETS, required = true) final List<PasswordSecret> secrets) {
+
         super(authId);
+        setSecrets(secrets);
     }
 
     /**
@@ -56,32 +62,39 @@ public class PasswordCredential extends CommonCredential {
         return TYPE;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return An unmodifiable list of secrets.
+     */
     @Override
-    public List<PasswordSecret> getSecrets() {
-        return secrets;
+    @JsonProperty(value = RegistryManagementConstants.FIELD_SECRETS)
+    public final List<PasswordSecret> getSecrets() {
+        return Collections.unmodifiableList(secrets);
     }
 
     /**
      * Sets the list of password secrets to use for authenticating a device to protocol adapters.
-     * <p>
-     * The list cannot be empty and each secret is scoped to its validity period.
      *
      * @param secrets The list of password secrets to set.
-     * @return        a reference to this for fluent use.
+     * @return A reference to this for fluent use.
+     * @throws NullPointerException if secrets is {@code null}.
      * @throws IllegalArgumentException if the list of secrets is empty.
      */
-    public PasswordCredential setSecrets(final List<PasswordSecret> secrets) {
-        if (secrets != null && secrets.isEmpty()) {
-            throw new IllegalArgumentException("secrets cannot be empty");
+    public final PasswordCredential setSecrets(final List<PasswordSecret> secrets) {
+        Objects.requireNonNull(secrets);
+        if (secrets.isEmpty()) {
+            throw new IllegalArgumentException("secrets must not be empty");
         }
-        this.secrets = secrets;
+        this.secrets.clear();
+        this.secrets.addAll(secrets);
         return this;
     }
 
     /**
      * {@inheritDoc}
      * <p>
-     * Removes hash function, password hash, salt and plaintext password from all secrets.
+     * Removes hash function, password hash, salt and plain text password from all secrets.
      */
     @Override
     public final PasswordCredential stripPrivateInfo() {

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
@@ -12,8 +12,10 @@
  *******************************************************************************/
 package org.eclipse.hono.service.management.credentials;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.hono.util.RegistryManagementConstants;
 
@@ -32,19 +34,22 @@ public class PskCredential extends CommonCredential {
 
     static final String TYPE = RegistryManagementConstants.SECRETS_TYPE_PRESHARED_KEY;
 
-    @JsonProperty(value = RegistryManagementConstants.FIELD_SECRETS)
-    @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
-    private List<PskSecret> secrets = new LinkedList<>();
+    private final List<PskSecret> secrets = new LinkedList<>();
 
     /**
      * Creates a new credentials object for an authentication identifier.
      *
      * @param authId The authentication identifier.
-     * @throws NullPointerException if the auth ID is {@code null}.
-     * @throws IllegalArgumentException if auth ID does not match {@link org.eclipse.hono.util.CredentialsConstants#PATTERN_AUTH_ID_VALUE}.
+     * @param secrets The credential's shared secret(s).
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @throws IllegalArgumentException if auth ID does not match {@link org.eclipse.hono.util.CredentialsConstants#PATTERN_AUTH_ID_VALUE}
+     *                                  or if secrets is empty.
      */
-    public PskCredential(@JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String authId) {
+    public PskCredential(
+            @JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String authId,
+            @JsonProperty(value = RegistryManagementConstants.FIELD_SECRETS, required = true) final List<PskSecret> secrets) {
         super(authId);
+        setSecrets(secrets);
     }
 
     /**
@@ -56,9 +61,15 @@ public class PskCredential extends CommonCredential {
         return TYPE;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return An unmodifiable list of secrets.
+     */
     @Override
+    @JsonProperty(value = RegistryManagementConstants.FIELD_SECRETS)
     public final List<PskSecret> getSecrets() {
-        return secrets;
+        return Collections.unmodifiableList(secrets);
     }
 
     /**
@@ -68,13 +79,16 @@ public class PskCredential extends CommonCredential {
      *
      * @param secrets The secret to set.
      * @return        a reference to this for fluent use.
+     * @throws NullPointerException if secrets is {@code null}.
      * @throws IllegalArgumentException if the list of secrets is empty.
      */
     public final PskCredential setSecrets(final List<PskSecret> secrets) {
-        if (secrets != null && secrets.isEmpty()) {
+        Objects.requireNonNull(secrets);
+        if (secrets.isEmpty()) {
             throw new IllegalArgumentException("secrets cannot be empty");
         }
-        this.secrets = secrets;
+        this.secrets.clear();
+        this.secrets.addAll(secrets);
         return this;
     }
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioning.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioning.java
@@ -83,8 +83,7 @@ public final class AutoProvisioning {
 
                     // 2. set the certificate credential
                     final String authId = clientCertificate.getSubjectX500Principal().getName(X500Principal.RFC2253);
-                    final X509CertificateCredential certCredential = new X509CertificateCredential(authId)
-                            .setSecrets(List.of(new X509CertificateSecret()));
+                    final X509CertificateCredential certCredential = new X509CertificateCredential(authId, List.of(new X509CertificateSecret()));
                     certCredential.setEnabled(true).setComment(comment);
 
                     final String deviceId = r.getPayload().getId();

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/Credentials.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/Credentials.java
@@ -14,7 +14,7 @@
 package org.eclipse.hono.service.credentials;
 
 import java.util.Base64;
-import java.util.Collections;
+import java.util.List;
 import java.util.OptionalInt;
 
 import org.eclipse.hono.auth.EncodedPassword;
@@ -40,14 +40,10 @@ public final class Credentials {
      * @return The fully populated secret.
      */
     public static PskCredential createPSKCredential(final String authId, final String psk) {
-        final PskCredential p = new PskCredential(authId);
 
         final PskSecret s = new PskSecret();
         s.setKey(psk.getBytes());
-
-        p.setSecrets(Collections.singletonList(s));
-
-        return p;
+        return new PskCredential(authId, List.of(s));
     }
 
     /**
@@ -63,11 +59,9 @@ public final class Credentials {
             final String password,
             final OptionalInt bcryptCostFactor) {
 
-        final PasswordCredential p = new PasswordCredential(authId);
-
-        p.setSecrets(Collections.singletonList(createPasswordSecret(password, bcryptCostFactor)));
-
-        return p;
+        return new PasswordCredential(
+                authId,
+                List.of(createPasswordSecret(password, bcryptCostFactor)));
     }
 
     /**
@@ -78,14 +72,10 @@ public final class Credentials {
      * @return The fully populated credential.
      */
     public static PasswordCredential createPlainPasswordCredential(final String authId, final String password) {
-        final PasswordCredential p = new PasswordCredential(authId);
 
         final PasswordSecret secret = new PasswordSecret();
         secret.setPasswordPlain(password);
-
-        p.setSecrets(Collections.singletonList(secret));
-
-        return p;
+        return new PasswordCredential(authId, List.of(secret));
     }
 
     /**

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -42,9 +41,7 @@ import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
-import org.eclipse.hono.service.management.credentials.PasswordSecret;
 import org.eclipse.hono.service.management.credentials.PskCredential;
-import org.eclipse.hono.service.management.credentials.PskSecret;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
@@ -374,28 +371,19 @@ public class FileBasedCredentialsServiceTest implements AbstractCredentialsServi
         when(fileSystem.existsBlocking(credentialsConfig.getFilename())).thenReturn(Boolean.TRUE);
 
         // 4700
-        final PasswordCredential passwordCredential = new PasswordCredential("bumlux");
-
-        final PasswordSecret hashedPassword = new PasswordSecret();
-        hashedPassword.setPasswordHash("$2a$10$UK9lmSMlYmeXqABkTrDRsu1nlZRnAmGnBdPIWZoDajtjyxX18Dry.");
-        hashedPassword.setHashFunction(CredentialsConstants.HASH_FUNCTION_BCRYPT);
-        passwordCredential.setSecrets(Collections.singletonList(hashedPassword));
+        final PasswordCredential passwordCredential = Credentials.createPasswordCredential("bumlux", "thepwd");
 
         // 4711RegistryManagementConstants.FIELD_ID
-        final PskCredential pskCredential = new PskCredential("sensor1");
-
-        final PskSecret pskSecret = new PskSecret();
-        pskSecret.setKey("sharedkey".getBytes(StandardCharsets.UTF_8));
-        pskCredential.setSecrets(Collections.singletonList(pskSecret));
+        final PskCredential pskCredential = Credentials.createPSKCredential("sensor1", "sharedkey");
 
         setCredentials(getCredentialsManagementService(),
                 Constants.DEFAULT_TENANT, "4700",
-                Collections.<CommonCredential> singletonList(pskCredential))
+                List.of(pskCredential))
 
                         .compose(ok -> {
                             return setCredentials(getCredentialsManagementService(),
                                     "OTHER_TENANT", "4711",
-                                    Collections.<CommonCredential> singletonList(passwordCredential));
+                                    List.of(passwordCredential));
                         })
 
                         .compose(ok -> {
@@ -527,18 +515,13 @@ public class FileBasedCredentialsServiceTest implements AbstractCredentialsServi
         credentialsConfig.setHashAlgorithmsWhitelist(whitelist);
 
         // 4700
-        final PasswordCredential passwordCredential = new PasswordCredential("bumlux");
-
-        final PasswordSecret hashedPassword = new PasswordSecret();
-        hashedPassword.setPasswordHash("$2a$10$UK9lmSMlYmeXqABkTrDRsu1nlZRnAmGnBdPIWZoDajtjyxX18Dry.");
-        hashedPassword.setHashFunction(CredentialsConstants.HASH_FUNCTION_BCRYPT);
-        passwordCredential.setSecrets(Collections.singletonList(hashedPassword));
+        final PasswordCredential passwordCredential = Credentials.createPasswordCredential("bumlux", "thepwd");
 
         // WHEN trying to set the credentials
             getCredentialsManagementService().updateCredentials(
                 "tenant",
                 "device",
-                Collections.singletonList(passwordCredential),
+                List.of(passwordCredential),
                 Optional.empty(),
                 NoopSpan.INSTANCE)
                 .onComplete(ctx.succeeding(s -> ctx.verify(() -> {
@@ -562,12 +545,8 @@ public class FileBasedCredentialsServiceTest implements AbstractCredentialsServi
         final var deviceId = UUID.randomUUID().toString();
         final var authId = UUID.randomUUID().toString();
 
-        final PskSecret pskSecret = new PskSecret();
-        pskSecret.setKey("sharedkey".getBytes(StandardCharsets.UTF_8));
-
-        final PskCredential pskCredential = new PskCredential(authId);
+        final PskCredential pskCredential = Credentials.createPSKCredential(authId, "haredkey");
         pskCredential.setExtensions(Map.of("property-to-match", expectedContextValue));
-        pskCredential.setSecrets(Collections.singletonList(pskSecret));
 
         setCredentials(getCredentialsManagementService(), tenantId, deviceId, List.of(pskCredential))
                 .compose(ok -> {

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDtoTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDtoTest.java
@@ -45,8 +45,7 @@ class CredentialsDtoTest {
         existingSecret = new PskSecret();
         existingSecret.setId("abc");
         existingSecret.setKey("shared-key".getBytes(StandardCharsets.UTF_8));
-        existingCred = new PskCredential("psk-id");
-        existingCred.setSecrets(List.of(existingSecret));
+        existingCred = new PskCredential("psk-id", List.of(existingSecret));
     }
 
     @Test
@@ -78,8 +77,7 @@ class CredentialsDtoTest {
         final PskSecret updatedSecret = new PskSecret();
         updatedSecret.setId("def");
         updatedSecret.setKey("irrelevant".getBytes(StandardCharsets.UTF_8));
-        final PskCredential updatedCred = new PskCredential("psk-id");
-        updatedCred.setSecrets(List.of(existingSecret, updatedSecret));
+        final PskCredential updatedCred = new PskCredential("psk-id", List.of(existingSecret, updatedSecret));
 
         final CredentialsDto updatedDto = new CredentialsDto("tenant", "device", List.of(updatedCred), "1");
         assertThat(updatedDto.requiresMerging());
@@ -102,8 +100,7 @@ class CredentialsDtoTest {
         final PskSecret newSecret = new PskSecret();
         newSecret.setKey("irrelevant".getBytes(StandardCharsets.UTF_8));
 
-        final PskCredential updatedCred = new PskCredential("psk-id");
-        updatedCred.setSecrets(List.of(unchangedSecret, newSecret));
+        final PskCredential updatedCred = new PskCredential("psk-id", List.of(unchangedSecret, newSecret));
 
         final CredentialsDto updatedDto = new CredentialsDto("tenant", "device", List.of(updatedCred), "1");
         assertThat(updatedDto.requiresMerging());

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -36,7 +36,7 @@ info:
    license:
       name: EPL-2.0
       url: https://www.eclipse.org/legal/epl-2.0/
-   version: 1.4.2
+   version: 1.4.3
 
 externalDocs:
    description: Eclipse Hono™ web page
@@ -1088,6 +1088,8 @@ components:
          allOf:
             - $ref: '#/components/schemas/CommonCredentials'
             - type: object
+              required:
+                 - secrets
               additionalProperties: false
               properties:
                  "type":
@@ -1097,12 +1099,15 @@ components:
                     type: array
                     items:
                        $ref: '#/components/schemas/PasswordSecret'
+                    minItems: 1
 
       PSKCredentials:
          additionalProperties: false
          allOf:
             - $ref: '#/components/schemas/CommonCredentials'
             - type: object
+              required:
+                 - secrets
               additionalProperties: false
               properties:
                  "type":
@@ -1112,12 +1117,15 @@ components:
                     type: array
                     items:
                        $ref: '#/components/schemas/PSKSecret'
+                    minItems: 1
 
       X509CertificateCredentials:
          additionalProperties: false
          allOf:
             - $ref: '#/components/schemas/CommonCredentials'
             - type: object
+              required:
+                 - secrets
               additionalProperties: false
               properties:
                  "type":
@@ -1127,6 +1135,7 @@ components:
                     type: array
                     items:
                        $ref: '#/components/schemas/X509CertificateSecret'
+                    minItems: 1
 
       CommonSecret:
          type: object

--- a/tests/src/test/java/org/eclipse/hono/tests/DeviceRegistryHttpClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/DeviceRegistryHttpClient.java
@@ -14,7 +14,6 @@
 package org.eclipse.hono.tests;
 
 import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +29,6 @@ import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
 import org.eclipse.hono.service.management.credentials.PskCredential;
-import org.eclipse.hono.service.management.credentials.PskSecret;
 import org.eclipse.hono.service.management.credentials.X509CertificateCredential;
 import org.eclipse.hono.service.management.credentials.X509CertificateSecret;
 import org.eclipse.hono.service.management.device.Device;
@@ -1057,8 +1055,7 @@ public final class DeviceRegistryHttpClient {
                 .compose(ok -> {
 
                     final String authId = deviceCert.getSubjectDN().getName();
-                    final X509CertificateCredential credential = new X509CertificateCredential(authId);
-                    credential.getSecrets().add(new X509CertificateSecret());
+                    final X509CertificateCredential credential = new X509CertificateCredential(authId, List.of(new X509CertificateSecret()));
 
                     return addCredentials(tenantId, deviceId, Collections.singleton(credential));
 
@@ -1113,11 +1110,7 @@ public final class DeviceRegistryHttpClient {
         Objects.requireNonNull(deviceData);
         Objects.requireNonNull(key);
 
-        final PskCredential credential = new PskCredential(deviceId);
-
-        final PskSecret secret = new PskSecret();
-        secret.setKey(key.getBytes(StandardCharsets.UTF_8));
-        credential.getSecrets().add(secret);
+        final PskCredential credential = IntegrationTestSupport.createPskCredentials(deviceId, key);
 
         return addTenant(tenantId, tenant)
                 .compose(ok -> registerDevice(tenantId, deviceId, deviceData))
@@ -1139,11 +1132,7 @@ public final class DeviceRegistryHttpClient {
      */
     public Future<HttpResponse<Buffer>> addPskDeviceToTenant(final String tenantId, final String deviceId, final String key) {
 
-        final PskCredential credential = new PskCredential(deviceId);
-
-        final PskSecret secret = new PskSecret();
-        secret.setKey(key.getBytes(StandardCharsets.UTF_8));
-        credential.getSecrets().add(secret);
+        final PskCredential credential = IntegrationTestSupport.createPskCredentials(deviceId, key);
 
         return registerDevice(tenantId, deviceId)
                 .compose(ok -> addCredentials(tenantId, deviceId, Collections.singleton(credential)));

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.tests.mqtt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -240,8 +241,7 @@ public class MqttConnectionIT extends MqttTestBase {
                 }).compose(ok -> helper.registry.registerDevice(tenantId, deviceId))
                 .compose(ok -> {
                     final String authId = new X500Principal("CN=4711").getName(X500Principal.RFC2253);
-                    final X509CertificateCredential credential = new X509CertificateCredential(authId);
-                    credential.getSecrets().add(new X509CertificateSecret());
+                    final X509CertificateCredential credential = new X509CertificateCredential(authId, List.of(new X509CertificateSecret()));
                     return helper.registry.addCredentials(tenantId, deviceId, Collections.singleton(credential));
                 })
                 // WHEN the device tries to connect using a client certificate with an unknown subject DN

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
@@ -23,7 +23,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -322,10 +321,7 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
         final var secret2 = Credentials.createPasswordSecret("hono-password",
                 OptionalInt.of(IntegrationTestSupport.MAX_BCRYPT_COST_FACTOR));
 
-        final var credential = new PasswordCredential(authId);
-        credential.setSecrets(Arrays.asList(secret1, secret2));
-
-        return credential;
+        return new PasswordCredential(authId, List.of(secret1, secret2));
     }
 
     private static void assertStandardProperties(

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
@@ -19,11 +19,14 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.GenericCredential;
@@ -31,6 +34,8 @@ import org.eclipse.hono.service.management.credentials.GenericSecret;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
 import org.eclipse.hono.service.management.credentials.PasswordSecret;
 import org.eclipse.hono.service.management.credentials.PskCredential;
+import org.eclipse.hono.service.management.credentials.X509CertificateCredential;
+import org.eclipse.hono.service.management.credentials.X509CertificateSecret;
 import org.eclipse.hono.tests.CrudHttpClient;
 import org.eclipse.hono.tests.DeviceRegistryHttpClient;
 import org.eclipse.hono.tests.IntegrationTestSupport;
@@ -216,12 +221,10 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
         // GIVEN a hashed password using bcrypt with more than the configured max iterations
         final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(IntegrationTestSupport.MAX_BCRYPT_COST_FACTOR + 1);
 
-        final PasswordCredential credential = new PasswordCredential(authId);
-
         final PasswordSecret secret = new PasswordSecret();
         secret.setHashFunction(CredentialsConstants.HASH_FUNCTION_BCRYPT);
         secret.setPasswordHash(encoder.encode("thePassword"));
-        credential.setSecrets(List.of(secret));
+        final PasswordCredential credential = new PasswordCredential(authId, List.of(secret));
 
         // WHEN adding the credentials
         testAddCredentialsWithErroneousPayload(
@@ -392,8 +395,9 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
                 final PasswordSecret newSecret = new PasswordSecret();
                 newSecret.setPasswordPlain("future-password");
                 newSecret.setNotBefore(Instant.now().plus(1, ChronoUnit.DAYS));
-                final PasswordCredential updatedCredentials = new PasswordCredential(existingCredentials.getAuthId());
-                updatedCredentials.setSecrets(List.of(changedSecret, newSecret));
+                final PasswordCredential updatedCredentials = new PasswordCredential(
+                        existingCredentials.getAuthId(),
+                        List.of(changedSecret, newSecret));
                 return registry.updateCredentialsWithVersion(
                         tenantId,
                         deviceId,
@@ -496,77 +500,34 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
     }
 
     /**
-     * Verify that multiple (2) correctly added credentials records of the same authId can be successfully looked up by
-     * single requests using their type and authId again.
-     *
-     * @param context The vert.x test context.
-     */
-    @Test
-    public void testGetAddedCredentialsMultipleTypesSingleRequests(final VertxTestContext context) {
-
-        final List<CommonCredential> credentialsListToAdd = new ArrayList<>();
-        credentialsListToAdd.add(hashedPasswordCredential);
-        credentialsListToAdd.add(pskCredentials);
-
-        registry.addCredentials(tenantId, deviceId, credentialsListToAdd)
-            .compose(ar -> registry.getCredentials(tenantId, deviceId))
-            .onComplete(context.succeeding(httpResponse -> {
-                context.verify(() -> assertResponseBodyContainsAllCredentials(httpResponse.bodyAsJsonArray(), credentialsListToAdd));
-                context.completeNow();
-        }));
-    }
-
-    /**
-     * Verifies that the service returns all credentials registered for a given device regardless of authentication identifier.
+     * Verifies that the service returns all credentials registered for a given device regardless of
+     * authentication identifier and type.
      * <p>
-     * The returned JsonArray must consist exactly the same credentials as originally added.
+     * The returned JsonArray must contain exactly the same credentials as originally added.
      *
      * @param context The vert.x test context.
-     * @throws InterruptedException if registration of credentials is interrupted.
      */
     @Test
-    public void testGetAllCredentialsForDeviceSucceeds(final VertxTestContext context) throws InterruptedException {
+    public void testGetAllCredentialsForDeviceSucceeds(final VertxTestContext context) {
 
         final List<CommonCredential> credentialsListToAdd = new ArrayList<>();
         credentialsListToAdd.add(pskCredentials);
         credentialsListToAdd.add(hashedPasswordCredential);
-        credentialsListToAdd.add(IntegrationTestSupport.createPskCredentials("other-auth", "other-key"));
-
-        registry.addCredentials(tenantId, deviceId, credentialsListToAdd)
-            .compose(ar -> registry.getCredentials(tenantId, deviceId))
-            .onComplete(context.succeeding(httpResponse -> {
-                context.verify(() -> assertResponseBodyContainsAllCredentials(httpResponse.bodyAsJsonArray(), credentialsListToAdd));
-                context.completeNow();
-            }));
-    }
-
-    /**
-     * Verifies that the service returns all credentials registered for a given device regardless of type.
-     * <p>
-     * The returned JsonArray must contain all the credentials previously added to the registry.
-     *
-     * @param context The vert.x test context.
-     * @throws InterruptedException if registration of credentials is interrupted.
-     */
-    @Test
-    public void testGetCredentialsForDeviceRegardlessOfType(final VertxTestContext context) throws InterruptedException {
-
-        final String pskAuthId = getRandomAuthId(PREFIX_AUTH_ID);
-        final List<CommonCredential> credentialsToAdd = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            final GenericCredential credential = new GenericCredential("type" + i, pskAuthId);
+        credentialsListToAdd.add(new X509CertificateCredential("CN=Acme", List.of(new X509CertificateSecret())));
+        for (int i = 0; i < 3; i++) {
 
             final GenericSecret secret = new GenericSecret();
-            secret.getAdditionalProperties().put("field" + i, "setec astronomy");
+            secret.setAdditionalProperties(Map.of("field-" + i, "setec astronomy"));
 
-            credential.setSecrets(List.of(secret));
-            credentialsToAdd.add(credential);
+            final GenericCredential credential = new GenericCredential("type-" + i, getRandomAuthId(PREFIX_AUTH_ID), List.of(secret));
+
+            credentialsListToAdd.add(credential);
         }
 
-        registry.addCredentials(tenantId, deviceId, credentialsToAdd)
+        registry.addCredentials(tenantId, deviceId, credentialsListToAdd)
             .compose(ar -> registry.getCredentials(tenantId, deviceId))
             .onComplete(context.succeeding(httpResponse -> {
-                context.verify(() -> assertResponseBodyContainsAllCredentials(httpResponse.bodyAsJsonArray(), credentialsToAdd));
+                context.verify(() -> assertResponseBodyContainsAllCredentials(httpResponse.bodyAsJsonArray(), credentialsListToAdd));
                 context.completeNow();
             }));
     }
@@ -579,8 +540,7 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
     @Test
     public void testGetAddedCredentialsButWithWrongType(final VertxTestContext context)  {
 
-        registry.updateCredentials(tenantId, deviceId, List.of(hashedPasswordCredential),
-                HttpURLConnection.HTTP_NO_CONTENT)
+        registry.updateCredentials(tenantId, deviceId, hashedPasswordCredential)
             .compose(ar -> registry.getCredentials(tenantId, authId, "wrong-type", HttpURLConnection.HTTP_NOT_FOUND))
             .onComplete(context.completing());
     }
@@ -593,8 +553,7 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
     @Test
     public void testGetAddedCredentialsButWithWrongAuthId(final VertxTestContext context)  {
 
-        registry.updateCredentials(tenantId, deviceId, List.of(hashedPasswordCredential),
-                HttpURLConnection.HTTP_NO_CONTENT)
+        registry.updateCredentials(tenantId, deviceId, hashedPasswordCredential)
             .compose(ar -> registry.getCredentials(
                     tenantId,
                     "wrong-auth-id",
@@ -605,59 +564,24 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
 
     private static void assertResponseBodyContainsAllCredentials(final JsonArray responseBody, final List<CommonCredential> expected) {
 
-        assertThat(expected.size()).isEqualTo(responseBody.size());
+        final List<CommonCredential> returnedCreds = responseBody.stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
+                .map(json -> json.mapTo(CommonCredential.class))
+                .collect(Collectors.toList());
 
-        responseBody.forEach(credential -> {
-            JsonObject.mapFrom(credential).getJsonArray(CredentialsConstants.FIELD_SECRETS)
-                    .forEach(secret -> {
-                        // each secret should contain an ID.
-                        assertThat(JsonObject.mapFrom(secret)
-                                .getString(RegistryManagementConstants.FIELD_ID))
-                                .as("contains 'id' field")
-                                .isNotNull();
-                    });
-        });
+        final RecursiveComparisonConfiguration config = RecursiveComparisonConfiguration.builder()
+                .withStrictTypeChecking(true)
+                .withIgnoreCollectionOrder(true)
+                .withIgnoredFields("secrets.id", "secrets.key", "secrets.passwordHash", "secrets.passwordPlain", "secrets.hashFunction", "secrets.salt")
+                .build();
 
-        // secrets id were added by registry, strip it so we can compare other fields.
-        responseBody.forEach(credential -> {
-            ((JsonObject) credential).getJsonArray(CredentialsConstants.FIELD_SECRETS)
-                    .forEach(secret -> {
-                        ((JsonObject) secret).remove(RegistryManagementConstants.FIELD_ID);
-                    });
-        });
-
-        // The returned secrets won't contains the hashed password details fields, strip them from the expected values.
-        final JsonArray expectedArray = new JsonArray();
-        expected.forEach(credential -> {
-            final JsonObject jsonCredential = JsonObject.mapFrom(credential);
-            expectedArray.add(stripPrivateInfoFromSecrets(jsonCredential));
-        });
-
-        // now compare
-        assertThat(responseBody)
-                .isEqualTo(expectedArray);
+        assertThat(returnedCreds)
+            .usingRecursiveFieldByFieldElementComparator(config)
+            .containsExactlyInAnyOrderElementsOf(expected);
     }
 
     private static String getRandomAuthId(final String authIdPrefix) {
         return authIdPrefix + "-" + UUID.randomUUID();
-    }
-
-    private static JsonObject stripPrivateInfoFromSecrets(final JsonObject credentials) {
-
-        Optional.ofNullable(credentials.getJsonArray(CredentialsConstants.FIELD_SECRETS))
-            .map(JsonArray.class::cast)
-            .ifPresent(array -> array.stream()
-                    .map(JsonObject.class::cast)
-                    .forEach(secret -> {
-                        // password hash
-                        secret.remove(RegistryManagementConstants.FIELD_SECRETS_HASH_FUNCTION);
-                        secret.remove(RegistryManagementConstants.FIELD_SECRETS_PWD_HASH);
-                        secret.remove(RegistryManagementConstants.FIELD_SECRETS_SALT);
-                        secret.remove(RegistryManagementConstants.FIELD_SECRETS_PWD_PLAIN);
-                        // pre-shared key
-                        secret.remove(RegistryManagementConstants.FIELD_SECRETS_KEY);
-                    }));
-
-        return credentials;
     }
 }


### PR DESCRIPTION
The supported credentials types now require the secrets array to be
non-empty.
