### PR TITLE
Fix search devices operation and integration tests

### DIFF
--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
@@ -421,13 +421,11 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
         final JsonArray searchDevicesAggregationPipeline = new JsonArray();
 
         // match documents based on the provided filters
-        if (!filters.isEmpty()) {
             final JsonObject matchDocument = MongoDbDocumentBuilder.builder()
                     .withTenantId(tenantId)
                     .withDeviceFilters(filters)
                     .document();
             searchDevicesAggregationPipeline.add(new JsonObject().put("$match", matchDocument));
-        }
 
         // sort documents based on the provided sort options
         if (!sortOptions.isEmpty()) {

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
@@ -207,12 +207,9 @@ public final class MongoDbDocumentBuilder {
         filters.forEach(filter -> {
             if (filter.getValue() instanceof String) {
                 final String value = (String) filter.getValue();
-                if (value.contains("*") || value.contains("?")) {
-                    // if the value contains * and ? then use regex matching
-                    document.put(mapDeviceField(filter.getField()),
-                            new JsonObject().put("$regex",
-                                    DeviceRegistryUtils.getRegexExpressionForSearchOperation(value)));
-                }
+                document.put(mapDeviceField(filter.getField()),
+                        new JsonObject().put("$regex",
+                                DeviceRegistryUtils.getRegexExpressionForSearchOperation(value)));
             } else {
                 document.put(mapDeviceField(filter.getField()), filter.getValue());
             }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -258,6 +258,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
         <hono.deviceregistry.resources.folder>deviceregistry-jdbc</hono.deviceregistry.resources.folder>
         <hono.deviceregistry.spring.profiles>registry-adapter,registry-management,tenant-service,${logging.profile}</hono.deviceregistry.spring.profiles>
         <hono.deviceregistry.credentials.supportsClientContext>false</hono.deviceregistry.credentials.supportsClientContext>
+        <hono.deviceregistry.supportsSearchDevices>false</hono.deviceregistry.supportsSearchDevices>
         <hono.h2.disabled>false</hono.h2.disabled>
         <hono.h2.host>hono-h2.hono</hono.h2.host>
         <hono.h2.port>9092</hono.h2.port>


### PR DESCRIPTION
* The integration tests for the search devices operation have not been running as it expects
  the system property `hono.deviceregistry.supportsSearchDevices` set to true. This property
  has been renamed to  `deviceregistry.supportsSearchDevices` in the `pom.xml` of _tests_ 
  module but not in the corresponding test class. This has been fixed now to use the renamed
  property in the test class.

* Integration tests corresponding to the search devices operation have been disabled for the 
 JDBC based device registry as it doesn't implement this operation.

* When the data type of a filter value is string and the value doesn't contain any search wild 
  card characters then that filter has been ignored by the MongoDB device registry. This has 
  been fixed.

* When there are no filters specified in the request, then at least the results should be 
  filtered based on the tenant identifier in the request URL. This has been fixed in the 
  MongoDB device registry.


* Fix integration tests corresponding to the search devices operation.