### PR TITLE
1.4.x: Let getContentType() return null if no header is set

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
@@ -22,7 +22,6 @@ import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.ExecutionContext;
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TelemetryExecutionContext;
@@ -145,20 +144,16 @@ public final class HttpContext implements TelemetryExecutionContext {
     }
 
     /**
-     * Gets the content type of the request payload.
-     * <p>
-     * The type is determined from the <em>Content-Type</em> HTTP header of the
-     * request, if that header is set.
-     * Otherwise, the {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM default
-     * content type} is used.
+     * Gets the value of the <em>Content-Type</em> HTTP header for a request.
      *
-     * @return The type of the request payload.
+     * @return The content type or {@code null} if the request doesn't contain a
+     *         <em>Content-Type</em> header.
      */
     public String getContentType() {
 
         final String contentType = routingContext.parsedHeaders().contentType().value();
         // contentType will be an empty string here if header isn't set
-        return Strings.isNullOrEmpty(contentType) ? MessageHelper.CONTENT_TYPE_OCTET_STREAM : contentType;
+        return Strings.isNullOrEmpty(contentType) ? null : contentType;
     }
 
     /**

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -9,8 +9,8 @@ title = "Release Notes"
 * The HTTP adapter did not properly forward the QoS level for events when the *qos-level* header is not set 
   or set to AT_MOST_ONCE. This has been fixed.
 * An HTTP device sending a command response request with no `Content-Type` header meant that the northbound
-  application received a message with an empty content type. Now, the `application/octet-stream`
-  content type is set, as it is also done for telemetry/event HTTP requests with no `Content-Type` header.
+  application received a message with the content type set to an empty string. Now, the content type property
+  isn't set in this case.
 
 ## 1.4.3
 


### PR DESCRIPTION
This reverts the behaviour introduced in the last commit of using CONTENT_TYPE_OCTET_STREAM as default.
Instead, null is returned to also enable usage of the tenant default content type if set.

Applies the getContentType() change suggested in #2340 (but omits the other changes to keep this only a small change in 1.4.x).