### PR TITLE
Fix getContentType() returning empty string

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
@@ -171,8 +171,8 @@ public final class MqttContext extends MapBasedTelemetryExecutionContext {
     /**
      * Gets the content type of the message payload.
      * <p>
-     * The type determined from the message topic's property
-     * bag, if if contains a content type.
+     * The type is determined from the message topic's property
+     * bag, if it contains a content type.
      * Otherwise, the {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM default
      * content type} is used.
      *

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
@@ -22,6 +22,7 @@ import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TelemetryExecutionContext;
@@ -175,14 +176,20 @@ public final class HttpContext implements TelemetryExecutionContext {
     }
 
     /**
-     * Gets the value of the <em>Content-Type</em> HTTP header for a request.
+     * Gets the content type of the request payload.
+     * <p>
+     * The type is determined from the <em>Content-Type</em> HTTP header of the
+     * request, if that header is set.
+     * Otherwise, the {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM default
+     * content type} is used.
      *
-     * @return The content type or {@code null} if the request doesn't contain a
-     *         <em>Content-Type</em> header.
+     * @return The type of the request payload.
      */
     public String getContentType() {
 
-        return routingContext.parsedHeaders().contentType().value();
+        final String contentType = routingContext.parsedHeaders().contentType().value();
+        // contentType will be an empty string here if header isn't set
+        return Strings.isNullOrEmpty(contentType) ? MessageHelper.CONTENT_TYPE_OCTET_STREAM : contentType;
     }
 
     private boolean isEventEndpoint() {


### PR DESCRIPTION
A not-set 'Content-Type' header caused an empty String to be returned by getContentType() although 'null' was
documented in the javadoc.
Since the AMQP message anyway gets the "application/octet-stream" content type in that case, the getContentType() method now returns "application/octet-stream" as the default (returning 'null' would have produced an NPE down the line).

Related to #2338.

Another option would have been returning `null` here and throwing a "BAD_REQUEST" error in the calling method when sending telemetry/events. That would be in accordance with the documentation as the content-type header is required, but I'd rather not introduce such a behaviour change that may break clients, instead keeping the behaviour analogous with MQTT and AMQP adapters (the CoAP adapter returns "BAD_REQUEST" though).