### PR TITLE
1.3.x: [#2346] Fix ConnectionEvent messages not getting sent

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/monitoring/AbstractMessageSenderConnectionEventProducer.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.hono.service.monitoring;
 
-import java.time.Duration;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
@@ -108,15 +107,14 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                     }
 
                     final ResourceIdentifier target = ResourceIdentifier.from(EventConstants.EVENT_ENDPOINT, tenantId, deviceId);
-                    final Duration timeToLive = Duration.ofSeconds(tenant.getResourceLimits().getMaxTtl());
 
                     return MessageHelper.newMessage(
                             QoS.AT_LEAST_ONCE,
                             target,
                             EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE,
                             payload.toBuffer(), 
-                            tenant, 
-                            timeToLive,
+                            tenant,
+                            null,
                             protocolAdapter);
                 })
                 .compose(msg -> downstreamSender.result().send(msg));


### PR DESCRIPTION
Fix for #2346 (1.3.x):
Using the tenant maxTtl as the ttl parameter value in the `MessageHelper.newMessage()` invocation has been removed since
the tenant maxTtl will be taken into account in `MessageHelper.newMessage()` anyway.