### PR TITLE
Fix javadoc in TelmetrySender and EventSender

### DIFF
--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
@@ -68,7 +68,6 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
     private void handleTenantTimeout(final Message<String> msg) {
         List.of(AddressHelper.getTargetAddress(TelemetryConstants.TELEMETRY_ENDPOINT, msg.body(), null, connection.getConfig()),
                 AddressHelper.getTargetAddress(EventConstants.EVENT_ENDPOINT, msg.body(), null, connection.getConfig()))
-            .stream()
             .forEach(key -> Optional.ofNullable(clientFactory.getClient(key)).ifPresent(client -> client.close(v -> clientFactory.removeClient(key))));
     }
 

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/EventSender.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/EventSender.java
@@ -48,7 +48,6 @@ public interface EventSender extends Lifecycle {
      *         could not be sent. The error code contained in the exception indicates the
      *         cause of the failure.
      * @throws NullPointerException if tenant ID, device ID or contentType are {@code null}.
-     * @throws IllegalArgumentException if tenant does not contain a tenantId property.
      */
     Future<Void> sendEvent(
             TenantObject tenant,

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/TelemetrySender.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/TelemetrySender.java
@@ -51,7 +51,6 @@ public interface TelemetrySender extends Lifecycle {
      *         could not be sent. The error code contained in the exception indicates the
      *         cause of the failure.
      * @throws NullPointerException if tenant, device, qos or contentType are {@code null}.
-     * @throws IllegalArgumentException if tenant does not contain a tenantId property.
      */
     Future<Void> sendTelemetry(
             TenantObject tenant,


### PR DESCRIPTION
* With PR #2259, the tenant identifier is made mandatory for the `TenantObject`. The `EventSender.sendEvent(...)` and `TelmetrySender.sendTelemetry(...)` methods throwing `IllegalArgumentException` in case of no tenant identifier, is obsolete. This has been fixed in the JavaDoc.
 * Minor improvement by replacing `stream().forEach()` with `forEach()`

