### PR TITLE
[#2252] Fix error while creating URI by encoding unsafe characters

### DIFF
--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/SQL.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/SQL.java
@@ -214,7 +214,7 @@ public final class SQL {
         if (!"jdbc".equals(scheme)) {
             throw new IllegalArgumentException("URL is not a JDBC url: " + url);
         }
-        final URI subUri = URI.create(uri.getSchemeSpecificPart());
+        final URI subUri = URI.create(UrlEscapers.urlPathSegmentEscaper().escape(uri.getSchemeSpecificPart()));
         return subUri.getScheme();
     }
 


### PR DESCRIPTION
This is related to the PR #2252. There is one more place where the URI creation should be fixed by encoding unsafe characters such as space in the URL string. This PR fixes it.