### PR TITLE
[#2244] Skip sendDisconnectedTtdEvent if consumer not mapped

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
@@ -98,6 +98,10 @@ public interface DeviceConnectionClient extends RequestResponseClient {
      * @return A future indicating the outcome of the operation, with its value indicating whether the protocol
      *         adapter instance value was removed or not.
      *         <p>
+     *         NOTE: this method maps an outcome with status 404 or 412 as defined in the
+     *         <a href="https://www.eclipse.org/hono/docs/api/device-connection/">Device Connection API
+     *         specification</a> to a succeeded future with value {@code false} here.
+     *         <p>
      *         The future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} if there
      *         was an error removing the value.
      * @throws NullPointerException if device id or adapter instance id is {@code null}.

--- a/client/src/main/java/org/eclipse/hono/client/ProtocolAdapterCommandConsumer.java
+++ b/client/src/main/java/org/eclipse/hono/client/ProtocolAdapterCommandConsumer.java
@@ -26,7 +26,10 @@ public interface ProtocolAdapterCommandConsumer {
      * Closes the consumer.
      *
      * @param spanContext The span context (may be {@code null}).
-     * @return A future indicating the outcome of the operation.
+     * @return A future indicating the outcome of the operation. The future will be failed with a
+     *         {@link ServiceInvocationException} if there was an error closing the consumer and with a
+     *         {@link ClientErrorException} with {@link java.net.HttpURLConnection#HTTP_PRECON_FAILED} if the consumer
+     *         was found to have been closed/overwritten already.
      */
     Future<Void> close(SpanContext spanContext);
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandHandlerWrapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandHandlerWrapper.java
@@ -90,8 +90,9 @@ public final class CommandHandlerWrapper {
     @Override
     public String toString() {
         return "CommandHandlerWrapper{" +
-                "deviceId='" + deviceId + '\'' +
-                ", gatewayId='" + gatewayId + '\'' +
+                "tenantId='" + tenantId + '\'' +
+                ", deviceId='" + deviceId + '\'' +
+                (gatewayId != null ? (", gatewayId='" + gatewayId + '\'') : "") +
                 '}';
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/Pair.java
+++ b/core/src/main/java/org/eclipse/hono/util/Pair.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.util;
+
+/**
+ * A pair of two values of arbitrary type.
+ *
+ * @param <A> The type of the first value.
+ * @param <B> The type of the second value.
+ */
+public final class Pair<A, B> {
+
+    private final A one;
+    private final B two;
+
+    private String stringRep;
+
+    private Pair(final A one, final B two) {
+
+        if (one == null && two == null) {
+            throw new IllegalArgumentException("at least one argument must be non-null");
+        }
+        this.one = one;
+        this.two = two;
+    }
+
+    /**
+     * Creates a new pair for two values of arbitrary type.
+     *
+     * @param one First value.
+     * @param two Second value.
+     * @param <A> The type of the first value.
+     * @param <B> The type of the second value.
+     * @return The pair.
+     * @throws IllegalArgumentException if all values are {@code null}.
+     */
+    public static <A, B> Pair<A, B> of(final A one, final B two) {
+        return new Pair<>(one, two);
+    }
+
+    /**
+     * @return The one.
+     */
+    public A one() {
+        return one;
+    }
+
+    /**
+     * @return The two.
+     */
+    public B two() {
+        return two;
+    }
+
+    @Override
+    public String toString() {
+        if (stringRep == null) {
+            stringRep = String.format("Pair[one: %s, two: %s]", one, two);
+        }
+        return stringRep;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (one == null ? 0 : one.hashCode());
+        result = prime * result + (two == null ? 0 : two.hashCode());
+        return result;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Pair other = (Pair) obj;
+        if (one == null) {
+            if (other.one != null) {
+                return false;
+            }
+        } else if (!one.equals(other.one)) {
+            return false;
+        }
+        if (two == null) {
+            if (other.two != null) {
+                return false;
+            }
+        } else if (!two.equals(other.two)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/core/src/test/java/org/eclipse/hono/util/PairTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/PairTest.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for Pair.
+ */
+public class PairTest {
+
+    /**
+     * Test the argument order.
+     */
+    @Test
+    public void testOrderOfArguments() {
+        final Pair<String, String> t1 = Pair.of("Foo", "Bar");
+
+        Assertions.assertEquals("Foo", t1.one());
+        Assertions.assertEquals("Bar", t1.two());
+    }
+
+    /**
+     * Test equality having the same type.
+     */
+    @Test
+    public void testEqualsSameType() {
+        final Pair<String, String> t1 = Pair.of("Foo", "Bar");
+        final Pair<String, String> t2 = Pair.of("Foo", "Bar");
+
+        Assertions.assertEquals(t1, t2);
+        Assertions.assertEquals(t2, t1);
+
+        Assertions.assertEquals(t1.hashCode(), t2.hashCode());
+    }
+
+    /**
+     * Test equality having a different type.
+     */
+    @Test
+    public void testEqualsDifferentType() {
+        expectNotEqual(
+                Pair.of("Foo", "42"),
+                Pair.of("Foo", 42));
+    }
+
+    /**
+     * Test non-equal pairs.
+     */
+    @Test
+    public void testNotEqual1() {
+        expectNotEqual(
+                Pair.of("Foo", "Bar"),
+                Pair.of("FooX", "Bar"));
+    }
+
+    /**
+     * Test non-equal pairs.
+     */
+    @Test
+    public void testNotEqual2() {
+        expectNotEqual(
+                Pair.of("Foo", "Bar"),
+                Pair.of("Foo", "BarX"));
+    }
+
+    /**
+     * Test all values are null.
+     */
+    @Test
+    public void testAllNull() {
+        assertThatThrownBy(() -> Pair.of(null, null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private void expectNotEqual(final Pair<?, ?> t1, final Pair<?, ?> t2) {
+        Assertions.assertNotEquals(t1, t2);
+        Assertions.assertNotEquals(t2, t1);
+
+        // Note: we are not testing the hashCode, as this might, in theory, actually be the same.
+    }
+}


### PR DESCRIPTION
No 'disconnectedTtdEvent' is now sent anymore when a command consumer is obviously not registered anymore
because its associated command handling adapter instance entry has already been removed or overwritten.

This resolves both cases described in #2244.