### PR TITLE
Use void future in client removeCommandHandlingAdapterInstance()

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfo.java
@@ -166,7 +166,7 @@ public final class CacheBasedDeviceConnectionInfo implements DeviceConnectionInf
     }
 
     @Override
-    public Future<Boolean> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
+    public Future<Void> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
             final String adapterInstanceId, final Span span) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
@@ -182,15 +182,16 @@ public final class CacheBasedDeviceConnectionInfo implements DeviceConnectionInf
                             tenantId, deviceId, adapterInstanceId, t);
                     return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, t));
                 })
-                .map(removed -> {
+                .compose(removed -> {
                     if (!removed) {
                         LOG.debug("command handling adapter instance was not removed, key not mapped or value didn't match [tenant: {}, device-id: {}, adapter-instance: {}]",
                                 tenantId, deviceId, adapterInstanceId);
+                        return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED));
                     } else {
                         LOG.debug("removed command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}]",
                                 tenantId, deviceId, adapterInstanceId);
+                        return Future.succeededFuture();
                     }
-                    return removed;
                 });
 
     }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
@@ -99,14 +99,13 @@ public interface DeviceConnectionInfo {
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
      *            An implementation should log (error) events on this span and it may set tags and use this span as the
      *            parent for any spans created in this method.
-     * @return A future indicating the outcome of the operation, with its value indicating whether the protocol
-     *         adapter instance value was removed or not.
+     * @return A future indicating the outcome of the operation.
      *         <p>
-     *         The future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} if there
-     *         was an error removing the value.
-     * @throws NullPointerException if any of the parameters is {@code null}.
+     *         The future will be succeeded if the entry was successfully removed.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters except context is {@code null}.
      */
-    Future<Boolean> removeCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId, Span span);
+    Future<Void> removeCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId, Span span);
 
     /**
      * Gets information about the adapter instances that can handle a command for the given device.

--- a/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/DeviceConnectionClient.java
@@ -95,18 +95,13 @@ public interface DeviceConnectionClient extends RequestResponseClient {
      * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            An implementation should use this as the parent for any span it creates for tracing
      *            the execution of this operation.
-     * @return A future indicating the outcome of the operation, with its value indicating whether the protocol
-     *         adapter instance value was removed or not.
+     * @return A future indicating the outcome of the operation.
      *         <p>
-     *         NOTE: this method maps an outcome with status 404 or 412 as defined in the
-     *         <a href="https://www.eclipse.org/hono/docs/api/device-connection/">Device Connection API
-     *         specification</a> to a succeeded future with value {@code false} here.
-     *         <p>
-     *         The future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} if there
-     *         was an error removing the value.
+     *         The future will be succeeded if the entry was successfully removed.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
      * @throws NullPointerException if device id or adapter instance id is {@code null}.
      */
-    Future<Boolean> removeCommandHandlingAdapterInstance(String deviceId, String adapterInstanceId, SpanContext context);
+    Future<Void> removeCommandHandlingAdapterInstance(String deviceId, String adapterInstanceId, SpanContext context);
 
     /**
      * Gets information about the adapter instances that can handle a command for the given device.

--- a/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
@@ -187,10 +187,9 @@ public class DeviceConnectionClientImplTest {
 
         // WHEN removing the command handling adapter instance
         client.removeCommandHandlingAdapterInstance("deviceId", "adapterInstanceId", span.context())
-                .onComplete(ctx.succeeding(result -> {
+                .onComplete(ctx.succeeding(r -> {
                     ctx.verify(() -> {
                         // THEN the response has been handled and the span is finished
-                        assertThat(result).isTrue();
                         verify(span).finish();
                     });
                     ctx.completeNow();
@@ -342,7 +341,7 @@ public class DeviceConnectionClientImplTest {
 
     /**
      * Verifies that a client invocation of the <em>remove-cmd-handling-adapter-instance</em> operation
-     * returns a <em>Boolean.FALSE</em> value if a <em>NOT_FOUND</em> response was returned.
+     * returns a <em>Boolean.FALSE</em> value if a <em>PRECON_FAILED</em> response was returned.
      *
      * @param ctx The vert.x test context.
      */
@@ -351,10 +350,10 @@ public class DeviceConnectionClientImplTest {
 
         // WHEN removing the command handling adapter instance
         client.removeCommandHandlingAdapterInstance("deviceId", "gatewayId", span.context())
-                .onComplete(ctx.succeeding(removed -> {
+                .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {
                         // THEN the response has been handled and the span is finished
-                        assertThat(removed).isFalse();
+                        assertThat(ServiceInvocationException.extractStatusCode(t)).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
                         verify(span).finish();
                     });
                     ctx.completeNow();
@@ -362,7 +361,7 @@ public class DeviceConnectionClientImplTest {
 
         final Message sentMessage = verifySenderSend();
         final Message response = ProtonHelper.message();
-        MessageHelper.addProperty(response, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_NOT_FOUND);
+        MessageHelper.addProperty(response, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_PRECON_FAILED);
         MessageHelper.addCacheDirective(response, CacheDirective.maxAgeDirective(60));
         response.setCorrelationId(sentMessage.getMessageId());
         client.handleResponse(mock(ProtonDelivery.class), response);
@@ -415,8 +414,8 @@ public class DeviceConnectionClientImplTest {
         // WHEN getting last known gateway information
         client.getLastKnownGatewayForDevice("deviceId", span.context())
                 .onComplete(ctx.failing(t -> {
-                    assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                     ctx.verify(() -> {
+                        assertThat(ServiceInvocationException.extractStatusCode(t)).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                         // THEN the invocation fails and the span is marked as erroneous
                         verify(span).setTag(eq(Tags.ERROR.getKey()), eq(Boolean.TRUE));
                         // and the span is finished
@@ -449,7 +448,7 @@ public class DeviceConnectionClientImplTest {
         client.setLastKnownGatewayForDevice("deviceId", "gatewayId", span.context())
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {
-                        assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
+                        assertThat(ServiceInvocationException.extractStatusCode(t)).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                         // THEN the invocation fails and the span is marked as erroneous
                         verify(span).setTag(eq(Tags.ERROR.getKey()), eq(Boolean.TRUE));
                         // and the span is finished
@@ -481,8 +480,8 @@ public class DeviceConnectionClientImplTest {
         // WHEN setting the command handling adapter instance
         client.setCommandHandlingAdapterInstance("deviceId", "adapterInstanceId", null, span.context())
                 .onComplete(ctx.failing(t -> {
-                    assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                     ctx.verify(() -> {
+                        assertThat(ServiceInvocationException.extractStatusCode(t)).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                         // THEN the invocation fails and the span is marked as erroneous
                         verify(span).setTag(eq(Tags.ERROR.getKey()), eq(Boolean.TRUE));
                         // and the span is finished
@@ -514,8 +513,8 @@ public class DeviceConnectionClientImplTest {
         // WHEN removing the command handling adapter instance
         client.removeCommandHandlingAdapterInstance("deviceId", "adapterInstanceId", span.context())
                 .onComplete(ctx.failing(t -> {
-                    assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                     ctx.verify(() -> {
+                        assertThat(ServiceInvocationException.extractStatusCode(t)).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                         // THEN the invocation fails and the span is marked as erroneous
                         verify(span).setTag(eq(Tags.ERROR.getKey()), eq(Boolean.TRUE));
                         // and the span is finished
@@ -547,8 +546,8 @@ public class DeviceConnectionClientImplTest {
         // WHEN getting the command handling adapter instances
         client.getCommandHandlingAdapterInstances("deviceId", Collections.emptyList(), span.context())
                 .onComplete(ctx.failing(t -> {
-                    assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                     ctx.verify(() -> {
+                        assertThat(ServiceInvocationException.extractStatusCode(t)).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
                         // THEN the invocation fails and the span is marked as erroneous
                         verify(span).setTag(eq(Tags.ERROR.getKey()), eq(Boolean.TRUE));
                         // and the span is finished

--- a/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
@@ -137,7 +137,7 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
         when(devConClient.setCommandHandlingAdapterInstance(anyString(), anyString(), any(), any()))
                 .thenReturn(Future.succeededFuture());
         when(devConClient.removeCommandHandlingAdapterInstance(anyString(), anyString(), any()))
-                .thenReturn(Future.succeededFuture(Boolean.TRUE));
+                .thenReturn(Future.succeededFuture());
 
         commandConsumerFactory = new ProtocolAdapterCommandConsumerFactoryImpl(connection, SendMessageSampler.Factory.noop());
         commandConsumerFactory.initialize(commandTargetMapper, deviceConnectionClientFactory);
@@ -165,7 +165,9 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
 
         commandConsumerFactory.createCommandConsumer(tenantId, deviceId, commandHandler, null, null)
             .onComplete(ctx.failing(t -> {
-                ctx.verify(() -> assertThat(((ServiceInvocationException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_UNAVAILABLE));
+                ctx.verify(() -> {
+                    assertThat(ServiceInvocationException.extractStatusCode(t)).isEqualTo(HttpURLConnection.HTTP_UNAVAILABLE);
+                });
                 ctx.completeNow();
             }));
     }

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionService.java
@@ -90,8 +90,7 @@ public class CacheBasedDeviceConnectionService extends AbstractVerticle implemen
     public Future<DeviceConnectionResult> removeCommandHandlingAdapterInstance(final String tenantId, final String deviceId,
             final String adapterInstanceId, final Span span) {
         return cache.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span)
-                .map(removed -> removed ? DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT)
-                        : DeviceConnectionResult.from(HttpURLConnection.HTTP_PRECON_FAILED))
+                .map(v -> DeviceConnectionResult.from(HttpURLConnection.HTTP_NO_CONTENT))
                 .otherwise(t -> DeviceConnectionResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
 

--- a/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
+++ b/services/device-connection/src/test/java/org/eclipse/hono/deviceconnection/infinispan/CacheBasedDeviceConnectionServiceTest.java
@@ -184,7 +184,7 @@ public class CacheBasedDeviceConnectionServiceTest {
         final String deviceId = "testDevice";
         final String adapterInstanceId = "adapterInstanceId";
         when(cache.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(Span.class)))
-                .thenReturn(Future.succeededFuture(true));
+                .thenReturn(Future.succeededFuture());
 
         givenAStartedService()
                 .compose(ok -> svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstanceId, span))
@@ -210,7 +210,7 @@ public class CacheBasedDeviceConnectionServiceTest {
         final String deviceId = "testDevice";
         final String adapterInstanceId = "adapterInstanceId";
         when(cache.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(Span.class)))
-                .thenReturn(Future.succeededFuture(false));
+                .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED)));
 
         givenAStartedService()
                 .compose(ok -> svc.removeCommandHandlingAdapterInstance(Constants.DEFAULT_TENANT, deviceId, adapterInstanceId, span))

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
@@ -182,8 +182,8 @@ abstract class DeviceConnectionApiTests extends DeviceRegistryTestBase {
     }
 
     /**
-     * Verifies that a request to remove the command-handling adapter instance for a device succeeds with
-     * a <em>true</em> value if there was a matching adapter instance entry.
+     * Verifies that a request to remove the command-handling adapter instance for a device succeeds
+     * if there was a matching adapter instance entry.
      *
      * @param ctx The vert.x test context.
      */
@@ -201,15 +201,12 @@ abstract class DeviceConnectionApiTests extends DeviceRegistryTestBase {
                         .map(client))
                 // then remove it
                 .compose(client -> client.removeCommandHandlingAdapterInstance(deviceId, adapterInstance, null))
-                .onComplete(ctx.succeeding(result -> {
-                    ctx.verify(() -> assertThat(result).isTrue());
-                    ctx.completeNow();
-                }));
+                .onComplete(ctx.completing());
     }
 
     /**
-     * Verifies that a request to remove the command-handling adapter instance for a device succeeds with
-     * a <em>false</em> value if no adapter is registered for the device.
+     * Verifies that a request to remove the command-handling adapter instance for a device fails if no
+     * adapter is registered for the device.
      *
      * @param ctx The vert.x test context.
      */
@@ -219,8 +216,8 @@ abstract class DeviceConnectionApiTests extends DeviceRegistryTestBase {
 
         getClient(randomId())
             .compose(client -> client.removeCommandHandlingAdapterInstance("non-existing-device", "adapterOne", null))
-            .onComplete(ctx.succeeding(result -> {
-                ctx.verify(() -> assertThat(result).isFalse());
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> assertErrorCode(t, HttpURLConnection.HTTP_PRECON_FAILED));
                 ctx.completeNow();
             }));
     }
@@ -240,8 +237,8 @@ abstract class DeviceConnectionApiTests extends DeviceRegistryTestBase {
         getClient(randomId())
             .compose(client -> client.setCommandHandlingAdapterInstance(deviceId, "adapterOne", Duration.ofMinutes(5), null).map(client))
             .compose(client -> client.removeCommandHandlingAdapterInstance(deviceId, "notAdapterOne", null))
-            .onComplete(ctx.succeeding(result -> {
-                ctx.verify(() -> assertThat(result).isFalse());
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> assertErrorCode(t, HttpURLConnection.HTTP_PRECON_FAILED));
                 ctx.completeNow();
             }));
     }


### PR DESCRIPTION
This reverts #1926 and makes the method behave according to the API spec again, returning a failed Future if the entry wasn't removed.
Motivated by discussion here: https://github.com/eclipse/hono/pull/2251#discussion_r505417615.