### PR TITLE
Add test-utils module

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -124,13 +124,13 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     private RegistrationClient registrationClient;
     private TenantClient tenantClient;
 
-    private AmqpAdapterProperties config;
     private AmqpAdapterMetrics metrics;
     private ResourceLimitChecks resourceLimitChecks;
     private ConnectionLimitManager connectionLimitManager;    
     private Vertx vertx;
     private Context context;
     private Span span;
+    private ProtonServer server;
 
     /**
      * Setups the protocol adapter.
@@ -179,10 +179,10 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
      */
     @Override
     protected AmqpAdapterProperties givenDefaultConfigurationProperties() {
-        config = new AmqpAdapterProperties();
-        config.setAuthenticationRequired(false);
-        config.setInsecurePort(5672);
-        return config;
+        properties = new AmqpAdapterProperties();
+        properties.setAuthenticationRequired(false);
+        properties.setInsecurePort(5672);
+        return properties;
     }
 
     /**
@@ -195,8 +195,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     @Test
     public void testStartUsesClientProvidedAmqpServer(final VertxTestContext ctx) {
         // GIVEN an adapter with a client provided Amqp Server
-        final ProtonServer server = getAmqpServer();
-        final VertxBasedAmqpProtocolAdapter adapter = newAdapter(server);
+        givenAnAdapter(properties);
 
         // WHEN starting the adapter
         final Promise<Void> startupTracker = Promise.promise();
@@ -220,7 +219,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testAdapterSupportsAnonymousRelay() {
 
         // GIVEN an AMQP adapter with a configured server.
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
 
         // WHEN a device connects
         final Device authenticatedDevice = new Device(TEST_TENANT_ID, TEST_DEVICE);
@@ -248,7 +247,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     @Test
     public void testAdapterAcceptsAnonymousRelayReceiverOnly() {
         // GIVEN an AMQP adapter with a configured server.
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
 
         // WHEN the adapter receives a link that contains a target address
         final ResourceIdentifier targetAddress = ResourceIdentifier.from(TelemetryConstants.TELEMETRY_ENDPOINT, TEST_TENANT_ID, TEST_DEVICE);
@@ -269,7 +268,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     @Test
     public void testUploadTelemetryWithAtMostOnceDeliverySemantics(final VertxTestContext ctx) {
         // GIVEN an AMQP adapter with a configured server
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         final DownstreamSender telemetrySender = givenATelemetrySenderForAnyTenant();
         when(telemetrySender.send(any(Message.class), (SpanContext) any())).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
 
@@ -310,7 +309,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     @Test
     public void testUploadTelemetryWithAtLeastOnceDeliverySemantics() {
         // GIVEN an adapter configured to use a user-define server.
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         final DownstreamSender telemetrySender = givenATelemetrySenderForAnyTenant();
         final Promise<ProtonDelivery> downstreamDelivery = Promise.promise();
         when(telemetrySender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any()))
@@ -358,7 +357,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testUploadTelemetryMessageFailsForDisabledAdapter(final VertxTestContext ctx) {
 
         // GIVEN an adapter configured to use a user-define server.
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         final DownstreamSender telemetrySender = givenATelemetrySenderForAnyTenant();
 
         // AND given a tenant for which the AMQP Adapter is disabled
@@ -404,8 +403,8 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testUploadEventFailsForGatewayOfDifferentTenant(final VertxTestContext ctx) {
 
         // GIVEN an adapter
-        givenAnAdapter(config);
-        final DownstreamSender eventSender = givenAnEventSender(Promise.promise());
+        givenAnAdapter(properties);
+        final DownstreamSender eventSender = givenAnEventSenderForAnyTenant();
 
         // with an enabled tenant
         givenAConfiguredTenant(TEST_TENANT_ID, true);
@@ -441,9 +440,9 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     @Test
     public void testAdapterOpensSenderLinkAndNotifyDownstreamApplication() {
         // GIVEN an AMQP adapter configured to use a user-defined server
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         final Promise<ProtonDelivery> outcome = Promise.promise();
-        final DownstreamSender eventSender = givenAnEventSender(outcome);
+        final DownstreamSender eventSender = givenAnEventSenderForAnyTenant(outcome);
 
         // WHEN an unauthenticated device opens a receiver link with a valid source address
         final ProtonConnection deviceConnection = mock(ProtonConnection.class);
@@ -475,9 +474,9 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testAdapterClosesCommandConsumerWhenDeviceClosesReceiverLink() {
 
         // GIVEN an AMQP adapter
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         final Promise<ProtonDelivery> outcome = Promise.promise();
-        final DownstreamSender eventSender = givenAnEventSender(outcome);
+        final DownstreamSender eventSender = givenAnEventSenderForAnyTenant(outcome);
 
         // and a device that wants to receive commands
         final ProtocolAdapterCommandConsumer commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
@@ -559,11 +558,8 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
             final Handler<ProtonConnection> connectionLossTrigger) throws InterruptedException {
 
         // GIVEN an AMQP adapter
-        final Promise<ProtonDelivery> outcome = Promise.promise();
-        outcome.complete();
-        final DownstreamSender downstreamEventSender = givenAnEventSender(outcome);
-        final ProtonServer server = getAmqpServer();
-        final VertxBasedAmqpProtocolAdapter adapter = newAdapter(server);
+        givenAnAdapter(properties);
+        final DownstreamSender downstreamEventSender = givenAnEventSenderForAnyTenant();
 
         final Promise<Void> startupTracker = Promise.promise();
         startupTracker.future().onComplete(ctx.completing());
@@ -611,7 +607,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testUploadCommandResponseSucceeds(final VertxTestContext ctx) {
 
         // GIVEN an AMQP adapter
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         final CommandResponseSender responseSender = givenACommandResponseSenderForAnyTenant();
         final ProtonDelivery delivery = mock(ProtonDelivery.class);
         when(responseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(Future.succeededFuture(delivery));
@@ -656,7 +652,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testUploadCommandResponseWithoutPayloadSucceeds(final VertxTestContext ctx) {
 
         // GIVEN an AMQP adapter
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         final CommandResponseSender responseSender = givenACommandResponseSenderForAnyTenant();
         final ProtonDelivery delivery = mock(ProtonDelivery.class);
         when(responseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any()))
@@ -754,7 +750,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
             final ProcessingOutcome expectedProcessingOutcome) {
 
         // GIVEN an AMQP adapter
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         //  to which a device is connected
         final ProtonSender deviceLink = mock(ProtonSender.class);
         when(deviceLink.getQoS()).thenReturn(ProtonQoS.AT_LEAST_ONCE);
@@ -811,7 +807,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
                 anyString(),
                 any(),
                 any())).thenReturn(Future.succeededFuture());
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         adapter.setConnectionEventProducer(connectionEventProducer);
 
         // WHEN a device connects
@@ -876,8 +872,8 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testConnectionCountForAnonymousDevice() {
 
         // GIVEN an AMQP adapter that does not require devices to authenticate
-        config.setAuthenticationRequired(false);
-        givenAnAdapter(config);
+        properties.setAuthenticationRequired(false);
+        givenAnAdapter(properties);
 
         // WHEN a device connects
         final ProtonConnection deviceConnection = mock(ProtonConnection.class);
@@ -916,7 +912,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testMessageLimitExceededForATelemetryMessage(final VertxTestContext ctx) {
 
         // GIVEN an AMQP adapter
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         final DownstreamSender telemetrySender = givenATelemetrySenderForAnyTenant();
         // which is enabled for a tenant
         final TenantObject tenantObject = givenAConfiguredTenant(TEST_TENANT_ID, true);
@@ -963,8 +959,8 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testMessageLimitExceededForAnEventMessage(final VertxTestContext ctx) {
 
         // GIVEN an AMQP adapter
-        givenAnAdapter(config);
-        final DownstreamSender eventSender = givenAnEventSender(Promise.promise());
+        givenAnAdapter(properties);
+        final DownstreamSender eventSender = givenAnEventSenderForAnyTenant(Promise.promise());
         // which is enabled for a tenant
         final TenantObject tenantObject = givenAConfiguredTenant(TEST_TENANT_ID, true);
         // WHEN the message limit exceeds
@@ -1010,7 +1006,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testMessageLimitExceededForACommandResponseMessage(final VertxTestContext ctx) {
 
         // GIVEN an AMQP adapter
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         final CommandResponseSender responseSender = givenACommandResponseSenderForAnyTenant();
         final ProtonDelivery delivery = mock(ProtonDelivery.class);
         // which is enabled for a tenant
@@ -1060,7 +1056,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     @Test
     public void testLinkForSendingCommandsCloseAfterTimeout() {
         // GIVEN an AMQP adapter
-        givenAnAdapter(config);
+        givenAnAdapter(properties);
         // to which a device is connected
         final ProtonSender deviceLink = mock(ProtonSender.class);
         when(deviceLink.getQoS()).thenReturn(ProtonQoS.AT_LEAST_ONCE);
@@ -1096,8 +1092,8 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     @Test
     public void testConnectionFailsIfTenantLevelConnectionLimitIsExceeded() {
         // GIVEN an AMQP adapter that requires devices to authenticate
-        config.setAuthenticationRequired(true);
-        givenAnAdapter(config);
+        properties.setAuthenticationRequired(true);
+        givenAnAdapter(properties);
         // WHEN the connection limit for the given tenant exceeds
         when(resourceLimitChecks.isConnectionLimitReached(any(TenantObject.class), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.TRUE));
@@ -1128,8 +1124,8 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     @Test
     public void testConnectionFailsIfAdapterIsDisabled() {
         // GIVEN an AMQP adapter that requires devices to authenticate
-        config.setAuthenticationRequired(true);
-        givenAnAdapter(config);
+        properties.setAuthenticationRequired(true);
+        givenAnAdapter(properties);
         // AND given a tenant for which the AMQP Adapter is disabled
         givenAConfiguredTenant(TEST_TENANT_ID, false);
         // WHEN a device connects
@@ -1161,8 +1157,8 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testConnectionFailsForAuthenticatedDeviceIfAdapterLevelConnectionLimitIsExceeded() {
 
         // GIVEN an AMQP adapter that requires devices to authenticate
-        config.setAuthenticationRequired(true);
-        givenAnAdapter(config);
+        properties.setAuthenticationRequired(true);
+        givenAnAdapter(properties);
         // WHEN the adapter's connection limit exceeds
         when(connectionLimitManager.isLimitExceeded()).thenReturn(true);
         // WHEN a device connects
@@ -1201,8 +1197,8 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testConnectionFailsForUnauthenticatedDeviceIfAdapterLevelConnectionLimitIsExceeded() {
 
         // GIVEN an AMQP adapter that does not require devices to authenticate
-        config.setAuthenticationRequired(false);
-        givenAnAdapter(config);
+        properties.setAuthenticationRequired(false);
+        givenAnAdapter(properties);
         // WHEN the adapter's connection limit exceeds
         when(connectionLimitManager.isLimitExceeded()).thenReturn(true);
         // WHEN a device connects
@@ -1294,26 +1290,29 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected VertxBasedAmqpProtocolAdapter newAdapter(final AmqpAdapterProperties configuration) {
-        final ProtonServer server = getAmqpServer();
-        return newAdapter(server, configuration);
-    }
-
-    /**
-     * Creates a protocol adapter for a given AMQP Proton server.
+     * Creates a new adapter instance to be tested.
+     * <p>
+     * This method
+     * <ol>
+     * <li>creates a new {@code ProtonServer} using {@link #getAmqpServer()}</li>
+     * <li>assigns the result to property <em>server</em></li>
+     * <li>passes the server in to {@link #newAdapter(ProtonServer, AmqpAdapterProperties)}</li>
+     * <li>assigns the result to property <em>adapter</em></li>
+     * </ol>
      *
-     * @param server The AMQP Proton server.
-     * @return The AMQP adapter instance.
+     * @param configuration The configuration properties to use.
+     * @return The adapter instance.
      */
-    private VertxBasedAmqpProtocolAdapter newAdapter(final ProtonServer server) {
-        return newAdapter(server, config);
+    private VertxBasedAmqpProtocolAdapter givenAnAdapter(final AmqpAdapterProperties configuration) {
+        this.server = getAmqpServer();
+        this.adapter = newAdapter(this.server, configuration);
+        return adapter;
     }
 
     /**
-     * Creates a protocol adapter for a given AMQP Proton server.
+     * Creates an AMQP protocol adapter for a server and configuration.
+     * <p>
+     * The adapter will use the given server for its <em>insecure</em> port.
      *
      * @param server The AMQP Proton server.
      * @param configuration The adapter's configuration properties.
@@ -1327,10 +1326,10 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
 
         adapter.setConfig(configuration);
         adapter.setInsecureAmqpServer(server);
-        setCollaborators(adapter);
         adapter.setMetrics(metrics);
         adapter.setResourceLimitChecks(resourceLimitChecks);
         adapter.setConnectionLimitManager(connectionLimitManager);
+        setCollaborators(adapter);
         adapter.init(vertx, context);
         return adapter;
     }

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -31,21 +31,11 @@ import java.util.concurrent.TimeUnit;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandContext;
-import org.eclipse.hono.client.CommandResponse;
-import org.eclipse.hono.client.CommandResponseSender;
-import org.eclipse.hono.client.CommandTargetMapper;
-import org.eclipse.hono.client.CredentialsClientFactory;
-import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.DownstreamSender;
-import org.eclipse.hono.client.DownstreamSenderFactory;
-import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumer;
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
 import org.eclipse.hono.client.RegistrationClient;
-import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.TenantClient;
-import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.http.HttpContext;
 import org.eclipse.hono.service.http.HttpUtils;
@@ -57,6 +47,7 @@ import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
 import org.eclipse.hono.service.metric.MetricsTags.QoS;
 import org.eclipse.hono.service.metric.MetricsTags.TtdStatus;
 import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
+import org.eclipse.hono.service.test.ProtocolAdapterTestSupport;
 import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
@@ -84,7 +75,6 @@ import io.vertx.ext.web.MIMEHeader;
 import io.vertx.ext.web.ParsedHeaderValues;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -96,26 +86,20 @@ import io.vertx.proton.ProtonDelivery;
  */
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-public class AbstractVertxBasedHttpProtocolAdapterTest {
+public class AbstractVertxBasedHttpProtocolAdapterTest extends
+    ProtocolAdapterTestSupport<HttpProtocolAdapterProperties, AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties>> {
 
     private static final String ADAPTER_TYPE = "http";
     private static final String CMD_REQ_ID = "12fcmd-client-c925910f-ea2a-455c-a3f9-a339171f335474f48a55-c60d-4b99-8950-a2fbb9e8f1b6";
 
-    private CredentialsClientFactory      credentialsClientFactory;
-    private TenantClientFactory           tenantClientFactory;
-    private DownstreamSenderFactory       downstreamSenderFactory;
-    private RegistrationClientFactory     registrationClientFactory;
-    private RegistrationClient            regClient;
-    private TenantClient                  tenantClient;
-    private HttpProtocolAdapterProperties config;
-    private ProtocolAdapterCommandConsumerFactory commandConsumerFactory;
-    private DeviceConnectionClientFactory deviceConnectionClientFactory;
-    private CommandTargetMapper           commandTargetMapper;
+    private RegistrationClient regClient;
+    private TenantClient tenantClient;
     private ProtocolAdapterCommandConsumer commandConsumer;
-    private Vertx                         vertx;
-    private Context                       context;
-    private HttpAdapterMetrics            metrics;
-    private ResourceLimitChecks           resourceLimitChecks;
+    private Vertx vertx;
+    private Context context;
+    private HttpAdapterMetrics metrics;
+    private ResourceLimitChecks resourceLimitChecks;
+    private HttpServer server;
 
     /**
      * Sets up common fixture.
@@ -133,49 +117,39 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
             return 1L;
         });
 
-        config = new HttpProtocolAdapterProperties();
-        config.setInsecurePortEnabled(true);
-
         metrics = mock(HttpAdapterMetrics.class);
 
         regClient = mock(RegistrationClient.class);
         final JsonObject result = new JsonObject();
         when(regClient.assertRegistration(anyString(), any(), (SpanContext) any())).thenReturn(Future.succeededFuture(result));
+        when(registrationClientFactory.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(regClient));
 
         tenantClient = mock(TenantClient.class);
         when(tenantClient.get(anyString(), (SpanContext) any())).thenAnswer(invocation -> {
             return Future.succeededFuture(TenantObject.from(invocation.getArgument(0), true));
         });
-
-        tenantClientFactory = mock(TenantClientFactory.class);
-        when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
         when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
 
-        credentialsClientFactory = mock(CredentialsClientFactory.class);
-        when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
-
-        downstreamSenderFactory = mock(DownstreamSenderFactory.class);
-        when(downstreamSenderFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
-
-        registrationClientFactory = mock(RegistrationClientFactory.class);
-        when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
-        when(registrationClientFactory.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(regClient));
-
-        deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
-        when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
 
         commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
-        commandConsumerFactory = mock(ProtocolAdapterCommandConsumerFactory.class);
-        when(commandConsumerFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
         when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), any(Handler.class), any(), any()))
             .thenReturn(Future.succeededFuture(commandConsumer));
-
-        commandTargetMapper = mock(CommandTargetMapper.class);
 
         resourceLimitChecks = mock(ResourceLimitChecks.class);
         when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
                 .thenReturn(Future.succeededFuture(Boolean.FALSE));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected HttpProtocolAdapterProperties givenDefaultConfigurationProperties() {
+        properties = new HttpProtocolAdapterProperties();
+        properties.setInsecurePortEnabled(true);
+
+        return properties;
     }
 
     /**
@@ -188,8 +162,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testStartUsesClientProvidedHttpServer(final VertxTestContext ctx) {
 
         // GIVEN an adapter with a client provided HTTP server
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        server = getHttpServer(false);
+        adapter = getAdapter(server, null);
 
         // WHEN starting the adapter
         final Promise<Void> startupTracker = Promise.promise();
@@ -210,24 +184,24 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
      *
      * @param ctx The helper to use for running async tests on vertx.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testStartInvokesOnStartupSuccess(final VertxTestContext ctx) {
 
         // GIVEN an adapter with a client provided http server
-        final HttpServer server = getHttpServer(false);
-        final Checkpoint startupDone = ctx.checkpoint();
-        final Checkpoint onStartupSuccess = ctx.checkpoint();
+        server = getHttpServer(false);
+        final Handler<Void> startupHandler = mock(Handler.class);
+        adapter = getAdapter(server, startupHandler);
 
         // WHEN starting the adapter
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(
-                server,
-                // THEN the onStartupSuccess method has been invoked
-                s -> onStartupSuccess.flag());
-
         final Promise<Void> startupTracker = Promise.promise();
         adapter.start(startupTracker);
 
-        startupTracker.future().onComplete(ctx.succeeding(v -> startupDone.flag()));
+        // THEN the onStartupSuccess method has been invoked
+        startupTracker.future().onComplete(ctx.succeeding(v -> {
+            ctx.verify(() -> verify(startupHandler).handle(any()));
+            ctx.completeNow();
+        }));
     }
 
     /**
@@ -240,16 +214,16 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testStartDoesNotInvokeOnStartupSuccessIfStartupFails(final VertxTestContext ctx) {
 
         // GIVEN an adapter with a client provided http server that fails to bind to a socket when started
-        final HttpServer server = getHttpServer(true);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server,
+        server = getHttpServer(true);
+        adapter = getAdapter(server,
                 s -> ctx.failNow(new IllegalStateException("should not invoke onStartupSuccess")));
 
         // WHEN starting the adapter
         final Promise<Void> startupTracker = Promise.promise();
-        startupTracker.future().onComplete(ctx.failing(t -> ctx.completeNow()));
         adapter.start(startupTracker);
 
         // THEN the onStartupSuccess method has not been invoked
+        startupTracker.future().onComplete(ctx.failing(t -> ctx.completeNow()));
     }
 
     /**
@@ -262,14 +236,13 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testUploadTelemetryFailsForDisabledTenant() {
 
         // GIVEN an adapter
-        final HttpServer server = getHttpServer(false);
-        final DownstreamSender sender = givenATelemetrySenderForOutcome(Future.succeededFuture());
+        givenAnAdapter(properties);
+        final DownstreamSender sender = givenATelemetrySenderForAnyTenant();
 
         // which is disabled for tenant "my-tenant"
         final TenantObject myTenantConfig = TenantObject.from("my-tenant", true);
         myTenantConfig.addAdapter(new Adapter(ADAPTER_TYPE).setEnabled(Boolean.FALSE));
         when(tenantClient.get(eq("my-tenant"), any())).thenReturn(Future.succeededFuture(myTenantConfig));
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
 
         // WHEN a device that belongs to "my-tenant" publishes a telemetry message
         final Buffer payload = Buffer.buffer("some payload");
@@ -307,13 +280,12 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testUploadTelemetryFailsForUnknownDevice() {
 
         // GIVEN an adapter
-        final HttpServer server = getHttpServer(false);
-        final DownstreamSender sender = givenATelemetrySenderForOutcome(Future.succeededFuture());
+        givenAnAdapter(properties);
+        final DownstreamSender sender = givenATelemetrySenderForAnyTenant();
 
         // with an enabled tenant
         final TenantObject myTenantConfig = TenantObject.from("my-tenant", true);
         when(tenantClient.get(eq("my-tenant"), any())).thenReturn(Future.succeededFuture(myTenantConfig));
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
 
         // WHEN an unknown device that supposedly belongs to that tenant publishes a telemetry message
         // with a TTD value set
@@ -357,10 +329,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
 
         // GIVEN an adapter with a downstream event consumer attached
         final Promise<ProtonDelivery> outcome = Promise.promise();
-        givenAnEventSenderForOutcome(outcome.future());
-
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenAnEventSenderForAnyTenant(outcome);
+        givenAnAdapter(properties);
 
         // WHEN a device publishes an event
         final Buffer payload = Buffer.buffer("some payload");
@@ -411,10 +381,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
 
         // GIVEN an adapter with a downstream event consumer attached
         final Promise<ProtonDelivery> outcome = Promise.promise();
-        givenAnEventSenderForOutcome(outcome.future());
-
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenAnEventSenderForAnyTenant(outcome);
+        givenAnAdapter(properties);
 
         // WHEN a device publishes an event that is not accepted by the peer
         final Buffer payload = Buffer.buffer("some payload");
@@ -445,10 +413,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testUploadEventWithTimeToLive() {
         // GIVEN an adapter with a downstream event consumer attached
         final Promise<ProtonDelivery> outcome = Promise.promise();
-        final DownstreamSender sender = givenAnEventSenderForOutcome(outcome.future());
-
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        final DownstreamSender sender = givenAnEventSenderForAnyTenant(outcome);
+        givenAnAdapter(properties);
 
         // WHEN a device publishes an event with a time to live value as a header
         final Buffer payload = Buffer.buffer("some payload");
@@ -480,10 +446,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
 
         // GIVEN an adapter with a downstream application attached
         final Promise<ProtonDelivery> outcome = Promise.promise();
-        givenACommandResponseSenderForOutcome(outcome.future());
-
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenACommandResponseSenderForAnyTenant(outcome);
+        givenAnAdapter(properties);
 
         // WHEN a device publishes a command response
         final Buffer payload = Buffer.buffer("some payload");
@@ -529,13 +493,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testUploadEmptyCommandResponseSucceeds() {
 
         // GIVEN an adapter with a downstream application attached
-        final CommandResponseSender sender = mock(CommandResponseSender.class);
-        when(sender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(Future.succeededFuture(mock(ProtonDelivery.class)));
-
-        when(commandConsumerFactory.getCommandResponseSender(anyString(), anyString())).thenReturn(Future.succeededFuture(sender));
-
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenACommandResponseSenderForAnyTenant();
+        givenAnAdapter(properties);
 
         // WHEN a device publishes a command response with an empty payload
         final Buffer payload = null;
@@ -573,8 +532,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         to.addAdapter(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_HTTP).setEnabled(Boolean.FALSE));
         when(tenantClient.get(eq("tenant"), (SpanContext) any())).thenReturn(Future.succeededFuture(to));
 
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenAnAdapter(properties);
 
         // WHEN a device publishes a command response
         final Buffer payload = Buffer.buffer("some payload");
@@ -601,8 +559,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     @Test
     public void testUploadCommandResponseFailsForOtherDevice() {
 
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenAnAdapter(properties);
         final Buffer payload = Buffer.buffer("some payload");
         final HttpContext ctx = newHttpContext(payload, "application/text", mock(HttpServerRequest.class),
                 mock(HttpServerResponse.class));
@@ -643,10 +600,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
 
         // GIVEN an adapter with a downstream application attached
         final Promise<ProtonDelivery> outcome = Promise.promise();
-        givenACommandResponseSenderForOutcome(outcome.future());
-
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenACommandResponseSenderForAnyTenant(outcome);
+        givenAnAdapter(properties);
 
         // WHEN a device publishes a command response that is not accepted by the application
         final Buffer payload = Buffer.buffer("some payload");
@@ -676,11 +631,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testUploadTelemetryDoesNotWaitForAcceptedOutcome() {
 
         // GIVEN an adapter with a downstream telemetry consumer attached
-        final Future<ProtonDelivery> outcome = Future.succeededFuture(mock(ProtonDelivery.class));
-        givenATelemetrySenderForOutcome(outcome);
-
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenATelemetrySenderForAnyTenant();
+        givenAnAdapter(properties);
 
         // WHEN a device publishes a telemetry message
         final Buffer payload = Buffer.buffer("some payload");
@@ -719,8 +671,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testUploadTelemetryWithTtdClosesCommandConsumerIfSenderCreationFailed() {
 
         // GIVEN an adapter with a downstream telemetry consumer attached
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenAnAdapter(properties);
 
         // WHEN a device publishes a telemetry message with a TTD
         final Buffer payload = Buffer.buffer("some payload");
@@ -768,9 +719,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testUploadTelemetryUsesConfiguredMaxTtd() {
 
         // GIVEN an adapter with a downstream telemetry consumer attached
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
-        final DownstreamSender sender = givenATelemetrySenderForOutcome(Future.succeededFuture());
+        givenAnAdapter(properties);
+        final DownstreamSender sender = givenATelemetrySenderForAnyTenant();
 
         // WHEN a device publishes a telemetry message that belongs to a tenant with
         // a max TTD of 20 secs
@@ -805,11 +755,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testMessageLimitExceededForATelemetryMessage() {
 
         // GIVEN an adapter with a downstream telemetry consumer attached
-        final Future<ProtonDelivery> outcome = Future.succeededFuture(mock(ProtonDelivery.class));
-        givenATelemetrySenderForOutcome(outcome);
-
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenATelemetrySenderForAnyTenant();
+        givenAnAdapter(properties);
 
         final Buffer payload = Buffer.buffer("some payload");
         final HttpContext routingContext = newHttpContext(payload);
@@ -842,11 +789,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testMessageLimitExceededForAnEventMessage() {
 
         // GIVEN an adapter with a downstream event consumer attached
-        final Future<ProtonDelivery> outcome = Future.succeededFuture(mock(ProtonDelivery.class));
-        givenAnEventSenderForOutcome(outcome);
-
-        final HttpServer server = getHttpServer(false);
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(server, null);
+        givenAnEventSenderForAnyTenant();
+        givenAnAdapter(properties);
 
         final Buffer payload = Buffer.buffer("some payload");
         final HttpContext routingContext = newHttpContext(payload);
@@ -880,10 +824,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
     public void testMessageLimitExceededForACommandResponseMessage() {
 
         // GIVEN an adapter with a downstream application attached
-        final AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> adapter = getAdapter(
-                getHttpServer(false), null);
-        final Promise<ProtonDelivery> outcome = Promise.promise();
-        givenACommandResponseSenderForOutcome(outcome.future());
+        givenAnAdapter(properties);
+        givenACommandResponseSenderForAnyTenant();
 
         // WHEN the message limit exceeds
         when(resourceLimitChecks.isMessageLimitReached(any(TenantObject.class), anyLong(), any(SpanContext.class)))
@@ -959,6 +901,27 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         return HttpContext.from(ctx);
     }
 
+    /**
+     * Creates a new adapter instance to be tested.
+     * <p>
+     * This method
+     * <ol>
+     * <li>creates a new {@code HttpServer} using {@link #getHttpServer(boolean)}</li>
+     * <li>assigns the result to property <em>server</em></li>
+     * <li>passes the server in to {@link #getAdapter(HttpServer, Handler)}</li>
+     * <li>assigns the result to property <em>adapter</em></li>
+     * </ol>
+     *
+     * @param configuration The configuration properties to use.
+     * @return The adapter instance.
+     */
+    private AbstractVertxBasedHttpProtocolAdapter<HttpProtocolAdapterProperties> givenAnAdapter(
+            final HttpProtocolAdapterProperties configuration) {
+        this.server = getHttpServer(false);
+        this.adapter = getAdapter(this.server, null);
+        return adapter;
+    }
+
     @SuppressWarnings("unchecked")
     private HttpServer getHttpServer(final boolean startupShouldFail) {
 
@@ -1009,45 +972,12 @@ public class AbstractVertxBasedHttpProtocolAdapterTest {
         };
 
         adapter.init(vertx, context);
-        adapter.setConfig(config);
+        adapter.setConfig(properties);
         adapter.setMetrics(metrics);
         adapter.setInsecureHttpServer(server);
-        adapter.setTenantClientFactory(tenantClientFactory);
-        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
-        adapter.setRegistrationClientFactory(registrationClientFactory);
-        adapter.setCredentialsClientFactory(credentialsClientFactory);
-        adapter.setCommandConsumerFactory(commandConsumerFactory);
-        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
-        adapter.setCommandTargetMapper(commandTargetMapper);
         adapter.setResourceLimitChecks(resourceLimitChecks);
+        setCollaborators(adapter);
         return adapter;
-    }
-
-    private CommandResponseSender givenACommandResponseSenderForOutcome(final Future<ProtonDelivery> outcome) {
-
-        final CommandResponseSender sender = mock(CommandResponseSender.class);
-        when(sender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(outcome);
-
-        when(commandConsumerFactory.getCommandResponseSender(anyString(), anyString())).thenReturn(Future.succeededFuture(sender));
-        return sender;
-    }
-
-    private DownstreamSender givenAnEventSenderForOutcome(final Future<ProtonDelivery> outcome) {
-
-        final DownstreamSender sender = mock(DownstreamSender.class);
-        when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(outcome);
-
-        when(downstreamSenderFactory.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
-        return sender;
-    }
-
-    private DownstreamSender givenATelemetrySenderForOutcome(final Future<ProtonDelivery> outcome) {
-
-        final DownstreamSender sender = mock(DownstreamSender.class);
-        when(sender.send(any(Message.class), (SpanContext) any())).thenReturn(outcome);
-
-        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
-        return sender;
     }
 
     private static void assertContextFailedWithClientError(final HttpContext ctx, final int statusCode) {

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -214,8 +214,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
     @Test
     public void testStartup(final VertxTestContext ctx) {
 
-        server = getMqttServer(false);
-        adapter = getAdapter(server);
+        givenAnAdapter(properties);
 
         final Promise<Void> startupTracker = Promise.promise();
         adapter.start(startupTracker);
@@ -1410,7 +1409,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
             final MqttProtocolAdapterProperties configuration) {
 
         this.server = getMqttServer(false);
-        this.adapter = getAdapter(this.server);
+        this.adapter = getAdapter(this.server, configuration);
         return adapter;
     }
 
@@ -1433,7 +1432,9 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         return server;
     }
 
-    private AbstractVertxBasedMqttProtocolAdapter<MqttProtocolAdapterProperties> getAdapter(final MqttServer server) {
+    private AbstractVertxBasedMqttProtocolAdapter<MqttProtocolAdapterProperties> getAdapter(
+            final MqttServer server,
+            final MqttProtocolAdapterProperties configuration) {
 
         final AbstractVertxBasedMqttProtocolAdapter<MqttProtocolAdapterProperties> adapter = new AbstractVertxBasedMqttProtocolAdapter<>() {
 
@@ -1448,7 +1449,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
                 return uploadTelemetryMessage(ctx, topic.getTenantId(), topic.getResourceId(), ctx.message().payload());
             }
         };
-        adapter.setConfig(properties);
+        adapter.setConfig(configuration);
         adapter.setMetrics(metrics);
         adapter.setAuthHandler(authHandler);
         adapter.setResourceLimitChecks(resourceLimitChecks);

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -113,6 +113,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>service-base-test-utils</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -10,9 +10,7 @@
     http://www.eclipse.org/legal/epl-2.0
    
     SPDX-License-Identifier: EPL-2.0
- -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+ --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -25,7 +23,7 @@
   <packaging>pom</packaging>
 
   <name>Hono Dependencies</name>
-  <description>A &quot;bill-of-materials&quot; for Hono.</description>
+  <description>A "bill-of-materials" for Hono.</description>
 
   <properties>
     <artemis.image.name>quay.io/enmasse/artemis-base:2.10.1</artemis.image.name>
@@ -779,6 +777,12 @@
       </dependency>
 
       <!-- Testing -->
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>service-base-test-utils</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>de.flapdoodle.embed</groupId>
         <artifactId>de.flapdoodle.embed.mongo</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -10,7 +10,9 @@
     http://www.eclipse.org/legal/epl-2.0
    
     SPDX-License-Identifier: EPL-2.0
- --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@
     <module>services</module>
     <module>site</module>
     <module>tests</module>
+    <module>test-utils</module>
   </modules>
 
 

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -140,14 +140,8 @@ public class AbstractProtocolAdapterBaseTest {
         commandTargetMapper = mock(CommandTargetMapper.class);
 
         properties = new ProtocolAdapterProperties();
-        adapter = newProtocolAdapter(properties);
-        adapter.setTenantClientFactory(tenantClientFactory);
-        adapter.setRegistrationClientFactory(registrationClientFactory);
-        adapter.setCredentialsClientFactory(credentialsClientFactory);
-        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
-        adapter.setCommandConsumerFactory(commandConsumerFactory);
-        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
-        adapter.setCommandTargetMapper(commandTargetMapper);
+        adapter = newProtocolAdapter(properties, ADAPTER_NAME);
+        setCollaborators(adapter);
 
         vertx = mock(Vertx.class);
         // run timers immediately
@@ -158,6 +152,30 @@ public class AbstractProtocolAdapterBaseTest {
         });
         context = mock(Context.class);
         adapter.init(vertx, context);
+    }
+
+    private void setCollaborators(final AbstractProtocolAdapterBase<?> adapter) {
+        adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setCommandTargetMapper(commandTargetMapper);
+        adapter.setCredentialsClientFactory(credentialsClientFactory);
+        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
+        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
+        adapter.setRegistrationClientFactory(registrationClientFactory);
+        adapter.setTenantClientFactory(tenantClientFactory);
+    }
+
+    private void givenAnAdapterConfiguredWithServiceClients(
+            final Handler<Void> startupHandler,
+            final Handler<Void> commandConnectionEstablishedHandler,
+            final Handler<Void> commandConnectionLostHandler) {
+
+        adapter = newProtocolAdapter(
+                properties,
+                ADAPTER_NAME,
+                startupHandler,
+                commandConnectionEstablishedHandler,
+                commandConnectionLostHandler);
+        setCollaborators(adapter);
     }
 
     /**
@@ -171,13 +189,7 @@ public class AbstractProtocolAdapterBaseTest {
 
         // GIVEN an adapter that does not define a type name
         adapter = newProtocolAdapter(properties, null);
-        adapter.setTenantClientFactory(tenantClientFactory);
-        adapter.setRegistrationClientFactory(registrationClientFactory);
-        adapter.setCredentialsClientFactory(credentialsClientFactory);
-        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
-        adapter.setCommandConsumerFactory(commandConsumerFactory);
-        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
-        adapter.setCommandTargetMapper(commandTargetMapper);
+        setCollaborators(adapter);
 
         // WHEN starting the adapter
         adapter.startInternal().onComplete(ctx.failing(t -> ctx.verify(() -> {
@@ -255,22 +267,6 @@ public class AbstractProtocolAdapterBaseTest {
 
             ctx.completeNow();
         })));
-    }
-
-    private void givenAnAdapterConfiguredWithServiceClients(
-            final Handler<Void> startupHandler,
-            final Handler<Void> commandConnectionEstablishedHandler,
-            final Handler<Void> commandConnectionLostHandler) {
-
-        adapter = newProtocolAdapter(properties, "test", startupHandler,
-                commandConnectionEstablishedHandler, commandConnectionLostHandler);
-        adapter.setCredentialsClientFactory(credentialsClientFactory);
-        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
-        adapter.setRegistrationClientFactory(registrationClientFactory);
-        adapter.setTenantClientFactory(tenantClientFactory);
-        adapter.setCommandConsumerFactory(commandConsumerFactory);
-        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
-        adapter.setCommandTargetMapper(commandTargetMapper);
     }
 
     /**
@@ -721,12 +717,9 @@ public class AbstractProtocolAdapterBaseTest {
         }));
     }
 
-    private AbstractProtocolAdapterBase<ProtocolAdapterProperties> newProtocolAdapter(final ProtocolAdapterProperties props) {
-
-        return newProtocolAdapter(props, ADAPTER_NAME);
-    }
-
-    private AbstractProtocolAdapterBase<ProtocolAdapterProperties> newProtocolAdapter(final ProtocolAdapterProperties props, final String typeName) {
+    private AbstractProtocolAdapterBase<ProtocolAdapterProperties> newProtocolAdapter(
+            final ProtocolAdapterProperties props,
+            final String typeName) {
         return newProtocolAdapter(props, typeName, start -> {});
     }
 

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>hono-bom</artifactId>
+    <groupId>org.eclipse.hono</groupId>
+    <version>1.5.0-SNAPSHOT</version>
+    <relativePath>../bom</relativePath>
+  </parent>
+  <artifactId>test-utils</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Hono Test Utils</name>
+  <url>https://www.eclipse.org/hono</url>
+  <description>Helper classes for implementing Hono's unit tests.</description>
+
+  <modules>
+    <module>service-base-test-utils</module>
+  </modules>
+
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+    <maven.source.skip>true</maven.source.skip>
+    <gpg.skip>true</gpg.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>hono-bom</artifactId>
@@ -41,4 +54,17 @@
       <scope>compile</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/test-utils/service-base-test-utils/pom.xml
+++ b/test-utils/service-base-test-utils/pom.xml
@@ -1,4 +1,18 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eclipse.hono</groupId>

--- a/test-utils/service-base-test-utils/pom.xml
+++ b/test-utils/service-base-test-utils/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>test-utils</artifactId>
+    <version>1.5.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>service-base-test-utils</artifactId>
+
+  <name>Hono Service Base Test Utils</name>
+  <description>Helper classes for implementing unit tests for components built on top of hono-service-base</description>
+  <url>https://www.eclipse.org/hono</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-service-base</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
+++ b/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.service.test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.CommandResponse;
+import org.eclipse.hono.client.CommandResponseSender;
+import org.eclipse.hono.client.CommandTargetMapper;
+import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.client.DeviceConnectionClientFactory;
+import org.eclipse.hono.client.DownstreamSender;
+import org.eclipse.hono.client.DownstreamSenderFactory;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
+import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.RegistrationClientFactory;
+import org.eclipse.hono.client.TenantClientFactory;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.service.AbstractProtocolAdapterBase;
+import org.eclipse.hono.service.monitoring.ConnectionEventProducer;
+import org.junit.jupiter.api.BeforeEach;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.proton.ProtonDelivery;
+
+/**
+ * A base class for implementing tests for protocol adapters.
+ *
+ * @param <T> The type of protocol adapter to test.
+ * @param <C> The type of configuration properties the adapter uses.
+ */
+public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProperties, T extends AbstractProtocolAdapterBase<C>> {
+
+    protected C properties;
+    protected T adapter;
+
+    protected ProtocolAdapterCommandConsumerFactory commandConsumerFactory;
+    protected CommandTargetMapper commandTargetMapper;
+    protected ConnectionEventProducer.Context connectionEventProducerContext;
+    protected CredentialsClientFactory credentialsClientFactory;
+    protected DeviceConnectionClientFactory deviceConnectionClientFactory;
+    protected DownstreamSenderFactory downstreamSenderFactory;
+    protected RegistrationClient registrationClient;
+    protected RegistrationClientFactory registrationClientFactory;
+    protected TenantClientFactory tenantClientFactory;
+
+    /**
+     * Sets up the adapter instance to be tested.
+     */
+    @BeforeEach
+    protected void setUpAdapterInstance() {
+
+        commandConsumerFactory = mock(ProtocolAdapterCommandConsumerFactory.class);
+        when(commandConsumerFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
+        commandTargetMapper = mock(CommandTargetMapper.class);
+
+        credentialsClientFactory = mock(CredentialsClientFactory.class);
+        when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
+        deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
+        when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
+        downstreamSenderFactory = mock(DownstreamSenderFactory.class);
+        when(downstreamSenderFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
+        registrationClientFactory = mock(RegistrationClientFactory.class);
+        when(registrationClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
+        registrationClient = mock(RegistrationClient.class);
+        when(registrationClientFactory.getOrCreateRegistrationClient(anyString())).thenReturn(Future.succeededFuture(registrationClient));
+
+        tenantClientFactory = mock(TenantClientFactory.class);
+        when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
+        connectionEventProducerContext = mock(ConnectionEventProducer.Context.class);
+        when(connectionEventProducerContext.getMessageSenderClient()).thenReturn(downstreamSenderFactory);
+        when(connectionEventProducerContext.getTenantClientFactory()).thenReturn(tenantClientFactory);
+
+        properties = givenDefaultConfigurationProperties();
+    }
+
+    /**
+     * Creates default configuration for the adapter.
+     *
+     * @return The configuration properties.
+     */
+    protected abstract C givenDefaultConfigurationProperties();
+
+    /**
+     * Creates an adapter instance.
+     *
+     * @param configuration The configuration properties to use.
+     * @return The adapter.
+     */
+    protected abstract T newAdapter(C configuration);
+
+    /**
+     * Sets the (mock) collaborators on an adapter.
+     *
+     * @param adapter The adapter.
+     */
+    protected void setCollaborators(final T adapter) {
+        adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setCommandTargetMapper(commandTargetMapper);
+        adapter.setCredentialsClientFactory(credentialsClientFactory);
+        adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
+        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
+        adapter.setRegistrationClientFactory(registrationClientFactory);
+        adapter.setTenantClientFactory(tenantClientFactory);
+    }
+
+    /**
+     * Sets up a new adapter instance as the unit under test.
+     * <p>
+     * {@linkplain #newAdapter(ProtocolAdapterProperties) Creates a new instance}
+     * and then {@linkplain #setCollaborators(AbstractProtocolAdapterBase)
+     * sets all collaborators} on the new instance.
+     *
+     * @param configuration The configuration properties to apply.
+     * @return The adapter instance to test.
+     */
+    protected T givenAnAdapter(final C configuration) {
+        adapter = newAdapter(configuration);
+        setCollaborators(adapter);
+        return adapter;
+    }
+
+    /**
+     * Configures the downstream sender factory to create a mock sender
+     * for telemetry messages regardless of tenant ID.
+     * <p>
+     * The returned sender's send methods will always return a succeeded future.
+     *
+     * @return The sender that the factory will create.
+     */
+    protected DownstreamSender givenATelemetrySenderForAnyTenant() {
+        final Promise<ProtonDelivery> delivery = Promise.promise();
+        delivery.complete(mock(ProtonDelivery.class));
+        return givenATelemetrySenderForAnyTenant(delivery);
+    }
+
+    /**
+     * Configures the downstream sender factory to create a mock sender
+     * for telemetry messages regardless of tenant ID.
+     * <p>
+     * The returned sender's send methods will return the given promise's
+     * corresponding future.
+     *
+     * @param outcome The outcome of sending a message using the returned sender.
+     * @return The sender that the factory will create.
+     */
+    protected DownstreamSender givenATelemetrySenderForAnyTenant(final Promise<ProtonDelivery> outcome) {
+        final DownstreamSender sender = mock(DownstreamSender.class);
+        when(sender.send(any(Message.class), any(SpanContext.class)))
+            .thenReturn(outcome.future());
+        when(sender.sendAndWaitForOutcome(any(Message.class), any(SpanContext.class)))
+            .thenReturn(outcome.future());
+
+        when(downstreamSenderFactory.getOrCreateTelemetrySender(anyString())).thenReturn(Future.succeededFuture(sender));
+        return sender;
+    }
+
+    /**
+     * Configures the downstream sender factory to create a mock sender
+     * for events regardless of tenant ID.
+     * <p>
+     * The returned sender's send methods will return the given promise's
+     * corresponding future.
+     *
+     * @param outcome The outcome of sending a message using the returned sender.
+     * @return The sender that the factory will create.
+     */
+    protected DownstreamSender givenAnEventSender(final Promise<ProtonDelivery> outcome) {
+        final DownstreamSender sender = mock(DownstreamSender.class);
+        when(sender.sendAndWaitForOutcome(any(Message.class), (SpanContext) any())).thenReturn(outcome.future());
+
+        when(downstreamSenderFactory.getOrCreateEventSender(anyString())).thenReturn(Future.succeededFuture(sender));
+        return sender;
+    }
+
+    protected CommandResponseSender givenACommandResponseSenderForAnyTenant() {
+        final Promise<ProtonDelivery> delivery = Promise.promise();
+        delivery.complete(mock(ProtonDelivery.class));
+        return givenACommandResponseSenderForAnyTenant(delivery);
+    }
+
+    protected CommandResponseSender givenACommandResponseSenderForAnyTenant(final Promise<ProtonDelivery> outcome) {
+        final CommandResponseSender responseSender = mock(CommandResponseSender.class);
+        when(responseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(outcome.future());
+
+        when(commandConsumerFactory.getCommandResponseSender(anyString(), anyString()))
+                .thenReturn(Future.succeededFuture(responseSender));
+        return responseSender;
+    }
+
+}


### PR DESCRIPTION
The module contains reusable classes that are helpful with implementing
unit tests for multiple Hono components.

This is just the first step illustrating the idea. The remaining adapter tests will be migrated once this PR is merged.
The *test-utils* module could also be the home for additional modules, e.g. *core-utils*. it could also be the home of the utility classes described by #1641 