### PR TITLE
tenantAdapterStore should use tenantsProperties().getAdapter()

### DIFF
--- a/legal/src/main/resources/legal/NOTICE.md
+++ b/legal/src/main/resources/legal/NOTICE.md
@@ -22,6 +22,7 @@ of the Eclipse Public License 2.0 which is available at https://www.eclipse.org/
 * Copyright 2019 Thiyagarajan B
 * Copyright 2019 Microsoft Corporation
 * Copyright 2020 pragmatic industries GmbH
+* Copyright 2020 Lari Hotari
 
 # Third-party Content
 

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -236,7 +236,7 @@ public class ApplicationConfig {
     @Bean
     @Profile(Profiles.PROFILE_REGISTRY_ADAPTER + " & " + Profiles.PROFILE_TENANT_SERVICE)
     public AdapterStore tenantAdapterStore() throws IOException {
-        return Stores.adapterStore(vertx(), tracer(), tenantsProperties().getManagement());
+        return Stores.adapterStore(vertx(), tracer(), tenantsProperties().getAdapter());
     }
 
     /**


### PR DESCRIPTION
tenantAdapterStore should use `tenantsProperties().getAdapter()` instead of `tenantsProperties().getManagement()`
I noticed this small bug while working on #2317 .