### PR TITLE
[#2288] Fixing device level QoS forwarding of events for HTTP adapter.

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -672,7 +672,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                     .map(c -> ttdTracker.result())
                     .orElse(null);
             final Message downstreamMessage = newMessage(
-                    ctx.getRequestedQos(),
+                    org.eclipse.hono.util.QoS.valueOf(qos.name()),
                     ResourceIdentifier.from(endpoint.getCanonicalName(), tenant, deviceId),
                     ctx.request().uri(),
                     contentType,

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -296,6 +296,17 @@ public final class MessageHelper {
     }
 
     /**
+     * Gets the value of a message's {@link #APP_PROPERTY_QOS} application property.
+     *
+     * @param msg The message.
+     * @return The property value or {@code null} if not set.
+     * @throws NullPointerException if message is {@code null}.
+     */
+    public static int getQoS(final Message msg) {
+        return getApplicationProperty(msg.getApplicationProperties(), APP_PROPERTY_QOS, Integer.class);
+    }
+
+    /**
      * Gets the registration assertion conveyed in an AMQP 1.0 message.
      * <p>
      * The assertion is expected to be contained in the messages's <em>application-properties</em> under key

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -2,6 +2,13 @@
 title = "Release Notes"
 +++
 
+## 1.3.2
+
+### Fixes & Enhancements
+
+* The HTTP adapter did not properly forward the QoS level for events when the *qos-level* header is not set 
+or set to AT_MOST_ONCE. This has been fixed.
+  
 ## 1.3.1
 
 ### Fixes & Enhancements

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
@@ -81,8 +81,8 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
         assertAdditionalMessageProperties(ctx, msg);
     }
 
-    private void assertQosLevel(final VertxTestContext ctx, final Message msg, final ProtonQoS qos) {
-        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(qos.ordinal()));
+    private void assertQosLevel(final VertxTestContext ctx, final Message msg, final ProtonQoS expectedQos) {
+        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(expectedQos.ordinal()));
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -63,6 +63,7 @@ import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -106,9 +107,9 @@ public abstract class CoapTestBase {
      */
     protected static final long TEST_TIMEOUT_MILLIS = 20000; // 20 seconds
 
-    private static final Vertx VERTX = Vertx.vertx();
+    protected static final int MESSAGES_TO_SEND = 60;
 
-    private static final int MESSAGES_TO_SEND = 60;
+    private static final Vertx VERTX = Vertx.vertx();
 
     private static final String COMMAND_TO_SEND = "setDarkness";
     private static final String COMMAND_JSON_KEY = "darkness";
@@ -457,7 +458,7 @@ public abstract class CoapTestBase {
             final Supplier<Future<?>> warmUp,
             final Consumer<Message> messageConsumer,
             final Function<Integer, Future<OptionSet>> requestSender) throws InterruptedException {
-        testUploadMessages(ctx, tenantId, warmUp, messageConsumer, requestSender, MESSAGES_TO_SEND);
+        testUploadMessages(ctx, tenantId, warmUp, messageConsumer, requestSender, MESSAGES_TO_SEND, null);
     }
 
     /**
@@ -470,6 +471,7 @@ public abstract class CoapTestBase {
      * @param messageConsumer Consumer that is invoked when a message was received.
      * @param requestSender The test device that will publish the data.
      * @param numberOfMessages The number of messages that are uploaded.
+     * @param expectedQos The expected QoS level, may be {@code null} leading to expecting the default for event or telemetry.
      * @throws InterruptedException if the test is interrupted before it has finished.
      */
     protected void testUploadMessages(
@@ -478,7 +480,8 @@ public abstract class CoapTestBase {
             final Supplier<Future<?>> warmUp,
             final Consumer<Message> messageConsumer,
             final Function<Integer, Future<OptionSet>> requestSender,
-            final int numberOfMessages) throws InterruptedException {
+            final int numberOfMessages,
+            final QoS expectedQos) throws InterruptedException {
 
         final CountDownLatch received = new CountDownLatch(numberOfMessages);
 
@@ -486,6 +489,7 @@ public abstract class CoapTestBase {
         createConsumer(tenantId, msg -> {
             logger.trace("received {}", msg);
             assertMessageProperties(ctx, msg);
+            assertQosLevel(ctx, msg, getExpectedQoS(expectedQos));
             if (messageConsumer != null) {
                 messageConsumer.accept(msg);
             }
@@ -920,6 +924,25 @@ public abstract class CoapTestBase {
             assertThat(msg.getCreationTime()).isGreaterThan(0);
         });
         assertAdditionalMessageProperties(ctx, msg);
+    }
+
+    private QoS getExpectedQoS(final QoS qos) {
+        if (qos != null) {
+            return qos;
+        }
+
+        switch (getMessageType()) {
+            case CON:
+                return QoS.AT_LEAST_ONCE;
+            case NON:
+                return QoS.AT_MOST_ONCE;
+            default:
+                throw new IllegalArgumentException("Either QoS must be non-null or message type must be CON or NON!");
+        }
+    }
+
+    private void  assertQosLevel(final VertxTestContext ctx, final Message msg, final QoS qos) {
+        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(qos.ordinal()));
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -941,8 +941,8 @@ public abstract class CoapTestBase {
         }
     }
 
-    private void  assertQosLevel(final VertxTestContext ctx, final Message msg, final QoS qos) {
-        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(qos.ordinal()));
+    private void  assertQosLevel(final VertxTestContext ctx, final Message msg, final QoS expectedQos) {
+        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(expectedQos.ordinal()));
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -81,7 +81,7 @@ public class TelemetryCoapIT extends CoapTestBase {
      * @throws InterruptedException if the test fails.
      */
     @Test
-        public void testUploadUsingQoS1(final VertxTestContext ctx) throws InterruptedException {
+    public void testUploadUsingQoS1(final VertxTestContext ctx) throws InterruptedException {
 
         final Tenant tenant = new Tenant();
 

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -30,6 +30,7 @@ import org.eclipse.californium.elements.exception.ConnectorException;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,7 +81,7 @@ public class TelemetryCoapIT extends CoapTestBase {
      * @throws InterruptedException if the test fails.
      */
     @Test
-    public void testUploadUsingQoS1(final VertxTestContext ctx) throws InterruptedException {
+        public void testUploadUsingQoS1(final VertxTestContext ctx) throws InterruptedException {
 
         final Tenant tenant = new Tenant();
 
@@ -93,12 +94,15 @@ public class TelemetryCoapIT extends CoapTestBase {
 
         testUploadMessages(ctx, tenantId,
                 () -> warmUp(client, createCoapsRequest(Code.POST, Type.CON, getPostResource(), 0)),
+                null,
                 count -> {
-            final Promise<OptionSet> result = Promise.promise();
-            final Request request = createCoapsRequest(Code.POST, Type.CON, getPostResource(), count);
-            client.advanced(getHandler(result), request);
-            return result.future();
-        });
+                    final Promise<OptionSet> result = Promise.promise();
+                    final Request request = createCoapsRequest(Code.POST, Type.CON, getPostResource(), count);
+                    client.advanced(getHandler(result), request);
+                    return result.future();
+                },
+                MESSAGES_TO_SEND,
+                QoS.AT_LEAST_ONCE);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -24,7 +24,6 @@ import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,14 +89,7 @@ public class EventHttpIT extends HttpTestBase {
         }
 
         testUploadMessages(ctx, tenantId,
-                msg -> {
-                    ctx.verify(() -> {
-                        assertThat(msg.getApplicationProperties().getValue().get(MessageHelper.APP_PROPERTY_QOS))
-                                .isEqualTo(QoS.AT_LEAST_ONCE.ordinal());
-                    });
-
-                    return Future.succeededFuture();
-                },
+                null,
                 count -> httpClient.create(
                         getEndpointUri(),
                         Buffer.buffer("hello " + count),

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -15,15 +15,26 @@ package org.eclipse.hono.tests.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 
 
 /**
@@ -51,5 +62,47 @@ public class EventHttpIT extends HttpTestBase {
         // assert that events are marked as "durable"
 
         assertThat(msg.isDurable()).isTrue();
+    }
+
+    /**
+     * Checks that device QoS level is ignored for events.
+     *
+     * @param ctx The test context.
+     *
+     * @throws InterruptedException if the test fails.
+     */
+    @Test
+    public void testDeviceQosLevelIsIgnored(final VertxTestContext ctx) throws InterruptedException {
+        final VertxTestContext setup = new VertxTestContext();
+        final Tenant tenant = new Tenant();
+        final MultiMap requestHeaders = MultiMap.caseInsensitiveMultiMap()
+                .add(HttpHeaders.CONTENT_TYPE, "text/plain")
+                .add(HttpHeaders.AUTHORIZATION, authorization)
+                .add(HttpHeaders.ORIGIN, ORIGIN_URI)
+                .add(Constants.HEADER_QOS_LEVEL, String.valueOf(QoS.AT_MOST_ONCE.ordinal()));
+
+        helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, PWD).onComplete(setup.completing());
+
+        assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
+        if (setup.failed()) {
+            ctx.failNow(setup.causeOfFailure());
+            return;
+        }
+
+        testUploadMessages(ctx, tenantId,
+                msg -> {
+                    ctx.verify(() -> {
+                        assertThat(msg.getApplicationProperties().getValue().get(MessageHelper.APP_PROPERTY_QOS))
+                                .isEqualTo(QoS.AT_LEAST_ONCE.ordinal());
+                    });
+
+                    return Future.succeededFuture();
+                },
+                count -> httpClient.create(
+                        getEndpointUri(),
+                        Buffer.buffer("hello " + count),
+                        requestHeaders,
+                        response -> response.statusCode() == HttpURLConnection.HTTP_ACCEPTED),
+                1);
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -103,6 +103,7 @@ public class EventHttpIT extends HttpTestBase {
                         Buffer.buffer("hello " + count),
                         requestHeaders,
                         response -> response.statusCode() == HttpURLConnection.HTTP_ACCEPTED),
-                1);
+                1,
+                QoS.AT_LEAST_ONCE);
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -1265,8 +1265,8 @@ public abstract class HttpTestBase {
         });
     }
 
-    private void  assertQosLevel(final VertxTestContext ctx, final Message msg, final QoS qos) {
-        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(qos.ordinal()));
+    private void  assertQosLevel(final VertxTestContext ctx, final Message msg, final QoS expectedQos) {
+        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(expectedQos.ordinal()));
     }
 
     private boolean hasAccessControlExposedHeaders(final MultiMap responseHeaders) {

--- a/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,13 +84,14 @@ public class TelemetryHttpIT extends HttpTestBase {
             return;
         }
 
-        testUploadMessages(ctx, tenantId, count -> {
-            return httpClient.create(
-                    getEndpointUri(),
-                    Buffer.buffer("hello " + count),
-                    requestHeaders,
-                    response -> response.statusCode() == HttpURLConnection.HTTP_ACCEPTED);
-        });
+        testUploadMessages(ctx, tenantId, null,
+            count -> httpClient.create(
+                getEndpointUri(),
+                Buffer.buffer("hello " + count),
+                requestHeaders,
+                response -> response.statusCode() == HttpURLConnection.HTTP_ACCEPTED),
+            MESSAGES_TO_SEND,
+            QoS.AT_LEAST_ONCE);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -49,7 +49,7 @@ public class EventMqttIT extends MqttPublishTestBase {
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
 
     @Override
-    protected MqttQoS getExpectedQos() {
+    protected MqttQoS getQos() {
         return MqttQoS.AT_LEAST_ONCE;
     }
 
@@ -78,7 +78,7 @@ public class EventMqttIT extends MqttPublishTestBase {
         mqttClient.publish(
                 topic,
                 payload,
-                getExpectedQos(),
+                getQos(),
                 false, // is duplicate
                 false, // is retained
                 sendAttempt -> sendAttemptHandler.accept(sendAttempt, result));

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -49,6 +49,11 @@ public class EventMqttIT extends MqttPublishTestBase {
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
 
     @Override
+    protected MqttQoS getExpectedQos() {
+        return MqttQoS.AT_LEAST_ONCE;
+    }
+
+    @Override
     protected Future<Void> send(
             final String tenantId,
             final String deviceId,
@@ -73,7 +78,7 @@ public class EventMqttIT extends MqttPublishTestBase {
         mqttClient.publish(
                 topic,
                 payload,
-                MqttQoS.AT_LEAST_ONCE,
+                getExpectedQos(),
                 false, // is duplicate
                 false, // is retained
                 sendAttempt -> sendAttemptHandler.accept(sendAttempt, result));

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -72,7 +72,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
      *
      * @return The QoS level.
      */
-    protected abstract MqttQoS getExpectedQos();
+    protected abstract MqttQoS getQos();
 
     /**
      * Sends a message on behalf of a device to the MQTT adapter.
@@ -85,7 +85,6 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
      *         message. The future will succeed if the message has been
      *         published successfully.
      */
-    // here
     protected abstract Future<Void> send(
             String tenantId,
             String deviceId,
@@ -332,7 +331,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
             assertThat(MessageHelper.getTenantIdAnnotation(msg)).isNotNull();
             assertThat(MessageHelper.getDeviceIdAnnotation(msg)).isNotNull();
             assertThat(MessageHelper.getRegistrationAssertion(msg)).isNull();
-            assertThat(MessageHelper.getQoS(msg)).isEqualTo(getExpectedQos().ordinal());
+            assertThat(MessageHelper.getQoS(msg)).isEqualTo(getQos().ordinal());
             assertThat(msg.getCreationTime()).isGreaterThan(0);
         });
         assertAdditionalMessageProperties(ctx, msg);

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -35,6 +35,7 @@ import org.eclipse.hono.tests.Tenants;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.Test;
 
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -67,6 +68,13 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
     private final Map<Integer, Handler<Integer>> pendingMessages = new HashMap<>();
 
     /**
+     * Gets the QoS level with which the MQTT message shall be sent.
+     *
+     * @return The QoS level.
+     */
+    protected abstract MqttQoS getExpectedQos();
+
+    /**
      * Sends a message on behalf of a device to the MQTT adapter.
      *
      * @param tenantId The tenant that the device belongs to.
@@ -77,6 +85,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
      *         message. The future will succeed if the message has been
      *         published successfully.
      */
+    // here
     protected abstract Future<Void> send(
             String tenantId,
             String deviceId,
@@ -323,6 +332,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
             assertThat(MessageHelper.getTenantIdAnnotation(msg)).isNotNull();
             assertThat(MessageHelper.getDeviceIdAnnotation(msg)).isNotNull();
             assertThat(MessageHelper.getRegistrationAssertion(msg)).isNull();
+            assertThat(MessageHelper.getQoS(msg)).isEqualTo(getExpectedQos().ordinal());
             assertThat(msg.getCreationTime()).isGreaterThan(0);
         });
         assertAdditionalMessageProperties(ctx, msg);

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
@@ -38,7 +38,7 @@ public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
 
     @Override
-    protected MqttQoS getExpectedQos() {
+    protected MqttQoS getQos() {
         return MqttQoS.AT_MOST_ONCE;
     }
 
@@ -60,7 +60,7 @@ public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
             mqttClient.publish(
                     topic,
                     payload,
-                    getExpectedQos(),
+                    getQos(),
                     false, // is duplicate
                     false, // is retained
                     sendAttempt -> {

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
@@ -38,6 +38,11 @@ public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
 
     @Override
+    protected MqttQoS getExpectedQos() {
+        return MqttQoS.AT_MOST_ONCE;
+    }
+
+    @Override
     protected Future<Void> send(
             final String tenantId,
             final String deviceId,
@@ -55,7 +60,7 @@ public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
             mqttClient.publish(
                     topic,
                     payload,
-                    MqttQoS.AT_MOST_ONCE,
+                    getExpectedQos(),
                     false, // is duplicate
                     false, // is retained
                     sendAttempt -> {

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
@@ -38,7 +38,7 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
 
     @Override
-    protected MqttQoS getExpectedQos() {
+    protected MqttQoS getQos() {
         return MqttQoS.AT_LEAST_ONCE;
     }
 
@@ -58,7 +58,7 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
         mqttClient.publish(
                 topic,
                 payload,
-                getExpectedQos(),
+                getQos(),
                 false, // is duplicate
                 false, // is retained
                 sendAttempt -> handlePublishAttempt(sendAttempt, result));

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
@@ -38,6 +38,11 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
 
     @Override
+    protected MqttQoS getExpectedQos() {
+        return MqttQoS.AT_LEAST_ONCE;
+    }
+
+    @Override
     protected Future<Void> send(
             final String tenantId,
             final String deviceId,
@@ -53,7 +58,7 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
         mqttClient.publish(
                 topic,
                 payload,
-                MqttQoS.AT_LEAST_ONCE,
+                getExpectedQos(),
                 false, // is duplicate
                 false, // is retained
                 sendAttempt -> handlePublishAttempt(sendAttempt, result));


### PR DESCRIPTION
The HTTP adapter suffered from a bug when a client sent an event and set a device level QoS to something different than 1 or set no device level QoS at all. In any case the event was sent with QoS 1 but the message property indicating the device level QoS to the northbound application (which should always be 1 as this is the only supported QoS for events) was wrong.

Signed-off-by: Florian Kaltner <florian.kaltner@bosch.io>