### PR TITLE
Remove UNKNOWN QoS level

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -823,12 +823,10 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             final Device authenticatedDevice, final OptionalInt traceSamplingPriority) {
 
         // try to extract a SpanContext from the property bag of the message's topic (if set)
-        final SpanContext spanContext = message.topicName() != null
-                ? Optional.ofNullable(PropertyBag.fromTopic(message.topicName()))
-                .map(propertyBag -> TracingHelper.extractSpanContext(tracer,
-                        propertyBag::getPropertiesIterator))
-                .orElse(null)
-                : null;
+        final SpanContext spanContext = Optional.ofNullable(message.topicName())
+                .flatMap(topic -> Optional.ofNullable(PropertyBag.fromTopic(message.topicName())))
+                .map(propertyBag -> TracingHelper.extractSpanContext(tracer, propertyBag::getPropertiesIterator))
+                .orElse(null);
         final Span span = newChildSpan(spanContext, "PUBLISH", endpoint, authenticatedDevice);
         span.setTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), message.topicName());
         span.setTag(TracingHelper.TAG_QOS.getKey(), message.qosLevel().toString());

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
@@ -58,7 +58,7 @@ public final class MqttContext extends MapBasedTelemetryExecutionContext {
             case AT_MOST_ONCE:
                 return QoS.AT_MOST_ONCE;
             default:
-                return QoS.UNKNOWN;
+                return null;
         }
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -1120,7 +1120,7 @@ public final class MessageHelper {
         msg.setAddress(ri.getBasePath());
         addDeviceId(msg, ri.getResourceId());
         addProperty(msg, MessageHelper.APP_PROPERTY_ORIG_ADAPTER, adapterTypeName);
-        if (qos != null && qos != QoS.UNKNOWN) {
+        if (qos != null) {
             addProperty(msg, MessageHelper.APP_PROPERTY_QOS, qos.ordinal());
         }
         annotate(msg, ri);

--- a/core/src/main/java/org/eclipse/hono/util/QoS.java
+++ b/core/src/main/java/org/eclipse/hono/util/QoS.java
@@ -19,9 +19,5 @@ package org.eclipse.hono.util;
 public enum QoS {
 
     AT_MOST_ONCE,
-    AT_LEAST_ONCE,
-    /**
-     * Indicates that the device set a QoS level which is not known or supported.
-     */
-    UNKNOWN;
+    AT_LEAST_ONCE;
 }

--- a/core/src/main/java/org/eclipse/hono/util/TelemetryExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/TelemetryExecutionContext.java
@@ -42,7 +42,7 @@ public interface TelemetryExecutionContext extends ExecutionContext {
     /**
      * Gets the QoS level as set in the request by the device.
      *
-     * @return The QoS level requested by the device.
+     * @return The QoS level requested by the device or {@code null} if the level could not be determined.
      */
     QoS getRequestedQos();
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
@@ -104,7 +104,7 @@ public final class HttpContext implements TelemetryExecutionContext {
         try {
             qosLevel = Integer.parseInt(qos);
         } catch (final NumberFormatException e) {
-            return QoS.UNKNOWN;
+            return null;
         }
 
         switch (qosLevel) {
@@ -113,7 +113,7 @@ public final class HttpContext implements TelemetryExecutionContext {
             case 1:
                 return QoS.AT_LEAST_ONCE;
             default:
-                return QoS.UNKNOWN;
+                return null;
         }
     }
 


### PR DESCRIPTION
The UNKNOWN QoS level has no particular meaning but prevents the QoS
class from being used in the new client implementation (#2168).