### PR TITLE
Remove auth-id and credentials type regex pattern from API

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CredentialsConstants.java
@@ -118,10 +118,6 @@ public final class CredentialsConstants extends RequestResponseApiConstants {
      */
     public static final String EVENT_BUS_ADDRESS_CREDENTIALS_IN = "credentials.in";
     /**
-     * The regular expression to validate that the auth-id field supplied in credentials is legal.
-     */
-    public static final Pattern PATTERN_AUTH_ID_VALUE = Pattern.compile("^[a-zA-Z0-9-_=.]+$");
-    /**
      * The regular expression to validate that the type field supplied in credentials is legal.
      */
     public static final Pattern PATTERN_TYPE_VALUE = Pattern.compile("^[a-z0-9-]+$");

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
@@ -18,10 +18,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.regex.Matcher;
 
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
-import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -39,21 +37,6 @@ import com.google.common.base.Strings;
 @JsonTypeIdResolver(CredentialTypeResolver.class)
 public abstract class CommonCredential {
 
-    /**
-     * A predicate for matching authentication identifiers against the
-     * {@linkplain CredentialsConstants#PATTERN_AUTH_ID_VALUE default pattern}.
-     */
-    protected static final Predicate<String> AUTH_ID_VALIDATOR_DEFAULT = authId -> {
-        final Matcher matcher = CredentialsConstants.PATTERN_AUTH_ID_VALUE.matcher(authId);
-        if (matcher.matches()) {
-            return true;
-        } else {
-            throw new IllegalArgumentException("authentication identifier must match pattern "
-                    + CredentialsConstants.PATTERN_AUTH_ID_VALUE.pattern());
-        }
-    };
-
-    @JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID)
     private String authId;
     @JsonProperty(RegistryManagementConstants.FIELD_ENABLED)
     private Boolean enabled;
@@ -69,7 +52,8 @@ public abstract class CommonCredential {
      *
      * @param authId The authentication identifier.
      * @throws NullPointerException if the auth ID is {@code null}.
-     * @throws IllegalArgumentException if auth ID does not match {@link CredentialsConstants#PATTERN_AUTH_ID_VALUE}.
+     * @throws IllegalArgumentException if the {@linkplain #getAuthIdValidator() auth-id validator} evaluates to
+     *                {@code false} for the given identifier.
      */
     protected CommonCredential(final String authId) {
         Objects.requireNonNull(authId);
@@ -98,8 +82,7 @@ public abstract class CommonCredential {
      * Gets a predicate to use for validating authentication identifiers.
      * <p>
      * The predicate is invoked by the constructor before setting the authId property.
-     * This default implementation returns a predicate that matches the identifier
-     * against the {@linkplain CredentialsConstants#PATTERN_AUTH_ID_VALUE default pattern}.
+     * This default implementation returns a predicate that always evaluates to {@code true}.
      * <p>
      * The constructor will re-throw an {@code IllegalArgumentException}y thrown by the
      * predicate's <em>test</em> method. This might be used to convey additional information
@@ -110,23 +93,15 @@ public abstract class CommonCredential {
      * @return The predicate.
      */
     protected Predicate<String> getAuthIdValidator() {
-        return AUTH_ID_VALIDATOR_DEFAULT;
+        return s -> true;
     }
 
     /**
-     * Sets the authentication identifier used by the device.
+     * Gets the authentication identifier used with these credentials.
      *
-     * @param authId The identifier.
-     * @return A reference to this for fluent use.
-     * @throws NullPointerException if ID is {@code null}.
+     * @return The identifier.
      */
-    @JsonIgnore
-    protected final CommonCredential setAuthId(final String authId) {
-        Objects.requireNonNull(authId);
-        this.authId = authId;
-        return this;
-    }
-
+    @JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID)
     public final String getAuthId() {
         return authId;
     }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
@@ -37,7 +37,8 @@ import com.google.common.base.Strings;
 @JsonTypeIdResolver(CredentialTypeResolver.class)
 public abstract class CommonCredential {
 
-    private String authId;
+    private final String authId;
+
     @JsonProperty(RegistryManagementConstants.FIELD_ENABLED)
     private Boolean enabled;
     @JsonProperty(RegistryManagementConstants.FIELD_COMMENT)

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/GenericCredential.java
@@ -49,9 +49,8 @@ public class GenericCredential extends CommonCredential {
      * @param authId The authentication identifier.
      * @param secrets The credential's (generic) secret(s).
      * @throws NullPointerException if any of the parameters are {@code null}.
-     * @throws IllegalArgumentException if type does not match {@link CredentialsConstants#PATTERN_TYPE_VALUE},
-     *         if auth ID does not match {@link CredentialsConstants#PATTERN_AUTH_ID_VALUE} or
-     *         if secrets is empty.
+     * @throws IllegalArgumentException if type does not match {@link CredentialsConstants#PATTERN_TYPE_VALUE} or
+     *                                  if secrets is empty.
      */
     public GenericCredential(
             @JsonProperty(value = RegistryManagementConstants.FIELD_TYPE, required = true) final String type,

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordCredential.java
@@ -16,7 +16,10 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
 
+import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -33,6 +36,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class PasswordCredential extends CommonCredential {
 
     static final String TYPE = RegistryManagementConstants.SECRETS_TYPE_HASHED_PASSWORD;
+
+    /**
+     * A predicate for matching authentication identifiers against the
+     * {@linkplain CredentialsConstants#PATTERN_AUTH_ID_VALUE default pattern}.
+     */
+    private static final Predicate<String> AUTH_ID_VALIDATOR_DEFAULT = authId -> {
+        final Matcher matcher = CredentialsConstants.PATTERN_AUTH_ID_VALUE.matcher(authId);
+        if (matcher.matches()) {
+            return true;
+        } else {
+            throw new IllegalArgumentException("authentication identifier must match pattern "
+                    + CredentialsConstants.PATTERN_AUTH_ID_VALUE.pattern());
+        }
+    };
 
     private final List<PasswordSecret> secrets = new LinkedList<>();
 
@@ -51,6 +68,17 @@ public class PasswordCredential extends CommonCredential {
 
         super(authId);
         setSecrets(secrets);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return A predicate that matches the identifier against the {@linkplain CredentialsConstants#PATTERN_AUTH_ID_VALUE
+     * default pattern}.
+     */
+    @Override
+    protected Predicate<String> getAuthIdValidator() {
+        return AUTH_ID_VALIDATOR_DEFAULT;
     }
 
     /**

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PasswordCredential.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.RegistryManagementConstants;
@@ -35,19 +36,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class PasswordCredential extends CommonCredential {
 
+    /**
+     * The regular expression that authentication identifiers need to match.
+     */
+    public static final String REGEX_AUTH_ID = "^[a-zA-Z0-9-_=\\.]+$";
+
     static final String TYPE = RegistryManagementConstants.SECRETS_TYPE_HASHED_PASSWORD;
 
+    private static final Pattern PATTERN_AUTH_ID_VALUE = Pattern.compile(REGEX_AUTH_ID);
     /**
      * A predicate for matching authentication identifiers against the
      * {@linkplain CredentialsConstants#PATTERN_AUTH_ID_VALUE default pattern}.
      */
     private static final Predicate<String> AUTH_ID_VALIDATOR_DEFAULT = authId -> {
-        final Matcher matcher = CredentialsConstants.PATTERN_AUTH_ID_VALUE.matcher(authId);
+        final Matcher matcher = PATTERN_AUTH_ID_VALUE.matcher(authId);
         if (matcher.matches()) {
             return true;
         } else {
             throw new IllegalArgumentException("authentication identifier must match pattern "
-                    + CredentialsConstants.PATTERN_AUTH_ID_VALUE.pattern());
+                    + PATTERN_AUTH_ID_VALUE.pattern());
         }
     };
 
@@ -59,8 +66,7 @@ public class PasswordCredential extends CommonCredential {
      * @param authId The authentication identifier.
      * @param secrets The credential's secret password(s).
      * @throws NullPointerException if any of the parameters are {@code null}.
-     * @throws IllegalArgumentException if auth ID does not match {@link org.eclipse.hono.util.CredentialsConstants#PATTERN_AUTH_ID_VALUE}
-     *                                  or if secrets is empty.
+     * @throws IllegalArgumentException if auth ID does not match {@value #REGEX_AUTH_ID} or if secrets is empty.
      */
     public PasswordCredential(
             @JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String authId,
@@ -73,8 +79,7 @@ public class PasswordCredential extends CommonCredential {
     /**
      * {@inheritDoc}
      *
-     * @return A predicate that matches the identifier against the {@linkplain CredentialsConstants#PATTERN_AUTH_ID_VALUE
-     * default pattern}.
+     * @return A predicate that matches the identifier against the {@linkplain #REGEX_AUTH_ID default pattern}.
      */
     @Override
     protected Predicate<String> getAuthIdValidator() {

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
@@ -42,8 +42,7 @@ public class PskCredential extends CommonCredential {
      * @param authId The authentication identifier.
      * @param secrets The credential's shared secret(s).
      * @throws NullPointerException if any of the parameters are {@code null}.
-     * @throws IllegalArgumentException if auth ID does not match {@link org.eclipse.hono.util.CredentialsConstants#PATTERN_AUTH_ID_VALUE}
-     *                                  or if secrets is empty.
+     * @throws IllegalArgumentException if secrets is empty.
      */
     public PskCredential(
             @JsonProperty(value = RegistryManagementConstants.FIELD_AUTH_ID, required = true) final String authId,

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -1073,10 +1073,8 @@ components:
          properties:
             "type":
                type: string
-               pattern: "^[a-z0-9-]+$"
             "auth-id":
                type: string
-               pattern: "^[a-zA-Z0-9-_=.]+$"
             "enabled":
                type: boolean
                default: true
@@ -1095,6 +1093,12 @@ components:
                  "type":
                     type: string
                     pattern: "hashed-password"
+                 "auth-id":
+                    type: string
+                    description: |
+                       The authentication identifier provided by the device as part of the *user name*.
+                       Example: For user name `sensor1@DEFAULT_TENANT` the authentication identifier to be registered
+                       is `sensor1`.
                  "secrets":
                     type: array
                     items:
@@ -1113,6 +1117,9 @@ components:
                  "type":
                     type: string
                     pattern: "psk"
+                 "auth-id":
+                    type: string
+                    description: The *PSK identity* provided by the device in the TLS handshake.
                  "secrets":
                     type: array
                     items:
@@ -1131,6 +1138,9 @@ components:
                  "type":
                     type: string
                     pattern: "x509-cert"
+                 "auth-id":
+                    type: string
+                    description: The *subject DN* of the public key contained in the device's X.509 certificate.
                  "secrets":
                     type: array
                     items:
@@ -1148,12 +1158,17 @@ components:
             "enabled":
                type: boolean
                default: true
+               description: Indicates if this secret can be used for authentication.
             "not-before":
                type: string
                format: date-time
+               description: |
+                  The point in time from which on this secret will be accepted for authentication.
             "not-after":
                type: string
                format: date-time
+               description: |
+                  The point in time after which this secret will no longer be accepted for authentication.
             "comment":
                type: string
 
@@ -1209,6 +1224,7 @@ components:
                  "key":
                     type: string
                     format: byte
+                    description: The secret key shared between device and Hono.
 
       FilterJson:
         description: Filters to be applied to bulk queries.
@@ -1268,16 +1284,6 @@ components:
          schema:
             type: string
          example: 4711
-
-      type:
-         name: type
-         in: path
-         description: The credentials type
-         required: true
-         schema:
-            type: string
-            pattern: "^[a-z0-9-]+$"
-         example: sha-256
 
       pageSize:
         name: pageSize


### PR DESCRIPTION
Also removed obsolete parameter type and improved documentation of
credentials and secrets objects.