### PR TITLE
[#2250] Use Jaeger profile in standard build instructions

### DIFF
--- a/site/documentation/content/deployment/helm-based-deployment.md
+++ b/site/documentation/content/deployment/helm-based-deployment.md
@@ -31,7 +31,7 @@ Once the source code has been retrieved, the build process can be started using 
 
 ~~~sh
 # in base directory of Hono working tree:
-mvn clean install -Pbuild-docker-image,metrics-prometheus
+mvn clean install -Pbuild-docker-image,metrics-prometheus,jaeger
 ~~~
 
 After the build process has finished, the custom container images need to be pushed to the registry so that the
@@ -90,7 +90,7 @@ In any case the build process can be started using the following command:
 
 ~~~sh
 # in base directory of Hono working tree:
-mvn clean install -Pbuild-docker-image,metrics-prometheus
+mvn clean install -Pbuild-docker-image,metrics-prometheus,jaeger
 ~~~
 The newly built images can then be deployed using Helm:
 

--- a/site/documentation/content/dev-guide/building_hono.md
+++ b/site/documentation/content/dev-guide/building_hono.md
@@ -45,7 +45,7 @@ Run the following from the source folder:
 
 ```sh
 # in the "hono" folder containing the source code
-mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus
+mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus,jaeger
 ```
 
 with `${host}` and `${port}` reflecting the name/IP address and port of the host where Docker is running on. This will build all libraries, Docker images and example code. If you are running on Linux and Docker is installed locally or you have set the `DOCKER_HOST` environment variable, you can omit the `-Ddocker.host` property definition.
@@ -66,7 +66,7 @@ The default value for *docker.image.org-name* is `eclipse`. The following build 
 and the `custom` repository name:
 
 ```sh
-mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus -Ddocker.registry-name=quay.io -Ddocker.image.org-name=custom
+mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus,jaeger -Ddocker.registry-name=quay.io -Ddocker.image.org-name=custom
 ```
 
 #### Building native Images
@@ -88,7 +88,7 @@ Support for *native* images is an experimental feature. The `build-native-image`
 The container images that are created as part of the build process can be automatically pushed to a container registry using the `docker-push-image` Maven profile:
 
 ```sh
-mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus,docker-push-image
+mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus,jaeger,docker-push-image
 ```
 
 Note that the container registry might require authentication in order to push images. The build uses the Docker Maven Plugin for creating and pushing images.

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -20,6 +20,8 @@ title = "Release Notes"
   Protocol adapters can be configured to either use that new API or they can continue
   using the now deprecated [Device Connection API]({{% doclink "/api/device-connection/" %}})
   instead, meaning command routing will be done without using the Command Router.
+* The pre-built Hono Docker images available from Docker Hub now include the Jaeger
+  OpenTracing client.
 
 ### Fixes & Enhancements
 


### PR DESCRIPTION
This is for #2250.

Also adds release notes entry about inclusion of Jaeger in images on Docker Hub.