### PR TITLE
Fix credentials caching and assert cache directives in AbstractCredentialsServiceTest

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/CacheDirective.java
+++ b/core/src/main/java/org/eclipse/hono/util/CacheDirective.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
  * A helper for parsing and creating <em>cache directives</em> compliant with
  * <a href="https://tools.ietf.org/html/rfc2616#section-14.9">RFC 2616, Section 14.9</a>.
  */
-public final class CacheDirective {
+public final class CacheDirective implements Comparable<CacheDirective> {
 
     private static final Pattern PATTERN_MAX_AGE = Pattern.compile("^\\s*max-age\\s*=\\s*(\\d*)\\s*$");
     private static final Pattern PATTERN_NO_CACHE = Pattern.compile("^\\s*no-cache\\s*$");
@@ -168,5 +168,14 @@ public final class CacheDirective {
             return false;
         }
         return true;
+    }
+
+    @Override
+    public int compareTo(final CacheDirective o) {
+        if (isCachingAllowed() == o.isCachingAllowed() == true) {
+            return Long.compare(getMaxAge(), o.getMaxAge());
+        } else {
+            return Boolean.compare(o.isCachingAllowed(), isCachingAllowed());
+        }
     }
 }

--- a/core/src/test/java/org/eclipse/hono/util/CacheDirectiveTest.java
+++ b/core/src/test/java/org/eclipse/hono/util/CacheDirectiveTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class CacheDirectiveTest {
+
+    @Test
+    void shouldCompareCacheDirectivesWhenDifferentMaxAge() {
+        final CacheDirective cacheDirective1 = CacheDirective.maxAgeDirective(1L);
+        final CacheDirective cacheDirective2 = CacheDirective.maxAgeDirective(2L);
+        assertTrue(cacheDirective1.compareTo(cacheDirective2) == -1);
+        assertTrue(cacheDirective2.compareTo(cacheDirective1) == 1);
+    }
+
+    @Test
+    void shouldCompareCacheDirectivesWhenSameMaxAge() {
+        final CacheDirective cacheDirective1 = CacheDirective.maxAgeDirective(1L);
+        final CacheDirective cacheDirective2 = CacheDirective.maxAgeDirective(1L);
+        assertTrue(cacheDirective1.compareTo(cacheDirective2) == 0);
+        assertTrue(cacheDirective2.compareTo(cacheDirective1) == 0);
+    }
+
+    @Test
+    void shouldCompareCacheDirectivesWhenOtherIsNoCache() {
+        final CacheDirective cacheDirective1 = CacheDirective.maxAgeDirective(1L);
+        final CacheDirective cacheDirective2 = CacheDirective.noCacheDirective();
+        assertTrue(cacheDirective1.compareTo(cacheDirective2) == -1);
+        assertTrue(cacheDirective2.compareTo(cacheDirective1) == 1);
+    }
+
+    @Test
+    void shouldCompareCacheDirectivesWhenBothAreNoCache() {
+        final CacheDirective cacheDirective1 = CacheDirective.noCacheDirective();
+        final CacheDirective cacheDirective2 = CacheDirective.noCacheDirective();
+        assertTrue(cacheDirective1.compareTo(cacheDirective2) == 0);
+        assertTrue(cacheDirective2.compareTo(cacheDirective1) == 0);
+    }
+
+    @Test
+    void shouldSortListOfCacheDirectives() {
+        final CacheDirective cacheDirective1 = CacheDirective.maxAgeDirective(1L);
+        final CacheDirective cacheDirective2 = CacheDirective.maxAgeDirective(2L);
+        final CacheDirective cacheDirective3 = CacheDirective.maxAgeDirective(3L);
+        final CacheDirective cacheDirective4 = CacheDirective.noCacheDirective();
+        final CacheDirective[] cacheDirectives = new CacheDirective[]{cacheDirective3, cacheDirective1, cacheDirective4, cacheDirective2};
+        Arrays.sort(cacheDirectives);
+        assertArrayEquals(new CacheDirective[]{cacheDirective1, cacheDirective2, cacheDirective3, cacheDirective4},
+                cacheDirectives);
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsManagementService.java
@@ -29,6 +29,8 @@ import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.Futures;
 import org.eclipse.hono.util.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -209,4 +211,24 @@ public abstract class AbstractCredentialsManagementService implements Credential
         return credentials;
     }
 
+    /**
+     * Resolves the cache directive for a list of credentials.
+     * @param credentials the list of credentials
+     * @return cache directive to use in response
+     */
+    protected CacheDirective resolveCacheDirective(final List<CommonCredential> credentials) {
+        // resolve cache directive for results, use the maximum value of cache directive when there are multiple entries
+        return credentials.stream().map(CommonCredential::getType)
+                .map(this::getCacheDirective)
+                .max(CacheDirective::compareTo)
+                // use cache options for hashed password when results is empty so that empty result get cached
+                .orElseGet(() -> getCacheDirective(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD));
+    }
+
+    /**
+     * Resolves the cache directive for a credentials type.
+     * @param type the type of credentials
+     * @return cache directive to use in response
+     */
+    protected abstract CacheDirective getCacheDirective(String type);
 }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
@@ -325,6 +325,7 @@ public interface AbstractCredentialsServiceTest {
                         assertNotNull(s3.getCacheDirective());
                         if (s3.isOk()) {
                             assertResourceVersion(s3);
+                            assertEquals(Optional.of(getExpectedCacheDirective(type)), s3.getCacheDirective());
                         }
 
                         mangementValidation.accept(s3);
@@ -345,6 +346,9 @@ public interface AbstractCredentialsServiceTest {
                                     ctx.verify(() -> {
 
                                         adapterValidation.accept(s4);
+                                        if (s4.isOk()) {
+                                            assertEquals(getExpectedCacheDirective(type), s4.getCacheDirective());
+                                        }
 
                                         whenComplete.apply();
                                     });

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/AbstractCredentialsServiceTest.java
@@ -325,7 +325,12 @@ public interface AbstractCredentialsServiceTest {
                         assertNotNull(s3.getCacheDirective());
                         if (s3.isOk()) {
                             assertResourceVersion(s3);
-                            assertEquals(Optional.of(getExpectedCacheDirective(type)), s3.getCacheDirective());
+                            final Optional<CacheDirective> expectedCacheDirective = s3.getPayload().stream()
+                                    .map(CommonCredential::getType)
+                                    .map(this::getExpectedCacheDirective)
+                                    .max(CacheDirective::compareTo)
+                                    .or(() -> Optional.of(getExpectedCacheDirective(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD)));
+                            assertEquals(expectedCacheDirective, s3.getCacheDirective());
                         }
 
                         mangementValidation.accept(s3);

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsService.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -608,6 +609,17 @@ public final class FileBasedCredentialsService extends AbstractCredentialsManage
                 .map(CommonCredential::stripPrivateInfo)
                 .collect(Collectors.toList());
 
+        // resolve cache directive for results.
+        // Limit caching to the case when cache directives are the same for all results
+        final Set<CacheDirective> cacheDirectives = result.stream().map(CommonCredential::getType)
+                .distinct()
+                .map(this::getCacheDirective)
+                .collect(Collectors.collectingAndThen(Collectors.toUnmodifiableSet(),
+                        // use cache options for hashed password when results is empty so that empty result gets cached
+                        set -> set.isEmpty() ? Set.of(getCacheDirective(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD)) : set));
+        final Optional<CacheDirective> cacheDirective = cacheDirectives.size() == 1 ?
+                cacheDirectives.stream().findFirst() : Optional.empty();
+
         // note that the result set might be empty
         // however, in this case an empty set of credentials has been
         // registered for the device explicitly and we return
@@ -615,8 +627,7 @@ public final class FileBasedCredentialsService extends AbstractCredentialsManage
         return Future.succeededFuture(
                 OperationResult.ok(HttpURLConnection.HTTP_OK,
                         result,
-                        // TODO check cache directive
-                        Optional.empty(),
+                        cacheDirective,
                         Optional.of(currentVersion)));
     }
 

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -423,7 +423,7 @@ public class ApplicationConfig {
     @Scope("prototype")
     @Profile(Profiles.PROFILE_REGISTRY_MANAGEMENT + " & " + Profiles.PROFILE_TENANT_SERVICE)
     public TenantManagementService tenantManagementService() throws IOException {
-        return new TenantManagementServiceImpl(tenantManagementStore());
+        return new TenantManagementServiceImpl(tenantManagementStore(), tenantServiceProperties());
     }
 
     /**

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -371,7 +371,7 @@ public class ApplicationConfig {
     @Scope("prototype")
     @Profile(Profiles.PROFILE_REGISTRY_ADAPTER)
     public CredentialsService credentialsService() throws IOException {
-        return new CredentialsServiceImpl(devicesAdapterStore());
+        return new CredentialsServiceImpl(devicesAdapterStore(), deviceRegistryServiceProperties());
     }
 
     /**

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.eclipse.hono.deviceregistry.jdbc.config.DeviceServiceProperties;
 import org.eclipse.hono.deviceregistry.service.credentials.AbstractCredentialsService;
 import org.eclipse.hono.deviceregistry.service.credentials.CredentialKey;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
@@ -43,14 +44,17 @@ import io.vertx.core.json.JsonObject;
 public class CredentialsServiceImpl extends AbstractCredentialsService {
 
     private final TableAdapterStore store;
+    private final CacheDirective ttl;
 
     /**
      * Create a new instance.
      *
      * @param store The backing service to use.
+     * @param properties The service properties.
      */
-    public CredentialsServiceImpl(final TableAdapterStore store) {
+    public CredentialsServiceImpl(final TableAdapterStore store, final DeviceServiceProperties properties) {
         this.store = store;
+        this.ttl = CacheDirective.maxAgeDirective(properties.getCredentialsTtl());
     }
 
     @Override
@@ -86,7 +90,7 @@ public class CredentialsServiceImpl extends AbstractCredentialsService {
                             .put(CredentialsConstants.FIELD_AUTH_ID, key.getAuthId())
                             .put(CredentialsConstants.FIELD_SECRETS, new JsonArray(secrets));
 
-                    return CredentialsResult.from(HttpURLConnection.HTTP_OK, payload, CacheDirective.noCacheDirective());
+                    return CredentialsResult.from(HttpURLConnection.HTTP_OK, payload, ttl);
 
                 });
     }

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
@@ -90,9 +90,19 @@ public class CredentialsServiceImpl extends AbstractCredentialsService {
                             .put(CredentialsConstants.FIELD_AUTH_ID, key.getAuthId())
                             .put(CredentialsConstants.FIELD_SECRETS, new JsonArray(secrets));
 
-                    return CredentialsResult.from(HttpURLConnection.HTTP_OK, payload, ttl);
+                    return CredentialsResult.from(HttpURLConnection.HTTP_OK, payload, getCacheDirective(key.getType()));
 
                 });
+    }
+
+    private CacheDirective getCacheDirective(final String type) {
+        switch (type) {
+            case CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD:
+            case CredentialsConstants.SECRETS_TYPE_X509_CERT:
+                return ttl;
+            default:
+                return CacheDirective.noCacheDirective();
+        }
     }
 
     private static boolean filterSecrets(final JsonObject secret) {

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
@@ -79,9 +79,11 @@ public class CredentialsServiceImpl extends AbstractCredentialsService {
                             .filter(CredentialsServiceImpl::filterSecrets)
                             .collect(Collectors.toList());
 
+                    final CacheDirective cacheDirective = resolveCacheDirective(result.getCredentials());
+
                     if (secrets.isEmpty()) {
                         // nothing was left after filtering ... not found
-                        return CredentialsResult.from(HttpURLConnection.HTTP_NOT_FOUND);
+                        return CredentialsResult.from(HttpURLConnection.HTTP_NOT_FOUND, null, cacheDirective);
                     }
 
                     final var payload = new JsonObject()
@@ -90,12 +92,12 @@ public class CredentialsServiceImpl extends AbstractCredentialsService {
                             .put(CredentialsConstants.FIELD_AUTH_ID, key.getAuthId())
                             .put(CredentialsConstants.FIELD_SECRETS, new JsonArray(secrets));
 
-                    return CredentialsResult.from(HttpURLConnection.HTTP_OK, payload, getCacheDirective(key.getType()));
-
+                    return CredentialsResult.from(HttpURLConnection.HTTP_OK, payload, cacheDirective);
                 });
     }
 
-    private CacheDirective getCacheDirective(final String type) {
+    @Override
+    protected CacheDirective getCacheDirective(final String type) {
         switch (type) {
             case CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD:
             case CredentialsConstants.SECRETS_TYPE_X509_CERT:

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/TenantManagementServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/TenantManagementServiceImpl.java
@@ -16,12 +16,14 @@ package org.eclipse.hono.deviceregistry.jdbc.impl;
 import java.net.HttpURLConnection;
 import java.util.Optional;
 
+import org.eclipse.hono.deviceregistry.jdbc.config.TenantServiceProperties;
 import org.eclipse.hono.deviceregistry.service.tenant.AbstractTenantManagementService;
 import org.eclipse.hono.service.base.jdbc.store.tenant.ManagementStore;
 import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.util.CacheDirective;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
@@ -32,14 +34,17 @@ import io.vertx.core.Future;
 public class TenantManagementServiceImpl extends AbstractTenantManagementService {
 
     private final ManagementStore store;
+    private final CacheDirective ttl;
 
     /**
      * Create a new instance.
      *
      * @param store The backing store to use.
+     * @param properties The service properties.
      */
-    public TenantManagementServiceImpl(final ManagementStore store) {
+    public TenantManagementServiceImpl(final ManagementStore store, final TenantServiceProperties properties) {
         this.store = store;
+        this.ttl = CacheDirective.maxAgeDirective(properties.getTenantTtl());
     }
 
     @Override
@@ -69,7 +74,7 @@ public class TenantManagementServiceImpl extends AbstractTenantManagementService
                         .map(tenant -> OperationResult.ok(
                                 HttpURLConnection.HTTP_OK,
                                 tenant.getTenant(),
-                                Optional.empty(),
+                                Optional.of(ttl),
                                 tenant.getResourceVersion()
                         ))
 

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/AbstractJdbcRegistryTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/AbstractJdbcRegistryTest.java
@@ -99,7 +99,8 @@ abstract class AbstractJdbcRegistryTest {
         final var properties = new DeviceServiceProperties();
 
         this.credentialsAdapter = new CredentialsServiceImpl(
-                DeviceStores.adapterStoreFactory().createTable(vertx, TRACER, jdbc, Optional.empty(), Optional.empty(), Optional.empty())
+                DeviceStores.adapterStoreFactory().createTable(vertx, TRACER, jdbc, Optional.empty(), Optional.empty(), Optional.empty()),
+                properties
         );
         this.registrationAdapter = new RegistrationServiceImpl(
                 DeviceStores.adapterStoreFactory().createTable(vertx, TRACER, jdbc, Optional.empty(), Optional.empty(), Optional.empty())

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/AbstractJdbcRegistryTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/AbstractJdbcRegistryTest.java
@@ -197,14 +197,15 @@ abstract class AbstractJdbcRegistryTest {
             RunScript.execute(connection, script);
         }
 
+        final TenantServiceProperties tenantServiceProperties = new TenantServiceProperties();
         this.tenantAdapter = new TenantServiceImpl(
                 Stores.adapterStore(vertx, TRACER, jdbc),
-                new TenantServiceProperties()
+                tenantServiceProperties
         );
 
         this.tenantManagement = new TenantManagementServiceImpl(
-                Stores.managementStore(vertx, TRACER, jdbc)
-        );
+                Stores.managementStore(vertx, TRACER, jdbc),
+                tenantServiceProperties);
     }
 
     public RegistrationService getRegistrationService() {

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/JdbcBasedCredentialsServiceTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/JdbcBasedCredentialsServiceTest.java
@@ -13,7 +13,25 @@
 
 package org.eclipse.hono.deviceregistry.jdbc.impl;
 
+import org.eclipse.hono.deviceregistry.jdbc.config.DeviceServiceProperties;
 import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.CredentialsConstants;
 
 class JdbcBasedCredentialsServiceTest extends AbstractJdbcRegistryTest implements AbstractCredentialsServiceTest {
+    private final CacheDirective expectedCacheDirective = CacheDirective.maxAgeDirective(new DeviceServiceProperties().getCredentialsTtl());
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CacheDirective getExpectedCacheDirective(final String credentialsType) {
+        switch (credentialsType) {
+            case CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD:
+            case CredentialsConstants.SECRETS_TYPE_X509_CERT:
+                return expectedCacheDirective;
+            default:
+                return CacheDirective.noCacheDirective();
+        }
+    }
 }

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/TenantServiceTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/TenantServiceTest.java
@@ -20,10 +20,12 @@ import java.util.Optional;
 
 import javax.security.auth.x500.X500Principal;
 
+import org.eclipse.hono.deviceregistry.jdbc.config.TenantServiceProperties;
 import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.util.Adapter;
+import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.eclipse.hono.util.TenantResult;
@@ -40,6 +42,7 @@ import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
 class TenantServiceTest extends AbstractJdbcRegistryTest {
+    private final CacheDirective expectedCacheDirective = CacheDirective.maxAgeDirective(new TenantServiceProperties().getTenantTtl());
 
     private Handler<AsyncResult<TenantResult<JsonObject>>> assertNotFound(final VertxTestContext context) {
 
@@ -115,6 +118,9 @@ class TenantServiceTest extends AbstractJdbcRegistryTest {
                             assertThat(result.isOk())
                                     .isTrue();
 
+                            assertThat(result.getCacheDirective())
+                                    .isEqualTo(expectedCacheDirective);
+
                             final var json = result.getPayload();
                             assertThat(json)
                                     .isNotNull();
@@ -150,6 +156,9 @@ class TenantServiceTest extends AbstractJdbcRegistryTest {
 
                             assertThat(result.isOk())
                                     .isTrue();
+
+                            assertThat(result.getCacheDirective())
+                                    .hasValue(expectedCacheDirective);
 
                             readManagement.flag();
                         });

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
@@ -22,6 +22,8 @@ import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.CredentialsConstants;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -142,5 +144,19 @@ public class MongoDbBasedCredentialServiceTest implements AbstractCredentialsSer
     @Override
     public DeviceManagementService getDeviceManagementService() {
         return this.deviceBackendService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CacheDirective getExpectedCacheDirective(final String credentialsType) {
+        switch (credentialsType) {
+            case CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD:
+            case CredentialsConstants.SECRETS_TYPE_X509_CERT:
+                return CacheDirective.maxAgeDirective(credentialsServiceConfig.getCacheMaxAge());
+            default:
+                return CacheDirective.noCacheDirective();
+        }
     }
 }


### PR DESCRIPTION
- Credential caching was not used when using JDBC device registry

- the pre-existing `org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest#getExpectedCacheDirective`
  was unused. Modify tests to assert the cache directives of read operations
   - for `CredentialsManagementService.readCredentials` calls
   - for `CredentialsService.get` calls

- also fix gaps in `FileBasedCredentialsService` & `MonoDbBasedCredentialsService`
  - cache `org.eclipse.hono.service.management.credentials.CredentialsManagementService#readCredentials`
    method, this resolves a TODO in `FileBasedCredentialsService`
    - use the maximum cache directive (or no cache) for a result with multiple credentials
    - cache an empty result by resolving the cache directive of `CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD`
