### PR TITLE
Fix the static method to extract status code from exceptions

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/ServiceInvocationException.java
+++ b/client/src/main/java/org/eclipse/hono/client/ServiceInvocationException.java
@@ -165,10 +165,11 @@ public class ServiceInvocationException extends RuntimeException {
      * Extract the HTTP status code from an exception.
      *
      * @param t The exception to extract the code from.
-     * @return The HTTP status code, or 500 if the exception is not of type {@link ServiceInvocationException}.
+     * @return The HTTP status code. Otherwise {@link HttpURLConnection#HTTP_INTERNAL_ERROR} 
+     *         if the exception is {@code null} or not of type {@link ServiceInvocationException}.
      */
     public static int extractStatusCode(final Throwable t) {
-        return Optional.of(t).map(cause -> {
+        return Optional.ofNullable(t).map(cause -> {
             if (cause instanceof ServiceInvocationException) {
                 return ((ServiceInvocationException) cause).getErrorCode();
             } else {

--- a/client/src/test/java/org/eclipse/hono/client/ServiceInvocationExceptionTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/ServiceInvocationExceptionTest.java
@@ -15,6 +15,8 @@ package org.eclipse.hono.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.HttpURLConnection;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,5 +34,39 @@ public class ServiceInvocationExceptionTest {
 
         // assert that getLocalizedMessage doesn't return the key as fallback
         assertThat(ServiceInvocationException.getLocalizedMessage(key)).isNotEqualTo(key);
+    }
+
+    /**
+     * Verifies that the extracted status code matches that of the given instance of
+     * {@link ServiceInvocationException}.
+     */
+    @Test
+    public void testExtractStatusCodeFromServiceInvocationException() {
+
+        final ServiceInvocationException exception = new ServiceInvocationException(
+                HttpURLConnection.HTTP_NOT_FOUND);
+        assertThat(ServiceInvocationException.extractStatusCode(exception)).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Verifies that the extracted status code is {@link HttpURLConnection#HTTP_INTERNAL_ERROR}
+     * when the given exception is not an instance of {@link ServiceInvocationException}.
+     */
+    @Test
+    public void testExtractStatusCodeFromNonServiceInvocationException() {
+
+        assertThat(ServiceInvocationException.extractStatusCode(new NullPointerException()))
+                .isEqualTo(HttpURLConnection.HTTP_INTERNAL_ERROR);
+    }
+
+    /**
+     * Verifies that the extracted status code matches {@link HttpURLConnection#HTTP_INTERNAL_ERROR}
+     * when the given exception is{@code null}.
+     */
+    @Test
+    public void testExtractStatusCodeWhenExceptionIsNull() {
+
+        assertThat(ServiceInvocationException.extractStatusCode(null))
+                .isEqualTo(HttpURLConnection.HTTP_INTERNAL_ERROR);
     }
 }


### PR DESCRIPTION
* Fix by replacing `Optional.of(...)` with `Optional.ofNullable(...)`
* Add tests to verify status code extraction

