### PR TITLE
Allow null contentType in Event/Telemetry Sender

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/AmqpContext.java
@@ -101,14 +101,11 @@ public class AmqpContext extends MapBasedTelemetryExecutionContext {
 
     /**
      * Gets the content type of the AMQP 1.0 message.
-     * <p>
-     * If the message does not contain a content type, the {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM default
-     * content type} is returned.
      *
-     * @return The content type of the AMQP 1.0 message.
+     * @return The content type or {@code null} if not set.
      */
     final String getMessageContentType() {
-        return Optional.ofNullable(message.getContentType()).orElse(MessageHelper.CONTENT_TYPE_OCTET_STREAM);
+        return message.getContentType();
     }
 
     /**

--- a/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx/src/test/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapterTest.java
@@ -334,32 +334,6 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     }
 
     /**
-     * Verifies that a request to upload telemetry message without a content-type set results in the adapter setting
-     * {@link MessageHelper#CONTENT_TYPE_OCTET_STREAM} as the content-type before uploading the message.
-     */
-    @Test
-    public void testUploadTelemetryWithoutContentType() {
-        // GIVEN an AMQP adapter with a configured server
-        givenAnAdapter(properties);
-
-        // IF a device sends telemetry data (with un-settled delivery)
-        final ProtonDelivery delivery = mock(ProtonDelivery.class);
-        when(delivery.remotelySettled()).thenReturn(false);
-        final String to = ResourceIdentifier
-                .from(TelemetryConstants.TELEMETRY_ENDPOINT_SHORT, TEST_TENANT_ID, TEST_DEVICE).toString();
-
-        // AND without a content-type set
-        final Message mockMessage = ProtonHelper.message(to, "payload");
-
-        adapter.onMessageReceived(AmqpContext.fromMessage(delivery, mockMessage, span, null));
-
-        // THEN the sender sends the message with the content-type "application/octet-stream"
-        assertTelemetryMessageHasBeenSentDownstream(QoS.AT_LEAST_ONCE, TEST_TENANT_ID, TEST_DEVICE,
-                "application/octet-stream");
-
-    }
-
-    /**
      * Verifies that a request to upload an "unsettled" telemetry message from a device that belongs to a tenant for which the AMQP
      * adapter is disabled fails and that the device is notified when the message cannot be processed.
      *

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttContext.java
@@ -116,8 +116,7 @@ public final class MqttContext extends MapBasedTelemetryExecutionContext {
                 result.topic = bag.topicWithoutPropertyBag();
                 result.endpoint = MetricsTags.EndpointType.fromString(result.topic.getEndpoint());
                 // set the content-type using the corresponding value from the property bag
-                result.contentType = Optional.ofNullable(bag.getProperty(MessageHelper.SYS_PROPERTY_CONTENT_TYPE))
-                        .orElse(MessageHelper.CONTENT_TYPE_OCTET_STREAM);
+                result.contentType = bag.getProperty(MessageHelper.SYS_PROPERTY_CONTENT_TYPE);
                 if (result.endpoint == EndpointType.EVENT) {
                     result.timeToLive = determineTimeToLive(bag);
                 }
@@ -171,12 +170,11 @@ public final class MqttContext extends MapBasedTelemetryExecutionContext {
     /**
      * Gets the content type of the message payload.
      * <p>
-     * The type is determined from the message topic's property
+     * The type has either been set via {@link #setContentType(String)}
+     * or it is the type determined from the message topic's property
      * bag, if it contains a content type.
-     * Otherwise, the {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM default
-     * content type} is used.
      *
-     * @return The type of the message payload.
+     * @return The type of the message payload or {@code null} if the type is unknown.
      */
     public String contentType() {
         return contentType;

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/impl/HttpBasedMessageMapping.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/impl/HttpBasedMessageMapping.java
@@ -120,7 +120,9 @@ public final class HttpBasedMessageMapping implements MessageMapping<MqttContext
             }
         });
         headers.add(MessageHelper.APP_PROPERTY_ORIG_ADDRESS, ctx.message().topicName());
-        headers.add(HttpHeaders.CONTENT_TYPE.toString(), ctx.contentType());
+        if (ctx.contentType() != null) {
+            headers.add(HttpHeaders.CONTENT_TYPE.toString(), ctx.contentType());
+        }
 
         final Promise<MappedMessage> result = Promise.promise();
 

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -834,7 +834,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
                             argThat(tenant -> tenant.getTenantId().equals("my-tenant")),
                             argThat(assertion -> assertion.getDeviceId().equals("4712")),
                             eq(QoS.AT_LEAST_ONCE),
-                            anyString(),
+                            any(),
                             any(),
                             argThat(props -> props.get(MessageHelper.ANNOTATION_X_OPT_RETAIN).equals(Boolean.TRUE)),
                             any());

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
@@ -118,7 +118,6 @@ public class ProtonBasedDownstreamSender extends SenderCachingServiceClient impl
         Objects.requireNonNull(tenant);
         Objects.requireNonNull(device);
         Objects.requireNonNull(qos);
-        Objects.requireNonNull(contentType);
 
         return getOrCreateTelemetrySender(tenant.getTenantId())
             .compose(sender -> {
@@ -148,7 +147,6 @@ public class ProtonBasedDownstreamSender extends SenderCachingServiceClient impl
 
         Objects.requireNonNull(tenant);
         Objects.requireNonNull(device);
-        Objects.requireNonNull(contentType);
 
         return getOrCreateEventSender(tenant.getTenantId())
                 .compose(sender -> {

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/EventSender.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/EventSender.java
@@ -47,7 +47,7 @@ public interface EventSender extends Lifecycle {
      *         The future will be failed with a {@code org.eclipse.hono.client.ServerErrorException} if the data
      *         could not be sent. The error code contained in the exception indicates the
      *         cause of the failure.
-     * @throws NullPointerException if tenant ID, device ID or contentType are {@code null}.
+     * @throws NullPointerException if tenant ID or device ID are {@code null}.
      */
     Future<Void> sendEvent(
             TenantObject tenant,

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/TelemetrySender.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/TelemetrySender.java
@@ -50,7 +50,7 @@ public interface TelemetrySender extends Lifecycle {
      *         The future will be failed with a {@code org.eclipse.hono.client.ServerErrorException} if the data
      *         could not be sent. The error code contained in the exception indicates the
      *         cause of the failure.
-     * @throws NullPointerException if tenant, device, qos or contentType are {@code null}.
+     * @throws NullPointerException if tenant, device or qos are {@code null}.
      */
     Future<Void> sendTelemetry(
             TenantObject tenant,

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpContext.java
@@ -22,7 +22,6 @@ import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TelemetryExecutionContext;
@@ -176,20 +175,16 @@ public final class HttpContext implements TelemetryExecutionContext {
     }
 
     /**
-     * Gets the content type of the request payload.
-     * <p>
-     * The type is determined from the <em>Content-Type</em> HTTP header of the
-     * request, if that header is set.
-     * Otherwise, the {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM default
-     * content type} is used.
+     * Gets the value of the <em>Content-Type</em> HTTP header for a request.
      *
-     * @return The type of the request payload.
+     * @return The content type or {@code null} if the request doesn't contain a
+     *         <em>Content-Type</em> header.
      */
     public String getContentType() {
 
         final String contentType = routingContext.parsedHeaders().contentType().value();
         // contentType will be an empty string here if header isn't set
-        return Strings.isNullOrEmpty(contentType) ? MessageHelper.CONTENT_TYPE_OCTET_STREAM : contentType;
+        return Strings.isNullOrEmpty(contentType) ? null : contentType;
     }
 
     private boolean isEventEndpoint() {

--- a/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/AbstractProtocolAdapterBaseTest.java
@@ -591,7 +591,7 @@ public class AbstractProtocolAdapterBaseTest {
         when(eventSender.sendEvent(
                 any(TenantObject.class),
                 any(RegistrationAssertion.class),
-                anyString(),
+                any(),
                 any(),
                 any(),
                 any())).thenReturn(Future.succeededFuture());

--- a/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
+++ b/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
@@ -316,7 +316,7 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
                 any(TenantObject.class),
                 any(RegistrationAssertion.class),
                 any(org.eclipse.hono.util.QoS.class),
-                anyString(),
+                any(),
                 any(),
                 any(),
                 any())).thenReturn(outcome.future());
@@ -348,7 +348,7 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
         when(this.eventSender.sendEvent(
                 any(TenantObject.class),
                 any(RegistrationAssertion.class),
-                anyString(),
+                any(),
                 any(),
                 any(),
                 any())).thenReturn(outcome.future());


### PR DESCRIPTION
This makes it possible that a content-type defined in the defaults of a tenant can be used as fallback.
This provides an alternative fix for #2338.

See also discussion in #2340 (changes regarding usage of "application/octet-stream" as default will go in separate PR).