### PR TITLE
[#2357] Skip closing tenant link on tenant timeout if still needed

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -368,18 +368,19 @@ public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClien
 
     private void handleTenantTimeout(final Message<String> msg) {
         final String tenantId = msg.body();
-        final MessageConsumer consumer = mappingAndDelegatingCommandConsumerFactory.getClient(tenantId);
-        if (consumer != null) {
-            log.info("timeout of tenant {}: closing and removing command consumer", tenantId);
-            consumer.close(v -> mappingAndDelegatingCommandConsumerFactory.removeClient(tenantId));
-        }
-        final List<CommandHandlerWrapper> handlersToRemove = adapterInstanceCommandHandler
+        final List<CommandHandlerWrapper> tenantRelatedHandlers = adapterInstanceCommandHandler
                 .getDeviceSpecificCommandHandlers().stream().filter(handler -> handler.getTenantId().equals(tenantId))
                 .collect(Collectors.toList());
-        handlersToRemove.forEach(handler -> {
-            log.info("timeout of tenant {}: removing command handler for device {}", tenantId, handler.getDeviceId());
-            adapterInstanceCommandHandler.removeDeviceSpecificCommandHandler(handler.getTenantId(), handler.getDeviceId());
-        });
+        if (tenantRelatedHandlers.isEmpty()) {
+            final MessageConsumer consumer = mappingAndDelegatingCommandConsumerFactory.getClient(tenantId);
+            if (consumer != null) {
+                log.info("tenant timeout: closing and removing command consumer [tenant {}]", tenantId);
+                consumer.close(v -> mappingAndDelegatingCommandConsumerFactory.removeClient(tenantId));
+            }
+        } else {
+            log.debug("ignoring tenant timeout; there are still {} command handlers for tenant devices [tenant {}]",
+                    tenantRelatedHandlers.size(), tenantId);
+        }
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImplTest.java
@@ -20,8 +20,8 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.qpid.proton.amqp.transport.Source;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.DeviceConnectionClient;
@@ -43,23 +44,25 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.proton.ProtonMessageHandler;
 import io.vertx.proton.ProtonQoS;
 import io.vertx.proton.ProtonReceiver;
-
 
 /**
  * Verifies behavior of {@link ProtocolAdapterCommandConsumerFactoryImpl}.
@@ -70,19 +73,14 @@ import io.vertx.proton.ProtonReceiver;
 public class ProtocolAdapterCommandConsumerFactoryImplTest {
 
     private Vertx vertx;
-    private Context context;
-    private ClientConfigProperties props;
     private HonoConnection connection;
-    private ProtocolAdapterCommandConsumerFactoryImpl commandConsumerFactory;
+    private DeviceConnectionClientFactory deviceConnectionClientFactory;
     private CommandTargetMapper commandTargetMapper;
     private DeviceConnectionClient devConClient;
-    private ProtonReceiver adapterInstanceCommandReceiver;
     private ProtonReceiver mappingAndDelegatingCommandReceiver;
-    private String adapterInstanceCommandConsumerAddress;
     private String tenantCommandAddress;
     private String tenantId;
     private String deviceId;
-    private String adapterInstanceId;
 
     /**
      * Sets up fixture.
@@ -91,27 +89,25 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
     public void setUp() {
 
         vertx = mock(Vertx.class);
-        context = VertxMockSupport.mockContext(vertx);
+        final Context context = VertxMockSupport.mockContext(vertx);
         when(vertx.getOrCreateContext()).thenReturn(context);
-        doAnswer(invocation -> {
-            final Handler<Void> handler = invocation.getArgument(1);
-            handler.handle(null);
-            return null;
-        }).when(vertx).setTimer(anyLong(), VertxMockSupport.anyHandler());
+        VertxMockSupport.runTimersImmediately(vertx);
         final EventBus eventBus = mock(EventBus.class);
         when(vertx.eventBus()).thenReturn(eventBus);
 
         deviceId = "theDevice";
         tenantId = "theTenant";
-        adapterInstanceId = UUID.randomUUID().toString();
+        final String adapterInstanceId = UUID.randomUUID().toString();
 
-        props = new ClientConfigProperties();
+        final ClientConfigProperties props = new ClientConfigProperties();
 
         connection = HonoClientUnitTestHelper.mockHonoConnection(vertx, props);
         when(connection.getContainerId()).thenReturn(adapterInstanceId);
 
-        adapterInstanceCommandReceiver = mock(ProtonReceiver.class);
-        adapterInstanceCommandConsumerAddress = CommandConstants.INTERNAL_COMMAND_ENDPOINT + "/" + adapterInstanceId;
+        final ProtonReceiver adapterInstanceCommandReceiver = HonoClientUnitTestHelper.mockProtonReceiver();
+        when(adapterInstanceCommandReceiver.getSource()).thenReturn(mock(Source.class));
+        final String adapterInstanceCommandConsumerAddress =
+                CommandConstants.INTERNAL_COMMAND_ENDPOINT + "/" + adapterInstanceId;
 
         when(connection.isConnected(anyLong())).thenReturn(Future.succeededFuture());
         when(connection.createReceiver(
@@ -121,7 +117,8 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
                 anyInt(),
                 anyBoolean(),
                 VertxMockSupport.anyHandler())).thenReturn(Future.succeededFuture(adapterInstanceCommandReceiver));
-        mappingAndDelegatingCommandReceiver = mock(ProtonReceiver.class);
+        mappingAndDelegatingCommandReceiver = HonoClientUnitTestHelper.mockProtonReceiver();
+        when(mappingAndDelegatingCommandReceiver.getSource()).thenReturn(mock(Source.class));
         tenantCommandAddress = ResourceIdentifier.from(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, null).toString();
         when(connection.createReceiver(
                 eq(tenantCommandAddress),
@@ -132,7 +129,7 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
                 VertxMockSupport.anyHandler())).thenReturn(Future.succeededFuture(mappingAndDelegatingCommandReceiver));
         commandTargetMapper = mock(CommandTargetMapper.class);
         devConClient = mock(DeviceConnectionClient.class);
-        final DeviceConnectionClientFactory deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
+        deviceConnectionClientFactory = mock(DeviceConnectionClientFactory.class);
         when(deviceConnectionClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
         when(deviceConnectionClientFactory.getOrCreateDeviceConnectionClient(anyString()))
                 .thenReturn(Future.succeededFuture(devConClient));
@@ -140,11 +137,15 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
                 .thenReturn(Future.succeededFuture());
         when(devConClient.removeCommandHandlingAdapterInstance(anyString(), anyString(), any()))
                 .thenReturn(Future.succeededFuture());
+    }
 
-        commandConsumerFactory = new ProtocolAdapterCommandConsumerFactoryImpl(connection, SendMessageSampler.Factory.noop());
-        commandConsumerFactory.initialize(
+    private ProtocolAdapterCommandConsumerFactoryImpl createCommandConsumerFactory() {
+        final ProtocolAdapterCommandConsumerFactoryImpl factory = new ProtocolAdapterCommandConsumerFactoryImpl(
+                connection, SendMessageSampler.Factory.noop());
+        factory.initialize(
                 commandTargetMapper,
                 ProtocolAdapterCommandConsumerFactory.createCommandHandlingAdapterInfoAccess(deviceConnectionClientFactory));
+        return factory;
     }
 
     /**
@@ -155,6 +156,8 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
      */
     @Test
     public void testCreateCommandConsumerFailsIfPeerRejectsLink(final VertxTestContext ctx) {
+
+        final ProtocolAdapterCommandConsumerFactoryImpl commandConsumerFactory = createCommandConsumerFactory();
 
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
         final ServerErrorException ex = new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE);
@@ -185,6 +188,8 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
     @Test
     public void testCreateCommandConsumerSucceeds(final VertxTestContext ctx) {
 
+        final ProtocolAdapterCommandConsumerFactoryImpl commandConsumerFactory = createCommandConsumerFactory();
+
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
 
         commandConsumerFactory.createCommandConsumer(tenantId, deviceId, commandHandler, null, null)
@@ -207,6 +212,8 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
     @Test
     public void testCreateTimeLimitedCommandConsumerSucceeds(final VertxTestContext ctx) {
 
+        final ProtocolAdapterCommandConsumerFactoryImpl commandConsumerFactory = createCommandConsumerFactory();
+
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
 
         final Duration lifespan = Duration.ofSeconds(10);
@@ -227,6 +234,87 @@ public class ProtocolAdapterCommandConsumerFactoryImplTest {
                 }));
             });
         }));
+    }
+
+    /**
+     * Verifies that upon getting a tenant timeout notification, the tenant-scoped
+     * consumer link is closed if there are no consumers for that tenant registered
+     * anymore.
+     *
+     * @param ctx The test context.
+     * @throws InterruptedException If the test execution gets interrupted.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testTenantTimeoutClosesTenantLink(final VertxTestContext ctx) throws InterruptedException {
+
+        final ArgumentCaptor<Handler<Message<Object>>> eventBusMsgHandler = ArgumentCaptor.forClass(Handler.class);
+        when(vertx.eventBus().consumer(eq(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT), eventBusMsgHandler.capture()))
+                .thenReturn(mock(io.vertx.core.eventbus.MessageConsumer.class));
+
+        final ProtocolAdapterCommandConsumerFactoryImpl commandConsumerFactory = createCommandConsumerFactory();
+
+        // GIVEN a scenario where a command consumer is created and then closed again
+        final VertxTestContext consumerCreationAndRemoval = new VertxTestContext();
+        final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
+        commandConsumerFactory.createCommandConsumer(tenantId, deviceId, commandHandler, null, null)
+                .onComplete(consumerCreationAndRemoval.succeeding(consumer -> {
+                    // close the consumer again
+                    consumer.close(null)
+                            .onComplete(consumerCreationAndRemoval.completing());
+                }));
+        assertThat(consumerCreationAndRemoval.awaitCompletion(2, TimeUnit.SECONDS)).isTrue();
+        if (consumerCreationAndRemoval.failed()) {
+            ctx.failNow(consumerCreationAndRemoval.causeOfFailure());
+            return;
+        }
+
+        // WHEN the tenant timeout is triggered
+        final Message<Object> eventBusMsg = mock(Message.class);
+        when(eventBusMsg.body()).thenReturn(tenantId);
+        eventBusMsgHandler.getValue().handle(eventBusMsg);
+
+        // THEN the tenant-scoped receiver link is closed
+        verify(connection).closeAndFree(eq(mappingAndDelegatingCommandReceiver), any());
+        ctx.completeNow();
+    }
+
+    /**
+     * Verifies that upon getting a tenant timeout notification, the tenant-scoped
+     * consumer link isn't closed if there are still consumers for that tenant registered.
+     *
+     * @param ctx The test context.
+     * @throws InterruptedException If the test execution gets interrupted.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testTenantTimeoutSkipsClosingTenantLink(final VertxTestContext ctx) throws InterruptedException {
+
+        final ArgumentCaptor<Handler<Message<Object>>> eventBusMsgHandler = ArgumentCaptor.forClass(Handler.class);
+        when(vertx.eventBus().consumer(eq(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT), eventBusMsgHandler.capture()))
+                .thenReturn(mock(io.vertx.core.eventbus.MessageConsumer.class));
+
+        final ProtocolAdapterCommandConsumerFactoryImpl commandConsumerFactory = createCommandConsumerFactory();
+
+        // GIVEN a scenario where a command consumer is created
+        final VertxTestContext consumerCreation = new VertxTestContext();
+        final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
+        commandConsumerFactory.createCommandConsumer(tenantId, deviceId, commandHandler, null, null)
+                .onComplete(consumerCreation.completing());
+        assertThat(consumerCreation.awaitCompletion(2, TimeUnit.SECONDS)).isTrue();
+        if (consumerCreation.failed()) {
+            consumerCreation.failNow(consumerCreation.causeOfFailure());
+            return;
+        }
+
+        // WHEN the tenant timeout is triggered
+        final Message<Object> eventBusMsg = mock(Message.class);
+        when(eventBusMsg.body()).thenReturn(tenantId);
+        eventBusMsgHandler.getValue().handle(eventBusMsg);
+
+        // THEN the tenant-scoped receiver link isn't closed because the command consumer is still alive
+        verify(connection, never()).closeAndFree(eq(mappingAndDelegatingCommandReceiver), any());
+        ctx.completeNow();
     }
 
 }


### PR DESCRIPTION
This fixes #2357.