### PR TITLE
Add MockSupport classes in core-test-utils

### DIFF
--- a/client-device-connection-infinispan/pom.xml
+++ b/client-device-connection-infinispan/pom.xml
@@ -29,12 +29,6 @@
       <artifactId>infinispan-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-query-dsl</artifactId>
-      <!-- This is currently only needed to mock a RemoteCache instance in a test. -->
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
     </dependency>
@@ -49,6 +43,48 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>protoparser</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-adapter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-query-dsl</artifactId>
+      <!-- This is currently only needed to mock a RemoteCache instance in a test. -->
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -86,40 +122,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup</groupId>
-      <artifactId>protoparser</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-client-adapter</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
+      <artifactId>core-test-utils</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -35,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -44,12 +44,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.tag.Tag;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -97,7 +94,6 @@ class CacheBasedDeviceConnectionInfoTest {
     /**
      * Sets up the fixture.
      */
-    @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp(final Vertx vertx, final VertxTestContext testContext) {
 
@@ -107,19 +103,8 @@ class CacheBasedDeviceConnectionInfoTest {
         cache = new EmbeddedCache<>(vertx, cacheManager, "cache-name", "foo", "bar");
         cache.start().onComplete(testContext.completing());
 
-        final SpanContext spanContext = mock(SpanContext.class);
-        span = mock(Span.class);
-        when(span.context()).thenReturn(spanContext);
-        final Tracer.SpanBuilder spanBuilder = mock(Tracer.SpanBuilder.class, Mockito.RETURNS_SMART_NULLS);
-        when(spanBuilder.addReference(anyString(), any())).thenReturn(spanBuilder);
-        when(spanBuilder.withTag(anyString(), anyBoolean())).thenReturn(spanBuilder);
-        when(spanBuilder.withTag(anyString(), (String) any())).thenReturn(spanBuilder);
-        when(spanBuilder.withTag(anyString(), (Number) any())).thenReturn(spanBuilder);
-        when(spanBuilder.withTag(any(Tag.class), any())).thenReturn(spanBuilder);
-        when(spanBuilder.ignoreActiveSpan()).thenReturn(spanBuilder);
-        when(spanBuilder.start()).thenReturn(span);
-        tracer = mock(Tracer.class);
-        when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
+        span = TracingMockSupport.mockSpan();
+        tracer = TracingMockSupport.mockTracer(span);
 
         info = new CacheBasedDeviceConnectionInfo(cache, tracer);
     }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>micrometer-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>core-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/client/src/test/java/org/eclipse/hono/client/AbstractAmqpAdapterClientDownstreamSenderTestBase.java
+++ b/client/src/test/java/org/eclipse/hono/client/AbstractAmqpAdapterClientDownstreamSenderTestBase.java
@@ -15,7 +15,6 @@ package org.eclipse.hono.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,13 +25,13 @@ import java.util.Map;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.impl.HonoClientUnitTestHelper;
-import org.eclipse.hono.client.impl.VertxMockSupport;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
 
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -74,12 +73,9 @@ public abstract class AbstractAmqpAdapterClientDownstreamSenderTestBase {
 
         when(sender.send(any(Message.class), VertxMockSupport.anyHandler())).thenReturn(protonDelivery);
 
-        final Span span = mock(Span.class);
-        when(span.context()).thenReturn(mock(SpanContext.class));
-        spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
-
-        final Tracer tracer = mock(Tracer.class);
-        when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
+        final Span span = TracingMockSupport.mockSpan();
+        spanBuilder = TracingMockSupport.mockSpanBuilder(span);
+        final Tracer tracer = TracingMockSupport.mockTracer(spanBuilder);
 
         connection = HonoClientUnitTestHelper.mockHonoConnection(mock(Vertx.class));
 

--- a/client/src/test/java/org/eclipse/hono/client/CommandTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/CommandTest.java
@@ -170,7 +170,7 @@ public class CommandTest {
         assertTrue(cmd.isValid());
         assertThat(cmd.getName()).isEqualTo("doThis");
         assertThat(cmd.getCorrelationId()).isEqualTo(correlationId);
-        assertThat(cmd.getReplyToId()).isNull();;
+        assertThat(cmd.getReplyToId()).isNull();
         assertTrue(cmd.isOneWay());
     }
 

--- a/client/src/test/java/org/eclipse/hono/client/device/amqp/internal/AmqpAdapterClientCommandConsumerTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/device/amqp/internal/AmqpAdapterClientCommandConsumerTest.java
@@ -31,7 +31,7 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.ReconnectListener;
 import org.eclipse.hono.client.impl.HonoClientUnitTestHelper;
-import org.eclipse.hono.client.impl.VertxMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
@@ -43,6 +43,7 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractSenderTest.java
@@ -31,6 +31,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractTenantTimeoutRelatedClientFactoryTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractTenantTimeoutRelatedClientFactoryTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.Constants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/client/src/test/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandlerTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandlerTest.java
@@ -15,7 +15,6 @@ package org.eclipse.hono.client.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,6 +27,8 @@ import org.apache.qpid.proton.amqp.messaging.Released;
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.CommandContext;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.Handler;
 import io.vertx.proton.ProtonDelivery;
@@ -54,12 +54,8 @@ public class AdapterInstanceCommandHandlerTest {
      */
     @BeforeEach
     public void setUp() {
-        final SpanContext spanContext = mock(SpanContext.class);
-        final Span span = mock(Span.class);
-        when(span.context()).thenReturn(spanContext);
-        final Tracer.SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
-        final Tracer tracer = mock(Tracer.class);
-        when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
+        final Span span = TracingMockSupport.mockSpan();
+        final Tracer tracer = TracingMockSupport.mockTracer(span);
 
         final String adapterInstanceId = "adapterInstanceId";
         adapterInstanceCommandHandler = new AdapterInstanceCommandHandler(tracer, adapterInstanceId);

--- a/client/src/test/java/org/eclipse/hono/client/impl/CachingClientFactoryTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CachingClientFactoryTest.java
@@ -26,6 +26,7 @@ import java.net.HttpURLConnection;
 
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandClientImplTest.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.Constants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/client/src/test/java/org/eclipse/hono/client/impl/CommandTargetMapperImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CommandTargetMapperImplTest.java
@@ -26,12 +26,12 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.hono.client.CommandTargetMapper.CommandTargetMapperContext;
+import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
@@ -53,12 +53,8 @@ public class CommandTargetMapperImplTest {
      */
     @BeforeEach
     public void setup() {
-        final SpanContext spanContext = mock(SpanContext.class);
-        span = mock(Span.class);
-        when(span.context()).thenReturn(spanContext);
-        final Tracer.SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
-        final Tracer tracer = mock(Tracer.class);
-        when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
+        span = TracingMockSupport.mockSpan();
+        final Tracer tracer = TracingMockSupport.mockTracer(span);
 
         tenantId = "testTenant";
         deviceId = "testDevice";

--- a/client/src/test/java/org/eclipse/hono/client/impl/CredentialsClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/CredentialsClientImplTest.java
@@ -15,7 +15,6 @@ package org.eclipse.hono.client.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -32,6 +31,8 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.CredentialsObject;
@@ -45,7 +46,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Future;
@@ -68,7 +68,6 @@ public class CredentialsClientImplTest {
     private ProtonSender sender;
     private CredentialsClientImpl client;
     private ExpiringValueCache<Object, CredentialsResult<CredentialsObject>> cache;
-    private Tracer tracer;
     private Span span;
 
     /**
@@ -78,18 +77,11 @@ public class CredentialsClientImplTest {
     @BeforeEach
     public void setUp() {
 
-        final SpanContext spanContext = mock(SpanContext.class);
-
-        span = mock(Span.class);
-        when(span.context()).thenReturn(spanContext);
-        final Tracer.SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
-
-        tracer = mock(Tracer.class);
-        when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
+        span = TracingMockSupport.mockSpan();
+        final Tracer tracer = TracingMockSupport.mockTracer(span);
 
         final HonoConnection connection = HonoClientUnitTestHelper.mockHonoConnection(mock(Vertx.class),
-                new RequestResponseClientConfigProperties());
-        when(connection.getTracer()).thenReturn(tracer);
+                new RequestResponseClientConfigProperties(), tracer);
 
         sender = HonoClientUnitTestHelper.mockProtonSender();
         cache = mock(ExpiringValueCache.class);

--- a/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DeviceConnectionClientImplTest.java
@@ -15,7 +15,6 @@ package org.eclipse.hono.client.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -31,6 +30,8 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
@@ -41,9 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -74,22 +73,15 @@ public class DeviceConnectionClientImplTest {
     @BeforeEach
     public void setUp() {
 
-        final SpanContext spanContext = mock(SpanContext.class);
-
-        span = mock(Span.class);
-        when(span.context()).thenReturn(spanContext);
-        final SpanBuilder spanBuilder = HonoClientUnitTestHelper.mockSpanBuilder(span);
-
-        final Tracer tracer = mock(Tracer.class);
-        when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
+        span = TracingMockSupport.mockSpan();
+        final Tracer tracer = TracingMockSupport.mockTracer(span);
 
         final Vertx vertx = mock(Vertx.class);
         final ProtonReceiver receiver = HonoClientUnitTestHelper.mockProtonReceiver();
         sender = HonoClientUnitTestHelper.mockProtonSender();
 
         final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
-        final HonoConnection connection = HonoClientUnitTestHelper.mockHonoConnection(vertx, config);
-        when(connection.getTracer()).thenReturn(tracer);
+        final HonoConnection connection = HonoClientUnitTestHelper.mockHonoConnection(vertx, config, tracer);
 
         client = new DeviceConnectionClientImpl(connection, Constants.DEFAULT_TENANT, sender, receiver, SendMessageSampler.noop());
     }

--- a/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/DownstreamSenderFactoryImplTest.java
@@ -29,6 +29,7 @@ import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/client/src/test/java/org/eclipse/hono/client/impl/EventConsumerImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/EventConsumerImplTest.java
@@ -29,6 +29,7 @@ import org.apache.qpid.proton.amqp.messaging.Released;
 import org.apache.qpid.proton.amqp.transport.Source;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/client/src/test/java/org/eclipse/hono/client/impl/EventSenderImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/EventSenderImplTest.java
@@ -31,6 +31,7 @@ import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/client/src/test/java/org/eclipse/hono/client/impl/HonoConnectionImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/HonoConnectionImplTest.java
@@ -47,6 +47,7 @@ import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.connection.ConnectionFactory;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,7 +95,7 @@ public class HonoConnectionImplTest {
     @BeforeEach
     public void setUp() {
         vertx = mock(Vertx.class);
-        final Context context = HonoClientUnitTestHelper.mockContext(vertx);
+        final Context context = VertxMockSupport.mockContext(vertx);
         when(vertx.getOrCreateContext()).thenReturn(context);
         // run any timer immediately
         when(vertx.setTimer(anyLong(), VertxMockSupport.anyHandler())).thenAnswer(invocation -> {

--- a/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
@@ -41,6 +41,7 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,7 +91,7 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
     public void setUp() {
 
         vertx = mock(Vertx.class);
-        context = HonoClientUnitTestHelper.mockContext(vertx);
+        context = VertxMockSupport.mockContext(vertx);
         when(vertx.getOrCreateContext()).thenReturn(context);
         doAnswer(invocation -> {
             final Handler<Void> handler = invocation.getArgument(1);

--- a/client/src/test/java/org/eclipse/hono/client/impl/TelemetrySenderImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/TelemetrySenderImplTest.java
@@ -31,6 +31,7 @@ import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.test.VertxMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/test-utils/core-test-utils/pom.xml
+++ b/test-utils/core-test-utils/pom.xml
@@ -18,10 +18,16 @@
     <groupId>org.eclipse.hono</groupId>
     <artifactId>test-utils</artifactId>
     <version>1.5.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>core-test-utils</artifactId>
 
   <name>Hono Core Test Utils</name>
   <description>Core helper classes for implementing tests.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/test-utils/core-test-utils/src/main/java/org/eclipse/hono/test/TracingMockSupport.java
+++ b/test-utils/core-test-utils/src/main/java/org/eclipse/hono/test/TracingMockSupport.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.mockito.Mockito;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.Tracer.SpanBuilder;
+
+/**
+ * Mocks for OpenTracing objects.
+ */
+public final class TracingMockSupport {
+
+    private TracingMockSupport() {
+    }
+
+    /**
+     * Creates a mocked OpenTracing Span.
+     *
+     * @return The span.
+     */
+    public static Span mockSpan() {
+        final SpanContext spanContext = mock(SpanContext.class);
+        final Span span = mock(Span.class, Mockito.RETURNS_SELF);
+        when(span.context()).thenReturn(spanContext);
+        return span;
+    }
+
+    /**
+     * Creates a mocked OpenTracing Tracer that will use a SpanBuilder that
+     * creates the given Span.
+     *
+     * @param spanToBuild The object that the <em>start</em> method of the
+     *                    SpanBuilder should produce that the tracer returns
+     *                    for its <em>buildSpan</em> method.
+     * @return The tracer.
+     */
+    public static Tracer mockTracer(final Span spanToBuild) {
+        return mockTracer(mockSpanBuilder(spanToBuild));
+    }
+
+    /**
+     * Creates a mocked OpenTracing Tracer that will use a given SpanBuilder.
+     *
+     * @param spanBuilder The object that the <em>buildSpan</em> method of the
+     *                    returned tracer should return.
+     * @return The tracer.
+     */
+    public static Tracer mockTracer(final SpanBuilder spanBuilder) {
+        final Tracer tracer = mock(Tracer.class);
+        when(tracer.buildSpan(anyString())).thenReturn(spanBuilder);
+        return tracer;
+    }
+
+    /**
+     * Creates a mocked OpenTracing SpanBuilder for creating a given Span.
+     * <p>
+     * All invocations on the mock are stubbed to return the builder by default.
+     *
+     * @param spanToCreate The object that the <em>start</em> method of the
+     *                     returned builder should produce.
+     * @return The builder.
+     */
+    public static SpanBuilder mockSpanBuilder(final Span spanToCreate) {
+        final SpanBuilder spanBuilder = mock(SpanBuilder.class, Mockito.RETURNS_SELF);
+        when(spanBuilder.start()).thenReturn(spanToCreate);
+        return spanBuilder;
+    }
+}

--- a/test-utils/core-test-utils/src/main/java/org/eclipse/hono/test/VertxMockSupport.java
+++ b/test-utils/core-test-utils/src/main/java/org/eclipse/hono/test/VertxMockSupport.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,20 +11,45 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.hono.client.impl;
+package org.eclipse.hono.test;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 
 /**
- * Argument matchers for the use with vert.x.
+ * Argument matchers and mocks for the use with vert.x.
  */
 public final class VertxMockSupport {
 
     private VertxMockSupport() {
+    }
+
+    /**
+     * Creates a mocked vert.x Context which immediately invokes any handler that is passed to its runOnContext method.
+     *
+     * @param vertx The vert.x instance that the mock of the context is created for.
+     * @return The mocked context.
+     */
+    public static Context mockContext(final Vertx vertx) {
+
+        final Context context = mock(Context.class);
+
+        when(context.owner()).thenReturn(vertx);
+        doAnswer(invocation -> {
+            final Handler<Void> handler = invocation.getArgument(0);
+            handler.handle(null);
+            return null;
+        }).when(context).runOnContext(VertxMockSupport.anyHandler());
+        return context;
     }
 
     /**

--- a/test-utils/service-base-test-utils/pom.xml
+++ b/test-utils/service-base-test-utils/pom.xml
@@ -31,6 +31,11 @@
       <artifactId>hono-service-base</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>core-test-utils</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
Move `VertxMockSupport` from `hono-client` to `core-test-utils`; introduce `TracingMockSupport` class.