### PR TITLE
Remove non-working HonoConnectionImpl test

### DIFF
--- a/client/src/test/java/org/eclipse/hono/client/impl/HonoConnectionImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/HonoConnectionImplTest.java
@@ -134,34 +134,6 @@ public class HonoConnectionImplTest {
     }
 
     /**
-     * Verifies that the client fails a connection attempt if no AMQP session can be established
-     * with the peer.
-     *
-     * @param ctx The vert.x test client.
-     */
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testConnectFailsIfSessionCannotBeEstablished(final VertxTestContext ctx) {
-
-        // GIVEN a client attempting to connect to a peer that does not allow opening
-        // a session
-        final Future<HonoConnection> result = honoConnection.connect();
-        ctx.verify(() -> {
-            verify(session).open();
-            // WHEN the peer closes the session
-            final ArgumentCaptor<Handler<AsyncResult<ProtonSession>>> sessionCloseHandler = ArgumentCaptor.forClass(Handler.class);
-            verify(session).closeHandler(sessionCloseHandler.capture());
-            sessionCloseHandler.getValue().handle(Future.failedFuture("malfunction"));
-
-            // THEN the connection attempt fails
-            assertThat(result.failed());
-            // and the connection has been closed again
-            verify(con).close();
-        });
-        ctx.completeNow();
-    }
-
-    /**
      * Verifies that the client tries to connect a limited
      * number of times only.
      *


### PR DESCRIPTION
The connection attempt doesn't actually fail here (`isTrue()` missing after `assertThat(result.failed())`).
The connection getting closed after closing the session is already getting tested by `testRemoteSessionCloseTriggersReconnection()`.

In order to establish the behaviour that this test wants to verify, the `connect()` invocation would have to wait for the session `openHandler` to be called and only then finish the `connect` Future.
But that is also not done in the `ProtonConnectionImpl` default session handling.