### PR TITLE
[#2234] Reject command message with unsupported body section

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/Command.java
+++ b/client/src/main/java/org/eclipse/hono/client/Command.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,6 +18,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
@@ -122,6 +124,11 @@ public final class Command {
             validationErrorJoiner.add("subject not set");
         }
 
+        if (message.getBody() != null) {
+            // check for unsupported message body
+            getUnsupportedPayloadReason(message).ifPresent(validationErrorJoiner::add);
+        }
+
         String correlationId = null;
         final Object correlationIdObj = MessageHelper.getCorrelationId(message);
         if (correlationIdObj != null) {
@@ -161,7 +168,7 @@ public final class Command {
             }
         }
 
-        final Command result = new Command(
+        return new Command(
                 validationErrorJoiner.length() > 0 ? Optional.of(validationErrorJoiner.toString()) : Optional.empty(),
                 message,
                 tenantId,
@@ -169,8 +176,6 @@ public final class Command {
                 correlationId,
                 originalReplyToId,
                 getRequestId(correlationId, originalReplyToId, originalDeviceId));
-
-        return result;
     }
 
     /**
@@ -327,12 +332,10 @@ public final class Command {
     /**
      * Gets the size of this command's payload.
      *
-     * @return The payload size in bytes, 0 if the command has no payload.
+     * @return The payload size in bytes, 0 if the command has no (valid) payload.
      */
     public int getPayloadSize() {
-        return Optional.ofNullable(MessageHelper.getPayload(message))
-                .map(b -> b.length())
-                .orElse(0);
+        return MessageHelper.getPayloadSize(message);
     }
 
     /**
@@ -499,5 +502,41 @@ public final class Command {
                 : replyToId;
         final String bitFlagString = encodeReplyToOptions(replyToContainedDeviceId);
         return String.format("%s/%s%s", deviceId, bitFlagString, replyToIdWithoutDeviceId);
+    }
+
+    /**
+     * Validates the type of the message body containing the payload data and returns an error string if it is
+     * unsupported.
+     * <p>
+     * The message body is considered unsupported if there is a body section and it is neither
+     * <ul>
+     * <li>a Data section,</li>
+     * <li>nor an AmqpValue section containing a byte array or a String.</li>
+     * </ul>
+     *
+     * @param msg The AMQP 1.0 message to parse.
+     * @return An Optional with the error string or an empty Optional if the payload is supported or the
+     *         message has no body section.
+     * @throws NullPointerException if the message is {@code null}.
+     * @see MessageHelper#getPayload(Message)
+     */
+    private static Optional<String> getUnsupportedPayloadReason(final Message msg) {
+        Objects.requireNonNull(msg);
+
+        String reason = null;
+        if (msg.getBody() instanceof AmqpValue) {
+            final Object value = ((AmqpValue) msg.getBody()).getValue();
+            if (value == null) {
+                reason = "message has body with empty amqp-value section";
+            } else if (!(value instanceof byte[] || value instanceof String)) {
+                reason = String.format("message has amqp-value section body with unsupported value type [%s], supported is byte[] or String",
+                        value.getClass().getName());
+            }
+
+        } else if (msg.getBody() != null && !(msg.getBody() instanceof Data)) {
+            reason = String.format("message has unsupported body section [%s], supported section types are 'data' and 'amqp-value'",
+                    msg.getBody().getClass().getName());
+        }
+        return Optional.ofNullable(reason);
     }
 }

--- a/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
@@ -16,9 +16,11 @@ package org.eclipse.hono.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.junit.jupiter.api.Test;
@@ -109,6 +111,25 @@ public class MessageHelperTest {
 
         msg.setBody(new Data(new Binary(new byte[] { (byte) 0xf0, (byte) 0x28, (byte) 0x8c, (byte) 0xbc })));
         assertThat(MessageHelper.getPayloadAsString(msg)).isNotNull();
+    }
+
+    /**
+     * Verifies that the helper returns the correct payload size for messages with different kinds of payload.
+     */
+    @Test
+    public void testGetPayloadSizeMatchesActualByteArrayLength() {
+
+        final Message msg = ProtonHelper.message();
+        final String testString = "über";
+        msg.setBody(new AmqpValue(testString));
+        assertThat(MessageHelper.getPayloadSize(msg)).isEqualTo(testString.getBytes(StandardCharsets.UTF_8).length);
+
+        final byte[] testBytes = { (byte) 0xc3, (byte) 0x28 };
+        msg.setBody(new AmqpValue(testBytes));
+        assertThat(MessageHelper.getPayloadSize(msg)).isEqualTo(testBytes.length);
+
+        msg.setBody(new Data(new Binary(testBytes)));
+        assertThat(MessageHelper.getPayloadSize(msg)).isEqualTo(testBytes.length);
     }
 
     /**


### PR DESCRIPTION
This fixes #2234:
Commands now get rejected if they have a non-null body section that is not supported.
This is a conservative approach in that it still allows the body section to be an `amqp-value` (not documented in the API), not wanting to break existing consumer applications.

Also introduce a getPayloadSize() method, preventing copy of body section bytes.