### PR TITLE
[#2267] Add AMQP 1.0 based CredentialsClient implementation

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -183,11 +183,11 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                                 .withTag(Tags.COMPONENT.getKey(), getTypeName())
                                 .start(),
                         new SaslPlainAuthHandler(
-                                new UsernamePasswordAuthProvider(getCredentialsClientFactory(), tracer),
+                                new UsernamePasswordAuthProvider(getCredentialsClient(), tracer),
                                 this::handleBeforeCredentialsValidation),
                         new SaslExternalAuthHandler(
                                 new TenantServiceBasedX509Authentication(getTenantClient(), tracer),
-                                new X509AuthProvider(getCredentialsClientFactory(), tracer),
+                                new X509AuthProvider(getCredentialsClient(), tracer),
                                 this::handleBeforeCredentialsValidation));
             }
             return Future.succeededFuture();

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -363,14 +363,14 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
 
         final ApplicationLevelInfoSupplier deviceResolver = Optional.ofNullable(honoDeviceResolver)
                 .orElseGet(() -> new DefaultDeviceResolver(context, tracer, getTypeName(), getConfig(),
-                        getCredentialsClientFactory(), getTenantClient()));
+                        getCredentialsClient(), getTenantClient()));
         final AdvancedPskStore store = Optional.ofNullable(pskStore)
                 .orElseGet(() -> {
                     if (deviceResolver instanceof AdvancedPskStore) {
                         return (AdvancedPskStore) deviceResolver;
                     } else {
                         return new DefaultDeviceResolver(context, tracer, getTypeName(), getConfig(),
-                                getCredentialsClientFactory(), getTenantClient());
+                                getCredentialsClient(), getTenantClient());
                     }
                 });
 

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DefaultDeviceResolver.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/DefaultDeviceResolver.java
@@ -89,7 +89,7 @@ public class DefaultDeviceResolver implements ApplicationLevelInfoSupplier, Adva
      * @param tracer The OpenTracing tracer.
      * @param adapterName The name of the protocol adapter.
      * @param config The configuration properties.
-     * @param credentialsClientFactory The factory to use for creating clients to the Credentials service.
+     * @param credentialsClient The client to use for accessing the Credentials service.
      * @param tenantClient The client to use for accessing the Tenant service.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
@@ -98,15 +98,15 @@ public class DefaultDeviceResolver implements ApplicationLevelInfoSupplier, Adva
             final Tracer tracer,
             final String adapterName,
             final CoapAdapterProperties config,
-            final CredentialsClient credentialsClientFactory,
+            final CredentialsClient credentialsClient,
             final TenantClient tenantClient) {
 
         this.context = Objects.requireNonNull(vertxContext);
         this.tracer = Objects.requireNonNull(tracer);
         this.adapterName = Objects.requireNonNull(adapterName);
         this.config = Objects.requireNonNull(config);
-        this.credentialsClient = Objects.requireNonNull(credentialsClientFactory);
-        this.tenantClient = tenantClient;
+        this.credentialsClient = Objects.requireNonNull(credentialsClient);
+        this.tenantClient = Objects.requireNonNull(tenantClient);
     }
 
     /**

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -990,7 +990,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         adapter.setTelemetrySender(telemetrySender);
         adapter.setRegistrationClient(registrationClient);
         if (complete) {
-            adapter.setCredentialsClientFactory(credentialsClientFactory);
+            adapter.setCredentialsClient(credentialsClient);
         }
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
@@ -106,10 +106,10 @@ public final class VertxBasedHttpProtocolAdapter extends AbstractVertxBasedHttpP
             authHandler.append(new X509AuthHandler(
                     new TenantServiceBasedX509Authentication(getTenantClient(), tracer),
                     Optional.ofNullable(clientCertAuthProvider).orElseGet(
-                            () -> new X509AuthProvider(getCredentialsClientFactory(), tracer))));
+                            () -> new X509AuthProvider(getCredentialsClient(), tracer))));
             authHandler.append(new HonoBasicAuthHandler(
                     Optional.ofNullable(usernamePasswordAuthProvider).orElseGet(
-                            () -> new UsernamePasswordAuthProvider(getCredentialsClientFactory(), tracer)),
+                            () -> new UsernamePasswordAuthProvider(getCredentialsClient(), tracer)),
                     getConfig().getRealm()));
             addTelemetryApiRoutes(router, authHandler);
             addEventApiRoutes(router, authHandler);

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -149,10 +149,10 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
         authHandler.append(new X509AuthHandler(
                 new TenantServiceBasedX509Authentication(getTenantClient(), tracer),
                 Optional.ofNullable(clientCertAuthProvider).orElseGet(
-                        () -> new X509AuthProvider(getCredentialsClientFactory(), tracer))));
+                        () -> new X509AuthProvider(getCredentialsClient(), tracer))));
         authHandler.append(new HonoBasicAuthHandler(
                 Optional.ofNullable(usernamePasswordAuthProvider).orElseGet(
-                        () -> new UsernamePasswordAuthProvider(getCredentialsClientFactory(), tracer)),
+                        () -> new UsernamePasswordAuthProvider(getCredentialsClient(), tracer)),
                 getConfig().getRealm()));
 
         router.route().handler(authHandler);

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -180,10 +180,10 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         return new ChainAuthHandler<>(this::handleBeforeCredentialsValidation)
                 .append(new X509AuthHandler(
                         new TenantServiceBasedX509Authentication(getTenantClient(), tracer),
-                        new X509AuthProvider(getCredentialsClientFactory(), tracer)))
+                        new X509AuthProvider(getCredentialsClient(), tracer)))
                 .append(new ConnectPacketAuthHandler(
                         new UsernamePasswordAuthProvider(
-                                getCredentialsClientFactory(),
+                                getCredentialsClient(),
                                 tracer)));
     }
 

--- a/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
+++ b/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
@@ -23,8 +23,10 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.TenantClient;
+import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedCredentialsClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient;
 import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
@@ -36,7 +38,6 @@ import org.eclipse.hono.adapter.mqtt.impl.VertxBasedMqttProtocolAdapter;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.CommandTargetMapper;
-import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
@@ -127,7 +128,7 @@ public class Application {
         adapter.setCommandConsumerFactory(commandConsumerFactory());
         adapter.setCommandTargetMapper(commandTargetMapper());
         adapter.setConfig(config.mqtt);
-        adapter.setCredentialsClientFactory(credentialsClientFactory());
+        adapter.setCredentialsClient(credentialsClient());
         adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory());
         adapter.setEventSender(newDownstreamSender());
         adapter.setHealthCheckServer(healthCheckServer());
@@ -164,11 +165,12 @@ public class Application {
     }
 
     @Produces
-    CredentialsClientFactory credentialsClientFactory() {
-        return CredentialsClientFactory.create(
+    CredentialsClient credentialsClient() {
+        return new ProtonBasedCredentialsClient(
                 HonoConnection.newConnection(vertx, config.credentials),
-                newCaffeineCache(config.credentials.getResponseCacheMinSize(), config.credentials.getResponseCacheMaxSize()),
-                metrics);
+                metrics,
+                config.mqtt,
+                newCaffeineCache(config.credentials.getResponseCacheMinSize(), config.credentials.getResponseCacheMaxSize()));
     }
 
     @Produces

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -106,7 +106,7 @@ public final class SigfoxProtocolAdapter
 
         authHandler.append(new HonoBasicAuthHandler(
                 Optional.ofNullable(this.usernamePasswordAuthProvider).orElseGet(
-                        () -> new UsernamePasswordAuthProvider(getCredentialsClientFactory(), this.tracer)),
+                        () -> new UsernamePasswordAuthProvider(getCredentialsClient(), this.tracer)),
                 getConfig().getRealm()));
 
         router.route().handler(authHandler);

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.registry.amqp;
+
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.registry.CredentialsClient;
+import org.eclipse.hono.cache.CacheProvider;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.impl.CachingClientFactory;
+import org.eclipse.hono.client.impl.CredentialsClientImpl;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.eclipse.hono.util.CredentialsObject;
+import org.eclipse.hono.util.CredentialsResult;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+
+
+/**
+ * A vertx-proton based client of Hono's Credentials service.
+ *
+ */
+public class ProtonBasedCredentialsClient extends AbstractRequestResponseClient<CredentialsResult<CredentialsObject>> implements CredentialsClient {
+
+    private final CachingClientFactory<org.eclipse.hono.client.CredentialsClient> clientFactory;
+
+    /**
+     * Creates a new client for a connection.
+     *
+     * @param connection The connection to the Credentials service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param cacheProvider The cache provider to use for creating a cache for service responses or
+     *                      {@code null} if responses should not be cached.
+     * @throws NullPointerException if any of the parameters other than the cache provider are {@code null}.
+     */
+    public ProtonBasedCredentialsClient(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig,
+            final CacheProvider cacheProvider) {
+        super(connection, samplerFactory, adapterConfig, cacheProvider);
+        this.clientFactory = new CachingClientFactory<>(connection.getVertx(), org.eclipse.hono.client.CredentialsClient::isOpen);
+        connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
+                this::handleTenantTimeout);
+    }
+
+    private void removeCredentialsClient(final String tenantId) {
+        clientFactory.removeClient(CredentialsClientImpl.getTargetAddress(tenantId));
+    }
+
+    private void handleTenantTimeout(final Message<String> msg) {
+        final String address = CredentialsClientImpl.getTargetAddress(msg.body());
+        final org.eclipse.hono.client.CredentialsClient client = clientFactory.getClient(address);
+        if (client != null) {
+            client.close(v -> clientFactory.removeClient(address));
+        }
+    }
+
+    private Future<org.eclipse.hono.client.CredentialsClient> getOrCreateCredentialsClient(
+            final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+        return connection.isConnected(getDefaultConnectionCheckTimeout())
+                .compose(v -> connection.executeOnContext(result -> {
+                    clientFactory.getOrCreateClient(
+                            CredentialsClientImpl.getTargetAddress(tenantId),
+                            () -> CredentialsClientImpl.create(
+                                    responseCacheProvider,
+                                    connection,
+                                    tenantId,
+                                    samplerFactory.create(CredentialsConstants.CREDENTIALS_ENDPOINT),
+                                    this::removeCredentialsClient,
+                                    this::removeCredentialsClient),
+                            result);
+                }));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<CredentialsObject> get(
+            final String tenantId,
+            final String type,
+            final String authId,
+            final SpanContext spanContext) {
+
+        return get(tenantId, type, authId, new JsonObject(), spanContext);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<CredentialsObject> get(
+            final String tenantId,
+            final String type,
+            final String authId,
+            final JsonObject clientContext,
+            final SpanContext spanContext) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(authId);
+        Objects.requireNonNull(clientContext);
+
+        return getOrCreateCredentialsClient(tenantId)
+                .compose(client -> client.get(type, authId, clientContext, spanContext));
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -305,7 +305,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * Sets the client to use for accessing the Credentials service.
      *
      * @param client The client.
-     * @throws NullPointerException if the factory is {@code null}.
+     * @throws NullPointerException if the client is {@code null}.
      */
     @Qualifier(CredentialsConstants.CREDENTIALS_ENDPOINT)
     @Autowired

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/UsernamePasswordAuthProvider.java
@@ -17,11 +17,11 @@ import java.net.HttpURLConnection;
 import java.util.Base64;
 import java.util.Objects;
 
+import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.util.CredentialsObject;
 import org.eclipse.hono.util.JsonHelper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,30 +44,30 @@ public final class UsernamePasswordAuthProvider extends CredentialsApiAuthProvid
     /**
      * Creates a new provider for a given configuration.
      *
-     * @param credentialsClientFactory The factory to use for creating a Credentials service client.
+     * @param credentialsClient The client to use for accessing the Credentials service.
      * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
-    public UsernamePasswordAuthProvider(final CredentialsClientFactory credentialsClientFactory, final Tracer tracer) {
-        this(credentialsClientFactory, new SpringBasedHonoPasswordEncoder(), tracer);
+    public UsernamePasswordAuthProvider(final CredentialsClient credentialsClient, final Tracer tracer) {
+        this(credentialsClient, new SpringBasedHonoPasswordEncoder(), tracer);
     }
 
     /**
      * Creates a new provider for a given configuration.
      *
-     * @param credentialsClientFactory The factory to use for creating a Credentials service client.
+     * @param credentialsClient The client to use for accessing the Credentials service.
      * @param pwdEncoder The object to use for validating hashed passwords.
      * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
     public UsernamePasswordAuthProvider(
-            final CredentialsClientFactory credentialsClientFactory,
+            final CredentialsClient credentialsClient,
             final HonoPasswordEncoder pwdEncoder,
             final Tracer tracer) {
 
-        super(credentialsClientFactory, tracer);
+        super(credentialsClient, tracer);
         this.pwdEncoder = Objects.requireNonNull(pwdEncoder);
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/device/X509AuthProvider.java
@@ -15,8 +15,8 @@ package org.eclipse.hono.service.auth.device;
 
 import java.util.Objects;
 
+import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,13 +36,13 @@ public class X509AuthProvider extends CredentialsApiAuthProvider<SubjectDnCreden
     /**
      * Creates a new provider for a given configuration.
      *
-     * @param credentialsClientFactory The factory to use for creating a Credentials service client.
+     * @param credentialsClient The client to use for accessing the Credentials service.
      * @param tracer The tracer instance.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     @Autowired
-    public X509AuthProvider(final CredentialsClientFactory credentialsClientFactory, final Tracer tracer) {
-        super(credentialsClientFactory, tracer);
+    public X509AuthProvider(final CredentialsClient credentialsClient, final Tracer tracer) {
+        super(credentialsClient, tracer);
     }
 
     /**

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.adapter.client.telemetry.EventSender;
@@ -42,7 +43,6 @@ import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.CommandTargetMapper;
-import org.eclipse.hono.client.CredentialsClientFactory;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.HonoConnection;
@@ -94,7 +94,7 @@ public class AbstractProtocolAdapterBaseTest {
     private AbstractProtocolAdapterBase<ProtocolAdapterProperties> adapter;
     private TenantClient tenantClient;
     private DeviceRegistrationClient registrationClient;
-    private CredentialsClientFactory credentialsClientFactory;
+    private CredentialsClient credentialsClient;
     private TelemetrySender telemetrySender;
     private EventSender eventSender;
     private ProtocolAdapterCommandConsumerFactory commandConsumerFactory;
@@ -115,8 +115,8 @@ public class AbstractProtocolAdapterBaseTest {
         registrationClient = mock(DeviceRegistrationClient.class);
         when(registrationClient.start()).thenReturn(Future.succeededFuture());
 
-        credentialsClientFactory = mock(CredentialsClientFactory.class);
-        when(credentialsClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+        credentialsClient = mock(CredentialsClient.class);
+        when(credentialsClient.start()).thenReturn(Future.succeededFuture());
 
         telemetrySender = mock(TelemetrySender.class);
         when(telemetrySender.start()).thenReturn(Future.succeededFuture());
@@ -153,7 +153,7 @@ public class AbstractProtocolAdapterBaseTest {
     private void setCollaborators(final AbstractProtocolAdapterBase<?> adapter) {
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setCommandTargetMapper(commandTargetMapper);
-        adapter.setCredentialsClientFactory(credentialsClientFactory);
+        adapter.setCredentialsClient(credentialsClient);
         adapter.setDeviceConnectionClientFactory(deviceConnectionClientFactory);
         adapter.setEventSender(eventSender);
         adapter.setRegistrationClient(registrationClient);
@@ -220,7 +220,7 @@ public class AbstractProtocolAdapterBaseTest {
             verify(eventSender).start();
             verify(tenantClient).start();
             verify(registrationClient).start();
-            verify(credentialsClientFactory).connect();
+            verify(credentialsClient).start();
             verify(commandConsumerFactory).connect();
             verify(commandConsumerFactory).addDisconnectListener(any(DisconnectListener.class));
             verify(commandConsumerFactory).addReconnectListener(any(ReconnectListener.class));

--- a/service-base/src/test/java/org/eclipse/hono/service/auth/device/X509AuthProviderTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/auth/device/X509AuthProviderTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import org.eclipse.hono.client.CredentialsClientFactory;
+import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -38,8 +38,8 @@ class X509AuthProviderTest {
 
     @BeforeAll
     static void setUp() {
-        final CredentialsClientFactory credentialsClientFactory = mock(CredentialsClientFactory.class);
-        provider = new X509AuthProvider(credentialsClientFactory, NoopTracerFactory.create());
+        final CredentialsClient credentialsClient = mock(CredentialsClient.class);
+        provider = new X509AuthProvider(credentialsClient, NoopTracerFactory.create());
 
     }
 


### PR DESCRIPTION
Added implementations of the adapter client's CredentialsClient
interface which simply wraps the existing vertx-proton based
"legacy" CredentialsClientImpl.