### PR TITLE
[#2288] Add integration tests verifying forwarding of QoS level in downstream messages

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -296,6 +296,17 @@ public final class MessageHelper {
     }
 
     /**
+     * Gets the value of a message's {@link #APP_PROPERTY_QOS} application property.
+     *
+     * @param msg The message.
+     * @return The property value or {@code null} if not set.
+     * @throws NullPointerException if message is {@code null}.
+     */
+    public static int getQoS(final Message msg) {
+        return getApplicationProperty(msg.getApplicationProperties(), APP_PROPERTY_QOS, Integer.class);
+    }
+
+    /**
      * Gets the registration assertion conveyed in an AMQP 1.0 message.
      * <p>
      * The assertion is expected to be contained in the messages's <em>application-properties</em> under key

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -73,7 +73,7 @@ public final class IntegrationTestSupport {
     /**
      * The default number of milliseconds to wait for a response to an AMQP 1.0 performative.
      */
-    public static final int DEFAULT_AMQP_TIMEOUT = 1000;
+    public static final int DEFAULT_AMQP_TIMEOUT = 400;
     /**
      * The default port exposed by the AMQP adapter.
      */

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -73,7 +73,7 @@ public final class IntegrationTestSupport {
     /**
      * The default number of milliseconds to wait for a response to an AMQP 1.0 performative.
      */
-    public static final int DEFAULT_AMQP_TIMEOUT = 400;
+    public static final int DEFAULT_AMQP_TIMEOUT = 1000;
     /**
      * The default port exposed by the AMQP adapter.
      */

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
@@ -82,6 +82,10 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
         assertAdditionalMessageProperties(ctx, msg);
     }
 
+    private void assertQosLevel(final VertxTestContext ctx, final Message msg, final ProtonQoS expectedQos) {
+        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(expectedQos.ordinal()));
+    }
+
     /**
      * Perform additional checks on a received message.
      * <p>
@@ -355,6 +359,7 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
                             msg.getContentType(), MessageHelper.getPayloadAsString(msg));
                 }
                 assertMessageProperties(messageSending, msg);
+                assertQosLevel(messageSending, msg, senderQoS);
                 callback.handle(null);
             }).map(c -> {
                 return null;

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -63,6 +63,7 @@ import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,7 +105,7 @@ public abstract class CoapTestBase {
      */
     protected static final long TEST_TIMEOUT_MILLIS = 20000; // 20 seconds
 
-    private static final int MESSAGES_TO_SEND = 60;
+    protected static final int MESSAGES_TO_SEND = 60;
 
     private static final String COMMAND_TO_SEND = "setDarkness";
     private static final String COMMAND_JSON_KEY = "darkness";
@@ -446,7 +447,7 @@ public abstract class CoapTestBase {
             final Supplier<Future<?>> warmUp,
             final Consumer<Message> messageConsumer,
             final Function<Integer, Future<OptionSet>> requestSender) throws InterruptedException {
-        testUploadMessages(ctx, tenantId, warmUp, messageConsumer, requestSender, MESSAGES_TO_SEND);
+        testUploadMessages(ctx, tenantId, warmUp, messageConsumer, requestSender, MESSAGES_TO_SEND, null);
     }
 
     /**
@@ -459,6 +460,7 @@ public abstract class CoapTestBase {
      * @param messageConsumer Consumer that is invoked when a message was received.
      * @param requestSender The test device that will publish the data.
      * @param numberOfMessages The number of messages that are uploaded.
+     * @param expectedQos The expected QoS level, may be {@code null} leading to expecting the default for event or telemetry.
      * @throws InterruptedException if the test is interrupted before it has finished.
      */
     protected void testUploadMessages(
@@ -467,7 +469,8 @@ public abstract class CoapTestBase {
             final Supplier<Future<?>> warmUp,
             final Consumer<Message> messageConsumer,
             final Function<Integer, Future<OptionSet>> requestSender,
-            final int numberOfMessages) throws InterruptedException {
+            final int numberOfMessages,
+            final QoS expectedQos) throws InterruptedException {
 
         final CountDownLatch received = new CountDownLatch(numberOfMessages);
 
@@ -475,6 +478,7 @@ public abstract class CoapTestBase {
         createConsumer(tenantId, msg -> {
             logger.trace("received {}", msg);
             assertMessageProperties(ctx, msg);
+            assertQosLevel(ctx, msg, getExpectedQoS(expectedQos));
             if (messageConsumer != null) {
                 messageConsumer.accept(msg);
             }
@@ -921,6 +925,25 @@ public abstract class CoapTestBase {
             assertThat(msg.getCreationTime()).isGreaterThan(0);
         });
         assertAdditionalMessageProperties(ctx, msg);
+    }
+
+    private QoS getExpectedQoS(final QoS qos) {
+        if (qos != null) {
+            return qos;
+        }
+
+        switch (getMessageType()) {
+            case CON:
+                return QoS.AT_LEAST_ONCE;
+            case NON:
+                return QoS.AT_MOST_ONCE;
+            default:
+                throw new IllegalArgumentException("Either QoS must be non-null or message type must be CON or NON!");
+        }
+    }
+
+    private void  assertQosLevel(final VertxTestContext ctx, final Message msg, final QoS expectedQos) {
+        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(expectedQos.ordinal()));
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -30,6 +30,7 @@ import org.eclipse.californium.elements.exception.ConnectorException;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,12 +94,15 @@ public class TelemetryCoapIT extends CoapTestBase {
 
         testUploadMessages(ctx, tenantId,
                 () -> warmUp(client, createCoapsRequest(Code.POST, Type.CON, getPostResource(), 0)),
+                null,
                 count -> {
-            final Promise<OptionSet> result = Promise.promise();
-            final Request request = createCoapsRequest(Code.POST, Type.CON, getPostResource(), count);
-            client.advanced(getHandler(result), request);
-            return result.future();
-        });
+                    final Promise<OptionSet> result = Promise.promise();
+                    final Request request = createCoapsRequest(Code.POST, Type.CON, getPostResource(), count);
+                    client.advanced(getHandler(result), request);
+                    return result.future();
+                },
+                MESSAGES_TO_SEND,
+                QoS.AT_LEAST_ONCE);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -15,15 +15,26 @@ package org.eclipse.hono.tests.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.QoS;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 
 
 /**
@@ -51,5 +62,38 @@ public class EventHttpIT extends HttpTestBase {
         // assert that events are marked as "durable"
 
         assertThat(msg.isDurable()).isTrue();
+    }
+
+    /**
+     * Checks an event with an unsupported device QoS level is rejected.
+     *
+     * @param ctx The test context.
+     *
+     * @throws InterruptedException if the test fails.
+     */
+    @Test
+    public void testEventIsRejectedForUnsupportedQosLevel(final VertxTestContext ctx) throws InterruptedException {
+        final VertxTestContext setup = new VertxTestContext();
+        final Tenant tenant = new Tenant();
+        final MultiMap requestHeaders = MultiMap.caseInsensitiveMultiMap()
+                .add(HttpHeaders.CONTENT_TYPE, "text/plain")
+                .add(HttpHeaders.AUTHORIZATION, authorization)
+                .add(HttpHeaders.ORIGIN, ORIGIN_URI)
+                .add(Constants.HEADER_QOS_LEVEL, String.valueOf(QoS.AT_MOST_ONCE.ordinal()));
+
+        helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, PWD).onComplete(setup.completing());
+
+        assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
+        if (setup.failed()) {
+            ctx.failNow(setup.causeOfFailure());
+            return;
+        }
+
+        httpClient.create(
+                getEndpointUri(),
+                Buffer.buffer("hello"),
+                requestHeaders,
+                ResponsePredicate.status(HttpURLConnection.HTTP_BAD_REQUEST))
+                .onComplete(ctx.completing());
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -37,6 +37,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.tests.CommandEndpointConfiguration.SubscriberRole;
 import org.eclipse.hono.tests.CrudHttpClient;
 import org.eclipse.hono.tests.IntegrationTestSupport;
@@ -44,6 +45,7 @@ import org.eclipse.hono.tests.Tenants;
 import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -93,12 +95,13 @@ public abstract class HttpTestBase {
      */
     protected static IntegrationTestSupport helper;
 
+    protected static final int MESSAGES_TO_SEND = 60;
+
     private static final String COMMAND_TO_SEND = "setBrightness";
     private static final String COMMAND_JSON_KEY = "brightness";
 
     private static final String ORIGIN_WILDCARD = "*";
     private static final long  TEST_TIMEOUT_MILLIS = 20000; // 20 seconds
-    private static final int MESSAGES_TO_SEND = 60;
 
     /**
      * The default options to use for creating HTTP clients.
@@ -477,7 +480,24 @@ public abstract class HttpTestBase {
             final String tenantId,
             final Function<Message, Future<?>> messageConsumer,
             final Function<Integer, Future<HttpResponse<Buffer>>> requestSender) throws InterruptedException {
-        testUploadMessages(ctx, tenantId, messageConsumer, requestSender, MESSAGES_TO_SEND);
+        testUploadMessages(ctx, tenantId, messageConsumer, requestSender, MESSAGES_TO_SEND, null);
+    }
+
+    private QoS getExpectedQoS(final QoS qos) {
+        if (qos != null) {
+            return qos;
+        }
+
+        final MetricsTags.EndpointType endpointType = MetricsTags.EndpointType.fromString(getEndpointUri().replaceFirst("/", ""));
+
+        switch (endpointType) {
+            case EVENT:
+                return QoS.AT_LEAST_ONCE;
+            case TELEMETRY:
+                return QoS.AT_MOST_ONCE;
+            default:
+                throw new IllegalArgumentException("Either QoS must be non-null or endpoint type must be telemetry or event!");
+        }
     }
 
     /**
@@ -488,6 +508,7 @@ public abstract class HttpTestBase {
      * @param messageConsumer Consumer that is invoked when a message was received.
      * @param requestSender The test device that will publish the data.
      * @param numberOfMessages The number of messages that are uploaded.
+     * @param expectedQos The expected QoS level, may be {@code null} leading to expecting the default for event or telemetry.
      * @throws InterruptedException if the test is interrupted before it has finished.
      */
     protected void testUploadMessages(
@@ -495,7 +516,8 @@ public abstract class HttpTestBase {
             final String tenantId,
             final Function<Message, Future<?>> messageConsumer,
             final Function<Integer, Future<HttpResponse<Buffer>>> requestSender,
-            final int numberOfMessages) throws InterruptedException {
+            final int numberOfMessages,
+            final QoS expectedQos) throws InterruptedException {
 
         final VertxTestContext messageSending = new VertxTestContext();
         final Checkpoint messageSent = messageSending.checkpoint(numberOfMessages);
@@ -507,6 +529,7 @@ public abstract class HttpTestBase {
         createConsumer(tenantId, msg -> {
             logger.trace("received {}", msg);
             assertMessageProperties(ctx, msg);
+            assertQosLevel(ctx, msg, getExpectedQoS(expectedQos));
             Optional.ofNullable(messageConsumer)
             .map(consumer -> consumer.apply(msg))
             .orElseGet(() -> Future.succeededFuture())
@@ -1013,7 +1036,8 @@ public abstract class HttpTestBase {
                                 return responseHeaders;
                             });
                 },
-                5);
+                5,
+                null);
     }
 
     /**
@@ -1274,6 +1298,10 @@ public abstract class HttpTestBase {
             assertThat(msg.getCreationTime()).isGreaterThan(0);
             assertAdditionalMessageProperties(msg);
         });
+    }
+
+    private void  assertQosLevel(final VertxTestContext ctx, final Message msg, final QoS expectedQos) {
+        ctx.verify(() -> assertThat(MessageHelper.getQoS(msg)).isEqualTo(expectedQos.ordinal()));
     }
 
     private <T> Future<HttpResponse<T>> verifyAccessControlExposedHeaders(final HttpResponse<T> response) {

--- a/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
@@ -29,6 +29,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,13 +93,15 @@ public class TelemetryHttpIT extends HttpTestBase {
             return;
         }
 
-        testUploadMessages(ctx, tenantId, count -> {
-            return httpClient.create(
+        testUploadMessages(ctx, tenantId,
+                null,
+                count -> httpClient.create(
                     getEndpointUri(),
                     Buffer.buffer("hello " + count),
                     requestHeaders,
-                    ResponsePredicate.status(HttpURLConnection.HTTP_ACCEPTED));
-        });
+                    ResponsePredicate.status(HttpURLConnection.HTTP_ACCEPTED)),
+                MESSAGES_TO_SEND,
+                QoS.AT_LEAST_ONCE);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -49,6 +49,11 @@ public class EventMqttIT extends MqttPublishTestBase {
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
 
     @Override
+    protected MqttQoS getQos() {
+        return MqttQoS.AT_LEAST_ONCE;
+    }
+
+    @Override
     protected Future<Void> send(
             final String tenantId,
             final String deviceId,
@@ -73,7 +78,7 @@ public class EventMqttIT extends MqttPublishTestBase {
         mqttClient.publish(
                 topic,
                 payload,
-                MqttQoS.AT_LEAST_ONCE,
+                getQos(),
                 false, // is duplicate
                 false, // is retained
                 sendAttempt -> sendAttemptHandler.accept(sendAttempt, result));

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -35,6 +35,7 @@ import org.eclipse.hono.tests.Tenants;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.Test;
 
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -65,6 +66,13 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
 
     // <MQTT message ID, PUBACK handler>
     private final Map<Integer, Handler<Integer>> pendingMessages = new HashMap<>();
+
+    /**
+     * Gets the QoS level with which the MQTT message shall be sent.
+     *
+     * @return The QoS level.
+     */
+    protected abstract MqttQoS getQos();
 
     /**
      * Sends a message on behalf of a device to the MQTT adapter.
@@ -323,6 +331,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
             assertThat(MessageHelper.getTenantIdAnnotation(msg)).isNotNull();
             assertThat(MessageHelper.getDeviceIdAnnotation(msg)).isNotNull();
             assertThat(MessageHelper.getRegistrationAssertion(msg)).isNull();
+            assertThat(MessageHelper.getQoS(msg)).isEqualTo(getQos().ordinal());
             assertThat(msg.getCreationTime()).isGreaterThan(0);
         });
         assertAdditionalMessageProperties(ctx, msg);

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
@@ -39,6 +39,11 @@ public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
 
     @Override
+    protected MqttQoS getQos() {
+        return MqttQoS.AT_MOST_ONCE;
+    }
+
+    @Override
     protected Future<Void> send(
             final String tenantId,
             final String deviceId,
@@ -56,7 +61,7 @@ public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
             mqttClient.publish(
                     topic,
                     payload,
-                    MqttQoS.AT_MOST_ONCE,
+                    getQos(),
                     false, // is duplicate
                     false, // is retained
                     sendAttempt -> {

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
@@ -38,6 +38,11 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
     private static final String TOPIC_TEMPLATE = "%s/%s/%s";
 
     @Override
+    protected MqttQoS getQos() {
+        return MqttQoS.AT_LEAST_ONCE;
+    }
+
+    @Override
     protected Future<Void> send(
             final String tenantId,
             final String deviceId,
@@ -53,7 +58,7 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
         mqttClient.publish(
                 topic,
                 payload,
-                MqttQoS.AT_LEAST_ONCE,
+                getQos(),
                 false, // is duplicate
                 false, // is retained
                 sendAttempt -> handlePublishAttempt(sendAttempt, result));


### PR DESCRIPTION
The HTTP adapter suffered from a bug when a client sent an event and set a device level QoS to something different than 1 or set no device level QoS at all. In any case the event was sent with QoS 1 but the message property indicating the device level QoS to the northbound application (which should always be 1 as this is the only supported QoS for events) was wrong.

Signed-off-by: Florian Kaltner <florian.kaltner@bosch.io>