### PR TITLE
[#1345] Making CoAP integration test client listen on wildcard address.

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.Inet4Address;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -224,7 +223,8 @@ public abstract class CoapTestBase {
     protected CoapClient getCoapsClient(final AdvancedPskStore pskStoreToUse) {
 
         final DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder();
-        dtlsConfig.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+        // listen on wildcard to support non-localhost docker daemons
+        dtlsConfig.setAddress(new InetSocketAddress(0));
         dtlsConfig.setAdvancedPskStore(pskStoreToUse);
         dtlsConfig.setMaxRetransmissions(1);
         final CoapEndpoint.Builder builder = new CoapEndpoint.Builder();


### PR DESCRIPTION
The client previously Listened on the loopback address which lead to an address not being possible to bind to a port when the tests were run on a machine with a non-localost docker daemon.

This fixes #1345.

Signed-off-by: Florian Kaltner <florian.kaltner@bosch.io>