### PR TITLE
Add 'to' address in AMQP device command message

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -938,6 +938,10 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
         } else {
 
             final Message msg = ProtonHelper.message();
+            msg.setAddress(String.format("%s/%s/%s",
+                    CommandConstants.COMMAND_ENDPOINT,
+                    command.getTenant(),
+                    command.getOriginalDeviceId()));
             msg.setCorrelationId(command.getCorrelationId());
             msg.setSubject(command.getName());
             MessageHelper.setPayload(msg, command.getContentType(), command.getPayload());

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -271,6 +271,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                     ctx.verify(() -> {
                         assertThat(msg.getReplyTo()).isNull();
                         assertThat(msg.getSubject()).isEqualTo("setValue");
+                        assertThat(msg.getAddress())
+                                .isEqualTo(endpointConfig.getCommandMessageAddress(tenantId, commandTargetDeviceId));
                     });
                     log.debug("received command [name: {}]", msg.getSubject());
                     ProtonHelper.accepted(delivery, true);


### PR DESCRIPTION
Preserving the behaviour of Hono 1.4, a command message sent to an AMQP device should have the 'to' address set as it was set on the AMQP message sent by the northbound application.
