### PR TITLE
Add GitHub Actions workflow for CI build and running integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+# Copyright (c) 2020 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# This workflow will build all of Hono's components, run unit tests and create
+# Docker images. Finally, the integration tests are run.
+# The job uses a matrix for the distinct device registry implementations. Thus,
+# for each registry implementation, the workflow is run on a separate VM.
+
+name: Build Hono's 'container images and run integration tests
+
+on: [push,pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        device-registry: [file,mongodb]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Cache embedded MongoDB for unit tests
+      uses: actions/cache@v2
+      with:
+        path: ~/.embedmongo/**/*.tgz
+        key: ${{ runner.os }}-mongodb-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-mongodb-
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: '11'
+    - name: Build all components ()incl. unit tests) and run integration tests
+      run: mvn install -B -e -DcreateJavadoc=true -DCI=$CI -Dhono.deviceregistry.type=${{ matrix.device-registry }} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pbuild-docker-image,run-tests

--- a/jmeter/pom.xml
+++ b/jmeter/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -28,6 +28,10 @@
   <name>Hono JMeter Plugin</name>
   <description>JMeter Plugin for Hono with sender and receiver samplers using the Hono Client</description>
   <url>https://www.eclipse.org/hono</url>
+
+  <properties>
+    <jmeter.disabled>true</jmeter.disabled>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -80,13 +84,14 @@
 
   <profiles>
     <profile>
-      <id>build-jmeter-image</id>
+      <id>build-docker-image</id>
       <build>
         <plugins>
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
             <configuration>
+              <skipBuild>${jmeter.disabled}</skipBuild>
               <images>
                 <image>
                   <build>
@@ -106,6 +111,9 @@
               <plugin>
                   <groupId>io.fabric8</groupId>
                   <artifactId>docker-maven-plugin</artifactId>
+                  <configuration>
+                    <skipPush>${jmeter.disabled}</skipPush>
+                  </configuration>
                   <executions>
                       <execution>
                           <id>docker-push-image</id>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -213,6 +213,12 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     </profile>
     <profile>
       <id>device-registry-mongodb</id>
+      <activation>
+        <property>
+          <name>hono.deviceregistry.type</name>
+          <value>mongodb</value>
+        </property>
+      </activation>
       <properties>
         <deviceregistry.image>hono-service-device-registry-mongodb</deviceregistry.image>
         <hono.mongodb.disabled>false</hono.mongodb.disabled>


### PR DESCRIPTION
The job uses a build matrix for the different device registry implementations. The jobs are run in parallel on separate VMs.