### PR TITLE
[#2115] Fix wrong exception if tenant not found in PreCredentialsValidationHandler

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -54,6 +54,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.AdapterConnectionsExceededException;
 import org.eclipse.hono.service.AdapterDisabledException;
+import org.eclipse.hono.service.auth.device.CredentialsApiAuthProvider;
 import org.eclipse.hono.service.auth.device.DeviceCredentials;
 import org.eclipse.hono.service.auth.device.TenantServiceBasedX509Authentication;
 import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
@@ -217,6 +218,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
         final String authId = credentials.getAuthId();
 
         return getTenantConfiguration(tenantId, span.context())
+                .recover(t -> Future.failedFuture(CredentialsApiAuthProvider.mapNotFoundToBadCredentialsException(t)))
                 .compose(tenantObject -> {
                     TracingHelper.setDeviceTags(span, tenantId, null, authId);
                     final OptionalInt traceSamplingPriority = TenantTraceSamplingHelper.applyTraceSamplingPriority(

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -35,6 +35,7 @@ import org.eclipse.hono.client.ProtocolAdapterCommandConsumer;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.impl.CommandConsumer;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
+import org.eclipse.hono.service.auth.device.CredentialsApiAuthProvider;
 import org.eclipse.hono.service.auth.device.DeviceCredentials;
 import org.eclipse.hono.service.http.ComponentMetaDataDecorator;
 import org.eclipse.hono.service.http.DefaultFailureHandler;
@@ -348,6 +349,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             return Future.succeededFuture();
         }
         return getTenantConfiguration(tenantId, span.context())
+                .recover(t -> Future.failedFuture(CredentialsApiAuthProvider.mapNotFoundToBadCredentialsException(t)))
                 .compose(tenantObject -> {
                     TracingHelper.setDeviceTags(span, tenantId, null, authId);
                     TenantTraceSamplingHelper.applyTraceSamplingPriority(tenantObject, authId, span);

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -44,6 +44,7 @@ import org.eclipse.hono.service.AuthorizationException;
 import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.auth.device.AuthHandler;
 import org.eclipse.hono.service.auth.device.ChainAuthHandler;
+import org.eclipse.hono.service.auth.device.CredentialsApiAuthProvider;
 import org.eclipse.hono.service.auth.device.DeviceCredentials;
 import org.eclipse.hono.service.auth.device.TenantServiceBasedX509Authentication;
 import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
@@ -210,6 +211,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         final String authId = credentials.getAuthId();
 
         return getTenantConfiguration(tenantId, span.context())
+                .recover(t -> Future.failedFuture(CredentialsApiAuthProvider.mapNotFoundToBadCredentialsException(t)))
                 .compose(tenantObject -> {
                     TracingHelper.setDeviceTags(span, tenantId, null, authId);
                     final OptionalInt traceSamplingPriority = TenantTraceSamplingHelper.applyTraceSamplingPriority(


### PR DESCRIPTION
Fix concerning the changes done for #2115:
A 404 error when fetching the tenant in the PreCredentialsValidationHandler should be interpreted as a "bad credentials" error (401).

This lead to the wrong status code in corresponding HTTP adapter responses.

Only applies to the yet-unreleased 1.5 Hono version.