### PR TITLE
Include hono-service-device-registry-jdbc image in pushed images

### DIFF
--- a/push_hono_images.sh
+++ b/push_hono_images.sh
@@ -24,6 +24,7 @@ IMAGES="hono-adapter-amqp-vertx \
         hono-service-auth \
         hono-service-device-connection \
         hono-service-device-registry-file \
+        hono-service-device-registry-jdbc \
         hono-service-device-registry-mongodb"
 
 if [ -n "$TAG" ]


### PR DESCRIPTION
include `hono-service-device-registry-jdbc` image in the images handled by `push_hono_images.sh` script