### PR TITLE
Use logging.profile for integration test log levels

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1370,6 +1370,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 <adapter.sendMessageToDeviceTimeout>${adapter.sendMessageToDeviceTimeout}</adapter.sendMessageToDeviceTimeout>
                 <trust-store.path>${project.build.directory}/certs/trusted-certs.pem</trust-store.path>
                 <test.env>${test.env}</test.env>
+                <logging.profile>${logging.profile}</logging.profile>
                 <max.bcrypt.costFactor>${max.bcrypt.costFactor}</max.bcrypt.costFactor>
                 <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
                 <!-- javax.net.debug>ssl:handshake</javax.net.debug-->

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -32,7 +32,7 @@ To run all tests of a certain class, or to run an individual test, set the `it.t
     $ mvn verify -Prun-tests -Dit.test=TelemetryHttpIT
     $ mvn verify -Prun-tests -Dit.test=TelemetryHttpIT#testUploadUsingQoS1
 
-The `logging.profile` property with a value of either `prod`, `dev` or `trace` can be used to set the log level in the Hono Docker containers:
+The `logging.profile` property with a value of either `prod`, `dev` or `trace` can be used to set the log level in the Hono Docker containers and the integration tests:
 
     $ mvn verify -Prun-tests -Dlogging.profile=trace
 

--- a/tests/src/test/resources/coap/logback-spring.xml
+++ b/tests/src/test/resources/coap/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -38,6 +38,7 @@
   <springProfile name="dev">
     <logger name="org.eclipse.hono.adapter" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
     <logger name="org.eclipse.hono.service" level="DEBUG"/>
   </springProfile>

--- a/tests/src/test/resources/http/logback-spring.xml
+++ b/tests/src/test/resources/http/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -38,6 +38,7 @@
   <springProfile name="dev">
     <logger name="org.eclipse.hono.adapter" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
     <logger name="org.eclipse.hono.service" level="DEBUG"/>
   </springProfile>

--- a/tests/src/test/resources/logback-test-include-dev.xml
+++ b/tests/src/test/resources/logback-test-include-dev.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+
+  <!--
+    This is the logging configuration included for the "dev" logging profile.
+   -->
+<included>
+  <logger name="org.eclipse.hono" level="DEBUG"/>
+  <logger name="org.eclipse.hono.client" level="DEBUG"/>
+  <logger name="org.eclipse.hono.client.impl" level="DEBUG"/>
+  <logger name="org.eclipse.hono.client.impl.HonoConnectionImpl" level="DEBUG"/>
+  <logger name="org.eclipse.hono.connection" level="DEBUG"/>
+  <logger name="org.eclipse.hono.tests" level="DEBUG"/>
+  <logger name="org.eclipse.hono.tests.CrudHttpClient" level="DEBUG"/>
+  <logger name="org.eclipse.hono.tests.amqp" level="DEBUG"/>
+  <logger name="org.eclipse.hono.tests.coap" level="DEBUG"/>
+  <logger name="org.eclipse.hono.tests.http" level="DEBUG"/>
+  <logger name="org.eclipse.hono.tests.jms" level="DEBUG"/>
+  <logger name="org.eclipse.hono.tests.mqtt" level="DEBUG"/>
+  <logger name="org.eclipse.hono.tests.registry" level="DEBUG"/>
+</included>

--- a/tests/src/test/resources/logback-test-include-prod.xml
+++ b/tests/src/test/resources/logback-test-include-prod.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+
+<!--
+  This is the logging configuration included for the "prod" logging profile.
+ -->
+<included>
+  <logger name="org.eclipse.hono" level="INFO"/>
+  <logger name="org.eclipse.hono.client" level="INFO"/>
+  <logger name="org.eclipse.hono.client.impl" level="INFO"/>
+  <logger name="org.eclipse.hono.client.impl.HonoConnectionImpl" level="ERROR"/>
+  <logger name="org.eclipse.hono.connection" level="INFO"/>
+  <logger name="org.eclipse.hono.tests" level="INFO"/>
+  <logger name="org.eclipse.hono.tests.CrudHttpClient" level="INFO"/>
+  <logger name="org.eclipse.hono.tests.amqp" level="INFO"/>
+  <logger name="org.eclipse.hono.tests.coap" level="INFO"/>
+  <logger name="org.eclipse.hono.tests.http" level="INFO"/>
+  <logger name="org.eclipse.hono.tests.jms" level="INFO"/>
+  <logger name="org.eclipse.hono.tests.mqtt" level="INFO"/>
+  <logger name="org.eclipse.hono.tests.registry" level="INFO"/>
+</included>

--- a/tests/src/test/resources/logback-test-include-trace.xml
+++ b/tests/src/test/resources/logback-test-include-trace.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+
+<!--
+  This is the logging configuration included for the "trace" logging profile.
+ -->
+<included>
+  <logger name="org.eclipse.hono" level="TRACE"/>
+  <logger name="org.eclipse.hono.client" level="TRACE"/>
+  <logger name="org.eclipse.hono.client.impl" level="TRACE"/>
+  <logger name="org.eclipse.hono.client.impl.HonoConnectionImpl" level="TRACE"/>
+  <logger name="org.eclipse.hono.connection" level="TRACE"/>
+  <logger name="org.eclipse.hono.tests" level="TRACE"/>
+  <logger name="org.eclipse.hono.tests.CrudHttpClient" level="TRACE"/>
+  <logger name="org.eclipse.hono.tests.amqp" level="TRACE"/>
+  <logger name="org.eclipse.hono.tests.coap" level="TRACE"/>
+  <logger name="org.eclipse.hono.tests.http" level="TRACE"/>
+  <logger name="org.eclipse.hono.tests.jms" level="TRACE"/>
+  <logger name="org.eclipse.hono.tests.mqtt" level="TRACE"/>
+  <logger name="org.eclipse.hono.tests.registry" level="TRACE"/>
+</included>

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -36,19 +36,8 @@
     <appender-ref ref="STDOUT" />
   </root>
 
-  <logger name="org.eclipse.hono" level="INFO"/>
-  <logger name="org.eclipse.hono.client" level="INFO"/>
-  <logger name="org.eclipse.hono.client.impl" level="INFO"/>
-  <logger name="org.eclipse.hono.client.impl.HonoConnectionImpl" level="ERROR"/>
-  <logger name="org.eclipse.hono.connection" level="INFO"/>
-  <logger name="org.eclipse.hono.tests" level="INFO"/>
-  <logger name="org.eclipse.hono.tests.CrudHttpClient" level="INFO"/>
-  <logger name="org.eclipse.hono.tests.amqp" level="INFO"/>
-  <logger name="org.eclipse.hono.tests.coap" level="INFO"/>
-  <logger name="org.eclipse.hono.tests.http" level="INFO"/>
-  <logger name="org.eclipse.hono.tests.jms" level="INFO"/>
-  <logger name="org.eclipse.hono.tests.mqtt" level="INFO"/>
-  <logger name="org.eclipse.hono.tests.registry" level="INFO"/>
+  <variable name="logging.profile" value="${logging.profile:-prod}" />
+  <include resource="logback-test-include-${logging.profile}.xml"/>
 
   <logger name="org.apache.qpid.jms" level="INFO"/>
   <!-- 

--- a/tests/src/test/resources/mqtt/logback-spring.xml
+++ b/tests/src/test/resources/mqtt/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -30,6 +30,9 @@
 
   <springProfile name="trace">
     <logger name="org.eclipse.hono.adapter" level="TRACE"/>
+    <logger name="org.eclipse.hono.client" level="TRACE"/>
+    <logger name="org.eclipse.hono.connection" level="TRACE"/>
+    <logger name="org.eclipse.hono.service" level="TRACE"/>
   </springProfile>
 
   <springProfile name="dev">
@@ -37,7 +40,7 @@
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
     <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
-    <logger name="org.eclipse.hono.service.auth" level="DEBUG"/>
+    <logger name="org.eclipse.hono.service" level="DEBUG"/>
   </springProfile>
 
   <springProfile name="prod">


### PR DESCRIPTION
When running the integration tests with the `logging.profile` parameter (e.g. `-Dlogging.profile=trace` ), the logging profile is currently only applied to the components started in the docker containers, not the integration tests themselves.
This PR fixes that.

Uses `<include resource="logback-test-include-${logging.profile}.xml"/>` to select/apply the loggers for the selected profile.

(Using `<if condition="some conditional expression">` instead would have allowed putting it all into logback-test.xml, but that would require the Janino library as an extra dependency.)