### PR TITLE
[#2267] Decouple command consumer from device connection client factory

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -72,8 +72,8 @@ public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClien
 
     /**
      * Identifier that has to be unique to this factory instance.
-     * Will be used to represent the protocol adapter instance that this factory instance is used in, when registering
-     * command handlers with the Device Connection service.
+     * Will be used to represent the protocol adapter instance that this factory instance is used in,
+     * when registering command handlers with the CommandHandlingAdapterInfoAccess service.
      */
     private final String adapterInstanceId;
     private final AdapterInstanceCommandHandler adapterInstanceCommandHandler;

--- a/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
@@ -36,6 +36,7 @@ import org.eclipse.hono.client.DeviceConnectionClient;
 import org.eclipse.hono.client.DeviceConnectionClientFactory;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumer;
+import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
@@ -140,7 +141,9 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
                 .thenReturn(Future.succeededFuture());
 
         commandConsumerFactory = new ProtocolAdapterCommandConsumerFactoryImpl(connection, SendMessageSampler.Factory.noop());
-        commandConsumerFactory.initialize(commandTargetMapper, deviceConnectionClientFactory);
+        commandConsumerFactory.initialize(
+                commandTargetMapper,
+                ProtocolAdapterCommandConsumerFactory.createCommandHandlingAdapterInfoAccess(deviceConnectionClientFactory));
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -544,7 +544,9 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                             .compose(client -> client.getCommandHandlingAdapterInstances(deviceId, viaGateways, context));
                 }
             });
-            commandConsumerFactory.initialize(commandTargetMapper, deviceConnectionClientFactory);
+            commandConsumerFactory.initialize(
+                    commandTargetMapper,
+                    ProtocolAdapterCommandConsumerFactory.createCommandHandlingAdapterInfoAccess(deviceConnectionClientFactory));
 
             doStart(result);
         }


### PR DESCRIPTION
The ProtocolAdapterCommandConsumerFactory's dependency on the legacy
DeviceConnectionClientFactory has been replaced by an interface that
provides access to the required command handling adapter instance
information. This is a preliminary step for introducing a new
DeviceConnectionClient to the adapter-client module.
