### PR TITLE
Add Kafka based downstream client

### DIFF
--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -74,6 +74,10 @@
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.security</groupId>
+      <artifactId>wildfly-elytron-password-impl</artifactId>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -123,12 +123,22 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-kafka-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-client-adapter</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-client-adapter-amqp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-adapter-kafka</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -420,6 +430,11 @@
         <artifactId>vertx-rx-java2</artifactId>
         <version>${vertx.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-kafka-client</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
 
       <!-- Netty -->
       <dependency>
@@ -651,6 +666,12 @@
       <dependency>
         <groupId>org.wildfly.security</groupId>
         <artifactId>wildfly-elytron-credential</artifactId>
+        <version>${wildfly-elytron.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.security</groupId>
+        <artifactId>wildfly-elytron-password-impl</artifactId>
         <version>${wildfly-elytron.version}</version>
         <scope>runtime</scope>
       </dependency>

--- a/clients/adapter-kafka/pom.xml
+++ b/clients/adapter-kafka/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-clients-parent</artifactId>
+        <version>1.6.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>hono-client-adapter-kafka</artifactId>
+
+    <name>Hono Client for Protocol Adapters (Kafka)</name>
+    <description>An Kafka based implementation of the Hono Client for Protocol Adapters</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-client-adapter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-client-kafka-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>core-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerFactory;
+import org.eclipse.hono.kafka.client.tracing.KafkaTracingHelper;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.EncodeException;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.RecordMetadata;
+import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
+
+/**
+ * A client for publishing messages to a Kafka cluster.
+ */
+public abstract class AbstractKafkaBasedDownstreamSender implements Lifecycle {
+
+    /**
+     * A logger to be shared with subclasses.
+     */
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final KafkaProducerFactory<String, Buffer> producerFactory;
+    private final String producerName;
+    private final Map<String, String> config;
+    private final ProtocolAdapterProperties adapterConfig;
+    private final Tracer tracer;
+
+    /**
+     * Creates a new Kafka-based telemetry sender.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param producerName The producer name to use.
+     * @param config The Kafka producer configuration properties to use.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+
+    public AbstractKafkaBasedDownstreamSender(final KafkaProducerFactory<String, Buffer> producerFactory,
+            final String producerName, final Map<String, String> config, final ProtocolAdapterProperties adapterConfig,
+            final Tracer tracer) {
+
+        Objects.requireNonNull(producerFactory);
+        Objects.requireNonNull(producerName);
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(adapterConfig);
+        Objects.requireNonNull(tracer);
+
+        this.producerFactory = producerFactory;
+        this.producerName = producerName;
+        this.config = config;
+        this.adapterConfig = adapterConfig;
+        this.tracer = tracer;
+    }
+
+    /**
+     * Sends a message downstream.
+     * <p>
+     * Default properties defined either at the device or tenant level are added to the message headers.
+     *
+     * @param topic The topic to send the message to.
+     * @param tenant The tenant that the device belongs to.
+     * @param device The registration assertion for the device that the data originates from.
+     * @param qos The delivery semantics to use for sending the data.
+     * @param contentType The content type of the data. If {@code null}, the content type be taken from the following
+     *            sources (in that order, the first one that is present is used):
+     *            <ol>
+     *            <li>the <em>contentType</em> parameter</li>
+     *            <li>the property with key {@link org.eclipse.hono.util.MessageHelper#SYS_PROPERTY_CONTENT_TYPE} in the
+     *            <em>properties</em> parameter</li>
+     *            <li>the device default</li>
+     *            <li>the tenant default</li>
+     *            <li>the {@linkplain org.eclipse.hono.util.MessageHelper#CONTENT_TYPE_OCTET_STREAM default content
+     *            type}</li>
+     *            </ol>
+     * @param payload The data to send.
+     * @param properties Additional meta data that should be included in the downstream message.
+     * @param context The currently active OpenTracing span (may be {@code null}). An implementation should use this as
+     *            the parent for any span it creates for tracing the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the message has been sent downstream.
+     *         <p>
+     *         The future will be failed with a {@link org.eclipse.hono.client.ServerErrorException} if the data could
+     *         not be sent. The error code contained in the exception indicates the cause of the failure.
+     * @throws NullPointerException if topic, tenant, device, or qos are {@code null}.
+     */
+    protected Future<Void> send(final HonoTopic topic, final TenantObject tenant, final RegistrationAssertion device,
+            final QoS qos, final String contentType, final Buffer payload, final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(topic);
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(qos);
+
+        final String tenantId = tenant.getTenantId();
+        final String deviceId = device.getDeviceId();
+
+        log.trace("sending to Kafka [topic: {}, tenantId: {}, deviceId: {}, qos: {}, contentType: {}, properties: {}]",
+                topic, tenantId, deviceId, qos, contentType, properties);
+        final Span span = startSpan(topic, tenantId, deviceId, qos, contentType, context);
+
+        final KafkaProducerRecord<String, Buffer> record = KafkaProducerRecord.create(topic.toString(), deviceId,
+                payload);
+
+        final Map<String, Object> propsWithDefaults = addDefaults(tenant, device, qos, contentType, properties);
+        record.addHeaders(encodePropertiesAsKafkaHeaders(propsWithDefaults, span));
+
+        KafkaTracingHelper.injectSpanContext(tracer, record, span.context());
+        logProducerRecord(span, record);
+
+        final Promise<RecordMetadata> promise = Promise.promise();
+        getOrCreateProducer().send(record, promise);
+
+        final Future<Void> producerFuture = promise.future()
+                .recover(t -> {
+                    logError(span, topic, tenantId, deviceId, qos, t);
+                    span.finish();
+                    return Future.failedFuture(new ServerErrorException(getErrorCode(t), t));
+                })
+                .map(recordMetadata -> {
+                    logRecordMetadata(span, deviceId, recordMetadata);
+                    span.finish();
+                    return null;
+                });
+
+        return qos.equals(QoS.AT_MOST_ONCE) ? Future.succeededFuture() : producerFuture;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Starts the producer.
+     */
+    @Override
+    public Future<Void> start() {
+        configureUniqueClientId();
+        getOrCreateProducer();
+        return Future.succeededFuture();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Closes the producer.
+     */
+    @Override
+    public Future<Void> stop() {
+        return producerFactory.closeProducer(producerName);
+    }
+
+    private KafkaProducer<String, Buffer> getOrCreateProducer() {
+        return producerFactory.getOrCreateProducer(producerName, config);
+    }
+
+    private Map<String, Object> addDefaults(final TenantObject tenant, final RegistrationAssertion device,
+            final QoS qos, final String contentType, final Map<String, Object> properties) {
+
+        final Map<String, Object> headerProperties = new HashMap<>();
+        if (adapterConfig.isDefaultsEnabled()) {
+            headerProperties.putAll(tenant.getDefaults().copy().getMap()); // (1) add tenant defaults
+            headerProperties.putAll(device.getDefaults()); // (2) overwrite with device defaults
+        }
+
+        // (3) overwrite with properties provided by protocol adapter
+        Optional.ofNullable(properties).ifPresent(headerProperties::putAll);
+
+        // (4) overwrite by values of separate parameters
+        headerProperties.put(MessageHelper.APP_PROPERTY_DEVICE_ID, device.getDeviceId());
+        headerProperties.put(MessageHelper.APP_PROPERTY_QOS, qos.ordinal());
+        if (contentType != null) {
+            headerProperties.put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, contentType);
+        }
+
+        // (5) if still no content type present, set the default content type
+        headerProperties.putIfAbsent(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, MessageHelper.CONTENT_TYPE_OCTET_STREAM);
+
+        if (headerProperties.containsKey(MessageHelper.APP_PROPERTY_DEVICE_TTD)
+                && !headerProperties.containsKey(MessageHelper.SYS_PROPERTY_CREATION_TIME)) {
+            // TODO set this as creation time in the KafkaRecord?
+
+            // must match http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-timestamp
+            // as defined in https://www.eclipse.org/hono/docs/api/telemetry/#forward-telemetry-data
+            final long timestamp = Instant.now().toEpochMilli();
+            headerProperties.put(MessageHelper.SYS_PROPERTY_CREATION_TIME, timestamp);
+        }
+
+        return headerProperties;
+    }
+
+    private List<KafkaHeader> encodePropertiesAsKafkaHeaders(final Map<String, Object> properties, final Span span) {
+        final List<KafkaHeader> headers = new ArrayList<>();
+        properties.forEach((k, v) -> {
+            try {
+                final Buffer headerValue = (v instanceof String)
+                        ? Buffer.buffer((String) v)
+                        : Buffer.buffer(Json.encode(v));
+
+                headers.add(new KafkaHeaderImpl(k, headerValue));
+            } catch (final EncodeException e) {
+                log.info("failed to serialize property with key [{}] to Kafka header", k);
+                span.log("failed to create Kafka header from property: " + k);
+            }
+        });
+
+        return headers;
+    }
+
+    private Span startSpan(final HonoTopic topic, final String tenantId, final String deviceId, final QoS qos,
+            final String contentType, final SpanContext context) {
+
+        final String referenceType = QoS.AT_MOST_ONCE.equals(qos) ? References.FOLLOWS_FROM : References.CHILD_OF;
+        return KafkaTracingHelper.newProducerSpan(tracer, topic, referenceType, context)
+                .setTag(TracingHelper.TAG_TENANT_ID.getKey(), tenantId)
+                .setTag(TracingHelper.TAG_DEVICE_ID.getKey(), deviceId)
+                .setTag(TracingHelper.TAG_QOS.getKey(), qos.name())
+                .setTag(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, contentType);
+    }
+
+    private void logProducerRecord(final Span span, final KafkaProducerRecord<String, Buffer> record) {
+        final String headersAsString = record.headers()
+                .stream()
+                .map(header -> header.key() + "=" + header.value())
+                .collect(Collectors.joining(",", "{", "}"));
+
+        log.trace("producing message [topic: {}, key: {}, partition: {}, timestamp: {}, headers: {}]",
+                record.topic(), record.key(), record.partition(), record.timestamp(), headersAsString);
+
+        span.log("producing message with headers: " + headersAsString);
+    }
+
+    private void logRecordMetadata(final Span span, final String recordKey, final RecordMetadata metadata) {
+
+        log.trace("message produced to Kafka [topic: {}, key: {}, partition: {}, offset: {}, timestamp: {}]",
+                metadata.getTopic(), recordKey, metadata.getPartition(), metadata.getOffset(), metadata.getTimestamp());
+
+        span.log("message produced to Kafka");
+        KafkaTracingHelper.setRecordMetadataTags(span, metadata);
+        Tags.HTTP_STATUS.set(span, HttpURLConnection.HTTP_ACCEPTED);
+
+    }
+
+    private void logError(final Span span, final HonoTopic topic, final String tenantId, final String deviceId,
+            final QoS qos, final Throwable cause) {
+        log.debug("sending message failed [topic: {}, key: {}, qos: {}, tenantId: {}, deviceId: {}]",
+                topic, deviceId, qos, tenantId, deviceId, cause);
+
+        Tags.HTTP_STATUS.set(span, getErrorCode(cause));
+        TracingHelper.logError(span, cause);
+    }
+
+    private int getErrorCode(final Throwable t) {
+        /*
+         * TODO set error code depending on exception?
+         *
+         * Possible thrown exceptions include:
+         *
+         * Non-Retriable exceptions (fatal, the message will never be sent):
+         *
+         * InvalidTopicException OffsetMetadataTooLargeException RecordBatchTooLargeException RecordTooLargeException
+         * UnknownServerException UnknownProducerIdException
+         *
+         * Retriable exceptions (transient, may be covered by increasing #.retries):
+         *
+         * CorruptRecordException InvalidMetadataException NotEnoughReplicasAfterAppendException
+         * NotEnoughReplicasException OffsetOutOfRangeException TimeoutException UnknownTopicOrPartitionException
+         */
+
+        return HttpURLConnection.HTTP_UNAVAILABLE;
+    }
+
+    private void configureUniqueClientId() {
+        final UUID uuid = UUID.randomUUID();
+
+        final String clientId = config.get(ProducerConfig.CLIENT_ID_CONFIG);
+        if (clientId == null) {
+            config.put(ProducerConfig.CLIENT_ID_CONFIG, String.format("%s-%s", producerName, uuid));
+        } else {
+            config.put(ProducerConfig.CLIENT_ID_CONFIG, String.format("%s-%s-%s", clientId, producerName, uuid));
+        }
+    }
+}

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSender.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.client.KafkaProducerFactory;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A client for publishing event messages to a Kafka cluster.
+ */
+public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender implements EventSender {
+
+    /**
+     * Creates a new Kafka-based event sender.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param kafkaProducerConfig The Kafka producer configuration properties to use.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public KafkaBasedEventSender(final KafkaProducerFactory<String, Buffer> producerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig, final ProtocolAdapterProperties adapterConfig,
+            final Tracer tracer) {
+
+        super(producerFactory, EventConstants.EVENT_ENDPOINT, kafkaProducerConfig.getProducerConfig(), adapterConfig,
+                tracer);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendEvent(final TenantObject tenant, final RegistrationAssertion device,
+            final String contentType, final Buffer payload, final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+
+        log.trace("sending event [tenantId: {}, deviceId: {}, contentType: {}, properties: {}]", tenant.getTenantId(),
+                device.getDeviceId(), contentType, properties);
+
+        final HonoTopic topic = new HonoTopic(HonoTopic.Type.EVENT, tenant.getTenantId());
+        return send(topic, tenant, device, QoS.AT_LEAST_ONCE, contentType, payload, properties, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return KafkaBasedEventSender.class.getName() + " via Kafka";
+    }
+
+}

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySender.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.client.KafkaProducerFactory;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TelemetryConstants;
+import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A client for publishing telemetry messages to a Kafka cluster.
+ */
+public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSender implements TelemetrySender {
+
+    /**
+     * Creates a new Kafka-based telemetry sender.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param kafkaProducerConfig The Kafka producer configuration properties to use.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public KafkaBasedTelemetrySender(final KafkaProducerFactory<String, Buffer> producerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig, final ProtocolAdapterProperties adapterConfig,
+            final Tracer tracer) {
+
+        super(producerFactory, TelemetryConstants.TELEMETRY_ENDPOINT, kafkaProducerConfig.getProducerConfig(),
+                adapterConfig, tracer);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendTelemetry(final TenantObject tenant, final RegistrationAssertion device, final QoS qos,
+            final String contentType, final Buffer payload, final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(qos);
+
+        log.trace("send telemetry data [tenantId: {}, deviceId: {}, qos: {}, contentType: {}, properties: {}]",
+                tenant.getTenantId(), device.getDeviceId(), qos, contentType, properties);
+
+        final HonoTopic topic = new HonoTopic(HonoTopic.Type.TELEMETRY, tenant.getTenantId());
+        return send(topic, tenant, device, qos, contentType, payload, properties, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return KafkaBasedTelemetrySender.class.getName() + " via Kafka";
+    }
+
+}

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.kafka.client.CachingKafkaProducerFactory;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Verifies behavior of {@link AbstractKafkaBasedDownstreamSender}.
+ */
+@ExtendWith(VertxExtension.class)
+public class AbstractKafkaBasedDownstreamSenderTest {
+
+    private static final String CONTENT_TYPE_KEY = MessageHelper.SYS_PROPERTY_CONTENT_TYPE;
+
+    private static final String TENANT_ID = "the-tenant";
+    private static final String DEVICE_ID = "the-device";
+    private static final QoS qos = QoS.AT_LEAST_ONCE;
+    private static final String CONTENT_TYPE = "the-content-type";
+    private static final String PRODUCER_NAME = "test-producer";
+
+    protected final Tracer tracer = NoopTracerFactory.create();
+    private final Map<String, String> config = new HashMap<>();
+    private final HonoTopic topic = new HonoTopic(HonoTopic.Type.EVENT, TENANT_ID);
+    private final TenantObject tenant = new TenantObject(TENANT_ID, true);
+    private final RegistrationAssertion device = new RegistrationAssertion(DEVICE_ID);
+    private final ProtocolAdapterProperties adapterConfig = new ProtocolAdapterProperties();
+
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+        config.put("hono.kafka.producerConfig.bootstrap.servers", "localhost:9092");
+    }
+
+    /**
+     * Verifies that {@link AbstractKafkaBasedDownstreamSender#start()} creates a producer and
+     * {@link AbstractKafkaBasedDownstreamSender#stop()} closes it.
+     */
+    @Test
+    public void testLifecycle() {
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(factory);
+
+        assertThat(factory.getProducer(PRODUCER_NAME)).isEmpty();
+        sender.start();
+        assertThat(factory.getProducer(PRODUCER_NAME)).isNotEmpty();
+        sender.stop();
+        assertThat(factory.getProducer(PRODUCER_NAME)).isEmpty();
+    }
+
+    /**
+     * Verifies that the Kafka record is created as expected.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendCreatesCorrectRecord(final VertxTestContext ctx) {
+
+        // GIVEN a sender
+        final String payload = "the-payload";
+        final Map<String, Object> properties = Collections.singletonMap("foo", "bar");
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+
+        // WHEN sending a message
+        sender.send(topic, tenant, device, qos, CONTENT_TYPE, Buffer.buffer(payload), properties, null)
+                .onComplete(ctx.succeeding(v -> {
+
+                    final ProducerRecord<String, Buffer> actual = mockProducer.history().get(0);
+                    ctx.verify(() -> {
+                        // THEN the producer record is created from the given values...
+                        assertThat(actual.key()).isEqualTo(DEVICE_ID);
+                        assertThat(actual.topic()).isEqualTo(topic.toString());
+                        assertThat(actual.value().toString()).isEqualTo(payload);
+                        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("foo", "bar".getBytes()));
+
+                        // ...AND contains the standard headers
+                        TestHelper.assertStandardHeaders(actual, DEVICE_ID, CONTENT_TYPE, qos);
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that the send method returns the underlying error wrapped in a {@link ServerErrorException}.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendFailsWithTheExpectedError(final VertxTestContext ctx) {
+
+        // GIVEN a sender sending a message
+        final RuntimeException expectedError = new RuntimeException("boom");
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(false);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+
+        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null)
+                .onComplete(ctx.failing(t -> {
+                    ctx.verify(() -> {
+                        // THEN it fails with the expected error
+                        assertThat(t).isInstanceOf(ServerErrorException.class);
+                        assertThat(((ServerErrorException) t).getErrorCode()).isEqualTo(503);
+                        assertThat(t.getCause()).isEqualTo(expectedError);
+                    });
+                    ctx.completeNow();
+                }));
+
+        // WHEN the send operation fails
+        mockProducer.errorNext(expectedError);
+
+    }
+
+    /**
+     * Verifies that the producer is closed when sending of a message fails with a fatal error.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testProducerIsClosedOnFatalError(final VertxTestContext ctx) {
+
+        final AuthorizationException expectedError = new AuthorizationException("go away");
+
+        // GIVEN a sender sending a message
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(false);
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        newSender(factory).send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null)
+                .onComplete(ctx.failing(t -> {
+                    ctx.verify(() -> {
+                        // THEN the producer is removed and closed
+                        assertThat(factory.getProducer(PRODUCER_NAME)).isEmpty();
+                        assertThat(mockProducer.closed()).isTrue();
+                    });
+                    ctx.completeNow();
+                }));
+
+        // WHEN the send operation fails
+        mockProducer.errorNext(expectedError);
+
+    }
+
+    /**
+     * Verifies that the producer is not closed when sending of a message fails with a non-fatal error.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testProducerIsNotClosedOnNonFatalError(final VertxTestContext ctx) {
+
+        final RuntimeException expectedError = new RuntimeException("foo");
+
+        // GIVEN a sender sending a message
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(false);
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        newSender(factory).send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null)
+                .onComplete(ctx.failing(t -> {
+                    ctx.verify(() -> {
+                        // THEN the producer is present and still open
+                        assertThat(factory.getProducer(PRODUCER_NAME)).isNotEmpty();
+                        assertThat(mockProducer.closed()).isFalse();
+                    });
+                    ctx.completeNow();
+                }));
+
+        // WHEN the send operation fails
+        mockProducer.errorNext(expectedError);
+
+    }
+
+    /**
+     * Verifies that if no content type is present, then the default content type <em>"application/octet-stream"</em> is
+     * set.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testDefaultContentTypeIsUsedWhenNotPresent(final VertxTestContext ctx) {
+        assertContentType("application/octet-stream", null, null, device, tenant, ctx);
+    }
+
+    /**
+     * Verifies that properties from the tenant defaults are added as headers.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testTenantDefaultsAreApplied(final VertxTestContext ctx) {
+
+        final String contentTypeTenant = "application/tenant";
+        tenant.setDefaults(new JsonObject(Collections.singletonMap(CONTENT_TYPE_KEY, contentTypeTenant)));
+
+        assertContentType(contentTypeTenant, null, null, device, tenant, ctx);
+    }
+
+    /**
+     * Verifies that the default properties specified at device level overwrite the tenant defaults.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testDeviceDefaultsTakePrecedenceOverTenantDefaults(final VertxTestContext ctx) {
+
+        final String expected = "application/device";
+
+        tenant.setDefaults(new JsonObject(Collections.singletonMap(CONTENT_TYPE_KEY, "application/tenant")));
+        device.setDefaults(Collections.singletonMap(CONTENT_TYPE_KEY, expected));
+
+        assertContentType(expected, null, null, device, tenant, ctx);
+
+    }
+
+    /**
+     * Verifies that the values in the <em>properties</em> parameter overwrite the device defaults.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testPropertiesParameterTakesPrecedenceOverDeviceDefaults(final VertxTestContext ctx) {
+
+        final String expected = "application/properties";
+
+        device.setDefaults(Collections.singletonMap(CONTENT_TYPE_KEY, "application/device"));
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put(CONTENT_TYPE_KEY, expected);
+
+        assertContentType(expected, null, properties, device, tenant, ctx);
+    }
+
+    /**
+     * Verifies that the <em>contentType</em> parameter overwrites the values in the <em>properties</em> parameter.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testContentTypeParameterTakesPrecedenceOverPropertiesParameter(final VertxTestContext ctx) {
+
+        final String expected = "application/parameter";
+
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put(CONTENT_TYPE_KEY, "application/properties");
+
+        assertContentType(expected, expected, properties, device, tenant, ctx);
+    }
+
+    private void assertContentType(final String expectedContentType, final String contentTypeParameter,
+            final Map<String, Object> properties, final RegistrationAssertion device, final TenantObject tenant,
+            final VertxTestContext ctx) {
+
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        newSender(TestHelper.newProducerFactory(mockProducer))
+                .send(topic, tenant, device, qos, contentTypeParameter, null, properties, null)
+                .onComplete(ctx.succeeding(v -> {
+                    ctx.verify(() -> {
+                        final Headers actual = mockProducer.history().get(0).headers();
+                        assertThat(actual)
+                                .containsOnlyOnce(new RecordHeader(CONTENT_TYPE_KEY, expectedContentType.getBytes()));
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that if the properties contain a <em>ttd</em> property but no <em>creation-time</em> then the later is
+     * added.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatCreationTimeIsAddedWhenNotPresentAndTtdIsSet(final VertxTestContext ctx) {
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+
+        // GIVEN properties that contain a TTD
+        final long ttd = 99L;
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("ttd", ttd);
+
+        // WHEN sending the message
+        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, properties, null)
+                .onComplete(ctx.succeeding(t -> {
+                    ctx.verify(() -> {
+                        // THEN the producer record contains a creation time
+                        final ProducerRecord<String, Buffer> record = mockProducer.history().get(0);
+                        assertThat(record.headers())
+                                .containsOnlyOnce(new RecordHeader("ttd", Json.encode(ttd).getBytes()));
+                        assertThat(record.headers().headers("creation-time")).isNotNull();
+                    });
+                    ctx.completeNow();
+                }));
+
+    }
+
+    /**
+     * Verifies that if the properties contain a <em>creation-time</em> property then it is preserved.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatCreationTimeIsNotChangedWhenPresentAndTtdIsSet(final VertxTestContext ctx) {
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+
+        // GIVEN properties that contain creation-time
+        final long creationTime = 12345L;
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("ttd", 99L);
+        properties.put("creation-time", creationTime);
+
+        // WHEN sending the message
+        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, properties, null)
+                .onComplete(ctx.succeeding(t -> {
+                    ctx.verify(() -> {
+                        // THEN the creation time is preserved
+                        final ProducerRecord<String, Buffer> record = mockProducer.history().get(0);
+                        final RecordHeader expectedHeader = new RecordHeader("creation-time",
+                                Json.encode(creationTime).getBytes());
+                        assertThat(record.headers()).containsOnlyOnce(expectedHeader);
+                    });
+                    ctx.completeNow();
+                }));
+
+    }
+
+    /**
+     * Verifies that the constructor throws a nullpointer exception if a parameter is {@code null}.
+     */
+    @Test
+    public void testThatConstructorThrowsOnMissingParameter() {
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+
+        assertThrows(NullPointerException.class,
+                () -> new AbstractKafkaBasedDownstreamSender(null, PRODUCER_NAME, config, adapterConfig, tracer) {
+                });
+
+        assertThrows(NullPointerException.class,
+                () -> new AbstractKafkaBasedDownstreamSender(factory, null, config, adapterConfig, tracer) {
+                });
+
+        assertThrows(NullPointerException.class,
+                () -> new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, null, adapterConfig, tracer) {
+                });
+
+        assertThrows(NullPointerException.class,
+                () -> new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, config, null, tracer) {
+                });
+
+        assertThrows(NullPointerException.class,
+                () -> new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, config, adapterConfig, null) {
+                });
+    }
+
+    /**
+     * Verifies that
+     * {@link AbstractKafkaBasedDownstreamSender#send(HonoTopic, org.eclipse.hono.util.TenantObject, org.eclipse.hono.util.RegistrationAssertion, QoS, String, Buffer, Map, SpanContext)}
+     * throws a nullpointer exception if a mandatory parameter is {@code null}.
+     */
+    @Test
+    public void testThatSendThrowsOnMissingMandatoryParameter() {
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.send(null, tenant, device, qos, CONTENT_TYPE, null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.send(topic, null, device, qos, CONTENT_TYPE, null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.send(topic, tenant, null, qos, CONTENT_TYPE, null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.send(topic, tenant, device, null, CONTENT_TYPE, null, null, null));
+
+    }
+
+    private AbstractKafkaBasedDownstreamSender newSender(final CachingKafkaProducerFactory<String, Buffer> factory) {
+        return new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, config, adapterConfig, tracer) {
+        };
+    }
+
+}

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSenderTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.kafka.client.CachingKafkaProducerFactory;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Verifies behavior of {@link KafkaBasedEventSender}.
+ */
+@ExtendWith(VertxExtension.class)
+public class KafkaBasedEventSenderTest {
+
+    private final TenantObject tenant = new TenantObject("the-tenant", true);
+    private final RegistrationAssertion device = new RegistrationAssertion("the-device");
+    private final ProtocolAdapterProperties adapterConfig = new ProtocolAdapterProperties();
+    private final Tracer tracer = NoopTracerFactory.create();
+
+    private KafkaProducerConfigProperties kafkaProducerConfig;
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+
+        kafkaProducerConfig = new KafkaProducerConfigProperties();
+        kafkaProducerConfig.setProducerConfig(new HashMap<>());
+
+    }
+
+    /**
+     * Verifies that the Kafka record is created as expected.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendEventCreatesCorrectRecord(final VertxTestContext ctx) {
+
+        // GIVEN a sender
+        final String contentType = "the-content-type";
+        final String payload = "the-payload";
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final KafkaBasedEventSender sender = new KafkaBasedEventSender(factory, kafkaProducerConfig, adapterConfig,
+                tracer);
+
+        // WHEN sending a message
+        sender.sendEvent(tenant, device, contentType, Buffer.buffer(payload), null, null)
+                .onComplete(ctx.succeeding(t -> {
+                    ctx.verify(() -> {
+                        // THEN the producer record is created from the given values...
+                        final ProducerRecord<String, Buffer> actual = mockProducer.history().get(0);
+
+                        assertThat(actual.key()).isEqualTo(device.getDeviceId());
+                        assertThat(actual.topic())
+                                .isEqualTo(new HonoTopic(HonoTopic.Type.EVENT, tenant.getTenantId()).toString());
+                        assertThat(actual.value().toString()).isEqualTo(payload);
+
+                        // ...AND contains the standard headers
+                        TestHelper.assertStandardHeaders(actual, device.getDeviceId(), contentType, QoS.AT_LEAST_ONCE);
+                    });
+                    ctx.completeNow();
+                }));
+
+    }
+
+
+    /**
+     * Verifies that the constructor throws a nullpointer exception if a parameter is {@code null}.
+     */
+    @Test
+    public void testThatConstructorThrowsOnMissingParameter() {
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper
+                .newProducerFactory(TestHelper.newMockProducer(true));
+
+        assertThrows(NullPointerException.class,
+                () -> new KafkaBasedEventSender(null, kafkaProducerConfig, adapterConfig, tracer));
+
+        assertThrows(NullPointerException.class,
+                () -> new KafkaBasedEventSender(factory, null, adapterConfig, tracer));
+
+        assertThrows(NullPointerException.class,
+                () -> new KafkaBasedEventSender(factory, kafkaProducerConfig, adapterConfig, null));
+    }
+
+    /**
+     * Verifies that
+     * {@link KafkaBasedEventSender#sendEvent(TenantObject, RegistrationAssertion, String, Buffer, Map, SpanContext)}
+     * throws a nullpointer exception if a mandatory parameter is {@code null}.
+     */
+    @Test
+    public void testThatSendEventThrowsOnMissingMandatoryParameter() {
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper
+                .newProducerFactory(TestHelper.newMockProducer(true));
+        final KafkaBasedEventSender sender = new KafkaBasedEventSender(factory, kafkaProducerConfig, adapterConfig,
+                tracer);
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendEvent(null, device, "the-content-type", null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendEvent(tenant, null, "the-content-type", null, null, null));
+
+    }
+}

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.kafka.client.CachingKafkaProducerFactory;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Verifies behavior of {@link KafkaBasedTelemetrySender}.
+ */
+@ExtendWith(VertxExtension.class)
+public class KafkaBasedTelemetrySenderTest {
+
+    private final TenantObject tenant = new TenantObject("the-tenant", true);
+    private final RegistrationAssertion device = new RegistrationAssertion("the-device");
+    private final ProtocolAdapterProperties adapterConfig = new ProtocolAdapterProperties();
+    private final Tracer tracer = NoopTracerFactory.create();
+
+    private KafkaProducerConfigProperties kafkaProducerConfig;
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+
+        kafkaProducerConfig = new KafkaProducerConfigProperties();
+        kafkaProducerConfig.setProducerConfig(new HashMap<>());
+
+    }
+
+    /**
+     * Verifies that the Kafka record is created as expected when sending telemetry data with QoS 0.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendTelemetryCreatesCorrectRecordWithQoS0(final VertxTestContext ctx) {
+
+        // GIVEN a telemetry sender
+        final QoS qos = QoS.AT_MOST_ONCE;
+        final String payload = "the-payload";
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final KafkaBasedTelemetrySender sender = new KafkaBasedTelemetrySender(factory, kafkaProducerConfig,
+                adapterConfig, tracer);
+
+        // WHEN sending telemetry data with QoS 0
+        sender.sendTelemetry(tenant, device, qos, "the-content-type", Buffer.buffer(payload), null, null)
+                .onComplete(ctx.succeeding(t -> {
+                    ctx.verify(() -> {
+                        // THEN the producer record is created from the given values...
+                        final ProducerRecord<String, Buffer> actual = mockProducer.history().get(0);
+
+                        assertThat(actual.key()).isEqualTo(device.getDeviceId());
+                        assertThat(actual.topic())
+                                .isEqualTo(new HonoTopic(HonoTopic.Type.TELEMETRY, tenant.getTenantId()).toString());
+                        assertThat(actual.value().toString()).isEqualTo(payload);
+
+                        // ...AND contains the standard headers
+                        TestHelper.assertStandardHeaders(actual, device.getDeviceId(), "the-content-type", qos);
+                    });
+                    ctx.completeNow();
+                }));
+
+    }
+
+    /**
+     * Verifies that the Kafka record is created as expected when sending telemetry data with QoS 1.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendTelemetryCreatesCorrectRecordWithQoS1(final VertxTestContext ctx) {
+
+        // GIVEN a telemetry sender
+        final QoS qos = QoS.AT_LEAST_ONCE;
+        final String contentType = "the-content-type";
+        final String payload = "the-payload";
+        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final KafkaBasedTelemetrySender sender = new KafkaBasedTelemetrySender(factory, kafkaProducerConfig,
+                adapterConfig, tracer);
+
+        // WHEN sending telemetry data with QoS 1
+        sender.sendTelemetry(tenant, device, qos, contentType, Buffer.buffer(payload), null, null)
+                .onComplete(ctx.succeeding(t -> {
+                    ctx.verify(() -> {
+                        // THEN the producer record is created from the given values...
+                        final ProducerRecord<String, Buffer> actual = mockProducer.history().get(0);
+
+                        assertThat(actual.key()).isEqualTo(device.getDeviceId());
+                        assertThat(actual.topic())
+                                .isEqualTo(new HonoTopic(HonoTopic.Type.TELEMETRY, tenant.getTenantId()).toString());
+                        assertThat(actual.value().toString()).isEqualTo(payload);
+
+                        // ...AND contains the standard headers
+                        TestHelper.assertStandardHeaders(actual, device.getDeviceId(), contentType, qos);
+                    });
+                    ctx.completeNow();
+                }));
+
+    }
+
+    /**
+     * Verifies that the constructor throws a nullpointer exception if a parameter is {@code null}.
+     */
+    @Test
+    public void testThatConstructorThrowsOnMissingParameter() {
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper
+                .newProducerFactory(TestHelper.newMockProducer(true));
+
+        assertThrows(NullPointerException.class,
+                () -> new KafkaBasedTelemetrySender(null, kafkaProducerConfig, adapterConfig, tracer));
+
+        assertThrows(NullPointerException.class,
+                () -> new KafkaBasedTelemetrySender(factory, null, adapterConfig, tracer));
+
+        assertThrows(NullPointerException.class,
+                () -> new KafkaBasedTelemetrySender(factory, kafkaProducerConfig, adapterConfig, null));
+    }
+
+    /**
+     * Verifies that
+     * {@link KafkaBasedTelemetrySender#sendTelemetry(TenantObject, RegistrationAssertion, QoS, String, Buffer, Map, SpanContext)}
+     * throws a nullpointer exception if a mandatory parameter is {@code null}.
+     */
+    @Test
+    public void testThatSendTelemetryThrowsOnMissingMandatoryParameter() {
+        final QoS qos = QoS.AT_LEAST_ONCE;
+        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper
+                .newProducerFactory(TestHelper.newMockProducer(true));
+        final KafkaBasedTelemetrySender sender = new KafkaBasedTelemetrySender(factory, kafkaProducerConfig,
+                adapterConfig, tracer);
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendTelemetry(null, device, qos, "the-content-type", null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendTelemetry(tenant, null, qos, "the-content-type", null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendTelemetry(tenant, device, null, "the-content-type", null, null, null));
+
+    }
+}

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/TestHelper.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/TestHelper.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.hono.kafka.client.CachingKafkaProducerFactory;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.QoS;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.serialization.BufferSerializer;
+
+/**
+ * A helper class for writing tests with the Kafka client.
+ */
+public class TestHelper {
+
+    private TestHelper() {
+    }
+
+    /**
+     * Returns a new {@link org.eclipse.hono.client.impl.CachingClientFactory} for the given native {@link Producer}.
+     * <p>
+     * All producers returned by this factory will use the given native producer instance wrapped in a
+     * {@link KafkaProducer}.
+     *
+     * @param producer The (mock) producer to be wrapped.
+     * @return The producer factory.
+     */
+    public static CachingKafkaProducerFactory<String, Buffer> newProducerFactory(
+            final Producer<String, Buffer> producer) {
+
+        final Vertx vertxMock = mock(Vertx.class);
+        final Context context = VertxMockSupport.mockContext(vertxMock);
+        when(vertxMock.getOrCreateContext()).thenReturn(context);
+
+        doAnswer(invocation -> {
+            final Promise<RecordMetadata> result = Promise.promise();
+            final Handler<Future<RecordMetadata>> blockingCode = invocation.getArgument(0);
+            blockingCode.handle(result.future());
+            return null;
+        }).when(context).executeBlocking(VertxMockSupport.anyHandler(), any());
+
+        return new CachingKafkaProducerFactory<>((n, c) -> KafkaProducer.create(vertxMock, producer));
+    }
+
+    /**
+     * Returns a new {@link MockProducer}.
+     *
+     * @param autoComplete If true, the producer automatically completes all requests successfully and executes the
+     *            callback. Otherwise the {@link MockProducer#completeNext()} or
+     *            {@link MockProducer#errorNext(RuntimeException)} must be invoked after sending a message.
+     * @return the mock producer.
+     */
+    public static MockProducer<String, Buffer> newMockProducer(final boolean autoComplete) {
+        return new MockProducer<>(autoComplete, new StringSerializer(), new BufferSerializer());
+    }
+
+    /**
+     * Asserts that a given Kafka producer record contains the standard headers only once and with the expected values.
+     * The following headers are expected:
+     * <ul>
+     * <li><em>content-type</em></li>
+     * <li><em>device_id</em></li>
+     * <li><em>qos</em></li>
+     * </ul>
+     *
+     * @param actual The record to be checked.
+     * @param deviceId The expected device ID.
+     * @param contentType The expected content type.
+     * @param qos The expected QoS level.
+     */
+    public static void assertStandardHeaders(final ProducerRecord<String, Buffer> actual, final String deviceId,
+            final String contentType, final QoS qos) {
+
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("content-type", contentType.getBytes()));
+
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("device_id", deviceId.getBytes()));
+
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("qos", Json.encode(qos.ordinal()).getBytes()));
+    }
+
+}

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-clients-parent</artifactId>
+        <version>1.6.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>hono-client-kafka-common</artifactId>
+
+    <name>Hono Client Kafka Common</name>
+    <description>Classes required for implementing Kafka based Hono clients</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-proton</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.jsonwebtoken</groupId>
+                    <artifactId>jjwt-jackson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.jsonwebtoken</groupId>
+                    <artifactId>jjwt-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.jsonwebtoken</groupId>
+                    <artifactId>jjwt-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-crypto</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-kafka-client</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>core-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/CachingKafkaProducerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/CachingKafkaProducerFactory.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.producer.KafkaProducer;
+
+/**
+ * A factory for creating Kafka producers. Created producers are being cached.
+ * <p>
+ * This implementation provides no synchronization and should not be used by multiple threads. To create producers that
+ * can safely be shared between verticle instances, use {@link KafkaProducerFactory#sharedProducerFactory(Vertx)}.
+ * <p>
+ * Producers are closed and removed from the cache if they throw a {@link #isFatalError(Throwable) fatal exception}.
+ * This is triggered by {@link KafkaProducer#exceptionHandler(Handler)} and run asynchronously after the
+ * {@link io.vertx.kafka.client.producer.impl.KafkaWriteStreamImpl#send(ProducerRecord, Handler) send operation} has
+ * finished. A following invocation of {@link #getOrCreateProducer(String, Map)} will then return a new instance.
+ *
+ * @param <K> The type for the record key serialization.
+ * @param <V> The type for the record value serialization.
+ */
+public class CachingKafkaProducerFactory<K, V> implements KafkaProducerFactory<K, V> {
+
+    private final Map<String, KafkaProducer<K, V>> activeProducers = new HashMap<>();
+    private final BiFunction<String, Map<String, String>, KafkaProducer<K, V>> producerInstanceSupplier;
+
+    /**
+     * Creates a new producer factory.
+     * <p>
+     * Use {@link KafkaProducerFactory#sharedProducerFactory(Vertx)} to create producers that can safely be shared
+     * between verticle instances.
+     *
+     * @param producerInstanceSupplier The function that provides new producer instances.
+     */
+    public CachingKafkaProducerFactory(
+            final BiFunction<String, Map<String, String>, KafkaProducer<K, V>> producerInstanceSupplier) {
+        this.producerInstanceSupplier = producerInstanceSupplier;
+    }
+
+    /**
+     * Gets a producer for sending data to Kafka.
+     * <p>
+     * This method first tries to look up an already existing producer using the given name. If no producer exists yet,
+     * a new instance is created using the given factory and put to the cache.
+     * <p>
+     * The given config is ignored when an existing producers is returned.
+     *
+     * @param producerName The name to identify the producer.
+     * @param config The Kafka configuration with which the producer is to be created.
+     * @return an existing or new producer.
+     */
+    @Override
+    public KafkaProducer<K, V> getOrCreateProducer(final String producerName, final Map<String, String> config) {
+
+        activeProducers.computeIfAbsent(producerName, (name) -> {
+            final KafkaProducer<K, V> producer = producerInstanceSupplier.apply(producerName, config);
+            return producer.exceptionHandler(getExceptionHandler(name, producer));
+        });
+
+        return activeProducers.get(producerName);
+    }
+
+    private Handler<Throwable> getExceptionHandler(final String producerName, final KafkaProducer<K, V> producer) {
+        return t -> {
+            // this is executed asynchronously after the send operation has finished
+            if (isFatalError(t)) {
+                activeProducers.remove(producerName);
+                producer.close();
+            }
+        };
+    }
+
+    /**
+     * Gets an existing producer.
+     *
+     * @param producerName The name to look up the producer.
+     * @return The producer or {@code null} if the cache does not contain the name.
+     */
+    public Optional<KafkaProducer<K, V>> getProducer(final String producerName) {
+        return Optional.ofNullable(activeProducers.get(producerName));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * If a producer with the given name exists, it is removed from the cache.
+     */
+    @Override
+    public Future<Void> closeProducer(final String producerName) {
+        final KafkaProducer<K, V> producer = activeProducers.remove(producerName);
+        if (producer == null) {
+            return Future.succeededFuture();
+        } else {
+            final Promise<Void> promise = Promise.promise();
+            producer.close(promise);
+            return promise.future();
+        }
+    }
+
+    /**
+     * Checks if the given throwable indicates a fatal producer error.
+     *
+     * @param error The error to be checked.
+     * @return {@code true} if error is an instance of one of the following ({@code false} otherwise):
+     *         <ul>
+     *         <li>{@link ProducerFencedException}</li>
+     *         <li>{@link OutOfOrderSequenceException}</li>
+     *         <li>{@link AuthorizationException}</li>
+     *         <li>{@link UnsupportedVersionException}</li>
+     *         <li>{@link UnsupportedForMessageFormatException}.</li>
+     *         </ul>
+     */
+    public static boolean isFatalError(final Throwable error) {
+        return error instanceof ProducerFencedException
+                || error instanceof OutOfOrderSequenceException
+                || error instanceof AuthorizationException
+                || error instanceof UnsupportedVersionException
+                || error instanceof UnsupportedForMessageFormatException;
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/HonoTopic.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/HonoTopic.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.Objects;
+
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.TelemetryConstants;
+
+/**
+ * Identifier for Hono's topics. The Kafka topic string is obtained by {@link #toString()}.
+ */
+public final class HonoTopic {
+
+    private static final String SEPARATOR = ".";
+    private static final String NAMESPACE = "hono" + SEPARATOR;
+
+    private final String topicString;
+
+    /**
+     * Creates a new topic from the given topic type and tenant ID.
+     *
+     * @param type The type of the topic.
+     * @param tenantId The ID of the tenant that the topic belongs to.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public HonoTopic(final Type type, final String tenantId) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(tenantId);
+
+        topicString = type.prefix + tenantId;
+    }
+
+    /**
+     * Creates a topic instance from the string representation.
+     *
+     * @param topicString The string to create a topic from.
+     * @return The topic or {@code null} if the string does not contain a valid Hono topic.
+     */
+    public static HonoTopic fromString(final String topicString) {
+        if (topicString.startsWith(Type.TELEMETRY.prefix)) {
+            return new HonoTopic(Type.TELEMETRY, topicString.substring(Type.TELEMETRY.prefix.length()));
+        } else if (topicString.startsWith(Type.EVENT.prefix)) {
+            return new HonoTopic(Type.EVENT, topicString.substring(Type.EVENT.prefix.length()));
+        } else if (topicString.startsWith(Type.COMMAND.prefix)) {
+            return new HonoTopic(Type.COMMAND, topicString.substring(Type.COMMAND.prefix.length()));
+        } else if (topicString.startsWith(Type.COMMAND_RESPONSE.prefix)) {
+            return new HonoTopic(Type.COMMAND_RESPONSE, topicString.substring(Type.COMMAND_RESPONSE.prefix.length()));
+        }
+        return null;
+    }
+
+    /**
+     * Returns the string representation of the topic as used by the Kafka client.
+     *
+     * @return The topic as a string.
+     */
+    @Override
+    public String toString() {
+        return topicString;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final HonoTopic honoTopic = (HonoTopic) o;
+        return topicString.equals(honoTopic.topicString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicString);
+    }
+
+    /**
+     * The type of a Hono specific Kafka topic.
+     */
+    public enum Type {
+
+        TELEMETRY(NAMESPACE + TelemetryConstants.TELEMETRY_ENDPOINT + SEPARATOR),
+        EVENT(NAMESPACE + EventConstants.EVENT_ENDPOINT + SEPARATOR),
+        COMMAND(NAMESPACE + CommandConstants.COMMAND_ENDPOINT + SEPARATOR),
+        COMMAND_RESPONSE(NAMESPACE + CommandConstants.COMMAND_RESPONSE_ENDPOINT + SEPARATOR);
+
+        final String prefix;
+
+        Type(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String toString() {
+            return name().toLowerCase();
+        }
+
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaConsumerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaConsumerConfigProperties.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configuration properties for Kafka consumers.
+ * <p>
+ * This class is intended to be as agnostic to the provided properties as possible in order to be forward-compatible
+ * with changes in new versions of the Kafka client. It only sets a couple of properties that are important for Hono to
+ * provide the expected quality of service.
+ *
+ * @see <a href="https://kafka.apache.org/documentation/#consumerconfigs">Kafka Consumer Configs</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/kafka">Documentation of Hono's Kafka-based APIs</a>
+ */
+// TODO check link to Hono documentation after the API specs are on master
+public class KafkaConsumerConfigProperties {
+
+    private final Logger log = LoggerFactory.getLogger(KafkaConsumerConfigProperties.class);
+
+    private Map<String, String> consumerConfig;
+    private String clientId;
+
+    /**
+     * Sets the Kafka consumer config properties to be used.
+     *
+     * @param consumerConfig The config properties.
+     * @throws NullPointerException if the config is {@code null}.
+     */
+    public void setConsumerConfig(final Map<String, String> consumerConfig) {
+        this.consumerConfig = Objects.requireNonNull(consumerConfig);
+    }
+
+    /**
+     * Sets the client ID that is passed to the Kafka server to allow application specific server-side request logging.
+     * <p>
+     * If the config set in {@link #setConsumerConfig(Map)} already contains a value for key {@code client.id}, that one
+     * will be used and the parameter here will be ignored.
+     *
+     * @param clientId The client ID to set.
+     * @throws NullPointerException if the client ID is {@code null}.
+     */
+    public final void setClientId(final String clientId) {
+        this.clientId = Objects.requireNonNull(clientId);
+    }
+
+    /**
+     * Gets the Kafka consumer configuration to which additional properties were applied. The following properties are
+     * set here to the given configuration:
+     * <ul>
+     * <li>{@code key.deserializer=org.apache.kafka.common.serialization.StringDeserializer}: defines how message keys
+     * are deserialized</li>
+     * <li>{@code value.deserializer=io.vertx.kafka.client.serialization.BufferDeserializer}: defines how message values
+     * are deserialized</li>
+     * <li>{@code client.id} if the property is not already present in the configuration and a value has been set with
+     * {@link #setClientId(String)}, this value will be taken</li>
+     * </ul>
+     *
+     * @return a copy of the consumer configuration with the applied properties an empty map if no consumer
+     *         configuration was set with {@link #setConsumerConfig(Map)}.
+     */
+    public Map<String, String> getConsumerConfig() {
+
+        if (consumerConfig == null) {
+            return Collections.emptyMap();
+        }
+
+        final HashMap<String, String> newConfig = new HashMap<>(consumerConfig);
+
+        overrideConsumerConfigProperty(newConfig, ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringDeserializer");
+
+        overrideConsumerConfigProperty(newConfig, ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                "io.vertx.kafka.client.serialization.BufferDeserializer");
+
+        if (clientId != null) {
+            newConfig.putIfAbsent(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
+        }
+
+        return newConfig;
+    }
+
+    private void overrideConsumerConfigProperty(final Map<String, String> config, final String key,
+            final String value) {
+
+        log.trace("Setting Kafka consumer config property [{}={}]", key, value);
+        final Object oldValue = config.put(key, value);
+        if (oldValue != null) {
+            log.debug("Provided Kafka consumer configuration contains property [{}={}], changing it to [{}]", key,
+                    oldValue, value);
+        }
+
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaProducerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaProducerConfigProperties.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configuration properties for Kafka producers.
+ * <p>
+ * This class is intended to be as agnostic to the provided properties as possible in order to be forward-compatible
+ * with changes in new versions of the Kafka client. It only sets a couple of properties that are important for Hono to
+ * provide the expected quality of service.
+ *
+ * @see <a href="https://kafka.apache.org/documentation/#producerconfigs">Kafka Producer Configs</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/kafka">Documentation of Hono's Kafka-based APIs</a>
+ */
+// TODO check link to Hono documentation after the API specs are on master
+public class KafkaProducerConfigProperties {
+
+    private final Logger log = LoggerFactory.getLogger(KafkaProducerConfigProperties.class);
+
+    private Map<String, String> producerConfig;
+    private String clientId;
+
+    /**
+     * Sets the Kafka producer config properties to be used.
+     *
+     * @param producerConfig The config properties.
+     * @throws NullPointerException if the config is {@code null}.
+     */
+    public void setProducerConfig(final Map<String, String> producerConfig) {
+        this.producerConfig = Objects.requireNonNull(producerConfig);
+    }
+
+    /**
+     * Sets the client ID that is passed to the Kafka server to allow application specific server-side request logging.
+     * <p>
+     * If the config set in {@link #setProducerConfig(Map)} already contains a value for key {@code client.id}, that one
+     * will be used and the parameter here will be ignored.
+     *
+     * @param clientId The client ID to set.
+     * @throws NullPointerException if the client ID is {@code null}.
+     */
+    public final void setClientId(final String clientId) {
+        this.clientId = Objects.requireNonNull(clientId);
+    }
+
+    /*
+     * Checks if a configuration has been set.
+     *
+     * @return true if configuration is present.
+     */
+    public boolean isConfigured() {
+        return producerConfig != null;
+    }
+
+    /**
+     * Gets the Kafka producer configuration to which additional properties were applied. The following properties are
+     * set here to the given configuration:
+     * <ul>
+     * <li>{@code enable.idempotence=true}: enables idempotent producer behavior</li>
+     * <li>{@code key.serializer=org.apache.kafka.common.serialization.StringSerializer}: defines how message keys are
+     * serialized</li>
+     * <li>{@code value.serializer=io.vertx.kafka.client.serialization.BufferSerializer}: defines how message values are
+     * serialized</li>
+     *
+     * <li>{@code client.id} if the property is not already present in the configuration and a value has been set with
+     * {@link #setClientId(String)}, this value will be taken</li>
+     * </ul>
+     *
+     * @return a copy of the producer configuration with the applied properties or an empty map if no producer
+     *         configuration was set with {@link #setProducerConfig(Map)}.
+     * @see <a href="https://kafka.apache.org/documentation/#enable.idempotence">The Kafka documentation -
+     *      "Producer Configs" - enable.idempotence</a>
+     */
+    public Map<String, String> getProducerConfig() {
+
+        if (producerConfig == null) {
+            return Collections.emptyMap();
+        }
+
+        final HashMap<String, String> newConfig = new HashMap<>(producerConfig);
+
+        overrideProducerConfigProperty(newConfig, ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringSerializer");
+
+        overrideProducerConfigProperty(newConfig, ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "io.vertx.kafka.client.serialization.BufferSerializer");
+
+        overrideProducerConfigProperty(newConfig, ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+
+        if (clientId != null) {
+            newConfig.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, clientId);
+        }
+
+        return newConfig;
+    }
+
+    private void overrideProducerConfigProperty(final Map<String, String> config, final String key,
+            final String value) {
+
+        log.trace("Setting Kafka producer config property [{}={}]", key, value);
+        final Object oldValue = config.put(key, value);
+        if (oldValue != null) {
+            log.debug("Provided Kafka producer configuration contains property [{}={}], changing it to [{}]", key,
+                    oldValue, value);
+        }
+
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaProducerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaProducerFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.Map;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.producer.KafkaProducer;
+
+/**
+ * A factory for creating Kafka producers.
+ * <p>
+ * Vert.x expects producers to be closed when they are no longer needed to close all open connections and release its
+ * resources. Producers are expected to be closed before the application shuts down (even if this is done automatically
+ * for producers that are created from inside of verticles).
+ *
+ * @param <K> The type for the record key serialization.
+ * @param <V> The type for the record value serialization.
+ */
+public interface KafkaProducerFactory<K, V> {
+
+    /**
+     * Creates a new factory that produces {@link KafkaProducer#createShared(Vertx, String, Map) shared producers}.
+     * Shared producers can safely be shared between verticle instances.
+     * <p>
+     * Config must always be the same for the same key in {@link #getOrCreateProducer(String, Map)}.
+     * <p>
+     * The resources of a shared producer are released when the last producer with a given name is closed.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param <K> The type for the record key serialization.
+     * @param <V> The type for the record value serialization.
+     * @return An instance of the factory.
+     */
+    static <K, V> KafkaProducerFactory<K, V> sharedProducerFactory(final Vertx vertx) {
+        return new CachingKafkaProducerFactory<>((name, config) -> KafkaProducer.createShared(vertx, name, config));
+    }
+
+    /**
+     * Gets a producer for sending data to Kafka.
+     * <p>
+     * The producer returned may be either newly created or it may be an existing producer for the given producer name.
+     * The config parameter might be ignored if an existing producer is returned.
+     * <p>
+     * Do not hold references to the returned producer between send operations, because the producer might be closed by
+     * the factory. Instead, always get an instance by invoking this method.
+     * <p>
+     * When the producer is no longer needed, it should be closed to release the resources (like connections). NB: Do
+     * not close the returned producer directly. Instead, call {@link #closeProducer(String)} to let the factory close
+     * the producer and update its internal state.
+     *
+     * @param producerName The name to identify the producer.
+     * @param config The Kafka configuration with which the producer is to be created.
+     * @return an existing or new producer.
+     */
+    KafkaProducer<K, V> getOrCreateProducer(String producerName, Map<String, String> config);
+
+    /**
+     * Closes the producer with the given producer name if it exists.
+     * <p>
+     * This method is expected to be invoked as soon as the producer is no longer needed, especially before the
+     * application shuts down.
+     *
+     * @param producerName The name of the producer to remove.
+     * @return A future that is completed when the close operation completed or a succeeded future if no producer
+     *         existed with the given name.
+     */
+    Future<Void> closeProducer(String producerName);
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaHeaderInjectAdapter.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaHeaderInjectAdapter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client.tracing;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import io.opentracing.propagation.TextMap;
+import io.vertx.kafka.client.producer.KafkaHeader;
+
+/**
+ * An adapter for injecting properties as a new {@link KafkaHeader} to a list of Vert.x Kafka producer headers.
+ *
+ */
+public final class KafkaHeaderInjectAdapter implements TextMap {
+
+    private final List<KafkaHeader> headers;
+
+    /**
+     * Creates an adapter for a list of {@link KafkaHeader} objects.
+     *
+     * @param headers The list of {@link KafkaHeader} objects.
+     * @throws NullPointerException if header is {@code null}.
+     */
+    public KafkaHeaderInjectAdapter(final List<KafkaHeader> headers) {
+        this.headers = Objects.requireNonNull(headers);
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void put(final String key, final String value) {
+        headers.add(KafkaHeader.header(key, value));
+    }
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaTracingHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaTracingHelper.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client.tracing;
+
+import java.util.Objects;
+
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.tracing.TracingHelper;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopSpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.IntTag;
+import io.opentracing.tag.Tags;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.RecordMetadata;
+
+/**
+ * A helper class providing Kafka-specific utility methods for interacting with the OpenTracing API.
+ *
+ */
+// TODO align with Kafka tracing support in Vert.x 4.0
+public final class KafkaTracingHelper {
+
+    /**
+     * An OpenTracing tag that contains the offset of a Kafka record.
+     */
+    public static final LongTag TAG_OFFSET = new LongTag("offset");
+
+    /**
+     * An OpenTracing tag that contains the partition of a Kafka record.
+     */
+    public static final IntTag TAG_PARTITION = new IntTag("partition");
+
+    /**
+     * An OpenTracing tag that contains the timestamp of a Kafka record.
+     */
+    public static final LongTag TAG_TIMESTAMP = new LongTag("timestamp");
+
+    private KafkaTracingHelper() {
+        // prevent instantiation
+    }
+
+    /**
+     * Creates a new <em>OpenTracing</em> span to trace producing messages to Kafka.
+     * <p>
+     * The returned span will already contain the following tags:
+     * <ul>
+     * <li>{@link Tags#COMPONENT} - set to <em>hono-client-kafka</em></li>
+     * <li>{@link Tags#MESSAGE_BUS_DESTINATION} - set to {@code To_<topic>}</li>
+     * <li>{@link Tags#SPAN_KIND} - set to {@link Tags#SPAN_KIND_PRODUCER}</li>
+     * <li>{@link Tags#PEER_SERVICE} - set to <em>kafka</em></li>
+     * </ul>
+     *
+     * @param tracer The Tracer to use.
+     * @param topic The topic from which the operation name is derived.
+     * @param referenceType The type of reference towards the span context.
+     * @param parent The span context to set as parent and to derive the sampling priority from (may be null).
+     * @return The new span.
+     * @throws NullPointerException if tracer or topic is {@code null}.
+     */
+    public static Span newProducerSpan(final Tracer tracer, final HonoTopic topic, final String referenceType,
+            final SpanContext parent) {
+        Objects.requireNonNull(tracer);
+        Objects.requireNonNull(topic);
+        Objects.requireNonNull(referenceType);
+
+        return TracingHelper.buildSpan(tracer, parent, "To_" + topic.toString(), referenceType)
+                .ignoreActiveSpan()
+                .withTag(Tags.COMPONENT.getKey(), "hono-client-kafka")
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
+                .withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), topic.toString())
+                .withTag(Tags.PEER_SERVICE.getKey(), "kafka")
+                .start();
+    }
+
+    /**
+     * Sets tags from record metadata.
+     * <p>
+     * It sets the following tags:
+     * <ul>
+     * <li>{@link #TAG_OFFSET}</li>
+     * <li>{@link #TAG_PARTITION}</li>
+     * <li>{@link #TAG_TIMESTAMP}</li>
+     * </ul>
+     * <p>
+     * <em>It does not set the topic, as this is expected to be already already set.</em>
+     *
+     * @param span The span to set the tags on.
+     * @param recordMetadata The record metadata.
+     */
+    public static void setRecordMetadataTags(final Span span, final RecordMetadata recordMetadata) {
+
+        TAG_OFFSET.set(span, recordMetadata.getOffset());
+        TAG_PARTITION.set(span, recordMetadata.getPartition());
+        TAG_TIMESTAMP.set(span, recordMetadata.getTimestamp());
+    }
+
+    /**
+     * Injects a {@code SpanContext} into a Kafka record.
+     * <p>
+     * The span context will be added as a Kafka producer header.
+     *
+     * @param tracer The Tracer to use for injecting the context.
+     * @param record The Kafka record to inject the context into.
+     * @param spanContext The context to inject or {@code null} if no context is available.
+     * @throws NullPointerException if tracer or record is {@code null}.
+     */
+    public static void injectSpanContext(final Tracer tracer, final KafkaProducerRecord<String, Buffer> record,
+            final SpanContext spanContext) {
+
+        Objects.requireNonNull(tracer);
+        Objects.requireNonNull(record);
+
+        if (spanContext != null && !(spanContext instanceof NoopSpanContext)) {
+            tracer.inject(spanContext, Format.Builtin.TEXT_MAP, new KafkaHeaderInjectAdapter(record.headers()));
+        }
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/LongTag.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/LongTag.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client.tracing;
+
+import io.opentracing.Span;
+import io.opentracing.tag.AbstractTag;
+
+/**
+ * An OpenTracing tag type for {@code long} values.
+ */
+public class LongTag extends AbstractTag<Long> {
+
+    /**
+     * Creates an instance for the given key.
+     *
+     * @param tagKey The tag key.
+     */
+    public LongTag(final String tagKey) {
+        super(tagKey);
+    }
+
+    @Override
+    public void set(final Span span, final Long tagValue) {
+
+    }
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/CachingKafkaProducerFactoryTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/CachingKafkaProducerFactoryTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.serialization.BufferSerializer;
+
+/**
+ * Verifies behavior of {@link CachingKafkaProducerFactory}.
+ */
+public class CachingKafkaProducerFactoryTest {
+
+    private static final String PRODUCER_NAME = "test-producer";
+
+    private final Map<String, String> config = new HashMap<>();
+
+    private CachingKafkaProducerFactory<String, Buffer> factory;
+
+    @BeforeEach
+    void setUp() {
+
+        final Vertx vertxMock = mock(Vertx.class);
+        final Context context = VertxMockSupport.mockContext(vertxMock);
+        when(vertxMock.getOrCreateContext()).thenReturn(context);
+
+        doAnswer(invocation -> {
+            final Promise<RecordMetadata> result = Promise.promise();
+            final Handler<Future<RecordMetadata>> blockingCode = invocation.getArgument(0);
+            blockingCode.handle(result.future());
+            return null;
+        }).when(context).executeBlocking(VertxMockSupport.anyHandler(), any());
+
+        final BiFunction<String, Map<String, String>, KafkaProducer<String, Buffer>> instanceSupplier = (n, c) -> {
+            final MockProducer<String, Buffer> mockProducer = new MockProducer<>(true, new StringSerializer(),
+                    new BufferSerializer());
+            return KafkaProducer.create(vertxMock, mockProducer);
+        };
+
+        factory = new CachingKafkaProducerFactory<>(instanceSupplier);
+
+        config.put("bootstrap.servers", "localhost:9092");
+        config.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        config.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    }
+
+    /**
+     * Verifies that getOrCreateProducer() creates a producers and adds it to the cache.
+     */
+    @Test
+    public void testThatProducerIsAddedToCache() {
+
+        assertThat(factory.getProducer(PRODUCER_NAME)).isEmpty();
+
+        final KafkaProducer<String, Buffer> createProducer = factory.getOrCreateProducer(PRODUCER_NAME, config);
+
+        final Optional<KafkaProducer<String, Buffer>> actual = factory.getProducer(PRODUCER_NAME);
+        assertThat(actual).isNotEmpty();
+        assertThat(actual.get()).isEqualTo(createProducer);
+
+    }
+
+    /**
+     * Verifies that {@link CachingKafkaProducerFactory#closeProducer(String)} closes the producer and removes it from
+     * the cache.
+     */
+    @Test
+    public void testRemoveProducerClosesAndRemovesFromCache() {
+        final String producerName1 = "first-producer";
+        final String producerName2 = "second-producer";
+
+        // GIVEN a factory that contains two producers
+        final KafkaProducer<String, Buffer> producer1 = factory.getOrCreateProducer(producerName1, config);
+        final KafkaProducer<String, Buffer> producer2 = factory.getOrCreateProducer(producerName2, config);
+
+        // WHEN removing one producer
+        factory.closeProducer(producerName1);
+
+        // THEN the producer is closed...
+        assertThat(((MockProducer<String, Buffer>) producer1.unwrap()).closed()).isTrue();
+        // ...AND removed from the cache
+        assertThat(factory.getProducer(producerName1)).isEmpty();
+        // ...AND the second producers is still present and open
+        assertThat(factory.getProducer(producerName2)).isNotEmpty();
+        assertThat(((MockProducer<String, Buffer>) producer2.unwrap()).closed()).isFalse();
+
+    }
+
+    /**
+     * Verifies that {@link CachingKafkaProducerFactory#isFatalError(Throwable)} returns true for the expected exception
+     * types.
+     */
+    @Test
+    public void testIsFatalError() {
+
+        assertThat(CachingKafkaProducerFactory.isFatalError(new ProducerFencedException("test"))).isTrue();
+        assertThat(CachingKafkaProducerFactory.isFatalError(new OutOfOrderSequenceException("test"))).isTrue();
+        assertThat(CachingKafkaProducerFactory.isFatalError(new AuthorizationException("test"))).isTrue();
+        assertThat(CachingKafkaProducerFactory.isFatalError(new UnsupportedVersionException("test"))).isTrue();
+        assertThat(CachingKafkaProducerFactory.isFatalError(new UnsupportedForMessageFormatException("test"))).isTrue();
+
+        assertThat(CachingKafkaProducerFactory.isFatalError(new KafkaException("test"))).isFalse();
+    }
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/HonoTopicTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/HonoTopicTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link HonoTopic}.
+ */
+public class HonoTopicTest {
+
+    /**
+     * Verifies that the toString method returns the expected string.
+     */
+    @Test
+    public void testToString() {
+        final String tenantId = "the-tenant";
+
+        final HonoTopic telemetry = new HonoTopic(HonoTopic.Type.TELEMETRY, tenantId);
+        assertThat(telemetry.toString()).isEqualTo("hono.telemetry." + tenantId);
+
+        final HonoTopic event = new HonoTopic(HonoTopic.Type.EVENT, tenantId);
+        assertThat(event.toString()).isEqualTo("hono.event." + tenantId);
+
+        final HonoTopic command = new HonoTopic(HonoTopic.Type.COMMAND, tenantId);
+        assertThat(command.toString()).isEqualTo("hono.command." + tenantId);
+
+        final HonoTopic commandResponse = new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId);
+        assertThat(commandResponse.toString()).isEqualTo("hono.command_response." + tenantId);
+
+    }
+
+    /**
+     * Verifies that the fromString method creates the the expected topic object.
+     */
+    @Test
+    public void testFromString() {
+        final String tenantId = "the-tenant";
+
+        final HonoTopic telemetry = HonoTopic.fromString("hono.telemetry." + tenantId);
+        assertThat(telemetry).isNotNull();
+        assertThat(telemetry.toString()).isEqualTo(HonoTopic.Type.TELEMETRY.prefix + tenantId);
+
+        final HonoTopic event = HonoTopic.fromString("hono.event." + tenantId);
+        assertThat(event).isNotNull();
+        assertThat(event.toString()).isEqualTo(HonoTopic.Type.EVENT.prefix + tenantId);
+
+        final HonoTopic command = HonoTopic.fromString("hono.command." + tenantId);
+        assertThat(command).isNotNull();
+        assertThat(command.toString()).isEqualTo(HonoTopic.Type.COMMAND.prefix + tenantId);
+
+        final HonoTopic commandResponse = HonoTopic.fromString("hono.command_response." + tenantId);
+        assertThat(commandResponse).isNotNull();
+        assertThat(commandResponse.toString()).isEqualTo(HonoTopic.Type.COMMAND_RESPONSE.prefix + tenantId);
+
+    }
+
+    /**
+     * Verifies that the fromString method returns {@code null} for unknown topic strings.
+     */
+    @Test
+    public void testThatFromStringReturnsNullForUnknownTopicString() {
+
+        assertThat(HonoTopic.fromString("bumlux.telemetry.tenant")).isNull();
+        assertThat(HonoTopic.fromString("hono.bumlux.tenant")).isNull();
+        assertThat(HonoTopic.fromString("hono.telemetry-tenant")).isNull();
+    }
+
+    /**
+     * Verifies that the equals method works as expected.
+     */
+    @Test
+    public void testEquals() {
+
+        assertThat(new HonoTopic(HonoTopic.Type.EVENT, "foo"))
+                .isEqualTo(new HonoTopic(HonoTopic.Type.EVENT, "foo"));
+
+        assertThat(new HonoTopic(HonoTopic.Type.EVENT, "foo"))
+                .isNotEqualTo(new HonoTopic(HonoTopic.Type.EVENT, "bar"));
+
+        assertThat(new HonoTopic(HonoTopic.Type.EVENT, "foo"))
+                .isNotEqualTo(new HonoTopic(HonoTopic.Type.COMMAND, "foo"));
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/KafkaConsumerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/KafkaConsumerConfigPropertiesTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link KafkaConsumerConfigProperties}.
+ */
+public class KafkaConsumerConfigPropertiesTest {
+
+    /**
+     * Verifies that trying to set a {@code null} config throws a Nullpointer exception.
+     */
+    @Test
+    public void testThatConfigCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaConsumerConfigProperties().setConsumerConfig(null));
+    }
+
+    /**
+     * Verifies that trying to set a {@code null} client ID throws a Nullpointer exception.
+     */
+    @Test
+    public void testThatClientIdCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaConsumerConfigProperties().setClientId(null));
+    }
+
+    /**
+     * Verifies that properties provided with {@link KafkaConsumerConfigProperties#setConsumerConfig(Map)} are returned
+     * in {@link KafkaConsumerConfigProperties#getConsumerConfig()}.
+     */
+    @Test
+    public void testThatGetConsumerConfigReturnsGivenProperties() {
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        config.setConsumerConfig(Collections.singletonMap("foo", "bar"));
+
+        assertThat(config.getConsumerConfig().get("foo")).isEqualTo("bar");
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setClientId(String)} is applied when it
+     * is not present in the configuration.
+     */
+    @Test
+    public void testThatGetConsumerConfigReturnsAdaptedConfig() {
+
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key.deserializer", "foo");
+        properties.put("value.deserializer", "bar");
+        properties.put("enable.idempotence", "baz");
+
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        config.setConsumerConfig(properties);
+
+        final Map<String, String> consumerConfig = config.getConsumerConfig();
+
+        assertThat(consumerConfig.get("key.deserializer"))
+                .isEqualTo("org.apache.kafka.common.serialization.StringDeserializer");
+        assertThat(consumerConfig.get("value.deserializer"))
+                .isEqualTo("io.vertx.kafka.client.serialization.BufferDeserializer");
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setClientId(String)} is applied when it
+     * is NOT present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsApplied() {
+        final String clientId = "the-client";
+
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        config.setConsumerConfig(Collections.emptyMap());
+        config.setClientId(clientId);
+
+        assertThat(config.getConsumerConfig().get("client.id")).isEqualTo(clientId);
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setClientId(String)} is NOT applied
+     * when it is present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
+        final String userProvidedClientId = "custom-client";
+
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        config.setConsumerConfig(Collections.singletonMap("client.id", userProvidedClientId));
+        config.setClientId("other-client");
+
+        assertThat(config.getConsumerConfig().get("client.id")).isEqualTo(userProvidedClientId);
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/KafkaProducerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/KafkaProducerConfigPropertiesTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link KafkaProducerConfigProperties}.
+ */
+public class KafkaProducerConfigPropertiesTest {
+
+    /**
+     * Verifies that trying to set a {@code null} config throws a Nullpointer exception.
+     */
+    @Test
+    public void testThatConfigCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaProducerConfigProperties().setProducerConfig(null));
+    }
+
+    /**
+     * Verifies that trying to set a {@code null} client ID throws a Nullpointer exception.
+     */
+    @Test
+    public void testThatClientIdCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaProducerConfigProperties().setClientId(null));
+    }
+
+    /**
+     * Verifies that properties provided with {@link KafkaProducerConfigProperties#setProducerConfig(Map)} are returned
+     * in {@link KafkaProducerConfigProperties#getProducerConfig()}.
+     */
+    @Test
+    public void testThatGetProducerConfigReturnsGivenProperties() {
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setProducerConfig(Collections.singletonMap("foo", "bar"));
+
+        assertThat(config.getProducerConfig().get("foo")).isEqualTo("bar");
+    }
+
+    /**
+     * Verifies that {@link KafkaProducerConfigProperties#isConfigured()} returns false if no configuration has been
+     * set, and true otherwise.
+     */
+    @Test
+    public void testIsConfiguredMethod() {
+
+        assertThat(new KafkaProducerConfigProperties().isConfigured()).isFalse();
+
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setProducerConfig(Collections.singletonMap("foo", "bar"));
+        assertThat(config.isConfigured()).isTrue();
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setClientId(String)} is applied when it
+     * is not present in the configuration.
+     */
+    @Test
+    public void testThatGetProducerConfigReturnsAdaptedConfig() {
+
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key.serializer", "foo");
+        properties.put("value.serializer", "bar");
+        properties.put("enable.idempotence", "baz");
+
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setProducerConfig(properties);
+
+        final Map<String, String> producerConfig = config.getProducerConfig();
+
+        assertThat(producerConfig.get("key.serializer"))
+                .isEqualTo("org.apache.kafka.common.serialization.StringSerializer");
+        assertThat(producerConfig.get("value.serializer"))
+                .isEqualTo("io.vertx.kafka.client.serialization.BufferSerializer");
+        assertThat(producerConfig.get("enable.idempotence")).isEqualTo("true");
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setClientId(String)} is applied when it
+     * is NOT present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsApplied() {
+        final String clientId = "the-client";
+
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setProducerConfig(Collections.emptyMap());
+        config.setClientId(clientId);
+
+        assertThat(config.getProducerConfig().get("client.id")).isEqualTo(clientId);
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setClientId(String)} is NOT applied
+     * when it is present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
+        final String userProvidedClientId = "custom-client";
+
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setProducerConfig(Collections.singletonMap("client.id", userProvidedClientId));
+        config.setClientId("other-client");
+
+        assertThat(config.getProducerConfig().get("client.id")).isEqualTo(userProvidedClientId);
+    }
+
+}

--- a/clients/kafka-common/src/test/resources/logback-test.xml
+++ b/clients/kafka-common/src/test/resources/logback-test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+
+  <!-- 
+    This is the logging configuration that is used by the
+    locally executing integration test cases.
+
+    Any changes made here will be reflected on the next test
+    execution.
+   -->
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.apache.kafka" level="ERROR"/>
+
+</configuration>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -30,6 +30,8 @@
   <modules>
     <module>adapter</module>
     <module>adapter-amqp</module>
+    <module>adapter-kafka</module>
+    <module>kafka-common</module>
   </modules>
 
   <dependencies>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>hono-client-adapter-amqp</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-adapter-kafka</artifactId>
+    </dependency>
+    <dependency>
      <groupId>org.eclipse.hono</groupId>
      <artifactId>hono-client</artifactId>
     </dependency>

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -36,6 +36,8 @@ import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient;
 import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
 import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
+import org.eclipse.hono.adapter.client.telemetry.kafka.KafkaBasedEventSender;
+import org.eclipse.hono.adapter.client.telemetry.kafka.KafkaBasedTelemetrySender;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
@@ -45,6 +47,8 @@ import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.config.ServerConfig;
 import org.eclipse.hono.config.VertxProperties;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.client.KafkaProducerFactory;
 import org.eclipse.hono.service.cache.SpringCacheProvider;
 import org.eclipse.hono.service.monitoring.ConnectionEventProducer;
 import org.eclipse.hono.service.monitoring.ConnectionEventProducerConfig;
@@ -83,6 +87,7 @@ import io.opentracing.contrib.tracerresolver.TracerResolver;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
@@ -136,14 +141,26 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
             adapter.setCommandConsumerFactory(commandConsumerFactory(adapterProperties, samplerFactory, commandRouterClient));
         }
 
+        final KafkaProducerConfigProperties kafkaProducerConfig = kafkaProducerConfig();
+        if (kafkaProducerConfig.isConfigured()) {
+            final KafkaProducerFactory<String, Buffer> kafkaProducerFactory = kafkaProducerFactory();
+            adapter.setEventSender(
+                    downstreamEventKafkaSender(kafkaProducerFactory, kafkaProducerConfig, adapterProperties));
+            adapter.setTelemetrySender(
+                    downstreamTelemetryKafkaSender(kafkaProducerFactory, kafkaProducerConfig, adapterProperties));
+        } else {
+            // look up via bean factory is not possible because EventSender and TelemetrySender are implemented by
+            // ProtonBasedDownstreamSender
+            adapter.setEventSender(downstreamEventSender(samplerFactory, adapterProperties));
+            adapter.setTelemetrySender(downstreamTelemetrySender(samplerFactory, adapterProperties));
+        }
+
         adapter.setCommandResponseSender(commandResponseSender(samplerFactory, adapterProperties));
         Optional.ofNullable(connectionEventProducer())
             .ifPresent(adapter::setConnectionEventProducer);
         adapter.setCredentialsClient(credentialsClient(samplerFactory, adapterProperties));
-        adapter.setEventSender(downstreamEventSender(samplerFactory, adapterProperties));
         adapter.setHealthCheckServer(healthCheckServer());
         adapter.setRegistrationClient(registrationClient);
-        adapter.setTelemetrySender(downstreamTelemetrySender(samplerFactory, adapterProperties));
         adapter.setTenantClient(tenantClient(samplerFactory, adapterProperties));
         adapter.setTracer(getTracer());
         resourceLimitChecks.ifPresent(adapter::setResourceLimitChecks);
@@ -228,6 +245,21 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     }
 
     /**
+     * Exposes configuration properties for accessing the Kafka cluster as a Spring bean.
+     *
+     * @return The properties.
+     */
+    @ConfigurationProperties(prefix = "hono.kafka")
+    @Bean
+    public KafkaProducerConfigProperties kafkaProducerConfig() {
+        final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+        if (getAdapterName() != null) {
+            configProperties.setClientId(getAdapterName());
+        }
+        return configProperties;
+    }
+
+    /**
      * Gets the default client properties, on top of which the configured properties will be loaded, to be then provided
      * via {@link #downstreamSenderConfig()}.
      * <p>
@@ -296,6 +328,51 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     }
 
     /**
+     * Exposes a factory for creating producers for sending downstream messages via the Kafka cluster.
+     *
+     * @return The factory.
+     */
+    @Bean
+    @Scope("prototype")
+    public KafkaProducerFactory<String, Buffer> kafkaProducerFactory() {
+        return KafkaProducerFactory.sharedProducerFactory(vertx());
+    }
+
+    /**
+     * Exposes a client for sending telemetry messages via <em>Kafka</em> as a Spring bean.
+     *
+     * @return The client.
+     * @param kafkaProducerFactory The producer factory to use.
+     * @param kafkaProducerConfig The producer configuration to use.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     */
+    @Bean
+    @Scope("prototype")
+    public TelemetrySender downstreamTelemetryKafkaSender(
+            final KafkaProducerFactory<String, Buffer> kafkaProducerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig,
+            final ProtocolAdapterProperties adapterConfig) {
+        return new KafkaBasedTelemetrySender(kafkaProducerFactory, kafkaProducerConfig, adapterConfig, getTracer());
+    }
+
+    /**
+     * Exposes a client for sending events via <em>Kafka</em> as a Spring bean.
+     *
+     * @return The client.
+     * @param kafkaProducerFactory The producer factory to use.
+     * @param kafkaProducerConfig The producer configuration to use.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     */
+    @Bean
+    @Scope("prototype")
+    public EventSender downstreamEventKafkaSender(
+            final KafkaProducerFactory<String, Buffer> kafkaProducerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig,
+            final ProtocolAdapterProperties adapterConfig) {
+        return new KafkaBasedEventSender(kafkaProducerFactory, kafkaProducerConfig, adapterConfig, getTracer());
+    }
+
+    /**
      * Exposes configuration properties for accessing the registration service as a Spring bean.
      *
      * @return The properties.
@@ -335,7 +412,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
     public DeviceRegistrationClient registrationClient(
-            final SendMessageSampler.Factory samplerFactory, 
+            final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
 
         return new ProtonBasedDeviceRegistrationClient(
@@ -483,7 +560,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     @Qualifier(TenantConstants.TENANT_ENDPOINT)
     @Scope("prototype")
     public TenantClient tenantClient(
-            final SendMessageSampler.Factory samplerFactory, 
+            final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
 
         return new ProtonBasedTenantClient(

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -194,6 +194,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     public final void setTelemetrySender(final TelemetrySender sender) {
         this.telemetrySender = Objects.requireNonNull(sender);
+        log.info("using TelemetrySender implementation [{}]", sender.getClass().getName());
     }
 
     /**
@@ -213,6 +214,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     public final void setEventSender(final EventSender sender) {
         this.eventSender = Objects.requireNonNull(sender);
+        log.info("using EventSender implementation [{}]", sender.getClass().getName());
     }
 
     /**

--- a/site/documentation/content/admin-guide/common-config.md
+++ b/site/documentation/content/admin-guide/common-config.md
@@ -48,6 +48,13 @@ Protocol adapters require a connection to the *AMQP 1.0 Messaging Network* in or
 The connection to the messaging network is configured according to [Hono Client Configuration]({{< relref "hono-client-configuration.md" >}})
 with `HONO_MESSAGING` being used as `${PREFIX}`. Since there are no responses being received, the properties for configuring response caching can be ignored.
 
+### Kafka based Messaging Configuration
+
+Alternatively, protocol adapters can be configured to publish messages to an *Apache Kafka&reg; cluster* instead of 
+an AMQP Messaging Network. 
+
+The Kafka client is configured according to [Hono Kafka Client Configuration]({{< relref "hono-kafka-client-configuration.md" >}}).
+
 ### Command & Control Connection Configuration
 
 Protocol adapters require an additional connection to the *AMQP 1.0 Messaging Network* in order to receive

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -1,0 +1,51 @@
++++
+title = "Hono Kafka Client Configuration"
+weight = 342
++++
+
+Protocol adapters can be configured to use Kafka for the messaging. The Kafka client used there can be configured with 
+environment variables and/or command line options.
+
+{{% note title="Tech preview" %}}
+The support of Kafka as a messaging system is currently a preview and not yet ready for production. 
+The implementation as well as it's APIs may change with the next version. 
+{{% /note %}}
+
+## Producer Configuration Properties
+
+The `org.eclipse.hono.kafka.client.CachingKafkaProducerFactory` factory can be used to create Kafka producers for Hono's Kafka based APIs. 
+The producers created by the factory are configured with instances of the class `org.eclipse.hono.kafka.client.KafkaProducerConfigProperties`
+which can be used to programmatically configure a producer. 
+
+The configuration needs to be provided in the form `HONO_KAFKA_PRODUCERCONFIG_${PROPERTY}` as an environment variable or
+as a command line option in the form `hono.kafka.producerConfig.${property}`, where `${PROPERTY}` respectively 
+`${property}` is any of the Kafka client's [producer properties](https://kafka.apache.org/documentation/#producerconfigs). 
+The provided configuration is passed directly to the Kafka producer without Hono parsing or validating it.
+
+The following properties can _not_ be set using this mechanism because the protocol adapters use fixed values instead 
+in order to implement the message delivery semantics defined by Hono's Telemetry and Event APIs.
+
+| Kafka Producer Config Property | Fixed Value |
+| :----------------------------- | :---------- |
+| `key.serializer` | `org.apache.kafka.common.serialization.StringSerializer` |
+| `value.serializer` | `io.vertx.kafka.client.serialization.BufferSerializer` |
+| `enable.idempotence` | `true` |
+
+{{% note title="Enable Kafka based Messaging" %}}
+The Kafka client requires the property `bootstrap.servers` to be provided. This variable is the minimal configuration 
+required to enable Kafka based messaging.
+{{% /note %}}
+
+### Using TLS
+
+The factory can be configured to use TLS for
+
+* authenticating the brokers in the Kafka cluster during connection establishment and
+* (optionally) authenticating to the broker using a client certificate
+
+To use this, a Kafka Producer configuration as described in 
+[Kafka documentation - section "Security"](https://kafka.apache.org/documentation/#security_configclients) needs to be provided. 
+The properties must be prefixed with `HONO_KAFKA_PRODUCERCONFIG_` respectively `hono.kafka.producerConfig.` as shown in 
+[Producer Configuration Properties]({{< relref "#producer-configuration-properties" >}}).
+The complete reference of available properties and the possible values is available in 
+[Kafka documentation - section "Producer Configs"](https://kafka.apache.org/documentation/#producerconfigs).

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -2,6 +2,16 @@
 title = "Release Notes"
 +++
 
+
+## 1.6.0 (not yet released)
+
+### New Features
+
+* Kafka is now supported as a messaging system for events and telemetry messages.
+  This can be enabled by configuring protocol adapters to use Hono's new Kafka-based
+  client. Please refer to [Hono Kafka Client Configuration]({{% doclink "/admin-guide/hono-kafka-client-configuration/" %}})
+  for details.
+
 ## 1.5.0
 
 ### New Features


### PR DESCRIPTION
Replaces #2216. 

* I have not tested it yet with the Quarkus based adapters.
* Only tested manually, integration tests are still missing.
* I have added new Spring `Condition`s to enable a clean control of the selection between AMQP and Kafka. @sophokles73, now I have seen that you have taken steps in `AbstractAdapterConfig` to move away from Spring Boot. What is your strategy there? Do you want to remove the bean creation by Spring Boot entirely?