### PR TITLE
Apply default content type in setPayload()

### DIFF
--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/EventSender.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/EventSender.java
@@ -34,7 +34,11 @@ public interface EventSender extends Lifecycle {
      *
      * @param tenant The tenant that the device belongs to.
      * @param device The registration assertion for the device that the data originates from.
-     * @param contentType The content type of the data.
+     * @param contentType The content type of the data. If {@code null}, the used content type will
+     *                    either be derived from the given properties or the tenant's default
+     *                    properties (if set) or it will be set to the
+     *                    {@linkplain org.eclipse.hono.util.MessageHelper#CONTENT_TYPE_OCTET_STREAM default content type}
+     *                    if the given payload isn't {@code null}.
      * @param payload The data to send.
      * @param properties Additional meta data that should be included in the downstream message.
      * @param context The currently active OpenTracing span (may be {@code null}). An implementation

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/TelemetrySender.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/TelemetrySender.java
@@ -36,7 +36,11 @@ public interface TelemetrySender extends Lifecycle {
      * @param tenant The tenant that the device belongs to.
      * @param device The registration assertion for the device that the data originates from.
      * @param qos The delivery semantics to use for sending the data.
-     * @param contentType The content type of the data.
+     * @param contentType The content type of the data. If {@code null}, the used content type will
+     *                    either be derived from the given properties or the tenant's default
+     *                    properties (if set) or it will be set to the
+     *                    {@linkplain org.eclipse.hono.util.MessageHelper#CONTENT_TYPE_OCTET_STREAM default content type}
+     *                    if the given payload isn't {@code null}.
      * @param payload The data to send.
      * @param properties Additional meta data that should be included in the downstream message.
      * @param context The currently active OpenTracing span (may be {@code null}). An implementation


### PR DESCRIPTION
Based on the discussion in #2340:
The "application/octet-stream" content type now gets applied as default in the setPayload() methods, provided the payload isn't null. The "payload not null" condition is now also used in the other places where the content type gets set.

This effectively means:
- non telemetry/event messages (e.g. command response messages), that aren't empty, get the "application/octet-stream" content type as default as well
- a telemetry/event AMQP message without payload and content type, sent to the AMQP adapter, will now be forwarded without a content type.
- a default content type defined in the tenant configuration will now only get applied if the payload isn't null (this probably only applies to telemetry/event AMQP messages without payload sent to the AMQP adapter).

Note the extra handling of "application/vnd.eclipse-hono-empty-notification" in setPayload, getting set also for a `null` payload: This allows for the places where such empty events get sent to keep using a `null` payload.