### PR TITLE
[#2267] Add AMQP 1.0 based Telemetry/EventSender implementation

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -301,7 +301,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testUploadTelemetryWithAtLeastOnceDeliverySemantics() {
         // GIVEN an adapter configured to use a user-define server.
         givenAnAdapter(properties);
-        final Promise<ProtonDelivery> sendResult = Promise.promise();
+        final Promise<Void> sendResult = Promise.promise();
         givenATelemetrySenderForAnyTenant(sendResult);
 
         // which is enabled for a tenant
@@ -325,7 +325,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         //  and waits for the outcome from the downstream peer
         verify(delivery, never()).disposition(any(DeliveryState.class), anyBoolean());
         // until the transfer is settled
-        sendResult.complete(mock(ProtonDelivery.class));
+        sendResult.complete();
         verify(delivery).disposition(any(Accepted.class), eq(true));
         // and has reported the telemetry message
         verify(metrics).reportTelemetry(

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
-import org.apache.qpid.proton.message.Message;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
@@ -53,7 +52,6 @@ import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.Command;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandResponse;
-import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumer;
 import org.eclipse.hono.client.impl.CommandConsumer;
 import org.eclipse.hono.config.KeyLoader;
@@ -61,6 +59,7 @@ import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.limiting.MemoryBasedConnectionLimitStrategy;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
+import org.eclipse.hono.service.metric.MetricsTags.EndpointType;
 import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
 import org.eclipse.hono.service.metric.MetricsTags.TtdStatus;
 import org.eclipse.hono.tracing.TracingHelper;
@@ -69,7 +68,6 @@ import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.Futures;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationAssertion;
-import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TenantObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -627,15 +625,11 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
      * @param context The context representing the request to be processed.
      * @return A future containing the response code that has been returned to
      *         the device.
-     * @throws NullPointerException if context or originDevice are {@code null}.
+     * @throws NullPointerException if context is {@code null}.
      */
-    public final Future<ResponseCode> uploadTelemetryMessage(
-            final CoapContext context) {
+    public final Future<ResponseCode> uploadTelemetryMessage(final CoapContext context) {
 
-        return doUploadMessage(
-                Objects.requireNonNull(context),
-                getTelemetrySender(context.getOriginDevice().getTenantId()),
-                MetricsTags.EndpointType.TELEMETRY);
+        return doUploadMessage(context, MetricsTags.EndpointType.TELEMETRY);
     }
 
     /**
@@ -651,10 +645,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
 
         Objects.requireNonNull(context);
         if (context.isConfirmable()) {
-            return doUploadMessage(
-                    context,
-                    getEventSender(context.getOriginDevice().getTenantId()),
-                    MetricsTags.EndpointType.EVENT);
+            return doUploadMessage(context, MetricsTags.EndpointType.EVENT);
         } else {
             context.respondWithCode(ResponseCode.BAD_REQUEST, "event endpoint supports confirmable request messages only");
             return Future.succeededFuture(ResponseCode.BAD_REQUEST);
@@ -667,15 +658,16 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
      * Depending on the outcome of the attempt to upload the message, the CoAP response code is set as
      * described by the <a href="https://www.eclipse.org/hono/docs/user-guide/coap-adapter/">CoAP adapter user guide</a>
      *
-     * @param context The context representing the request to be processed.
-     * @param senderTracker hono message sender tracker
      * @param endpoint message destination endpoint
      * @return A succeeded future containing the CoAP status code that has been returned to the device.
+     * @throws NullPointerException if any of the parameters are {@code null}.
      */
     private Future<ResponseCode> doUploadMessage(
             final CoapContext context,
-            final Future<DownstreamSender> senderTracker,
             final MetricsTags.EndpointType endpoint) {
+
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(endpoint);
 
         final String contentType = context.getContentType();
         final Buffer payload = context.getPayload();
@@ -739,108 +731,104 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                             responseReady,
                             currentSpan));
 
-            return CompositeFuture.join(senderTracker, commandConsumerTracker)
-            .compose(ok -> {
+            return commandConsumerTracker
+                .compose(ok -> {
+                    final Map<String, Object> props = getDownstreamMessageProperties(context);
+                    Optional.ofNullable(commandConsumerTracker.result())
+                            .map(c -> ttdTracker.result())
+                            .ifPresent(ttd -> props.put(MessageHelper.APP_PROPERTY_DEVICE_TTD, ttd));
+                    customizeDownstreamMessageProperties(props, context);
 
-                final Map<String, Object> props = getDownstreamMessageProperties(context);
-                Optional.ofNullable(commandConsumerTracker.result())
-                        .map(c -> ttdTracker.result())
-                        .ifPresent(ttd -> props.put(MessageHelper.APP_PROPERTY_DEVICE_TTD, ttd));
-                props.put(MessageHelper.APP_PROPERTY_QOS, context.getRequestedQos().ordinal());
-                customizeDownstreamMessageProperties(props, context);
-                final Message downstreamMessage = MessageHelper.newMessage(
-                        ResourceIdentifier.from(endpoint.getCanonicalName(), tenantId, deviceId),
-                        contentType,
-                        payload,
-                        tenantTracker.result(),
-                        props,
-                        tokenTracker.result().getDefaults(),
-                        getConfig().isDefaultsEnabled(),
-                        getConfig().isJmsVendorPropsEnabled());
+                    if (context.isConfirmable()) {
+                        context.startAcceptTimer(vertx, tenantTracker.result(), getConfig().getTimeoutToAck());
+                    }
+                    final Future<Void> sendResult;
+                    if (endpoint == EndpointType.EVENT) {
+                        sendResult = getEventSender().sendEvent(
+                                tenantTracker.result(),
+                                tokenTracker.result(),
+                                contentType,
+                                payload,
+                                props,
+                                currentSpan.context());
+                    } else {
+                        sendResult = getTelemetrySender().sendTelemetry(
+                                tenantTracker.result(),
+                                tokenTracker.result(),
+                                context.getRequestedQos(),
+                                contentType,
+                                payload,
+                                props,
+                                currentSpan.context());
+                    }
+                    return CompositeFuture.all(sendResult, responseReady.future()).mapEmpty();
+                }).map(proceed -> {
+                    // downstream message sent and (if ttd was set) command was received or ttd has timed out
+                    final Future<Void> commandConsumerClosedTracker = commandConsumerTracker.result() != null
+                            ? commandConsumerTracker.result().close(currentSpan.context())
+                                    .onFailure(thr -> TracingHelper.logError(currentSpan, thr))
+                            : Future.succeededFuture();
 
-                final DownstreamSender sender = senderTracker.result();
+                    final CommandContext commandContext = context.get(CommandContext.KEY_COMMAND_CONTEXT);
+                    final Response response = new Response(ResponseCode.CHANGED);
+                    if (commandContext != null) {
+                        addCommandToResponse(response, commandContext, currentSpan);
+                        commandContext.accept();
+                        metrics.reportCommand(
+                                commandContext.getCommand().isOneWay() ? Direction.ONE_WAY : Direction.REQUEST,
+                                tenantId,
+                                tenantTracker.result(),
+                                ProcessingOutcome.FORWARDED,
+                                commandContext.getCommand().getPayloadSize(),
+                                context.getTimer());
+                    }
 
-                if (context.isConfirmable()) {
-                    // wait for outcome, ensure message order, if CoAP NSTART-1 is used.
-                    context.startAcceptTimer(vertx, tenantTracker.result(), getConfig().getTimeoutToAck());
-                    return CompositeFuture.all(
-                            sender.sendAndWaitForOutcome(downstreamMessage, currentSpan.context()),
-                            responseReady.future())
-                            .mapEmpty();
-                } else {
-                    return CompositeFuture.all(
-                            sender.send(downstreamMessage, currentSpan.context()),
-                            responseReady.future())
-                            .mapEmpty();
-                }
-
-            }).map(proceed -> {
-                // downstream message sent and (if ttd was set) command was received or ttd has timed out
-                final Future<Void> commandConsumerClosedTracker = commandConsumerTracker.result() != null
-                        ? commandConsumerTracker.result().close(currentSpan.context())
-                                .onFailure(thr -> TracingHelper.logError(currentSpan, thr))
-                        : Future.succeededFuture();
-
-                final CommandContext commandContext = context.get(CommandContext.KEY_COMMAND_CONTEXT);
-                final Response response = new Response(ResponseCode.CHANGED);
-                if (commandContext != null) {
-                    addCommandToResponse(response, commandContext, currentSpan);
-                    commandContext.accept();
-                    metrics.reportCommand(
-                            commandContext.getCommand().isOneWay() ? Direction.ONE_WAY : Direction.REQUEST,
+                    log.trace("successfully processed message for device [tenantId: {}, deviceId: {}, endpoint: {}]",
+                            tenantId, deviceId, endpoint.getCanonicalName());
+                    metrics.reportTelemetry(
+                            endpoint,
                             tenantId,
                             tenantTracker.result(),
-                            ProcessingOutcome.FORWARDED,
-                            commandContext.getCommand().getPayloadSize(),
+                            MetricsTags.ProcessingOutcome.FORWARDED,
+                            qos,
+                            payload.length(),
+                            getTtdStatus(context),
                             context.getTimer());
-                }
 
-                log.trace("successfully processed message for device [tenantId: {}, deviceId: {}, endpoint: {}]",
-                        tenantId, deviceId, endpoint.getCanonicalName());
-                metrics.reportTelemetry(
-                        endpoint,
-                        tenantId,
-                        tenantTracker.result(),
-                        MetricsTags.ProcessingOutcome.FORWARDED,
-                        qos,
-                        payload.length(),
-                        getTtdStatus(context),
-                        context.getTimer());
+                    context.getExchange().respond(response);
+                    commandConsumerClosedTracker.onComplete(res -> currentSpan.finish());
+                    return response.getCode();
 
-                context.getExchange().respond(response);
-                commandConsumerClosedTracker.onComplete(res -> currentSpan.finish());
-                return response.getCode();
+                }).recover(t -> {
 
-            }).recover(t -> {
-
-                log.debug("cannot process message from device [tenantId: {}, deviceId: {}, endpoint: {}]",
-                        tenantId, deviceId, endpoint.getCanonicalName(), t);
-                final Future<Void> commandConsumerClosedTracker = commandConsumerTracker.result() != null
-                        ? commandConsumerTracker.result().close(currentSpan.context())
-                                .onFailure(thr -> TracingHelper.logError(currentSpan, thr))
-                        : Future.succeededFuture();
-                final CommandContext commandContext = context.get(CommandContext.KEY_COMMAND_CONTEXT);
-                if (commandContext != null) {
-                    TracingHelper.logError(commandContext.getTracingSpan(),
-                            "command won't be forwarded to device in CoAP response, CoAP request handling failed", t);
-                    commandContext.release();
-                    currentSpan.log("released command for device");
-                }
-                metrics.reportTelemetry(
-                        endpoint,
-                        tenantId,
-                        tenantTracker.result(),
-                        ClientErrorException.class.isInstance(t) ? MetricsTags.ProcessingOutcome.UNPROCESSABLE : MetricsTags.ProcessingOutcome.UNDELIVERABLE,
-                        qos,
-                        payload.length(),
-                        getTtdStatus(context),
-                        context.getTimer());
-                TracingHelper.logError(currentSpan, t);
-                final Response response = CoapErrorResponse.respond(t, ResponseCode.INTERNAL_SERVER_ERROR);
-                final ResponseCode responseCode = context.respond(response);
-                commandConsumerClosedTracker.onComplete(res -> currentSpan.finish());
-                return Future.succeededFuture(responseCode);
-            });
+                    log.debug("cannot process message from device [tenantId: {}, deviceId: {}, endpoint: {}]",
+                            tenantId, deviceId, endpoint.getCanonicalName(), t);
+                    final Future<Void> commandConsumerClosedTracker = commandConsumerTracker.result() != null
+                            ? commandConsumerTracker.result().close(currentSpan.context())
+                                    .onFailure(thr -> TracingHelper.logError(currentSpan, thr))
+                            : Future.succeededFuture();
+                    final CommandContext commandContext = context.get(CommandContext.KEY_COMMAND_CONTEXT);
+                    if (commandContext != null) {
+                        TracingHelper.logError(commandContext.getTracingSpan(),
+                                "command won't be forwarded to device in CoAP response, CoAP request handling failed", t);
+                        commandContext.release();
+                        currentSpan.log("released command for device");
+                    }
+                    metrics.reportTelemetry(
+                            endpoint,
+                            tenantId,
+                            tenantTracker.result(),
+                            ClientErrorException.class.isInstance(t) ? MetricsTags.ProcessingOutcome.UNPROCESSABLE : MetricsTags.ProcessingOutcome.UNDELIVERABLE,
+                            qos,
+                            payload.length(),
+                            getTtdStatus(context),
+                            context.getTimer());
+                    TracingHelper.logError(currentSpan, t);
+                    final Response response = CoapErrorResponse.respond(t, ResponseCode.INTERNAL_SERVER_ERROR);
+                    final ResponseCode responseCode = context.respond(response);
+                    commandConsumerClosedTracker.onComplete(res -> currentSpan.finish());
+                    return Future.succeededFuture(responseCode);
+                });
         }
     }
 

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -638,7 +638,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
      * @param context The context representing the request to be processed.
      * @return A future containing the response code that has been returned to
      *         the device.
-     * @throws NullPointerException if context or originDevice are {@code null}.
+     * @throws NullPointerException if context is {@code null}.
      */
     public final Future<ResponseCode> uploadEventMessage(
             final CoapContext context) {

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -493,7 +493,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
 
         // GIVEN an adapter with a downstream telemetry consumer attached
         givenAnAdapter(properties);
-        final Promise<ProtonDelivery> outcome = Promise.promise();
+        final Promise<Void> outcome = Promise.promise();
         givenATelemetrySenderForAnyTenant(outcome);
 
         // WHEN a device publishes an telemetry message with QoS 1
@@ -513,7 +513,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         // and the device does not get a response
         verify(coapExchange, never()).respond(any(Response.class));
         // until the telemetry message has been accepted
-        outcome.complete(mock(ProtonDelivery.class));
+        outcome.complete();
 
         verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED.equals(res.getCode())));
         verify(metrics).reportTelemetry(
@@ -536,7 +536,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
 
         // GIVEN an adapter with a downstream event consumer attached
         givenAnAdapter(properties);
-        final Promise<ProtonDelivery> outcome = Promise.promise();
+        final Promise<Void> outcome = Promise.promise();
         givenAnEventSenderForAnyTenant(outcome);
 
         // WHEN a device publishes an event
@@ -553,7 +553,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         verify(coapExchange, never()).respond(any(Response.class));
 
         // until the event has been accepted
-        outcome.complete(mock(ProtonDelivery.class));
+        outcome.complete();
 
         verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED.equals(res.getCode())));
         verify(metrics).reportTelemetry(
@@ -576,7 +576,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
 
         // GIVEN an adapter with a downstream event consumer attached
         givenAnAdapter(properties);
-        final Promise<ProtonDelivery> outcome = Promise.promise();
+        final Promise<Void> outcome = Promise.promise();
         givenAnEventSenderForAnyTenant(outcome);
 
         // WHEN a device publishes an event that is not accepted by the peer
@@ -613,7 +613,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
 
         // GIVEN an adapter with a downstream telemetry consumer attached
         givenAnAdapter(properties);
-        final Promise<ProtonDelivery> sendTelemetryOutcome = Promise.promise();
+        final Promise<Void> sendTelemetryOutcome = Promise.promise();
         givenATelemetrySenderForAnyTenant(sendTelemetryOutcome);
 
         // and a commandConsumerFactory that upon creating a consumer will invoke it with a command
@@ -986,7 +986,8 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         adapter.setResourceLimitChecks(resourceLimitChecks);
 
         adapter.setTenantClientFactory(tenantClientFactory);
-        adapter.setDownstreamSenderFactory(downstreamSenderFactory);
+        adapter.setEventSender(eventSender);
+        adapter.setTelemetrySender(telemetrySender);
         adapter.setRegistrationClientFactory(registrationClientFactory);
         if (complete) {
             adapter.setCredentialsClientFactory(credentialsClientFactory);

--- a/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
+++ b/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
@@ -23,6 +23,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.adapter.mqtt.MicrometerBasedMqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.impl.VertxBasedMqttProtocolAdapter;
 import org.eclipse.hono.cache.CacheProvider;
@@ -30,7 +31,6 @@ import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
-import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
 import org.eclipse.hono.client.RegistrationClientFactory;
@@ -123,14 +123,22 @@ public class Application {
         adapter.setConfig(config.mqtt);
         adapter.setCredentialsClientFactory(credentialsClientFactory());
         adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory());
-        adapter.setDownstreamSenderFactory(downstreamSenderFactory());
+        adapter.setEventSender(newDownstreamSender());
         adapter.setHealthCheckServer(healthCheckServer());
         adapter.setMetrics(metrics);
         adapter.setRegistrationClientFactory(registrationClientFactory());
+        adapter.setTelemetrySender(newDownstreamSender());
         adapter.setTenantClientFactory(tenantClientFactory());
         adapter.setTracer(tracer);
         adapter.setResourceLimitChecks(resourceLimitChecks);
         return adapter;
+    }
+
+    private ProtonBasedDownstreamSender newDownstreamSender() {
+        return new ProtonBasedDownstreamSender(
+                HonoConnection.newConnection(vertx, config.messaging),
+                metrics,
+                config.mqtt);
     }
 
     @Produces
@@ -159,11 +167,6 @@ public class Application {
     @Produces
     DeviceConnectionClientFactory deviceConnectionClientFactory() {
         return DeviceConnectionClientFactory.create(HonoConnection.newConnection(vertx, config.deviceConnection), metrics);
-    }
-
-    @Produces
-    DownstreamSenderFactory downstreamSenderFactory() {
-        return DownstreamSenderFactory.create(HonoConnection.newConnection(vertx, config.messaging));
     }
 
     @Singleton

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -130,6 +130,11 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-adapter-amqp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-service-base</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
@@ -183,4 +183,14 @@ public class ProtonBasedDownstreamSender extends SenderCachingServiceClient impl
                 adapterConfig.isDefaultsEnabled(),
                 adapterConfig.isJmsVendorPropsEnabled());
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return new StringBuilder(ProtonBasedDownstreamSender.class.getName())
+                .append(" via AMQP 1.0 Messaging Network")
+                .toString();
+    }
 }

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -26,6 +26,22 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-legal</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-adapter-amqp</artifactId>
+    </dependency>
+    <dependency>
+     <groupId>org.eclipse.hono</groupId>
+     <artifactId>hono-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
       <exclusions>
@@ -38,10 +54,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -68,14 +80,6 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-     <groupId>org.eclipse.hono</groupId>
-     <artifactId>hono-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-legal</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -203,7 +203,7 @@ public abstract class AbstractAdapterConfig {
      *                       {@link org.eclipse.hono.service.metric.MicrometerBasedMetrics}
      *                       out of the box.
      * @param adapterConfig The protocol adapter's configuration properties.
-     * @return The factory.
+     * @return The client.
      */
     @Qualifier(TelemetryConstants.TELEMETRY_ENDPOINT)
     @Bean
@@ -223,7 +223,7 @@ public abstract class AbstractAdapterConfig {
      *                       {@link org.eclipse.hono.service.metric.MicrometerBasedMetrics}
      *                       out of the box.
      * @param adapterConfig The protocol adapter's configuration properties.
-     * @return The factory.
+     * @return The client.
      */
     @Qualifier(EventConstants.EVENT_ENDPOINT)
     @Bean

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -503,8 +503,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
             log.info("using ResourceLimitChecks [{}]", resourceLimitChecks.getClass().getName());
 
-            startServiceClient(telemetrySender, "AMQP Messaging Network (Telemetry)");
-            startServiceClient(eventSender, "AMQP Messaging Network (Event)");
+            startServiceClient(telemetrySender, "Telemetry");
+            startServiceClient(eventSender, "Event");
             connectToService(tenantClientFactory, "Tenant service");
             connectToService(registrationClientFactory, "Device Registration service");
             connectToService(credentialsClientFactory, "Credentials service");
@@ -860,10 +860,10 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         Objects.requireNonNull(serviceName);
 
         return serviceClient.start().map(c -> {
-            log.info(" {} successfully connected to {}", serviceClient, serviceName);
+            log.info("{} client [{}] successfully connected", serviceName, serviceClient);
             return c;
         }).recover(t -> {
-            log.warn("{} failed to connect to {}", serviceClient, serviceName, t);
+            log.warn("{} client [{}] failed to connect", serviceName, serviceClient, t);
             return Future.failedFuture(t);
         });
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -249,7 +249,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     }
 
     /**
-     * Sets the client to use for sending telemetry messages via the AMQP Messaging Network.
+     * Sets the client to use for sending telemetry messages downstream.
      *
      * @param sender The sender.
      * @throws NullPointerException if the sender is {@code null}.
@@ -261,7 +261,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     }
 
     /**
-     * Gets the client being used for sending telemetry messages via the AMQP Messaging Network.
+     * Gets the client being used for sending telemetry messages downstream.
      *
      * @return The sender.
      */
@@ -270,7 +270,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     }
 
     /**
-     * Sets the client to use for sending events via the AMQP Messaging Network.
+     * Sets the client to use for sending events downstream.
      *
      * @param sender The sender.
      * @throws NullPointerException if the sender is {@code null}.
@@ -282,7 +282,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     }
 
     /**
-     * Gets the client being used for sending events via the AMQP Messaging Network.
+     * Gets the client being used for sending events downstream.
      *
      * @return The sender.
      */
@@ -860,10 +860,10 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         Objects.requireNonNull(serviceName);
 
         return serviceClient.start().map(c -> {
-            log.info("connected to {}", serviceName);
+            log.info(" {} successfully connected to {}", serviceClient, serviceName);
             return c;
         }).recover(t -> {
-            log.warn("failed to connect to {}", serviceName, t);
+            log.warn("{} failed to connect to {}", serviceClient, serviceName, t);
             return Future.failedFuture(t);
         });
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,8 @@
 package org.eclipse.hono.service.monitoring;
 
 
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.TenantClientFactory;
 
 import io.vertx.core.Future;
@@ -47,12 +47,12 @@ public interface ConnectionEventProducer {
     interface Context {
 
         /**
-         * Provide the device message sender client provided by the caller.
+         * Gets the client for sending connection events downstream.
          *
-         * @return The instance of the message sender client which the {@link ConnectionEventProducer} method should
+         * @return The instance of the message sender client which the {@link ConnectionEventProducer} should
          *         use. This client has to be initialized and started.
          */
-        DownstreamSenderFactory getMessageSenderClient();
+        EventSender getMessageSenderClient();
         /**
          * Provides the tenant client which the {@link ConnectionEventProducer} should use to lookup the tenant
          * that the device connecting to a protocol adapter belongs to.

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/HonoEventConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/HonoEventConnectionEventProducer.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.hono.service.monitoring;
 
-import org.eclipse.hono.client.DownstreamSenderFactory;
-
 /**
  * A connection event producer based on the Hono <em>Event API</em>.
  */
@@ -23,7 +21,7 @@ public final class HonoEventConnectionEventProducer extends AbstractMessageSende
      * Create a new <em>connection event producer</em> based on the Hono <em>Event API</em>.
      */
     public HonoEventConnectionEventProducer() {
-        super(DownstreamSenderFactory::getOrCreateEventSender);
+        super();
     }
 
     /**

--- a/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
+++ b/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
@@ -87,12 +87,14 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
     private TelemetrySender createTelemetrySenderMock() {
         final TelemetrySender sender = mock(TelemetrySender.class);
         when(sender.start()).thenReturn(Future.succeededFuture());
+        when(sender.stop()).thenReturn(Future.succeededFuture());
         return sender;
     }
 
     private EventSender createEventSenderMock() {
         final EventSender sender = mock(EventSender.class);
         when(sender.start()).thenReturn(Future.succeededFuture());
+        when(sender.stop()).thenReturn(Future.succeededFuture());
         return sender;
     }
 


### PR DESCRIPTION
Added implementations of the adapter client's TelemetrySender and
EventSender interfaces which wrap the existing vertx-proton based
"legacy" DownstreamSender.
