### PR TITLE
[#2333] Use ANYCAST routing type in broker config

### DIFF
--- a/deploy/src/main/sandbox/artemis/broker.xml
+++ b/deploy/src/main/sandbox/artemis/broker.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--
-    Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -146,6 +146,7 @@
             <auto-create-addresses>true</auto-create-addresses>
             <auto-create-jms-queues>true</auto-create-jms-queues>
             <auto-create-jms-topics>true</auto-create-jms-topics>
+            <default-address-routing-type>ANYCAST</default-address-routing-type>
          </address-setting>
       </address-settings>
 

--- a/tests/src/test/resources/artemis/broker.xml
+++ b/tests/src/test/resources/artemis/broker.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 
 <!--
-    Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -143,6 +143,7 @@
             <auto-create-addresses>true</auto-create-addresses>
             <auto-create-jms-queues>true</auto-create-jms-queues>
             <auto-create-jms-topics>true</auto-create-jms-topics>
+            <default-address-routing-type>ANYCAST</default-address-routing-type>
          </address-setting>
       </address-settings>
 


### PR DESCRIPTION
This fixes #2333:
This fixes the issue of broker queues not getting created when event messages are sent and of event messages getting forwarded to multiple consumers.

Integration tests verifying the behaviour will be added in a separate PR (prepared by @kaniyan).