### PR TITLE
Use Maven profile for running Quarkus based adapters in ITs

### DIFF
--- a/adapters/base-quarkus/pom.xml
+++ b/adapters/base-quarkus/pom.xml
@@ -44,6 +44,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.jboss.logmanager</groupId>
+        <artifactId>jboss-logmanager-embedded</artifactId>
+        <version>1.0.6</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -67,12 +72,6 @@
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.jaegertracing</groupId>
-      <artifactId>jaeger-client</artifactId>
-      <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/adapters/http-vertx-quarkus/src/main/docker/Dockerfile.jvm
+++ b/adapters/http-vertx-quarkus/src/main/docker/Dockerfile.jvm
@@ -43,7 +43,7 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTIONS="-Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar

--- a/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/MetricsFactory.java
+++ b/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/MetricsFactory.java
@@ -48,11 +48,10 @@ public class MetricsFactory {
         return Collections.singletonList(new PrometheusScrapingResource((PrometheusMeterRegistry) registry));
     }
 
-    @SuppressWarnings("unchecked")
     @Produces
     @DefaultBean
     List<Handler<Router>> emptyResources() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Produces

--- a/adapters/mqtt-vertx-quarkus/src/main/docker/Dockerfile.jvm
+++ b/adapters/mqtt-vertx-quarkus/src/main/docker/Dockerfile.jvm
@@ -43,7 +43,7 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTIONS="-Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar

--- a/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
+++ b/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
@@ -28,7 +28,10 @@ import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient;
 import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
+import org.eclipse.hono.adapter.mqtt.MessageMapping;
 import org.eclipse.hono.adapter.mqtt.MicrometerBasedMqttAdapterMetrics;
+import org.eclipse.hono.adapter.mqtt.MqttContext;
+import org.eclipse.hono.adapter.mqtt.impl.HttpBasedMessageMapping;
 import org.eclipse.hono.adapter.mqtt.impl.VertxBasedMqttProtocolAdapter;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.cache.ExpiringValueCache;
@@ -55,6 +58,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.WebClient;
 
 /**
  * The Hono MQTT adapter main application class.
@@ -133,6 +137,7 @@ public class Application {
         adapter.setTenantClient(tenantClient());
         adapter.setTracer(tracer);
         adapter.setResourceLimitChecks(resourceLimitChecks);
+        adapter.setMessageMapping(messageMapping());
         return adapter;
     }
 
@@ -194,6 +199,12 @@ public class Application {
                 metrics,
                 config.mqtt,
                 newCaffeineCache(config.tenant.getResponseCacheMinSize(), config.tenant.getResponseCacheMaxSize()));
+    }
+
+    @Produces
+    MessageMapping<MqttContext> messageMapping() {
+        final WebClient webClient = WebClient.create(vertx);
+        return new HttpBasedMessageMapping(webClient, config.mqtt);
     }
 
     /**

--- a/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/MetricsFactory.java
+++ b/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/MetricsFactory.java
@@ -51,7 +51,7 @@ public class MetricsFactory {
     @Produces
     @DefaultBean
     List<Handler<Router>> emptyResources() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Produces

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -541,6 +541,11 @@
       </dependency>
       <dependency>
         <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-util</artifactId>
+        <version>${opentracing.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing</groupId>
         <artifactId>opentracing-noop</artifactId>
         <version>${opentracing.version}</version>
       </dependency>
@@ -886,6 +891,18 @@
         <artifactId>infinispan-query-dsl</artifactId>
         <version>${infinispan.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.jaegertracing</groupId>
+        <artifactId>jaeger-core</artifactId>
+        <version>${jaeger.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.jaegertracing</groupId>
+        <artifactId>jaeger-thrift</artifactId>
+        <version>${jaeger.version}</version>
+        <scope>runtime</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/service-base-quarkus/pom.xml
+++ b/service-base-quarkus/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-core</artifactId>
-      <version>${jaeger.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
@@ -165,4 +164,13 @@
       </build>
     </profile>
   </profiles>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.logmanager</groupId>
+        <artifactId>jboss-logmanager-embedded</artifactId>
+        <version>1.0.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -33,23 +33,69 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <maven.source.skip>true</maven.source.skip>
     <maven.install.skip>true</maven.install.skip>
     <gpg.skip>true</gpg.skip>
+
+    <!--
+      Hono service names
+    -->
+    <hono.amqp-network.host>hono-dispatch-router.hono</hono.amqp-network.host>
+    <hono.device-connection.host>hono-service-device-connection.hono</hono.device-connection.host>
+    <hono.registration.host>hono-service-device-registry.hono</hono.registration.host>
+    <hono.auth.host>hono-service-auth.hono</hono.auth.host>
+
+    <!-- milliseconds before vert.x complains about blocking the event loop -->
+    <max.event-loop.execute-time>5000</max.event-loop.execute-time>
+
+    <!-- logging profile used by all Hono components: prod, dev or trace -->
+    <logging.profile>prod</logging.profile>
+    <!-- maximum time (milliseconds) to wait for successful startup of a single service component -->
     <service.startup.timeout>120000</service.startup.timeout>
+    <!-- color used by components of the AMQP Messaging Network for logging -->
+    <log.color.amqp-network>magenta</log.color.amqp-network>
+    <!-- color used by components of the device registry for logging -->
+    <log.color.hono-device-registry>green</log.color.hono-device-registry>
+    <!-- color used by protocol adapters for logging -->
+    <log.color.hono-protocol-adapters>red</log.color.hono-protocol-adapters>
+    <!-- color used by remaining Hono services for logging -->
+    <log.color.hono-services>yellow</log.color.hono-services>
+    <!-- color used by extra (non-Hono) services for logging -->
+    <log.color.extra-services>cyan</log.color.extra-services>
+
+    <!--
+      Properties shared by all protocol adapters
+    -->
     <link.establishment.timeout>5000</link.establishment.timeout>
     <flow.latency>1000</flow.latency>
     <request.timeout>500</request.timeout>
     <adapter.sendMessageToDeviceTimeout>1000</adapter.sendMessageToDeviceTimeout>
     <!-- use minimum cost factor in order to speed up test execution -->
     <max.bcrypt.costFactor>4</max.bcrypt.costFactor>
-    <max.event-loop.execute-time>5000</max.event-loop.execute-time>
+
+    <!--
+      Device Registry related properties
+    -->
+    <!-- should be set to false if testing against a registry that doesn't support comparing client context
+         when retrieving credentials -->
+    <hono.deviceregistry.credentials.supportsClientContext>true</hono.deviceregistry.credentials.supportsClientContext>
     <!-- should be set to false if testing against a registry that doesn't support GW mode -->
-    <deviceregistry.supportsGatewayMode>true</deviceregistry.supportsGatewayMode>
-    <deviceregistry.credentials.supportsClientContext>true</deviceregistry.credentials.supportsClientContext>
-    <!-- should be set to true if testing against a registry that supports search devices operation -->
-    <deviceregistry.supportsSearchDevices>true</deviceregistry.supportsSearchDevices>
-    <hono.amqp-network.host>hono-dispatch-router.hono</hono.amqp-network.host>
-    <hono.device-connection.host>hono-service-device-connection.hono</hono.device-connection.host>
-    <hono.registration.host>hono-service-device-registry.hono</hono.registration.host>
-    <hono.auth.host>hono-service-auth.hono</hono.auth.host>
+    <hono.deviceregistry.supportsGatewayMode>true</hono.deviceregistry.supportsGatewayMode>
+    <!-- should be set to false if testing against a registry that doesn't support the "search Devices" operation -->
+    <hono.deviceregistry.supportsSearchDevices>true</hono.deviceregistry.supportsSearchDevices>
+    <hono.deviceregistry.image>hono-service-device-registry-file</hono.deviceregistry.image>
+    <hono.deviceregistry.resources.folder>deviceregistry</hono.deviceregistry.resources.folder>
+    <!-- Spring application profiles to activate for the registry -->
+    <hono.deviceregistry.spring.profiles>${logging.profile}</hono.deviceregistry.spring.profiles>
+
+    <hono.h2.disabled>true</hono.h2.disabled>
+    <hono.mongodb.disabled>true</hono.mongodb.disabled>
+
+    <hono.http-adapter.image>hono-adapter-http-vertx</hono.http-adapter.image>
+    <hono.http-adapter.config-dir>etc/hono</hono.http-adapter.config-dir>
+    <hono.http-adapter.nativeTlsRequired>true</hono.http-adapter.nativeTlsRequired>
+
+    <hono.mqtt-adapter.image>hono-adapter-mqtt-vertx</hono.mqtt-adapter.image>
+    <hono.mqtt-adapter.config-dir>etc/hono</hono.mqtt-adapter.config-dir>
+    <hono.mqtt-adapter.useNativeTransport>true</hono.mqtt-adapter.useNativeTransport>
+
     <default.java.options>
       -XX:MinRAMPercentage=80
       -XX:MaxRAMPercentage=90
@@ -59,23 +105,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <coap.java.options></coap.java.options>
     <http.java.options></http.java.options>
     <mqtt.java.options></mqtt.java.options>
-    <deviceregistry.image>hono-service-device-registry-file</deviceregistry.image>
-    <hono.deviceregistry.resources.folder>deviceregistry</hono.deviceregistry.resources.folder>
-    <hono.deviceregistry.spring.profiles></hono.deviceregistry.spring.profiles>
-    <hono.h2.disabled>true</hono.h2.disabled>
-    <hono.mongodb.image.repository>mongo</hono.mongodb.image.repository>
-    <hono.mongodb.disabled>true</hono.mongodb.disabled>
-    <!-- logging profile: either prod, dev or trace -->
-    <logging.profile>prod</logging.profile>
+
     <trace.frames>0</trace.frames>
     <jaeger.disabled>true</jaeger.disabled>
     <jaeger.host>hono-jaeger.hono</jaeger.host>
     <jaeger.query.port>18080</jaeger.query.port>
-    <log.color.amqp-network>magenta</log.color.amqp-network>
-    <log.color.hono-device-registry>green</log.color.hono-device-registry>
-    <log.color.hono-protocol-adapters>red</log.color.hono-protocol-adapters>
-    <log.color.hono-services>yellow</log.color.hono-services>
-    <log.color.extra-services>cyan</log.color.extra-services>
   </properties>
 
   <dependencies>
@@ -220,7 +254,10 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <profile>
       <id>device-registry-jdbc</id>
       <properties>
-        <deviceregistry.image>hono-service-device-registry-jdbc</deviceregistry.image>
+        <hono.deviceregistry.image>hono-service-device-registry-jdbc</hono.deviceregistry.image>
+        <hono.deviceregistry.resources.folder>deviceregistry-jdbc</hono.deviceregistry.resources.folder>
+        <hono.deviceregistry.spring.profiles>registry-adapter,registry-management,tenant-service,${logging.profile}</hono.deviceregistry.spring.profiles>
+        <hono.deviceregistry.credentials.supportsClientContext>false</hono.deviceregistry.credentials.supportsClientContext>
         <hono.h2.disabled>false</hono.h2.disabled>
         <hono.h2.host>hono-h2.hono</hono.h2.host>
         <hono.h2.port>9092</hono.h2.port>
@@ -229,9 +266,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
         <hono.jdbc.h2.admin.password>admin1234</hono.jdbc.h2.admin.password>
         <hono.jdbc.h2.registry.username>registry</hono.jdbc.h2.registry.username>
         <hono.jdbc.h2.registry.password>user12</hono.jdbc.h2.registry.password>
-        <hono.deviceregistry.resources.folder>deviceregistry-jdbc</hono.deviceregistry.resources.folder>
-        <hono.deviceregistry.spring.profiles>registry-adapter,registry-management,tenant-service,</hono.deviceregistry.spring.profiles>
-        <deviceregistry.credentials.supportsClientContext>false</deviceregistry.credentials.supportsClientContext>
       </properties>
     </profile>
     <profile>
@@ -243,15 +277,31 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
         </property>
       </activation>
       <properties>
-        <deviceregistry.image>hono-service-device-registry-mongodb</deviceregistry.image>
+        <hono.deviceregistry.image>hono-service-device-registry-mongodb</hono.deviceregistry.image>
+        <hono.deviceregistry.resources.folder>deviceregistry-mongodb</hono.deviceregistry.resources.folder>
         <hono.mongodb.disabled>false</hono.mongodb.disabled>
         <hono.mongodb.host>hono-mongodb.hono</hono.mongodb.host>
         <hono.mongodb.port>27017</hono.mongodb.port>
         <hono.mongodb.username>device-registry@HONO</hono.mongodb.username>
         <hono.mongodb.password>device-registry-secret</hono.mongodb.password>
         <hono.mongodb.database.name>hono-it-tests</hono.mongodb.database.name>
-        <hono.deviceregistry.resources.folder>deviceregistry-mongodb</hono.deviceregistry.resources.folder>
-        <deviceregistry.supportsSearchDevices>true</deviceregistry.supportsSearchDevices>
+      </properties>
+    </profile>
+    <profile>
+      <id>protocol-adapters-quarkus</id>
+      <activation>
+        <property>
+          <name>hono.adapters.type</name>
+          <value>quarkus</value>
+        </property>
+      </activation>
+      <properties>
+        <hono.http-adapter.config-dir>deployments/config</hono.http-adapter.config-dir>
+        <hono.http-adapter.image>hono-adapter-http-vertx-quarkus</hono.http-adapter.image>
+        <hono.http-adapter.nativeTlsRequired>false</hono.http-adapter.nativeTlsRequired>
+        <hono.mqtt-adapter.config-dir>deployments/config</hono.mqtt-adapter.config-dir>
+        <hono.mqtt-adapter.image>hono-adapter-mqtt-vertx-quarkus</hono.mqtt-adapter.image>
+        <hono.mqtt-adapter.useNativeTransport>false</hono.mqtt-adapter.useNativeTransport>
       </properties>
     </profile>
     <profile>
@@ -371,7 +421,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <build>
                     <skip>${hono.mongodb.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${hono.mongodb.image.repository}:${mongodb.version}</from>
+                    <from>mongo:${mongodb.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -551,7 +601,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <alias>device-registry</alias>
                   <build>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/${deviceregistry.image}:${project.version}</from>
+                    <from>${docker.repository}/${hono.deviceregistry.image}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -595,7 +645,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <env>
                       <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
-                      <SPRING_PROFILES_ACTIVE>${hono.deviceregistry.spring.profiles}${logging.profile}</SPRING_PROFILES_ACTIVE>
+                      <SPRING_PROFILES_ACTIVE>${hono.deviceregistry.spring.profiles}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${default.java.options}</JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
                       <JAEGER_SERVICE_NAME>device-registry</JAEGER_SERVICE_NAME>
@@ -830,11 +880,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <alias>http-adapter</alias>
                   <build>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/hono-adapter-http-vertx:${project.version}</from>
-                    <!--
-                    Enable to test with Quarkus adapter
-                    <from>${docker.image.org-name}/hono-adapter-http-vertx-quarkus:${project.version}</from>
-                    -->
+                    <from>${docker.repository}/${hono.http-adapter.image}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -852,21 +898,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                         <fileSets>
                           <fileSet>
                             <directory>${project.build.directory}/resources/http</directory>
-                            <outputDirectory>etc/hono</outputDirectory>
+                            <outputDirectory>${hono.http-adapter.config-dir}</outputDirectory>
                             <includes>
                               <include>*</include>
                             </includes>
                           </fileSet>
-                          <!--
-                          Enable to configure Quarkus JVM image
-                          <fileSet>
-                            <directory>${project.build.directory}/resources/http</directory>
-                            <outputDirectory>/deployments/config</outputDirectory>
-                            <includes>
-                              <include>*</include>
-                            </includes>
-                          </fileSet>
-                          -->
                           <fileSet>
                             <directory>${project.build.directory}/certs</directory>
                             <outputDirectory>etc/hono/certs</outputDirectory>
@@ -898,6 +934,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <SPRING_CONFIG_LOCATION>file:/etc/hono/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${default.java.options} ${http.java.options}</JDK_JAVA_OPTIONS>
+                      <!--
+                        disable -Xmx calculation done by the runJava.sh script
+                        used by the Quarkus based images
+                      -->
+                      <JAVA_MAX_MEM_RATIO>0</JAVA_MAX_MEM_RATIO>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
                       <JAEGER_SERVICE_NAME>hono-adapter-http</JAEGER_SERVICE_NAME>
                       <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
@@ -925,7 +966,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <alias>mqtt-adapter</alias>
                   <build>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/hono-adapter-mqtt-vertx:${project.version}</from>
+                    <from>${docker.repository}/${hono.mqtt-adapter.image}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -943,7 +984,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                         <fileSets>
                           <fileSet>
                             <directory>${project.build.directory}/resources/mqtt</directory>
-                            <outputDirectory>etc/hono</outputDirectory>
+                            <outputDirectory>${hono.mqtt-adapter.config-dir}</outputDirectory>
                             <includes>
                               <include>*</include>
                             </includes>
@@ -979,6 +1020,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>${logging.profile}</SPRING_PROFILES_ACTIVE>
                       <JDK_JAVA_OPTIONS>${default.java.options} ${mqtt.java.options}</JDK_JAVA_OPTIONS>
+                      <!--
+                        disable -Xmx calculation done by the runJava.sh script
+                        used by the Quarkus based images
+                      -->
+                      <JAVA_MAX_MEM_RATIO>0</JAVA_MAX_MEM_RATIO>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
                       <JAEGER_SERVICE_NAME>hono-adapter-mqtt</JAEGER_SERVICE_NAME>
                       <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
@@ -1205,9 +1251,9 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 <deviceregistry.host>${deviceregistry.ip}</deviceregistry.host>
                 <deviceregistry.amqp.port>${deviceregistry.amqp.port}</deviceregistry.amqp.port>
                 <deviceregistry.http.port>${deviceregistry.http.port}</deviceregistry.http.port>
-                <deviceregistry.supportsGatewayMode>${deviceregistry.supportsGatewayMode}</deviceregistry.supportsGatewayMode>
-                <deviceregistry.credentials.supportsClientContext>${deviceregistry.credentials.supportsClientContext}</deviceregistry.credentials.supportsClientContext>
-                <deviceregistry.supportsSearchDevices>${deviceregistry.supportsSearchDevices}</deviceregistry.supportsSearchDevices>
+                <deviceregistry.supportsGatewayMode>${hono.deviceregistry.supportsGatewayMode}</deviceregistry.supportsGatewayMode>
+                <deviceregistry.credentials.supportsClientContext>${hono.deviceregistry.credentials.supportsClientContext}</deviceregistry.credentials.supportsClientContext>
+                <deviceregistry.supportsSearchDevices>${hono.deviceregistry.supportsSearchDevices}</deviceregistry.supportsSearchDevices>
                 <adapter.coap.host>${coap.ip}</adapter.coap.host>
                 <adapter.coap.port>${coap.port}</adapter.coap.port>
                 <adapter.coaps.port>${coaps.port}</adapter.coaps.port>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -93,3 +93,12 @@ Start subsequent test runs using the running containers with the `useRunningCont
 In order to stop and remove the Docker containers started by a test run, use:
 
     $ mvn verify -PstopContainers
+
+### Running the Tests with the Quarkus based Protocol Adapters
+
+By default, the integration tests are run using the Spring Boot based protocol adapters. For some protocol adapters there are
+Quarkus based alternative implememtations. The tests can be run using these Quarkus based adapters by means of activating
+the `protocol-adapters-quarkus` maven profile:
+
+    $ mvn verify -Prun-tests,protocol-adapters-quarkus
+

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -11,7 +11,7 @@ hono:
     bindAddress: 0.0.0.0
     insecurePortBindAddress: 0.0.0.0
     insecurePortEnabled: true
-    nativeTlsRequired: true # Use false when testing with Quarkus image for now
+    nativeTlsRequired: ${hono.http-adapter.nativeTlsRequired}
     keyPath: /etc/hono/certs/http-adapter-key.pem
     certPath: /etc/hono/certs/http-adapter-cert.pem
     maxPayloadSize: 2048
@@ -75,6 +75,17 @@ hono:
     requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+
+quarkus:
+  log:
+    console:
+      color: true
+    level: INFO
+    category:
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.adapter":
+        level: INFO
 
 spring:
   jmx:

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -75,7 +75,18 @@ hono:
     requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
-    preferNative: true
+    preferNative: ${hono.mqtt-adapter.useNativeTransport}
+
+quarkus:
+  log:
+    console:
+      color: true
+    level: INFO
+    category:
+      "org.eclipse.hono":
+        level: INFO
+      "org.eclipse.hono.adapter":
+        level: INFO
 
 spring:
   jmx:


### PR DESCRIPTION
The ITs can now be run by activating the "protocol-adapters-quarkus"
Maven profile.