### PR TITLE
Fix tracing for Quarkus based adapters

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
+++ b/client/src/main/java/org/eclipse/hono/client/HonoConnection.java
@@ -83,6 +83,25 @@ public interface HonoConnection extends ConnectionLifecycle<HonoConnection> {
     }
 
     /**
+     * Creates a new connection using the default implementation.
+     * <p>
+     * <strong>Note:</strong> Instances of {@link ClientConfigProperties} are not thread safe and not immutable.
+     * They must therefore not be modified after calling this method.
+     *
+     * @param vertx The vert.x instance to use.
+     * @param clientConfigProperties The client properties to use.
+     * @param tracer The OpenTracing tracer.
+     * @return The newly created connection. Note that the underlying AMQP connection will not be established
+     *         until one of its <em>connect</em> methods is invoked.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    static HonoConnection newConnection(final Vertx vertx, final ClientConfigProperties clientConfigProperties, final Tracer tracer) {
+        final HonoConnectionImpl connection = new HonoConnectionImpl(vertx, clientConfigProperties);
+        connection.setTracer(tracer);
+        return connection;
+    }
+
+    /**
      * Gets the vert.x instance used by this connection.
      * <p>
      * The returned instance may be used to e.g. schedule timers.

--- a/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AsyncCommandClientImpl.java
@@ -55,13 +55,9 @@ public class AsyncCommandClientImpl extends AbstractSender implements AsyncComma
 
     @Override
     protected Span startSpan(final SpanContext parent, final Message message) {
-        if (connection.getTracer() == null) {
-            throw new IllegalStateException("no tracer configured");
-        } else {
-            final Span span = newFollowingSpan(parent, "sending async command");
-            Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_PRODUCER);
-            return span;
-        }
+        final Span span = newFollowingSpan(parent, "sending async command");
+        Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_PRODUCER);
+        return span;
     }
 
     @Override

--- a/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/DelegatedCommandSenderImpl.java
@@ -261,12 +261,8 @@ public class DelegatedCommandSenderImpl extends AbstractSender implements Delega
     @Override
     protected Span startSpan(final SpanContext parent, final Message rawMessage) {
 
-        if (connection.getTracer() == null) {
-            throw new IllegalStateException("no tracer configured");
-        } else {
-            final Span span = newChildSpan(parent, "delegate Command request");
-            Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_CLIENT);
-            return span;
-        }
+        final Span span = newChildSpan(parent, "delegate Command request");
+        Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_CLIENT);
+        return span;
     }
 }

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
@@ -166,7 +166,7 @@ public abstract class AbstractProtocolAdapterApplication {
      */
     protected TenantClient tenantClient() {
         return new ProtonBasedTenantClient(
-                HonoConnection.newConnection(vertx, config.tenant),
+                HonoConnection.newConnection(vertx, config.tenant, tracer),
                 messageSamplerFactory,
                 protocolAdapterProperties,
                 newCaffeineCache(config.tenant));
@@ -179,7 +179,7 @@ public abstract class AbstractProtocolAdapterApplication {
      */
     protected DeviceRegistrationClient registrationClient() {
         return new ProtonBasedDeviceRegistrationClient(
-                HonoConnection.newConnection(vertx, config.registration),
+                HonoConnection.newConnection(vertx, config.registration, tracer),
                 messageSamplerFactory,
                 protocolAdapterProperties,
                 newCaffeineCache(config.registration));
@@ -192,7 +192,7 @@ public abstract class AbstractProtocolAdapterApplication {
      */
     protected CredentialsClient credentialsClient() {
         return new ProtonBasedCredentialsClient(
-                HonoConnection.newConnection(vertx, config.credentials),
+                HonoConnection.newConnection(vertx, config.credentials, tracer),
                 messageSamplerFactory,
                 protocolAdapterProperties,
                 newCaffeineCache(config.credentials));
@@ -205,7 +205,7 @@ public abstract class AbstractProtocolAdapterApplication {
      */
     protected CommandRouterClient commandRouterClient() {
         return new ProtonBasedCommandRouterClient(
-                HonoConnection.newConnection(vertx, config.commandRouter),
+                HonoConnection.newConnection(vertx, config.commandRouter, tracer),
                 messageSamplerFactory,
                 protocolAdapterProperties);
     }
@@ -217,7 +217,7 @@ public abstract class AbstractProtocolAdapterApplication {
      */
     protected DeviceConnectionClient deviceConnectionClient() {
         return new ProtonBasedDeviceConnectionClient(
-                HonoConnection.newConnection(vertx, config.deviceConnection),
+                HonoConnection.newConnection(vertx, config.deviceConnection, tracer),
                 messageSamplerFactory,
                 protocolAdapterProperties);
     }
@@ -229,7 +229,7 @@ public abstract class AbstractProtocolAdapterApplication {
      */
     protected ProtonBasedDownstreamSender downstreamSender() {
         return new ProtonBasedDownstreamSender(
-                HonoConnection.newConnection(vertx, config.messaging),
+                HonoConnection.newConnection(vertx, config.messaging, tracer),
                 messageSamplerFactory,
                 protocolAdapterProperties);
     }
@@ -240,7 +240,7 @@ public abstract class AbstractProtocolAdapterApplication {
      * @return The connection.
      */
     protected HonoConnection commandConsumerConnection() {
-        return HonoConnection.newConnection(vertx, config.command);
+        return HonoConnection.newConnection(vertx, config.command, tracer);
     }
 
     /**
@@ -298,7 +298,7 @@ public abstract class AbstractProtocolAdapterApplication {
      */
     protected CommandResponseSender commandResponseSender() {
         return new ProtonBasedCommandResponseSender(
-                HonoConnection.newConnection(vertx, config.command),
+                HonoConnection.newConnection(vertx, config.command, tracer),
                 messageSamplerFactory,
                 protocolAdapterProperties);
     }


### PR DESCRIPTION
HonoConnectionImpl#tracer needs to be set explicitly, otherwise the NoopTracer is used.