### PR TITLE
[#2267] Add AMQP 1.0 based CommandConsumerFactory implementation

### DIFF
--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -977,7 +977,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         }
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setCommandResponseSender(commandResponseSender);
-        adapter.setCommandRouterClient(deviceConnectionClient);
+        adapter.setCommandRouterClient(commandRouterClient);
         adapter.init(vertx, mock(Context.class));
 
         return adapter;

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -33,8 +33,6 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.qpid.proton.amqp.messaging.Released;
-import org.apache.qpid.proton.message.Message;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.CoAP.Code;
@@ -48,13 +46,13 @@ import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.hono.adapter.client.command.CommandConsumer;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.adapter.client.command.CommandResponse;
+import org.eclipse.hono.adapter.client.command.CommandResponseSender;
+import org.eclipse.hono.adapter.client.command.Commands;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.Command;
-import org.eclipse.hono.client.CommandContext;
-import org.eclipse.hono.client.CommandResponse;
-import org.eclipse.hono.client.CommandResponseSender;
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumer;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
@@ -85,7 +83,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import io.vertx.proton.ProtonDelivery;
 
 /**
  * Verifies behavior of {@link AbstractVertxBasedCoapAdapter}.
@@ -98,7 +95,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
 
     private static final Vertx vertx = Vertx.vertx();
 
-    private ProtocolAdapterCommandConsumer commandConsumer;
+    private CommandConsumer commandConsumer;
     private ResourceLimitChecks resourceLimitChecks;
     private CoapAdapterMetrics metrics;
     private Span span;
@@ -123,7 +120,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         createClientFactories();
         prepareClients();
 
-        commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
+        commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
         when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), any(Handler.class), any(), any()))
             .thenReturn(Future.succeededFuture(commandConsumer));
@@ -604,12 +601,12 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
     }
 
     /**
-     * Verifies that the adapter will release an incoming command delivery if the delivery of the preceding telemetry
-     * message hasn't been accepted.
+     * Verifies that the adapter releases an incoming command if the forwarding of the preceding telemetry
+     * message did not succeed.
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testUploadTelemetryWithFailedDeliveryReleasesCommand() {
+    public void testUploadTelemetryReleasesCommandForFailedDownstreamSender() {
 
         // GIVEN an adapter with a downstream telemetry consumer attached
         givenAnAdapter(properties);
@@ -617,16 +614,13 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         givenATelemetrySenderForAnyTenant(sendTelemetryOutcome);
 
         // and a commandConsumerFactory that upon creating a consumer will invoke it with a command
-        final Message commandMessage = newMockedCommandMessage("tenant", "device", "doThis");
-        final Command pendingCommand = Command.from(commandMessage, "tenant", "device");
-        final ProtonDelivery commandDelivery = mock(ProtonDelivery.class);
-        final CommandContext commandContext = CommandContext.from(pendingCommand, commandDelivery, mock(Span.class));
+        final CommandContext commandContext = givenAOneWayCommandContext("tenant", "device", "doThis", null, null);
         when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("device"), any(Handler.class), any(), any()))
-        .thenAnswer(invocation -> {
-            final Handler<CommandContext> consumer = invocation.getArgument(2);
-            consumer.handle(commandContext);
-            return Future.succeededFuture(commandConsumer);
-        });
+            .thenAnswer(invocation -> {
+                final Handler<CommandContext> consumer = invocation.getArgument(2);
+                consumer.handle(commandContext);
+                return Future.succeededFuture(commandConsumer);
+            });
 
         // WHEN a device publishes a telemetry message with a hono-ttd parameter
         final Buffer payload = Buffer.buffer("some payload");
@@ -663,23 +657,23 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
                 eq(TtdStatus.COMMAND),
                 any());
         // and the command delivery is released
-        verify(commandDelivery).disposition(eq(Released.getInstance()), eq(true));
+        verify(commandContext).release();
     }
 
     /**
-     * Verifies that the adapter waits for a command response being settled and accepted
-     * by a downstream peer before responding with a 2.04 status to the device.
+     * Verifies that the adapter waits for a command response being successfully sent
+     * downstream before responding with a 2.04 status to the device.
      */
     @Test
     public void testUploadCommandResponseWaitsForAcceptedOutcome() {
 
         // GIVEN an adapter with a downstream application attached
         givenAnAdapter(properties);
-        final Promise<ProtonDelivery> outcome = Promise.promise();
+        final Promise<Void> outcome = Promise.promise();
         final CommandResponseSender sender = givenACommandResponseSenderForAnyTenant(outcome);
 
         // WHEN a device publishes an command response
-        final String reqId = Command.getRequestId("correlation", "replyToId", "device");
+        final String reqId = Commands.getRequestId("correlation", "replyToId", "device");
         final Buffer payload = Buffer.buffer("some payload");
         final OptionSet options = new OptionSet();
         options.addUriPath(CommandConstants.COMMAND_RESPONSE_ENDPOINT).addUriPath(reqId);
@@ -705,7 +699,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
                 any());
 
         // until the message has been accepted
-        outcome.complete(mock(ProtonDelivery.class));
+        outcome.complete();
 
         verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED.equals(res.getCode())));
         verify(metrics).reportCommand(
@@ -725,12 +719,12 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
     public void testUploadCommandResponseFailsForRejectedOutcome() {
 
         // GIVEN an adapter with a downstream application attached
-        final Promise<ProtonDelivery> outcome = Promise.promise();
+        final Promise<Void> outcome = Promise.promise();
         final CommandResponseSender sender = givenACommandResponseSenderForAnyTenant(outcome);
         givenAnAdapter(properties);
 
         // WHEN a device publishes an command response
-        final String reqId = Command.getRequestId("correlation", "replyToId", "device");
+        final String reqId = Commands.getRequestId("correlation", "replyToId", "device");
         final Buffer payload = Buffer.buffer("some payload");
         final OptionSet options = new OptionSet();
         options.addUriPath(CommandConstants.COMMAND_RESPONSE_ENDPOINT).addUriPath(reqId);
@@ -769,12 +763,12 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         to.addAdapter(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_COAP).setEnabled(Boolean.FALSE));
         when(tenantClient.get(eq("tenant"), (SpanContext) any())).thenReturn(Future.succeededFuture(to));
 
-        final Promise<ProtonDelivery> outcome = Promise.promise();
+        final Promise<Void> outcome = Promise.promise();
         final CommandResponseSender sender = givenACommandResponseSenderForAnyTenant(outcome);
         givenAnAdapter(properties);
 
         // WHEN a device publishes an command response
-        final String reqId = Command.getRequestId("correlation", "replyToId", "device");
+        final String reqId = Commands.getRequestId("correlation", "replyToId", "device");
         final Buffer payload = Buffer.buffer("some payload");
         final OptionSet options = new OptionSet();
         options.addUriPath(CommandConstants.COMMAND_RESPONSE_ENDPOINT).addUriPath(reqId);
@@ -916,17 +910,6 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         return server;
     }
 
-    private static Message newMockedCommandMessage(final String tenantId, final String deviceId, final String name) {
-        final Message msg = mock(Message.class);
-        when(msg.getAddress()).thenReturn(String.format("%s/%s/%s",
-                CommandConstants.COMMAND_ENDPOINT, tenantId, deviceId));
-        when(msg.getSubject()).thenReturn(name);
-        when(msg.getCorrelationId()).thenReturn("the-correlation-id");
-        when(msg.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT,
-                tenantId, deviceId, "the-reply-to-id"));
-        return msg;
-    }
-
     /**
      * Creates a new adapter instance to be tested.
      * <p>
@@ -993,7 +976,8 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
             adapter.setCredentialsClient(credentialsClient);
         }
         adapter.setCommandConsumerFactory(commandConsumerFactory);
-        adapter.setDeviceConnectionClient(deviceConnectionClient);
+        adapter.setCommandResponseSender(commandResponseSender);
+        adapter.setCommandRouterClient(deviceConnectionClient);
         adapter.init(vertx, mock(Context.class));
 
         return adapter;

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapterTest.java
@@ -30,9 +30,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.hono.adapter.client.command.CommandConsumer;
+import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.CommandContext;
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumer;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.http.HttpContext;
@@ -76,7 +76,6 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import io.vertx.proton.ProtonDelivery;
 
 /**
  * Verifies behavior of {@link AbstractVertxBasedHttpProtocolAdapter}.
@@ -90,7 +89,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
     private static final String ADAPTER_TYPE = "http";
     private static final String CMD_REQ_ID = "12fcmd-client-c925910f-ea2a-455c-a3f9-a339171f335474f48a55-c60d-4b99-8950-a2fbb9e8f1b6";
 
-    private ProtocolAdapterCommandConsumer commandConsumer;
+    private CommandConsumer commandConsumer;
     private Vertx vertx;
     private Context context;
     private HttpAdapterMetrics metrics;
@@ -121,7 +120,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
         createClientFactories();
         prepareClients();
 
-        commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
+        commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
         when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), any(Handler.class), any(), any()))
             .thenReturn(Future.succeededFuture(commandConsumer));
@@ -434,7 +433,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
 
         // GIVEN an adapter with a downstream application attached
         givenAnAdapter(properties);
-        final Promise<ProtonDelivery> outcome = Promise.promise();
+        final Promise<Void> outcome = Promise.promise();
         givenACommandResponseSenderForAnyTenant(outcome);
 
         // WHEN a device publishes a command response
@@ -461,7 +460,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
                 any());
 
         // until the command response has been accepted by the application
-        outcome.complete(mock(ProtonDelivery.class));
+        outcome.complete();
         verify(response).setStatusCode(202);
         verify(response).end();
         verify(metrics).reportCommand(
@@ -587,7 +586,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
     public void testUploadCommandResponseFailsForRejectedOutcome() {
 
         // GIVEN an adapter with a downstream application attached
-        final Promise<ProtonDelivery> outcome = Promise.promise();
+        final Promise<Void> outcome = Promise.promise();
         givenACommandResponseSenderForAnyTenant(outcome);
         givenAnAdapter(properties);
 
@@ -680,7 +679,7 @@ public class AbstractVertxBasedHttpProtocolAdapterTest extends
             return 0;
         });
         // and the creation of the command consumer completes at a later point
-        final Promise<ProtocolAdapterCommandConsumer> commandConsumerPromise = Promise.promise();
+        final Promise<CommandConsumer> commandConsumerPromise = Promise.promise();
         when(commandConsumerFactory.createCommandConsumer(anyString(), anyString(), any(Handler.class), any(), any()))
                 .thenReturn(commandConsumerPromise.future());
 

--- a/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
+++ b/adapters/http-vertx/src/main/java/org/eclipse/hono/adapter/http/impl/Config.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/Config.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscriptionsManager.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscriptionsManager.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumer;
+import org.eclipse.hono.adapter.client.command.CommandConsumer;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Pair;
 import org.slf4j.Logger;
@@ -43,7 +43,7 @@ public final class CommandSubscriptionsManager<T extends MqttProtocolAdapterProp
     /**
      * Map of the current subscriptions. Key is the topic name.
      */
-    private final Map<String, Pair<CommandSubscription, ProtocolAdapterCommandConsumer>> subscriptions = new ConcurrentHashMap<>();
+    private final Map<String, Pair<CommandSubscription, CommandConsumer>> subscriptions = new ConcurrentHashMap<>();
     /**
      * Map of the requests waiting for an acknowledgement. Key is the command message id.
      */
@@ -121,7 +121,7 @@ public final class CommandSubscriptionsManager<T extends MqttProtocolAdapterProp
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public void addSubscription(final CommandSubscription subscription,
-            final ProtocolAdapterCommandConsumer commandConsumer) {
+            final CommandConsumer commandConsumer) {
         Objects.requireNonNull(subscription);
         Objects.requireNonNull(commandConsumer);
         subscriptions.put(subscription.getTopic(), Pair.of(subscription, commandConsumer));
@@ -136,12 +136,12 @@ public final class CommandSubscriptionsManager<T extends MqttProtocolAdapterProp
      *         if no subscription entry was found for the given topic.
      * @throws NullPointerException if topic or span is {@code null}.
      **/
-    public Future<Pair<CommandSubscription, ProtocolAdapterCommandConsumer>> removeSubscription(final String topic,
+    public Future<Pair<CommandSubscription, CommandConsumer>> removeSubscription(final String topic,
             final Span span) {
         Objects.requireNonNull(topic);
         Objects.requireNonNull(span);
 
-        final Pair<CommandSubscription, ProtocolAdapterCommandConsumer> removed = subscriptions.remove(topic);
+        final Pair<CommandSubscription, CommandConsumer> removed = subscriptions.remove(topic);
         if (removed != null) {
             return Future.succeededFuture(removed);
         } else {
@@ -163,7 +163,7 @@ public final class CommandSubscriptionsManager<T extends MqttProtocolAdapterProp
      * @throws NullPointerException if onSubscriptionRemovedFunction or span is {@code null}.
      **/
     public CompositeFuture removeAllSubscriptions(
-            final Function<Pair<CommandSubscription, ProtocolAdapterCommandConsumer>, Future<Void>> onSubscriptionRemovedFunction,
+            final Function<Pair<CommandSubscription, CommandConsumer>, Future<Void>> onSubscriptionRemovedFunction,
             final Span span) {
 
         Objects.requireNonNull(onSubscriptionRemovedFunction);

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -35,12 +35,12 @@ import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
+import org.eclipse.hono.adapter.client.command.CommandConsumer;
+import org.eclipse.hono.adapter.client.command.CommandResponse;
+import org.eclipse.hono.adapter.client.command.CommandResponseSender;
+import org.eclipse.hono.adapter.client.command.Commands;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.Command;
-import org.eclipse.hono.client.CommandResponse;
-import org.eclipse.hono.client.CommandResponseSender;
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumer;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.auth.device.AuthHandler;
@@ -747,7 +747,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         adapter.uploadCommandResponseMessage(newMqttContext(messageFromDevice, endpoint, span), address)
                 .onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
-                        verify(sender).sendCommandResponse(any(), any());
+                        verify(sender).sendCommandResponse(any(CommandResponse.class), any());
                         // then it is forwarded successfully
                         verify(metrics).reportCommand(
                                 eq(MetricsTags.Direction.RESPONSE),
@@ -889,7 +889,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         when(endpoint.keepAliveTimeSeconds()).thenReturn(10); // 10 seconds
 
         // WHEN a device subscribes to commands
-        final ProtocolAdapterCommandConsumer commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
+        final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
         when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class), any(), any()))
                         .thenReturn(Future.succeededFuture(commandConsumer));
@@ -933,7 +933,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         when(endpoint.keepAliveTimeSeconds()).thenReturn(10); // 10 seconds
 
         // WHEN a device subscribes to commands
-        final ProtocolAdapterCommandConsumer commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
+        final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED)));
         when(commandConsumerFactory.createCommandConsumer(eq("tenant"), eq("deviceId"), any(Handler.class), any(), any()))
                 .thenReturn(Future.succeededFuture(commandConsumer));
@@ -982,7 +982,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         subscriptions.add(newMockTopicSubscription("bumlux/+/+/#", MqttQoS.AT_MOST_ONCE));
         subscriptions.add(newMockTopicSubscription("bumlux/+/+/#", MqttQoS.AT_MOST_ONCE));
         // and for subscribing to commands
-        final ProtocolAdapterCommandConsumer commandConsumer = mock(ProtocolAdapterCommandConsumer.class);
+        final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
         when(commandConsumerFactory.createCommandConsumer(eq("tenant-1"), eq("device-A"), any(Handler.class), any(), any()))
                         .thenReturn(Future.succeededFuture(commandConsumer));
@@ -1302,7 +1302,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
 
         adapter.uploadMessage(newMqttContext(msg, mockEndpoint(), span),
                 ResourceIdentifier.fromString(String.format("%s/tenant/device/res/%s/200", getCommandEndpoint(),
-                        Command.getRequestId("cmd123", "to", "deviceId"))),
+                        Commands.getRequestId("cmd123", "to", "deviceId"))),
                 msg)
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -18,11 +18,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.hono.adapter.client.command.Command;
+import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.Command;
-import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
@@ -39,7 +39,6 @@ import io.vertx.ext.healthchecks.HealthCheckHandler;
  */
 public final class CacheBasedDeviceConnectionClient implements DeviceConnectionClient, ServiceClient {
 
-    private static final String SPAN_NAME_GET_LAST_GATEWAY = "get last known gateway";
     private static final String SPAN_NAME_SET_LAST_GATEWAY = "set last known gateway";
     private static final String SPAN_NAME_GET_CMD_HANDLING_ADAPTER_INSTANCES = "get command handling adapter instances";
     private static final String SPAN_NAME_SET_CMD_HANDLING_ADAPTER_INSTANCE = "set command handling adapter instance";
@@ -81,21 +80,25 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
 
     /**
      * {@inheritDoc}
+     * <p>
+     * Simply delegates to {@link #registerCommandConsumer(String, String, String, Duration, SpanContext)}.
      */
     @Override
-    public Future<JsonObject> getLastKnownGatewayForDevice(
+    public Future<Void> setCommandHandlingAdapterInstance(
             final String tenantId,
             final String deviceId,
+            final String adapterInstanceId,
+            final Duration lifespan,
             final SpanContext context) {
 
-        final Span span = newSpan(context, SPAN_NAME_GET_LAST_GATEWAY);
-        TracingHelper.setDeviceTags(span, tenantId, deviceId);
-
-        return finishSpan(connectionInfoCache.getLastKnownGatewayForDevice(tenantId, deviceId, span), span);
+        return registerCommandConsumer(tenantId, deviceId, adapterInstanceId, lifespan, context);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public Future<Void> setCommandHandlingAdapterInstance(
+    public Future<Void> registerCommandConsumer(
             final String tenantId,
             final String deviceId,
             final String adapterInstanceId,
@@ -111,8 +114,26 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
         return finishSpan(connectionInfoCache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, span), span);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Simply delegates to {@link #unregisterCommandConsumer(String, String, String, SpanContext)}.
+     */
     @Override
     public Future<Void> removeCommandHandlingAdapterInstance(
+            final String tenantId,
+            final String deviceId,
+            final String adapterInstanceId,
+            final SpanContext context) {
+
+        return unregisterCommandConsumer(tenantId, deviceId, adapterInstanceId, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> unregisterCommandConsumer(
             final String tenantId,
             final String deviceId,
             final String adapterInstanceId,

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommand.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommand.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.command.Command;
+import org.eclipse.hono.tracing.TracingHelper;
+
+import io.opentracing.Span;
+import io.opentracing.log.Fields;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A wrapper around a legacy {@link org.eclipse.hono.client.Command}.
+ *
+ */
+public final class ProtonBasedCommand implements Command {
+
+    private final org.eclipse.hono.client.Command command;
+
+    /**
+     * Creates a new wrapper around a command.
+     *
+     * @param command The command to wrap.
+     * @throws NullPointerException if the command is {@code null}.
+     */
+    public ProtonBasedCommand(final org.eclipse.hono.client.Command command) {
+        this.command = Objects.requireNonNull(command);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isOneWay() {
+        return command.isOneWay();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isValid() {
+        return command.isValid();
+    }
+
+    /**
+     * {@inheritDoc}}
+     */
+    @Override
+    public String getInvalidCommandReason() {
+        return command.getInvalidCommandReason();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName() {
+        return command.getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTenant() {
+        return command.getTenant();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDeviceId() {
+        return command.getDeviceId();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isTargetedAtGateway() {
+        return command.isTargetedAtGateway();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOriginalDeviceId() {
+        return command.getOriginalDeviceId();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequestId() {
+        return command.getRequestId();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Buffer getPayload() {
+        return command.getPayload();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPayloadSize() {
+        return command.getPayloadSize();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getContentType() {
+        return command.getContentType();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getReplyToId() {
+        return command.getReplyToId();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getCorrelationId() {
+        return command.getCorrelationId();
+    }
+
+    @Override
+    public String toString() {
+        return command.toString();
+    }
+
+    /**
+     * Logs information about the command.
+     *
+     * @param span The span to log to.
+     * @throws NullPointerException if span is {@code null}.
+     */
+    public void logToSpan(final Span span) {
+        Objects.requireNonNull(span);
+        if (command.isValid()) {
+            final Map<String, String> items = new HashMap<>(4);
+            items.put(Fields.EVENT, "received command message");
+            TracingHelper.TAG_CORRELATION_ID.set(span, command.getCorrelationId());
+            items.put("to", command.getCommandMessage().getAddress());
+            items.put("reply-to", command.getCommandMessage().getReplyTo());
+            items.put("name", command.getName());
+            items.put("content-type", command.getContentType());
+            span.log(items);
+        } else {
+            TracingHelper.logError(span, "received invalid command message [" + command + "]");
+        }
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandConsumerFactory.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandConsumerFactory.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.eclipse.hono.adapter.client.amqp.AbstractServiceClient;
+import org.eclipse.hono.adapter.client.command.Command;
+import org.eclipse.hono.adapter.client.command.CommandConsumer;
+import org.eclipse.hono.adapter.client.command.CommandConsumerFactory;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.client.CommandTargetMapper;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
+import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory.CommandHandlingAdapterInfoAccess;
+import org.eclipse.hono.client.SendMessageSampler.Factory;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.Constants;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonHelper;
+
+
+/**
+ * A vertx-proton based factory for creating consumers of command messages received via the
+ * AMQP 1.0 Messaging Network.
+ * <p>
+ * This implementation wraps a {@link ProtocolAdapterCommandConsumerFactory} and thus also supports
+ * routing of commands to a target protocol adapter instance.
+ *
+ */
+public class ProtonBasedCommandConsumerFactory extends AbstractServiceClient implements CommandConsumerFactory {
+
+    private final ProtocolAdapterCommandConsumerFactory factory;
+
+    /**
+     * Creates a new client for a connection.
+     *
+     * @param connection The connection to the AMQP 1.0 Messaging Network.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param commandTargetMapper The component for mapping an incoming command to the gateway (if applicable) and
+     *            protocol adapter instance that can handle it.
+     * @param commandRoutingInfoAccess The component for setting and clearing information that maps a device to
+     *                                 a protocol adapter instance.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public ProtonBasedCommandConsumerFactory(
+            final HonoConnection connection,
+            final Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig,
+            final CommandTargetMapper commandTargetMapper,
+            final CommandHandlingAdapterInfoAccess commandRoutingInfoAccess) {
+
+        super(connection, samplerFactory, adapterConfig);
+
+        Objects.requireNonNull(commandTargetMapper);
+        Objects.requireNonNull(commandRoutingInfoAccess);
+
+        factory = ProtocolAdapterCommandConsumerFactory.create(connection, samplerFactory);
+        factory.initialize(commandTargetMapper, commandRoutingInfoAccess);
+    }
+
+    private static class CommandContextAdapter implements CommandContext {
+
+        private final org.eclipse.hono.client.CommandContext ctx;
+        private final ProtonBasedCommand command;
+
+        /**
+         * Creates a new adapter for a context.
+         *
+         * @throws NullPointerException if context is {@code null}.
+         */
+        CommandContextAdapter(final org.eclipse.hono.client.CommandContext context) {
+            this.ctx = Objects.requireNonNull(context);
+            this.command = new ProtonBasedCommand(context.getCommand());
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void logCommandToSpan(final Span span) {
+            command.logToSpan(span);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Command getCommand() {
+            return command;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void accept() {
+            ctx.accept();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void release() {
+            ctx.release();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
+            ctx.modify(deliveryFailed, undeliverableHere);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void reject(final String cause) {
+            final ErrorCondition error = ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, cause);
+            ctx.reject(error);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <T> T get(final String key) {
+            return ctx.get(key);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <T> T get(final String key, final T defaultValue) {
+            return ctx.get(key, defaultValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void put(final String key, final Object value) {
+            ctx.put(key, value);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public SpanContext getTracingContext() {
+            return ctx.getTracingContext();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Span getTracingSpan() {
+            return ctx.getTracingSpan();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<CommandConsumer> createCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final Handler<CommandContext> commandHandler,
+            final Duration lifespan,
+            final SpanContext context) {
+
+        return factory.createCommandConsumer(
+                tenantId,
+                deviceId,
+                ctx -> {
+                    commandHandler.handle(new CommandContextAdapter(ctx));
+                },
+                lifespan,
+                context)
+                .map(adapterCommandConsumer -> {
+                    return new CommandConsumer() {
+
+                        @Override
+                        public Future<Void> close(final SpanContext spanContext) {
+                            return adapterCommandConsumer.close(spanContext);
+                        }
+                    };
+                });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<CommandConsumer> createCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final String gatewayId,
+            final Handler<CommandContext> commandHandler,
+            final Duration lifespan,
+            final SpanContext context) {
+
+        return factory.createCommandConsumer(
+                tenantId,
+                deviceId,
+                gatewayId,
+                ctx -> {
+                    commandHandler.handle(new CommandContextAdapter(ctx));
+                },
+                lifespan,
+                context)
+                .map(adapterCommandConsumer -> {
+                    return new CommandConsumer() {
+
+                        @Override
+                        public Future<Void> close(final SpanContext spanContext) {
+                            return adapterCommandConsumer.close(spanContext);
+                        }
+                    };
+                });
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandConsumerFactory.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandConsumerFactory.java
@@ -78,6 +78,68 @@ public class ProtonBasedCommandConsumerFactory extends AbstractServiceClient imp
         factory.initialize(commandTargetMapper, commandRoutingInfoAccess);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<CommandConsumer> createCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final Handler<CommandContext> commandHandler,
+            final Duration lifespan,
+            final SpanContext context) {
+
+        return factory.createCommandConsumer(
+                tenantId,
+                deviceId,
+                ctx -> {
+                    commandHandler.handle(new CommandContextAdapter(ctx));
+                },
+                lifespan,
+                context)
+                .map(adapterCommandConsumer -> {
+                    return new CommandConsumer() {
+
+                        @Override
+                        public Future<Void> close(final SpanContext spanContext) {
+                            return adapterCommandConsumer.close(spanContext);
+                        }
+                    };
+                });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<CommandConsumer> createCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final String gatewayId,
+            final Handler<CommandContext> commandHandler,
+            final Duration lifespan,
+            final SpanContext context) {
+
+        return factory.createCommandConsumer(
+                tenantId,
+                deviceId,
+                gatewayId,
+                ctx -> {
+                    commandHandler.handle(new CommandContextAdapter(ctx));
+                },
+                lifespan,
+                context)
+                .map(adapterCommandConsumer -> {
+                    return new CommandConsumer() {
+
+                        @Override
+                        public Future<Void> close(final SpanContext spanContext) {
+                            return adapterCommandConsumer.close(spanContext);
+                        }
+                    };
+                });
+    }
+
     private static class CommandContextAdapter implements CommandContext {
 
         private final org.eclipse.hono.client.CommandContext ctx;
@@ -181,67 +243,5 @@ public class ProtonBasedCommandConsumerFactory extends AbstractServiceClient imp
         public Span getTracingSpan() {
             return ctx.getTracingSpan();
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Future<CommandConsumer> createCommandConsumer(
-            final String tenantId,
-            final String deviceId,
-            final Handler<CommandContext> commandHandler,
-            final Duration lifespan,
-            final SpanContext context) {
-
-        return factory.createCommandConsumer(
-                tenantId,
-                deviceId,
-                ctx -> {
-                    commandHandler.handle(new CommandContextAdapter(ctx));
-                },
-                lifespan,
-                context)
-                .map(adapterCommandConsumer -> {
-                    return new CommandConsumer() {
-
-                        @Override
-                        public Future<Void> close(final SpanContext spanContext) {
-                            return adapterCommandConsumer.close(spanContext);
-                        }
-                    };
-                });
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Future<CommandConsumer> createCommandConsumer(
-            final String tenantId,
-            final String deviceId,
-            final String gatewayId,
-            final Handler<CommandContext> commandHandler,
-            final Duration lifespan,
-            final SpanContext context) {
-
-        return factory.createCommandConsumer(
-                tenantId,
-                deviceId,
-                gatewayId,
-                ctx -> {
-                    commandHandler.handle(new CommandContextAdapter(ctx));
-                },
-                lifespan,
-                context)
-                .map(adapterCommandConsumer -> {
-                    return new CommandConsumer() {
-
-                        @Override
-                        public Future<Void> close(final SpanContext spanContext) {
-                            return adapterCommandConsumer.close(spanContext);
-                        }
-                    };
-                });
     }
 }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandConsumerFactory.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandConsumerFactory.java
@@ -15,6 +15,7 @@
 package org.eclipse.hono.adapter.client.command.amqp;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
@@ -23,18 +24,24 @@ import org.eclipse.hono.adapter.client.command.Command;
 import org.eclipse.hono.adapter.client.command.CommandConsumer;
 import org.eclipse.hono.adapter.client.command.CommandConsumerFactory;
 import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
+import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.CommandTargetMapper;
+import org.eclipse.hono.client.CommandTargetMapper.CommandTargetMapperContext;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory.CommandHandlingAdapterInfoAccess;
 import org.eclipse.hono.client.SendMessageSampler.Factory;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.RegistrationAssertion;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
 import io.vertx.proton.ProtonHelper;
 
 
@@ -56,26 +63,79 @@ public class ProtonBasedCommandConsumerFactory extends AbstractServiceClient imp
      * @param connection The connection to the AMQP 1.0 Messaging Network.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
      * @param adapterConfig The protocol adapter's configuration properties.
-     * @param commandTargetMapper The component for mapping an incoming command to the gateway (if applicable) and
-     *            protocol adapter instance that can handle it.
-     * @param commandRoutingInfoAccess The component for setting and clearing information that maps a device to
-     *                                 a protocol adapter instance.
+     * @param deviceConnectionClient The client to use for accessing the Device Connection service.
+     * @param deviceRegistrationClient The client to use for accessing the Device Registration service.
+     * @param tracer The OpenTracing tracer to use for tracking the processing of messages.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public ProtonBasedCommandConsumerFactory(
             final HonoConnection connection,
             final Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig,
-            final CommandTargetMapper commandTargetMapper,
-            final CommandHandlingAdapterInfoAccess commandRoutingInfoAccess) {
+            final DeviceConnectionClient deviceConnectionClient,
+            final DeviceRegistrationClient deviceRegistrationClient,
+            final Tracer tracer) {
 
         super(connection, samplerFactory, adapterConfig);
 
-        Objects.requireNonNull(commandTargetMapper);
-        Objects.requireNonNull(commandRoutingInfoAccess);
+        Objects.requireNonNull(deviceConnectionClient);
+        Objects.requireNonNull(deviceRegistrationClient);
+        Objects.requireNonNull(tracer);
+
+        final CommandTargetMapper commandTargetMapper = CommandTargetMapper.create(tracer);
+        commandTargetMapper.initialize(new CommandTargetMapperContext() {
+
+            @Override
+            public Future<List<String>> getViaGateways(
+                    final String tenant,
+                    final String deviceId,
+                    final SpanContext context) {
+
+                Objects.requireNonNull(tenant);
+                Objects.requireNonNull(deviceId);
+
+                return deviceRegistrationClient.assertRegistration(tenant, deviceId, null, context)
+                        .map(RegistrationAssertion::getAuthorizedGateways);
+            }
+
+            @Override
+            public Future<JsonObject> getCommandHandlingAdapterInstances(
+                    final String tenant,
+                    final String deviceId,
+                    final List<String> viaGateways,
+                    final SpanContext context) {
+
+                Objects.requireNonNull(tenant);
+                Objects.requireNonNull(deviceId);
+                Objects.requireNonNull(viaGateways);
+
+                return deviceConnectionClient.getCommandHandlingAdapterInstances(
+                        tenant, deviceId, viaGateways, context);
+            }
+        });
 
         factory = ProtocolAdapterCommandConsumerFactory.create(connection, samplerFactory);
-        factory.initialize(commandTargetMapper, commandRoutingInfoAccess);
+        factory.initialize(commandTargetMapper, new CommandHandlingAdapterInfoAccess() {
+
+            @Override
+            public Future<Void> setCommandHandlingAdapterInstance(
+                    final String tenant,
+                    final String deviceId,
+                    final String adapterInstanceId,
+                    final Duration lifespan,
+                    final SpanContext context) {
+                return deviceConnectionClient.setCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, lifespan, context);
+            }
+
+            @Override
+            public Future<Void> removeCommandHandlingAdapterInstance(
+                    final String tenant,
+                    final String deviceId,
+                    final String adapterInstanceId,
+                    final SpanContext context) {
+                return deviceConnectionClient.removeCommandHandlingAdapterInstance(tenant, deviceId, adapterInstanceId, context);
+            }
+        });
     }
 
     /**

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandResponseSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandResponseSender.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import java.util.Objects;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.client.amqp.AbstractServiceClient;
+import org.eclipse.hono.adapter.client.command.CommandResponse;
+import org.eclipse.hono.adapter.client.command.CommandResponseSender;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.impl.CommandResponseSenderImpl;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.AddressHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.proton.ProtonHelper;
+
+
+/**
+ * A vertx-proton based client for sending command response messages downstream via the AMQP 1.0 Messaging Network.
+ *
+ */
+public class ProtonBasedCommandResponseSender extends AbstractServiceClient implements CommandResponseSender {
+
+    /**
+     * Creates a new sender for a connection.
+     *
+     * @param connection The connection to the AMQP 1.0 Messaging Network.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public ProtonBasedCommandResponseSender(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig) {
+        super(connection, samplerFactory, adapterConfig);
+    }
+
+    private Future<org.eclipse.hono.client.CommandResponseSender> getSender(final String tenantId, final String replyId) {
+        return connection.executeOnContext(result -> {
+            CommandResponseSenderImpl.create(
+                    connection,
+                    tenantId,
+                    replyId,
+                    samplerFactory.create(CommandConstants.COMMAND_RESPONSE_ENDPOINT),
+                    onRemoteClose -> {})
+            .onComplete(result);
+        });
+    }
+
+    private Message createDownstreamMessage(final CommandResponse response) {
+        final Message msg = ProtonHelper.message();
+        MessageHelper.setCreationTime(msg);
+        msg.setCorrelationId(response.getCorrelationId());
+        MessageHelper.setPayload(msg, response.getContentType(), response.getPayload());
+        MessageHelper.addStatus(msg, response.getStatus());
+        msg.setAddress(AddressHelper.getTargetAddress(
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT,
+                response.getTenantId(),
+                response.getReplyToId(),
+                null));
+        MessageHelper.addTenantId(msg, response.getTenantId());
+        MessageHelper.addDeviceId(msg, response.getDeviceId());
+        return msg;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendCommandResponse(final CommandResponse response, final SpanContext context) {
+
+        Objects.requireNonNull(response);
+        return getSender(response.getTenantId(), response.getReplyToId())
+                .compose(sender -> {
+                    final Message msg = createDownstreamMessage(response);
+                    return sender.sendAndWaitForOutcome(msg, context)
+                            .onComplete(delivery -> sender.close(r -> {}));
+                })
+                .mapEmpty();
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
@@ -38,7 +38,7 @@ import io.vertx.core.json.JsonObject;
 
 
 /**
- * A ProtonBasedDeviceConnectionClient.
+ * A vertx-proton based client for accessing Hono's <em>Device Connection</em> API.
  *
  */
 public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseClient<DeviceConnectionResult>
@@ -122,22 +122,8 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseCl
 
     /**
      * {@inheritDoc}
-     */
-    @Override
-    public Future<JsonObject> getLastKnownGatewayForDevice(
-            final String tenant,
-            final String deviceId,
-            final SpanContext context) {
-
-        Objects.requireNonNull(tenant);
-        Objects.requireNonNull(deviceId);
-
-        return getOrCreateDeviceConnectionClient(tenant)
-                .compose(client -> client.getLastKnownGatewayForDevice(deviceId, context));
-    }
-
-    /**
-     * {@inheritDoc}
+     * <p>
+     * Simply delegates to {@link #registerCommandConsumer(String, String, String, Duration, SpanContext)}.
      */
     @Override
     public Future<Void> setCommandHandlingAdapterInstance(
@@ -147,16 +133,32 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseCl
             final Duration lifespan,
             final SpanContext context) {
 
-        Objects.requireNonNull(tenant);
+        return registerCommandConsumer(tenant, deviceId, adapterInstanceId, lifespan, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> registerCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final String adapterInstanceId,
+            final Duration lifespan,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(adapterInstanceId);
 
-        return getOrCreateDeviceConnectionClient(tenant)
+        return getOrCreateDeviceConnectionClient(tenantId)
                 .compose(client -> client.setCommandHandlingAdapterInstance(deviceId, adapterInstanceId, lifespan, context));
     }
 
     /**
      * {@inheritDoc}
+     * <p>
+     * Simply delegates to {@link #unregisterCommandConsumer(String, String, String, SpanContext)}.
      */
     @Override
     public Future<Void> removeCommandHandlingAdapterInstance(
@@ -165,11 +167,24 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseCl
             final String adapterInstanceId,
             final SpanContext context) {
 
-        Objects.requireNonNull(tenant);
+        return unregisterCommandConsumer(tenant, deviceId, adapterInstanceId, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> unregisterCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final String adapterInstanceId,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(adapterInstanceId);
 
-        return getOrCreateDeviceConnectionClient(tenant)
+        return getOrCreateDeviceConnectionClient(tenantId)
                 .compose(client -> client.removeCommandHandlingAdapterInstance(deviceId, adapterInstanceId, context));
     }
 

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
@@ -106,6 +106,22 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseCl
      * {@inheritDoc}
      */
     @Override
+    public Future<JsonObject> getLastKnownGatewayForDevice(
+            final String tenant,
+            final String deviceId,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(deviceId);
+
+        return getOrCreateDeviceConnectionClient(tenant)
+                .compose(client -> client.getLastKnownGatewayForDevice(deviceId, context));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Future<Void> setLastKnownGatewayForDevice(
             final String tenant,
             final String deviceId,
@@ -122,25 +138,9 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseCl
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Simply delegates to {@link #registerCommandConsumer(String, String, String, Duration, SpanContext)}.
      */
     @Override
     public Future<Void> setCommandHandlingAdapterInstance(
-            final String tenant,
-            final String deviceId,
-            final String adapterInstanceId,
-            final Duration lifespan,
-            final SpanContext context) {
-
-        return registerCommandConsumer(tenant, deviceId, adapterInstanceId, lifespan, context);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Future<Void> registerCommandConsumer(
             final String tenantId,
             final String deviceId,
             final String adapterInstanceId,
@@ -157,24 +157,9 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseCl
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Simply delegates to {@link #unregisterCommandConsumer(String, String, String, SpanContext)}.
      */
     @Override
     public Future<Void> removeCommandHandlingAdapterInstance(
-            final String tenant,
-            final String deviceId,
-            final String adapterInstanceId,
-            final SpanContext context) {
-
-        return unregisterCommandConsumer(tenant, deviceId, adapterInstanceId, context);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Future<Void> unregisterCommandConsumer(
             final String tenantId,
             final String deviceId,
             final String adapterInstanceId,

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -9,201 +9,31 @@
  * http://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
- *******************************************************************************/
+ */
 
 package org.eclipse.hono.adapter.client.command;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.StringJoiner;
-
-import org.apache.qpid.proton.amqp.messaging.AmqpValue;
-import org.apache.qpid.proton.amqp.messaging.Data;
-import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.util.CommandConstants;
-import org.eclipse.hono.util.MessageHelper;
-import org.eclipse.hono.util.ResourceIdentifier;
-import org.eclipse.hono.util.Strings;
 
 import io.vertx.core.buffer.Buffer;
 
 /**
- * A wrapper around an AMQP 1.0 message representing a command.
+ * A message representing a Hono Command to be sent to a device.
  *
  */
-public final class Command {
-
-    /**
-     * Bit flag value for the boolean option that defines whether the original reply-to address of the command message
-     * contained the device id.
-     */
-    private static final byte FLAG_REPLY_TO_CONTAINED_DEVICE_ID = 1;
-
-    /**
-     * If present, the command is invalid.
-     */
-    private final Optional<String> validationError;
-    private final Message message;
-    private final String tenantId;
-    private final String deviceId;
-    private final String correlationId;
-    private final String replyToId;
-    private final String requestId;
-
-    private Command(
-            final Optional<String> validationError,
-            final Message message,
-            final String tenantId,
-            final String deviceId,
-            final String correlationId,
-            final String replyToId,
-            final String requestId) {
-
-        this.validationError = validationError;
-        this.message = message;
-        this.tenantId = tenantId;
-        this.deviceId = deviceId;
-        this.correlationId = correlationId;
-        this.replyToId = replyToId;
-        this.requestId = requestId;
-    }
-
-    /**
-     * Creates a command for an AMQP 1.0 message that should be sent to a device.
-     * <p>
-     * The message is expected to contain
-     * <ul>
-     * <li>a non-null <em>address</em>, containing a matching tenant part and a non-empty device-id part</li>
-     * <li>a non-null <em>subject</em></li>
-     * <li>either a null <em>reply-to</em> address (for a one-way command)
-     * or a non-null <em>reply-to</em> address that matches the tenant and device IDs and consists
-     * of four segments</li>
-     * <li>a String valued <em>correlation-id</em> and/or <em>message-id</em></li>
-     * </ul>
-     * <p>
-     * If any of the requirements above are not met, then the returned command's {@link Command#isValid()}
-     * method will return {@code false}.
-     * <p>
-     * Note that, if set, the <em>reply-to</em> address of the given message will be adapted, making sure it contains
-     * the device id.
-     *
-     * @param message The message containing the command.
-     * @param tenantId The tenant that the device belongs to.
-     * @param deviceId The identifier of the device that the command will be sent to. If the command has been mapped
-     *                 to a gateway, this id is the gateway id and the original command target device is given in
-     *                 the message address.
-     * @return The command.
-     * @throws NullPointerException if any of the parameters is {@code null}.
-     */
-    public static Command from(
-            final Message message,
-            final String tenantId,
-            final String deviceId) {
-
-        Objects.requireNonNull(message);
-        Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(deviceId);
-
-        final StringJoiner validationErrorJoiner = new StringJoiner(", ");
-        String originalDeviceId = deviceId;
-        if (Strings.isNullOrEmpty(message.getAddress())) {
-            validationErrorJoiner.add("address is not set");
-        } else {
-            final ResourceIdentifier addressIdentifier = ResourceIdentifier.fromString(message.getAddress());
-            if (!tenantId.equals(addressIdentifier.getTenantId())) {
-                validationErrorJoiner.add("address contains wrong tenant '" + addressIdentifier.getTenantId() + "'");
-            }
-            if (addressIdentifier.getResourceId() == null) {
-                validationErrorJoiner.add("address is missing device-id part");
-            }
-            originalDeviceId = addressIdentifier.getResourceId();
-        }
-
-        if (message.getSubject() == null) {
-            validationErrorJoiner.add("subject not set");
-        }
-
-        if (message.getBody() != null) {
-            // check for unsupported message body
-            getUnsupportedPayloadReason(message).ifPresent(validationErrorJoiner::add);
-        }
-
-        String correlationId = null;
-        final Object correlationIdObj = MessageHelper.getCorrelationId(message);
-        if (correlationIdObj != null) {
-            if (correlationIdObj instanceof String) {
-                correlationId = (String) correlationIdObj;
-            } else {
-                validationErrorJoiner.add("message/correlation-id is not of type string, actual type: " + correlationIdObj.getClass().getName());
-            }
-        } else if (message.getReplyTo() != null) {
-            // correlation id is required if a command response is expected
-            validationErrorJoiner.add("neither message-id nor correlation-id is set");
-        }
-
-        String originalReplyToId = null;
-        if (message.getReplyTo() != null) {
-            try {
-                final ResourceIdentifier replyTo = ResourceIdentifier.fromString(message.getReplyTo());
-                if (!CommandConstants.isNorthboundCommandResponseEndpoint(replyTo.getEndpoint())) {
-                    // not a command message
-                    validationErrorJoiner.add("reply-to not a command address: " + message.getReplyTo());
-                } else if (!tenantId.equals(replyTo.getTenantId())) {
-                    // command response is targeted at wrong tenant
-                    validationErrorJoiner.add("reply-to not targeted at tenant " + tenantId + ": " + message.getReplyTo());
-                } else {
-                    originalReplyToId = replyTo.getPathWithoutBase();
-                    if (originalReplyToId.isEmpty()) {
-                        validationErrorJoiner.add("reply-to part after tenant not set: " + message.getReplyTo());
-                    } else {
-                        message.setReplyTo(
-                                String.format("%s/%s/%s", CommandConstants.COMMAND_RESPONSE_ENDPOINT, tenantId,
-                                        getDeviceFacingReplyToId(originalReplyToId, originalDeviceId)));
-                    }
-                }
-            } catch (final IllegalArgumentException e) {
-                // reply-to could not be parsed
-                validationErrorJoiner.add("reply-to cannot be parsed: " + message.getReplyTo());
-            }
-        }
-
-        return new Command(
-                validationErrorJoiner.length() > 0 ? Optional.of(validationErrorJoiner.toString()) : Optional.empty(),
-                message,
-                tenantId,
-                deviceId,
-                correlationId,
-                originalReplyToId,
-                getRequestId(correlationId, originalReplyToId, originalDeviceId));
-    }
-
-    /**
-     * Gets the AMQP 1.0 message representing this command.
-     *
-     * @return The command message.
-     */
-    public Message getCommandMessage() {
-        return message;
-    }
+public interface Command {
 
     /**
      * Checks if this command is a <em>one-way</em> command (meaning there is no response expected).
      *
      * @return {@code true} if the message's <em>reply-to</em> property is empty or invalid.
      */
-    public boolean isOneWay() {
-        return replyToId == null;
-    }
+    boolean isOneWay();
 
     /**
      * Checks if this command contains all required information.
      *
      * @return {@code true} if this is a valid command.
      */
-    public boolean isValid() {
-        return !validationError.isPresent();
-    }
+    boolean isValid();
 
     /**
      * Gets info about why the command is invalid.
@@ -211,12 +41,7 @@ public final class Command {
      * @return Info string.
      * @throws IllegalStateException if this command is valid.
      */
-    public String getInvalidCommandReason() {
-        if (isValid()) {
-            throw new IllegalStateException("command is valid");
-        }
-        return validationError.get();
-    }
+    String getInvalidCommandReason();
 
     /**
      * Gets the name of this command.
@@ -224,13 +49,7 @@ public final class Command {
      * @return The name.
      * @throws IllegalStateException if this command is invalid.
      */
-    public String getName() {
-        if (isValid()) {
-            return message.getSubject();
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
+    String getName();
 
     /**
      * Gets the tenant that the device belongs to.
@@ -238,13 +57,7 @@ public final class Command {
      * @return The tenant identifier.
      * @throws IllegalStateException if this command is invalid.
      */
-    public String getTenant() {
-        if (isValid()) {
-            return tenantId;
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
+    String getTenant();
 
     /**
      * Gets the device's identifier.
@@ -256,13 +69,7 @@ public final class Command {
      * @return The identifier.
      * @throws IllegalStateException if this command is invalid.
      */
-    public String getDeviceId() {
-        if (isValid()) {
-            return deviceId;
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
+    String getDeviceId();
 
     /**
      * Checks whether the command is targeted at a gateway.
@@ -274,14 +81,7 @@ public final class Command {
      * @return {@code true} if the device id is a gateway id.
      * @throws IllegalStateException if this command is invalid.
      */
-    public boolean isTargetedAtGateway() {
-        if (isValid()) {
-            final String originalDeviceId = getOriginalDeviceId();
-            return originalDeviceId != null && !originalDeviceId.equals(getDeviceId());
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
+    boolean isTargetedAtGateway();
 
     /**
      * Gets the device identifier used in the original command. It is extracted from the
@@ -293,13 +93,7 @@ public final class Command {
      * @return The identifier.
      * @throws IllegalStateException if this command is invalid.
      */
-    public String getOriginalDeviceId() {
-        if (isValid()) {
-            return ResourceIdentifier.fromString(message.getAddress()).getResourceId();
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
+    String getOriginalDeviceId();
 
     /**
      * Gets the request identifier of this command.
@@ -307,13 +101,7 @@ public final class Command {
      * @return The identifier or {@code null} if not set.
      * @throws IllegalStateException if this command is invalid.
      */
-    public String getRequestId() {
-        if (isValid()) {
-            return requestId;
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
+    String getRequestId();
 
     /**
      * Gets the payload of this command.
@@ -321,22 +109,14 @@ public final class Command {
      * @return The message payload or {@code null} if the command message contains no payload.
      * @throws IllegalStateException if this command is invalid.
      */
-    public Buffer getPayload() {
-        if (isValid()) {
-            return MessageHelper.getPayload(message);
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
+    Buffer getPayload();
 
     /**
      * Gets the size of this command's payload.
      *
      * @return The payload size in bytes, 0 if the command has no (valid) payload.
      */
-    public int getPayloadSize() {
-        return MessageHelper.getPayloadSize(message);
-    }
+    int getPayloadSize();
 
     /**
      * Gets the type of this command's payload.
@@ -344,13 +124,7 @@ public final class Command {
      * @return The content type or {@code null} if not set.
      * @throws IllegalStateException if this command is invalid.
      */
-    public String getContentType() {
-        if (isValid()) {
-            return message.getContentType();
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
+    String getContentType();
 
     /**
      * Gets this command's reply-to-id as given in the incoming command message.
@@ -361,30 +135,7 @@ public final class Command {
      * @return The identifier.
      * @throws IllegalStateException if this command is invalid.
      */
-    public String getReplyToId() {
-        if (isValid()) {
-            return replyToId;
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
-
-    /**
-     * Gets the name of the endpoint used in the <em>reply-to</em> address of the incoming command message.
-     * <p>
-     * If the command message didn't contain a <em>reply-to</em> address, the default
-     * {@link CommandConstants#NORTHBOUND_COMMAND_RESPONSE_ENDPOINT} is returned here.
-     *
-     * @return The name of the endpoint.
-     * @throws IllegalStateException if this command is invalid.
-     */
-    public String getReplyToEndpoint() {
-        if (isValid()) {
-            return CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT;
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
+    String getReplyToId();
 
     /**
      * Gets the ID to use for correlating a response to this command.
@@ -392,151 +143,5 @@ public final class Command {
      * @return The identifier or {@code null} if not set.
      * @throws IllegalStateException if this command is invalid.
      */
-    public String getCorrelationId() {
-        if (isValid()) {
-            return correlationId;
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
-
-    /**
-     * Gets the application properties of a message if any.
-     *
-     * @return The application properties.
-     * @throws IllegalStateException if this command is invalid.
-     */
-    public Map<String, Object> getApplicationProperties() {
-        if (isValid()) {
-            if (message.getApplicationProperties() == null) {
-                return null;
-            }
-            return message.getApplicationProperties().getValue();
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
-    /**
-     * Creates a request ID for a command.
-     *
-     * @param correlationId The identifier to use for correlating the response with the request.
-     * @param replyToId An arbitrary identifier to encode into the request ID.
-     * @param deviceId The target of the command.
-     * @return The request identifier or {@code null} if correlationId or deviceId is {@code null}.
-     */
-    public static String getRequestId(final String correlationId, final String replyToId, final String deviceId) {
-
-        if (correlationId == null || deviceId == null) {
-            return null;
-        }
-
-        String replyToIdWithoutDeviceOrEmpty = Optional.ofNullable(replyToId).orElse("");
-        final boolean replyToContainedDeviceId = replyToIdWithoutDeviceOrEmpty.startsWith(deviceId + "/");
-        if (replyToContainedDeviceId) {
-            replyToIdWithoutDeviceOrEmpty = replyToIdWithoutDeviceOrEmpty.substring(deviceId.length() + 1);
-        }
-        return String.format("%s%02x%s%s", encodeReplyToOptions(replyToContainedDeviceId),
-                correlationId.length(), correlationId, replyToIdWithoutDeviceOrEmpty);
-    }
-
-    /**
-     * Encodes the given boolean parameters related to the original reply-to address of the command message as a single
-     * digit string.
-     *
-     * @param replyToContainedDeviceId Whether the original reply-to address of the command message contained the device
-     *            id.
-     * @return The encoded options as a single digit string.
-     */
-    static String encodeReplyToOptions(final boolean replyToContainedDeviceId) {
-        int bitFlag = 0;
-        if (replyToContainedDeviceId) {
-            bitFlag |= FLAG_REPLY_TO_CONTAINED_DEVICE_ID;
-        }
-        return String.valueOf(bitFlag);
-    }
-
-    /**
-     * Checks if the original reply-to address of the command message contained the device id.
-     *
-     * @param replyToOptionsBitFlag The bit flag returned by {@link #encodeReplyToOptions(boolean)}.
-     * @return {@code true} if the original reply-to address of the command message contained the device id.
-     * @throws NumberFormatException If the given replyToOptionsBitFlag can't be parsed as an integer.
-     */
-    static boolean isReplyToContainedDeviceIdOptionSet(final String replyToOptionsBitFlag) {
-        return decodeReplyToOption(replyToOptionsBitFlag, FLAG_REPLY_TO_CONTAINED_DEVICE_ID);
-    }
-
-    private static boolean decodeReplyToOption(final String replyToOptionsBitFlag, final byte optionBitConstant) {
-        return (Integer.parseInt(replyToOptionsBitFlag) & optionBitConstant) == optionBitConstant;
-    }
-
-    @Override
-    public String toString() {
-        if (isValid()) {
-            final String originalDeviceId = getOriginalDeviceId();
-            if (!getDeviceId().equals(originalDeviceId)) {
-                return String.format("Command [name: %s, tenant-id: %s, device-id %s, original device-id %s, request-id: %s]",
-                        getName(), getTenant(), getDeviceId(), originalDeviceId, getRequestId());
-            } else {
-                return String.format("Command [name: %s, tenant-id: %s, device-id %s, request-id: %s]",
-                        getName(), getTenant(), getDeviceId(), getRequestId());
-            }
-        } else {
-            return String.format("Invalid Command [tenant-id: %s, device-id: %s. error: %s]", tenantId, deviceId, validationError.get());
-        }
-    }
-
-    /**
-     * Gets the reply-to-id that will be set when forwarding the command to the device.
-     * <p>
-     * It is ensured that this id starts with the device id.
-     *
-     * @param replyToId The reply-to-id as extracted from the 'reply-to' of the command AMQP message. Potentially not
-     *            containing the device id.
-     * @param deviceId The device id.
-     * @return The reply-to-id, starting with the device id.
-     */
-    public static String getDeviceFacingReplyToId(final String replyToId, final String deviceId) {
-        final boolean replyToContainedDeviceId = replyToId.startsWith(deviceId + "/");
-        final String replyToIdWithoutDeviceId = replyToContainedDeviceId ? replyToId.substring(deviceId.length() + 1)
-                : replyToId;
-        final String bitFlagString = encodeReplyToOptions(replyToContainedDeviceId);
-        return String.format("%s/%s%s", deviceId, bitFlagString, replyToIdWithoutDeviceId);
-    }
-
-    /**
-     * Validates the type of the message body containing the payload data and returns an error string if it is
-     * unsupported.
-     * <p>
-     * The message body is considered unsupported if there is a body section and it is neither
-     * <ul>
-     * <li>a Data section,</li>
-     * <li>nor an AmqpValue section containing a byte array or a String.</li>
-     * </ul>
-     *
-     * @param msg The AMQP 1.0 message to parse.
-     * @return An Optional with the error string or an empty Optional if the payload is supported or the
-     *         message has no body section.
-     * @throws NullPointerException if the message is {@code null}.
-     * @see MessageHelper#getPayload(Message)
-     */
-    private static Optional<String> getUnsupportedPayloadReason(final Message msg) {
-        Objects.requireNonNull(msg);
-
-        String reason = null;
-        if (msg.getBody() instanceof AmqpValue) {
-            final Object value = ((AmqpValue) msg.getBody()).getValue();
-            if (value == null) {
-                reason = "message has body with empty amqp-value section";
-            } else if (!(value instanceof byte[] || value instanceof String)) {
-                reason = String.format("message has amqp-value section body with unsupported value type [%s], supported is byte[] or String",
-                        value.getClass().getName());
-            }
-
-        } else if (msg.getBody() != null && !(msg.getBody() instanceof Data)) {
-            reason = String.format("message has unsupported body section [%s], supported section types are 'data' and 'amqp-value'",
-                    msg.getBody().getClass().getName());
-        }
-        return Optional.ofNullable(reason);
-    }
+    String getCorrelationId();
 }

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandConsumer.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandConsumer.java
@@ -26,7 +26,11 @@ public interface CommandConsumer {
      * Closes the consumer.
      *
      * @param spanContext The span context (may be {@code null}).
-     * @return A future indicating the outcome of the operation.
+     * @return A future indicating the outcome of the operation. The future will be failed with a
+     *         {@code org.eclipse.hono.client.ServiceInvocationException} if there was an error closing
+     *         the consumer and with a {@code org.eclipse.hono.client.ClientErrorException} with
+     *         {@link java.net.HttpURLConnection#HTTP_PRECON_FAILED} if the consumer has been
+     *         closed/overwritten already.
      */
     Future<Void> close(SpanContext spanContext);
 }

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandConsumerFactory.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandConsumerFactory.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command;
+
+import java.time.Duration;
+
+import org.eclipse.hono.util.Lifecycle;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * A factory for creating consumers for commands targeted at devices.
+ */
+public interface CommandConsumerFactory extends Lifecycle {
+
+    /**
+     * Creates a command consumer for a device.
+     * <p>
+     * For each device only one command consumer may be active at any given time. Invoking this method multiple times
+     * with the same parameters will each time overwrite the previous entry.
+     * <p>
+     * It is the responsibility of the calling code to properly close a consumer
+     * once it is no longer needed by invoking its {@link CommandConsumer#close(SpanContext)}
+     * method.
+     *
+     * @param tenantId The tenant to consume commands from.
+     * @param deviceId The device for which the consumer will be created.
+     * @param commandHandler The handler to invoke with every command received. The handler must invoke one of the
+     *                       terminal methods of the passed in {@link CommandContext} in order to settle the command
+     *                       message transfer and finish the trace span associated with the {@link CommandContext}.
+     * @param lifespan The time period in which the command consumer shall be active. Using a negative duration or
+     *                 {@code null} here is interpreted as an unlimited life span. The guaranteed granularity
+     *                 taken into account here is seconds.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *                An implementation should use this as the parent for any span it creates for tracing
+     *                the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be completed with the newly created consumer once the link
+     *         has been established.
+     *         <p>
+     *         The future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException} with an
+     *         error code indicating the cause of the failure.
+     * @throws NullPointerException if any of tenant, device ID or command handler is {@code null}.
+     */
+    Future<CommandConsumer> createCommandConsumer(
+            String tenantId,
+            String deviceId,
+            Handler<CommandContext> commandHandler,
+            Duration lifespan,
+            SpanContext context);
+
+    /**
+     * Creates a command consumer for a device that is connected via a gateway.
+     * <p>
+     * For each device only one command consumer may be active at any given time. Invoking this method multiple times
+     * with the same parameters will each time overwrite the previous entry.
+     * <p>
+     * It is the responsibility of the calling code to properly close a consumer
+     * once it is no longer needed by invoking its {@link CommandConsumer#close(SpanContext)}
+     * method.
+     *
+     * @param tenantId The tenant to consume commands from.
+     * @param deviceId The device for which the consumer will be created.
+     * @param gatewayId The gateway that wants to act on behalf of the device.
+     * @param commandHandler The handler to invoke with every command received. The handler must invoke one of the
+     *                       terminal methods of the passed in {@link CommandContext} in order to settle the command
+     *                       message transfer and finish the trace span associated with the {@link CommandContext}.
+     * @param lifespan The time period in which the command consumer shall be active. Using a negative duration or
+     *                 {@code null} here is interpreted as an unlimited life span. The guaranteed granularity
+     *                 taken into account here is seconds.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *                An implementation should use this as the parent for any span it creates for tracing
+     *                the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be completed with the newly created consumer once the link
+     *         has been established.
+     *         <p>
+     *         The future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException} with an error code indicating
+     *         the cause of the failure.
+     * @throws NullPointerException if any of tenant, device ID, gateway ID or command handler is {@code null}.
+     */
+    Future<CommandConsumer> createCommandConsumer(
+            String tenantId,
+            String deviceId,
+            String gatewayId,
+            Handler<CommandContext> commandHandler,
+            Duration lifespan,
+            SpanContext context);
+}

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandContext.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandContext.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.command;
+
+import org.eclipse.hono.util.ExecutionContext;
+
+import io.opentracing.Span;
+
+/**
+ * A context for processing a command that is targeted at a device.
+ *
+ */
+public interface CommandContext extends ExecutionContext {
+
+    /**
+     * The key under which the current CommandContext is stored.
+     */
+    String KEY_COMMAND_CONTEXT = "command-context";
+
+    /**
+     * Logs information about the command.
+     *
+     * @param span The span to log to.
+     * @throws NullPointerException if span is {@code null}.
+     */
+    void logCommandToSpan(Span span);
+
+    /**
+     * Gets the command to process.
+     *
+     * @return The command.
+     */
+    Command getCommand();
+
+    /**
+     * Indicates to the sender that the command message has been delivered to its target.
+     */
+    void accept();
+
+    /**
+     * Indicates to the sender that the command message could not be delivered to its target due to
+     * reasons that are not the responsibility of the sender of the command.
+     */
+    void release();
+
+    /**
+     * Indicates to the sender that the command message could not be delivered to its target due to
+     * reasons that are not the responsibility of the sender of the command.
+     *
+     * @param deliveryFailed {@code true} if the attempt to send the command to the target device
+     *                       has failed.
+     * @param undeliverableHere {@code true} if the component processing the context
+     *                          has no access to the command's target device.
+     */
+    void modify(boolean deliveryFailed, boolean undeliverableHere);
+
+    /**
+     * Indicates to the sender that the command message cannot not be delivered to its target due to
+     * reasons that are the responsibility of the sender of the command.
+     *
+     * @param cause The error that caused he command to be rejected or {@code null} if the cause is unknown.
+     */
+    void reject(String cause);
+}

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandContext.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandContext.java
@@ -66,8 +66,11 @@ public interface CommandContext extends ExecutionContext {
     void modify(boolean deliveryFailed, boolean undeliverableHere);
 
     /**
-     * Indicates to the sender that the command message cannot not be delivered to its target due to
+     * Indicates to the sender that the command message cannot be delivered to its target due to
      * reasons that are the responsibility of the sender of the command.
+     * <p>
+     * The reason for a command being rejected often is that the command is invalid, e.g. lacking a
+     * subject or having a malformed address.
      *
      * @param cause The error that caused he command to be rejected or {@code null} if the cause is unknown.
      */

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Commands.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Commands.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.command;
+
+import java.util.Optional;
+
+/**
+ * Utility methods for handling Command &amp; Control messages.
+ *
+ */
+public final class Commands {
+
+    /**
+     * Bit flag value for the boolean option that defines whether the original reply-to address of the command message
+     * contained the device id.
+     */
+    private static final byte FLAG_REPLY_TO_CONTAINED_DEVICE_ID = 1;
+
+    private Commands() {
+        // prevent instantiation
+    }
+
+    /**
+     * Creates a request ID for a command.
+     *
+     * @param correlationId The identifier to use for correlating the response with the request.
+     * @param replyToId An arbitrary identifier to encode into the request ID.
+     * @param deviceId The target of the command.
+     * @return The request identifier or {@code null} if correlationId or deviceId is {@code null}.
+     */
+    public static String getRequestId(final String correlationId, final String replyToId, final String deviceId) {
+
+        if (correlationId == null || deviceId == null) {
+            return null;
+        }
+
+        String replyToIdWithoutDeviceOrEmpty = Optional.ofNullable(replyToId).orElse("");
+        final boolean replyToContainedDeviceId = replyToIdWithoutDeviceOrEmpty.startsWith(deviceId + "/");
+        if (replyToContainedDeviceId) {
+            replyToIdWithoutDeviceOrEmpty = replyToIdWithoutDeviceOrEmpty.substring(deviceId.length() + 1);
+        }
+        return String.format("%s%02x%s%s", encodeReplyToOptions(replyToContainedDeviceId),
+                correlationId.length(), correlationId, replyToIdWithoutDeviceOrEmpty);
+    }
+
+    /**
+     * Gets the reply-to-id that will be set when forwarding the command to the device.
+     * <p>
+     * It is ensured that this id starts with the device id.
+     *
+     * @param replyToId The reply-to-id as extracted from the 'reply-to' of the command AMQP message. Potentially not
+     *            containing the device id.
+     * @param deviceId The device id.
+     * @return The reply-to-id, starting with the device id.
+     */
+    public static String getDeviceFacingReplyToId(final String replyToId, final String deviceId) {
+        final boolean replyToContainedDeviceId = replyToId.startsWith(deviceId + "/");
+        final String replyToIdWithoutDeviceId = replyToContainedDeviceId ? replyToId.substring(deviceId.length() + 1)
+                : replyToId;
+        final String bitFlagString = encodeReplyToOptions(replyToContainedDeviceId);
+        return String.format("%s/%s%s", deviceId, bitFlagString, replyToIdWithoutDeviceId);
+    }
+
+    /**
+     * Encodes the given boolean parameters related to the original reply-to address of the command message as a single
+     * digit string.
+     *
+     * @param replyToContainedDeviceId Whether the original reply-to address of the command message contained the device
+     *            id.
+     * @return The encoded options as a single digit string.
+     */
+    public static String encodeReplyToOptions(final boolean replyToContainedDeviceId) {
+        int bitFlag = 0;
+        if (replyToContainedDeviceId) {
+            bitFlag |= FLAG_REPLY_TO_CONTAINED_DEVICE_ID;
+        }
+        return String.valueOf(bitFlag);
+    }
+
+    /**
+     * Checks if the original reply-to address of the command message contained the device id.
+     *
+     * @param replyToOptionsBitFlag The bit flag returned by {@link #encodeReplyToOptions(boolean)}.
+     * @return {@code true} if the original reply-to address of the command message contained the device id.
+     * @throws NumberFormatException If the given replyToOptionsBitFlag can't be parsed as an integer.
+     */
+    public static boolean isReplyToContainedDeviceIdOptionSet(final String replyToOptionsBitFlag) {
+        return decodeReplyToOption(replyToOptionsBitFlag, FLAG_REPLY_TO_CONTAINED_DEVICE_ID);
+    }
+
+    private static boolean decodeReplyToOption(final String replyToOptionsBitFlag, final byte optionBitConstant) {
+        return (Integer.parseInt(replyToOptionsBitFlag) & optionBitConstant) == optionBitConstant;
+    }
+}

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/DeviceConnectionClient.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/DeviceConnectionClient.java
@@ -16,8 +16,6 @@ package org.eclipse.hono.adapter.client.command;
 import java.time.Duration;
 import java.util.List;
 
-import org.eclipse.hono.util.Lifecycle;
-
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
@@ -28,47 +26,7 @@ import io.vertx.core.json.JsonObject;
  * See Hono's <a href="https://www.eclipse.org/hono/docs/api/device-connection/">
  * Device Connection API specification</a> for a description of the result codes returned.
  */
-public interface DeviceConnectionClient extends Lifecycle {
-
-    /**
-     * Sets the given gateway as the last gateway that acted on behalf of the given device.
-     * <p>
-     * If a device connects directly instead of through a gateway, the device identifier itself is to be used as value
-     * for the <em>gatewayId</em> parameter.
-     *
-     * @param tenant The tenant that the device belongs to.
-     * @param deviceId The device id.
-     * @param gatewayId The gateway id (or the device id if the last message came from the device directly).
-     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
-     *            An implementation should use this as the parent for any span it creates for tracing
-     *            the execution of this operation.
-     * @return A future indicating whether the operation succeeded or not.
-     * @throws NullPointerException if tenant, device id or gateway id are {@code null}.
-     */
-    Future<Void> setLastKnownGatewayForDevice(String tenant, String deviceId, String gatewayId, SpanContext context);
-
-    /**
-     * Gets the gateway that last acted on behalf of the given device.
-     * <p>
-     * If no last known gateway has been set for the given device yet, a failed future with status <em>Not Found</em>
-     * is returned.
-     *
-     * @param tenant The tenant that the device belongs to.
-     * @param deviceId The device id.
-     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
-     *            An implementation should use this as the parent for any span it creates for tracing
-     *            the execution of this operation.
-     * @return A future indicating the result of the operation.
-     *         <p>
-     *         The future will succeed if a response with status 200 has been received from the device connection service.
-     *         In that case the value of the future will contain a <em>gateway-id</em> property with the
-     *         gateway id.
-     *         <p>
-     *         In case a status other then 200 is received, the future will fail with a
-     *         {@code org.eclipse.hono.client.ServiceInvocationException} containing the (error) status code returned by the service.
-     * @throws NullPointerException if tenant or device id are {@code null}.
-     */
-    Future<JsonObject> getLastKnownGatewayForDevice(String tenant, String deviceId, SpanContext context);
+public interface DeviceConnectionClient extends CommandRouterClient {
 
     /**
      * Sets the protocol adapter instance that handles commands for the given device.

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/DeviceConnectionClient.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/DeviceConnectionClient.java
@@ -16,6 +16,8 @@ package org.eclipse.hono.adapter.client.command;
 import java.time.Duration;
 import java.util.List;
 
+import org.eclipse.hono.util.Lifecycle;
+
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
@@ -26,7 +28,47 @@ import io.vertx.core.json.JsonObject;
  * See Hono's <a href="https://www.eclipse.org/hono/docs/api/device-connection/">
  * Device Connection API specification</a> for a description of the result codes returned.
  */
-public interface DeviceConnectionClient extends CommandRouterClient {
+public interface DeviceConnectionClient extends Lifecycle {
+
+    /**
+     * Sets the given gateway as the last gateway that acted on behalf of the given device.
+     * <p>
+     * If a device connects directly instead of through a gateway, the device identifier itself is to be used as value
+     * for the <em>gatewayId</em> parameter.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceId The device id.
+     * @param gatewayId The gateway id (or the device id if the last message came from the device directly).
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            An implementation should use this as the parent for any span it creates for tracing
+     *            the execution of this operation.
+     * @return A future indicating whether the operation succeeded or not.
+     * @throws NullPointerException if tenant, device id or gateway id are {@code null}.
+     */
+    Future<Void> setLastKnownGatewayForDevice(String tenant, String deviceId, String gatewayId, SpanContext context);
+
+    /**
+     * Gets the gateway that last acted on behalf of the given device.
+     * <p>
+     * If no last known gateway has been set for the given device yet, a failed future with status <em>Not Found</em>
+     * is returned.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceId The device id.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            An implementation should use this as the parent for any span it creates for tracing
+     *            the execution of this operation.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed if a response with status 200 has been received from the device connection service.
+     *         In that case the value of the future will contain a <em>gateway-id</em> property with the
+     *         gateway id.
+     *         <p>
+     *         In case a status other then 200 is received, the future will fail with a
+     *         {@code org.eclipse.hono.client.ServiceInvocationException} containing the (error) status code returned by the service.
+     * @throws NullPointerException if tenant or device id are {@code null}.
+     */
+    Future<JsonObject> getLastKnownGatewayForDevice(String tenant, String deviceId, SpanContext context);
 
     /**
      * Sets the protocol adapter instance that handles commands for the given device.

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/DeviceConnectionClientAdapter.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/DeviceConnectionClientAdapter.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.command;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.util.ServiceClient;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
+
+/**
+ * An adapter that maps CommandRouterClient method invocations to a
+ * {@link DeviceConnectionClient}.
+ *
+ */
+public final class DeviceConnectionClientAdapter implements CommandRouterClient, ServiceClient {
+
+    private final DeviceConnectionClient deviceConnectionClient;
+
+    /**
+     * Creates a new adapter for a Device Connection service client.
+     *
+     * @param client The client that needs to be adapted.
+     * @throws NullPointerException if client is {@code null}.
+     */
+    public DeviceConnectionClientAdapter(final DeviceConnectionClient client) {
+        this.deviceConnectionClient = Objects.requireNonNull(client);
+    }
+
+
+    @Override
+    public Future<Void> stop() {
+        return deviceConnectionClient.stop();
+    }
+
+    @Override
+    public Future<Void> start() {
+        return deviceConnectionClient.start();
+    }
+
+    @Override
+    public Future<Void> registerCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final String adapterInstanceId,
+            final Duration lifespan,
+            final SpanContext context) {
+        return deviceConnectionClient.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, context);
+    }
+
+    @Override
+    public Future<Void> unregisterCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final String adapterInstanceId,
+            final SpanContext context) {
+        return deviceConnectionClient.removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, context);
+    }
+
+    @Override
+    public Future<Void> setLastKnownGatewayForDevice(
+            final String tenantId,
+            final String deviceId,
+            final String gatewayId,
+            final SpanContext context) {
+        return deviceConnectionClient.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
+        if (deviceConnectionClient instanceof ServiceClient) {
+            ((ServiceClient) deviceConnectionClient).registerReadinessChecks(readinessHandler);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
+        if (deviceConnectionClient instanceof ServiceClient) {
+            ((ServiceClient) deviceConnectionClient).registerLivenessChecks(livenessHandler);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return new StringBuilder(getClass().getSimpleName())
+                .append("{deviceConnectionClient: ")
+                .append(deviceConnectionClient)
+                .append("]}")
+                .toString();
+    }
+}

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
@@ -186,6 +186,7 @@ public abstract class AbstractProtocolAdapterApplication {
             .ifPresent(adapter::setConnectionEventProducer);
         adapter.setCredentialsClient(credentialsClient());
         adapter.setCommandRouterClient(deviceConnectionClient);
+        adapter.setCommandResponseSender(commandResponseSender());
         adapter.setEventSender(downstreamSender());
         adapter.setHealthCheckServer(healthCheckServer);
         adapter.setRegistrationClient(registrationClient);
@@ -298,7 +299,7 @@ public abstract class AbstractProtocolAdapterApplication {
             final CommandHandlingAdapterInfoAccess commandRoutingInfoAccess) {
 
         return new ProtonBasedCommandConsumerFactory(
-                HonoConnection.newConnection(vertx, config.command),
+                commandConsumerConnection(),
                 messageSamplerFactory,
                 protocolAdapterProperties,
                 commandTargetMapper,

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/ProtocolAdapterConfig.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/ProtocolAdapterConfig.java
@@ -17,6 +17,9 @@ import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ServerConfig;
 import org.eclipse.hono.service.monitoring.ConnectionEventProducerConfig;
 import org.eclipse.hono.service.resourcelimits.PrometheusBasedResourceLimitChecksConfig;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import com.google.common.base.Strings;
 
 import io.quarkus.arc.config.ConfigProperties;
 
@@ -27,6 +30,8 @@ import io.quarkus.arc.config.ConfigProperties;
 public class ProtocolAdapterConfig {
 
      public CommandConfig command;
+
+     public CommandRouterConfig commandRouter;
 
      public HealthCheckConfig healthCheck;
 
@@ -45,6 +50,13 @@ public class ProtocolAdapterConfig {
      public ResourceLimitChecksConfig resourceLimitChecks;
 
      public QuarkusConnectionEventProducerConfig connectionEvents;
+
+     @ConfigProperty(name = "hono.commandRouter.host")
+     protected String commandRouterHost;
+
+     public boolean isCommandRouterConfigured() {
+         return !Strings.isNullOrEmpty(commandRouterHost);
+     }
 
      /**
       * Command configuration.
@@ -75,6 +87,12 @@ public class ProtocolAdapterConfig {
       */
      @ConfigProperties(prefix = "hono.device-connection", failOnMismatchingMember = false)
      public static class DeviceConnectionConfig extends RequestResponseClientConfigProperties { }
+
+     /**
+      * Command Router client configuration.
+      */
+     @ConfigProperties(prefix = "hono.command-router", failOnMismatchingMember = false)
+     public static class CommandRouterConfig extends RequestResponseClientConfigProperties { }
 
      /**
       * Messaging client configuration.

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -36,7 +36,6 @@ import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
 import org.eclipse.hono.adapter.client.util.ServiceClient;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.auth.ValidityBasedTrustOptions;
@@ -762,42 +761,6 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             log.warn("{} client [{}] failed to connect", serviceName, serviceClient, t);
             return Future.failedFuture(t);
         });
-    }
-
-    /**
-     * Invoked when a connection for receiving commands and sending responses has been
-     * unexpectedly lost.
-     * <p>
-     * Subclasses may override this method in order to perform housekeeping and/or clear
-     * state that is associated with the connection. Implementors <em>must not</em> try
-     * to re-establish the connection, the adapter will try to re-establish the connection
-     * by default.
-     * <p>
-     * This default implementation does nothing.
-     *
-     * @param commandConnection The lost connection.
-     */
-    protected void onCommandConnectionLost(final HonoConnection commandConnection) {
-        // empty by default
-    }
-
-    /**
-     * Invoked when a connection for receiving commands and sending responses has been
-     * established.
-     * <p>
-     * Note that this method is invoked once the initial connection has been established
-     * but also when the connection has been re-established after a connection loss.
-     * <p>
-     * Subclasses may override this method in order to e.g. re-establish device specific
-     * links for receiving commands or to create a permanent link for receiving commands
-     * for all devices.
-     * <p>
-     * This default implementation does nothing.
-     *
-     * @param commandConnection The (re-)established connection.
-     */
-    protected void onCommandConnectionEstablished(final HonoConnection commandConnection) {
-        // empty by default
     }
 
     /**

--- a/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
+++ b/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -29,16 +28,18 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.hono.adapter.client.command.Command;
+import org.eclipse.hono.adapter.client.command.CommandConsumerFactory;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.adapter.client.command.CommandResponse;
+import org.eclipse.hono.adapter.client.command.CommandResponseSender;
+import org.eclipse.hono.adapter.client.command.Commands;
 import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
 import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
-import org.eclipse.hono.client.CommandResponse;
-import org.eclipse.hono.client.CommandResponseSender;
-import org.eclipse.hono.client.HonoConnection;
-import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.util.EventConstants;
@@ -49,11 +50,10 @@ import org.eclipse.hono.util.TenantObject;
 import org.mockito.ArgumentCaptor;
 
 import io.opentracing.SpanContext;
-import io.vertx.core.AsyncResult;
+import io.opentracing.noop.NoopSpan;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
-import io.vertx.proton.ProtonDelivery;
+import io.vertx.core.buffer.Buffer;
 
 /**
  * A base class for implementing tests for protocol adapters.
@@ -69,10 +69,25 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
     protected CredentialsClient credentialsClient;
     protected DeviceConnectionClient deviceConnectionClient;
     protected EventSender eventSender;
-    protected ProtocolAdapterCommandConsumerFactory commandConsumerFactory;
+    protected CommandConsumerFactory commandConsumerFactory;
+    protected CommandResponseSender commandResponseSender;
     protected DeviceRegistrationClient registrationClient;
     protected TenantClient tenantClient;
     protected TelemetrySender telemetrySender;
+
+    private CommandConsumerFactory createCommandConsumerFactory() {
+        final CommandConsumerFactory factory = mock(CommandConsumerFactory.class);
+        when(factory.start()).thenReturn(Future.succeededFuture());
+        when(factory.stop()).thenReturn(Future.succeededFuture());
+        return factory;
+    }
+
+    private CommandResponseSender createCommandResponseSender() {
+        final CommandResponseSender client = mock(CommandResponseSender.class);
+        when(client.start()).thenReturn(Future.succeededFuture());
+        when(client.stop()).thenReturn(Future.succeededFuture());
+        return client;
+    }
 
     private TenantClient createTenantClientMock() {
         final TenantClient client = mock(TenantClient.class);
@@ -128,17 +143,10 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
      * <p>
      * All factories are configured to successfully connect/disconnect to/from their peer.
      */
-    @SuppressWarnings("unchecked")
     protected void createClientFactories() {
 
-        commandConsumerFactory = mock(ProtocolAdapterCommandConsumerFactory.class);
-        when(commandConsumerFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
-        when(commandConsumerFactory.isConnected()).thenReturn(Future.succeededFuture());
-        doAnswer(invocation -> {
-            final Handler<AsyncResult<Void>> shutdownHandler = invocation.getArgument(0);
-            shutdownHandler.handle(Future.succeededFuture());
-            return null;
-        }).when(commandConsumerFactory).disconnect(any(Handler.class));
+        this.commandConsumerFactory = createCommandConsumerFactory();
+        this.commandResponseSender = createCommandResponseSender();
 
         this.deviceConnectionClient = createDeviceConnectionClientMock();
         this.tenantClient = createTenantClientMock();
@@ -189,12 +197,99 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
      */
     protected void setServiceClients(final T adapter) {
         adapter.setCommandConsumerFactory(commandConsumerFactory);
+        adapter.setCommandResponseSender(commandResponseSender);
         adapter.setCredentialsClient(credentialsClient);
-        adapter.setDeviceConnectionClient(deviceConnectionClient);
+        adapter.setCommandRouterClient(deviceConnectionClient);
         adapter.setEventSender(eventSender);
         adapter.setRegistrationClient(registrationClient);
         adapter.setTelemetrySender(telemetrySender);
         adapter.setTenantClient(tenantClient);
+    }
+
+    /**
+     * Creates a mocked context for a one-way command.
+     *
+     * @param tenantId The tenant that the command's target device belongs to.
+     * @param deviceId The target device's identifier.
+     * @param name The command name.
+     * @param contentType The type of the payload or {@code null} if the command has no payload.
+     * @param payload The command's payload.
+     * @return The mocked context.
+     */
+    protected CommandContext givenAOneWayCommandContext(
+            final String tenantId,
+            final String deviceId,
+            final String name,
+            final String contentType,
+            final Buffer payload) {
+
+        final Command command = newOneWayCommand(tenantId, deviceId, name, contentType, payload);
+
+        final CommandContext context = mock(CommandContext.class);
+        when(context.getCommand()).thenReturn(command);
+        when(context.getTracingSpan()).thenReturn(NoopSpan.INSTANCE);
+        return context;
+    }
+
+    /**
+     * Creates a mocked context for a request-response command.
+     *
+     * @param tenantId The tenant that the command's target device belongs to.
+     * @param deviceId The target device's identifier.
+     * @param name The command name.
+     * @param contentType The type of the payload or {@code null} if the command has no payload.
+     * @param payload The command's payload.
+     * @param replyToId The reply-to-id to use.
+     * @return The mocked context.
+     */
+    protected CommandContext givenARequestResponseCommandContext(
+            final String tenantId,
+            final String deviceId,
+            final String name,
+            final String replyToId,
+            final String contentType,
+            final Buffer payload) {
+
+        final Command command = newRequestResponseCommand(tenantId, deviceId, name, replyToId, contentType, payload);
+
+        final CommandContext context = mock(CommandContext.class);
+        when(context.getCommand()).thenReturn(command);
+        when(context.getTracingSpan()).thenReturn(NoopSpan.INSTANCE);
+        return context;
+    }
+
+    private Command newOneWayCommand(
+            final String tenantId,
+            final String deviceId,
+            final String name,
+            final String contentType,
+            final Buffer payload) {
+
+        final Command command = mock(Command.class);
+        when(command.getTenant()).thenReturn(tenantId);
+        when(command.getDeviceId()).thenReturn(deviceId);
+        when(command.getOriginalDeviceId()).thenReturn(deviceId);
+        when(command.getName()).thenReturn(name);
+        when(command.getContentType()).thenReturn(contentType);
+        when(command.getPayload()).thenReturn(payload);
+        when(command.getPayloadSize()).thenReturn(Optional.ofNullable(payload).map(Buffer::length).orElse(0));
+        when(command.isOneWay()).thenReturn(true);
+        when(command.isValid()).thenReturn(true);
+        return command;
+    }
+
+    private Command newRequestResponseCommand(
+            final String tenantId,
+            final String deviceId,
+            final String name,
+            final String replyToId,
+            final String contentType,
+            final Buffer payload) {
+
+        final Command command = newOneWayCommand(tenantId, deviceId, name, contentType, payload);
+        when(command.isOneWay()).thenReturn(false);
+        when(command.getRequestId()).thenReturn(Commands.getRequestId("correlation-id", replyToId, deviceId));
+        return command;
     }
 
     /**
@@ -270,8 +365,8 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
      * @return The sender that the factory will create.
      */
     protected CommandResponseSender givenACommandResponseSenderForAnyTenant() {
-        final Promise<ProtonDelivery> delivery = Promise.promise();
-        delivery.complete(mock(ProtonDelivery.class));
+        final Promise<Void> delivery = Promise.promise();
+        delivery.complete();
         return givenACommandResponseSenderForAnyTenant(delivery);
     }
 
@@ -285,13 +380,9 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
      * @param outcome The outcome of sending a response using the returned sender.
      * @return The sender that the factory will create.
      */
-    protected CommandResponseSender givenACommandResponseSenderForAnyTenant(final Promise<ProtonDelivery> outcome) {
-        final CommandResponseSender responseSender = mock(CommandResponseSender.class);
-        when(responseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(outcome.future());
-
-        when(commandConsumerFactory.getCommandResponseSender(anyString(), anyString()))
-                .thenReturn(Future.succeededFuture(responseSender));
-        return responseSender;
+    protected CommandResponseSender givenACommandResponseSenderForAnyTenant(final Promise<Void> outcome) {
+        when(commandResponseSender.sendCommandResponse(any(CommandResponse.class), (SpanContext) any())).thenReturn(outcome.future());
+        return commandResponseSender;
     }
 
     /**
@@ -494,5 +585,14 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
                 any(),
                 any(),
                 any());
+    }
+
+    /**
+     * Asserts that no command response message has been sent using the command response sender.
+     *
+     * @throws AssertionError if a message has been sent.
+     */
+    protected void assertNoCommandResponseHasBeenSentDownstream() {
+        verify(commandResponseSender, never()).sendCommandResponse(any(CommandResponse.class), any());
     }
 }

--- a/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
+++ b/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
@@ -33,8 +33,8 @@ import org.eclipse.hono.adapter.client.command.CommandConsumerFactory;
 import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.adapter.client.command.CommandResponse;
 import org.eclipse.hono.adapter.client.command.CommandResponseSender;
+import org.eclipse.hono.adapter.client.command.CommandRouterClient;
 import org.eclipse.hono.adapter.client.command.Commands;
-import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
 import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.TenantClient;
@@ -67,7 +67,7 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
     protected T adapter;
 
     protected CredentialsClient credentialsClient;
-    protected DeviceConnectionClient deviceConnectionClient;
+    protected CommandRouterClient commandRouterClient;
     protected EventSender eventSender;
     protected CommandConsumerFactory commandConsumerFactory;
     protected CommandResponseSender commandResponseSender;
@@ -110,8 +110,8 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
         return client;
     }
 
-    private DeviceConnectionClient createDeviceConnectionClientMock() {
-        final DeviceConnectionClient client = mock(DeviceConnectionClient.class);
+    private CommandRouterClient createCommandRouterClientMock() {
+        final CommandRouterClient client = mock(CommandRouterClient.class);
         when(client.start()).thenReturn(Future.succeededFuture());
         when(client.stop()).thenReturn(Future.succeededFuture());
         return client;
@@ -148,7 +148,7 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
         this.commandConsumerFactory = createCommandConsumerFactory();
         this.commandResponseSender = createCommandResponseSender();
 
-        this.deviceConnectionClient = createDeviceConnectionClientMock();
+        this.commandRouterClient = createCommandRouterClientMock();
         this.tenantClient = createTenantClientMock();
         this.registrationClient = createDeviceRegistrationClientMock();
         this.credentialsClient = createCredentialsClientMock();
@@ -199,7 +199,7 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
         adapter.setCommandConsumerFactory(commandConsumerFactory);
         adapter.setCommandResponseSender(commandResponseSender);
         adapter.setCredentialsClient(credentialsClient);
-        adapter.setCommandRouterClient(deviceConnectionClient);
+        adapter.setCommandRouterClient(commandRouterClient);
         adapter.setEventSender(eventSender);
         adapter.setRegistrationClient(registrationClient);
         adapter.setTelemetrySender(telemetrySender);


### PR DESCRIPTION
Added transport protocol agnostic CommandConsumerFactory interface to
the adapter client module.
Added AMQP 1.0 based implementation which simply wraps the existing
vertx-proton based "legacy" AdapterProtocolCommandConsumerFactoryImpl.
