### PR TITLE
Fix unit test

### DIFF
--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
@@ -1132,7 +1132,10 @@ public interface AbstractCredentialsServiceTest {
                     getCredentialsResult -> {
                         assertThat(getCredentialsResult.getStatus()).isEqualTo(HttpURLConnection.HTTP_OK);
                         final CredentialsObject credentialsObj = getCredentialsResult.getPayload().mapTo(CredentialsObject.class);
-                        assertThat(credentialsObj.getSecrets()).hasSize(2);
+                        // according to the Credentials API spec, the service implementation
+                        // may choose to NOT include secrets that are disabled or which are not valid at the
+                        // current point in time, according to its notBefore and notAfter properties
+                        assertThat(credentialsObj.getSecrets()).hasSizeBetween(1, 2);
                         // verify that none of the secrets contains the original password hash anymore
                         credentialsObj.getSecrets()
                             .stream()


### PR DESCRIPTION
Account for the fact that Credentials service implementations might
filter out disabled or currently not valid secrets.

@ctron Can you check if this does the trick for the JDBC registry implementation?