### PR TITLE
[#2267] Add AMQP 1.0 based DeviceRegistrationClient implementation

### DIFF
--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -148,7 +148,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
 
         this.properties = givenDefaultConfigurationProperties();
         createClientFactories();
-        createClients();
+        prepareClients();
 
         connectionLimitManager = mock(ConnectionLimitManager.class);
 

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -121,7 +121,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
 
         this.properties = givenDefaultConfigurationProperties();
         createClientFactories();
-        createClients();
+        prepareClients();
 
         commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -988,7 +988,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         adapter.setTenantClient(tenantClient);
         adapter.setEventSender(eventSender);
         adapter.setTelemetrySender(telemetrySender);
-        adapter.setRegistrationClientFactory(registrationClientFactory);
+        adapter.setRegistrationClient(registrationClient);
         if (complete) {
             adapter.setCredentialsClientFactory(credentialsClientFactory);
         }

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -277,8 +277,8 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         // WHEN an unknown device that supposedly belongs to that tenant publishes a telemetry message
         // with a TTD value set
-        when(registrationClient.assertRegistration(eq("unknown-device"), any(), any(SpanContext.class))).thenReturn(
-                Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
+        when(registrationClient.assertRegistration(eq("my-tenant"), eq("unknown-device"), any(), any(SpanContext.class)))
+            .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
         final Buffer payload = Buffer.buffer("some payload");
         final HttpServerResponse response = mock(HttpServerResponse.class);
         final HttpServerRequest request = mock(HttpServerRequest.class);
@@ -289,7 +289,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         // THEN the device gets a 404
         assertContextFailedWithClientError(ctx, HttpURLConnection.HTTP_NOT_FOUND);
-        verify(registrationClient).assertRegistration(eq("unknown-device"), any(), any(SpanContext.class));
+        verify(registrationClient).assertRegistration(eq("my-tenant"), eq("unknown-device"), any(), any(SpanContext.class));
         // and the message has not been forwarded downstream
         assertNoTelemetryMessageHasBeenSentDownstream();
         // and no Command consumer has been created for the device
@@ -561,7 +561,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         when(ctx.getAuthenticatedDevice()).thenReturn(new DeviceUser("tenant", "9999"));
 
         // but for which no registration information is available
-        when(registrationClient.assertRegistration((String) any(), (String) any(), (SpanContext) any()))
+        when(registrationClient.assertRegistration(anyString(), anyString(), any(), any()))
                 .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND,
                         "cannot publish data for device of other tenant")));
 

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -119,7 +119,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         this.properties = givenDefaultConfigurationProperties();
         createClientFactories();
-        createClients();
+        prepareClients();
 
         commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -137,7 +137,7 @@ public class VertxBasedHttpProtocolAdapterTest extends ProtocolAdapterTestSuppor
 
         LOG.info("running test case [{}]", testInfo.getDisplayName());
 
-        createClients();
+        prepareClients();
 
         final ProtocolAdapterCommandConsumer commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());

--- a/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/Application.java
+++ b/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/Application.java
@@ -23,7 +23,9 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.TenantClient;
+import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient;
 import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.adapter.http.MicrometerBasedHttpAdapterMetrics;
@@ -35,7 +37,6 @@ import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
-import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.quarkus.CaffeineBasedExpiringValueCache;
@@ -127,7 +128,7 @@ public class Application {
         adapter.setEventSender(newDownstreamSender());
         adapter.setHealthCheckServer(healthCheckServer());
         adapter.setMetrics(metrics);
-        adapter.setRegistrationClientFactory(registrationClientFactory());
+        adapter.setRegistrationClient(registrationClient());
         adapter.setTelemetrySender(newDownstreamSender());
         adapter.setTenantClient(tenantClient());
         adapter.setTracer(tracer);
@@ -178,11 +179,12 @@ public class Application {
     }
 
     @Produces
-    RegistrationClientFactory registrationClientFactory() {
-        return RegistrationClientFactory.create(
+    DeviceRegistrationClient registrationClient() {
+        return new ProtonBasedDeviceRegistrationClient(
                 HonoConnection.newConnection(vertx, config.registration),
-                newCaffeineCache(config.registration.getResponseCacheMinSize(), config.registration.getResponseCacheMaxSize()),
-                metrics);
+                metrics,
+                config.http,
+                newCaffeineCache(config.registration.getResponseCacheMinSize(), config.registration.getResponseCacheMaxSize()));
     }
 
     @Produces

--- a/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapterTest.java
+++ b/adapters/lora-vertx/src/test/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapterTest.java
@@ -84,7 +84,7 @@ public class LoraProtocolAdapterTest extends ProtocolAdapterTestSupport<LoraProt
 
         this.properties = givenDefaultConfigurationProperties();
         createClientFactories();
-        createClients();
+        prepareClients();
 
         currentSpan = mock(Span.class);
         when(currentSpan.context()).thenReturn(mock(SpanContext.class));

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -387,7 +387,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         when(authHandler.authenticateDevice(any(MqttConnectContext.class)))
                 .thenReturn(Future.succeededFuture(new DeviceUser(Constants.DEFAULT_TENANT, "9999")));
         // but for which no registration information is available
-        when(registrationClient.assertRegistration(eq("9999"), (String) any(), (SpanContext) any()))
+        when(registrationClient.assertRegistration(anyString(), eq("9999"), (String) any(), (SpanContext) any()))
                 .thenReturn(Future.failedFuture(new ClientErrorException(
                         HttpURLConnection.HTTP_NOT_FOUND, "device unknown or disabled")));
 
@@ -553,7 +553,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         givenATelemetrySenderForAnyTenant();
 
         // WHEN an unknown device publishes a telemetry message
-        when(registrationClient.assertRegistration(eq("unknown"), any(), any())).thenReturn(
+        when(registrationClient.assertRegistration(anyString(), eq("unknown"), any(), any())).thenReturn(
                 Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
 
         final MqttEndpoint endpoint = mockEndpoint();

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -134,7 +134,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
 
         this.properties = givenDefaultConfigurationProperties();
         createClientFactories();
-        createClients();
+        prepareClients();
 
         authHandler = mock(AuthHandler.class);
         resourceLimitChecks = mock(ResourceLimitChecks.class);

--- a/client/src/main/java/org/eclipse/hono/client/CommandTargetMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandTargetMapper.java
@@ -116,6 +116,7 @@ public interface CommandTargetMapper {
      * @param registrationClientFactory The factory for creating Device Registration service clients.
      * @param deviceConnectionClientFactory The factory for creating Device Connection service clients.
      * @return The mapper context.
+     * @throws NullPointerException if any of the parameters are {@code null}.
      */
     static CommandTargetMapperContext createContext(
             final RegistrationClientFactory registrationClientFactory,

--- a/client/src/main/java/org/eclipse/hono/client/CommandTargetMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandTargetMapper.java
@@ -56,7 +56,7 @@ public interface CommandTargetMapper {
      * Access to collaborators that the mapper needs for doing its work.
      *
      */
-    public interface CommandTargetMapperContext {
+    interface CommandTargetMapperContext {
 
         /**
          * Gets the device identifiers of the gateways that an edge device may connect via.
@@ -118,8 +118,8 @@ public interface CommandTargetMapper {
      * @return The mapper context.
      */
     static CommandTargetMapperContext createContext(
-            RegistrationClientFactory registrationClientFactory,
-            BasicDeviceConnectionClientFactory deviceConnectionClientFactory) {
+            final RegistrationClientFactory registrationClientFactory,
+            final BasicDeviceConnectionClientFactory deviceConnectionClientFactory) {
 
         Objects.requireNonNull(registrationClientFactory);
         Objects.requireNonNull(deviceConnectionClientFactory);
@@ -138,13 +138,10 @@ public interface CommandTargetMapper {
                 return registrationClientFactory.getOrCreateRegistrationClient(tenant)
                         .compose(client -> client.assertRegistration(deviceId, null, context))
                         .map(json -> Optional.ofNullable(json.getJsonArray(RegistrationConstants.FIELD_VIA))
-                                .map(array -> {
-                                    final List<String> result = array.stream()
-                                            .filter(String.class::isInstance)
-                                            .map(String.class::cast)
-                                            .collect(Collectors.toList());
-                                    return result;
-                                })
+                                .map(array -> array.stream()
+                                        .filter(String.class::isInstance)
+                                        .map(String.class::cast)
+                                        .collect(Collectors.toList()))
                                 .orElse(Collections.emptyList()));
             }
 

--- a/client/src/main/java/org/eclipse/hono/client/CommandTargetMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandTargetMapper.java
@@ -13,8 +13,15 @@
 
 package org.eclipse.hono.client;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.eclipse.hono.client.impl.CommandTargetMapperImpl;
 import org.eclipse.hono.util.DeviceConnectionConstants;
+import org.eclipse.hono.util.RegistrationConstants;
 
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -46,6 +53,53 @@ import io.vertx.core.json.JsonObject;
 public interface CommandTargetMapper {
 
     /**
+     * Access to collaborators that the mapper needs for doing its work.
+     *
+     */
+    public interface CommandTargetMapperContext {
+
+        /**
+         * Gets the device identifiers of the gateways that an edge device may connect via.
+         *
+         * @param tenant The tenant that the device belongs to.
+         * @param deviceId The device id.
+         * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+         *            Implementing classes should use this as the parent for any span they create for tracing the execution
+         *            of this operation.
+         * @return The gateway identifiers.
+         * @throws NullPointerException if any of the parameters except context is {@code null}.
+         */
+        Future<List<String>> getViaGateways(String tenant, String deviceId, SpanContext context);
+
+        /**
+         * Gets information about the adapter instances that can handle a command for the given device.
+         * <p>
+         * See Hono's <a href="https://www.eclipse.org/hono/docs/api/device-connection/">Device Connection API
+         * specification</a> for a detailed description of the method's behaviour and the returned JSON object.
+         * <p>
+         * If no adapter instances are found, the returned future is failed.
+         *
+         * @param tenant The tenant that the device belongs to.
+         * @param deviceId The device id.
+         * @param viaGateways The list of gateways that may act on behalf of the given device.
+         * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+         *            Implementing classes should use this as the parent for any span they create for tracing the execution
+         *            of this operation.
+         * @return A future indicating the outcome of the operation.
+         *         <p>
+         *         If instances were found, the future will be succeeded with a JSON object containing one or more mappings
+         *         from device id to adapter instance id. Otherwise the future will be failed with a
+         *         {@link org.eclipse.hono.client.ServiceInvocationException}.
+         * @throws NullPointerException if any of the parameters except context is {@code null}.
+         */
+        Future<JsonObject> getCommandHandlingAdapterInstances(
+                String tenant,
+                String deviceId,
+                List<String> viaGateways,
+                SpanContext context);
+    }
+
+    /**
      * Creates a new {@link CommandTargetMapper} using the default implementation.
      *
      * @param tracer The tracer instance.
@@ -57,16 +111,67 @@ public interface CommandTargetMapper {
     }
 
     /**
-     * Initializes the CommandTargetMapper with the given components.
+     * Creates a mapper context for client factories.
      *
-     * @param registrationClientFactory The factory to create a registration client instance. Note that no
-     *            initialization of this factory will be done here, that is supposed to be done by the calling method.
-     * @param deviceConnectionClientFactory The factory to create a device connection client instance. Note that no
-     *            initialization of this factory will be done here, that is supposed to be done by the calling method.
-     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @param registrationClientFactory The factory for creating Device Registration service clients.
+     * @param deviceConnectionClientFactory The factory for creating Device Connection service clients.
+     * @return The mapper context.
      */
-    void initialize(RegistrationClientFactory registrationClientFactory,
-            BasicDeviceConnectionClientFactory deviceConnectionClientFactory);
+    static CommandTargetMapperContext createContext(
+            RegistrationClientFactory registrationClientFactory,
+            BasicDeviceConnectionClientFactory deviceConnectionClientFactory) {
+
+        Objects.requireNonNull(registrationClientFactory);
+        Objects.requireNonNull(deviceConnectionClientFactory);
+
+        return new CommandTargetMapperContext() {
+
+            @Override
+            public Future<List<String>> getViaGateways(
+                    final String tenant,
+                    final String deviceId,
+                    final SpanContext context) {
+
+                Objects.requireNonNull(tenant);
+                Objects.requireNonNull(deviceId);
+
+                return registrationClientFactory.getOrCreateRegistrationClient(tenant)
+                        .compose(client -> client.assertRegistration(deviceId, null, context))
+                        .map(json -> Optional.ofNullable(json.getJsonArray(RegistrationConstants.FIELD_VIA))
+                                .map(array -> {
+                                    final List<String> result = array.stream()
+                                            .filter(String.class::isInstance)
+                                            .map(String.class::cast)
+                                            .collect(Collectors.toList());
+                                    return result;
+                                })
+                                .orElse(Collections.emptyList()));
+            }
+
+            @Override
+            public Future<JsonObject> getCommandHandlingAdapterInstances(
+                    final String tenant, 
+                    final String deviceId,
+                    final List<String> viaGateways,
+                    final SpanContext context) {
+
+                Objects.requireNonNull(tenant);
+                Objects.requireNonNull(deviceId);
+                Objects.requireNonNull(viaGateways);
+
+                return deviceConnectionClientFactory.getOrCreateDeviceConnectionClient(tenant)
+                        .compose(client -> client.getCommandHandlingAdapterInstances(deviceId, viaGateways, context));
+            }
+        };
+    }
+
+    /**
+     * Initializes the mapper with the given context.
+     *
+     * @param context The context that the mapper needs for doing its work.
+     * @throws NullPointerException if context is {@code null}.
+     */
+    void initialize(CommandTargetMapperContext context);
 
     /**
      * Determines the target protocol adapter instance for a command directed at the given device. Also determines
@@ -90,8 +195,8 @@ public interface CommandTargetMapper {
      * mapped to a gateway here, the {@link DeviceConnectionConstants#FIELD_PAYLOAD_DEVICE_ID} contains the given device
      * id itself.
      * <p>
-     * Note that {@link #initialize(RegistrationClientFactory, BasicDeviceConnectionClientFactory)} has to have been
-     * called already, otherwise a failed future is returned.
+     * Note that {@link #initialize(CommandTargetMapperContext)} has to have been called already,
+     * otherwise a failed future is returned.
      *
      * @param tenantId The tenant identifier.
      * @param deviceId The device identifier.

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandTargetMapperImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandTargetMapperImpl.java
@@ -14,21 +14,16 @@
 package org.eclipse.hono.client.impl;
 
 import java.net.HttpURLConnection;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.eclipse.hono.client.BasicDeviceConnectionClientFactory;
 import org.eclipse.hono.client.CommandTargetMapper;
-import org.eclipse.hono.client.RegistrationClientFactory;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.eclipse.hono.util.MessageHelper;
-import org.eclipse.hono.util.RegistrationConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,8 +45,7 @@ public class CommandTargetMapperImpl implements CommandTargetMapper {
 
     private final Tracer tracer;
     private final AtomicBoolean initialized = new AtomicBoolean(false);
-    private RegistrationClientFactory registrationClientFactory;
-    private BasicDeviceConnectionClientFactory deviceConnectionClientFactory;
+    private CommandTargetMapperContext mapperContext;
 
     /**
      * Creates a new GatewayMapperImpl instance.
@@ -64,10 +58,8 @@ public class CommandTargetMapperImpl implements CommandTargetMapper {
     }
 
     @Override
-    public void initialize(final RegistrationClientFactory registrationClientFactory,
-            final BasicDeviceConnectionClientFactory deviceConnectionClientFactory) {
-        this.registrationClientFactory = Objects.requireNonNull(registrationClientFactory);
-        this.deviceConnectionClientFactory = Objects.requireNonNull(deviceConnectionClientFactory);
+    public void initialize(final CommandTargetMapperContext context) {
+        this.mapperContext = Objects.requireNonNull(context);
         initialized.set(true);
     }
 
@@ -85,19 +77,12 @@ public class CommandTargetMapperImpl implements CommandTargetMapper {
                 .withTag(TracingHelper.TAG_DEVICE_ID, deviceId)
                 .start();
 
-        return registrationClientFactory.getOrCreateRegistrationClient(tenantId)
-                .compose(client -> client.assertRegistration(deviceId, null, span.context()))
+        return mapperContext.getViaGateways(tenantId, deviceId, span.context())
                 .recover(t -> {
                     LOG.debug("Error getting registration assertion", t);
                     return Future.failedFuture(t);
-                }).compose(registrationAssertionJson -> {
-                    final Object viaObject = registrationAssertionJson.getValue(RegistrationConstants.FIELD_VIA);
-                    @SuppressWarnings("unchecked")
-                    final List<String> viaGateways = viaObject instanceof JsonArray
-                            ? new ArrayList<String>(((JsonArray) viaObject).getList())
-                            : Collections.emptyList();
-                    return deviceConnectionClientFactory.getOrCreateDeviceConnectionClient(tenantId)
-                            .compose(client -> client.getCommandHandlingAdapterInstances(deviceId, viaGateways, span.context()))
+                }).compose(viaGateways -> {
+                    return mapperContext.getCommandHandlingAdapterInstances(tenantId, deviceId, viaGateways, span.context())
                             .compose(resultJson -> determineTargetInstanceJson(resultJson, deviceId, viaGateways, span));
                 }).map(result -> {
                     span.finish();

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandTargetMapperImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandTargetMapperImpl.java
@@ -79,7 +79,8 @@ public class CommandTargetMapperImpl implements CommandTargetMapper {
 
         return mapperContext.getViaGateways(tenantId, deviceId, span.context())
                 .recover(t -> {
-                    LOG.debug("Error getting registration assertion", t);
+                    LOG.debug("Error retrieving gateways authorized to act on behalf of device [tenant-id: {}, device-id: {}]",
+                            tenantId, deviceId, t);
                     return Future.failedFuture(t);
                 }).compose(viaGateways -> {
                     return mapperContext.getCommandHandlingAdapterInstances(tenantId, deviceId, viaGateways, span.context())

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
@@ -52,8 +52,9 @@ public class ProtonBasedDeviceRegistrationClient extends AbstractRequestResponse
      * @param connection The connection to the Device Registration service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
      * @param adapterConfig The protocol adapter's configuration properties.
-     * @param cacheProvider The cache provider to use for creating a cache for service responses.
-     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @param cacheProvider The cache provider to use for creating a cache for service responses or
+     *                      {@code null} if responses should not be cached.
+     * @throws NullPointerException if any of the parameters other than the cache provider are {@code null}.
      */
     public ProtonBasedDeviceRegistrationClient(
             final HonoConnection connection,
@@ -61,7 +62,7 @@ public class ProtonBasedDeviceRegistrationClient extends AbstractRequestResponse
             final ProtocolAdapterProperties adapterConfig,
             final CacheProvider cacheProvider) {
         super(connection, samplerFactory, adapterConfig, cacheProvider);
-        this.clientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
+        this.clientFactory = new CachingClientFactory<>(connection.getVertx(), RegistrationClient::isOpen);
         connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
                 this::handleTenantTimeout);
     }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.registry.amqp;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
+import org.eclipse.hono.cache.CacheProvider;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.RegistrationClient;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.impl.CachingClientFactory;
+import org.eclipse.hono.client.impl.RegistrationClientImpl;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.RegistrationConstants;
+import org.eclipse.hono.util.RegistrationResult;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.DecodeException;
+
+
+/**
+ * A vertx-proton based client of Hono's Device Registration service.
+ *
+ */
+public class ProtonBasedDeviceRegistrationClient extends AbstractRequestResponseClient<RegistrationResult>
+        implements DeviceRegistrationClient {
+
+    private final CachingClientFactory<org.eclipse.hono.client.RegistrationClient> clientFactory;
+
+    /**
+     * Creates a new client for a connection.
+     *
+     * @param connection The connection to the Device Registration service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param cacheProvider The cache provider to use for creating a cache for service responses.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public ProtonBasedDeviceRegistrationClient(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig,
+            final CacheProvider cacheProvider) {
+        super(connection, samplerFactory, adapterConfig, cacheProvider);
+        this.clientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
+        connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
+                this::handleTenantTimeout);
+    }
+
+    private Future<RegistrationClient> getOrCreateRegistrationClient(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+
+        return connection.isConnected(getDefaultConnectionCheckTimeout())
+                .compose(v -> connection.executeOnContext(result -> {
+                    clientFactory.getOrCreateClient(
+                            RegistrationClientImpl.getTargetAddress(tenantId),
+                            () -> RegistrationClientImpl.create(
+                                    responseCacheProvider,
+                                    connection,
+                                    tenantId,
+                                    samplerFactory.create(RegistrationConstants.REGISTRATION_ENDPOINT),
+                                    this::removeRegistrationClient,
+                                    this::removeRegistrationClient),
+                            result);
+                }));
+    }
+
+    private void removeRegistrationClient(final String tenantId) {
+        clientFactory.removeClient(RegistrationClientImpl.getTargetAddress(tenantId));
+    }
+
+    private void handleTenantTimeout(final Message<String> msg) {
+        final String address = RegistrationClientImpl.getTargetAddress(msg.body());
+        final RegistrationClient client = clientFactory.getClient(address);
+        if (client != null) {
+            client.close(v -> clientFactory.removeClient(address));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<RegistrationAssertion> assertRegistration(
+            final String tenantId,
+            final String deviceId,
+            final String gatewayId,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return getOrCreateRegistrationClient(tenantId)
+                .compose(client -> client.assertRegistration(deviceId, gatewayId, context))
+                .map(json -> {
+                    try {
+                        return json.mapTo(RegistrationAssertion.class);
+                    } catch (final DecodeException e) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("registration service returned invalid response:{}{}",
+                                    System.lineSeparator(), json.encodePrettily());
+                        }
+                        throw new ServerErrorException(
+                                HttpURLConnection.HTTP_INTERNAL_ERROR,
+                                "registration service returned invalid response");
+                    }
+                });
+    }
+}

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/registry/DeviceRegistrationClient.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/registry/DeviceRegistrationClient.java
@@ -33,28 +33,6 @@ public interface DeviceRegistrationClient extends Lifecycle {
      *
      * @param tenantId The ID of the tenant that the device belongs to.
      * @param deviceId The ID of the device to get the assertion for.
-     * @param context The currently active OpenTracing span. An implementation
-     *         should use this as the parent for any span it creates for tracing
-     *         the execution of this operation.
-     * @return A future indicating the result of the operation.
-     *         <p>
-     *         The future will succeed if a response with a status code in the [200, 300) range
-     *         has been received from the Device Registration service. The contained object will
-     *         then have properties according to the response message defined by
-     *         <a href="https://www.eclipse.org/hono/docs/api/device-registration/#assert-device-registration">
-     *         Assert Device Registration</a>.
-     *         <p>
-     *         Otherwise, the future will fail with a {@code org.eclipse.hono.client.ServiceInvocationException}
-     *         containing the (error) status code returned by the service.
-     * @throws NullPointerException if tenant or device ID are {@code null}.
-     */
-    Future<RegistrationAssertion> assertRegistration(String tenantId, String deviceId, SpanContext context);
-
-    /**
-     * Asserts that a device is registered and <em>enabled</em>.
-     *
-     * @param tenantId The ID of the tenant that the device belongs to.
-     * @param deviceId The ID of the device to get the assertion for.
      * @param gatewayId The gateway that tries to act on behalf of the device.
      *                  <p>
      *                  If not {@code null}, the service will verify that the gateway
@@ -73,7 +51,7 @@ public interface DeviceRegistrationClient extends Lifecycle {
      *         <p>
      *         Otherwise, the future will fail with a {@code org.eclipse.hono.client.ServiceInvocationException}
      *         containing the (error) status code returned by the service.
-     * @throws NullPointerException if tenant, device or gateway ID are {@code null}.
+     * @throws NullPointerException if tenant or device ID are {@code null}.
      */
     Future<RegistrationAssertion> assertRegistration(
             String tenantId,


### PR DESCRIPTION
Added implementations of the adapter client's DeviceRegistrationClient
interface which simply wraps the existing vertx-proton based
"legacy" RegistrationClientImpl.

In order to be able to use the legacy CommandTargetMapper, its direct
dependency on RegistrationClientFactory and
BasicDeviceConnectionClientFactory has been replaced with a
CommandTargetMapperContext interface which provides access to the
required functionality. Existing code using the CommandTargetMapper with
the legacy client will need to be adapted. For convenience, the
CommandTargetMapper.createContext() method can be used to get an
implementation based on RegistrationClientFactory and
BasicDeviceConnectionClientFactory.
