### PR TITLE
Use the existing static method to get status codes for exceptions

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -849,12 +849,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                         Tags.HTTP_STATUS.set(span, HttpURLConnection.HTTP_ACCEPTED);
                         onMessageSent(context);
                     } else {
-                        if (processing.cause() instanceof ServiceInvocationException) {
-                            final ServiceInvocationException sie = (ServiceInvocationException) processing.cause();
-                            Tags.HTTP_STATUS.set(span, sie.getErrorCode());
-                        } else {
-                            Tags.HTTP_STATUS.set(span, HttpURLConnection.HTTP_INTERNAL_ERROR);
-                        }
+                        Tags.HTTP_STATUS.set(span, ServiceInvocationException.extractStatusCode(processing.cause()));
                         if (processing.cause() instanceof ClientErrorException) {
                             // nothing to do
                         } else {

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/devices/AmqpExampleDevice.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/devices/AmqpExampleDevice.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
-import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.util.MessageHelper;
@@ -135,14 +135,12 @@ public class AmqpExampleDevice {
                     if (ar.succeeded()) {
                         System.out.println("Telemetry message with QoS 'AT_LEAST_ONCE' sent: " + payload);
                     } else {
-                        final Throwable cause = ar.cause();
                         String hint = "";
-                        if (cause instanceof ServerErrorException
-                                && ((ServerErrorException) cause).getErrorCode() == 503) {
+                        if (ServiceInvocationException.extractStatusCode(ar.cause()) == 503) {
                             hint = " (Is there a consumer connected?)";
                         }
                         System.out
-                                .println("Sending telemetry message with QoS 'AT_LEAST_ONCE' failed: " + cause + hint);
+                                .println("Sending telemetry message with QoS 'AT_LEAST_ONCE' failed: " + ar.cause() + hint);
                     }
                 });
     }

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/devices/AmqpExampleDevice.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/devices/AmqpExampleDevice.java
@@ -98,9 +98,9 @@ public class AmqpExampleDevice {
     private void startDevice(final HonoConnection connection) {
         factory = AmqpAdapterClientFactory.create(connection, TENANT_ID, SendMessageSampler.Factory.noop());
 
-        sendTelemetryMessageWithQos1();
+        sendTelemetryMessageWithQos0();
 
-        VERTX.setTimer(1000, l -> sendTelemetryMessageWithQos2());
+        VERTX.setTimer(1000, l -> sendTelemetryMessageWithQos1());
 
         VERTX.setTimer(2000, l -> sendEvent());
 
@@ -110,7 +110,7 @@ public class AmqpExampleDevice {
         });
     }
 
-    private void sendTelemetryMessageWithQos1() {
+    private void sendTelemetryMessageWithQos0() {
         System.out.println();
 
         final String payload = "42";
@@ -126,7 +126,7 @@ public class AmqpExampleDevice {
                 });
     }
 
-    private void sendTelemetryMessageWithQos2() {
+    private void sendTelemetryMessageWithQos1() {
         final JsonObject payload = new JsonObject().put("weather", "cloudy");
         factory.getOrCreateTelemetrySender()
                 .compose(telemetrySender -> telemetrySender.sendAndWaitForOutcome(DEVICE_ID,

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/BaseAuthenticationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/BaseAuthenticationService.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.hono.service.auth;
 
-import java.net.HttpURLConnection;
-
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.AuthenticationConstants;
 import org.eclipse.hono.util.ConfigurationSupportingVerticle;
@@ -90,12 +88,8 @@ public abstract class BaseAuthenticationService<T> extends ConfigurationSupporti
             if (validation.succeeded()) {
                 message.reply(AuthenticationConstants.getAuthenticationReply(validation.result().getToken()));
             } else {
-                if (validation.cause() instanceof ServiceInvocationException) {
-                    message.fail(((ServiceInvocationException) validation.cause()).getErrorCode(), validation.cause().getMessage());
-                } else {
-                    LOG.debug("unable to get status code from non-ServiceInvocationException", validation.cause());
-                    message.fail(HttpURLConnection.HTTP_INTERNAL_ERROR, validation.cause().getMessage());
-                }
+                message.fail(ServiceInvocationException.extractStatusCode(validation.cause()),
+                        validation.cause().getMessage());
             }
         });
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedDeviceConnectionClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedDeviceConnectionClient.java
@@ -164,13 +164,12 @@ public class JmsBasedDeviceConnectionClient extends JmsBasedRequestResponseClien
                 null)
                 .compose(this::send)
                 .recover(thr -> {
-                    if (thr instanceof ServiceInvocationException) {
-                        final int errorCode = ((ServiceInvocationException) thr).getErrorCode();
-                        if (errorCode == HttpURLConnection.HTTP_NOT_FOUND || errorCode == HttpURLConnection.HTTP_PRECON_FAILED) {
-                            return Future.succeededFuture(DeviceConnectionResult.from(errorCode));
-                        }
-                    }
-                    return Future.failedFuture(thr);
+                            final int errorCode = ServiceInvocationException.extractStatusCode(thr);
+                            if (errorCode == HttpURLConnection.HTTP_NOT_FOUND
+                                    || errorCode == HttpURLConnection.HTTP_PRECON_FAILED) {
+                                return Future.succeededFuture(DeviceConnectionResult.from(errorCode));
+                            }
+                            return Future.failedFuture(thr);
                 }).compose(devConResult -> {
                     final Promise<Boolean> result = Promise.promise();
                     switch (devConResult.getStatus()) {


### PR DESCRIPTION
Make use of `ServiceInvocationException.extractStatusCode()` method instead of duplicating the same code.

