### PR TITLE
[#2267] Do not use Spring autowiring for adapters anymore

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/MicrometerBasedAmqpAdapterMetrics.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/MicrometerBasedAmqpAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,8 +14,6 @@
 package org.eclipse.hono.adapter.amqp;
 
 import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;
@@ -23,7 +21,6 @@ import io.vertx.core.Vertx;
 /**
  * Micrometer based metrics for the AMQP adapter.
  */
-@Component
 public class MicrometerBasedAmqpAdapterMetrics extends MicrometerBasedMetrics implements AmqpAdapterMetrics {
 
     /**
@@ -34,7 +31,6 @@ public class MicrometerBasedAmqpAdapterMetrics extends MicrometerBasedMetrics im
      *
      * @throws NullPointerException if either parameter is {@code null}.
      */
-    @Autowired
     public MicrometerBasedAmqpAdapterMetrics(final MeterRegistry registry, final Vertx vertx) {
         super(registry, vertx);
     }

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
@@ -12,9 +12,14 @@
  *******************************************************************************/
 package org.eclipse.hono.adapter.amqp.impl;
 
+import java.util.Optional;
+
+import org.eclipse.hono.adapter.amqp.AmqpAdapterMetrics;
 import org.eclipse.hono.adapter.amqp.AmqpAdapterProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
@@ -37,12 +42,24 @@ public class Config extends AbstractAdapterConfig {
     /**
      * Creates an AMQP protocol adapter instance.
      *
+     * @param samplerFactory The sampler factory to use.
+     * @param metrics The component to use for reporting metrics.
+     * @param resourceLimitChecks The component to use for checking if the adapter's
+     *                            resource limits are exceeded.
      * @return The new instance.
      */
     @Bean(name = BEAN_NAME_VERTX_BASED_AMQP_PROTOCOL_ADAPTER)
     @Scope("prototype")
-    public VertxBasedAmqpProtocolAdapter vertxBasedAmqpProtocolAdapter() {
-        return new VertxBasedAmqpProtocolAdapter();
+    public VertxBasedAmqpProtocolAdapter vertxBasedAmqpProtocolAdapter(
+            final SendMessageSampler.Factory samplerFactory,
+            final AmqpAdapterMetrics metrics,
+            final Optional<ResourceLimitChecks> resourceLimitChecks) {
+
+        final VertxBasedAmqpProtocolAdapter adapter = new VertxBasedAmqpProtocolAdapter();
+        setCollaborators(adapter, adapterProperties(), samplerFactory, resourceLimitChecks);
+        adapter.setConfig(adapterProperties());
+        adapter.setMetrics(metrics);
+        return adapter;
     }
 
     @Override

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/Config.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import org.eclipse.hono.adapter.amqp.AmqpAdapterMetrics;
 import org.eclipse.hono.adapter.amqp.AmqpAdapterProperties;
+import org.eclipse.hono.adapter.amqp.MicrometerBasedAmqpAdapterMetrics;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
@@ -29,6 +30,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.Vertx;
 
 /**
  * Spring Boot configuration for the AMQP protocol adapter.
@@ -65,6 +67,11 @@ public class Config extends AbstractAdapterConfig {
     @Override
     protected String getAdapterName() {
         return CONTAINER_ID_HONO_AMQP_ADAPTER;
+    }
+
+    @Bean
+    AmqpAdapterMetrics metrics(final MeterRegistry meterRegistry, final Vertx vertx) {
+        return new MicrometerBasedAmqpAdapterMetrics(meterRegistry, vertx);
     }
 
     /**

--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -76,7 +76,6 @@ import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TenantObject;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.micrometer.core.instrument.Timer.Sample;
 import io.opentracing.Span;
@@ -148,8 +147,9 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
      *
      * @param metrics The metrics
      */
-    @Autowired
     public void setMetrics(final AmqpAdapterMetrics metrics) {
+        Optional.ofNullable(metrics)
+            .ifPresent(m -> log.info("reporting metrics using [{}]", metrics.getClass().getName()));
         this.metrics = metrics;
     }
 

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -71,7 +71,6 @@ import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.TenantObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.micrometer.core.instrument.Timer.Sample;
 import io.opentracing.Span;
@@ -144,8 +143,9 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
      *
      * @param metrics The metrics
      */
-    @Autowired
     public final void setMetrics(final CoapAdapterMetrics metrics) {
+        Optional.ofNullable(metrics)
+            .ifPresent(m -> log.info("reporting metrics using [{}]", metrics.getClass().getName()));
         this.metrics = metrics;
     }
 
@@ -165,7 +165,6 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
      * @param resources The resources.
      * @throws NullPointerException if resources is {@code null}.
      */
-    @Autowired(required = false)
     public final void setResources(final Set<Resource> resources) {
         this.resourcesToAdd.addAll(Objects.requireNonNull(resources));
     }
@@ -215,7 +214,6 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
      * @param server The coap server.
      * @throws NullPointerException if server is {@code null}.
      */
-    @Autowired(required = false)
     public final void setCoapServer(final CoapServer server) {
         Objects.requireNonNull(server);
         this.server = server;

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/MicrometerBasedCoapAdapterMetrics.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/MicrometerBasedCoapAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,8 +14,6 @@
 package org.eclipse.hono.adapter.coap;
 
 import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;
@@ -23,7 +21,6 @@ import io.vertx.core.Vertx;
 /**
  * Metrics for the COAP based adapters.
  */
-@Component
 public class MicrometerBasedCoapAdapterMetrics extends MicrometerBasedMetrics implements CoapAdapterMetrics {
 
     /**
@@ -34,7 +31,6 @@ public class MicrometerBasedCoapAdapterMetrics extends MicrometerBasedMetrics im
      *
      * @throws NullPointerException if either parameter is {@code null}.
      */
-    @Autowired
     public MicrometerBasedCoapAdapterMetrics(final MeterRegistry registry, final Vertx vertx) {
         super(registry, vertx);
     }

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -994,7 +994,6 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         }
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setDeviceConnectionClient(deviceConnectionClient);
-        adapter.setCommandTargetMapper(commandTargetMapper);
         adapter.init(vertx, mock(Context.class));
 
         return adapter;

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import org.eclipse.hono.adapter.coap.CoapAdapterMetrics;
 import org.eclipse.hono.adapter.coap.CoapAdapterProperties;
+import org.eclipse.hono.adapter.coap.MicrometerBasedCoapAdapterMetrics;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
@@ -30,6 +31,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.Vertx;
 
 /**
  * Spring Boot configuration for the COAP adapter.
@@ -49,6 +51,11 @@ public class Config extends AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.coap")
     public CoapAdapterProperties adapterProperties() {
         return new CoapAdapterProperties();
+    }
+
+    @Bean
+    CoapAdapterMetrics metrics(final MeterRegistry registry, final Vertx vertx) {
+        return new MicrometerBasedCoapAdapterMetrics(registry, vertx);
     }
 
     /**

--- a/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
+++ b/adapters/coap-vertx/src/main/java/org/eclipse/hono/adapter/coap/impl/Config.java
@@ -13,9 +13,14 @@
 
 package org.eclipse.hono.adapter.coap.impl;
 
+import java.util.Optional;
+
+import org.eclipse.hono.adapter.coap.CoapAdapterMetrics;
 import org.eclipse.hono.adapter.coap.CoapAdapterProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
@@ -49,12 +54,24 @@ public class Config extends AbstractAdapterConfig {
     /**
      * Creates a new COAP adapter instance.
      *
+     * @param samplerFactory The sampler factory to use.
+     * @param metrics The component to use for reporting metrics.
+     * @param resourceLimitChecks The component to use for checking if the adapter's
+     *                            resource limits are exceeded.
      * @return The new instance.
      */
     @Bean(name = BEAN_NAME_VERTX_BASED_COAP_ADAPTER)
     @Scope("prototype")
-    public VertxBasedCoapAdapter vertxBasedCoapAdapter() {
-        return new VertxBasedCoapAdapter();
+    public VertxBasedCoapAdapter vertxBasedCoapAdapter(
+            final SendMessageSampler.Factory samplerFactory,
+            final CoapAdapterMetrics metrics,
+            final Optional<ResourceLimitChecks> resourceLimitChecks) {
+
+        final VertxBasedCoapAdapter adapter = new VertxBasedCoapAdapter();
+        setCollaborators(adapter, adapterProperties(), samplerFactory, resourceLimitChecks);
+        adapter.setConfig(adapterProperties());
+        adapter.setMetrics(metrics);
+        return adapter;
     }
 
     @Override

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -53,7 +53,6 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TenantObject;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.micrometer.core.instrument.Timer.Sample;
 import io.opentracing.Span;
@@ -98,10 +97,10 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      *
      * @param metrics The metrics
      */
-    @Autowired
     public final void setMetrics(final HttpAdapterMetrics metrics) {
+        Optional.ofNullable(metrics)
+            .ifPresent(m -> log.info("reporting metrics using [{}]", metrics.getClass().getName()));
         this.metrics = metrics;
-        log.info("using Metrics implementation [{}]", metrics.getClass().getName());
     }
 
     /**
@@ -150,7 +149,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      * @throws NullPointerException if server is {@code null}.
      * @throws IllegalArgumentException if the server is already started and listening on an address/port.
      */
-    @Autowired(required = false)
     public final void setHttpServer(final HttpServer server) {
         Objects.requireNonNull(server);
         if (server.actualPort() > 0) {
@@ -171,7 +169,6 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
      * @throws NullPointerException if server is {@code null}.
      * @throws IllegalArgumentException if the server is already started and listening on an address/port.
      */
-    @Autowired(required = false)
     public final void setInsecureHttpServer(final HttpServer server) {
         Objects.requireNonNull(server);
         if (server.actualPort() > 0) {

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/MicrometerBasedHttpAdapterMetrics.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/MicrometerBasedHttpAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,8 +14,6 @@
 package org.eclipse.hono.adapter.http;
 
 import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;
@@ -23,7 +21,6 @@ import io.vertx.core.Vertx;
 /**
  * Metrics for the HTTP based adapters.
  */
-@Component
 public class MicrometerBasedHttpAdapterMetrics extends MicrometerBasedMetrics implements HttpAdapterMetrics {
 
     /**
@@ -34,7 +31,6 @@ public class MicrometerBasedHttpAdapterMetrics extends MicrometerBasedMetrics im
      *
      * @throws NullPointerException if either parameter is {@code null}.
      */
-    @Autowired
     public MicrometerBasedHttpAdapterMetrics(final MeterRegistry registry, final Vertx vertx) {
         super(registry, vertx);
     }

--- a/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/Application.java
+++ b/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/Application.java
@@ -12,36 +12,23 @@
  */
 package org.eclipse.hono.adapter.http.quarkus;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
-import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.http.impl.VertxBasedHttpProtocolAdapter;
-import org.eclipse.hono.client.CommandTargetMapper;
-import org.eclipse.hono.client.CommandTargetMapper.CommandTargetMapperContext;
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory.CommandHandlingAdapterInfoAccess;
 import org.eclipse.hono.service.quarkus.AbstractProtocolAdapterApplication;
-import org.eclipse.hono.util.RegistrationAssertion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.opentracing.SpanContext;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.json.JsonObject;
 
 /**
  * The Hono HTTP adapter main application class.
@@ -92,77 +79,10 @@ public class Application extends AbstractProtocolAdapterApplication {
 
     private VertxBasedHttpProtocolAdapter adapter() {
 
-        final DeviceRegistrationClient registrationClient = registrationClient();
-        final DeviceConnectionClient deviceConnectionClient = deviceConnectionClient();
-        final CommandTargetMapper commandTargetMapper = commandTargetMapper();
-
-        commandTargetMapper.initialize(new CommandTargetMapperContext() {
-
-            @Override
-            public Future<List<String>> getViaGateways(
-                    final String tenant,
-                    final String deviceId,
-                    final SpanContext context) {
-
-                Objects.requireNonNull(tenant);
-                Objects.requireNonNull(deviceId);
-
-                return registrationClient.assertRegistration(tenant, deviceId, null, context)
-                        .map(RegistrationAssertion::getAuthorizedGateways);
-            }
-
-            @Override
-            public Future<JsonObject> getCommandHandlingAdapterInstances(
-                    final String tenant,
-                    final String deviceId,
-                    final List<String> viaGateways,
-                    final SpanContext context) {
-
-                Objects.requireNonNull(tenant);
-                Objects.requireNonNull(deviceId);
-                Objects.requireNonNull(viaGateways);
-
-                return deviceConnectionClient.getCommandHandlingAdapterInstances(
-                        tenant, deviceId, viaGateways, context);
-            }
-        });
-
-        final ProtocolAdapterCommandConsumerFactory commandConsumerFactory = commandConsumerFactory();
-        commandConsumerFactory.initialize(commandTargetMapper, new CommandHandlingAdapterInfoAccess() {
-
-            @Override
-            public Future<Void> setCommandHandlingAdapterInstance(
-                    final String tenant,
-                    final String deviceId,
-                    final String adapterInstanceId,
-                    final Duration lifespan,
-                    final SpanContext context) {
-                return deviceConnectionClient.setCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, lifespan, context);
-            }
-
-            @Override
-            public Future<Void> removeCommandHandlingAdapterInstance(
-                    final String tenant,
-                    final String deviceId,
-                    final String adapterInstanceId,
-                    final SpanContext context) {
-                return deviceConnectionClient.removeCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, context);
-            }
-        });
-
         final VertxBasedHttpProtocolAdapter adapter = new VertxBasedHttpProtocolAdapter();
-        adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setConfig(adapterProperties);
-        adapter.setCredentialsClient(credentialsClient());
-        adapter.setDeviceConnectionClient(deviceConnectionClient);
-        adapter.setEventSender(downstreamSender());
-        adapter.setHealthCheckServer(healthCheckServer);
         adapter.setMetrics(metrics);
-        adapter.setRegistrationClient(registrationClient);
-        adapter.setTelemetrySender(downstreamSender());
-        adapter.setTenantClient(tenantClient());
-        adapter.setTracer(tracer);
-        adapter.setResourceLimitChecks(resourceLimitChecks);
+        setCollaborators(adapter);
         return adapter;
     }
 }

--- a/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/Application.java
+++ b/adapters/http-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/http/quarkus/Application.java
@@ -12,23 +12,36 @@
  */
 package org.eclipse.hono.adapter.http.quarkus;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
+import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.http.impl.VertxBasedHttpProtocolAdapter;
+import org.eclipse.hono.client.CommandTargetMapper;
+import org.eclipse.hono.client.CommandTargetMapper.CommandTargetMapperContext;
+import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
+import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory.CommandHandlingAdapterInfoAccess;
 import org.eclipse.hono.service.quarkus.AbstractProtocolAdapterApplication;
+import org.eclipse.hono.util.RegistrationAssertion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.opentracing.SpanContext;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
 
 /**
  * The Hono HTTP adapter main application class.
@@ -79,16 +92,73 @@ public class Application extends AbstractProtocolAdapterApplication {
 
     private VertxBasedHttpProtocolAdapter adapter() {
 
+        final DeviceRegistrationClient registrationClient = registrationClient();
+        final DeviceConnectionClient deviceConnectionClient = deviceConnectionClient();
+        final CommandTargetMapper commandTargetMapper = commandTargetMapper();
+
+        commandTargetMapper.initialize(new CommandTargetMapperContext() {
+
+            @Override
+            public Future<List<String>> getViaGateways(
+                    final String tenant,
+                    final String deviceId,
+                    final SpanContext context) {
+
+                Objects.requireNonNull(tenant);
+                Objects.requireNonNull(deviceId);
+
+                return registrationClient.assertRegistration(tenant, deviceId, null, context)
+                        .map(RegistrationAssertion::getAuthorizedGateways);
+            }
+
+            @Override
+            public Future<JsonObject> getCommandHandlingAdapterInstances(
+                    final String tenant,
+                    final String deviceId,
+                    final List<String> viaGateways,
+                    final SpanContext context) {
+
+                Objects.requireNonNull(tenant);
+                Objects.requireNonNull(deviceId);
+                Objects.requireNonNull(viaGateways);
+
+                return deviceConnectionClient.getCommandHandlingAdapterInstances(
+                        tenant, deviceId, viaGateways, context);
+            }
+        });
+
+        final ProtocolAdapterCommandConsumerFactory commandConsumerFactory = commandConsumerFactory();
+        commandConsumerFactory.initialize(commandTargetMapper, new CommandHandlingAdapterInfoAccess() {
+
+            @Override
+            public Future<Void> setCommandHandlingAdapterInstance(
+                    final String tenant,
+                    final String deviceId,
+                    final String adapterInstanceId,
+                    final Duration lifespan,
+                    final SpanContext context) {
+                return deviceConnectionClient.setCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, lifespan, context);
+            }
+
+            @Override
+            public Future<Void> removeCommandHandlingAdapterInstance(
+                    final String tenant,
+                    final String deviceId,
+                    final String adapterInstanceId,
+                    final SpanContext context) {
+                return deviceConnectionClient.removeCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, context);
+            }
+        });
+
         final VertxBasedHttpProtocolAdapter adapter = new VertxBasedHttpProtocolAdapter();
-        adapter.setCommandConsumerFactory(commandConsumerFactory());
-        adapter.setCommandTargetMapper(commandTargetMapper());
+        adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setConfig(adapterProperties);
         adapter.setCredentialsClient(credentialsClient());
-        adapter.setDeviceConnectionClient(deviceConnectionClient());
+        adapter.setDeviceConnectionClient(deviceConnectionClient);
         adapter.setEventSender(downstreamSender());
         adapter.setHealthCheckServer(healthCheckServer);
         adapter.setMetrics(metrics);
-        adapter.setRegistrationClient(registrationClient());
+        adapter.setRegistrationClient(registrationClient);
         adapter.setTelemetrySender(downstreamSender());
         adapter.setTenantClient(tenantClient());
         adapter.setTracer(tracer);

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
+import org.eclipse.hono.adapter.http.MicrometerBasedHttpAdapterMetrics;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
@@ -30,6 +31,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.Vertx;
 
 /**
  * Spring Boot configuration for the HTTP adapter.
@@ -77,6 +79,11 @@ public class Config extends AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.http")
     public HttpProtocolAdapterProperties adapterProperties() {
         return new HttpProtocolAdapterProperties();
+    }
+
+    @Bean
+    HttpAdapterMetrics metrics(final MeterRegistry registry, final Vertx vertx) {
+        return new MicrometerBasedHttpAdapterMetrics(registry, vertx);
     }
 
     /**

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
@@ -13,9 +13,14 @@
 
 package org.eclipse.hono.adapter.http.impl;
 
+import java.util.Optional;
+
+import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
@@ -38,12 +43,24 @@ public class Config extends AbstractAdapterConfig {
     /**
      * Creates a new HTTP adapter instance.
      *
+     * @param samplerFactory The sampler factory to use.
+     * @param metrics The component to use for reporting metrics.
+     * @param resourceLimitChecks The component to use for checking if the adapter's
+     *                            resource limits are exceeded.
      * @return The new instance.
      */
     @Bean(name = BEAN_NAME_VERTX_BASED_HTTP_PROTOCOL_ADAPTER)
     @Scope("prototype")
-    public VertxBasedHttpProtocolAdapter vertxBasedHttpProtocolAdapter() {
-        return new VertxBasedHttpProtocolAdapter();
+    public VertxBasedHttpProtocolAdapter vertxBasedHttpProtocolAdapter(
+            final SendMessageSampler.Factory samplerFactory,
+            final HttpAdapterMetrics metrics,
+            final Optional<ResourceLimitChecks> resourceLimitChecks) {
+
+        final VertxBasedHttpProtocolAdapter adapter = new VertxBasedHttpProtocolAdapter();
+        setCollaborators(adapter, adapterProperties(), samplerFactory, resourceLimitChecks);
+        adapter.setConfig(adapterProperties());
+        adapter.setMetrics(metrics);
+        return adapter;
     }
 
     @Override

--- a/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
+++ b/adapters/kura/src/main/java/org/eclipse/hono/adapter/kura/impl/Config.java
@@ -13,10 +13,14 @@
 
 package org.eclipse.hono.adapter.kura.impl;
 
+import java.util.Optional;
+
 import org.eclipse.hono.adapter.mqtt.MicrometerBasedMqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.MqttAdapterMetrics;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
@@ -39,12 +43,24 @@ public class Config extends AbstractAdapterConfig {
     /**
      * Creates a new Kura protocol adapter instance.
      *
+     * @param samplerFactory The sampler factory to use.
+     * @param metrics The component to use for reporting metrics.
+     * @param resourceLimitChecks The component to use for checking if the adapter's
+     *                            resource limits are exceeded.
      * @return The new instance.
      */
     @Bean(name = BEAN_NAME_KURA_PROTOCOL_ADAPTER)
     @Scope("prototype")
-    public KuraProtocolAdapter kuraProtocolAdapter() {
-        return new KuraProtocolAdapter();
+    public KuraProtocolAdapter kuraProtocolAdapter(
+            final SendMessageSampler.Factory samplerFactory,
+            final MqttAdapterMetrics metrics,
+            final Optional<ResourceLimitChecks> resourceLimitChecks) {
+
+        final KuraProtocolAdapter adapter = new KuraProtocolAdapter();
+        setCollaborators(adapter, adapterProperties(), samplerFactory, resourceLimitChecks);
+        adapter.setConfig(adapterProperties());
+        adapter.setMetrics(metrics);
+        return adapter;
     }
 
     @Override

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
@@ -13,12 +13,17 @@
 
 package org.eclipse.hono.adapter.lora.impl;
 
+import java.util.Optional;
+
 import javax.annotation.PostConstruct;
 
+import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.lora.LoraProtocolAdapterProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
@@ -54,12 +59,24 @@ public class Config extends AbstractAdapterConfig {
     /**
      * Creates a new LoRa adapter instance.
      *
+     * @param samplerFactory The sampler factory to use.
+     * @param metrics The component to use for reporting metrics.
+     * @param resourceLimitChecks The component to use for checking if the adapter's
+     *                            resource limits are exceeded.
      * @return The new instance.
      */
     @Bean(name = BEAN_NAME_LORA_PROTOCOL_ADAPTER)
     @Scope("prototype")
-    public LoraProtocolAdapter loraProtocolAdapter() {
-        return new LoraProtocolAdapter();
+    public LoraProtocolAdapter loraProtocolAdapter(
+            final SendMessageSampler.Factory samplerFactory,
+            final HttpAdapterMetrics metrics,
+            final Optional<ResourceLimitChecks> resourceLimitChecks) {
+
+        final LoraProtocolAdapter adapter = new LoraProtocolAdapter();
+        setCollaborators(adapter, adapterProperties(), samplerFactory, resourceLimitChecks);
+        adapter.setConfig(adapterProperties());
+        adapter.setMetrics(metrics);
+        return adapter;
     }
 
     @Override

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.adapter.lora.impl;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.annotation.PostConstruct;
@@ -20,6 +21,7 @@ import javax.annotation.PostConstruct;
 import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.lora.LoraProtocolAdapterProperties;
+import org.eclipse.hono.adapter.lora.providers.LoraProvider;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
@@ -63,6 +65,7 @@ public class Config extends AbstractAdapterConfig {
      * @param metrics The component to use for reporting metrics.
      * @param resourceLimitChecks The component to use for checking if the adapter's
      *                            resource limits are exceeded.
+     * @param providers The provider specific endpoint handlers.
      * @return The new instance.
      */
     @Bean(name = BEAN_NAME_LORA_PROTOCOL_ADAPTER)
@@ -70,12 +73,14 @@ public class Config extends AbstractAdapterConfig {
     public LoraProtocolAdapter loraProtocolAdapter(
             final SendMessageSampler.Factory samplerFactory,
             final HttpAdapterMetrics metrics,
-            final Optional<ResourceLimitChecks> resourceLimitChecks) {
+            final Optional<ResourceLimitChecks> resourceLimitChecks,
+            final List<LoraProvider> providers) {
 
         final LoraProtocolAdapter adapter = new LoraProtocolAdapter();
         setCollaborators(adapter, adapterProperties(), samplerFactory, resourceLimitChecks);
         adapter.setConfig(adapterProperties());
         adapter.setMetrics(metrics);
+        adapter.setLoraProviders(providers);
         return adapter;
     }
 

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -46,7 +46,6 @@ import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.opentracing.Span;
 import io.opentracing.log.Fields;
@@ -84,7 +83,6 @@ public final class LoraProtocolAdapter extends AbstractVertxBasedHttpProtocolAda
      * @param providers The providers.
      * @throws NullPointerException if providers is {@code null}.
      */
-    @Autowired(required = false)
     public void setLoraProviders(final List<LoraProvider> providers) {
         Objects.requireNonNull(providers);
         this.loraProviders.clear();

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -63,7 +63,6 @@ import org.eclipse.hono.util.Pair;
 import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TenantObject;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.micrometer.core.instrument.Timer.Sample;
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
@@ -149,8 +148,9 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
      *
      * @param metrics The metrics
      */
-    @Autowired
     public final void setMetrics(final MqttAdapterMetrics metrics) {
+        Optional.ofNullable(metrics)
+            .ifPresent(m -> log.info("reporting metrics using [{}]", metrics.getClass().getName()));
         this.metrics = metrics;
     }
 

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MicrometerBasedMqttAdapterMetrics.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MicrometerBasedMqttAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,8 +14,6 @@
 package org.eclipse.hono.adapter.mqtt;
 
 import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;
@@ -23,7 +21,6 @@ import io.vertx.core.Vertx;
 /**
  * Metrics for the MQTT based adapters.
  */
-@Component
 public class MicrometerBasedMqttAdapterMetrics extends MicrometerBasedMetrics implements MqttAdapterMetrics {
 
     /**
@@ -34,7 +31,6 @@ public class MicrometerBasedMqttAdapterMetrics extends MicrometerBasedMetrics im
      *
      * @throws NullPointerException if either parameter is {@code null}.
      */
-    @Autowired
     public MicrometerBasedMqttAdapterMetrics(final MeterRegistry registry, final Vertx vertx) {
         super(registry, vertx);
     }

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/impl/VertxBasedMqttProtocolAdapter.java
@@ -26,7 +26,6 @@ import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.ResourceIdentifier;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.Future;
@@ -63,7 +62,6 @@ public final class VertxBasedMqttProtocolAdapter extends AbstractVertxBasedMqttP
      * @param messageMappingService The service to use for mapping messages.
      * @throws NullPointerException if messageMapping is {@code null}.
      */
-    @Autowired
     public void setMessageMapping(final MessageMapping<MqttContext> messageMappingService) {
         Objects.requireNonNull(messageMappingService);
         this.messageMapping = messageMappingService;

--- a/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
+++ b/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
@@ -12,39 +12,26 @@
  */
 package org.eclipse.hono.adapter.mqtt.quarkus;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
-import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.mqtt.MessageMapping;
 import org.eclipse.hono.adapter.mqtt.MqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.MqttContext;
 import org.eclipse.hono.adapter.mqtt.MqttProtocolAdapterProperties;
 import org.eclipse.hono.adapter.mqtt.impl.HttpBasedMessageMapping;
 import org.eclipse.hono.adapter.mqtt.impl.VertxBasedMqttProtocolAdapter;
-import org.eclipse.hono.client.CommandTargetMapper;
-import org.eclipse.hono.client.CommandTargetMapper.CommandTargetMapperContext;
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory.CommandHandlingAdapterInfoAccess;
 import org.eclipse.hono.service.quarkus.AbstractProtocolAdapterApplication;
-import org.eclipse.hono.util.RegistrationAssertion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.opentracing.SpanContext;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 
 /**
@@ -96,78 +83,11 @@ public class Application extends AbstractProtocolAdapterApplication {
 
     private VertxBasedMqttProtocolAdapter adapter() {
 
-        final DeviceRegistrationClient registrationClient = registrationClient();
-        final DeviceConnectionClient deviceConnectionClient = deviceConnectionClient();
-        final CommandTargetMapper commandTargetMapper = commandTargetMapper();
-
-        commandTargetMapper.initialize(new CommandTargetMapperContext() {
-
-            @Override
-            public Future<List<String>> getViaGateways(
-                    final String tenant,
-                    final String deviceId,
-                    final SpanContext context) {
-
-                Objects.requireNonNull(tenant);
-                Objects.requireNonNull(deviceId);
-
-                return registrationClient.assertRegistration(tenant, deviceId, null, context)
-                        .map(RegistrationAssertion::getAuthorizedGateways);
-            }
-
-            @Override
-            public Future<JsonObject> getCommandHandlingAdapterInstances(
-                    final String tenant,
-                    final String deviceId,
-                    final List<String> viaGateways,
-                    final SpanContext context) {
-
-                Objects.requireNonNull(tenant);
-                Objects.requireNonNull(deviceId);
-                Objects.requireNonNull(viaGateways);
-
-                return deviceConnectionClient.getCommandHandlingAdapterInstances(
-                        tenant, deviceId, viaGateways, context);
-            }
-        });
-
-        final ProtocolAdapterCommandConsumerFactory commandConsumerFactory = commandConsumerFactory();
-        commandConsumerFactory.initialize(commandTargetMapper, new CommandHandlingAdapterInfoAccess() {
-
-            @Override
-            public Future<Void> setCommandHandlingAdapterInstance(
-                    final String tenant,
-                    final String deviceId,
-                    final String adapterInstanceId,
-                    final Duration lifespan,
-                    final SpanContext context) {
-                return deviceConnectionClient.setCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, lifespan, context);
-            }
-
-            @Override
-            public Future<Void> removeCommandHandlingAdapterInstance(
-                    final String tenant,
-                    final String deviceId,
-                    final String adapterInstanceId,
-                    final SpanContext context) {
-                return deviceConnectionClient.removeCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, context);
-            }
-        });
-
         final VertxBasedMqttProtocolAdapter adapter = new VertxBasedMqttProtocolAdapter();
-        adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setConfig(adapterProperties);
-        adapter.setCredentialsClient(credentialsClient());
-        adapter.setDeviceConnectionClient(deviceConnectionClient);
-        adapter.setEventSender(downstreamSender());
-        adapter.setHealthCheckServer(healthCheckServer);
         adapter.setMetrics(metrics);
-        adapter.setRegistrationClient(registrationClient);
-        adapter.setTelemetrySender(downstreamSender());
-        adapter.setTenantClient(tenantClient());
-        adapter.setTracer(tracer);
-        adapter.setResourceLimitChecks(resourceLimitChecks);
         adapter.setMessageMapping(messageMapping());
+        setCollaborators(adapter);
         return adapter;
     }
 

--- a/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
+++ b/adapters/mqtt-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/mqtt/quarkus/Application.java
@@ -12,26 +12,39 @@
  */
 package org.eclipse.hono.adapter.mqtt.quarkus;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
+import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.mqtt.MessageMapping;
 import org.eclipse.hono.adapter.mqtt.MqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.MqttContext;
 import org.eclipse.hono.adapter.mqtt.MqttProtocolAdapterProperties;
 import org.eclipse.hono.adapter.mqtt.impl.HttpBasedMessageMapping;
 import org.eclipse.hono.adapter.mqtt.impl.VertxBasedMqttProtocolAdapter;
+import org.eclipse.hono.client.CommandTargetMapper;
+import org.eclipse.hono.client.CommandTargetMapper.CommandTargetMapperContext;
+import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
+import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory.CommandHandlingAdapterInfoAccess;
 import org.eclipse.hono.service.quarkus.AbstractProtocolAdapterApplication;
+import org.eclipse.hono.util.RegistrationAssertion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.opentracing.SpanContext;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 
 /**
@@ -83,16 +96,73 @@ public class Application extends AbstractProtocolAdapterApplication {
 
     private VertxBasedMqttProtocolAdapter adapter() {
 
+        final DeviceRegistrationClient registrationClient = registrationClient();
+        final DeviceConnectionClient deviceConnectionClient = deviceConnectionClient();
+        final CommandTargetMapper commandTargetMapper = commandTargetMapper();
+
+        commandTargetMapper.initialize(new CommandTargetMapperContext() {
+
+            @Override
+            public Future<List<String>> getViaGateways(
+                    final String tenant,
+                    final String deviceId,
+                    final SpanContext context) {
+
+                Objects.requireNonNull(tenant);
+                Objects.requireNonNull(deviceId);
+
+                return registrationClient.assertRegistration(tenant, deviceId, null, context)
+                        .map(RegistrationAssertion::getAuthorizedGateways);
+            }
+
+            @Override
+            public Future<JsonObject> getCommandHandlingAdapterInstances(
+                    final String tenant,
+                    final String deviceId,
+                    final List<String> viaGateways,
+                    final SpanContext context) {
+
+                Objects.requireNonNull(tenant);
+                Objects.requireNonNull(deviceId);
+                Objects.requireNonNull(viaGateways);
+
+                return deviceConnectionClient.getCommandHandlingAdapterInstances(
+                        tenant, deviceId, viaGateways, context);
+            }
+        });
+
+        final ProtocolAdapterCommandConsumerFactory commandConsumerFactory = commandConsumerFactory();
+        commandConsumerFactory.initialize(commandTargetMapper, new CommandHandlingAdapterInfoAccess() {
+
+            @Override
+            public Future<Void> setCommandHandlingAdapterInstance(
+                    final String tenant,
+                    final String deviceId,
+                    final String adapterInstanceId,
+                    final Duration lifespan,
+                    final SpanContext context) {
+                return deviceConnectionClient.setCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, lifespan, context);
+            }
+
+            @Override
+            public Future<Void> removeCommandHandlingAdapterInstance(
+                    final String tenant,
+                    final String deviceId,
+                    final String adapterInstanceId,
+                    final SpanContext context) {
+                return deviceConnectionClient.removeCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, context);
+            }
+        });
+
         final VertxBasedMqttProtocolAdapter adapter = new VertxBasedMqttProtocolAdapter();
-        adapter.setCommandConsumerFactory(commandConsumerFactory());
-        adapter.setCommandTargetMapper(commandTargetMapper());
+        adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setConfig(adapterProperties);
         adapter.setCredentialsClient(credentialsClient());
-        adapter.setDeviceConnectionClient(deviceConnectionClient());
+        adapter.setDeviceConnectionClient(deviceConnectionClient);
         adapter.setEventSender(downstreamSender());
         adapter.setHealthCheckServer(healthCheckServer);
         adapter.setMetrics(metrics);
-        adapter.setRegistrationClient(registrationClient());
+        adapter.setRegistrationClient(registrationClient);
         adapter.setTelemetrySender(downstreamSender());
         adapter.setTenantClient(tenantClient());
         adapter.setTracer(tracer);

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.adapter.mqtt.impl;
 import java.util.Optional;
 
 import org.eclipse.hono.adapter.mqtt.MessageMapping;
+import org.eclipse.hono.adapter.mqtt.MicrometerBasedMqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.MqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.MqttContext;
 import org.eclipse.hono.adapter.mqtt.MqttProtocolAdapterProperties;
@@ -32,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 
 /**
@@ -81,6 +83,11 @@ public class Config extends AbstractAdapterConfig {
     @ConfigurationProperties(prefix = "hono.mqtt")
     public MqttProtocolAdapterProperties adapterProperties() {
         return new MqttProtocolAdapterProperties();
+    }
+
+    @Bean
+    MqttAdapterMetrics metrics(final MeterRegistry registry, final Vertx vertx) {
+        return new MicrometerBasedMqttAdapterMetrics(registry, vertx);
     }
 
     /**

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/impl/Config.java
@@ -13,11 +13,16 @@
 
 package org.eclipse.hono.adapter.mqtt.impl;
 
+import java.util.Optional;
+
 import org.eclipse.hono.adapter.mqtt.MessageMapping;
+import org.eclipse.hono.adapter.mqtt.MqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.MqttContext;
 import org.eclipse.hono.adapter.mqtt.MqttProtocolAdapterProperties;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
@@ -41,12 +46,25 @@ public class Config extends AbstractAdapterConfig {
     /**
      * Creates a new MQTT protocol adapter instance.
      *
+     * @param samplerFactory The sampler factory to use.
+     * @param metrics The component to use for reporting metrics.
+     * @param resourceLimitChecks The component to use for checking if the adapter's
+     *                            resource limits are exceeded.
      * @return The new instance.
      */
     @Bean(name = BEAN_NAME_VERTX_BASED_MQTT_PROTOCOL_ADAPTER)
     @Scope("prototype")
-    public VertxBasedMqttProtocolAdapter vertxBasedMqttProtocolAdapter() {
-        return new VertxBasedMqttProtocolAdapter();
+    public VertxBasedMqttProtocolAdapter vertxBasedMqttProtocolAdapter(
+            final SendMessageSampler.Factory samplerFactory,
+            final MqttAdapterMetrics metrics,
+            final Optional<ResourceLimitChecks> resourceLimitChecks) {
+
+        final VertxBasedMqttProtocolAdapter adapter = new VertxBasedMqttProtocolAdapter();
+        setCollaborators(adapter, adapterProperties(), samplerFactory, resourceLimitChecks);
+        adapter.setConfig(adapterProperties());
+        adapter.setMetrics(metrics);
+        adapter.setMessageMapping(messageMapping());
+        return adapter;
     }
 
     @Override

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/Config.java
@@ -13,10 +13,15 @@
 
 package org.eclipse.hono.adapter.sigfox.impl;
 
+import java.util.Optional;
+
 import javax.annotation.PostConstruct;
 
+import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.util.Constants;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
@@ -48,12 +53,24 @@ public class Config extends AbstractAdapterConfig {
     /**
      * Creates a new SigFox adapter instance.
      *
+     * @param samplerFactory The sampler factory to use.
+     * @param metrics The component to use for reporting metrics.
+     * @param resourceLimitChecks The component to use for checking if the adapter's
+     *                            resource limits are exceeded.
      * @return The new instance.
      */
     @Bean(name = BEAN_NAME_SIGFOX_PROTOCOL_ADAPTER)
     @Scope("prototype")
-    public SigfoxProtocolAdapter sigfoxProtocolAdapter() {
-        return new SigfoxProtocolAdapter();
+    public SigfoxProtocolAdapter sigfoxProtocolAdapter(
+            final SendMessageSampler.Factory samplerFactory,
+            final HttpAdapterMetrics metrics,
+            final Optional<ResourceLimitChecks> resourceLimitChecks) {
+
+        final SigfoxProtocolAdapter adapter = new SigfoxProtocolAdapter();
+        setCollaborators(adapter, adapterProperties(), samplerFactory, resourceLimitChecks);
+        adapter.setConfig(adapterProperties());
+        adapter.setMetrics(metrics);
+        return adapter;
     }
 
     @Override

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/ProtocolAdapterConfig.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/ProtocolAdapterConfig.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.service.quarkus;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ServerConfig;
+import org.eclipse.hono.service.monitoring.ConnectionEventProducerConfig;
 import org.eclipse.hono.service.resourcelimits.PrometheusBasedResourceLimitChecksConfig;
 
 import io.quarkus.arc.config.ConfigProperties;
@@ -42,6 +43,8 @@ public class ProtocolAdapterConfig {
      public TenantClientConfig tenant;
 
      public ResourceLimitChecksConfig resourceLimitChecks;
+
+     public QuarkusConnectionEventProducerConfig connectionEvents;
 
      /**
       * Command configuration.
@@ -96,4 +99,11 @@ public class ProtocolAdapterConfig {
       */
      @ConfigProperties(prefix = "hono.resource-limits.prometheus-based", failOnMismatchingMember = false)
      public static class ResourceLimitChecksConfig extends PrometheusBasedResourceLimitChecksConfig { }
+
+     /**
+      * Connection event producer configuration.
+      */
+     @ConfigProperties(prefix = "hono.connection-events", failOnMismatchingMember = false)
+     public static class QuarkusConnectionEventProducerConfig extends ConnectionEventProducerConfig { }
+
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducerConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/ConnectionEventProducerConfig.java
@@ -20,7 +20,7 @@ import java.util.Objects;
  * Properties for selecting and configuring a {@code ConnectionEventProducer}.
  *
  */
-public final class ConnectionEventProducerConfig {
+public class ConnectionEventProducerConfig {
 
     public static final String DEFAULT_LOG_LEVEL = "info";
     public static final ConnectionEventProducerType DEFAULT_TYPE = ConnectionEventProducerType.logging;
@@ -29,15 +29,11 @@ public final class ConnectionEventProducerConfig {
     private String logLevel = DEFAULT_LOG_LEVEL;
     private boolean debugLogLevel = false;
 
-//    public void setProducer(final String type) {
-//        this.type = ConnectionEventProducerType.from(type);
-//    }
-
-    public void setProducer(final ConnectionEventProducerType type) {
+    public final void setProducer(final ConnectionEventProducerType type) {
         this.type = Objects.requireNonNull(type);
     }
 
-    public ConnectionEventProducerType getType() {
+    public final ConnectionEventProducerType getType() {
         return type;
     }
 
@@ -50,7 +46,7 @@ public final class ConnectionEventProducerConfig {
      * @throws NullPointerException if level is {@code null}.
      * @throws IllegalArgumentException if level is anything other than <em>debug</em> or <em>info</em>.
      */
-    public void setLogLevel(final String level) {
+    public final void setLogLevel(final String level) {
         Objects.requireNonNull(level);
         final String levelToUse = level.toLowerCase();
         switch (levelToUse) {
@@ -65,11 +61,11 @@ public final class ConnectionEventProducerConfig {
         }
     }
 
-    public String getLogLevel() {
+    public final String getLogLevel() {
         return logLevel;
     }
 
-    public boolean isDebugLogLevel() {
+    public final boolean isDebugLogLevel() {
         return debugLogLevel;
     }
 

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -43,7 +43,6 @@ import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
@@ -99,7 +98,6 @@ public class AbstractProtocolAdapterBaseTest {
     private EventSender eventSender;
     private ProtocolAdapterCommandConsumerFactory commandConsumerFactory;
     private DeviceConnectionClient deviceConnectionClient;
-    private CommandTargetMapper commandTargetMapper;
     private ConnectionEventProducer.Context connectionEventProducerContext;
 
     /**
@@ -133,8 +131,6 @@ public class AbstractProtocolAdapterBaseTest {
         when(connectionEventProducerContext.getMessageSenderClient()).thenReturn(eventSender);
         when(connectionEventProducerContext.getTenantClient()).thenReturn(tenantClient);
 
-        commandTargetMapper = mock(CommandTargetMapper.class);
-
         properties = new ProtocolAdapterProperties();
         adapter = newProtocolAdapter(properties, ADAPTER_NAME);
         setCollaborators(adapter);
@@ -152,7 +148,6 @@ public class AbstractProtocolAdapterBaseTest {
 
     private void setCollaborators(final AbstractProtocolAdapterBase<?> adapter) {
         adapter.setCommandConsumerFactory(commandConsumerFactory);
-        adapter.setCommandTargetMapper(commandTargetMapper);
         adapter.setCredentialsClient(credentialsClient);
         adapter.setDeviceConnectionClient(deviceConnectionClient);
         adapter.setEventSender(eventSender);

--- a/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
+++ b/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
@@ -37,7 +37,6 @@ import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
 import org.eclipse.hono.client.CommandResponse;
 import org.eclipse.hono.client.CommandResponseSender;
-import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
@@ -67,7 +66,6 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
     protected C properties;
     protected T adapter;
 
-    protected CommandTargetMapper commandTargetMapper;
     protected CredentialsClient credentialsClient;
     protected DeviceConnectionClient deviceConnectionClient;
     protected EventSender eventSender;
@@ -147,7 +145,6 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
         this.registrationClient = createDeviceRegistrationClientMock();
         this.credentialsClient = createCredentialsClientMock();
 
-        commandTargetMapper = mock(CommandTargetMapper.class);
         this.telemetrySender = createTelemetrySenderMock();
         this.eventSender = createEventSenderMock();
     }
@@ -192,7 +189,6 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
      */
     protected void setServiceClients(final T adapter) {
         adapter.setCommandConsumerFactory(commandConsumerFactory);
-        adapter.setCommandTargetMapper(commandTargetMapper);
         adapter.setCredentialsClient(credentialsClient);
         adapter.setDeviceConnectionClient(deviceConnectionClient);
         adapter.setEventSender(eventSender);


### PR DESCRIPTION
The collaborators required by protocol adapters are not injected using
autowiring anymore. This allows for shifting responsibility of object
instantiation/initialization from AbstractProtocolAdapterBase to the
Spring Boot/Quarkus configuration classes which helps with hiding
implementation details from the adapter implementation classes.
