### PR TITLE
[#2338] Fix NPE in AMQP adapter when content-type is null.

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
@@ -101,11 +101,14 @@ public class AmqpContext extends MapBasedTelemetryExecutionContext {
 
     /**
      * Gets the content type of the AMQP 1.0 message.
+     * <p>
+     * If the message does not contain a content type, the {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM default
+     * content type} is returned.
      *
      * @return The content type of the AMQP 1.0 message.
      */
     final String getMessageContentType() {
-        return message.getContentType();
+        return Optional.ofNullable(message.getContentType()).orElse(MessageHelper.CONTENT_TYPE_OCTET_STREAM);
     }
 
     /**

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -334,6 +334,32 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     }
 
     /**
+     * Verifies that a request to upload telemetry message without a content-type set results in the adapter setting
+     * {@link MessageHelper#CONTENT_TYPE_OCTET_STREAM} as the content-type before uploading the message.
+     */
+    @Test
+    public void testUploadTelemetryWithoutContentType() {
+        // GIVEN an AMQP adapter with a configured server
+        givenAnAdapter(properties);
+
+        // IF a device sends telemetry data (with un-settled delivery)
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        when(delivery.remotelySettled()).thenReturn(false);
+        final String to = ResourceIdentifier
+                .from(TelemetryConstants.TELEMETRY_ENDPOINT_SHORT, TEST_TENANT_ID, TEST_DEVICE).toString();
+
+        // AND without a content-type set
+        final Message mockMessage = ProtonHelper.message(to, "payload");
+
+        adapter.onMessageReceived(AmqpContext.fromMessage(delivery, mockMessage, span, null));
+
+        // THEN the sender sends the message with the content-type "application/octet-stream"
+        assertTelemetryMessageHasBeenSentDownstream(QoS.AT_LEAST_ONCE, TEST_TENANT_ID, TEST_DEVICE,
+                "application/octet-stream");
+
+    }
+
+    /**
      * Verifies that a request to upload an "unsettled" telemetry message from a device that belongs to a tenant for which the AMQP
      * adapter is disabled fails and that the device is notified when the message cannot be processed.
      *


### PR DESCRIPTION
This patch fixes #2338 by setting "application/octet-stream" as the content-type if nothing is set (analogous to the MQTT adapter).
