### PR TITLE
[#2029] Use Command Router in adapters and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@
 # The job uses a matrix for the distinct device registry implementations. Thus,
 # for each registry implementation, the workflow is run on a separate VM.
 
-name: Build Hono's 'container images and run integration tests
+name: Build and run integration tests
 
 on: [push,pull_request]
 
@@ -25,7 +25,12 @@ jobs:
     strategy:
       matrix:
         device-registry: [file,jdbc,mongodb]
+        include:
+          # let the jdbc test-run use the command-router component
+          - device-registry: jdbc
+            commandrouting-mode: commandrouter
 
+    name: Use ${{ matrix.device-registry }}-registry [${{ matrix.commandrouting-mode }}]
     steps:
     - uses: actions/checkout@v2
     - name: Cache local Maven repository
@@ -47,4 +52,4 @@ jobs:
       with:
         java-version: '11'
     - name: Build all components (incl. unit tests) and run integration tests
-      run: mvn install -B -e -DcreateJavadoc=true -DCI=$CI -Dhono.deviceregistry.type=${{ matrix.device-registry }} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pbuild-docker-image,run-tests
+      run: mvn install -B -e -DcreateJavadoc=true -DCI=$CI -Dhono.deviceregistry.type=${{ matrix.device-registry }} -Dhono.commandrouting.mode=${{ matrix.commandrouting-mode }} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pbuild-docker-image,run-tests

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandContext.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandContext.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import java.util.Objects;
+
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.eclipse.hono.adapter.client.command.Command;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.util.Constants;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.vertx.proton.ProtonHelper;
+
+/**
+ * A wrapper around a legacy {@link org.eclipse.hono.client.CommandContext}.
+ */
+public class ProtonBasedCommandContext implements CommandContext {
+
+    private final org.eclipse.hono.client.CommandContext ctx;
+    private final ProtonBasedCommand command;
+
+    /**
+     * Creates a new command context.
+     *
+     * @param context The legacy command context to wrap.
+     * @throws NullPointerException if context is {@code null}.
+     */
+    public ProtonBasedCommandContext(final org.eclipse.hono.client.CommandContext context) {
+        this.ctx = Objects.requireNonNull(context);
+        this.command = new ProtonBasedCommand(context.getCommand());
+    }
+
+    @Override
+    public void logCommandToSpan(final Span span) {
+        command.logToSpan(span);
+    }
+
+    @Override
+    public Command getCommand() {
+        return command;
+    }
+
+    @Override
+    public void accept() {
+        ctx.accept();
+    }
+
+    @Override
+    public void release() {
+        ctx.release();
+    }
+
+    @Override
+    public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
+        ctx.modify(deliveryFailed, undeliverableHere);
+    }
+
+    @Override
+    public void reject(final String cause) {
+        final ErrorCondition error = ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, cause);
+        ctx.reject(error);
+    }
+
+    @Override
+    public <T> T get(final String key) {
+        return ctx.get(key);
+    }
+
+    @Override
+    public <T> T get(final String key, final T defaultValue) {
+        return ctx.get(key, defaultValue);
+    }
+
+    @Override
+    public void put(final String key, final Object value) {
+        ctx.put(key, value);
+    }
+
+    @Override
+    public SpanContext getTracingContext() {
+        return ctx.getTracingContext();
+    }
+
+    @Override
+    public Span getTracingSpan() {
+        return ctx.getTracingSpan();
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterCommandConsumerFactoryImpl.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterCommandConsumerFactoryImpl.java
@@ -1,0 +1,325 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import java.net.HttpURLConnection;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.hono.adapter.client.amqp.AbstractServiceClient;
+import org.eclipse.hono.adapter.client.command.CommandConsumer;
+import org.eclipse.hono.adapter.client.command.CommandConsumerFactory;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.adapter.client.command.CommandRouterClient;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.impl.AdapterInstanceCommandHandler;
+import org.eclipse.hono.client.impl.CommandHandlerWrapper;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.Constants;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+
+/**
+ * A vertx-proton based factory for creating consumers of command messages received via the
+ * AMQP 1.0 Messaging Network.
+ * <p>
+ * This implementation uses the Command Router service and receives commands forwarded by the Command Router
+ * component on a link with an address containing the protocol adapter instance id.
+ *
+ */
+public class ProtonBasedCommandRouterCommandConsumerFactoryImpl extends AbstractServiceClient implements CommandConsumerFactory {
+
+    private static final int RECREATE_CONSUMER_DELAY = 20;
+
+    /**
+     * Identifier that has to be unique to this factory instance.
+     * Will be used to represent the protocol adapter instance that this factory instance is used in,
+     * when registering command handlers with the command router service client.
+     */
+    private final String adapterInstanceId;
+    private final AdapterInstanceCommandHandler adapterInstanceCommandHandler;
+    private final AtomicBoolean recreatingConsumer = new AtomicBoolean(false);
+    private final AtomicBoolean tryAgainRecreatingConsumer = new AtomicBoolean(false);
+
+    private final CommandRouterClient commandRouterClient;
+    private ProtonReceiver adapterSpecificConsumer;
+
+    /**
+     * Creates a new factory for an existing connection.
+     *
+     * @param connection The connection to the AMQP network.
+     * @param samplerFactory The sampler factory to use.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param commandRouterClient The client to use for accessing the command router service.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public ProtonBasedCommandRouterCommandConsumerFactoryImpl(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig,
+            final CommandRouterClient commandRouterClient) {
+        super(connection, samplerFactory, adapterConfig);
+        this.commandRouterClient = Objects.requireNonNull(commandRouterClient);
+
+        // the container id contains a UUID therefore it can be used as a unique adapter instance id
+        adapterInstanceId = connection.getContainerId();
+        adapterInstanceCommandHandler = new AdapterInstanceCommandHandler(connection.getTracer(), adapterInstanceId);
+    }
+
+    @Override
+    public Future<Void> start() {
+        return super.start()
+                .onComplete(v -> {
+                    connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
+                            this::handleTenantTimeout);
+                    connection.addReconnectListener(c -> recreateConsumer());
+                    // trigger creation of adapter specific consumer link (with retry if failed)
+                    recreateConsumer();
+                });
+    }
+
+    @Override
+    protected void onDisconnect() {
+        adapterSpecificConsumer = null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final Future<CommandConsumer> createCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final Handler<CommandContext> commandHandler,
+            final Duration lifespan,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(commandHandler);
+
+        return doCreateCommandConsumer(tenantId, deviceId, null, commandHandler, lifespan, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final Future<CommandConsumer> createCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final String gatewayId,
+            final Handler<CommandContext> commandHandler,
+            final Duration lifespan,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(gatewayId);
+        Objects.requireNonNull(commandHandler);
+
+        return doCreateCommandConsumer(tenantId, deviceId, gatewayId, commandHandler, lifespan, context);
+    }
+
+    private Future<CommandConsumer> doCreateCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final String gatewayId,
+            final Handler<CommandContext> commandHandler,
+            final Duration lifespan,
+            final SpanContext context) {
+        // lifespan greater than what can be expressed in nanoseconds (i.e. 292 years) is considered unlimited, preventing ArithmeticExceptions down the road
+        final Duration sanitizedLifespan = lifespan == null || lifespan.isNegative()
+                || lifespan.getSeconds() > (Long.MAX_VALUE / 1000_000_000L) ? Duration.ofSeconds(-1) : lifespan;
+        log.trace("create command consumer [tenant-id: {}, device-id: {}, gateway-id: {}]", tenantId, deviceId, gatewayId);
+        return connection.executeOnContext(result -> {
+            // register the command handler
+            final CommandHandlerWrapper commandHandlerWrapper = new CommandHandlerWrapper(
+                    tenantId,
+                    deviceId,
+                    gatewayId,
+                    ctx -> commandHandler.handle(new ProtonBasedCommandContext(ctx)));
+            final CommandHandlerWrapper replacedHandler = adapterInstanceCommandHandler
+                    .putDeviceSpecificCommandHandler(commandHandlerWrapper);
+            if (replacedHandler != null) {
+                // TODO find a way to provide a notification here so that potential resources associated with the replaced consumer can be freed (maybe add a commandHandlerOverwritten Handler param to createCommandConsumer())
+            }
+            // associate handler with this adapter instance
+            final Instant lifespanStart = Instant.now();
+            registerCommandConsumer(tenantId, deviceId, sanitizedLifespan, context)
+                    .map(v -> {
+                        return (CommandConsumer) new CommandConsumer() {
+                            @Override
+                            public Future<Void> close(final SpanContext spanContext) {
+                                return removeCommandConsumer(commandHandlerWrapper, sanitizedLifespan,
+                                        lifespanStart, spanContext);
+                            }
+                        };
+                    })
+                    .onComplete(result);
+        });
+    }
+
+    private Future<Void> registerCommandConsumer(
+            final String tenantId,
+            final String deviceId,
+            final Duration lifespan,
+            final SpanContext context) {
+
+        return commandRouterClient.registerCommandConsumer(tenantId, deviceId, adapterInstanceId, lifespan, context)
+                .recover(thr -> {
+                    log.info("error registering consumer with the command router service [tenant: {}, device: {}]", tenantId,
+                            deviceId, thr);
+                    // handler association failed - unregister the handler
+                    adapterInstanceCommandHandler.removeDeviceSpecificCommandHandler(tenantId, deviceId);
+                    return Future.failedFuture(thr);
+                });
+    }
+
+    private Future<Void> removeCommandConsumer(
+            final CommandHandlerWrapper commandHandlerWrapper,
+            final Duration lifespan,
+            final Instant lifespanStart,
+            final SpanContext onCloseSpanContext) {
+
+        final String tenantId = commandHandlerWrapper.getTenantId();
+        final String deviceId = commandHandlerWrapper.getDeviceId();
+
+        log.trace("remove command consumer [tenant-id: {}, device-id: {}]", tenantId, deviceId);
+        if (!adapterInstanceCommandHandler.removeDeviceSpecificCommandHandler(commandHandlerWrapper)) {
+            // This case happens when trying to remove a command consumer which has been overwritten since its creation
+            // via a 2nd invocation of 'createCommandConsumer' with the same device/tenant id. Since the 2nd 'createCommandConsumer'
+            // invocation has registered a different 'commandHandlerWrapper' instance (and possibly already removed it),
+            // trying to remove the original object will return false here.
+            // On a more abstract level, this case happens when 2 consecutive command subscription requests from the
+            // same device (with no intermittent disconnect/unsubscribe - possibly because of a broken connection in between) have
+            // reached the *same* adapter instance and verticle, using this CommandConsumerFactory. Invoking 'removeCommandConsumer'
+            // on the 1st (obsolete and overwritten) command subscription shall have no impact. Throwing an explicit exception
+            // here will enable the protocol adapter to detect this case and skip an (incorrect) "disconnectedTtd" event message.
+            log.debug("command consumer not removed - handler already replaced or removed [tenant: {}, device: {}]",
+                    tenantId, deviceId);
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
+                    "local command handler already replaced or removed"));
+        }
+        return commandRouterClient.unregisterCommandConsumer(
+                    tenantId,
+                    deviceId,
+                    adapterInstanceId,
+                    onCloseSpanContext)
+                .recover(thr -> {
+                    if (ServiceInvocationException.extractStatusCode(thr) == HttpURLConnection.HTTP_PRECON_FAILED) {
+                        final boolean entryMayHaveExpired = !lifespan.isNegative() && Instant.now().isAfter(lifespanStart.plus(lifespan));
+                        if (entryMayHaveExpired) {
+                            log.trace("ignoring 412 error when unregistering consumer with the command router service; entry may have already expired [tenant: {}, device: {}]",
+                                    tenantId, deviceId);
+                            return Future.succeededFuture();
+                        } else {
+                            // entry wasn't actually removed and entry hasn't expired (yet);
+                            // This case happens when 2 consecutive command subscription requests from the same device
+                            // (with no intermittent disconnect/unsubscribe - possibly because of a broken connection in between)
+                            // have reached *different* protocol adapter instances/verticles. Now calling 'unregisterCommandConsumer'
+                            // on the 1st subscription fails because of the non-matching adapterInstanceId parameter.
+                            // Throwing an explicit exception here will enable the protocol adapter to detect this case
+                            // and skip sending an (incorrect) "disconnectedTtd" event message.
+                            log.debug("consumer not unregistered - not matched or already removed [tenant: {}, device: {}]",
+                                    tenantId, deviceId);
+                            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
+                                    "no matching command consumer mapping found to be removed"));
+                        }
+                    } else {
+                        log.info("error unregistering consumer with the command router service [tenant: {}, device: {}]", tenantId,
+                                deviceId, thr);
+                        return Future.failedFuture(thr);
+                    }
+                });
+    }
+
+    private Future<ProtonReceiver> createAdapterSpecificConsumer() {
+        log.trace("creating new adapter instance command consumer");
+        final String adapterInstanceConsumerAddress = CommandConstants.INTERNAL_COMMAND_ENDPOINT + "/"
+                + adapterInstanceId;
+        return connection.createReceiver(
+                adapterInstanceConsumerAddress,
+                ProtonQoS.AT_LEAST_ONCE,
+                (delivery, msg) -> adapterInstanceCommandHandler.handleCommandMessage(msg, delivery),
+                connection.getConfig().getInitialCredits(),
+                false, // no auto-accept
+                sourceAddress -> { // remote close hook
+                    log.debug("command receiver link closed remotely");
+                    invokeRecreateConsumerWithDelay();
+                }).map(receiver -> {
+                    log.debug("successfully created adapter specific command consumer");
+                    adapterSpecificConsumer = receiver;
+                    return receiver;
+                }).recover(t -> {
+                    log.error("failed to create adapter specific command consumer", t);
+                    return Future.failedFuture(t);
+                });
+    }
+
+    private void recreateConsumer() {
+        if (recreatingConsumer.compareAndSet(false, true)) {
+            connection.isConnected(getDefaultConnectionCheckTimeout())
+                    .compose(res -> {
+                        // recreate adapter specific consumer
+                        if (adapterSpecificConsumer == null || !adapterSpecificConsumer.isOpen()) {
+                            log.debug("recreate adapter specific command consumer link");
+                            return createAdapterSpecificConsumer();
+                        }
+                        return Future.succeededFuture();
+                    }).onComplete(ar -> {
+                        recreatingConsumer.set(false);
+                        if (tryAgainRecreatingConsumer.compareAndSet(true, false) || ar.failed()) {
+                            if (ar.succeeded()) {
+                                // tryAgainRecreatingConsumers was set - try again immediately
+                                recreateConsumer();
+                            } else {
+                                invokeRecreateConsumerWithDelay();
+                            }
+                        }
+                    });
+        } else {
+            // if recreateConsumer() was triggered by a remote link closing, that might have occurred after that link was dealt with above;
+            // therefore be sure recreateConsumer() gets called again once the current invocation has finished.
+            log.debug("already recreating consumer");
+            tryAgainRecreatingConsumer.set(true);
+        }
+    }
+
+    private void invokeRecreateConsumerWithDelay() {
+        connection.getVertx().setTimer(RECREATE_CONSUMER_DELAY, tid -> recreateConsumer());
+    }
+
+    private void handleTenantTimeout(final Message<String> msg) {
+        final String tenantId = msg.body();
+        adapterInstanceCommandHandler.getDeviceSpecificCommandHandlers().stream()
+                .filter(handler -> handler.getTenantId().equals(tenantId))
+                .forEach(handler -> {
+                    log.info("timeout of tenant {}: removing command handler for device {}", tenantId, handler.getDeviceId());
+                    adapterInstanceCommandHandler.removeDeviceSpecificCommandHandler(handler.getTenantId(), handler.getDeviceId());
+                });
+    }
+
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
@@ -52,7 +52,7 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseCl
      * @param connection The connection to the Device Connection service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
      * @param adapterConfig The protocol adapter's configuration properties.
-     * @throws NullPointerException if any of the parameters other than the cache provider are {@code null}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public ProtonBasedDeviceConnectionClient(
             final HonoConnection connection,

--- a/deploy/src/main/deploy/example-permissions.json
+++ b/deploy/src/main/deploy/example-permissions.json
@@ -38,6 +38,14 @@
         "activities": [ "EXECUTE" ]
       },
       {
+        "resource": "cmd_router/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "cmd_router/*:*",
+        "activities": [ "EXECUTE" ]
+      },
+      {
         "resource": "device_con/*",
         "activities": [ "READ", "WRITE" ]
       },

--- a/deploy/src/main/sandbox/sandbox-permissions.json
+++ b/deploy/src/main/sandbox/sandbox-permissions.json
@@ -38,6 +38,14 @@
         "activities": [ "EXECUTE" ]
       },
       {
+        "resource": "cmd_router/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "cmd_router/*:*",
+        "activities": [ "EXECUTE" ]
+      },
+      {
         "resource": "device_con/*",
         "activities": [ "READ", "WRITE" ]
       },

--- a/jenkins/Hono-Deploy-Eclipse-Pipeline.groovy
+++ b/jenkins/Hono-Deploy-Eclipse-Pipeline.groovy
@@ -57,7 +57,7 @@ def buildAndDeploy(def utils) {
                 jdk: utils.getJDKVersion(),
                 mavenLocalRepo: '.repository',
                 options: [artifactsPublisher(disabled: true)]) {
-            sh "mvn --projects :hono-service-auth,:hono-service-device-registry-file,:hono-service-device-registry-jdbc,:hono-service-device-registry-mongodb,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am deploy -DskipTests=true -DcreateJavadoc=true -DenableEclipseJarSigner=true -DskipStaging=true"
+            sh "mvn --projects :hono-service-auth,:hono-service-device-registry-file,:hono-service-device-registry-jdbc,:hono-service-device-registry-mongodb,:hono-service-command-router,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am deploy -DskipTests=true -DcreateJavadoc=true -DenableEclipseJarSigner=true -DskipStaging=true"
         }
     }
 }

--- a/jenkins/Hono-Deploy-Maven-Central-Pipeline.groovy
+++ b/jenkins/Hono-Deploy-Maven-Central-Pipeline.groovy
@@ -62,7 +62,7 @@ def buildAndDeploy(def utils) {
                 mavenLocalRepo: '.repository',
                 mavenSettingsFilePath: "${params.MAVEN_SETTINGS_FILE}",
                 options: [artifactsPublisher(disabled: true)]) {
-            sh "mvn deploy -pl :hono-service-auth,:hono-service-device-registry-file,:hono-service-device-registry-jdbc,:hono-service-device-registry-mongodb,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am -DskipTests=true -DcreateGPGSignature=true -DcreateJavadoc=true -DenableEclipseJarSigner=true"
+            sh "mvn deploy -pl :hono-service-auth,:hono-service-device-registry-file,:hono-service-device-registry-jdbc,:hono-service-device-registry-mongodb,:hono-service-command-router,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am -DskipTests=true -DcreateGPGSignature=true -DcreateJavadoc=true -DenableEclipseJarSigner=true"
         }
     }
 }

--- a/jenkins/Hono-Nightly-Pipeline.groovy
+++ b/jenkins/Hono-Nightly-Pipeline.groovy
@@ -49,7 +49,7 @@ def nightlyBuild(def utils) {
     stage('Build') {
         withMaven(maven: utils.getMavenVersion(), jdk: utils.getJDKVersion(), options: [artifactsPublisher(disabled: true)]) {
             sh 'mvn clean package javadoc:aggregate'
-            sh 'mvn --projects :hono-service-auth,:hono-service-device-registry-file,:hono-service-device-registry-jdbc,:hono-service-device-registry-mongodb,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am deploy -DcreateJavadoc=true -DenableEclipseJarSigner=true'
+            sh 'mvn --projects :hono-service-auth,:hono-service-device-registry-file,:hono-service-device-registry-jdbc,:hono-service-device-registry-mongodb,:hono-service-command-router,:hono-service-device-connection,:hono-adapter-http-vertx,:hono-adapter-mqtt-vertx,:hono-adapter-kura,:hono-adapter-amqp-vertx,:hono-adapter-lora-vertx,:hono-adapter-sigfox-vertx,:hono-adapter-coap-vertx,:hono-example,:hono-cli -am deploy -DcreateJavadoc=true -DenableEclipseJarSigner=true'
         }
     }
 }

--- a/push_hono_images.sh
+++ b/push_hono_images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #*******************************************************************************
-# Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,6 +22,7 @@ IMAGES="hono-adapter-amqp-vertx \
         hono-adapter-mqtt-vertx \
         hono-adapter-sigfox-vertx \
         hono-service-auth \
+        hono-service-command-router \
         hono-service-device-connection \
         hono-service-device-registry-file \
         hono-service-device-registry-jdbc \

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
@@ -25,9 +25,10 @@ import org.eclipse.hono.adapter.client.command.CommandResponseSender;
 import org.eclipse.hono.adapter.client.command.CommandRouterClient;
 import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
 import org.eclipse.hono.adapter.client.command.DeviceConnectionClientAdapter;
-import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedCommandConsumerFactory;
 import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedCommandResponseSender;
 import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedCommandRouterClient;
+import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedCommandRouterCommandConsumerFactoryImpl;
+import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedDelegatingCommandConsumerFactory;
 import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedDeviceConnectionClient;
 import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
@@ -282,8 +283,8 @@ public abstract class AbstractProtocolAdapterApplication {
             final DeviceRegistrationClient deviceRegistrationClient) {
 
         LOG.debug("using Device Connection service client, configuring CommandConsumerFactory [{}]",
-                ProtonBasedCommandConsumerFactory.class.getName());
-        return new ProtonBasedCommandConsumerFactory(
+                ProtonBasedDelegatingCommandConsumerFactory.class.getName());
+        return new ProtonBasedDelegatingCommandConsumerFactory(
                 commandConsumerConnection(),
                 messageSamplerFactory,
                 protocolAdapterProperties,
@@ -299,12 +300,15 @@ public abstract class AbstractProtocolAdapterApplication {
      *
      * @param commandRouterClient The client for accessing the Command Router service.
      * @return The factory.
-     * @throws UnsupportedOperationException if the factory type is not supported yet
      */
-    protected CommandConsumerFactory commandConsumerFactory(
-            final CommandRouterClient commandRouterClient) {
-        LOG.debug("using Command Router service client, configuring CommandConsumerFactory [unknown]");
-        throw new UnsupportedOperationException("not supported yet");
+    protected CommandConsumerFactory commandConsumerFactory(final CommandRouterClient commandRouterClient) {
+        LOG.debug("using Command Router service client, configuring CommandConsumerFactory [{}}]",
+                ProtonBasedCommandRouterCommandConsumerFactoryImpl.class.getName());
+        return new ProtonBasedCommandRouterCommandConsumerFactoryImpl(
+                commandConsumerConnection(),
+                messageSamplerFactory,
+                protocolAdapterProperties,
+                commandRouterClient);
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -1029,7 +1029,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             ((ServiceClient) telemetrySender).registerReadinessChecks(handler);
         }
         if (eventSender instanceof ServiceClient) {
-            ((ServiceClient ) eventSender).registerReadinessChecks(handler);
+            ((ServiceClient) eventSender).registerReadinessChecks(handler);
         }
     }
 
@@ -1065,7 +1065,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             ((ServiceClient) telemetrySender).registerLivenessChecks(handler);
         }
         if (eventSender instanceof ServiceClient) {
-            ((ServiceClient ) eventSender).registerLivenessChecks(handler);
+            ((ServiceClient) eventSender).registerLivenessChecks(handler);
         }
     }
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -39,6 +39,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     -->
     <hono.amqp-network.host>hono-dispatch-router.hono</hono.amqp-network.host>
     <hono.device-connection.host>hono-service-device-connection.hono</hono.device-connection.host>
+    <hono.commandrouter.host>hono-service-command-router.hono</hono.commandrouter.host>
     <hono.registration.host>hono-service-device-registry.hono</hono.registration.host>
     <hono.auth.host>hono-service-auth.hono</hono.auth.host>
 
@@ -69,6 +70,16 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <adapter.sendMessageToDeviceTimeout>1000</adapter.sendMessageToDeviceTimeout>
     <!-- use minimum cost factor in order to speed up test execution -->
     <max.bcrypt.costFactor>4</max.bcrypt.costFactor>
+
+    <!--
+     Properties defining whether the Device Connection service (now deprecated) or the Command Router service
+     shall be used for Command & Control. The default here lets the Device Connection service be used.
+     See the 'command-router' maven profile below for the Command Router values.
+     -->
+    <hono.command-related-service.configname>deviceConnection</hono.command-related-service.configname>
+    <hono.command-related-service.host>${hono.device-connection.host}</hono.command-related-service.host>
+    <hono.commandrouter.disabled>true</hono.commandrouter.disabled>
+    <hono.device-connection.disabled>false</hono.device-connection.disabled>
 
     <!--
       Device Registry related properties
@@ -249,6 +260,21 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
         <max.event-loop.execute-time>20000</max.event-loop.execute-time>
         <request.timeout>3000</request.timeout>
         <service.startup.timeout>240000</service.startup.timeout>
+      </properties>
+    </profile>
+    <profile>
+      <id>command-router</id>
+      <activation>
+        <property>
+          <name>hono.commandrouting.mode</name>
+          <value>commandrouter</value>
+        </property>
+      </activation>
+      <properties>
+        <hono.command-related-service.configname>commandRouter</hono.command-related-service.configname>
+        <hono.command-related-service.host>${hono.commandrouter.host}</hono.command-related-service.host>
+        <hono.commandrouter.disabled>false</hono.commandrouter.disabled>
+        <hono.device-connection.disabled>true</hono.device-connection.disabled>
       </properties>
     </profile>
     <profile>
@@ -477,6 +503,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <name>${docker.repository}/hono-jaeger-all-in-one-test</name>
                   <alias>jaeger</alias>
                   <build>
+                    <skip>${jaeger.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
                     <from>${jaeger.image.name}</from>
                   </build>
@@ -808,6 +835,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <name>${docker.repository}/hono-service-device-connection-test</name>
                   <alias>device-connection</alias>
                   <build>
+                    <skip>${hono.device-connection.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
                     <from>${docker.repository}/hono-service-device-connection:${project.version}</from>
                     <assembly>
@@ -837,6 +865,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </assembly>
                   </build>
                   <run>
+                    <skip>${hono.device-connection.disabled}</skip>
                     <ports>
                       <port>+deviceconnection.ip:deviceconnection.amqp.port:5672</port>
                       <port>+deviceconnection.ip:deviceconnection.health.port:${vertx.health.port}</port>
@@ -870,6 +899,80 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <http>
                         <method>GET</method>
                         <url>http://${deviceconnection.ip}:${deviceconnection.health.port}/readiness</url>
+                        <status>200..299</status>
+                      </http>
+                    </wait>
+                  </run>
+                </image>
+                <!-- ##### Command Router service (may also act as Device Connection service via 'enable-device-connection-endpoint') ##### -->
+                <image>
+                  <name>${docker.repository}/hono-service-command-router-test</name>
+                  <alias>command-router</alias>
+                  <build>
+                    <skip>${hono.commandrouter.disabled}</skip>
+                    <imagePullPolicy>IfNotPresent</imagePullPolicy>
+                    <from>${docker.repository}/hono-service-command-router:${project.version}</from>
+                    <assembly>
+                      <mode>dir</mode>
+                      <basedir>/</basedir>
+                      <inline>
+                        <id>config</id>
+                        <fileSets>
+                          <fileSet>
+                            <directory>${project.build.directory}/resources/commandrouter</directory>
+                            <outputDirectory>etc/hono</outputDirectory>
+                            <includes>
+                              <include>*</include>
+                            </includes>
+                          </fileSet>
+                          <fileSet>
+                            <directory>${project.build.directory}/certs</directory>
+                            <outputDirectory>etc/hono/certs</outputDirectory>
+                            <includes>
+                              <include>command-router-*.pem</include>
+                              <include>auth-server-cert.pem</include>
+                              <include>trusted-certs.pem</include>
+                            </includes>
+                          </fileSet>
+                        </fileSets>
+                      </inline>
+                    </assembly>
+                  </build>
+                  <run>
+                    <skip>${hono.commandrouter.disabled}</skip>
+                    <ports>
+                      <port>+commandrouter.ip:commandrouter.amqp.port:5672</port>
+                      <port>+commandrouter.ip:commandrouter.health.port:${vertx.health.port}</port>
+                    </ports>
+                    <portPropertyFile>${project.build.directory}/docker/commandrouter.port.properties</portPropertyFile>
+                    <network>
+                      <mode>custom</mode>
+                      <name>hono</name>
+                      <alias>hono-service-command-router.hono</alias>
+                    </network>
+                    <memorySwap>314572800</memorySwap>
+                    <memory>314572800</memory>
+                    <env>
+                      <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
+                      <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
+                      <SPRING_PROFILES_ACTIVE>${logging.profile},embedded-cache,enable-device-connection-endpoint</SPRING_PROFILES_ACTIVE>
+                      <JDK_JAVA_OPTIONS>${default.java.options}</JDK_JAVA_OPTIONS>
+                      <PN_TRACE_FRM>0</PN_TRACE_FRM>
+                      <JAEGER_SERVICE_NAME>command-router</JAEGER_SERVICE_NAME>
+                      <JAEGER_AGENT_HOST>${jaeger.host}</JAEGER_AGENT_HOST>
+                      <JAEGER_AGENT_PORT>6831</JAEGER_AGENT_PORT>
+                      <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
+                      <JAEGER_SAMPLER_PARAM>1</JAEGER_SAMPLER_PARAM>
+                    </env>
+                    <log>
+                      <prefix>CMDROUTER</prefix>
+                      <color>${log.color.hono-services}</color>
+                    </log>
+                    <wait>
+                      <time>${service.startup.timeout}</time>
+                      <http>
+                        <method>GET</method>
+                        <url>http://${commandrouter.ip}:${commandrouter.health.port}/readiness</url>
                         <status>200..299</status>
                       </http>
                     </wait>
@@ -1247,8 +1350,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 <downstream.amqp.port>${qpid.amqp.port}</downstream.amqp.port>
                 <downstream.username>consumer@HONO</downstream.username>
                 <downstream.password>verysecret</downstream.password>
+                <deviceconnection.enabled>${hono.commandrouter.disabled}</deviceconnection.enabled>
                 <deviceconnection.host>${deviceconnection.ip}</deviceconnection.host>
                 <deviceconnection.amqp.port>${deviceconnection.amqp.port}</deviceconnection.amqp.port>
+                <commandrouter.host>${commandrouter.ip}</commandrouter.host>
+                <commandrouter.amqp.port>${commandrouter.amqp.port}</commandrouter.amqp.port>
                 <deviceregistry.host>${deviceregistry.ip}</deviceregistry.host>
                 <deviceregistry.amqp.port>${deviceregistry.amqp.port}</deviceregistry.amqp.port>
                 <deviceregistry.http.port>${deviceregistry.http.port}</deviceregistry.http.port>
@@ -1307,6 +1413,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     <file>${project.build.directory}/docker/auth.port.properties</file>
                     <file>${project.build.directory}/docker/deviceregistry.port.properties</file>
                     <file>${project.build.directory}/docker/deviceconnection.port.properties</file>
+                    <file>${project.build.directory}/docker/commandrouter.port.properties</file>
                     <file>${project.build.directory}/docker/broker.port.properties</file>
                     <file>${project.build.directory}/docker/qpid.port.properties</file>
                     <file>${project.build.directory}/docker/adapter.http.port.properties</file>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -97,8 +97,14 @@ In order to stop and remove the Docker containers started by a test run, use:
 ### Running the Tests with the Quarkus based Protocol Adapters
 
 By default, the integration tests are run using the Spring Boot based protocol adapters. For some protocol adapters there are
-Quarkus based alternative implememtations. The tests can be run using these Quarkus based adapters by means of activating
+Quarkus based alternative implementations. The tests can be run using these Quarkus based adapters by means of activating
 the `protocol-adapters-quarkus` maven profile:
 
     $ mvn verify -Prun-tests,protocol-adapters-quarkus
 
+### Running the Tests with the Command Router component
+
+By default, the integration tests are run using the Device Connection service component. In order to use the Command
+Router service component instead, the `command-router` maven profile can be set:
+
+    $ mvn verify -Prun-tests,command-router

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -170,6 +170,10 @@ public final class IntegrationTestSupport {
      */
     public static final String PROPERTY_TENANT_ADMIN_PASSWORD = "tenant.admin.password";
     /**
+     * The name of the system property to use for indicating whether the Device Connection service is enabled.
+     */
+    public static final String PROPERTY_DEVICECONNECTION_SERVICE_ENABLED = "deviceconnection.enabled";
+    /**
      * The name of the system property to use for setting the IP address of the Device Connection service.
      */
     public static final String PROPERTY_DEVICECONNECTION_HOST = "deviceconnection.host";
@@ -323,6 +327,11 @@ public final class IntegrationTestSupport {
      */
     public static final int HONO_DEVICEREGISTRY_HTTP_PORT = Integer.getInteger(PROPERTY_DEVICEREGISTRY_HTTP_PORT, DEFAULT_DEVICEREGISTRY_HTTP_PORT);
 
+    /**
+     * The boolean value indicating whether the Device Connection service is enabled.
+     */
+    public static final boolean HONO_DEVICECONNECTION_SERVICE_ENABLED = Boolean.parseBoolean(System.getProperty(
+            PROPERTY_DEVICECONNECTION_SERVICE_ENABLED, "true"));
     /**
      * The IP address of the Device Connection service.
      */
@@ -539,6 +548,17 @@ public final class IntegrationTestSupport {
                 IntegrationTestSupport.HONO_DEVICEREGISTRY_AMQP_PORT,
                 username,
                 password);
+    }
+
+    /**
+     * Checks if the Device Connection service is enabled.
+     * <p>
+     * Evaluates the system property <em>deviceconnection.enabled</em>. Returns {@code true} if it doesn't exist.
+     *
+     * @return {@code true} if the Device Connection service is enabled.
+     */
+    public static boolean isDeviceConnectionServiceEnabled() {
+        return HONO_DEVICECONNECTION_SERVICE_ENABLED;
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
@@ -15,6 +15,7 @@
 package org.eclipse.hono.tests.registry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.net.HttpURLConnection;
 import java.time.Duration;
@@ -23,7 +24,9 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.client.DeviceConnectionClient;
+import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.DeviceConnectionConstants;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.Future;
@@ -39,6 +42,11 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 abstract class DeviceConnectionApiTests extends DeviceRegistryTestBase {
+
+    @BeforeAll
+    public static void setup() {
+        assumeTrue(IntegrationTestSupport.isDeviceConnectionServiceEnabled());
+    }
 
     /**
      * Gets a client for interacting with the Device Connection service.

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -53,10 +53,10 @@ hono:
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
     requestTimeout: ${request.timeout}
-  deviceConnection:
+  ${hono.command-related-service.configname}:
     name: 'Hono AMQP Adapter'
-    host: ${hono.device-connection.host}
-    port: 5672 # AMQP port of the device registry
+    host: ${hono.command-related-service.host}
+    port: 5672
     username: amqp-adapter@HONO
     password: amqp-secret
     linkEstablishmentTimeout: ${link.establishment.timeout}

--- a/tests/src/test/resources/auth/permissions.json
+++ b/tests/src/test/resources/auth/permissions.json
@@ -34,11 +34,29 @@
         "activities": [ "EXECUTE" ]
       },
       {
+        "resource": "cmd_router/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "cmd_router/*:*",
+        "activities": [ "EXECUTE" ]
+      },
+      {
         "resource": "device_con/*",
         "activities": [ "READ", "WRITE" ]
       },
       {
         "operation": "device_con/*:*",
+        "activities": [ "EXECUTE" ]
+      }
+    ],
+    "command-router": [
+      {
+        "resource": "registration/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "operation": "registration/*:*",
         "activities": [ "EXECUTE" ]
       }
     ],
@@ -171,6 +189,14 @@
       "authorities": [
         "hono-component",
         "protocol-adapter"
+      ]
+    },
+    "command-router@HONO": {
+      "mechanism": "PLAIN",
+      "password": "cmd-router-secret",
+      "authorities": [
+        "hono-component",
+        "command-router"
       ]
     },
     "hono-client": {

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -52,9 +52,9 @@ hono:
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
     requestTimeout: ${request.timeout}
-  deviceConnection:
+  ${hono.command-related-service.configname}:
     name: 'Hono CoAP Adapter'
-    host: ${hono.device-connection.host}
+    host: ${hono.command-related-service.host}
     port: 5672
     username: coap-adapter@HONO
     password: coap-secret

--- a/tests/src/test/resources/commandrouter/application.yml
+++ b/tests/src/test/resources/commandrouter/application.yml
@@ -1,0 +1,43 @@
+hono:
+  app:
+    maxInstances: 1
+    startupTimeout: 90
+  healthCheck:
+    insecurePortBindAddress: 0.0.0.0
+    insecurePort: ${vertx.health.port}
+  auth:
+    host: ${hono.auth.host}
+    port: 5672
+    name: command-router
+    validation:
+      certPath: /etc/hono/certs/auth-server-cert.pem
+  commandRouter:
+    amqp:
+      insecurePortEnabled: true
+      insecurePortBindAddress: 0.0.0.0
+  registration:
+    name: 'Hono Command Router'
+    host: ${hono.registration.host}
+    port: 5672
+    username: command-router@HONO
+    password: cmd-router-secret
+    linkEstablishmentTimeout: ${link.establishment.timeout}
+    flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
+  command:
+    name: 'Hono Command Router'
+    host: ${hono.amqp-network.host}
+    port: 5673
+    amqpHostname: hono-internal
+    keyPath: /etc/hono/certs/command-router-key.pem
+    certPath: /etc/hono/certs/command-router-cert.pem
+    trustStorePath: /etc/hono/certs/trusted-certs.pem
+    linkEstablishmentTimeout: ${link.establishment.timeout}
+    flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
+  vertx:
+    maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+
+spring:
+  jmx:
+    enabled: false

--- a/tests/src/test/resources/commandrouter/cache-config.xml
+++ b/tests/src/test/resources/commandrouter/cache-config.xml
@@ -1,0 +1,21 @@
+<!-- 
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<infinispan>
+  <cache-container default-cache="device-connection">
+    <local-cache name="device-connection" simple-cache="true">
+      <memory>
+        <object size="100" strategy="REMOVE" />
+      </memory>
+    </local-cache>
+  </cache-container>
+</infinispan>

--- a/tests/src/test/resources/commandrouter/logback-spring.xml
+++ b/tests/src/test/resources/commandrouter/logback-spring.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+
+  <!-- 
+    This is the logging configuration that is used by the
+    Hono Command Router Docker image while executing the integration tests.
+
+    Any changes made here will be reflected on the next start
+    of the Hono Command Router Docker image only, i.e. the next time
+
+    mvn -Prun-tests verify
+
+    is invoked.
+   -->
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <springProfile name="trace">
+    <logger name="org.eclipse.hono.commandrouter" level="TRACE"/>
+    <logger name="org.eclipse.hono" level="DEBUG"/>
+  </springProfile>
+
+  <springProfile name="dev">
+    <logger name="org.eclipse.hono" level="DEBUG"/>
+  </springProfile>
+
+  <springProfile name="prod">
+    <logger name="org.eclipse.hono" level="INFO"/>
+  </springProfile>
+
+  <logger name="io.netty.handler.logging.LoggingHandler" level="INFO"/>
+
+  <logger name="io.vertx.proton.impl" level="INFO"/>
+  <logger name="io.vertx.core.net.impl" level="INFO"/>
+
+</configuration>

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -53,9 +53,9 @@ hono:
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
     requestTimeout: ${request.timeout}
-  deviceConnection:
+  ${hono.command-related-service.configname}:
     name: 'Hono HTTP Adapter'
-    host: ${hono.device-connection.host}
+    host: ${hono.command-related-service.host}
     port: 5672
     username: http-adapter@HONO
     password: http-secret

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -53,9 +53,9 @@ hono:
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
     requestTimeout: ${request.timeout}
-  deviceConnection:
+  ${hono.command-related-service.configname}:
     name: 'Hono MQTT Adapter'
-    host: ${hono.device-connection.host}
+    host: ${hono.command-related-service.host}
     port: 5672
     username: mqtt-adapter@HONO
     password: mqtt-secret

--- a/tests/src/test/resources/qpid/qdrouterd-with-broker.json
+++ b/tests/src/test/resources/qpid/qdrouterd-with-broker.json
@@ -110,7 +110,7 @@
       "maxConnections": 40,
       "groups": {
         "Hono": {
-          "users": "Eclipse IoT;Hono;http-adapter,Eclipse IoT;Hono;mqtt-adapter,Eclipse IoT;Hono;amqp-adapter,Eclipse IoT;Hono;coap-adapter",
+          "users": "Eclipse IoT;Hono;http-adapter,Eclipse IoT;Hono;mqtt-adapter,Eclipse IoT;Hono;amqp-adapter,Eclipse IoT;Hono;coap-adapter,Eclipse IoT;Hono;command-router",
           "remoteHosts": "*",
           "maxSessions": 2,
           "maxMessageSize": 131072,


### PR DESCRIPTION
This is for #2029.

This adds a `org.eclipse.hono.adapter.client.command.CommandConsumerFactory` implementation that uses the new Command Router component.
For the integration tests, a new maven profile `command-router` is added to let the tests run using the Command Router component.
The GitHub action workflow has been adapted to use that profile in the test-run that uses the jdbc device registry (so that the other test-runs still use the old command routing mechanism).
