### PR TITLE
[#2267] Add implementation of Telemetry and EventSender

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/CachingClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CachingClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -41,7 +41,7 @@ import io.vertx.core.Vertx;
  *
  * @param <T> The type of client to be created.
  */
-class CachingClientFactory<T> extends ClientFactory<T> {
+public final class CachingClientFactory<T> extends ClientFactory<T> {
 
     /**
      * The maximum number of retries for getting or creating a client while a concurrent request with the same key is
@@ -69,10 +69,12 @@ class CachingClientFactory<T> extends ClientFactory<T> {
     private final Map<String, Boolean> creationLocks = new HashMap<>();
 
     /**
+     * Creates a new factory.
+     *
      * @param vertx The Vert.x instance to use for creating a timer.
      * @param livenessCheck A predicate for checking if a cached client is usable.
      */
-    CachingClientFactory(final Vertx vertx, final Predicate<T> livenessCheck) {
+    public CachingClientFactory(final Vertx vertx, final Predicate<T> livenessCheck) {
         this.vertx = vertx;
         this.livenessCheck = Objects.requireNonNull(livenessCheck);
     }
@@ -100,7 +102,9 @@ class CachingClientFactory<T> extends ClientFactory<T> {
     }
 
     /**
-     * Clears the cache.
+     * {@inheritDoc}
+     * <p>
+     * Clears this factory's cache.
      */
     @Override
     protected void doClearState() {

--- a/clients/adapter-amqp/pom.xml
+++ b/clients/adapter-amqp/pom.xml
@@ -16,26 +16,25 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eclipse.hono</groupId>
-    <artifactId>hono-bom</artifactId>
+    <artifactId>hono-clients-parent</artifactId>
     <version>1.5.0-SNAPSHOT</version>
-    <relativePath>../bom</relativePath>
   </parent>
+  <artifactId>hono-client-adapter-amqp</artifactId>
 
-  <artifactId>hono-clients-parent</artifactId>
-  <packaging>pom</packaging>
-
-  <name>Hono Clients</name>
-  <description>Client role specific libraries for accessing Hono's remote APIs</description>
-
-  <modules>
-    <module>adapter</module>
-    <module>adapter-amqp</module>
-  </modules>
-
+  <name>Hono Client for Protocol Adapters (AMQP)</name>
+  <description>An AMQP 1.0 based implementation of the Hono Client for Protocol Adapters</description>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-legal</artifactId>
+      <artifactId>hono-client-adapter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractServiceClient.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.amqp;
+
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.util.ServiceClient;
+import org.eclipse.hono.client.ConnectionLifecycle;
+import org.eclipse.hono.client.DisconnectListener;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.ReconnectListener;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
+
+/**
+ * A base class for implementing Hono service clients.
+ */
+public abstract class AbstractServiceClient implements ConnectionLifecycle<HonoConnection>, ServiceClient, Lifecycle {
+
+    /**
+     * A logger to be shared with subclasses.
+     */
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+    /**
+     * The connection to use for interacting with Hono.
+     */
+    protected final HonoConnection connection;
+    /**
+     * The factory for creating <em>send message</em> samplers.
+     */
+    protected final SendMessageSampler.Factory samplerFactory;
+    /**
+     * The protocol adapter configuration.
+     */
+    protected final ProtocolAdapterProperties adapterConfig;
+
+    /**
+     * Creates a new client.
+     *
+     * @param connection The connection to the Hono service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    protected AbstractServiceClient(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig) {
+
+        this.connection = Objects.requireNonNull(connection);
+        this.connection.addDisconnectListener(con -> onDisconnect());
+        this.samplerFactory = Objects.requireNonNull(samplerFactory);
+        this.adapterConfig = Objects.requireNonNull(adapterConfig);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Simply delegates to {@link HonoConnection#addDisconnectListener(DisconnectListener)}.
+     */
+    @Override
+    public void addDisconnectListener(final DisconnectListener<HonoConnection> listener) {
+        connection.addDisconnectListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Simply delegates to {@link HonoConnection#addReconnectListener(ReconnectListener)}.
+     */
+    @Override
+    public void addReconnectListener(final ReconnectListener<HonoConnection> listener) {
+        connection.addReconnectListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Simply delegates to {@link HonoConnection#connect()}.
+     */
+    @Override
+    public Future<HonoConnection> connect() {
+        return connection.connect();
+    }
+
+    /**
+     * Checks whether this client is connected to the service.
+     * <p>
+     * Simply delegates to {@link HonoConnection#isConnected()}.
+     *
+     * @return A succeeded future if this factory is connected.
+     *         Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServerErrorException}.
+     */
+    @Override
+    public final Future<Void> isConnected() {
+        return connection.isConnected();
+    }
+
+    /**
+     * Checks whether this client is connected to the service.
+     * <p>
+     * If a connection attempt is currently in progress, the returned future is completed
+     * with the outcome of the connection attempt. If the connection attempt (including
+     * potential reconnect attempts) isn't finished after the given timeout, the returned
+     * future is failed.
+     * <p>
+     * Simply delegates to {@link HonoConnection#isConnected(long)}.
+     *
+     * @param waitForCurrentConnectAttemptTimeout The maximum number of milliseconds to wait for
+     *                                            an ongoing connection attempt to finish.
+     * @return A succeeded future if this factory is connected.
+     *         Otherwise, the future will be failed with a {@link org.eclipse.hono.client.ServerErrorException}.
+     */
+    @Override
+    public final Future<Void> isConnected(final long waitForCurrentConnectAttemptTimeout) {
+        return connection.isConnected(waitForCurrentConnectAttemptTimeout);
+    }
+
+    /**
+     * Gets the default timeout used when checking whether this client is connected to the service.
+     * <p>
+     * The value returned here is the {@link org.eclipse.hono.config.ClientConfigProperties#getLinkEstablishmentTimeout()}.
+     *
+     * @return The timeout value in milliseconds.
+     */
+    public final long getDefaultConnectionCheckTimeout() {
+        return connection.getConfig().getLinkEstablishmentTimeout();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This default implementation simply delegates to {@link HonoConnection#disconnect()}.
+     */
+    @Override
+    public void disconnect() {
+        connection.disconnect();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This default implementation simply delegates to {@link HonoConnection#disconnect(Handler)}.
+     */
+    @Override
+    public void disconnect(final Handler<AsyncResult<Void>> completionHandler) {
+        connection.disconnect(completionHandler);
+    }
+
+    /**
+     * Invoked when the underlying connection to the Hono server
+     * is lost unexpectedly.
+     * <p>
+     * This default implementation does nothing.
+     * Subclasses should override this method in order to clean
+     * up any state that may have become stale with the loss
+     * of the connection.
+     */
+    protected void onDisconnect() {
+        // do nothing
+    }
+
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Registers a procedure for checking if this client's connection is established.
+     */
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
+        // verify that client is connected
+        readinessHandler.register(
+                String.format("connection to %s", connection.getConfig().getServerRole()),
+                status -> {
+                    connection.isConnected()
+                        .onSuccess(ok -> status.complete(Status.OK()))
+                        .onFailure(t -> status.complete(Status.KO()));
+                });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
+        // no liveness checks to be added
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> start() {
+        return connection.connect().mapEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> stop() {
+        final Promise<Void> result = Promise.promise();
+        connection.disconnect(result);
+        return result.future();
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.amqp;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.hono.client.DownstreamSender;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.impl.CachingClientFactory;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.AddressHelper;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.TelemetryConstants;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+
+
+/**
+ * A base class for implementing AMQP 1.0 based clients for Hono's service APIs.
+ * <p>
+ * This class provides support for caching sender links.
+ */
+public abstract class SenderCachingServiceClient extends AbstractServiceClient {
+
+    /**
+     * The factory for creating downstream sender links.
+     */
+    private final CachingClientFactory<DownstreamSender> clientFactory;
+
+    /**
+     * Creates a new client.
+     *
+     * @param connection The connection to the Hono service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    protected SenderCachingServiceClient(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig) {
+
+        super(connection, samplerFactory, adapterConfig);
+        this.clientFactory = new CachingClientFactory<>(connection.getVertx(), s -> s.isOpen());
+        connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
+                this::handleTenantTimeout);
+    }
+
+    private void handleTenantTimeout(final Message<String> msg) {
+        List.of(AddressHelper.getTargetAddress(TelemetryConstants.TELEMETRY_ENDPOINT, msg.body(), null, connection.getConfig()),
+                AddressHelper.getTargetAddress(EventConstants.EVENT_ENDPOINT, msg.body(), null, connection.getConfig()))
+            .stream()
+            .forEach(key -> Optional.ofNullable(clientFactory.getClient(key)).ifPresent(client -> client.close(v -> clientFactory.removeClient(key))));
+    }
+
+    /**
+     * Gets an existing or creates a new sender for telemetry and/or event messages.
+     * <p>
+     * This method first tries to look up an already existing
+     * sender using the given key. If no sender exists yet, a new
+     * instance is created using the given factory and put to the cache.
+     *
+     * @param key The key to cache the sender under.
+     * @param clientInstanceSupplier The factory to use for creating a
+     *        new sender (if necessary).
+     * @param result The handler to invoke with the outcome of the creation attempt.
+     *         The handler will be invoked with a succeeded future containing
+     *         the sender or with a failed future containing a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} if no sender
+     *         could be created.
+     */
+    protected void getOrCreateSender(
+            final String key,
+            final Supplier<Future<DownstreamSender>> clientInstanceSupplier,
+            final Handler<AsyncResult<DownstreamSender>> result) {
+
+        clientFactory.getOrCreateClient(key, clientInstanceSupplier, result);
+    }
+
+    /**
+     * Removes a sender from the cache.
+     *
+     * @param key The key of the sender to remove.
+     */
+    protected void removeClient(final String key) {
+        clientFactory.removeClient(key);
+    }
+
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.telemetry.amqp;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.client.amqp.SenderCachingServiceClient;
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
+import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
+import org.eclipse.hono.client.DownstreamSender;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.impl.EventSenderImpl;
+import org.eclipse.hono.client.impl.TelemetrySenderImpl;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.AddressHelper;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TelemetryConstants;
+import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A vertx-proton based sender for telemetry messages and events.
+ */
+public class ProtonBasedDownstreamSender extends SenderCachingServiceClient implements TelemetrySender, EventSender {
+
+    /**
+     * Creates a new sender for a connection.
+     *
+     * @param connection The connection to the Hono service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public ProtonBasedDownstreamSender(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig) {
+        super(connection, samplerFactory, adapterConfig);
+    }
+
+    private Future<DownstreamSender> getOrCreateTelemetrySender(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+        return connection
+                .isConnected(getDefaultConnectionCheckTimeout())
+                .compose(v -> connection.executeOnContext(result -> {
+                    final String key = AddressHelper.getTargetAddress(
+                            TelemetryConstants.TELEMETRY_ENDPOINT,
+                            tenantId,
+                            null,
+                            connection.getConfig());
+                    getOrCreateSender(
+                            key,
+                            () -> TelemetrySenderImpl.create(
+                                    connection,
+                                    tenantId,
+                                    samplerFactory.create(TelemetryConstants.TELEMETRY_ENDPOINT),
+                                    onSenderClosed -> removeClient(key)),
+                            result);
+                }));
+    }
+
+    private Future<DownstreamSender> getOrCreateEventSender(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+        return connection
+                .isConnected(getDefaultConnectionCheckTimeout())
+                .compose(v -> connection.executeOnContext(result -> {
+                    final String key = AddressHelper.getTargetAddress(EventConstants.EVENT_ENDPOINT, tenantId, null, connection.getConfig());
+                    getOrCreateSender(
+                            key,
+                            () -> EventSenderImpl.create(
+                                    connection,
+                                    tenantId,
+                                    samplerFactory.create(EventConstants.EVENT_ENDPOINT),
+                                    onSenderClosed -> removeClient(key)),
+                            result);
+                }));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendTelemetry(
+            final TenantObject tenant,
+            final RegistrationAssertion device,
+            final QoS qos,
+            final String contentType,
+            final Buffer payload,
+            final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(qos);
+        Objects.requireNonNull(contentType);
+
+        return getOrCreateTelemetrySender(tenant.getTenantId())
+            .compose(sender -> {
+                final ResourceIdentifier target = ResourceIdentifier.from(TelemetryConstants.TELEMETRY_ENDPOINT, tenant.getTenantId(), device.getDeviceId());
+                final Message message = createMessage(tenant, device, qos, target, contentType, payload, properties);
+                switch (qos) {
+                case AT_MOST_ONCE:
+                    return sender.send(message, context);
+                default:
+                    return sender.sendAndWaitForOutcome(message, context);
+                }
+            })
+            .mapEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendEvent(
+            final TenantObject tenant,
+            final RegistrationAssertion device,
+            final String contentType,
+            final Buffer payload,
+            final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(contentType);
+
+        return getOrCreateEventSender(tenant.getTenantId())
+                .compose(sender -> {
+                    final ResourceIdentifier target = ResourceIdentifier.from(EventConstants.EVENT_ENDPOINT, tenant.getTenantId(), device.getDeviceId());
+                    final Message message = createMessage(tenant, device, QoS.AT_LEAST_ONCE, target, contentType, payload, properties);
+                    return sender.sendAndWaitForOutcome(message, context);
+                })
+                .mapEmpty();
+    }
+
+    private Message createMessage(
+            final TenantObject tenant,
+            final RegistrationAssertion device,
+            final QoS qos,
+            final ResourceIdentifier target,
+            final String contentType,
+            final Buffer payload,
+            final Map<String, Object> properties) {
+
+        final Map<String, Object> props = Optional.ofNullable(properties)
+                .orElseGet(HashMap::new);
+        props.put(MessageHelper.APP_PROPERTY_QOS, qos.ordinal());
+        props.put(MessageHelper.APP_PROPERTY_DEVICE_ID, device.getDeviceId());
+
+        return MessageHelper.newMessage(
+                target,
+                contentType,
+                payload,
+                tenant,
+                props,
+                device.getDefaults(),
+                adapterConfig.isDefaultsEnabled(),
+                adapterConfig.isJmsVendorPropsEnabled());
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -946,7 +946,7 @@ public final class MessageHelper {
      * @deprecated Use {@link #newMessage(ResourceIdentifier, String, Buffer, TenantObject, Map, Map, boolean, boolean)}
      *             instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public static Message newMessage(
             final QoS qos,
             final ResourceIdentifier target,
@@ -956,22 +956,17 @@ public final class MessageHelper {
             final Duration timeToLive,
             final String adapterTypeName) {
 
-        Objects.requireNonNull(target);
-        Objects.requireNonNull(adapterTypeName);
-
-        final Map<String, Object> props = new HashMap<>();
-        props.put(MessageHelper.APP_PROPERTY_ORIG_ADAPTER, adapterTypeName);
-        if (qos != null) {
-            props.put(MessageHelper.APP_PROPERTY_QOS, qos.ordinal());
-        }
-
-        return MessageHelper.newMessage(
+        return newMessage(
+                qos,
                 target,
+                null,
                 contentType,
                 payload,
                 tenant,
-                props,
                 null,
+                null,
+                timeToLive,
+                adapterTypeName,
                 false,
                 false);
     }
@@ -1020,7 +1015,7 @@ public final class MessageHelper {
      * @throws NullPointerException if target or adapterTypeName is {@code null}.
      * @deprecated Use {@link #newMessage(ResourceIdentifier, String, Buffer, TenantObject, Map, Map, boolean, boolean)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public static Message newMessage(
             final QoS qos,
             final ResourceIdentifier target,
@@ -1183,7 +1178,7 @@ public final class MessageHelper {
      * @throws IllegalArgumentException if target is {@code null} and the message does not have an address set.
      * @deprecated Use {@link #addProperties(Message, ResourceIdentifier, TenantObject, Map, Map, boolean, boolean)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public static Message addProperties(
             final Message msg,
             final QoS qos,

--- a/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/MessageHelperTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.qpid.proton.amqp.Binary;
@@ -304,7 +305,7 @@ public class MessageHelperTest {
     public void testNewMessageUsesGivenTtlValue() {
 
         final Duration timeToLive = Duration.ofSeconds(10);
-        final Map<String, Object> props = Map.of(MessageHelper.SYS_HEADER_PROPERTY_TTL, timeToLive.toSeconds());
+        final Map<String, Object> props = Collections.singletonMap(MessageHelper.SYS_HEADER_PROPERTY_TTL, timeToLive.getSeconds());
         final ResourceIdentifier target = ResourceIdentifier.from(EventConstants.EVENT_ENDPOINT,
                 Constants.DEFAULT_TENANT, "4711");
         final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);
@@ -333,7 +334,7 @@ public class MessageHelperTest {
     public void testNewMessageLimitsTtlToMaxValue() {
 
         final Duration timeToLive = Duration.ofSeconds(50);
-        final Map<String, Object> props = Map.of(MessageHelper.SYS_HEADER_PROPERTY_TTL, timeToLive.toSeconds());
+        final Map<String, Object> props = Collections.singletonMap(MessageHelper.SYS_HEADER_PROPERTY_TTL, timeToLive.getSeconds());
         final ResourceIdentifier target = ResourceIdentifier.from(EventConstants.EVENT_ENDPOINT,
                 Constants.DEFAULT_TENANT, "4711");
         final TenantObject tenant = TenantObject.from(Constants.DEFAULT_TENANT, true);


### PR DESCRIPTION
The implementation reuses the existing vertx-proton based
implementations but replaces the existing factories.

In a subsequent PR the protocol adapters will be refactored to use the new TelemetrySender and EventSender instead of the existing DownstreamSenderFactory. 