### PR TITLE
Refactor ProtonBasedDownstreamSender into separate subclasses.

### DIFF
--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedEventSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedEventSender.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.amqp;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
+import org.eclipse.hono.client.DownstreamSender;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.impl.EventSenderImpl;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.AddressHelper;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A vertx-proton based sender for events.
+ */
+public class ProtonBasedEventSender extends ProtonBasedDownstreamSender implements EventSender {
+
+    /**
+     * Creates a new event sender for a connection.
+     *
+     * @param connection The connection to the Hono service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public ProtonBasedEventSender(final HonoConnection connection, final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig) {
+        super(connection, samplerFactory, adapterConfig);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendEvent(
+            final TenantObject tenant,
+            final RegistrationAssertion device,
+            final String contentType,
+            final Buffer payload,
+            final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(contentType);
+
+        return getOrCreateEventSender(tenant.getTenantId())
+                .compose(sender -> {
+                    final ResourceIdentifier target = ResourceIdentifier.from(EventConstants.EVENT_ENDPOINT,
+                            tenant.getTenantId(), device.getDeviceId());
+                    final Message message = createMessage(tenant, device, QoS.AT_LEAST_ONCE, target, contentType,
+                            payload, properties);
+                    return sender.sendAndWaitForOutcome(message, context);
+                })
+                .mapEmpty();
+    }
+
+    private Future<DownstreamSender> getOrCreateEventSender(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+        return connection
+                .isConnected(getDefaultConnectionCheckTimeout())
+                .compose(v -> connection.executeOnContext(result -> {
+                    final String key = AddressHelper.getTargetAddress(EventConstants.EVENT_ENDPOINT, tenantId, null,
+                            connection.getConfig());
+                    getOrCreateSender(
+                            key,
+                            () -> EventSenderImpl.create(
+                                    connection,
+                                    tenantId,
+                                    samplerFactory.create(EventConstants.EVENT_ENDPOINT),
+                                    onSenderClosed -> removeClient(key)),
+                            result);
+                }));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return new StringBuilder(ProtonBasedEventSender.class.getName())
+                .append(" via AMQP 1.0 Messaging Network")
+                .toString();
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedTelemetrySender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedTelemetrySender.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.amqp;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
+import org.eclipse.hono.client.DownstreamSender;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.impl.TelemetrySenderImpl;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.AddressHelper;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TelemetryConstants;
+import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A vertx-proton based sender for telemetry messages.
+ */
+public class ProtonBasedTelemetrySender extends ProtonBasedDownstreamSender implements TelemetrySender {
+
+    /**
+     * Creates a new telemetry sender for a connection.
+     *
+     * @param connection The connection to the Hono service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public ProtonBasedTelemetrySender(final HonoConnection connection, final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig) {
+        super(connection, samplerFactory, adapterConfig);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendTelemetry(
+            final TenantObject tenant,
+            final RegistrationAssertion device,
+            final QoS qos,
+            final String contentType,
+            final Buffer payload,
+            final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(qos);
+        Objects.requireNonNull(contentType);
+
+        return getOrCreateTelemetrySender(tenant.getTenantId())
+                .compose(sender -> {
+                    final ResourceIdentifier target = ResourceIdentifier.from(TelemetryConstants.TELEMETRY_ENDPOINT,
+                            tenant.getTenantId(), device.getDeviceId());
+                    final Message message = createMessage(tenant, device, qos, target, contentType, payload,
+                            properties);
+                    switch (qos) {
+                    case AT_MOST_ONCE:
+                        return sender.send(message, context);
+                    default:
+                        return sender.sendAndWaitForOutcome(message, context);
+                    }
+                })
+                .mapEmpty();
+    }
+
+    private Future<DownstreamSender> getOrCreateTelemetrySender(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+        return connection
+                .isConnected(getDefaultConnectionCheckTimeout())
+                .compose(v -> connection.executeOnContext(result -> {
+                    final String key = AddressHelper.getTargetAddress(
+                            TelemetryConstants.TELEMETRY_ENDPOINT,
+                            tenantId,
+                            null,
+                            connection.getConfig());
+                    getOrCreateSender(
+                            key,
+                            () -> TelemetrySenderImpl.create(
+                                    connection,
+                                    tenantId,
+                                    samplerFactory.create(TelemetryConstants.TELEMETRY_ENDPOINT),
+                                    onSenderClosed -> removeClient(key)),
+                            result);
+                }));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return new StringBuilder(ProtonBasedTelemetrySender.class.getName())
+                .append(" via AMQP 1.0 Messaging Network")
+                .toString();
+    }
+}

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
@@ -35,7 +35,10 @@ import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedCredentialsClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient;
-import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
+import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedEventSender;
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedTelemetrySender;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
@@ -141,11 +144,11 @@ public abstract class AbstractProtocolAdapterApplication {
         Optional.ofNullable(connectionEventProducer())
             .ifPresent(adapter::setConnectionEventProducer);
         adapter.setCredentialsClient(credentialsClient());
-        adapter.setEventSender(downstreamSender());
+        adapter.setEventSender(eventSender());
         adapter.setHealthCheckServer(healthCheckServer);
         adapter.setRegistrationClient(registrationClient);
         adapter.setResourceLimitChecks(resourceLimitChecks);
-        adapter.setTelemetrySender(downstreamSender());
+        adapter.setTelemetrySender(telemetrySender());
         adapter.setTenantClient(tenantClient());
         adapter.setTracer(tracer);
     }
@@ -248,12 +251,24 @@ public abstract class AbstractProtocolAdapterApplication {
     }
 
     /**
-     * Creates a new downstream sender for telemetry and event messages.
+     * Creates a new sender for events.
      *
      * @return The sender.
      */
-    protected ProtonBasedDownstreamSender downstreamSender() {
-        return new ProtonBasedDownstreamSender(
+    protected EventSender eventSender() {
+        return new ProtonBasedEventSender(
+                HonoConnection.newConnection(vertx, config.messaging, tracer),
+                messageSamplerFactory,
+                protocolAdapterProperties);
+    }
+
+    /**
+     * Creates a new sender for telemetry messages.
+     *
+     * @return The sender.
+     */
+    protected TelemetrySender telemetrySender() {
+        return new ProtonBasedTelemetrySender(
                 HonoConnection.newConnection(vertx, config.messaging, tracer),
                 messageSamplerFactory,
                 protocolAdapterProperties);

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -33,7 +33,8 @@ import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedDeviceRegistrati
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient;
 import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
-import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedEventSender;
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedTelemetrySender;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
@@ -56,9 +57,7 @@ import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
-import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.RegistrationConstants;
-import org.eclipse.hono.util.TelemetryConstants;
 import org.eclipse.hono.util.TenantConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -275,13 +274,12 @@ public abstract class AbstractAdapterConfig {
      * @param adapterConfig The protocol adapter's configuration properties.
      * @return The client.
      */
-    @Qualifier(TelemetryConstants.TELEMETRY_ENDPOINT)
     @Bean
     @Scope("prototype")
     public TelemetrySender downstreamTelemetrySender(
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
-        return new ProtonBasedDownstreamSender(downstreamConnection(), samplerFactory, adapterConfig);
+        return new ProtonBasedTelemetrySender(downstreamConnection(), samplerFactory, adapterConfig);
     }
 
     /**
@@ -295,13 +293,12 @@ public abstract class AbstractAdapterConfig {
      * @param adapterConfig The protocol adapter's configuration properties.
      * @return The client.
      */
-    @Qualifier(EventConstants.EVENT_ENDPOINT)
     @Bean
     @Scope("prototype")
     public EventSender downstreamEventSender(
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
-        return new ProtonBasedDownstreamSender(downstreamConnection(), samplerFactory, adapterConfig);
+        return new ProtonBasedEventSender(downstreamConnection(), samplerFactory, adapterConfig);
     }
 
     /**
@@ -344,7 +341,7 @@ public abstract class AbstractAdapterConfig {
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
     public DeviceRegistrationClient registrationClient(
-            final SendMessageSampler.Factory samplerFactory, 
+            final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
 
         return new ProtonBasedDeviceRegistrationClient(
@@ -492,7 +489,7 @@ public abstract class AbstractAdapterConfig {
     @Qualifier(TenantConstants.TENANT_ENDPOINT)
     @Scope("prototype")
     public TenantClient tenantClient(
-            final SendMessageSampler.Factory samplerFactory, 
+            final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
 
         return new ProtonBasedTenantClient(
@@ -666,7 +663,7 @@ public abstract class AbstractAdapterConfig {
     @Bean
     @Scope("prototype")
     public CommandResponseSender commandResponseSender(
-            final SendMessageSampler.Factory samplerFactory, 
+            final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
 
         return new ProtonBasedCommandResponseSender(


### PR DESCRIPTION
Having separate types for the downstream senders makes the qualifiers obsolete and allows leveraging conditional bean creation for multiple implementations by retrieving the beans from Spring's application context.