### PR TITLE
Make tenant ID property mandatory

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/TenantObject.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantObject.java
@@ -56,6 +56,23 @@ public final class TenantObject extends JsonBackedValueObject {
     private Set<TrustAnchor> trustAnchors;
 
     /**
+     * Creates a new tenant.
+     *
+     * @param tenantId The tenant's identifier.
+     * @param enabled {@code true} if devices of this tenant are allowed to connect to Hono.
+     * @throws NullPointerException if identifier is {@code null}.
+     */
+    public TenantObject(
+            @JsonProperty(value = TenantConstants.FIELD_PAYLOAD_TENANT_ID, required = true)
+            final String tenantId,
+            @JsonProperty(value = TenantConstants.FIELD_ENABLED, required = true)
+            final boolean enabled) {
+        Objects.requireNonNull(tenantId);
+        setProperty(TenantConstants.FIELD_PAYLOAD_TENANT_ID, tenantId);
+        setProperty(TenantConstants.FIELD_ENABLED, enabled);
+    }
+
+    /**
      * Adds a property to this tenant.
      *
      * @param name The property name.
@@ -80,17 +97,6 @@ public final class TenantObject extends JsonBackedValueObject {
     }
 
     /**
-     * Sets this tenant's identifier.
-     *
-     * @param tenantId The identifier.
-     * @return This tenant for command chaining.
-     */
-    @JsonIgnore
-    public TenantObject setTenantId(final String tenantId) {
-        return setProperty(TenantConstants.FIELD_PAYLOAD_TENANT_ID, tenantId);
-    }
-
-    /**
      * Checks if this tenant is enabled.
      *
      * @return {@code true} if this tenant is enabled.
@@ -98,17 +104,6 @@ public final class TenantObject extends JsonBackedValueObject {
     @JsonIgnore
     public boolean isEnabled() {
         return getProperty(TenantConstants.FIELD_ENABLED, Boolean.class, true);
-    }
-
-    /**
-     * Sets whether this tenant is enabled.
-     *
-     * @param flag {@code true} if this tenant is enabled.
-     * @return This tenant for command chaining.
-     */
-    @JsonIgnore
-    public TenantObject setEnabled(final boolean flag) {
-        return setProperty(TenantConstants.FIELD_ENABLED, flag);
     }
 
     /**
@@ -393,38 +388,28 @@ public final class TenantObject extends JsonBackedValueObject {
     }
 
     /**
+     * Creates an enabled tenant for a tenantId.
+     *
+     * @param tenantId The tenant for which the object is constructed.
+     * @return The TenantObject.
+     * @throws NullPointerException if tenantId is {@code null}.
+     */
+    public static TenantObject from(final String tenantId) {
+
+        return new TenantObject(tenantId, true);
+    }
+
+    /**
      * Creates a TenantObject for a tenantId and the enabled property.
      *
      * @param tenantId The tenant for which the object is constructed.
      * @param enabled {@code true} if the tenant shall be enabled.
      * @return The TenantObject.
-     * @throws NullPointerException if any of tenantId or enabled is {@code null}.
+     * @throws NullPointerException if tenantId is {@code null}.
      */
-    public static TenantObject from(final String tenantId, final Boolean enabled) {
+    public static TenantObject from(final String tenantId, final boolean enabled) {
 
-        Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(enabled);
-
-        final TenantObject result = new TenantObject();
-        result.setTenantId(tenantId);
-        result.setEnabled(enabled);
-        return result;
-    }
-
-    /**
-     * Creates a TenantObject from the enabled property.
-     *
-     * @param enabled {@code true} if the tenant shall be enabled.
-     * @return The TenantObject.
-     * @throws NullPointerException if enabled is {@code null}.
-     */
-    public static TenantObject from(final Boolean enabled) {
-
-        Objects.requireNonNull(enabled);
-
-        final TenantObject result = new TenantObject();
-        result.setEnabled(enabled);
-        return result;
+        return new TenantObject(tenantId, enabled);
     }
 
     /**

--- a/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/TenantObjectTest.java
@@ -112,9 +112,11 @@ public class TenantObjectTest {
 
         final JsonObject config = new JsonObject()
                 .put(TenantConstants.FIELD_PAYLOAD_TENANT_ID, "my-tenant")
+                .put(TenantConstants.FIELD_ENABLED, Boolean.TRUE)
                 .put(TenantConstants.FIELD_PAYLOAD_TRUSTED_CA, new JsonArray());
 
         final TenantObject tenant = config.mapTo(TenantObject.class);
+        assertThat(tenant.isEnabled());
         assertThat(tenant.getTrustAnchors()).isNotNull();
         assertThat(tenant.getTrustAnchors()).isEmpty();
     }

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509AuthenticationTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509AuthenticationTest.java
@@ -74,7 +74,7 @@ class TenantServiceBasedX509AuthenticationTest {
     void testValidateClientCertificateContainsReadableCertificate() throws GeneralSecurityException {
 
         // GIVEN a trust anchor that is enabled for auto-provisioning
-        final TenantObject tenant = new TenantObject().addTrustAnchor(cert.getPublicKey(),
+        final TenantObject tenant = new TenantObject("tenant", true).addTrustAnchor(cert.getPublicKey(),
                 cert.getSubjectX500Principal(), true);
         when(tenantClient.get(any(X500Principal.class), any())).thenReturn(Future.succeededFuture(tenant));
 
@@ -94,7 +94,7 @@ class TenantServiceBasedX509AuthenticationTest {
     void testValidateClientCertificateContainsNoCertificate() {
 
         // GIVEN a trust anchor that is disabled for auto-provisioning
-        final TenantObject tenant = new TenantObject().addTrustAnchor(cert.getPublicKey(),
+        final TenantObject tenant = new TenantObject("tenant", true).addTrustAnchor(cert.getPublicKey(),
                 cert.getSubjectX500Principal(), false);
         when(tenantClient.get(any(X500Principal.class), any())).thenReturn(Future.succeededFuture(tenant));
 

--- a/service-base/src/test/java/org/eclipse/hono/service/monitoring/HonoEventConnectionEventProducerTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/monitoring/HonoEventConnectionEventProducerTest.java
@@ -79,8 +79,7 @@ class HonoEventConnectionEventProducerTest {
 
         final String tenantId = "tenant";
         final Device authenticatedDevice = new Device(tenantId, "device");
-        tenant = new TenantObject()
-                .setTenantId(tenantId)
+        tenant = new TenantObject(tenantId, true)
                 .setResourceLimits(new ResourceLimits().setMaxTtl(500));
         when(tenantClient.get(anyString())).thenReturn(Future.succeededFuture(tenant));
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/NoopTenantService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/NoopTenantService.java
@@ -32,9 +32,7 @@ public class NoopTenantService implements TenantService {
 
     @Override
     public Future<TenantResult<JsonObject>> get(final String tenantId, final Span span) {
-        final TenantObject tenant = new TenantObject();
-        tenant.setTenantId(tenantId);
-        tenant.setEnabled(true);
+        final TenantObject tenant = new TenantObject(tenantId, true);
         return Future.succeededFuture(TenantResult.from(HttpURLConnection.HTTP_OK, JsonObject.mapFrom(tenant), null));
     }
 


### PR DESCRIPTION
The TenantObject now requires the mandatory properties tenant-id and
enabled to be specified in the constructor.
