### PR TITLE
[#2068] Use cached connected check result in HotrodCache

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Cache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Cache.java
@@ -30,6 +30,8 @@ public interface Cache<K, V> {
 
     /**
      * Checks if the cache is connected to the data grid.
+     * <p>
+     * If a cache is found to be not connected here, this method may trigger a connection (re)establishment.
      *
      * @return A future that is completed with information about a successful check's result.
      *         Otherwise, the future will be failed with a

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/HotrodCache.java
@@ -13,18 +13,23 @@
 
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.eclipse.hono.client.ServerErrorException;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 
 /**
  * A remote cache that connects to a data grid using the Hotrod protocol.
@@ -36,14 +41,26 @@ public final class HotrodCache<K, V> extends BasicCache<K, V> {
 
     private static final Logger LOG = LoggerFactory.getLogger(HotrodCache.class);
 
+    /**
+     * Maximum age for a cached connection check result to be used in {@link #checkForCacheAvailability()}.
+     */
+    private static final Duration CACHED_CONNECTION_CHECK_RESULT_MAX_AGE = Duration.ofSeconds(30);
+
     private final AtomicBoolean connecting = new AtomicBoolean(false);
     private final RemoteCacheContainer cacheManager;
     private final String cacheName;
 
+    private final K connectionCheckKey;
+    private final V connectionCheckValue;
+
+    private ConnectionCheckResult lastConnectionCheckResult;
+
     /**
+     * Creates a new HotrodCache instance.
+     *
      * @param vertx The vert.x instance to run on.
      * @param cacheManager The connection to the remote cache.
-     * @param name The name of the (remote) cache.
+     * @param cacheName The name of the (remote) cache.
      * @param connectionCheckKey The key to use for checking the connection
      *                           to the data grid.
      * @param connectionCheckValue The value to use for checking the connection
@@ -52,16 +69,18 @@ public final class HotrodCache<K, V> extends BasicCache<K, V> {
     public HotrodCache(
             final Vertx vertx,
             final RemoteCacheContainer cacheManager,
-            final String name,
+            final String cacheName,
             final K connectionCheckKey,
             final V connectionCheckValue) {
-        super(vertx, cacheManager, connectionCheckKey, connectionCheckValue);
+        super(vertx, cacheManager);
         this.cacheManager = Objects.requireNonNull(cacheManager);
-        this.cacheName = Objects.requireNonNull(name);
+        this.cacheName = Objects.requireNonNull(cacheName);
+        this.connectionCheckKey = Objects.requireNonNull(connectionCheckKey);
+        this.connectionCheckValue = Objects.requireNonNull(connectionCheckValue);
     }
 
     @Override
-    protected Future<Void> connectToGrid() {
+    protected Future<Void> connectToCache() {
 
         final Promise<Void> result = Promise.promise();
 
@@ -125,6 +144,80 @@ public final class HotrodCache<K, V> extends BasicCache<K, V> {
                 }
             });
         });
+    }
+
+    @Override
+    protected <T> void postCacheAccess(final AsyncResult<T> cacheOperationResult) {
+        lastConnectionCheckResult = new ConnectionCheckResult(cacheOperationResult.cause());
+    }
+
+    /**
+     * Checks if the cache is connected.
+     *
+     * @return A future that is completed with information about a successful check's result.
+     *         Otherwise, the future will be failed with a {@link ServerErrorException}.
+     */
+    @Override
+    public Future<JsonObject> checkForCacheAvailability() {
+
+        if (isStarted()) {
+            final ConnectionCheckResult lastResult = lastConnectionCheckResult;
+            if (lastResult != null && !lastResult.isOlderThan(CACHED_CONNECTION_CHECK_RESULT_MAX_AGE)) {
+                return lastResult.asFuture();
+            } else {
+                final Promise<JsonObject> result = Promise.promise();
+                put(connectionCheckKey, connectionCheckValue)
+                        .onComplete(r -> {
+                            if (r.succeeded()) {
+                                result.complete(new JsonObject());
+                            } else {
+                                LOG.debug("failed to put test value to cache", r.cause());
+                                result.fail(r.cause());
+                            }
+                        });
+                return result.future();
+            }
+        } else {
+            // try to (re-)establish connection
+            connectToCache();
+            return Future.failedFuture("not connected to data grid");
+        }
+    }
+
+    /**
+     * Keeps the result of a connection check.
+     */
+    private static class ConnectionCheckResult {
+        private final Instant creationTimestamp = Instant.now();
+        private final Throwable errorResult;
+
+        /**
+         * Creates a new ConnectionCheckResult.
+         *
+         * @param errorResult The error in case the check failed; use {@code null} if the check succeeded.
+         */
+        ConnectionCheckResult(final Throwable errorResult) {
+            this.errorResult = errorResult;
+        }
+
+        /**
+         * Checks if the result is older than the given time span, determined from the current point in time.
+         *
+         * @param timespan The time span.
+         * @return {@code true} if the result is older.
+         */
+        public boolean isOlderThan(final Duration timespan) {
+            return creationTimestamp.isBefore(Instant.now().minus(timespan));
+        }
+
+        /**
+         * Gets a future indicating the connection check outcome.
+         *
+         * @return A succeeded future if the check succeeded, otherwise a failed future.
+         */
+        public Future<JsonObject> asFuture() {
+            return errorResult != null ? Future.failedFuture(errorResult) : Future.succeededFuture(new JsonObject());
+        }
     }
 
 }

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/AbstractBasicCacheTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/AbstractBasicCacheTest.java
@@ -44,7 +44,7 @@ import io.vertx.junit5.VertxTestContext;
 
 
 /**
- * Tests verifying behavior of the {@link HotrodCache}.
+ * Tests verifying behavior of the {@link BasicCache}.
  *
  */
 @ExtendWith(VertxExtension.class)

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfoTest.java
@@ -100,7 +100,7 @@ class CacheBasedDeviceConnectionInfoTest {
         final var cacheManager = new DefaultCacheManager(false);
         cacheManager.defineConfiguration("cache-name", new ConfigurationBuilder()
                 .build());
-        cache = new EmbeddedCache<>(vertx, cacheManager, "cache-name", "foo", "bar");
+        cache = new EmbeddedCache<>(vertx, cacheManager, "cache-name");
         cache.start().onComplete(testContext.completing());
 
         span = TracingMockSupport.mockSpan();

--- a/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/EmbeddedCacheTest.java
+++ b/client-device-connection-infinispan/src/test/java/org/eclipse/hono/deviceconnection/infinispan/client/EmbeddedCacheTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.Cache;
+import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +46,7 @@ class EmbeddedCacheTest extends AbstractBasicCacheTest {
     @BeforeEach
     void setUpCache() {
         remoteCacheManager = mock(EmbeddedCacheManager.class);
-        cache = new EmbeddedCache<>(vertx, remoteCacheManager, "cache", "testKey", "testValue");
+        cache = new EmbeddedCache<>(vertx, remoteCacheManager, "cache");
     }
 
     @Override
@@ -53,6 +54,7 @@ class EmbeddedCacheTest extends AbstractBasicCacheTest {
         @SuppressWarnings("unchecked")
         final Cache<Object, Object> result = mock(Cache.class);
         when(remoteCacheManager.getCache(anyString())).thenReturn(result);
+        when(remoteCacheManager.getStatus()).thenReturn(ComponentStatus.RUNNING);
         return result;
     }
 }

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/infinispan/EmbeddedCacheConfig.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/infinispan/EmbeddedCacheConfig.java
@@ -59,13 +59,11 @@ public class EmbeddedCacheConfig {
         return new EmbeddedCache<>(
                 vertx,
                 embeddedCacheManager(cacheConfig),
-                cacheConfig.getCacheName(),
-                cacheConfig.getCheckKey(),
-                cacheConfig.getCheckValue());
+                cacheConfig.getCacheName());
     }
 
     /**
-     * Create a new configuration, either from a configured file, or with some reasonable defaults.
+     * Creates a new configuration, either from a configured file, or with some reasonable defaults.
      *
      * @param cacheConfig Common cache configuration options.
      * @return A new configuration.

--- a/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/EmbeddedCacheConfig.java
+++ b/services/device-connection/src/main/java/org/eclipse/hono/deviceconnection/infinispan/EmbeddedCacheConfig.java
@@ -58,13 +58,11 @@ public class EmbeddedCacheConfig {
         return new EmbeddedCache<>(
                 vertx,
                 embeddedCacheManager(cacheConfig),
-                cacheConfig.getCacheName(),
-                cacheConfig.getCheckKey(),
-                cacheConfig.getCheckValue());
+                cacheConfig.getCacheName());
     }
 
     /**
-     * Create a new configuration, either from a configured file, or with some reasonable defaults.
+     * Creates a new configuration, either from a configured file, or with some reasonable defaults.
      *
      * @param cacheConfig Common cache configuration options.
      * @return A new configuration.

--- a/site/documentation/content/admin-guide/device-connection-config.md
+++ b/site/documentation/content/admin-guide/device-connection-config.md
@@ -98,8 +98,8 @@ The following table provides an overview of the configuration variables and corr
 | Environment Variable<br>Command Line Option | Mandatory | Default | Description                                                             |
 | :------------------------------------------ | :-------: | :------ | :-----------------------------------------------------------------------|
 | `HONO_DEVICECONNECTION_COMMON_CACHENAME`<br>`--hono.deviceConnection.common.cacheName` | no | `device-connection` | The name of the cache |
-| `HONO_DEVICECONNECTION_COMMON_CHECKKEY`<br>`--hono.deviceConnection.common.checkKey` | no | `KEY_CONNECTION_CHECK` | The key used to check the health of the cache. |
-| `HONO_DEVICECONNECTION_COMMON_CHECKVALUE`<br>`--hono.deviceConnection.common.checkValue` | no | `VALUE_CONNECTION_CHECK` | The value used to check the health of the cache. |
+| `HONO_DEVICECONNECTION_COMMON_CHECKKEY`<br>`--hono.deviceConnection.common.checkKey` | no | `KEY_CONNECTION_CHECK` | The key used to check the health of the cache. This is only used in case of a remote cache. |
+| `HONO_DEVICECONNECTION_COMMON_CHECKVALUE`<br>`--hono.deviceConnection.common.checkValue` | no | `VALUE_CONNECTION_CHECK` | The value used to check the health of the cache. This is only used in case of a remote cache. |
 
 The type of the cache is selected on startup by enabling or disabling the
 profile `embedded-cache`. If the profile is enabled the embedded cache is


### PR DESCRIPTION
This fixes #2068:
The `HotrodCache#checkForCacheAvailability()` method will now determine its outcome based on whether the last cache operation was successful or not. It will only "put" the connectionCheckKey/Value if the last cache operation took place more than 30s ago.
The `EmbeddedCache#checkForCacheAvailability()` method now only checks whether the cache instance was successfully obtained, not doing the "put" operation with connectionCheckKey/Value anymore.