### PR TITLE
[#2267] Add AMQP 1.0 based TenantClient implementation

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -186,7 +186,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                                 new UsernamePasswordAuthProvider(getCredentialsClientFactory(), tracer),
                                 this::handleBeforeCredentialsValidation),
                         new SaslExternalAuthHandler(
-                                new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
+                                new TenantServiceBasedX509Authentication(getTenantClient(), tracer),
                                 new X509AuthProvider(getCredentialsClientFactory(), tracer),
                                 this::handleBeforeCredentialsValidation));
             }

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -363,14 +363,14 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
 
         final ApplicationLevelInfoSupplier deviceResolver = Optional.ofNullable(honoDeviceResolver)
                 .orElseGet(() -> new DefaultDeviceResolver(context, tracer, getTypeName(), getConfig(),
-                        getCredentialsClientFactory(), getTenantClientFactory()));
+                        getCredentialsClientFactory(), getTenantClient()));
         final AdvancedPskStore store = Optional.ofNullable(pskStore)
                 .orElseGet(() -> {
                     if (deviceResolver instanceof AdvancedPskStore) {
                         return (AdvancedPskStore) deviceResolver;
                     } else {
                         return new DefaultDeviceResolver(context, tracer, getTypeName(), getConfig(),
-                                getCredentialsClientFactory(), getTenantClientFactory());
+                                getCredentialsClientFactory(), getTenantClient());
                     }
                 });
 

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DefaultDeviceResolver.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DefaultDeviceResolver.java
@@ -79,7 +79,7 @@ public class DefaultDeviceResolver implements ApplicationLevelInfoSupplier, Adva
     private final String adapterName;
     private final CoapAdapterProperties config;
     private final CredentialsClientFactory credentialsClientFactory;
-    private final TenantClient tenantClientFactory;
+    private final TenantClient tenantClient;
     private volatile PskSecretResultHandler californiumResultHandler;
 
     /**
@@ -106,7 +106,7 @@ public class DefaultDeviceResolver implements ApplicationLevelInfoSupplier, Adva
         this.adapterName = Objects.requireNonNull(adapterName);
         this.config = Objects.requireNonNull(config);
         this.credentialsClientFactory = Objects.requireNonNull(credentialsClientFactory);
-        this.tenantClientFactory = tenantClient;
+        this.tenantClient = tenantClient;
     }
 
     /**
@@ -252,7 +252,7 @@ public class DefaultDeviceResolver implements ApplicationLevelInfoSupplier, Adva
     }
 
     private Future<Void> applyTraceSamplingPriority(final PreSharedKeyDeviceIdentity deviceIdentity, final Span span) {
-        return tenantClientFactory.get(deviceIdentity.getTenantId(), span.context())
+        return tenantClient.get(deviceIdentity.getTenantId(), span.context())
                 .map(tenantObject -> {
                     TracingHelper.setDeviceTags(span, tenantObject.getTenantId(), null, deviceIdentity.getAuthId());
                     TenantTraceSamplingHelper.applyTraceSamplingPriority(tenantObject, deviceIdentity.getAuthId(), span);

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DefaultDeviceResolver.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DefaultDeviceResolver.java
@@ -36,9 +36,9 @@ import org.eclipse.californium.scandium.dtls.PskSecretResultHandler;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
 import org.eclipse.californium.scandium.util.SecretUtil;
 import org.eclipse.californium.scandium.util.ServerNames;
+import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.CredentialsClientFactory;
-import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.tracing.TenantTraceSamplingHelper;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CredentialsConstants;
@@ -79,7 +79,7 @@ public class DefaultDeviceResolver implements ApplicationLevelInfoSupplier, Adva
     private final String adapterName;
     private final CoapAdapterProperties config;
     private final CredentialsClientFactory credentialsClientFactory;
-    private final TenantClientFactory tenantClientFactory;
+    private final TenantClient tenantClientFactory;
     private volatile PskSecretResultHandler californiumResultHandler;
 
     /**
@@ -90,7 +90,7 @@ public class DefaultDeviceResolver implements ApplicationLevelInfoSupplier, Adva
      * @param adapterName The name of the protocol adapter.
      * @param config The configuration properties.
      * @param credentialsClientFactory The factory to use for creating clients to the Credentials service.
-     * @param tenantClientFactory The factory to use for creating a Tenant service client.
+     * @param tenantClient The client to use for accessing the Tenant service.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public DefaultDeviceResolver(
@@ -99,14 +99,14 @@ public class DefaultDeviceResolver implements ApplicationLevelInfoSupplier, Adva
             final String adapterName,
             final CoapAdapterProperties config,
             final CredentialsClientFactory credentialsClientFactory,
-            final TenantClientFactory tenantClientFactory) {
+            final TenantClient tenantClient) {
 
         this.context = Objects.requireNonNull(vertxContext);
         this.tracer = Objects.requireNonNull(tracer);
         this.adapterName = Objects.requireNonNull(adapterName);
         this.config = Objects.requireNonNull(config);
         this.credentialsClientFactory = Objects.requireNonNull(credentialsClientFactory);
-        this.tenantClientFactory = tenantClientFactory;
+        this.tenantClientFactory = tenantClient;
     }
 
     /**
@@ -252,8 +252,7 @@ public class DefaultDeviceResolver implements ApplicationLevelInfoSupplier, Adva
     }
 
     private Future<Void> applyTraceSamplingPriority(final PreSharedKeyDeviceIdentity deviceIdentity, final Span span) {
-        return tenantClientFactory.getOrCreateTenantClient()
-                .compose(tenantClient -> tenantClient.get(deviceIdentity.getTenantId(), span.context()))
+        return tenantClientFactory.get(deviceIdentity.getTenantId(), span.context())
                 .map(tenantObject -> {
                     TracingHelper.setDeviceTags(span, tenantObject.getTenantId(), null, deviceIdentity.getAuthId());
                     TenantTraceSamplingHelper.applyTraceSamplingPriority(tenantObject, deviceIdentity.getAuthId(), span);

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/impl/VertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/impl/VertxBasedCoapAdapter.java
@@ -122,7 +122,7 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
     protected Future<Void> preStartup() {
 
         final Set<Resource> result = new HashSet<>();
-        result.add(new TracingSupportingHonoResource(tracer, TelemetryConstants.TELEMETRY_ENDPOINT, getTypeName(), getTenantClientFactory()) {
+        result.add(new TracingSupportingHonoResource(tracer, TelemetryConstants.TELEMETRY_ENDPOINT, getTypeName(), getTenantClient()) {
 
             @Override
             protected Future<CoapContext> createCoapContextForPost(final CoapExchange exchange, final Span span) {
@@ -145,7 +145,7 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
             }
         });
 
-        result.add(new TracingSupportingHonoResource(tracer, EventConstants.EVENT_ENDPOINT, getTypeName(), getTenantClientFactory()) {
+        result.add(new TracingSupportingHonoResource(tracer, EventConstants.EVENT_ENDPOINT, getTypeName(), getTenantClient()) {
 
             @Override
             protected Future<CoapContext> createCoapContextForPost(final CoapExchange exchange, final Span span) {
@@ -167,7 +167,7 @@ public final class VertxBasedCoapAdapter extends AbstractVertxBasedCoapAdapter<C
                 return uploadEventMessage(ctx);
             }
         });
-        result.add(new TracingSupportingHonoResource(tracer, CommandConstants.COMMAND_RESPONSE_ENDPOINT, getTypeName(), getTenantClientFactory()) {
+        result.add(new TracingSupportingHonoResource(tracer, CommandConstants.COMMAND_RESPONSE_ENDPOINT, getTypeName(), getTenantClient()) {
 
             @Override
             protected Future<CoapContext> createCoapContextForPost(final CoapExchange exchange, final Span span) {

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -985,7 +985,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         adapter.setMetrics(metrics);
         adapter.setResourceLimitChecks(resourceLimitChecks);
 
-        adapter.setTenantClientFactory(tenantClientFactory);
+        adapter.setTenantClient(tenantClient);
         adapter.setEventSender(eventSender);
         adapter.setTelemetrySender(telemetrySender);
         adapter.setRegistrationClientFactory(registrationClientFactory);

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResourceTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResourceTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.net.HttpURLConnection;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -35,11 +34,8 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.HonoConnection;
-import org.eclipse.hono.client.ServerErrorException;
-import org.eclipse.hono.client.TenantClient;
-import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.util.TenantObject;
 import org.eclipse.hono.util.TenantTracingConfig;
 import org.eclipse.hono.util.TracingSamplingMode;
@@ -72,7 +68,6 @@ public class TracingSupportingHonoResourceTest {
     private SpanBuilder spanBuilder;
     private TracingSupportingHonoResource resource;
     private TenantClient tenantClient;
-    private TenantClientFactory tenantClientFactory;
 
     /**
      * Sets up the fixture.
@@ -90,13 +85,7 @@ public class TracingSupportingHonoResourceTest {
             return Future.succeededFuture(TenantObject.from(invocation.getArgument(0), true));
         });
 
-        tenantClientFactory = mock(TenantClientFactory.class);
-        when(tenantClientFactory.isConnected())
-                .thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
-        when(tenantClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
-        when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
-
-        resource = new TracingSupportingHonoResource(tracer, "test", "adapter", tenantClientFactory) {
+        resource = new TracingSupportingHonoResource(tracer, "test", "adapter", tenantClient) {
 
             @Override
             protected Future<CoapContext> createCoapContextForPost(final CoapExchange coapExchange, final Span span) {

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
@@ -104,7 +104,7 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
 
             final ChainAuthHandler authHandler = new HonoChainAuthHandler(this::handleBeforeCredentialsValidation);
             authHandler.append(new X509AuthHandler(
-                    new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
+                    new TenantServiceBasedX509Authentication(getTenantClient(), tracer),
                     Optional.ofNullable(clientCertAuthProvider).orElseGet(
                             () -> new X509AuthProvider(getCredentialsClientFactory(), tracer))));
             authHandler.append(new HonoBasicAuthHandler(

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -147,7 +147,7 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
 
         final ChainAuthHandler authHandler = new HonoChainAuthHandler(this::handleBeforeCredentialsValidation);
         authHandler.append(new X509AuthHandler(
-                new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
+                new TenantServiceBasedX509Authentication(getTenantClient(), tracer),
                 Optional.ofNullable(clientCertAuthProvider).orElseGet(
                         () -> new X509AuthProvider(getCredentialsClientFactory(), tracer))));
         authHandler.append(new HonoBasicAuthHandler(

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -179,7 +179,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
 
         return new ChainAuthHandler<>(this::handleBeforeCredentialsValidation)
                 .append(new X509AuthHandler(
-                        new TenantServiceBasedX509Authentication(getTenantClientFactory(), tracer),
+                        new TenantServiceBasedX509Authentication(getTenantClient(), tracer),
                         new X509AuthProvider(getCredentialsClientFactory(), tracer)))
                 .append(new ConnectPacketAuthHandler(
                         new UsernamePasswordAuthProvider(

--- a/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
+++ b/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
@@ -23,6 +23,8 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.eclipse.hono.adapter.client.registry.TenantClient;
+import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient;
 import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.adapter.mqtt.MicrometerBasedMqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.impl.VertxBasedMqttProtocolAdapter;
@@ -34,7 +36,6 @@ import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
 import org.eclipse.hono.client.RegistrationClientFactory;
-import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.quarkus.CaffeineBasedExpiringValueCache;
@@ -128,7 +129,7 @@ public class Application {
         adapter.setMetrics(metrics);
         adapter.setRegistrationClientFactory(registrationClientFactory());
         adapter.setTelemetrySender(newDownstreamSender());
-        adapter.setTenantClientFactory(tenantClientFactory());
+        adapter.setTenantClient(tenantClient());
         adapter.setTracer(tracer);
         adapter.setResourceLimitChecks(resourceLimitChecks);
         return adapter;
@@ -185,11 +186,12 @@ public class Application {
     }
 
     @Produces
-    TenantClientFactory tenantClientFactory() {
-        return TenantClientFactory.create(
+    TenantClient tenantClient() {
+        return new ProtonBasedTenantClient(
                 HonoConnection.newConnection(vertx, config.tenant),
-                newCaffeineCache(config.tenant.getResponseCacheMinSize(), config.tenant.getResponseCacheMaxSize()),
-                metrics);
+                metrics,
+                config.mqtt,
+                newCaffeineCache(config.tenant.getResponseCacheMinSize(), config.tenant.getResponseCacheMaxSize()));
     }
 
     /**
@@ -213,7 +215,6 @@ public class Application {
             private final Map<String, ExpiringValueCache<Object, Object>> caches = new HashMap<>();
 
             @Override
-            @SuppressWarnings("unchecked")
             public ExpiringValueCache<Object, Object> getCache(final String cacheName) {
 
                 return caches.computeIfAbsent(cacheName, name -> new CaffeineBasedExpiringValueCache<>(caffeine.build()));

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractServiceClient.java
@@ -81,7 +81,7 @@ public abstract class AbstractServiceClient implements ConnectionLifecycle<HonoC
      * Simply delegates to {@link HonoConnection#addDisconnectListener(DisconnectListener)}.
      */
     @Override
-    public void addDisconnectListener(final DisconnectListener<HonoConnection> listener) {
+    public final void addDisconnectListener(final DisconnectListener<HonoConnection> listener) {
         connection.addDisconnectListener(listener);
     }
 
@@ -91,7 +91,7 @@ public abstract class AbstractServiceClient implements ConnectionLifecycle<HonoC
      * Simply delegates to {@link HonoConnection#addReconnectListener(ReconnectListener)}.
      */
     @Override
-    public void addReconnectListener(final ReconnectListener<HonoConnection> listener) {
+    public final void addReconnectListener(final ReconnectListener<HonoConnection> listener) {
         connection.addReconnectListener(listener);
     }
 

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/AbstractRequestResponseClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/AbstractRequestResponseClient.java
@@ -42,7 +42,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
      * @param adapterConfig The protocol adapter's configuration properties.
      * @param cacheProvider The provider to use for creating cache instances for service responses.
-     * @throws NullPointerException if any of context or configuration are {@code null}.
+     * @throws NullPointerException if any of the parameters other than cacheProvider are {@code null}.
      */
     protected AbstractRequestResponseClient(
             final HonoConnection connection,

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/AbstractRequestResponseClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/AbstractRequestResponseClient.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.adapter.client.registry.amqp;
+
+import org.eclipse.hono.adapter.client.amqp.AbstractServiceClient;
+import org.eclipse.hono.cache.CacheProvider;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.RequestResponseResult;
+
+/**
+ * A vertx-proton based parent class for the implementation of API clients that follow the request response pattern.
+ * <p>
+ * Provides access to a {@link CacheProvider} which can be used to create caches for service response messages.
+ *
+ * @param <R> The type of result this client expects the peer to return.
+ *
+ */
+public abstract class AbstractRequestResponseClient<R extends RequestResponseResult<?>>
+        extends AbstractServiceClient {
+
+    /**
+     * A provider for caches to use for responses received from the service.
+     */
+    protected CacheProvider responseCacheProvider;
+
+    /**
+     * Creates a request-response client.
+     *
+     * @param connection The connection to the service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param cacheProvider The provider to use for creating cache instances for service responses.
+     * @throws NullPointerException if any of context or configuration are {@code null}.
+     */
+    protected AbstractRequestResponseClient(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig,
+            final CacheProvider cacheProvider) {
+
+        super(connection, samplerFactory, adapterConfig);
+        this.responseCacheProvider = cacheProvider;
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
@@ -32,7 +32,7 @@ import io.vertx.core.Future;
 
 
 /**
- * A vertx-proton based client of Hono's Device Registration service.
+ * A vertx-proton based client of Hono's Tenant service.
  *
  */
 public final class ProtonBasedTenantClient extends AbstractRequestResponseClient<TenantResult<TenantObject>> implements TenantClient {
@@ -42,10 +42,10 @@ public final class ProtonBasedTenantClient extends AbstractRequestResponseClient
     /**
      * Creates a new client for a connection.
      *
-     * @param connection The connection to the Device Registration service.
+     * @param connection The connection to the service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
      * @param adapterConfig The protocol adapter's configuration properties.
-     * @param cacheProvider The cache provider to use for creating the cache for tenant service responses.
+     * @param cacheProvider The cache provider to use for creating the cache for service responses.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public ProtonBasedTenantClient(

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.registry.amqp;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.hono.adapter.client.registry.TenantClient;
+import org.eclipse.hono.cache.CacheProvider;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.impl.CachingClientFactory;
+import org.eclipse.hono.client.impl.TenantClientImpl;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantObject;
+import org.eclipse.hono.util.TenantResult;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+
+
+/**
+ * A vertx-proton based client of Hono's Device Registration service.
+ *
+ */
+public final class ProtonBasedTenantClient extends AbstractRequestResponseClient<TenantResult<TenantObject>> implements TenantClient {
+
+    private final CachingClientFactory<org.eclipse.hono.client.TenantClient> tenantClientFactory;
+
+    /**
+     * Creates a new client for a connection.
+     *
+     * @param connection The connection to the Device Registration service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param cacheProvider The cache provider to use for creating the cache for tenant service responses.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public ProtonBasedTenantClient(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig,
+            final CacheProvider cacheProvider) {
+        super(connection, samplerFactory, adapterConfig, cacheProvider);
+        this.tenantClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
+    }
+
+    private Future<org.eclipse.hono.client.TenantClient> getOrCreateTenantClient() {
+
+        return connection.isConnected(getDefaultConnectionCheckTimeout())
+                .compose(v -> connection.executeOnContext(result -> {
+                    tenantClientFactory.getOrCreateClient(
+                            TenantClientImpl.getTargetAddress(),
+                            () -> TenantClientImpl.create(
+                                    responseCacheProvider,
+                                    connection,
+                                    samplerFactory.create(TenantConstants.TENANT_ENDPOINT),
+                                    this::removeTenantClient,
+                                    this::removeTenantClient),
+                            result);
+                }));
+    }
+
+    private void removeTenantClient(final String tenantId) {
+        // the tenantId is not relevant for this client, so ignore it
+        tenantClientFactory.removeClient(TenantClientImpl.getTargetAddress());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Clears the state of the client factory.
+     */
+    @Override
+    protected void onDisconnect() {
+        tenantClientFactory.clearState();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<TenantObject> get(final String tenantId, final SpanContext context) {
+        return getOrCreateTenantClient()
+                .compose(client -> client.get(tenantId, context));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<TenantObject> get(final X500Principal subjectDn, final SpanContext context) {
+        return getOrCreateTenantClient()
+                .compose(client -> client.get(subjectDn, context));
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
@@ -46,7 +46,7 @@ public final class ProtonBasedTenantClient extends AbstractRequestResponseClient
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
      * @param adapterConfig The protocol adapter's configuration properties.
      * @param cacheProvider The cache provider to use for creating the cache for service responses.
-     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @throws NullPointerException if any of the parameters other than cacheProvider are {@code null}.
      */
     public ProtonBasedTenantClient(
             final HonoConnection connection,

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
@@ -16,11 +16,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationAssertion;
-import org.eclipse.hono.util.TenantObject;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
@@ -74,7 +72,7 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
         final String tenantId = authenticatedDevice.getTenantId();
         final String deviceId = authenticatedDevice.getDeviceId();
 
-        return getTenant(context.getTenantClientFactory(), tenantId)
+        return context.getTenantClient().get(tenantId, null)
                 .compose(tenant -> {
 
                     final JsonObject payload = new JsonObject();
@@ -99,9 +97,5 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                             props,
                             null);
                 });
-    }
-
-    private Future<TenantObject> getTenant(final TenantClientFactory factory, final String tenant) {
-        return factory.getOrCreateTenantClient().compose(client -> client.get(tenant));
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducer.java
@@ -13,9 +13,9 @@
 package org.eclipse.hono.service.monitoring;
 
 
+import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.TenantClientFactory;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
@@ -57,10 +57,9 @@ public interface ConnectionEventProducer {
          * Provides the tenant client which the {@link ConnectionEventProducer} should use to lookup the tenant
          * that the device connecting to a protocol adapter belongs to.
          *
-         * @return The tenant client instance. This client has to be initialized and started.
+         * @return The tenant client instance.
          */
-        TenantClientFactory getTenantClientFactory();
-
+        TenantClient getTenantClient();
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509AuthenticationTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/device/TenantServiceBasedX509AuthenticationTest.java
@@ -29,8 +29,7 @@ import java.security.cert.X509Certificate;
 
 import javax.security.auth.x500.X500Principal;
 
-import org.eclipse.hono.client.TenantClient;
-import org.eclipse.hono.client.TenantClientFactory;
+import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.util.TenantObject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -57,11 +56,9 @@ class TenantServiceBasedX509AuthenticationTest {
         cert = (X509Certificate) factory.generateCertificate(new FileInputStream(ssc.certificatePath()));
         certPath = new Certificate[] { cert };
 
-        final TenantClientFactory tcf = mock(TenantClientFactory.class);
         tenantClient = mock(TenantClient.class);
-        when(tcf.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
 
-        underTest = new TenantServiceBasedX509Authentication(tcf);
+        underTest = new TenantServiceBasedX509Authentication(tenantClient);
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/monitoring/HonoEventConnectionEventProducerTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/monitoring/HonoEventConnectionEventProducerTest.java
@@ -22,10 +22,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.TenantClient;
-import org.eclipse.hono.client.TenantClientFactory;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationAssertion;
@@ -51,7 +50,6 @@ class HonoEventConnectionEventProducerTest {
     private HonoEventConnectionEventProducer producer;
     private ConnectionEventProducer.Context context;
     private EventSender sender;
-    private TenantClientFactory tenantClientFactory;
     private TenantClient tenantClient;
     private TenantObject tenant;
 
@@ -61,8 +59,6 @@ class HonoEventConnectionEventProducerTest {
     @BeforeEach
     void setUp() {
         tenantClient = mock(TenantClient.class);
-        tenantClientFactory = mock(TenantClientFactory.class);
-        when(tenantClientFactory.getOrCreateTenantClient()).thenReturn(Future.succeededFuture(tenantClient));
         sender = mock(EventSender.class);
         when(sender.sendEvent(
                 any(TenantObject.class),
@@ -73,7 +69,7 @@ class HonoEventConnectionEventProducerTest {
                 any())).thenReturn(Future.succeededFuture());
         context = mock(ConnectionEventProducer.Context.class);
         when(context.getMessageSenderClient()).thenReturn(sender);
-        when(context.getTenantClientFactory()).thenReturn(tenantClientFactory);
+        when(context.getTenantClient()).thenReturn(tenantClient);
         producer = new HonoEventConnectionEventProducer();
     }
 
@@ -84,7 +80,7 @@ class HonoEventConnectionEventProducerTest {
         final Device authenticatedDevice = new Device(tenantId, "device");
         tenant = new TenantObject(tenantId, true)
                 .setResourceLimits(new ResourceLimits().setMaxTtl(500));
-        when(tenantClient.get(anyString())).thenReturn(Future.succeededFuture(tenant));
+        when(tenantClient.get(anyString(), any())).thenReturn(Future.succeededFuture(tenant));
 
         producer.connected(context, "device-internal-id", "custom-adapter", authenticatedDevice, new JsonObject())
             .onComplete(ctx.succeeding(ok -> {


### PR DESCRIPTION
Added implementations of the adapter client's TenantClient interface
which simply wraps the existing vertx-proton based
"legacy" TenantClientImpl.

This is the most straight forward implementation which simply delegates all method invocations to TenantClientImpl.
This also means that caching of response messages from the Tenant service is still done inside of TenantClientImpl instances.
This might/should be improved in the future to provide caching at the ProtonBasedTenantClient level in order to be able to return caches values even if the connection/link to the service is (currently) unavailable.