### PR TITLE
[#2133] Improve message mapping API

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MessageMapping.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MessageMapping.java
@@ -31,15 +31,23 @@ public interface MessageMapping<T extends ExecutionContext> {
 
     /**
      * Maps a message uploaded by a device.
+     * <p>
+     * If a mapping service is not configured for a gateway or a protocol adapter, this method returns
+     * a successful future containing the original device payload and target address. If a mapping service is configured for a gateway
+     * or a protocol adapter and the mapping service returns a 200 OK HTTP status code, then this method returns a successful
+     * future containing the mapped payload.
+     * <p>
+     * For all other 2XX HTTP status codes, this method returns a mapped message containing the original device payload and 
+     * target address. In all other cases, this method returns a failed future with a {@link org.eclipse.hono.client.ServiceInvocationException}.
      *
-     * @param ctx The context in which the message has been uploaded.
-     * @param targetAddress The downstream address that the message will be forwarded to.
+     * @param ctx              The context in which the message has been uploaded.
+     * @param targetAddress    The downstream address that the message will be forwarded to.
      * @param registrationInfo The information included in the registration assertion for
      *                         the authenticated device that has uploaded the message.
-     * @return A future indicating the outcome of the operation.
-     *         The future will be completed with the mapped message or failed with
-     *         a {@link org.eclipse.hono.client.ServiceInvocationException} if the
-     *         message could not be mapped.
+     * @return                 A successful future containing either the mapped message or {@code null} if no mapper is configured.
+     *                         Otherwise, the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} if the
+     *                         message could not be mapped.
+     *
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     Future<MappedMessage> mapMessage(

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/impl/HttpBasedMessageMapping.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/impl/HttpBasedMessageMapping.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.adapter.mqtt.impl;
 
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -22,6 +23,7 @@ import org.eclipse.hono.adapter.mqtt.MappedMessage;
 import org.eclipse.hono.adapter.mqtt.MessageMapping;
 import org.eclipse.hono.adapter.mqtt.MqttContext;
 import org.eclipse.hono.adapter.mqtt.MqttProtocolAdapterProperties;
+import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.MapperEndpoint;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistrationAssertion;
@@ -42,7 +44,6 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 
 /**
  * A message mapper that calls out to a service implementation using HTTP.
@@ -127,28 +128,36 @@ public final class HttpBasedMessageMapping implements MessageMapping<MqttContext
         webClient.post(mapperEndpoint.getPort(), mapperEndpoint.getHost(), mapperEndpoint.getUri())
             .putHeaders(headers)
             .ssl(mapperEndpoint.isTlsEnabled())
-            .expect(ResponsePredicate.SC_OK)
             .sendBuffer(ctx.message().payload(), httpResponseAsyncResult -> {
-                if (httpResponseAsyncResult.succeeded()) {
-                    final HttpResponse<Buffer> httpResponse = httpResponseAsyncResult.result();
-
-                    final Map<String, String> additionalProperties = new HashMap<>();
-                    httpResponse.headers().forEach(entry -> additionalProperties.put(entry.getKey(), entry.getValue()));
-
-                    final String mappedDeviceId = Optional.ofNullable(additionalProperties.remove(MessageHelper.APP_PROPERTY_DEVICE_ID))
-                            .map(id -> {
-                                LOG.debug("original {} has been mapped to [device-id: {}]", ctx.authenticatedDevice(), id);
-                                return id;
-                            })
-                            .orElseGet(() -> targetAddress.getResourceId());
-
-                    result.complete(new MappedMessage(
-                            ResourceIdentifier.from(targetAddress.getEndpoint(), targetAddress.getTenantId(), mappedDeviceId),
-                            httpResponse.bodyAsBuffer(),
-                            additionalProperties));
-                } else {
+                if (httpResponseAsyncResult.failed()) {
                     LOG.debug("mapping of message published by {} failed", ctx.authenticatedDevice(), httpResponseAsyncResult.cause());
-                    result.complete(new MappedMessage(targetAddress, ctx.message().payload()));
+                    result.fail(new ServiceInvocationException(HttpURLConnection.HTTP_INTERNAL_ERROR, httpResponseAsyncResult.cause()));
+                } else {
+                    final HttpResponse<Buffer> httpResponse = httpResponseAsyncResult.result();
+                    if (httpResponse.statusCode() == HttpURLConnection.HTTP_OK) {
+                        final Map<String, String> additionalProperties = new HashMap<>();
+                        httpResponse.headers().forEach(entry -> additionalProperties.put(entry.getKey(), entry.getValue()));
+
+                        final String mappedDeviceId = Optional.ofNullable(additionalProperties.remove(MessageHelper.APP_PROPERTY_DEVICE_ID))
+                                .map(id -> {
+                                    LOG.debug("original {} has been mapped to [device-id: {}]", ctx.authenticatedDevice(), id);
+                                    return id;
+                                })
+                                .orElseGet(() -> targetAddress.getResourceId());
+
+                        result.complete(new MappedMessage(
+                                ResourceIdentifier.from(targetAddress.getEndpoint(), targetAddress.getTenantId(), mappedDeviceId),
+                                httpResponse.bodyAsBuffer(),
+                                additionalProperties));
+                    } else {
+                        if (httpResponse.statusCode() > 200 && httpResponse.statusCode() < 300) {
+                            result.complete(new MappedMessage(targetAddress, ctx.message().payload()));
+                        } else {
+                            result.fail(new ServiceInvocationException(httpResponse.statusCode(),
+                                    String.format("Payload mapping failed [DeviceId=%s, StatusCode=%s]",
+                                                targetAddress.getResourceId(), httpResponse.statusCode())));
+                        }
+                    }
                 }
                 resultHandler.handle(result.future());
             });

--- a/core/src/main/java/org/eclipse/hono/config/MapperEndpoint.java
+++ b/core/src/main/java/org/eclipse/hono/config/MapperEndpoint.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.config;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Objects;
 
 /**
@@ -77,9 +79,14 @@ public final class MapperEndpoint {
      *
      * @param uri The uri.
      * @throws NullPointerException if uri is {@code null}.
+     * @throws IllegalArgumentException if the URI cannot be parsed to a URI referenced as specified in RFC&nbsp;2396.
      */
     public void setUri(final String uri) {
-        this.uri = Objects.requireNonNull(uri);
+        Objects.requireNonNull(uri);
+        if (!isUriValid(uri)) {
+            throw new IllegalArgumentException("Invalid mapper URI");
+        }
+        this.uri = uri;
     }
 
     /**
@@ -118,10 +125,20 @@ public final class MapperEndpoint {
      */
     public static MapperEndpoint from(final String host, final int port, final String uri, final boolean tlsEnabled) {
         final MapperEndpoint ep = new MapperEndpoint();
-        ep.host = host;
-        ep.port = port;
-        ep.uri = uri;
-        ep.tlsEnabled = tlsEnabled;
+        ep.setHost(host);
+        ep.setPort(port);
+        ep.setUri(uri);
+        ep.setTlsEnabled(tlsEnabled);
         return ep;
     }
+
+    private boolean isUriValid(final String uri) {
+        try {
+            new URI(uri);
+            return true;
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>

@BobClaerhout @sophokles73 sorry, this took quiet sometime :-) This patch addresses the cases discussed in #2133

> No mapping service is configured for the gateway.

The default mapper now returns a `null` result in this case. The MQTT adapter checks for the presence of a null value and forwards the original message without any mapping

> Mapping service is configured for the gateway but invocation of the service results in an error status code.

We distinguish between success codes (2XX) and error codes (4XX, 5XX). The 200 status code results in a mapped message with the mapped payload and target address while status codes > 200 results in a mapped message with the original payload  and target address

