### PR TITLE
[#2053] Adding integration tests for gateway-based auto provisioning.

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -301,6 +301,17 @@ public final class MessageHelper {
     }
 
     /**
+     * Gets the value of a message's {@link #APP_PROPERTY_REGISTRATION_STATUS} application property.
+     *
+     * @param msg The message.
+     * @return The property value or {@code null} if not set.
+     * @throws NullPointerException if message is {@code null}.
+     */
+    public static String getRegistrationStatus(final Message msg) {
+        return getApplicationProperty(msg.getApplicationProperties(), APP_PROPERTY_REGISTRATION_STATUS, String.class);
+    }
+
+    /**
      * Gets the value of a message's {@link #APP_PROPERTY_QOS} application property.
      *
      * @param msg The message.

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -61,8 +61,10 @@ import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistryManagementConstants;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -406,6 +408,56 @@ public abstract class CoapTestBase {
                     client.advanced(getHandler(result), request);
                     return result.future();
                 });
+    }
+
+    /**
+     * Verifies that an edge device is auto-provisioned if it connects via a gateway equipped with the corresponding
+     * authority.
+     *
+     * @param ctx The test context.
+     * @throws InterruptedException if the test fails.
+     */
+    @Test
+    public void testAutoProvisioningViaGateway(final VertxTestContext ctx) throws InterruptedException {
+
+        // GIVEN a device that is connected via two gateways
+        final Tenant tenant = new Tenant();
+        final String gatewayId = helper.getRandomDeviceId(tenantId);
+        final Device gateway = new Device()
+                .setAuthorities(Collections.singleton(RegistryManagementConstants.AUTHORITY_AUTO_PROVISIONING_ENABLED));
+
+        final VertxTestContext setup = new VertxTestContext();
+        helper.registry.addPskDeviceForTenant(tenantId, tenant, gatewayId, gateway, SECRET)
+                .onComplete(setup.completing());
+        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
+
+        final CoapClient gatewayClient = getCoapsClient(gatewayId, tenantId, SECRET);
+
+        final VertxTestContext emptyEventReceived = new VertxTestContext();
+        helper.applicationClientFactory.createEventConsumer(tenantId,
+                msg -> emptyEventReceived.verify( () -> {
+                    // ignore potential events of warmup
+                    if (MessageHelper.getDeviceId(msg).equals(deviceId)) {
+                        assertThat(msg.getContentType()).isEqualTo(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION);
+                        assertThat(MessageHelper.getRegistrationStatus(msg)).isEqualTo(EventConstants.RegistrationStatus.NEW.name());
+                        emptyEventReceived.completeNow();
+                    }
+                }),
+                close -> {});
+
+        testUploadMessages(ctx, tenantId,
+                () -> warmUp(gatewayClient, createCoapsRequest(Code.PUT, getPutResource(tenantId, helper.getRandomDeviceId(tenantId)), 0)),
+                null,
+                count -> {
+                    final Promise<OptionSet> result = Promise.promise();
+                    final Request request = createCoapsRequest(Code.PUT, getPutResource(tenantId, deviceId), count);
+                    gatewayClient.advanced(getHandler(result), request);
+                    return result.future();
+                },
+                1,
+                null);
+
+        assertThat(emptyEventReceived.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -44,7 +44,6 @@ import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.Tenants;
 import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistryManagementConstants;
@@ -874,47 +873,24 @@ public abstract class HttpTestBase {
         final Device gateway = new Device()
                 .setAuthorities(Collections.singleton(RegistryManagementConstants.AUTHORITY_AUTO_PROVISIONING_ENABLED));
 
-        final VertxTestContext setup = new VertxTestContext();
-        helper.registry.addDeviceForTenant(tenantId, tenant, gatewayId, gateway, PWD)
-                .onComplete(setup.completing());
+        final String edgeDeviceId = helper.getRandomDeviceId(tenantId);
+        helper.createAutoProvisioningMessageConsumers(ctx, tenantId, edgeDeviceId)
+                .compose(ok -> helper.registry.addDeviceForTenant(tenantId, tenant, gatewayId, gateway, PWD))
+                .compose(ok -> {
+                    final MultiMap requestHeaders = MultiMap.caseInsensitiveMultiMap()
+                            .add(HttpHeaders.CONTENT_TYPE, "text/plain")
+                            .add(HttpHeaders.AUTHORIZATION, getBasicAuth(tenantId, gatewayId, PWD))
+                            .add(HttpHeaders.ORIGIN, ORIGIN_URI);
 
-        assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
-        if (setup.failed()) {
-            ctx.failNow(setup.causeOfFailure());
-            return;
-        }
+                    final String uri = String.format("%s/%s/%s", getEndpointUri(), tenantId, edgeDeviceId);
 
-        final MultiMap requestHeaders = MultiMap.caseInsensitiveMultiMap()
-                .add(HttpHeaders.CONTENT_TYPE, "text/plain")
-                .add(HttpHeaders.AUTHORIZATION, getBasicAuth(tenantId, gatewayId, PWD))
-                .add(HttpHeaders.ORIGIN, ORIGIN_URI);
-
-        final String uri = String.format("%s/%s/%s", getEndpointUri(), tenantId, helper.getRandomDeviceId(tenantId));
-
-        helper.applicationClientFactory.createEventConsumer(tenantId, msg -> {
-            ctx.verify(() -> {
-                assertThat(msg.getContentType()).isEqualTo(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION);
-                assertThat(MessageHelper.getRegistrationStatus(msg)).isEqualTo(EventConstants.RegistrationStatus.NEW.name());
-            });
-        }, remoteClose -> {});
-
-        testUploadMessages(
-                ctx,
-                tenantId,
-                msg -> {
-                    ctx.verify(()  -> {
-                        assertThat(msg.getContentType()).isEqualTo("text/plain");
-                        assertMessageProperties(ctx, msg);
-                    });
-                    return Future.succeededFuture();
-                },
-                count -> httpClient.update( // GW uses PUT when acting on behalf of a device
-                    uri,
-                    Buffer.buffer("hello " + count),
-                    requestHeaders,
-                    ResponsePredicate.status(HttpURLConnection.HTTP_ACCEPTED)),
-                1,
-                getExpectedQoS(null));
+                    return httpClient.update(
+                            uri,
+                            Buffer.buffer("hello"),
+                            requestHeaders,
+                            ResponsePredicate.status(HttpURLConnection.HTTP_ACCEPTED));
+                })
+                .onComplete(ctx.succeeding());
     }
 
     /**


### PR DESCRIPTION
This PR adds integration tests for auto-provisioning.

Before merging this PR 
https://github.com/eclipse/hono/pull/2358
https://github.com/eclipse/hono/pull/2360
https://github.com/eclipse/hono/pull/2359
need to be merged, so that tests will run successfully