### PR TITLE
Fix Hono CI build by encoding unsafe characters while creating URI

### DIFF
--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/SQL.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/SQL.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
+import com.google.common.net.UrlEscapers;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -208,7 +209,7 @@ public final class SQL {
      * @throws IllegalArgumentException if the URL is not a JDBC URL, it must start with {@code jdbc:}.
      */
     public static String getDatabaseDialect(final String url) {
-        final URI uri = URI.create(url);
+        final URI uri = URI.create(UrlEscapers.urlPathSegmentEscaper().escape(url));
         final String scheme = uri.getScheme();
         if (!"jdbc".equals(scheme)) {
             throw new IllegalArgumentException("URL is not a JDBC url: " + url);


### PR DESCRIPTION
Some tests as below fail during the Hono CI build. The reasons is that the URL namely `jdbc:h2:/jobs/genie.hono/Hono CI Pipeline/workspace/services/device-registry-jdbc/target/data/d222ff86-346d-413b-b40e-17fb48004579` contains space characters. This causes issue while creating an URI object to get the JDBC database type. This has been fixed by encoding unsafe characters in the URL.

```
[ERROR] Tests run: 16, Failures: 0, Errors: 16, Skipped: 0, Time elapsed: 3.971 s <<< FAILURE! - in org.eclipse.hono.deviceregistry.jdbc.impl.JdbcBasedCredentialsServiceTest
[ERROR] testUpdateCredentialsSupportsRemovingExistingCredentialsAndSecrets{VertxTestContext}  Time elapsed: 0.009 s  <<< ERROR!
java.lang.IllegalArgumentException: Illegal character in opaque part at index 29: jdbc:h2:/jobs/genie.hono/Hono CI Pipeline/workspace/services/device-registry-jdbc/target/data/d222ff86-346d-413b-b40e-17fb48004579
```