### PR TITLE
Workaround for quarkus system logging issue

### DIFF
--- a/service-base-quarkus/pom.xml
+++ b/service-base-quarkus/pom.xml
@@ -35,6 +35,12 @@
       <artifactId>quarkus-arc</artifactId>
       <version>${quarkus.platform.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.logmanager</groupId>
+          <artifactId>jboss-logmanager-embedded</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>
@@ -149,6 +155,14 @@
   <profiles>
     <profile>
       <id>jboss-logmanager</id>
+      <!-- alternative until the problem with jboss-logmanager-embedded is fixed -->
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.logmanager</groupId>
+          <artifactId>jboss-logmanager</artifactId>
+          <version>2.1.17.Final</version>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
The issue with the Quarkus system logging is rooted in the jboss-logmanager-embedded library. The PR to fix it is already in (https://github.com/dmlloyd/jboss-logmanager-embedded/pull/2).

This workaround helps the test pass, but I'm not sure it'll be fully configurable in Quarkus per (https://groups.google.com/g/quarkus-dev/c/g0pSv77NNno/m/K9ZijGDmBwAJ). But it should get us going until jbos-logmanager-embedded:1.0.6 is released.