### PR TITLE
Create downstream message from properties gathered from context

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.hono.adapter.amqp.impl;
 
+import java.time.Duration;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.auth.Device;
@@ -107,6 +109,18 @@ public class AmqpContext extends MapBasedTelemetryExecutionContext {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final Optional<Duration> getTimeToLive() {
+        if (endpoint == EndpointType.EVENT && message.getTtl() > 0) {
+            // make sure it is at least one second
+            return Optional.of(Duration.ofMillis(message.getTtl() + 1000L));
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Gets the delivery state.
      *
      * @return The delivery state of this context.
@@ -174,5 +188,15 @@ public class AmqpContext extends MapBasedTelemetryExecutionContext {
     @Override
     public QoS getRequestedQos() {
         return isRemotelySettled() ? QoS.AT_MOST_ONCE : QoS.AT_LEAST_ONCE;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The value of the message's <em>to</em> property.
+     */
+    @Override
+    public String getOrigAddress() {
+        return message.getAddress();
     }
 }

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
@@ -115,7 +115,7 @@ public class AmqpContext extends MapBasedTelemetryExecutionContext {
     public final Optional<Duration> getTimeToLive() {
         if (endpoint == EndpointType.EVENT && message.getTtl() > 0) {
             // make sure it is at least one second
-            return Optional.of(Duration.ofMillis(message.getTtl() + 1000L));
+            return Optional.of(Duration.ofMillis(message.getTtl() >= 1000L ? message.getTtl() : 1000L));
         }
         return Optional.empty();
     }

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -22,6 +22,7 @@ import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -527,15 +528,14 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
     /**
      * Invoked before the message is sent to the downstream peer.
      * <p>
-     * Subclasses may override this method in order to customize the message before it is sent, e.g. adding custom
-     * properties.
-     * <p>
-     * This default implementation does nothing.
+     * Subclasses may override this method in order to customize the
+     * properties used for sending the message, e.g. adding custom properties.
      *
-     * @param downstreamMessage The message that will be sent downstream.
-     * @param context The context representing the request to be processed.
+     * @param messageProperties The properties that are being added to the downstream message.
+     * @param ctx The routing context.
      */
-    protected void customizeDownstreamMessage(final Message downstreamMessage, final CoapContext context) {
+    protected void customizeDownstreamMessageProperties(final Map<String, Object> messageProperties, final CoapContext ctx) {
+        // this default implementation does nothing
     }
 
     @Override
@@ -695,7 +695,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
             final String gatewayId = context.getGatewayId();
             final String tenantId = context.getOriginDevice().getTenantId();
             final String deviceId = context.getOriginDevice().getDeviceId();
-            final MetricsTags.QoS qos = waitForOutcome ? MetricsTags.QoS.AT_LEAST_ONCE : MetricsTags.QoS.AT_MOST_ONCE;
+            final MetricsTags.QoS qos = context.isConfirmable() ? MetricsTags.QoS.AT_LEAST_ONCE : MetricsTags.QoS.AT_MOST_ONCE;
 
             final Span currentSpan = TracingHelper
                     .buildChildSpan(tracer, context.getTracingContext(),
@@ -746,22 +746,26 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
 
             return CompositeFuture.join(senderTracker, commandConsumerTracker)
             .compose(ok -> {
-                final DownstreamSender sender = senderTracker.result();
-                final Integer ttd = Optional.ofNullable(commandConsumerTracker.result())
+
+                final Map<String, Object> props = getDownstreamMessageProperties(context);
+                Optional.ofNullable(commandConsumerTracker.result())
                         .map(c -> ttdTracker.result())
-                        .orElse(null);
-                final Message downstreamMessage = newMessage(
-                        context.getRequestedQos(),
+                        .ifPresent(ttd -> props.put(MessageHelper.APP_PROPERTY_DEVICE_TTD, ttd));
+                props.put(MessageHelper.APP_PROPERTY_QOS, context.getRequestedQos().ordinal());
+                customizeDownstreamMessageProperties(props, context);
+                final Message downstreamMessage = MessageHelper.newMessage(
                         ResourceIdentifier.from(endpoint.getCanonicalName(), tenantId, deviceId),
-                        "/" + context.getExchange().getRequestOptions().getUriPathString(),
                         contentType,
                         payload,
                         tenantTracker.result(),
-                        tokenTracker.result(),
-                        ttd);
-                customizeDownstreamMessage(downstreamMessage, context);
+                        props,
+                        tokenTracker.result().getDefaults(),
+                        getConfig().isDefaultsEnabled(),
+                        getConfig().isJmsVendorPropsEnabled());
 
-                if (waitForOutcome) {
+                final DownstreamSender sender = senderTracker.result();
+
+                if (context.isConfirmable()) {
                     // wait for outcome, ensure message order, if CoAP NSTART-1 is used.
                     context.startAcceptTimer(vertx, tenantTracker.result(), getConfig().getTimeoutToAck());
                     return CompositeFuture.all(
@@ -774,6 +778,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                             responseReady.future())
                             .mapEmpty();
                 }
+
             }).map(proceed -> {
                 // downstream message sent and (if ttd was set) command was received or ttd has timed out
                 final Future<Void> commandConsumerClosedTracker = commandConsumerTracker.result() != null

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -634,7 +634,6 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
 
         return doUploadMessage(
                 Objects.requireNonNull(context),
-                context.isConfirmable(),
                 getTelemetrySender(context.getOriginDevice().getTenantId()),
                 MetricsTags.EndpointType.TELEMETRY);
     }
@@ -654,7 +653,6 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
         if (context.isConfirmable()) {
             return doUploadMessage(
                     context,
-                    true,
                     getEventSender(context.getOriginDevice().getTenantId()),
                     MetricsTags.EndpointType.EVENT);
         } else {
@@ -670,15 +668,12 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
      * described by the <a href="https://www.eclipse.org/hono/docs/user-guide/coap-adapter/">CoAP adapter user guide</a>
      *
      * @param context The context representing the request to be processed.
-     * @param waitForOutcome {@code true} to send the message waiting for the outcome, {@code false}, to wait just for
-     *            the sent.
      * @param senderTracker hono message sender tracker
      * @param endpoint message destination endpoint
      * @return A succeeded future containing the CoAP status code that has been returned to the device.
      */
     private Future<ResponseCode> doUploadMessage(
             final CoapContext context,
-            final boolean waitForOutcome,
             final Future<DownstreamSender> senderTracker,
             final MetricsTags.EndpointType endpoint) {
 

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.adapter.coap;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -415,5 +416,27 @@ public final class CoapContext extends MapBasedTelemetryExecutionContext {
     @Override
     public QoS getRequestedQos() {
         return isConfirmable() ? QoS.AT_LEAST_ONCE : QoS.AT_MOST_ONCE;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return An empty optional.
+     */
+    @Override
+    public Optional<Duration> getTimeToLive() {
+        return Optional.empty();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The <em>Uri-Path</em> request option prefixed with a <em>/</em> character.
+     */
+    @Override
+    public String getOrigAddress() {
+        return Optional.ofNullable(exchange.getRequestOptions().getUriPathString())
+                .map(address -> "/" + address)
+                .orElse(null);
     }
 }

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapContext.java
@@ -435,8 +435,6 @@ public final class CoapContext extends MapBasedTelemetryExecutionContext {
      */
     @Override
     public String getOrigAddress() {
-        return Optional.ofNullable(exchange.getRequestOptions().getUriPathString())
-                .map(address -> "/" + address)
-                .orElse(null);
+        return "/" + exchange.getRequestOptions().getUriPathString();
     }
 }

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
 import org.eclipse.hono.adapter.lora.LoraConstants;
 import org.eclipse.hono.adapter.lora.LoraMessage;
@@ -45,7 +44,6 @@ import org.eclipse.hono.service.http.X509AuthHandler;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
-import org.eclipse.hono.util.MessageHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -161,23 +159,24 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
     }
 
     @Override
-    protected void customizeDownstreamMessage(final Message downstreamMessage, final HttpContext ctx) {
+    protected void customizeDownstreamMessageProperties(final Map<String, Object> properties, final HttpContext ctx) {
 
-        MessageHelper.addProperty(downstreamMessage, LoraConstants.APP_PROPERTY_ORIG_LORA_PROVIDER,
+        properties.put(
+                LoraConstants.APP_PROPERTY_ORIG_LORA_PROVIDER,
                 ctx.get(LoraConstants.APP_PROPERTY_ORIG_LORA_PROVIDER));
 
         Optional.ofNullable(ctx.get(LoraConstants.APP_PROPERTY_META_DATA))
             .map(LoraMetaData.class::cast)
             .ifPresent(metaData -> {
                 Optional.ofNullable(metaData.getFunctionPort())
-                    .ifPresent(port -> MessageHelper.addProperty(downstreamMessage, LoraConstants.APP_PROPERTY_FUNCTION_PORT, port));
+                    .ifPresent(port -> properties.put(LoraConstants.APP_PROPERTY_FUNCTION_PORT, port));
                 final String json = Json.encode(metaData);
-                MessageHelper.addProperty(downstreamMessage, LoraConstants.APP_PROPERTY_META_DATA, json);
+                properties.put(LoraConstants.APP_PROPERTY_META_DATA, json);
             });
 
         Optional.ofNullable(ctx.get(LoraConstants.APP_PROPERTY_ADDITIONAL_DATA))
             .map(JsonObject.class::cast)
-            .ifPresent(data -> MessageHelper.addProperty(downstreamMessage, LoraConstants.APP_PROPERTY_ADDITIONAL_DATA, data.encode()));
+            .ifPresent(data -> properties.put(LoraConstants.APP_PROPERTY_ADDITIONAL_DATA, data.encode()));
     }
 
     void handleProviderRoute(final HttpContext ctx, final LoraProvider provider) {

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/PropertyBag.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/PropertyBag.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -36,17 +36,24 @@ public final class PropertyBag {
     }
 
     /**
-     * Creates a property bag object from the given topic by retrieving 
-     * all the properties from the <em>property-bag</em>.
+     * Creates a property bag object from a topic.
+     * <p>
+     * The properties are retrieved from the topic by means of parsing
+     * the topic after the last occurrence of <em>/?</em> as an HTTP query
+     * string.
      *
      * @param topic The topic that the message has been published to.
-     * @return The property bag object or {@code null} if no 
-     *         <em>property-bag</em> is set in the topic.
+     * @return The property bag (which may be empty) or {@code null} if the
+     *         topic has zero length.
      * @throws NullPointerException if topic is {@code null}.
      */
     public static PropertyBag fromTopic(final String topic) {
 
         Objects.requireNonNull(topic);
+
+        if (topic.isEmpty()) {
+            return null;
+        }
 
         final int index = topic.lastIndexOf("/?");
         if (index > 0) {
@@ -60,7 +67,8 @@ public final class PropertyBag {
 
             return new PropertyBag(ResourceIdentifier.fromString(topic.substring(0, index)), properties);
         }
-        return null;
+        // topic does not contain property bag
+        return new PropertyBag(ResourceIdentifier.fromString(topic), MultiMap.caseInsensitiveMultiMap());
     }
 
     /**

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
@@ -17,7 +17,6 @@ import java.net.HttpURLConnection;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.adapter.mqtt.AbstractVertxBasedMqttProtocolAdapter;
 import org.eclipse.hono.adapter.mqtt.MappedMessage;
 import org.eclipse.hono.adapter.mqtt.MessageMapping;
@@ -26,7 +25,6 @@ import org.eclipse.hono.adapter.mqtt.MqttProtocolAdapterProperties;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -115,7 +113,7 @@ public final class VertxBasedMqttProtocolAdapter extends AbstractVertxBasedMqttP
 
     @SuppressWarnings("unchecked")
     @Override
-    protected void customizeDownstreamMessage(final Message downstreamMessage, final MqttContext ctx) {
+    protected void customizeDownstreamMessageProperties(final Map<String, Object> props, final MqttContext ctx) {
 
         final Object additionalProperties = ctx.get(MAPPER_DATA);
         if (additionalProperties instanceof Map) {
@@ -126,9 +124,9 @@ public final class VertxBasedMqttProtocolAdapter extends AbstractVertxBasedMqttP
                     final Object value = entry.getValue();
                     if (value instanceof String) {
                         // prevent quotes around strings
-                        MessageHelper.addProperty(downstreamMessage, key, value);
+                        props.put(key, value);
                     } else {
-                        MessageHelper.addProperty(downstreamMessage, key, Json.encode(value));
+                        props.put(key, Json.encode(value));
                     }
                 });
         }

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/PropertyBagTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/PropertyBagTest.java
@@ -13,9 +13,9 @@
 
 package org.eclipse.hono.adapter.mqtt;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -44,7 +44,11 @@ public class PropertyBagTest {
      */
     @Test
     public void verifyWhenNoPropertyBagIsSet() {
-        assertNull(PropertyBag.fromTopic("event/tenant/device"));
+        final PropertyBag bag = PropertyBag.fromTopic("event/tenant/device");
+        assertThat(bag.getPropertiesIterator()).isExhausted();
+        assertThat(bag.topicWithoutPropertyBag().getEndpoint()).isEqualTo("event");
+        assertThat(bag.topicWithoutPropertyBag().getTenantId()).isEqualTo("tenant");
+        assertThat(bag.topicWithoutPropertyBag().getResourceId()).isEqualTo("device");
     }
 
     /**
@@ -52,7 +56,12 @@ public class PropertyBagTest {
      */
     @Test
     public void verifyTopicWithSpecialCharacters() {
-        assertNull(PropertyBag.fromTopic("event/tenant/device/segment1?param=value/segment2/"));
+        final PropertyBag bag = PropertyBag.fromTopic("event/tenant/device/segment1?param=value/segment2/");
+        assertThat(bag.getPropertiesIterator()).isExhausted();
+        assertThat(bag.topicWithoutPropertyBag().getEndpoint()).isEqualTo("event");
+        assertThat(bag.topicWithoutPropertyBag().getTenantId()).isEqualTo("tenant");
+        assertThat(bag.topicWithoutPropertyBag().getResourceId()).isEqualTo("device");
+        assertThat(bag.topicWithoutPropertyBag().getPathWithoutBase()).isEqualTo("device/segment1?param=value/segment2");
     }
 
     /**

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -14,10 +14,10 @@
 package org.eclipse.hono.adapter.sigfox.impl;
 
 import java.net.HttpURLConnection;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
@@ -178,8 +178,8 @@ public final class SigfoxProtocolAdapter
     }
 
     @Override
-    protected void customizeDownstreamMessage(final Message downstreamMessage, final HttpContext ctx) {
-        super.customizeDownstreamMessage(downstreamMessage, ctx);
+    protected void customizeDownstreamMessageProperties(final Map<String, Object> properties, final HttpContext ctx) {
+        super.customizeDownstreamMessageProperties(properties, ctx);
 
         // pass along all query parameters that start with 'sigfox.'
         // If a key has multiple values, then only one of them will be mapped.
@@ -188,7 +188,7 @@ public final class SigfoxProtocolAdapter
             if (entry.getKey() == null || !entry.getKey().startsWith(SIGFOX_PROPERTY_PREFIX)) {
                 continue;
             }
-            downstreamMessage.getApplicationProperties().getValue().put(entry.getKey(), entry.getValue());
+            properties.put(entry.getKey(), entry.getValue());
         }
 
     }

--- a/core/src/main/java/org/eclipse/hono/util/TelemetryExecutionContext.java
+++ b/core/src/main/java/org/eclipse/hono/util/TelemetryExecutionContext.java
@@ -13,6 +13,11 @@
 
 package org.eclipse.hono.util;
 
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import org.eclipse.hono.auth.Device;
 
 /**
@@ -45,4 +50,41 @@ public interface TelemetryExecutionContext extends ExecutionContext {
      * @return The QoS level requested by the device or {@code null} if the level could not be determined.
      */
     QoS getRequestedQos();
+
+    /**
+     * Gets the <em>time-to-live</em> set by the device for an event.
+     *
+     * @return An optional containing the <em>time-to-live</em> duration or an empty optional if
+     *         the device did not specify a ttl or if the message is not an event.
+     */
+    Optional<Duration> getTimeToLive();
+
+    /**
+     * Gets the transport protocol specific address of the message.
+     *
+     * @return The address.
+     */
+    String getOrigAddress();
+
+    /**
+     * Gets the properties that need to be included in the message being sent
+     * downstream.
+     * <p>
+     * This default implementation puts the following properties to the returned map:
+     * <ul>
+     * <li>the value returned by {@link #getOrigAddress()} under key {@value MessageHelper#APP_PROPERTY_ORIG_ADDRESS},
+     * if not {@code null}</li>
+     * <li>the value returned by {@link #getTimeToLive()} under key {@value MessageHelper#SYS_HEADER_PROPERTY_TTL},
+     * if not {@code null}</li>
+     * </ul>
+     *
+     * @return The properties.
+     */
+    default Map<String, Object> getDownstreamMessageProperties() {
+        final Map<String, Object> props = new HashMap<>();
+        Optional.ofNullable(getOrigAddress())
+            .ifPresent(address -> props.put(MessageHelper.APP_PROPERTY_ORIG_ADDRESS, address));
+        getTimeToLive().ifPresent(ttl -> props.put(MessageHelper.SYS_HEADER_PROPERTY_TTL, ttl.getSeconds()));
+        return props;
+    }
 }

--- a/service-base/src/test/java/org/eclipse/hono/service/http/HttpContextTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/http/HttpContextTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.service.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -101,6 +102,8 @@ public class HttpContextTest {
      */
     @Test
     public void testGetTimeToLiveUsesHeader() {
+
+        when(httpServerRequest.uri()).thenReturn("/event");
         final HttpContext httpContext = HttpContext.from(routingContext);
 
         // GIVEN a time to live in seconds
@@ -110,7 +113,7 @@ public class HttpContextTest {
                 .thenReturn(String.valueOf(timeToLive));
 
         // THEN the get method returns this value
-        assertEquals(timeToLive, httpContext.getTimeToLive().toSeconds());
+        assertEquals(timeToLive, httpContext.getTimeToLive().get().toSeconds());
     }
 
     /**
@@ -119,6 +122,8 @@ public class HttpContextTest {
      */
     @Test
     public void testGetTimeToLiveUsesQueryParam() {
+
+        when(httpServerRequest.uri()).thenReturn("/event");
         final HttpContext httpContext = HttpContext.from(routingContext);
 
         // GIVEN a time to live in seconds
@@ -128,17 +133,17 @@ public class HttpContextTest {
                 .thenReturn(String.valueOf(timeToLive));
 
         // THEN the get method returns this value
-        assertEquals(timeToLive, httpContext.getTimeToLive().toSeconds());
+        assertEquals(timeToLive, httpContext.getTimeToLive().get().toSeconds());
     }
 
     /**
      * Verifies that the {@link HttpContext#getTimeToLive()} method
-     * returns {@code null} if {@link Constants#HEADER_TIME_TO_LIVE} is neither
+     * returns an empty Optional if {@link Constants#HEADER_TIME_TO_LIVE} is neither
      * provided as query parameter nor as header.
      */
     @Test
-    public void testGetTimeToLiveReturnsNullIfNotSpecified() {
+    public void testGetTimeToLiveReturnsEmptyOptionalIfNotSpecified() {
         final HttpContext httpContext = HttpContext.from(routingContext);
-        assertNull(httpContext.getTimeToLive());
+        assertTrue(httpContext.getTimeToLive().isEmpty());
     }
 }

--- a/test-utils/service-base-test-utils/pom.xml
+++ b/test-utils/service-base-test-utils/pom.xml
@@ -30,5 +30,10 @@
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-service-base</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The protocol adapters now create downstream messages using the new
MessageHelper.newMessage() method which accepts a Map of properties to
include in the message.

This is in preparation for the adapters being refactored to use the new
TelemetrySender and EventSender instead of the legacy DownstreamSender.
