### PR TITLE
[#2174][#2183] Accept X.509 credentials

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -12,10 +12,6 @@
  *******************************************************************************/
 package org.eclipse.hono.util;
 
-import java.util.Objects;
-
-import io.vertx.core.json.JsonObject;
-
 /**
  * Constants &amp; utility methods used throughout the Device Management API.
  */
@@ -353,17 +349,5 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
 
     private RegistryManagementConstants() {
         // prevent instantiation
-    }
-
-    /**
-     * Checks if a given secret is of type {@value #SECRETS_TYPE_HASHED_PASSWORD}.
-     *
-     * @param secret The secret to check.
-     * @return {@code true} if the secret has a string property with name {@value #FIELD_TYPE}
-     *         and value {@value #SECRETS_TYPE_HASHED_PASSWORD}.
-     */
-    public static boolean isHashedPasswordSecret(final JsonObject secret) {
-        Objects.requireNonNull(secret);
-        return SECRETS_TYPE_HASHED_PASSWORD.equals(secret.getValue(FIELD_TYPE));
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -12,6 +12,10 @@
  *******************************************************************************/
 package org.eclipse.hono.util;
 
+import java.util.Objects;
+
+import io.vertx.core.json.JsonObject;
+
 /**
  * Constants &amp; utility methods used throughout the Device Management API.
  */
@@ -349,5 +353,17 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
 
     private RegistryManagementConstants() {
         // prevent instantiation
+    }
+
+    /**
+     * Checks if a given secret is of type {@value #SECRETS_TYPE_HASHED_PASSWORD}.
+     *
+     * @param secret The secret to check.
+     * @return {@code true} if the secret has a string property with name {@value #FIELD_TYPE}
+     *         and value {@value #SECRETS_TYPE_HASHED_PASSWORD}.
+     */
+    public static boolean isHashedPasswordSecret(final JsonObject secret) {
+        Objects.requireNonNull(secret);
+        return SECRETS_TYPE_HASHED_PASSWORD.equals(secret.getValue(FIELD_TYPE));
     }
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonSecret.java
@@ -14,10 +14,12 @@ package org.eclipse.hono.service.management.credentials;
 
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.hono.annotation.HonoTimestamp;
 import org.eclipse.hono.util.RegistryManagementConstants;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -30,10 +32,10 @@ import com.google.common.base.Strings;
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public abstract class CommonSecret {
 
-    @JsonProperty
+    @JsonProperty(RegistryManagementConstants.FIELD_ENABLED)
     private Boolean enabled;
 
-    @JsonProperty
+    @JsonProperty(RegistryManagementConstants.FIELD_ID)
     private String id;
 
     @JsonProperty(RegistryManagementConstants.FIELD_SECRETS_NOT_BEFORE)
@@ -42,11 +44,12 @@ public abstract class CommonSecret {
     @JsonProperty(RegistryManagementConstants.FIELD_SECRETS_NOT_AFTER)
     @HonoTimestamp
     private Instant notAfter;
-    @JsonProperty
+    @JsonProperty(RegistryManagementConstants.FIELD_COMMENT)
     private String comment;
 
-    public Boolean getEnabled() {
-        return enabled;
+    @JsonIgnore
+    public final boolean isEnabled() {
+        return Optional.ofNullable(enabled).orElse(true);
     }
 
     /**
@@ -55,20 +58,31 @@ public abstract class CommonSecret {
      * @param enabled  Whether this secret type should be used to authenticate devices.
      * @return         a reference to this for fluent use.
      */
+    @JsonIgnore
     public final CommonSecret setEnabled(final Boolean enabled) {
         this.enabled = enabled;
         return this;
     }
 
+    /**
+     * Gets the identifier of the secret.
+     * <p>
+     * This id may be assigned by the device registry.
+     * The id must be unique within the credentials set containing it.
+     *
+     * @return The identifier or {@code null} if not assigned.
+     */
     public final String getId() {
         return id;
     }
 
     /**
-     * Sets the ID of the secret. This id may be assigned by the device registry.
+     * Sets the identifier of the secret.
+     * <p>
+     * This id may be assigned by the device registry.
      * The id must be unique within the credentials set containing it.
      *
-     * @param id The string to set as the id.
+     * @param id The identifier.
      * @return   a reference to this for fluent use.
      */
     public final CommonSecret setId(final String id) {

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
@@ -31,6 +31,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.management.OperationResult;
@@ -38,7 +41,10 @@ import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
 import org.eclipse.hono.service.management.credentials.PasswordSecret;
+import org.eclipse.hono.service.management.credentials.PskCredential;
 import org.eclipse.hono.service.management.credentials.PskSecret;
+import org.eclipse.hono.service.management.credentials.X509CertificateCredential;
+import org.eclipse.hono.service.management.credentials.X509CertificateSecret;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.util.CacheDirective;
@@ -316,7 +322,9 @@ public interface AbstractCredentialsServiceTest {
                         // assert a few basics, optionals may be empty
                         // but must not be null
                         assertNotNull(s3.getCacheDirective());
-                        assertResourceVersion(s3);
+                        if (s3.isOk()) {
+                            assertResourceVersion(s3);
+                        }
 
                         mangementValidation.accept(s3);
 
@@ -404,7 +412,9 @@ public interface AbstractCredentialsServiceTest {
         final var deviceId = UUID.randomUUID().toString();
         final var authId = UUID.randomUUID().toString();
         final var pwdCredentials = Credentials.createPasswordCredential(authId, "bar");
-        final var pskCredentials = Credentials.createPSKCredential(authId, "the-shared-key");
+        final var pskCredentials = Credentials.createPSKCredential("psk-id", "the-shared-key");
+        final String subjectDn = new X500Principal("emailAddress=foo@bar.com, CN=foo, O=bar").getName(X500Principal.RFC2253);
+        final var x509Credentials = new X509CertificateCredential(subjectDn, List.of(new X509CertificateSecret()));
 
         //create device and set credentials.
         assertGetMissing(ctx, tenantId, deviceId, authId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD,
@@ -413,7 +423,7 @@ public interface AbstractCredentialsServiceTest {
                         .compose(response -> getCredentialsManagementService().updateCredentials(
                                 tenantId,
                                 deviceId,
-                                List.of(pwdCredentials, pskCredentials),
+                                List.of(pwdCredentials, pskCredentials, x509Credentials),
                                 Optional.empty(),
                                 NoopSpan.INSTANCE))
                         .compose(response -> {
@@ -427,8 +437,20 @@ public interface AbstractCredentialsServiceTest {
                             ctx.verify(() -> {
                                 assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_OK);
                                 assertResourceVersion(response);
-                                assertThat(response.getPayload()).hasSize(2);
+                                assertThat(response.getPayload()).hasSize(3);
                                 assertReadCredentialsResponseProperties(response.getPayload());
+                            });
+                            return getCredentialsService().get(tenantId, CredentialsConstants.SECRETS_TYPE_X509_CERT, subjectDn);
+                        })
+                        .compose(response -> {
+                            ctx.verify(() -> {
+                                assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_OK);
+                                assertGetCredentialsResponseProperties(
+                                        response.getPayload(),
+                                        deviceId,
+                                        CredentialsConstants.SECRETS_TYPE_X509_CERT,
+                                        subjectDn);
+                                assertThat(response.getPayload().getJsonArray(CredentialsConstants.FIELD_SECRETS)).isNotEmpty();
                             });
                             return getCredentialsService().get(tenantId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, authId);
                         })
@@ -445,7 +467,7 @@ public interface AbstractCredentialsServiceTest {
                                     .map(JsonObject.class::cast)
                                     .forEach(secret -> assertPwdSecretContainsHash(secret, false));
                             });
-                            return getCredentialsService().get(tenantId, CredentialsConstants.SECRETS_TYPE_PRESHARED_KEY, authId);
+                            return getCredentialsService().get(tenantId, CredentialsConstants.SECRETS_TYPE_PRESHARED_KEY, "psk-id");
                         })
                         .onComplete(ctx.succeeding(response -> {
                             ctx.verify(() -> {
@@ -454,7 +476,7 @@ public interface AbstractCredentialsServiceTest {
                                         response.getPayload(),
                                         deviceId,
                                         CredentialsConstants.SECRETS_TYPE_PRESHARED_KEY,
-                                        authId);
+                                        "psk-id");
                                 final JsonArray secrets = response.getPayload().getJsonArray(CredentialsConstants.FIELD_SECRETS);
                                 secrets.stream()
                                     .map(JsonObject.class::cast)
@@ -482,19 +504,24 @@ public interface AbstractCredentialsServiceTest {
         assertGetMissing(ctx, tenantId, deviceId, authId, RegistryManagementConstants.SECRETS_TYPE_HASHED_PASSWORD,
                 () -> getDeviceManagementService()
                         .createDevice(tenantId, Optional.of(deviceId), new Device(), NoopSpan.INSTANCE)
-                        .compose(response -> getCredentialsManagementService().updateCredentials(
-                                tenantId,
-                                deviceId,
-                                List.of(pwdCredentials),
-                                Optional.empty(),
-                                NoopSpan.INSTANCE))
+                        .compose(response -> {
+                            ctx.verify(() -> {
+                                assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_CREATED);
+                            });
+                            log.debug("before update");
+                            return getCredentialsManagementService().updateCredentials(
+                                    tenantId,
+                                    deviceId,
+                                    List.of(pwdCredentials),
+                                    Optional.empty(),
+                                    NoopSpan.INSTANCE);
+                        })
                         .onComplete(ctx.succeeding(response -> ctx.verify(() -> {
-
+                            log.debug("after update");
                             assertEquals(HttpURLConnection.HTTP_NO_CONTENT, response.getStatus());
                             assertResourceVersion(response);
 
-                            assertGet(ctx, tenantId, deviceId, authId,
-                                    RegistryManagementConstants.SECRETS_TYPE_HASHED_PASSWORD,
+                            assertGet(ctx, tenantId, deviceId, authId, RegistryManagementConstants.SECRETS_TYPE_HASHED_PASSWORD,
                                     r -> {
                                         assertThat(r.getStatus()).isEqualTo(HttpURLConnection.HTTP_OK);
                                         final List<CommonCredential> credentials = r.getPayload();
@@ -857,22 +884,25 @@ public interface AbstractCredentialsServiceTest {
     }
 
     /**
-     * Verifies that existing secrets are deleted when their IDs are not contained
-     * in the request payload.
+     * Verifies that existing credentials and secrets are deleted when they are omitted from
+     * the body of an update Credentials request.
      *
      * @param ctx The vert.x test context.
      */
     @Test
-    default void testUpdateCredentialsSupportsRemovingExistingSecrets(final VertxTestContext ctx) {
+    default void testUpdateCredentialsSupportsRemovingExistingCredentialsAndSecrets(final VertxTestContext ctx) {
 
         final String tenantId = UUID.randomUUID().toString();
         final String deviceId = UUID.randomUUID().toString();
         final String authId = UUID.randomUUID().toString();
+        final String otherAuthId = UUID.randomUUID().toString();
 
         final PasswordSecret sec1 = new PasswordSecret().setPasswordPlain("bar");
         final PasswordSecret sec2 = new PasswordSecret().setPasswordPlain("foo");
 
         final PasswordCredential credential = new PasswordCredential(authId, List.of(sec1, sec2));
+        final PskCredential pskCredentialSameAuthId = Credentials.createPSKCredential(authId, "shared-key");
+        final PskCredential pskCredential = Credentials.createPSKCredential(otherAuthId, "other-shared-key");
 
         // create device & set credentials
 
@@ -880,11 +910,19 @@ public interface AbstractCredentialsServiceTest {
 
         getDeviceManagementService()
                 .createDevice(tenantId, Optional.of(deviceId), new Device(), NoopSpan.INSTANCE)
-                .onComplete(ctx.succeeding(n -> getCredentialsManagementService()
-                        .updateCredentials(tenantId, deviceId, Collections.singletonList(credential),
-                                Optional.empty(),
-                                NoopSpan.INSTANCE)
-                        .onComplete(ctx.succeeding(s -> phase1.complete()))));
+                .compose(result -> {
+                    ctx.verify(() -> assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_CREATED));
+                    return getCredentialsManagementService().updateCredentials(
+                            tenantId,
+                            deviceId,
+                            List.of(credential, pskCredential, pskCredentialSameAuthId),
+                            Optional.empty(),
+                            NoopSpan.INSTANCE);
+                })
+                .onComplete(ctx.succeeding(result -> {
+                    ctx.verify(() -> assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT));
+                    phase1.complete();
+                }));
 
         // Retrieve credentials IDs
 
@@ -892,71 +930,99 @@ public interface AbstractCredentialsServiceTest {
         final List<String> secretIDs = new ArrayList<>();
 
         phase1.future()
-                .onComplete(ctx.succeeding(n -> getCredentialsService()
-                        .get(tenantId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, authId)
-                        .onComplete(ctx.succeeding(s -> ctx.verify(() -> {
+            .compose(ok -> getCredentialsManagementService().readCredentials(tenantId, deviceId, NoopSpan.INSTANCE))
+            .onComplete(ctx.succeeding(s -> {
+                ctx.verify(() -> {
 
-                            assertEquals(HttpURLConnection.HTTP_OK, s.getStatus());
+                    assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_OK);
+                    assertThat(s.getPayload()).hasSize(3);
+                    assertResourceVersion(s);
+                    assertReadCredentialsResponseProperties(s.getPayload());
 
-                            final CredentialsObject creds = s.getPayload().mapTo(CredentialsObject.class);
+                    final List<PskCredential> pskCredentials = s.getPayload().stream()
+                            .filter(PskCredential.class::isInstance)
+                            .map(PskCredential.class::cast)
+                            .collect(Collectors.toList());
+                    assertThat(pskCredentials).as("PSK credentials have been registered").hasSize(2);
 
-                            assertEquals(authId, creds.getAuthId());
-                            assertEquals(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, creds.getType());
-                            assertEquals(2, creds.getSecrets().size());
+                    s.getPayload().stream()
+                        .filter(PasswordCredential.class::isInstance)
+                        .map(PasswordCredential.class::cast)
+                        .findFirst()
+                        .ifPresentOrElse(
+                                creds -> {
+                                    assertThat(creds.getAuthId()).isEqualTo(authId);
+                                    assertThat(creds.getSecrets()).hasSize(2);
+                                    creds.getSecrets().stream()
+                                        .forEach(secret -> {
+                                            assertThat(secret.getId()).isNotNull();
+                                            secretIDs.add(secret.getId());
+                                        });
+                                },
+                                () -> ctx.failNow(new AssertionError("failed to retrieve hashed-password credential")));
 
-                            for (Object secret : creds.getSecrets()) {
-                                final String id = ((JsonObject) secret).getString(RegistryManagementConstants.FIELD_ID);
-                                assertNotNull(id);
-                                secretIDs.add(id);
-                            }
+                });
+                phase2.complete();
+           }));
 
-                            phase2.complete();
-                        })))));
-
-        // re-set credentials
+        // update credentials
         final Promise<?> phase3 = Promise.promise();
 
-        phase2.future().onComplete(ctx.succeeding(n -> {
-            // create a credential object with only one of the ID.
-            final PasswordSecret secretWithOnlyId = new PasswordSecret();
-            secretWithOnlyId.setId(secretIDs.get(0));
+        phase2.future()
+            .compose(ok -> {
+                // create a hashed-password credential with only one of the existing secrets
+                final PasswordSecret firstSecret = new PasswordSecret();
+                firstSecret.setId(secretIDs.get(0));
+                final PasswordCredential credentialWithFirstSecretOnly = new PasswordCredential(authId, List.of(firstSecret));
 
-            final PasswordCredential credentialWithOnlyId = new PasswordCredential(authId, List.of(secretWithOnlyId));
+                // and omit the PSK credentials
+                return getCredentialsManagementService().updateCredentials(
+                        tenantId,
+                        deviceId,
+                        List.of(credentialWithFirstSecretOnly),
+                        Optional.empty(),
+                        NoopSpan.INSTANCE);
+            })
+           .onComplete(ctx.succeeding(s -> {
+               ctx.verify(() -> assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT));
+               phase3.complete();
+           }));
 
-            getCredentialsManagementService()
-                    .updateCredentials(tenantId, deviceId, Collections.singletonList(credentialWithOnlyId),
-                            Optional.empty(), NoopSpan.INSTANCE)
-                    .onComplete(ctx.succeeding(s -> phase3.complete()));
-        }));
 
-
-        // Retrieve credentials again, one should be deleted.
-
-        final Promise<?> phase4 = Promise.promise();
+        // Retrieve credentials again
 
         phase3.future()
-                .onComplete(ctx.succeeding(n -> getCredentialsService()
-                        .get(tenantId, CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, authId)
-                        .onComplete(ctx.succeeding(s -> ctx.verify(() -> {
+            .compose(ok -> getCredentialsManagementService().readCredentials(tenantId, deviceId, NoopSpan.INSTANCE))
+            .compose(result -> {
+                ctx.verify(() -> {
+                    assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_OK);
 
-                            assertEquals(HttpURLConnection.HTTP_OK, s.getStatus());
+                    final boolean pskCredentialHasBeenDeleted = result.getPayload().stream()
+                        .noneMatch(PskCredential.class::isInstance);
+                    assertThat(pskCredentialHasBeenDeleted).as("PSK credentials have been deleted");
 
-                            final CredentialsObject creds = s.getPayload().mapTo(CredentialsObject.class);
-
-                            assertEquals(authId, creds.getAuthId());
-                            assertEquals(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD, creds.getType());
-                            assertEquals(1, creds.getSecrets().size());
-
-                            final String id = creds.getSecrets().getJsonObject(0)
-                                    .getString(RegistryManagementConstants.FIELD_ID);
-                            assertEquals(id, secretIDs.get(0));
-
-                            phase4.complete();
-                        })))));
-
-        // finally complete
-
-        phase4.future().onComplete(ctx.succeeding(s -> ctx.completeNow()));
+                    assertThat(result.getPayload().get(0)).isInstanceOf(PasswordCredential.class);
+                    final PasswordCredential creds = (PasswordCredential) result.getPayload().get(0);
+                    assertThat(creds.getAuthId()).isEqualTo(authId);
+                    assertThat(creds.getSecrets())
+                        .as("second password has been deleted")
+                        .hasSize(1);
+                    assertThat(creds.getSecrets().get(0).getId()).isEqualTo(secretIDs.get(0));
+                });
+                return getCredentialsService().get(tenantId, RegistryManagementConstants.SECRETS_TYPE_PRESHARED_KEY, authId);
+            })
+            .compose(result -> {
+                ctx.verify(() -> assertThat(result.getStatus())
+                        .as("Credentials service does not return PSK credential")
+                        .isEqualTo(HttpURLConnection.HTTP_NOT_FOUND));
+                return getCredentialsService().get(tenantId, RegistryManagementConstants.SECRETS_TYPE_PRESHARED_KEY, otherAuthId);
+            })
+            .onComplete(ctx.succeeding(result -> {
+                ctx.verify(() -> assertThat(result.getStatus())
+                        .as("Credentials service does not return PSK credential")
+                        .isEqualTo(HttpURLConnection.HTTP_NOT_FOUND));
+                ctx.completeNow();
+            }));
     }
 
     /**

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsService.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
@@ -26,23 +27,23 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.eclipse.hono.auth.HonoPasswordEncoder;
-import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.deviceregistry.service.credentials.AbstractCredentialsManagementService;
+import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.service.Lifecycle;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
-import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsResult;
 import org.eclipse.hono.util.RegistryManagementConstants;
-import org.eclipse.hono.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,7 +67,7 @@ import io.vertx.core.json.JsonObject;
  * On startup this adapter tries to load credentials from a file (if configured).
  * On shutdown all credentials kept in memory are written to the file (if configured).
  */
-public final class FileBasedCredentialsService implements CredentialsManagementService, CredentialsService, Lifecycle {
+public final class FileBasedCredentialsService extends AbstractCredentialsManagementService implements CredentialsService, Lifecycle {
 
     /**
      * The name of the JSON array within a tenant that contains the credentials.
@@ -80,36 +81,29 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
     private static final Logger LOG = LoggerFactory.getLogger(FileBasedCredentialsService.class);
 
     // <tenantId, <authId, credentialsData[]>>
-    private final ConcurrentMap<String, ConcurrentMap<String, JsonArray>> credentials = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, JsonArray>> credentials = new ConcurrentHashMap<>();
     // <tenantId, <deviceId, version>>
-    private final ConcurrentMap<String, ConcurrentMap<String, String>> versions = new ConcurrentHashMap<>();
-    private final Vertx vertx;
+    private final Map<String, Map<String, String>> versions = new ConcurrentHashMap<>();
 
     private AtomicBoolean running = new AtomicBoolean(false);
     private AtomicBoolean dirty = new AtomicBoolean(false);
     private FileBasedCredentialsConfigProperties config;
 
-    private HonoPasswordEncoder passwordEncoder;
-
     /**
      * Creates a new service instance.
      *
      * @param vertx The vert.x instance to run on.
-     * @throws NullPointerException if vertx is {@code null}.
+     * @param configuration The service's configuration properties.
+     * @param passwordEncoder The password encoder.
+     * @throws NullPointerException if any of the parameters are {@code null};
      */
     @Autowired
-    public FileBasedCredentialsService(final Vertx vertx) {
-        this.vertx = Objects.requireNonNull(vertx);
-    }
-
-    @Autowired
-    public void setConfig(final FileBasedCredentialsConfigProperties configuration) {
+    public FileBasedCredentialsService(
+            final Vertx vertx,
+            final FileBasedCredentialsConfigProperties configuration,
+            final HonoPasswordEncoder passwordEncoder) {
+        super(vertx, passwordEncoder, configuration.getMaxBcryptCostFactor(), configuration.getHashAlgorithmsWhitelist());
         this.config = configuration;
-    }
-
-    @Autowired
-    public void setPasswordEncoder(final HonoPasswordEncoder passwordEncoder) {
-        this.passwordEncoder = passwordEncoder;
     }
 
     public FileBasedCredentialsConfigProperties getConfig() {
@@ -247,7 +241,7 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
             return checkFileExists(true).compose(s -> {
                 final AtomicInteger idCount = new AtomicInteger();
                 final JsonArray tenants = new JsonArray();
-                for (final Entry<String, ConcurrentMap<String, JsonArray>> entry : credentials.entrySet()) {
+                for (final Entry<String, Map<String, JsonArray>> entry : credentials.entrySet()) {
                     final JsonArray credentialsArray = new JsonArray();
                     for (final JsonArray singleAuthIdCredentials : entry.getValue().values()) {
                         credentialsArray.addAll(singleAuthIdCredentials.copy());
@@ -317,18 +311,29 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
         }
     }
 
-    private void findCredentialsForDevice(final JsonArray credentials, final String deviceId, final JsonArray result) {
+    /**
+     * Gets all credentials for a device.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The identifier of the device.
+     * @return A list containing copies of the credentials objects.
+     */
+    private List<JsonObject> findCredentialsForDevice(final String tenantId, final String deviceId) {
 
-        for (final Object obj : credentials) {
-            if (obj instanceof JsonObject) {
-                final JsonObject currentCredentials = (JsonObject) obj;
-                if (deviceId.equals(getTypesafeValueForField(String.class, currentCredentials,
-                        CredentialsConstants.FIELD_PAYLOAD_DEVICE_ID))) {
-                    // device ID matches, add a copy of credentials to result
-                    result.add(currentCredentials.copy());
-                }
-            }
-        }
+        final List<JsonObject> result = new ArrayList<>();
+        getCredentialsForTenant(tenantId).entrySet().forEach(entry -> {
+            entry.getValue().stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
+                .filter(obj -> deviceId.equals(getTypesafeValueForField(
+                        String.class,
+                        obj,
+                        CredentialsConstants.FIELD_PAYLOAD_DEVICE_ID)))
+                // device ID matches, add a copy of credentials to result
+                .map(JsonObject::copy)
+                .forEach(result::add);
+        });
+        return result;
     }
 
     /**
@@ -358,8 +363,7 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
     }
 
     /**
-     * Get the credentials associated with the authId and the given type. If type is null, all credentials associated
-     * with the authId are returned (as JsonArray inside the return value).
+     * Get the credentials associated with the authId and the given type.
      *
      * @param tenantId The id of the tenant the credentials belong to.
      * @param authId The authentication identifier to look up credentials for.
@@ -367,14 +371,18 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
      * @param span The active OpenTracing span for this operation.
      * @return The credentials object of the given type or {@code null} if no matching credentials exist.
      */
-    private JsonObject getSingleCredentials(final String tenantId, final String authId, final String type,
-            final JsonObject clientContext, final Span span) {
+    private JsonObject getSingleCredentials(
+            final String tenantId,
+            final String authId,
+            final String type,
+            final JsonObject clientContext,
+            final Span span) {
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(authId);
         Objects.requireNonNull(type);
 
-        final ConcurrentMap<String, JsonArray> credentialsForTenant = credentials.get(tenantId);
+        final Map<String, JsonArray> credentialsForTenant = credentials.get(tenantId);
         if (credentialsForTenant == null) {
             TracingHelper.logError(span, "no credentials found for tenant");
             return null;
@@ -387,6 +395,7 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
         }
 
         for (final Object authIdCredentialEntry : authIdCredentials) {
+
             final JsonObject authIdCredential = (JsonObject) authIdCredentialEntry;
 
             if (!type.equals(authIdCredential.getString(CredentialsConstants.FIELD_TYPE))) {
@@ -405,26 +414,14 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
 
             // copy
             final var authIdCredentialCopy = authIdCredential.copy();
-            final var secrets = authIdCredentialCopy.getJsonArray(CredentialsConstants.FIELD_SECRETS);
+            final JsonArray secrets = authIdCredentialCopy.getJsonArray(CredentialsConstants.FIELD_SECRETS, new JsonArray())
+                    .stream()
+                    .filter(JsonObject.class::isInstance)
+                    .map(JsonObject.class::cast)
+                    .filter(secret -> secret.getBoolean(CredentialsConstants.FIELD_ENABLED, true))
+                    .collect(JsonArray::new, JsonArray::add, JsonArray::addAll);
 
-            for (final Iterator<Object> i = secrets.iterator(); i.hasNext();) {
-
-                final Object o = i.next();
-                if (!(o instanceof JsonObject)) {
-                    i.remove();
-                    continue;
-                }
-
-                final JsonObject secret = (JsonObject) o;
-                if (Boolean.FALSE.equals(secret.getBoolean(CredentialsConstants.FIELD_ENABLED, true))) {
-                    i.remove();
-                }
-            }
-
-            if (secrets.isEmpty()) {
-                // no more secrets left
-                continue;
-            }
+            authIdCredentialCopy.put(CredentialsConstants.FIELD_SECRETS, secrets);
 
             // return the first entry that matches
             return authIdCredentialCopy;
@@ -440,150 +437,221 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public Future<OperationResult<Void>> updateCredentials(final String tenantId, final String deviceId,
-            final List<CommonCredential> credentials,
+    protected Future<OperationResult<Void>> processUpdateCredentials(
+            final DeviceKey key,
             final Optional<String> resourceVersion,
+            final List<CommonCredential> credentials,
             final Span span) {
 
-        return Future.succeededFuture(set(tenantId, deviceId, resourceVersion, span, credentials));
+        return Future.succeededFuture(set(key.getTenantId(), key.getDeviceId(), resourceVersion, span, credentials));
 
     }
 
-    private OperationResult<Void> set(final String tenantId, final String deviceId,
-            final Optional<String> resourceVersion, final Span span, final List<CommonCredential> credentials) {
+    private OperationResult<Void> set(
+            final String tenantId,
+            final String deviceId,
+            final Optional<String> resourceVersion,
+            final Span span,
+            final List<CommonCredential> updatedCredentials) {
 
-        if (!checkResourceVersion(tenantId, deviceId, resourceVersion)) {
-            TracingHelper.logError(span, "Resource version mismatch");
+        final String currentVersion = getResourceVersion(tenantId, deviceId);
+        if (!checkResourceVersion(currentVersion, resourceVersion)) {
+            TracingHelper.logError(span, "resource version mismatch");
             return OperationResult.empty(HttpURLConnection.HTTP_PRECON_FAILED);
         }
 
-        // change version
-        final var newVersion = UUID.randomUUID().toString();
-        setResourceVersion(tenantId, deviceId, newVersion);
-
-
         // authId->credentials[]
-        final ConcurrentMap<String, JsonArray> credentialsForTenant = createOrGetCredentialsForTenant(tenantId);
+        final Map<String, JsonArray> credentialsForTenant = getCredentialsForTenant(tenantId);
 
-        if (!credentialsForTenant.isEmpty()) {
-            try {
-                verifyOverwriteEnabled(span);
-            } catch (ClientErrorException e) {
-                TracingHelper.logError(span, e);
-                return OperationResult.empty(e.getErrorCode());
+        // authid->credentials
+        final Map<String, JsonArray> newCredentials = new ConcurrentHashMap<>();
+
+        // now follow the algorithm described by the Device Registry Management API
+        // https://www.eclipse.org/hono/docs/api/management/#/credentials/setAllCredentials
+
+        for (final CommonCredential credential : updatedCredentials) {
+
+            final JsonObject credentialObject = JsonObject.mapFrom(credential);
+            credentialObject.put(RegistryManagementConstants.FIELD_PAYLOAD_DEVICE_ID, deviceId);
+
+            // find credentials - matching by type and auth-id
+            final String type = credential.getType();
+            final String authId = credential.getAuthId();
+            final JsonArray credentialsForAuthId = getCredentialsForAuthId(credentialsForTenant, authId);
+            final JsonObject existingCredentials = credentialsForAuthId.stream()
+                    .filter(JsonObject.class::isInstance)
+                    .map(JsonObject.class::cast)
+                    .filter(j -> type.equals(j.getString(RegistryManagementConstants.FIELD_TYPE)))
+                    .findAny()
+                    .orElse(null);
+
+            if (existingCredentials != null) {
+
+                if (!deviceId.equals(existingCredentials.getString(CredentialsConstants.FIELD_PAYLOAD_DEVICE_ID))) {
+                    // found an entry for another device, with the same auth-id
+                    TracingHelper.logError(span, "auth-id already in use with another device of the tenant");
+                    return OperationResult.empty(HttpURLConnection.HTTP_CONFLICT);
+                } else if (!config.isModificationEnabled()) {
+                    TracingHelper.logError(span, "modification is disabled for the Credentials service");
+                    return OperationResult.empty(HttpURLConnection.HTTP_FORBIDDEN);
+                }
+
+                // we have found an existing credential for the device that should be updated
+
+                // merge existing secrets into updated secrets, if necessary
+                final JsonArray existingSecrets = existingCredentials.getJsonArray(CredentialsConstants.FIELD_SECRETS, new JsonArray());
+                final JsonArray updatedSecrets = credentialObject.getJsonArray(CredentialsConstants.FIELD_SECRETS, new JsonArray());
+
+                for (final Object obj : updatedSecrets) {
+
+                    final JsonObject updatedSecret = (JsonObject) obj;
+                    final String secretId = updatedSecret.getString(RegistryManagementConstants.FIELD_ID);
+
+                    if (secretId != null) {
+                        // Find the corresponding secret with the given ID.
+                        final JsonObject existingSecretWithId = existingSecrets.stream()
+                                .filter(JsonObject.class::isInstance).map(JsonObject.class::cast)
+                                .filter(existingSecret -> secretId.equals(existingSecret.getString(RegistryManagementConstants.FIELD_ID)))
+                                .findAny().orElse(null);
+
+                        if (existingSecretWithId == null) {
+                            TracingHelper.logError(span, "no secret with given ID found for credentials");
+                            return OperationResult.empty(HttpURLConnection.HTTP_BAD_REQUEST);
+                        }
+
+                        mergeSecretProperties(type, existingSecretWithId, updatedSecret);
+                    }
+                }
+
             }
-        }
 
-        // now add the new ones
-        for (final CommonCredential credential : credentials) {
-
-            try {
-                DeviceRegistryUtils.checkCredential(credential, passwordEncoder, config.getHashAlgorithmsWhitelist(),
-                        config.getMaxBcryptCostFactor());
-            } catch (final IllegalStateException e) {
-                TracingHelper.logError(span, e);
-                LOG.debug("Failed to validate credentials", e);
+            // make sure every secret has or gets a unique ID
+            if (hasUniqueSecretIds(credentialObject)) {
+                newCredentials.computeIfAbsent(authId, key -> new JsonArray()).add(credentialObject);
+                dirty.set(true);
+            } else {
+                TracingHelper.logError(span, "secret IDs must be unique within each credentials object");
+                LOG.debug("secret IDs must be unique within each credentials object");
                 return OperationResult.empty(HttpURLConnection.HTTP_BAD_REQUEST);
             }
 
-            final String authId = credential.getAuthId();
-            final JsonObject credentialObject = JsonObject.mapFrom(credential);
-            final String type = credentialObject.getString(CredentialsConstants.FIELD_TYPE);
-            final JsonArray json = createOrGetAuthIdCredentials(authId, credentialsForTenant);
-
-            // find credentials - matching by type
-            JsonObject credentialsJson = json.stream()
-                    .filter(JsonObject.class::isInstance).map(JsonObject.class::cast)
-                    .filter(j -> type.equals(j.getString(CredentialsConstants.FIELD_TYPE)))
-                    .findAny().orElse(null);
-
-            if (credentialsJson == null) {
-                // did not find an entry, add new one
-                credentialsJson = new JsonObject();
-                credentialsJson.put(CredentialsConstants.FIELD_AUTH_ID, authId);
-                credentialsJson.put(CredentialsConstants.FIELD_PAYLOAD_DEVICE_ID, deviceId);
-                credentialsJson.put(CredentialsConstants.FIELD_TYPE, type);
-                if (!credential.isEnabled()) {
-                    // only add non-default value
-                    credentialsJson.put(CredentialsConstants.FIELD_ENABLED, credential.isEnabled());
-                }
-                credentialsJson.put(RegistryManagementConstants.FIELD_EXT, credential.getExtensions());
-                json.add(credentialsJson);
-            }
-
-            if (!deviceId.equals(credentialsJson.getString(CredentialsConstants.FIELD_PAYLOAD_DEVICE_ID))) {
-                // found an entry for another device, with the same auth-id
-                TracingHelper.logError(span, "Auth-id already used for another device");
-                return OperationResult.empty(HttpURLConnection.HTTP_CONFLICT);
-            }
-
-            JsonArray secretsJson = credentialsJson.getJsonArray(CredentialsConstants.FIELD_SECRETS);
-            if (secretsJson == null) {
-                // secrets field was missing, assign
-                secretsJson = new JsonArray();
-            }
-
-            final JsonArray inputSecrets = credentialObject.getJsonArray(CredentialsConstants.FIELD_SECRETS);
-            final JsonArray definitiveInputSecret = new JsonArray();
-            for (Object inputSecret : inputSecrets) {
-                final JsonObject secret = (JsonObject) inputSecret;
-                final String secretId = secret.getString(RegistryManagementConstants.FIELD_ID);
-
-                // No secret ID specified : create a new secret
-                if (Strings.isNullOrEmpty(secretId)) {
-                    secret.put(RegistryManagementConstants.FIELD_ID, UUID.randomUUID().toString());
-                    definitiveInputSecret.add(secret);
-                // secret ID specified
-                } else {
-                    // Find the corresponding secret with the given ID.
-                    boolean found = false;
-                    for (Object st : secretsJson) {
-                        final JsonObject existingSecret = (JsonObject) st;
-                        if (secretId.equals(existingSecret.getString(RegistryManagementConstants.FIELD_ID))) {
-                            found = true;
-                            final JsonObject newSecret = new JsonObject();
-                            copySecretFields(secret, newSecret);
-
-                            // update the secret : remove the old values.
-                            if (secret.containsKey(CredentialsConstants.FIELD_SECRETS_PWD_PLAIN)
-                                    || secret.containsKey(CredentialsConstants.FIELD_SECRETS_KEY)
-                                    || secret.containsKey(CredentialsConstants.FIELD_SECRETS_PWD_HASH)
-                                    || secret.containsKey(CredentialsConstants.FIELD_SECRETS_SALT)) {
-
-                                removeConfidentialDataFromSecret(newSecret);
-                            }
-                            // then copy the new details.
-                            for (String field : secret.fieldNames()) {
-                                newSecret.put(field, secret.getValue(field));
-                            }
-                            definitiveInputSecret.add(newSecret);
-                        }
-                    }
-
-                    // check if the secretID given was found
-                    if (!found) {
-                        TracingHelper.logError(span, "secret ID given does not exist for this auth-id and type");
-                        return OperationResult.empty(HttpURLConnection.HTTP_BAD_REQUEST);
-                    }
-                }
-            }
-
-            dirty.set(true);
-
-            // Now we can remove all the secrets
-            secretsJson.clear();
-
-            // Write the new secrets
-            secretsJson.addAll(definitiveInputSecret);
-
-            // Commit the update
-            credentialsJson.put(CredentialsConstants.FIELD_SECRETS, secretsJson);
-
-            credentialsForTenant.put(authId, json);
         }
 
+        // delete all existing credentials registered for the device in order to be sure to
+        // only keep the credentials contained in the request body on record
+        Optional.ofNullable(currentVersion).ifPresent(ver -> removeAllForDevice(tenantId, deviceId, span));
+        // now add the new/updated credentials to the store
+        credentialsForTenant.putAll(newCredentials);
+
+        // and change the resource version
+        final String newVersion = DeviceRegistryUtils.getUniqueIdentifier();
+        setResourceVersion(tenantId, deviceId, newVersion);
         return OperationResult.ok(HttpURLConnection.HTTP_NO_CONTENT, null, Optional.empty(), Optional.of(newVersion));
+    }
+
+    private boolean hasUniqueSecretIds(final JsonObject credentialObject) {
+        final JsonArray secrets = credentialObject.getJsonArray(RegistryManagementConstants.FIELD_SECRETS, new JsonArray());
+        final long distinctIds = secrets.stream()
+                .map(JsonObject.class::cast)
+                .map(secret -> {
+                    final String id = secret.getString(RegistryManagementConstants.FIELD_ID);
+                    if (id == null) {
+                        final String newId = DeviceRegistryUtils.getUniqueIdentifier();
+                        secret.put(RegistryManagementConstants.FIELD_ID, newId);
+                        return newId;
+                    } else {
+                        return id;
+                    }
+                })
+                .distinct()
+                .count();
+        return distinctIds == secrets.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Future<OperationResult<List<CommonCredential>>> processReadCredentials(
+            final DeviceKey key,
+            final Span span) {
+
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(span);
+
+        final String tenantId = key.getTenantId();
+        final String deviceId = key.getDeviceId();
+
+        final String currentVersion = getResourceVersion(tenantId, deviceId);
+
+        // if we do not have a resource version on record for the device
+        // then either no credentials have ever been registered for the device or
+        // the device has been deleted
+        if (currentVersion == null) {
+            return Future.succeededFuture(OperationResult.ok(
+                    HttpURLConnection.HTTP_NOT_FOUND,
+                    null,
+                    Optional.of(CacheDirective.noCacheDirective()),
+                    Optional.empty()));
+        }
+
+        final List<CommonCredential> result = findCredentialsForDevice(tenantId, deviceId)
+                .stream()
+                .map(creds -> {
+                    creds.remove(CredentialsConstants.FIELD_PAYLOAD_DEVICE_ID);
+                    return creds.mapTo(CommonCredential.class);
+                })
+                .map(CommonCredential::stripPrivateInfo)
+                .collect(Collectors.toList());
+
+        // note that the result set might be empty
+        // however, in this case an empty set of credentials has been
+        // registered for the device explicitly and we return
+        // a response with status 200 and an empty JSON array in the body
+        return Future.succeededFuture(
+                OperationResult.ok(HttpURLConnection.HTTP_OK,
+                        result,
+                        // TODO check cache directive
+                        Optional.empty(),
+                        Optional.of(currentVersion)));
+    }
+
+    /**
+     * Removes all credentials for a device.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The identifier of the device.
+     * @param span The active OpenTracing span for this operation.
+     * @param resultHandler The operation result.
+     * @throws NullPointerException if any of the parameters except span is {@code null}.
+     */
+    public void remove(
+            final String tenantId,
+            final String deviceId,
+            final Span span,
+            final Handler<AsyncResult<Result<Void>>> resultHandler) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(resultHandler);
+
+        LOG.debug("removing credentials for device [tenant-id: {}, device-id: {}]", tenantId, deviceId);
+
+        final Promise<Result<Void>> result = Promise.promise();
+
+        if (config.isModificationEnabled()) {
+            setResourceVersion(tenantId, deviceId, null);
+            removeAllForDevice(tenantId, deviceId, span);
+            result.complete(Result.from(HttpURLConnection.HTTP_NO_CONTENT));
+        } else {
+            TracingHelper.logError(span, "modification is disabled for the Credentials service");
+            result.complete(OperationResult.empty(HttpURLConnection.HTTP_FORBIDDEN));
+        }
+        resultHandler.handle(result.future());
     }
 
     /**
@@ -594,7 +662,7 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
      */
     private void removeAllForDevice(final String tenantId, final String deviceId, final Span span) {
 
-        final ConcurrentMap<String, JsonArray> credentialsForTenant = createOrGetCredentialsForTenant(tenantId);
+        final Map<String, JsonArray> credentialsForTenant = getCredentialsForTenant(tenantId);
 
         for (final JsonArray versionedCredentials : credentialsForTenant.values()) {
 
@@ -608,118 +676,55 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
 
                 final JsonObject credentials = (JsonObject) o;
                 final String currentDeviceId = credentials.getString(Constants.JSON_FIELD_DEVICE_ID);
-                if (!deviceId.equals(currentDeviceId)) {
-                    continue;
+                if (deviceId.equals(currentDeviceId)) {
+                    // remove credentials from credentials set
+                    i.remove();
+                    dirty.set(true);
                 }
-
-                verifyOverwriteEnabled(span);
-
-                // remove device from credentials set
-                i.remove();
-                dirty.set(true);
             }
         }
     }
 
-    @Override
-    public Future<OperationResult<List<CommonCredential>>> readCredentials(final String tenantId, final String deviceId,
-            final Span span) {
+    private boolean checkResourceVersion(final String tenantId, final String deviceId, final Optional<String> requestedVersion) {
 
-        Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(deviceId);
-
-        final ConcurrentMap<String, JsonArray> credentialsForTenant = credentials.get(tenantId);
-        if (credentialsForTenant == null) {
-            TracingHelper.logError(span, "No credentials found for tenant");
-            return Future.succeededFuture(OperationResult.ok(HttpURLConnection.HTTP_NOT_FOUND, null, Optional.empty(),
-                    Optional.of(getOrCreateResourceVersion(tenantId, deviceId))));
-        }
-
-        final JsonArray matchingCredentials = new JsonArray();
-        // iterate over all credentials per auth-id in order to find credentials matching the given device
-        for (final JsonArray credentialsForAuthId : credentialsForTenant.values()) {
-            findCredentialsForDevice(credentialsForAuthId, deviceId, matchingCredentials);
-        }
-        if (matchingCredentials.isEmpty()) {
-            TracingHelper.logError(span, "No credentials found for device");
-            return Future.succeededFuture(OperationResult.ok(HttpURLConnection.HTTP_NOT_FOUND, null, Optional.empty(),
-                    Optional.of(getOrCreateResourceVersion(tenantId, deviceId))));
-        }
-
-        // convert credentials
-
-        final List<CommonCredential> credentials = new ArrayList<>();
-        for (final Object credential : matchingCredentials) {
-            final JsonObject credentialsObject = (JsonObject) credential;
-            credentialsObject.remove(CredentialsConstants.FIELD_PAYLOAD_DEVICE_ID);
-            final CommonCredential cred = credentialsObject.mapTo(CommonCredential.class);
-            cred.stripPrivateInfo();
-            credentials.add(cred);
-        }
-
-        return Future.succeededFuture(
-                OperationResult.ok(HttpURLConnection.HTTP_OK,
-                        credentials,
-                        // TODO check cache directive
-                        Optional.empty(),
-                        Optional.of(getOrCreateResourceVersion(tenantId, deviceId))));
-    }
-
-    /**
-     * Remove all the credentials for the given device ID.
-     * @param tenantId the Id of the tenant which the device belongs to.
-     * @param deviceId the id of the device that is deleted.
-     * @param span The active OpenTracing span for this operation.
-     * @param resultHandler the operation result.
-     * @throws NullPointerException if any of the parameters except span is {@code null}.
-     */
-    public void remove(final String tenantId, final String deviceId,
-            final Span span, final Handler<AsyncResult<Result<Void>>> resultHandler) {
-        Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(deviceId);
-        Objects.requireNonNull(resultHandler);
-
-        LOG.debug("removing credentials for device [tenant-id: {}, device-id: {}]", tenantId, deviceId);
-
-        resultHandler.handle(Future.succeededFuture(remove(tenantId, deviceId, span)));
-    }
-
-    private Result<Void> remove(final String tenantId, final String deviceId, final Span span) {
-
-        setResourceVersion(tenantId, deviceId, null);
-
-        try {
-            removeAllForDevice(tenantId, deviceId, span);
-        } catch (final ClientErrorException e) {
-            TracingHelper.logError(span, e);
-            return Result.from(e.getErrorCode());
-        }
-
-        return Result.from(HttpURLConnection.HTTP_NO_CONTENT);
-    }
-
-    private boolean checkResourceVersion(final String tenantId, final String deviceId, final Optional<String> resourceVersion) {
-
-        if (resourceVersion.isEmpty()) {
+        if (requestedVersion.isEmpty()) {
             return true;
         }
 
-        final String version = versions.getOrDefault(tenantId, new ConcurrentHashMap<>()).get(deviceId);
-        if (version == null) {
-            // we have no version, and never told anyone, so the requested version of wrong.
+        return checkResourceVersion(getResourceVersion(tenantId, deviceId), requestedVersion);
+    }
+
+    private boolean checkResourceVersion(final String currentVersion, final Optional<String> requestedVersion) {
+
+        if (requestedVersion.isEmpty()) {
+            return true;
+        }
+
+        if (currentVersion == null) {
             return false;
         }
 
-        return version.equals(resourceVersion.get());
+        return currentVersion.equals(requestedVersion.get());
     }
 
+    private String getResourceVersion(final String tenantId, final String deviceId) {
+        return versions.computeIfAbsent(tenantId, key -> new ConcurrentHashMap<>()).get(deviceId);
+    }
+
+    /**
+     * Sets the version of a device's credentials resource.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The identifier of the device.
+     * @param version The resource version or {@code null} to remove the resource version.
+     * @return The resource version.
+     */
     private String setResourceVersion(final String tenantId, final String deviceId, final String version) {
 
         if (version != null) {
 
-            versions
-                    .computeIfAbsent(tenantId, key -> new ConcurrentHashMap<>())
-                    .put(deviceId, version);
+            versions.computeIfAbsent(tenantId, key -> new ConcurrentHashMap<>())
+                .put(deviceId, version);
 
         } else {
 
@@ -748,18 +753,20 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
     }
 
     /**
-     * Create or get credentials map for a single tenant.
+     * Gets all credentials registered for a tenant.
      *
      * @param tenantId The tenant to get
-     * @return The map, never returns {@code null}.
+     * @return A mapping of authentication identifiers of the tenant's devices to the credentials
+     *         registered for the auth-ids.
      */
-    private ConcurrentMap<String, JsonArray> createOrGetCredentialsForTenant(final String tenantId) {
+    private Map<String, JsonArray> getCredentialsForTenant(final String tenantId) {
         return credentials.computeIfAbsent(tenantId, id -> new ConcurrentHashMap<>());
     }
 
-    private JsonArray createOrGetAuthIdCredentials(final String authId,
-            final ConcurrentMap<String, JsonArray> credentialsForTenant) {
-        return credentialsForTenant.computeIfAbsent(authId, id -> new JsonArray());
+    private JsonArray getCredentialsForAuthId(
+            final Map<String, JsonArray> credentials,
+            final String authId) {
+        return credentials.computeIfAbsent(authId, id -> new JsonArray());
     }
 
     private CacheDirective getCacheDirective(final String type) {
@@ -790,29 +797,40 @@ public final class FileBasedCredentialsService implements CredentialsManagementS
         return String.format("%s[filename=%s]", FileBasedCredentialsService.class.getSimpleName(), getConfig().getFilename());
     }
 
-    private static void removeConfidentialDataFromSecret(final JsonObject secret) {
+    private static void mergeSecretProperties(final String type, final JsonObject sourceSecret, final JsonObject targetSecret) {
 
-        secret.remove(RegistryManagementConstants.FIELD_SECRETS_HASH_FUNCTION);
-        secret.remove(RegistryManagementConstants.FIELD_SECRETS_PWD_HASH);
-        secret.remove(RegistryManagementConstants.FIELD_SECRETS_SALT);
-        secret.remove(RegistryManagementConstants.FIELD_SECRETS_PWD_PLAIN);
-        secret.remove(RegistryManagementConstants.FIELD_SECRETS_KEY);
+        switch (type) {
+        case RegistryManagementConstants.SECRETS_TYPE_HASHED_PASSWORD:
+            copyPasswordSecretProperties(sourceSecret, targetSecret);
+            break;
+        case RegistryManagementConstants.SECRETS_TYPE_PRESHARED_KEY:
+            if (!targetSecret.containsKey(RegistryManagementConstants.FIELD_SECRETS_KEY)) {
+                Optional.ofNullable(sourceSecret.getString(RegistryManagementConstants.FIELD_SECRETS_KEY))
+                    .ifPresent(s -> targetSecret.put(RegistryManagementConstants.FIELD_SECRETS_KEY, s));
+            }
+            break;
+        case RegistryManagementConstants.SECRETS_TYPE_X509_CERT:
+            // nothing to merge
+            // fall through
+        default:
+            // do nothing
+        }
     }
 
-    private static void copySecretFields(final JsonObject in, final JsonObject out) {
+    private static void copyPasswordSecretProperties(final JsonObject sourceSecret, final JsonObject targetSecret) {
+        if (targetSecret.containsKey(RegistryManagementConstants.FIELD_ID)
+                && !targetSecret.containsKey(RegistryManagementConstants.FIELD_SECRETS_HASH_FUNCTION)
+                && !targetSecret.containsKey(RegistryManagementConstants.FIELD_SECRETS_PWD_HASH)
+                && !targetSecret.containsKey(RegistryManagementConstants.FIELD_SECRETS_PWD_PLAIN)
+                && !targetSecret.containsKey(RegistryManagementConstants.FIELD_SECRETS_SALT)) {
 
-        out.put(CredentialsConstants.FIELD_SECRETS_HASH_FUNCTION, in.getString(CredentialsConstants.FIELD_SECRETS_HASH_FUNCTION));
-        out.put(CredentialsConstants.FIELD_SECRETS_PWD_HASH, in.getString(CredentialsConstants.FIELD_SECRETS_PWD_HASH));
-        out.put(CredentialsConstants.FIELD_SECRETS_SALT, in.getString(CredentialsConstants.FIELD_SECRETS_SALT));
-        out.put(CredentialsConstants.FIELD_SECRETS_PWD_PLAIN, in.getString(CredentialsConstants.FIELD_SECRETS_PWD_PLAIN));
-    }
-
-    private void verifyOverwriteEnabled(final Span span) {
-
-        // check if we may overwrite
-        if (!config.isModificationEnabled()) {
-            TracingHelper.logError(span, "Modification is disabled for the Credentials service.");
-            throw new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN);
+            // copy confidential password properties
+            Optional.ofNullable(sourceSecret.getString(RegistryManagementConstants.FIELD_SECRETS_HASH_FUNCTION))
+                .ifPresent(s -> targetSecret.put(RegistryManagementConstants.FIELD_SECRETS_HASH_FUNCTION, s));
+            Optional.ofNullable(sourceSecret.getString(RegistryManagementConstants.FIELD_SECRETS_PWD_HASH))
+                .ifPresent(s -> targetSecret.put(RegistryManagementConstants.FIELD_SECRETS_PWD_HASH, s));
+            Optional.ofNullable(sourceSecret.getString(RegistryManagementConstants.FIELD_SECRETS_SALT))
+                .ifPresent(s -> targetSecret.put(RegistryManagementConstants.FIELD_SECRETS_SALT, s));
         }
     }
 }

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -139,9 +139,10 @@ public class FileBasedServiceConfig {
         final FileBasedRegistrationService registrationService = new FileBasedRegistrationService(vertx);
         registrationService.setConfig(registrationProperties());
 
-        final FileBasedCredentialsService credentialsService = new FileBasedCredentialsService(vertx);
-        credentialsService.setConfig(credentialsProperties());
-        credentialsService.setPasswordEncoder(passwordEncoder());
+        final FileBasedCredentialsService credentialsService = new FileBasedCredentialsService(
+                vertx,
+                credentialsProperties(),
+                passwordEncoder());
 
         return new FileBasedDeviceBackend(registrationService, credentialsService);
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDto.java
@@ -53,11 +53,8 @@ public final class CredentialsDto extends BaseDto {
     /**
      * Creates a new instance for a list of credentials.
      * <p>
-     * This constructor also makes sure that
-     * <ul>
-     * <li>none of the credentials have the same type and authentication identifier and</li>
-     * <li>that the identifiers of the credentials' secrets are unique within their credentials object.</li>
-     * </ul>
+     * This constructor also makes sure that the identifiers of the credentials'
+     * secrets are unique within their credentials object.
      * <p>
      * These properties are supposed to be asserted before persisting this DTO.
      *
@@ -66,7 +63,7 @@ public final class CredentialsDto extends BaseDto {
      * @param credentials The list of credentials.
      * @param version The version of the credentials to be sent as request header.
      * @throws NullPointerException if any of the parameters except credentials is {@code null}
-     * @throws ClientErrorException if any of the checks fail.
+     * @throws org.eclipse.hono.client.ClientErrorException if any of the checks fail.
      */
     public CredentialsDto(
             final String tenantId,
@@ -80,7 +77,6 @@ public final class CredentialsDto extends BaseDto {
         //Validate the given credentials, secrets and generate secret ids if not available.
         Optional.ofNullable(credentials)
                 .ifPresent(creds -> {
-                    assertTypeAndAuthId(creds);
                     assertSecretIdUniqueness(creds);
                 });
         setCredentials(credentials);
@@ -216,22 +212,9 @@ public final class CredentialsDto extends BaseDto {
             final String authId,
             final String authType,
             final List<CommonCredential> credentials) {
+
         return credentials.stream()
                 .filter(credential -> authId.equals(credential.getAuthId()) && authType.equals(credential.getType()))
                 .findFirst();
-    }
-
-    @JsonIgnore
-    private static void assertTypeAndAuthId(final List<? extends CommonCredential> credentials) {
-
-        final long uniqueAuthIdAndTypeCount = credentials.stream()
-            .map(credential -> String.format("%s::%s", credential.getType(), credential.getAuthId()))
-            .distinct()
-            .count();
-
-        if (credentials.size() > uniqueAuthIdAndTypeCount) {
-            throw new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
-                    "credentials must have unique (type, auth-id)");
-        }
     }
 }

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -626,6 +626,8 @@ paths:
                $ref: '#/components/responses/NotAllowed'
             404:
                $ref: '#/components/responses/DeviceNotFound'
+            409:
+               $ref: '#/components/responses/AlreadyExists'
             412:
                $ref: '#/components/responses/ResourceVersionMismatch'
 

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
@@ -18,6 +18,7 @@ import java.net.HttpURLConnection;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,7 +52,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Timeout;
@@ -118,41 +118,53 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
     }
 
     /**
-     * Verifies that when a device is created, an associated entry is created in the credential Service.
+     * Verifies that a newly added device has an empty set of credentials and that the
+     * service successfully adds arbitrary types of credentials.
      *
      * @param context The vert.x test context.
      */
     @Test
-    public void testNewDeviceReturnsEmptyCredentials(final VertxTestContext context) {
+    public void testAddCredentialsSucceeds(final VertxTestContext context) {
+
+        final PasswordCredential pwdCredential = IntegrationTestSupport.createPasswordCredential(authId, "thePassword");
+        pwdCredential.getExtensions().put("client-id", "MQTT-client-2384236854");
+
+        final PskCredential pskCredential = IntegrationTestSupport.createPskCredentials("psk-id", "psk-key");
+
+        final X509CertificateCredential x509Credential = new X509CertificateCredential(
+                "emailAddress=foo@bar.com, CN=foo, O=bar",
+                List.of(new X509CertificateSecret()));
+        x509Credential.setComment("non-standard attribute type");
+
+        final List<CommonCredential> credentials = List.of(pwdCredential, pskCredential, x509Credential);
 
         registry.getCredentials(tenantId, deviceId)
+            .compose(httpResponse -> {
+                context.verify(() -> assertThat(httpResponse.bodyAsJsonArray()).isEmpty());
+                return registry.addCredentials(tenantId, deviceId, credentials);
+            })
+            .compose(httpResponse -> {
+                context.verify(() -> assertResourceVersionHasChanged(resourceVersion, httpResponse.headers()));
+                return registry.getCredentials(tenantId, deviceId);
+            })
             .onComplete(context.succeeding(httpResponse -> {
                 context.verify(() -> {
-                    final CommonCredential[] credentials = Json.decodeValue(httpResponse.bodyAsBuffer(),
-                            CommonCredential[].class);
-                    assertThat(credentials).isEmpty();
-                });
-                context.completeNow();
-            }));
-
-    }
-
-    /**
-     * Verifies that the service accepts a request to add credentials request containing valid credentials.
-     *
-     * @param context The vert.x test context.
-     */
-    @Test
-    public void testAddCredentialsSucceeds(final VertxTestContext context)  {
-
-        registry.updateCredentials(
-                tenantId,
-                deviceId,
-                List.of(hashedPasswordCredential),
-                HttpURLConnection.HTTP_NO_CONTENT)
-            .onComplete(context.succeeding(httpResponse -> {
-                context.verify(() -> {
-                    assertResourceVersionHasChanged(resourceVersion, httpResponse.headers());
+                    final CommonCredential[] credsOnRecord = httpResponse.bodyAsJson(CommonCredential[].class);
+                    assertThat(credsOnRecord).hasSize(3);
+                    Arrays.stream(credsOnRecord)
+                        .forEach(creds -> {
+                            assertThat(creds.getExtensions().get("device-id")).isNull();
+                            if (creds instanceof PasswordCredential) {
+                                assertThat(creds.getExtensions().get("client-id")).isEqualTo("MQTT-client-2384236854");
+                            } else if (creds instanceof X509CertificateCredential) {
+                                assertThat(creds.getComment()).isEqualTo("non-standard attribute type");
+                            }
+                            creds.getSecrets()
+                                .forEach(secret -> {
+                                    assertThat(secret.isEnabled());
+                                    assertThat(secret.getId()).isNotNull();
+                                });
+                        });
                 });
                 context.completeNow();
             }));


### PR DESCRIPTION
The registry implementations now accept X.509 credentials in update
Credentials requests. The registry now also removes existing credentials
on record that do not match any of the credentials in an update
Credentials request's body.
