### PR TITLE
Include native transport libs by default

### DIFF
--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -78,6 +78,18 @@
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-noop</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <classifier>osx-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- Testing -->
     <dependency>
@@ -108,6 +120,7 @@
     <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>service-base-test-utils</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -132,28 +145,6 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-tcnative</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>netty-native-linux-x86_64</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <classifier>linux-x86_64</classifier>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>netty-native-osx-x86_64</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <classifier>osx-x86_64</classifier>
         </dependency>
       </dependencies>
     </profile>

--- a/core/src/main/java/org/eclipse/hono/config/VertxProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/VertxProperties.java
@@ -22,23 +22,21 @@ import io.vertx.core.metrics.MetricsOptions;
  */
 public class VertxProperties {
 
-    private boolean preferNative = VertxOptions.DEFAULT_PREFER_NATIVE_TRANSPORT;
+    private boolean preferNative = false;
     private boolean enableMetrics = MetricsOptions.DEFAULT_METRICS_ENABLED;
     private long maxEventLoopExecuteTimeMillis = 2000L;
     private long dnsQueryTimeout = 5000L;
 
     /**
-     * Prefer to use native networking, or not.
+     * Prefer to use native networking or not.
      * <p>
      * Also see {@link VertxOptions#setPreferNativeTransport(boolean)}.
-     * </p>
      * <p>
-     * The default is to not prefer native networking.
-     * </p>
+     * The default value of this property is {@code false}.
      *
      * @param preferNative {@code true} to prefer native networking, {@code false} otherwise.
      */
-    public void setPreferNative(final boolean preferNative) {
+    public final void setPreferNative(final boolean preferNative) {
         this.preferNative = preferNative;
     }
 
@@ -55,7 +53,7 @@ public class VertxProperties {
      *
      * @param enableMetrics {@code true} to enable the metrics system, {@code false} otherwise.
      */
-    public void setEnableMetrics(final boolean enableMetrics) {
+    public final void setEnableMetrics(final boolean enableMetrics) {
         this.enableMetrics = enableMetrics;
     }
 
@@ -68,7 +66,7 @@ public class VertxProperties {
      * @param executeTime The number of milliseconds.
      * @throws IllegalArgumentException if execute time is less than 1.
      */
-    public void setMaxEventLoopExecuteTime(final long executeTime) {
+    public final void setMaxEventLoopExecuteTime(final long executeTime) {
         if (executeTime < 1) {
             throw new IllegalArgumentException("maxEventLoopExecuteTime must be > 0");
           }
@@ -84,7 +82,7 @@ public class VertxProperties {
      * @param timeout The timeout in milliseconds.
      * @throws IllegalArgumentException if timeout is less than 100ms.
      */
-    public void setDnsQueryTimeout(final long timeout) {
+    public final void setDnsQueryTimeout(final long timeout) {
         if (timeout < 100) {
             throw new IllegalArgumentException("DNS query timeout must be at least 100ms");
           }
@@ -97,7 +95,7 @@ public class VertxProperties {
      * @param options The options to configure.
      * @return The (updated) options.
      */
-    public VertxOptions configureVertx(final VertxOptions options) {
+    public final VertxOptions configureVertx(final VertxOptions options) {
 
         options.setPreferNativeTransport(this.preferNative);
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -80,6 +80,18 @@
       <artifactId>snakeyaml</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <classifier>osx-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
@@ -118,28 +130,6 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-tcnative</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>netty-native-linux-x86_64</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <classifier>linux-x86_64</classifier>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>netty-native-osx-x86_64</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <classifier>osx-x86_64</classifier>
         </dependency>
       </dependencies>
     </profile>

--- a/site/documentation/content/admin-guide/common-config.md
+++ b/site/documentation/content/admin-guide/common-config.md
@@ -26,23 +26,18 @@ The vert.x framework instance used to run Hono's components on can be configured
 | :------------------------------------------ | :-------: | :------ | :-----------------------------------------------------------------------|
 | `HONO_VERTX_DNS_QUERY_TIMEOUT`<br>`--hono.vertx.dnsQueryTimeout` | no | `5000` | The amount of time (in milliseconds) after which a DNS query is considered to be failed. Setting this variable to a smaller value may help to reduce the time required to establish connections to the services this adapter depends on. However, setting it to a value that is too small for any DNS query to succeed will effectively prevent any connections to be established at all. |
 | `HONO_VERTX_MAX_EVENT_LOOP_EXECUTE_TIME_MILLIS`<br>`--hono.vertx.maxEventLoopExecuteTimeMillis` | no | `2000` | The maximum number of milliseconds that a task on the event loop may run without being considered to block the event loop. |
-| `HONO_VERTX_PREFER_NATIVE`<br>`--hono.vertx.preferNative`| no | `false` | Tries to enable *epoll()* support on Linux (if available). See the [notes below](./#epoll) for an explanation of the benefits of enabling *epoll*. |
+| `HONO_VERTX_PREFER_NATIVE`<br>`--hono.vertx.preferNative`| no | `false` | Enables/disables *epoll()* support on Linux/MacOS. See the [notes below](./#epoll) for an explanation of the benefits of enabling *epoll*. It is generally safe to set this property to `true` because Netty will disable native transport if the platform doesn't support it. |
 
 <a name="epoll"></a>
-### Using epoll() on Linux 
+### Using Native Transport on Linux/MacOS
 
-Using `epoll()` on Linux may provide better performance for applications which
+Using `epoll()` on Linux/MacOS may provide better performance for applications which
 have a high I/O throughput. Especially when the application supports an
 asynchronous I/O model. This is true for most Hono components and applications using Hono.
 
-The *Netty* framework supports using `epoll()` on Linux x86_64 based systems.
-Hono provides a Maven build profile for enabling
-support for *epoll* during the build process.
+The *Netty* framework supports using `epoll()` on Linux/MacOS x86_64 based systems.
 
-In order to use *epoll*
-
-* Hono needs to be built with the `netty-native-linux-x86_64` Maven profile enabled and
-* the `HONO_VERTX_PREFER_NATIVE` environment variable needs to be set to `true` on startup.
+In order to use *epoll*, the `HONO_VERTX_PREFER_NATIVE` environment variable needs to be set to `true` on startup.
 
 ## Protocol Adapter Options
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -105,7 +105,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
 
     <hono.mqtt-adapter.image>hono-adapter-mqtt-vertx</hono.mqtt-adapter.image>
     <hono.mqtt-adapter.config-dir>etc/hono</hono.mqtt-adapter.config-dir>
-    <hono.mqtt-adapter.useNativeTransport>true</hono.mqtt-adapter.useNativeTransport>
 
     <default.java.options>
       -XX:MinRAMPercentage=80
@@ -158,6 +157,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       <version>${project.version}</version>
       <classifier>tests</classifier>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>core-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -220,10 +224,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       <artifactId>netty-transport-native-kqueue</artifactId>
       <classifier>osx-x86_64</classifier>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.hono</groupId>
-      <artifactId>core-test-utils</artifactId>
     </dependency>
   </dependencies>
 
@@ -328,7 +328,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
         <hono.http-adapter.nativeTlsRequired>false</hono.http-adapter.nativeTlsRequired>
         <hono.mqtt-adapter.config-dir>deployments/config</hono.mqtt-adapter.config-dir>
         <hono.mqtt-adapter.image>hono-adapter-mqtt-vertx-quarkus</hono.mqtt-adapter.image>
-        <hono.mqtt-adapter.useNativeTransport>false</hono.mqtt-adapter.useNativeTransport>
       </properties>
     </profile>
     <profile>
@@ -1076,15 +1075,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <basedir>/</basedir>
                       <inline>
                         <id>config</id>
-                        <dependencySets>
-                          <dependencySet>
-                            <includes>
-                              <!--  use native transport in MQTT adapter -->
-                              <include>io.netty:netty-transport-native-*</include>
-                            </includes>
-                            <outputDirectory>opt/hono/extensions</outputDirectory>
-                          </dependencySet>
-                        </dependencySets>
                         <fileSets>
                           <fileSet>
                             <directory>${project.build.directory}/resources/mqtt</directory>

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -75,6 +75,7 @@ hono:
     requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+    preferNative: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/auth/application.yml
+++ b/tests/src/test/resources/auth/application.yml
@@ -18,6 +18,7 @@ hono:
         tokenExpiration: 3600
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+    preferNative: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -74,6 +74,7 @@ hono:
     requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+    preferNative: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/commandrouter/application.yml
+++ b/tests/src/test/resources/commandrouter/application.yml
@@ -37,6 +37,7 @@ hono:
     requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+    preferNative: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/deviceconnection/application.yml
+++ b/tests/src/test/resources/deviceconnection/application.yml
@@ -17,6 +17,7 @@ hono:
       insecurePortBindAddress: 0.0.0.0
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+    preferNative: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/deviceregistry-jdbc/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc/application.yml
@@ -53,6 +53,7 @@ hono:
 
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+    preferNative: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/deviceregistry-mongodb/application.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/application.yml
@@ -33,6 +33,7 @@ hono:
     password: ${hono.mongodb.password}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+    preferNative: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/deviceregistry/application.yml
+++ b/tests/src/test/resources/deviceregistry/application.yml
@@ -32,6 +32,7 @@ hono:
       saveToFile: false
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+    preferNative: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -75,6 +75,7 @@ hono:
     requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
+    preferNative: true
 
 quarkus:
   log:
@@ -86,6 +87,8 @@ quarkus:
         level: INFO
       "org.eclipse.hono.adapter":
         level: INFO
+  vertx:
+    prefer-native-transport: true
 
 spring:
   jmx:

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -75,7 +75,7 @@ hono:
     requestTimeout: ${request.timeout}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
-    preferNative: ${hono.mqtt-adapter.useNativeTransport}
+    preferNative: true
 
 quarkus:
   log:
@@ -87,6 +87,8 @@ quarkus:
         level: INFO
       "org.eclipse.hono.adapter":
         level: INFO
+  vertx:
+    prefer-native-transport: true
 
 spring:
   jmx:


### PR DESCRIPTION
All of Hono's service components now include Netty's native transport
libraries by default. The libraries are license compatible with EPL so
there is no reason to not include them by default and then allow users
to simply enable native transport using the existing configuration
property.