### PR TITLE
[#2273] Prototype: Kafka based command router

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -123,12 +123,22 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-kafka-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-client-adapter</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-client-adapter-amqp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-adapter-kafka</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -418,6 +428,11 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rx-java2</artifactId>
+        <version>${vertx.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-kafka-client</artifactId>
         <version>${vertx.version}</version>
       </dependency>
 
@@ -805,6 +820,12 @@
       <dependency>
         <groupId>org.eclipse.hono</groupId>
         <artifactId>service-base-test-utils</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>kafka-test-utils</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>
       </dependency>

--- a/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -96,8 +96,9 @@ public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClien
         super(connection, samplerFactory);
 
         // the container id contains a UUID therefore it can be used as a unique adapter instance id
-        adapterInstanceId = connection.getContainerId();
-
+        //NOTE: the spaces in adapter instance id are replaced with underscore as the kafka topics doesn't allow it.
+        //TODO: to find a generic solution for the above.
+        adapterInstanceId = connection.getContainerId().replaceAll(" ", "_");
         adapterInstanceCommandHandler = new AdapterInstanceCommandHandler(connection.getTracer(), adapterInstanceId);
     }
 

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterCommandConsumerFactoryImpl.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterCommandConsumerFactoryImpl.java
@@ -82,7 +82,9 @@ public class ProtonBasedCommandRouterCommandConsumerFactoryImpl extends Abstract
         this.commandRouterClient = Objects.requireNonNull(commandRouterClient);
 
         // the container id contains a UUID therefore it can be used as a unique adapter instance id
-        adapterInstanceId = connection.getContainerId();
+        //NOTE: the spaces in adapter instance id are replaced with underscore as the kafka topics doesn't allow it.
+        //TODO: to find a generic solution for the above.
+        adapterInstanceId = connection.getContainerId().replaceAll(" ", "_");
         adapterInstanceCommandHandler = new AdapterInstanceCommandHandler(connection.getTracer(), adapterInstanceId);
     }
 

--- a/clients/adapter-kafka/pom.xml
+++ b/clients/adapter-kafka/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-clients-parent</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>hono-client-adapter-kafka</artifactId>
+
+    <name>Hono Client for Protocol Adapters (Kafka)</name>
+    <description>An Kafka based implementation of the Hono Client for Protocol Adapters</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-client-adapter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-client-kafka-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>kafka-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/clients/adapter-kafka/pom.xml
+++ b/clients/adapter-kafka/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-clients-parent</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>hono-client-adapter-kafka</artifactId>
 

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerFactory;
+import org.eclipse.hono.kafka.client.tracing.KafkaTracingHelper;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.EncodeException;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.RecordMetadata;
+import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
+
+/**
+ * A client for publishing messages to a Kafka cluster.
+ */
+public abstract class AbstractKafkaBasedDownstreamSender implements Lifecycle {
+
+    /**
+     * A logger to be shared with subclasses.
+     */
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final KafkaProducerFactory<String, Buffer> producerFactory;
+    private final String producerName;
+    private final Map<String, String> config;
+    private final Tracer tracer;
+
+    /**
+     * Creates a new Kafka-based telemetry sender.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param producerName The producer name to use.
+     * @param config The Kafka producer configuration properties to use.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+
+    public AbstractKafkaBasedDownstreamSender(final KafkaProducerFactory<String, Buffer> producerFactory,
+            final String producerName, final Map<String, String> config, final Tracer tracer) {
+
+        Objects.requireNonNull(producerFactory);
+        Objects.requireNonNull(producerName);
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(tracer);
+
+        this.config = config;
+        this.producerName = producerName;
+        this.tracer = tracer;
+        this.producerFactory = producerFactory;
+    }
+
+    /**
+     * Sends a message downstream.
+     *
+     * @param topic The topic to send the message to.
+     * @param tenantId The ID of the tenant that the device belongs to.
+     * @param deviceId The ID of the device that the data originates from.
+     * @param qos The delivery semantics to use for sending the data.
+     * @param contentType The content type of the data.
+     * @param payload The data to send.
+     * @param properties Additional meta data that should be included in the downstream message.
+     * @param context The currently active OpenTracing span (may be {@code null}). An implementation should use this as
+     *            the parent for any span it creates for tracing the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the message has been sent downstream.
+     *         <p>
+     *         The future will be failed with a {@link org.eclipse.hono.client.ServerErrorException} if the data could
+     *         not be sent. The error code contained in the exception indicates the cause of the failure.
+     * @throws NullPointerException if topic, tenant ID, device ID, qos or contentType are {@code null}.
+     */
+    protected Future<Void> send(final HonoTopic topic, final String tenantId, final String deviceId, final QoS qos,
+            final String contentType, final Buffer payload, final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(topic);
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(qos);
+        Objects.requireNonNull(contentType);
+
+        log.trace("sending to Kafka [topic: {}, tenantId: {}, deviceId: {}, qos: {}, contentType: {}, properties: {}]",
+                topic, tenantId, deviceId, qos, contentType, properties);
+        final Span span = startSpan(topic, tenantId, deviceId, qos, contentType, context);
+
+        final KafkaProducerRecord<String, Buffer> record = KafkaProducerRecord.create(topic.toString(), deviceId,
+                payload);
+        record.addHeaders(createHeaders(properties, deviceId, qos, contentType, span));
+
+        KafkaTracingHelper.injectSpanContext(tracer, record, span.context());
+        logProducerRecord(span, record);
+
+        final Promise<RecordMetadata> promise = Promise.promise();
+        getOrCreateProducer().send(record, promise);
+
+        final Future<Void> producerFuture = promise.future()
+                .recover(t -> {
+                    logError(span, topic, tenantId, deviceId, qos, t);
+                    span.finish();
+                    return Future.failedFuture(new ServerErrorException(getErrorCode(t), t));
+                })
+                .map(recordMetadata -> {
+                    logRecordMetadata(span, deviceId, recordMetadata);
+                    span.finish();
+                    return null;
+                });
+
+        return qos.equals(QoS.AT_MOST_ONCE) ? Future.succeededFuture() : producerFuture;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Starts the producer.
+     */
+    @Override
+    public Future<Void> start() {
+        getOrCreateProducer();
+        return Future.succeededFuture();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Closes the producer.
+     */
+    @Override
+    public Future<Void> stop() {
+        return producerFactory.closeProducer(producerName);
+    }
+
+    private KafkaProducer<String, Buffer> getOrCreateProducer() {
+        return producerFactory.getOrCreateProducer(producerName, config);
+    }
+
+    private List<KafkaHeader> createHeaders(final Map<String, Object> properties, final String deviceId,
+            final QoS qos, final String contentType, final Span span) {
+
+        // ensure that we have a modifiable map
+        final Map<String, Object> headerProperties = new HashMap<>();
+        if (properties != null) {
+            headerProperties.putAll(properties);
+        }
+
+        setStandardProperties(headerProperties, deviceId, qos, contentType);
+
+        return encodePropertiesAsKafkaHeaders(headerProperties, span);
+    }
+
+    private void setStandardProperties(final Map<String, Object> headerProperties, final String deviceId,
+            final QoS qos, final String contentType) {
+
+        // ensure that the standard properties are set correctly
+        headerProperties.put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, contentType);
+        headerProperties.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId);
+        headerProperties.put(MessageHelper.APP_PROPERTY_QOS, qos.ordinal());
+
+        if (headerProperties.containsKey(MessageHelper.APP_PROPERTY_DEVICE_TTD)
+                && !headerProperties.containsKey(MessageHelper.SYS_PROPERTY_CREATION_TIME)) {
+            // TODO set this as creation time in the KafkaRecord?
+
+            // must match http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-timestamp
+            // as defined in https://www.eclipse.org/hono/docs/api/telemetry/#forward-telemetry-data
+            final long timestamp = Instant.now().toEpochMilli();
+            headerProperties.put(MessageHelper.SYS_PROPERTY_CREATION_TIME, timestamp);
+        }
+    }
+
+    private List<KafkaHeader> encodePropertiesAsKafkaHeaders(final Map<String, Object> properties, final Span span) {
+        final List<KafkaHeader> headers = new ArrayList<>();
+        properties.forEach((k, v) -> {
+            try {
+                final Buffer headerValue = (v instanceof String)
+                        ? Buffer.buffer((String) v)
+                        : Buffer.buffer(Json.encode(v));
+
+                headers.add(new KafkaHeaderImpl(k, headerValue));
+            } catch (final EncodeException e) {
+                log.info("failed to serialize property with key [{}] to Kafka header", k);
+                span.log("failed to create Kafka header from property: " + k);
+            }
+        });
+
+        return headers;
+    }
+
+    private Span startSpan(final HonoTopic topic, final String tenantId, final String deviceId, final QoS qos,
+            final String contentType, final SpanContext context) {
+
+        final String referenceType = QoS.AT_MOST_ONCE.equals(qos) ? References.FOLLOWS_FROM : References.CHILD_OF;
+        return KafkaTracingHelper.newProducerSpan(tracer, topic, referenceType, context)
+                .setTag(TracingHelper.TAG_TENANT_ID.getKey(), tenantId)
+                .setTag(TracingHelper.TAG_DEVICE_ID.getKey(), deviceId)
+                .setTag(TracingHelper.TAG_QOS.getKey(), qos.name())
+                .setTag(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, contentType);
+    }
+
+    private void logProducerRecord(final Span span, final KafkaProducerRecord<String, Buffer> record) {
+        final String headersAsString = record.headers()
+                .stream()
+                .map(header -> header.key() + "=" + header.value())
+                .collect(Collectors.joining(",", "{", "}"));
+
+        log.trace("producing message [topic: {}, key: {}, partition: {}, timestamp: {}, headers: {}]",
+                record.topic(), record.key(), record.partition(), record.timestamp(), headersAsString);
+
+        span.log("producing message with headers: " + headersAsString);
+    }
+
+    private void logRecordMetadata(final Span span, final String recordKey, final RecordMetadata metadata) {
+
+        log.trace("message produced to Kafka [topic: {}, key: {}, partition: {}, offset: {}, timestamp: {}]",
+                metadata.getTopic(), recordKey, metadata.getPartition(), metadata.getOffset(), metadata.getTimestamp());
+
+        span.log("message produced to Kafka");
+        KafkaTracingHelper.setRecordMetadataTags(span, metadata);
+        Tags.HTTP_STATUS.set(span, HttpURLConnection.HTTP_ACCEPTED);
+
+    }
+
+    private void logError(final Span span, final HonoTopic topic, final String tenantId, final String deviceId,
+            final QoS qos, final Throwable cause) {
+        log.debug("sending message failed [topic: {}, key: {}, qos: {}, tenantId: {}, deviceId: {}]",
+                topic, deviceId, qos, tenantId, deviceId, cause);
+
+        Tags.HTTP_STATUS.set(span, getErrorCode(cause));
+        TracingHelper.logError(span, cause);
+    }
+
+    private int getErrorCode(final Throwable t) {
+        /*
+         * TODO set error code depending on exception?
+         *
+         * Possible thrown exceptions include:
+         *
+         * Non-Retriable exceptions (fatal, the message will never be sent):
+         *
+         * InvalidTopicException OffsetMetadataTooLargeException RecordBatchTooLargeException RecordTooLargeException
+         * UnknownServerException UnknownProducerIdException
+         *
+         * Retriable exceptions (transient, may be covered by increasing #.retries):
+         *
+         * CorruptRecordException InvalidMetadataException NotEnoughReplicasAfterAppendException
+         * NotEnoughReplicasException OffsetOutOfRangeException TimeoutException UnknownTopicOrPartitionException
+         */
+
+        return HttpURLConnection.HTTP_UNAVAILABLE;
+    }
+}

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedMessageSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedMessageSender.java
@@ -52,7 +52,7 @@ import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
 /**
  * A client for publishing messages to a Kafka cluster.
  */
-public abstract class AbstractKafkaBasedDownstreamSender implements Lifecycle {
+public abstract class AbstractKafkaBasedMessageSender implements Lifecycle {
 
     /**
      * A logger to be shared with subclasses.
@@ -74,7 +74,7 @@ public abstract class AbstractKafkaBasedDownstreamSender implements Lifecycle {
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
 
-    public AbstractKafkaBasedDownstreamSender(final KafkaProducerFactory<String, Buffer> producerFactory,
+    public AbstractKafkaBasedMessageSender(final KafkaProducerFactory<String, Buffer> producerFactory,
             final String producerName, final Map<String, String> config, final Tracer tracer) {
 
         Objects.requireNonNull(producerFactory);

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedMessageSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedMessageSender.java
@@ -58,11 +58,11 @@ public abstract class AbstractKafkaBasedMessageSender implements Lifecycle {
      * A logger to be shared with subclasses.
      */
     protected final Logger log = LoggerFactory.getLogger(getClass());
+    protected final Tracer tracer;
 
     private final KafkaProducerFactory<String, Buffer> producerFactory;
     private final String producerName;
     private final Map<String, String> config;
-    private final Tracer tracer;
 
     /**
      * Creates a new Kafka-based telemetry sender.

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSender.java
@@ -33,7 +33,7 @@ import io.vertx.core.buffer.Buffer;
 /**
  * A client for publishing event messages to a Kafka cluster.
  */
-public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender implements EventSender {
+public class KafkaBasedEventSender extends AbstractKafkaBasedMessageSender implements EventSender {
 
     /**
      * Creates a new Kafka-based event sender.

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSender.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.client.KafkaProducerFactory;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A client for publishing event messages to a Kafka cluster.
+ */
+public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender implements EventSender {
+
+    /**
+     * Creates a new Kafka-based event sender.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param kafkaProducerConfig The Kafka producer configuration properties to use.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public KafkaBasedEventSender(final KafkaProducerFactory<String, Buffer> producerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig, final Tracer tracer) {
+
+        super(producerFactory, EventConstants.EVENT_ENDPOINT, kafkaProducerConfig.getProducerConfig(), tracer);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendEvent(final TenantObject tenant, final RegistrationAssertion device,
+            final String contentType, final Buffer payload, final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(contentType);
+
+        final String tenantId = tenant.getTenantId();
+        final String deviceId = device.getDeviceId();
+
+        log.trace("sending event [tenantId: {}, deviceId: {}, contentType: {}, properties: {}]", tenantId, deviceId,
+                contentType, properties);
+
+        final HonoTopic topic = new HonoTopic(HonoTopic.Type.EVENT, tenantId);
+        return send(topic, tenantId, deviceId, QoS.AT_LEAST_ONCE, contentType, payload, properties, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return KafkaBasedEventSender.class.getName() + " via Kafka";
+    }
+
+}

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySender.java
@@ -33,7 +33,7 @@ import io.vertx.core.buffer.Buffer;
 /**
  * A client for publishing telemetry messages to a Kafka cluster.
  */
-public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSender implements TelemetrySender {
+public class KafkaBasedTelemetrySender extends AbstractKafkaBasedMessageSender implements TelemetrySender {
 
     /**
      * Creates a new Kafka-based telemetry sender.

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySender.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.client.KafkaProducerFactory;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TelemetryConstants;
+import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A client for publishing telemetry messages to a Kafka cluster.
+ */
+public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSender implements TelemetrySender {
+
+    /**
+     * Creates a new Kafka-based telemetry sender.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param kafkaProducerConfig The Kafka producer configuration properties to use.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public KafkaBasedTelemetrySender(final KafkaProducerFactory<String, Buffer> producerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig, final Tracer tracer) {
+
+        super(producerFactory, TelemetryConstants.TELEMETRY_ENDPOINT, kafkaProducerConfig.getProducerConfig(), tracer);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendTelemetry(final TenantObject tenant, final RegistrationAssertion device, final QoS qos,
+            final String contentType, final Buffer payload, final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(contentType);
+        Objects.requireNonNull(qos);
+
+        final String tenantId = tenant.getTenantId();
+        final String deviceId = device.getDeviceId();
+
+        log.trace("send telemetry data [tenantId: {}, deviceId: {}, qos: {}, contentType: {}, properties: {}]",
+                tenantId, deviceId, qos, contentType, properties);
+
+        final HonoTopic topic = new HonoTopic(HonoTopic.Type.TELEMETRY, tenantId);
+        return send(topic, tenantId, deviceId, qos, contentType, payload, properties, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return KafkaBasedTelemetrySender.class.getName() + " via Kafka";
+    }
+
+}

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.kafka.client.CachingKafkaProducerFactory;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.test.FakeProducer;
+import org.eclipse.hono.util.QoS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+import io.vertx.junit5.VertxExtension;
+
+/**
+ * Verifies behavior of {@link AbstractKafkaBasedDownstreamSender}.
+ */
+@ExtendWith(VertxExtension.class)
+public class AbstractKafkaBasedDownstreamSenderTest {
+
+    private static final String TENANT_ID = "the-tenant";
+    private static final String DEVICE_ID = "the-device";
+    private static final QoS qos = QoS.AT_LEAST_ONCE;
+    private static final String CONTENT_TYPE = "the-content-type";
+    private static final String PRODUCER_NAME = "test-producer";
+
+    private final Tracer tracer = NoopTracerFactory.create();
+    private final HashMap<String, String> config = new HashMap<>();
+    private final HonoTopic topic = new HonoTopic(HonoTopic.Type.EVENT, "foo");
+
+    private CachingKafkaProducerFactory<String, Buffer> factory;
+    private AbstractKafkaBasedDownstreamSender sender;
+
+    /**
+     * Sets up the downstream sender.
+     */
+    @BeforeEach
+    public void setUp() {
+        config.put("hono.kafka.producerConfig.bootstrap.servers", "localhost:9092");
+
+        factory = new CachingKafkaProducerFactory<>((n, c) -> new FakeProducer<>());
+
+        sender = new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, config, tracer) {
+        };
+    }
+
+    /**
+     * Verifies that {@link AbstractKafkaBasedDownstreamSender#start()} creates a producer and
+     * {@link AbstractKafkaBasedDownstreamSender#stop()} closes it.
+     */
+    @Test
+    public void testLifecycle() {
+        assertThat(factory.getProducer(PRODUCER_NAME)).isEmpty();
+        sender.start();
+        assertThat(factory.getProducer(PRODUCER_NAME)).isNotEmpty();
+        sender.stop();
+        assertThat(factory.getProducer(PRODUCER_NAME)).isEmpty();
+    }
+
+    /**
+     * Verifies that the Kafka record is created as expected.
+     */
+    @Test
+    public void testSendCreatesCorrectRecord() {
+
+        // GIVEN a sender
+        final String payload = "the-payload";
+        final Map<String, Object> properties = Collections.singletonMap("foo", "bar");
+
+        // WHEN sending a message
+        sender.send(topic, TENANT_ID, DEVICE_ID, qos, CONTENT_TYPE, Buffer.buffer(payload), properties, null);
+
+        // THEN the producer record is created from the given values...
+        final ProducerRecord<String, Buffer> actual = TestHelper.getUnderlyingMockProducer(factory, PRODUCER_NAME)
+                .history().get(0);
+
+        assertThat(actual.key()).isEqualTo(DEVICE_ID);
+        assertThat(actual.topic()).isEqualTo(topic.toString());
+        assertThat(actual.value().toString()).isEqualTo(payload);
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("foo", "bar".getBytes()));
+
+        // ...AND contains the standard headers
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("content-type", CONTENT_TYPE.getBytes()));
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("device_id", DEVICE_ID.getBytes()));
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("qos", Json.encode(qos.ordinal()).getBytes()));
+
+    }
+
+    /**
+     * Verifies that the future returned by
+     * {@link AbstractKafkaBasedDownstreamSender#send(HonoTopic, String, String, QoS, String, Buffer, Map, SpanContext)}
+     * completes successfully when the send operation of the Kafka client succeeds.
+     */
+    @Test
+    public void testThatSendCompletes() {
+
+        // GIVEN a sender sending a message
+        final Future<Void> sendFuture = sender.send(topic, TENANT_ID, DEVICE_ID, qos, CONTENT_TYPE, null, null, null);
+
+        // WHEN the send operation completes successfully
+        TestHelper.getUnderlyingMockProducer(factory, PRODUCER_NAME).completeNext();
+
+        // THEN the returned future also succeeds
+        assertThat(sendFuture.isComplete()).isTrue();
+        assertThat(sendFuture.succeeded()).isTrue();
+    }
+
+    /**
+     * Verifies that the producer is closed when sending of a message fails with a fatal error.
+     */
+    @Test
+    public void testSenderClosesWhenSendFails() {
+
+        // GIVEN a sender sending a message
+        final Future<Void> future = sender.send(topic, TENANT_ID, DEVICE_ID, qos, CONTENT_TYPE, null, null, null);
+
+        // WHEN the send operation fails
+        final AuthorizationException expectedError = new AuthorizationException("go away");
+        TestHelper.getUnderlyingMockProducer(factory, PRODUCER_NAME).errorNext(expectedError);
+
+        // THEN the returned future is failed...
+        assertThat(future.isComplete()).isTrue();
+        assertThat(future.failed()).isTrue();
+        assertThat(future.cause()).isInstanceOf(ServerErrorException.class);
+        assertThat(future.cause().getCause()).isEqualTo(expectedError);
+
+        // ... AND the producer is closed
+        assertThat(factory.getProducer(PRODUCER_NAME)).isEmpty();
+
+    }
+
+    /**
+     * Verifies that if the properties contain a <em>ttd</em> property but no <em>creation-time</em> then the later is
+     * added.
+     */
+    @Test
+    public void testThatCreationTimeIsAddedWhenNotPresentAndTtdIsSet() {
+
+        // GIVEN properties that contain a TTD
+        final long ttd = 99L;
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("ttd", ttd);
+
+        // WHEN sending the message
+        sender.send(topic, TENANT_ID, DEVICE_ID, qos, CONTENT_TYPE, null, properties, null);
+
+        // THEN the producer record contains a creation time
+        final ProducerRecord<String, Buffer> record = TestHelper.getUnderlyingMockProducer(factory, PRODUCER_NAME)
+                .history().get(0);
+
+        assertThat(record.headers()).containsOnlyOnce(new RecordHeader("ttd", Json.encode(ttd).getBytes()));
+        assertThat(record.headers().headers("creation-time")).isNotNull();
+
+    }
+
+    /**
+     * Verifies that if the properties contain a <em>creation-time</em> property then it is preserved.
+     */
+    @Test
+    public void testThatCreationTimeIsNotChangedWhenPresentAndTtdIsSet() {
+
+        // GIVEN properties that contain creation-time
+        final long creationTime = 12345L;
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("ttd", 99L);
+        properties.put("creation-time", creationTime);
+
+        // WHEN sending the message
+        sender.send(topic, TENANT_ID, DEVICE_ID, qos, CONTENT_TYPE, null, properties, null);
+
+        // THEN the creation time is preserved
+        final ProducerRecord<String, Buffer> record = TestHelper.getUnderlyingMockProducer(factory, PRODUCER_NAME)
+                .history().get(0);
+
+        final RecordHeader expectedHeader = new RecordHeader("creation-time", Json.encode(creationTime).getBytes());
+
+        assertThat(record.headers()).containsOnlyOnce(expectedHeader);
+
+    }
+
+    /**
+     * Verifies that the constructor throws a nullpointer exception if a parameter is {@code null}.
+     */
+    @Test
+    public void testThatConstructorThrowsOnMissingParameter() {
+
+        assertThrows(NullPointerException.class,
+                () -> new AbstractKafkaBasedDownstreamSender(null, PRODUCER_NAME, config, tracer) {
+                });
+
+        assertThrows(NullPointerException.class,
+                () -> new AbstractKafkaBasedDownstreamSender(factory, null, config, tracer) {
+                });
+
+        assertThrows(NullPointerException.class,
+                () -> new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, null, tracer) {
+                });
+
+        assertThrows(NullPointerException.class,
+                () -> new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, config, null) {
+                });
+    }
+
+    /**
+     * Verifies that
+     * {@link AbstractKafkaBasedDownstreamSender#send(HonoTopic, String, String, QoS, String, Buffer, Map, SpanContext)}
+     * throws a nullpointer exception if a mandatory parameter is {@code null}.
+     */
+    @Test
+    public void testThatSendThrowsOnMissingMandatoryParameter() {
+        assertThrows(NullPointerException.class,
+                () -> sender.send(null, TENANT_ID, DEVICE_ID, qos, CONTENT_TYPE, null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.send(topic, null, DEVICE_ID, qos, CONTENT_TYPE, null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.send(topic, TENANT_ID, null, qos, CONTENT_TYPE, null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.send(topic, TENANT_ID, DEVICE_ID, null, CONTENT_TYPE, null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.send(topic, TENANT_ID, DEVICE_ID, qos, null, null, null, null));
+
+    }
+}

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedMessageSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedMessageSenderTest.java
@@ -41,10 +41,10 @@ import io.vertx.core.json.Json;
 import io.vertx.junit5.VertxExtension;
 
 /**
- * Verifies behavior of {@link AbstractKafkaBasedDownstreamSender}.
+ * Verifies behavior of {@link AbstractKafkaBasedMessageSender}.
  */
 @ExtendWith(VertxExtension.class)
-public class AbstractKafkaBasedDownstreamSenderTest {
+public class AbstractKafkaBasedMessageSenderTest {
 
     private static final String TENANT_ID = "the-tenant";
     private static final String DEVICE_ID = "the-device";
@@ -57,7 +57,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
     private final HonoTopic topic = new HonoTopic(HonoTopic.Type.EVENT, "foo");
 
     private CachingKafkaProducerFactory<String, Buffer> factory;
-    private AbstractKafkaBasedDownstreamSender sender;
+    private AbstractKafkaBasedMessageSender sender;
 
     /**
      * Sets up the downstream sender.
@@ -68,13 +68,13 @@ public class AbstractKafkaBasedDownstreamSenderTest {
 
         factory = new CachingKafkaProducerFactory<>((n, c) -> new FakeProducer<>());
 
-        sender = new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, config, tracer) {
+        sender = new AbstractKafkaBasedMessageSender(factory, PRODUCER_NAME, config, tracer) {
         };
     }
 
     /**
-     * Verifies that {@link AbstractKafkaBasedDownstreamSender#start()} creates a producer and
-     * {@link AbstractKafkaBasedDownstreamSender#stop()} closes it.
+     * Verifies that {@link AbstractKafkaBasedMessageSender#start()} creates a producer and
+     * {@link AbstractKafkaBasedMessageSender#stop()} closes it.
      */
     @Test
     public void testLifecycle() {
@@ -116,7 +116,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
 
     /**
      * Verifies that the future returned by
-     * {@link AbstractKafkaBasedDownstreamSender#send(HonoTopic, String, String, QoS, String, Buffer, Map, SpanContext)}
+     * {@link AbstractKafkaBasedMessageSender#send(HonoTopic, String, String, QoS, String, Buffer, Map, SpanContext)}
      * completes successfully when the send operation of the Kafka client succeeds.
      */
     @Test
@@ -213,25 +213,25 @@ public class AbstractKafkaBasedDownstreamSenderTest {
     public void testThatConstructorThrowsOnMissingParameter() {
 
         assertThrows(NullPointerException.class,
-                () -> new AbstractKafkaBasedDownstreamSender(null, PRODUCER_NAME, config, tracer) {
+                () -> new AbstractKafkaBasedMessageSender(null, PRODUCER_NAME, config, tracer) {
                 });
 
         assertThrows(NullPointerException.class,
-                () -> new AbstractKafkaBasedDownstreamSender(factory, null, config, tracer) {
+                () -> new AbstractKafkaBasedMessageSender(factory, null, config, tracer) {
                 });
 
         assertThrows(NullPointerException.class,
-                () -> new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, null, tracer) {
+                () -> new AbstractKafkaBasedMessageSender(factory, PRODUCER_NAME, null, tracer) {
                 });
 
         assertThrows(NullPointerException.class,
-                () -> new AbstractKafkaBasedDownstreamSender(factory, PRODUCER_NAME, config, null) {
+                () -> new AbstractKafkaBasedMessageSender(factory, PRODUCER_NAME, config, null) {
                 });
     }
 
     /**
      * Verifies that
-     * {@link AbstractKafkaBasedDownstreamSender#send(HonoTopic, String, String, QoS, String, Buffer, Map, SpanContext)}
+     * {@link AbstractKafkaBasedMessageSender#send(HonoTopic, String, String, QoS, String, Buffer, Map, SpanContext)}
      * throws a nullpointer exception if a mandatory parameter is {@code null}.
      */
     @Test

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSenderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.eclipse.hono.kafka.client.CachingKafkaProducerFactory;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.test.FakeProducer;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+
+/**
+ * Verifies behavior of {@link KafkaBasedEventSender}.
+ */
+public class KafkaBasedEventSenderTest {
+
+    private final RegistrationAssertion device = new RegistrationAssertion("the-device");
+    private final TenantObject tenant = new TenantObject("the-tenant", true);
+    private final Tracer tracer = NoopTracerFactory.create();
+
+    private CachingKafkaProducerFactory<String, Buffer> factory;
+    private KafkaProducerConfigProperties kafkaProducerConfig;
+    private KafkaBasedEventSender sender;
+
+    /**
+     * Sets up the event sender.
+     */
+    @BeforeEach
+    public void setUp() {
+
+        kafkaProducerConfig = new KafkaProducerConfigProperties();
+        kafkaProducerConfig.setProducerConfig(new HashMap<>());
+
+        factory = new CachingKafkaProducerFactory<>((name, config) -> new FakeProducer<>());
+        sender = new KafkaBasedEventSender(factory, kafkaProducerConfig, tracer);
+
+    }
+
+    /**
+     * Verifies that the Kafka record is created as expected.
+     */
+    @Test
+    public void testSendEventCreatesCorrectRecord() {
+
+        // GIVEN a sender
+        final String payload = "the-payload";
+
+        // WHEN sending a message
+        sender.sendEvent(tenant, device, "the-content-type", Buffer.buffer(payload), null, null);
+
+        // THEN the producer record is created from the given values...
+        final ProducerRecord<String, Buffer> actual = TestHelper.getUnderlyingMockProducer(factory, "event")
+                .history().get(0);
+
+        assertThat(actual.key()).isEqualTo(device.getDeviceId());
+        assertThat(actual.topic()).isEqualTo(new HonoTopic(HonoTopic.Type.EVENT, tenant.getTenantId()).toString());
+        assertThat(actual.value().toString()).isEqualTo(payload);
+
+        // ...AND contains the standard headers
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("content-type", "the-content-type".getBytes()));
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("device_id", device.getDeviceId().getBytes()));
+        assertThat(actual.headers())
+                .containsOnlyOnce(new RecordHeader("qos", Json.encode(QoS.AT_LEAST_ONCE.ordinal()).getBytes()));
+
+    }
+
+
+    /**
+     * Verifies that the constructor throws a nullpointer exception if a parameter is {@code null}.
+     */
+    @Test
+    public void testThatConstructorThrowsOnMissingParameter() {
+        assertThrows(NullPointerException.class, () -> new KafkaBasedEventSender(null, kafkaProducerConfig, tracer));
+        assertThrows(NullPointerException.class, () -> new KafkaBasedEventSender(factory, null, tracer));
+        assertThrows(NullPointerException.class, () -> new KafkaBasedEventSender(factory, kafkaProducerConfig, null));
+    }
+
+    /**
+     * Verifies that
+     * {@link KafkaBasedEventSender#sendEvent(TenantObject, RegistrationAssertion, String, Buffer, Map, SpanContext)}
+     * throws a nullpointer exception if a mandatory parameter is {@code null}.
+     */
+    @Test
+    public void testThatSendEventThrowsOnMissingMandatoryParameter() {
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendEvent(null, device, "the-content-type", null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendEvent(tenant, null, "the-content-type", null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendEvent(tenant, device, null, null, null, null));
+
+    }
+}

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.eclipse.hono.kafka.client.CachingKafkaProducerFactory;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.test.FakeProducer;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+
+/**
+ * Verifies behavior of {@link KafkaBasedTelemetrySender}.
+ */
+public class KafkaBasedTelemetrySenderTest {
+
+    private final RegistrationAssertion device = new RegistrationAssertion("the-device");
+    private final TenantObject tenant = new TenantObject("the-tenant", true);
+    private final Tracer tracer = NoopTracerFactory.create();
+
+    private CachingKafkaProducerFactory<String, Buffer> factory;
+    private KafkaProducerConfigProperties kafkaProducerConfig;
+    private KafkaBasedTelemetrySender sender;
+
+    /**
+     * Sets up the telemetry sender.
+     */
+    @BeforeEach
+    public void setUp() {
+
+        kafkaProducerConfig = new KafkaProducerConfigProperties();
+        kafkaProducerConfig.setProducerConfig(new HashMap<>());
+
+        factory = new CachingKafkaProducerFactory<>((name, config) -> new FakeProducer<>());
+        sender = new KafkaBasedTelemetrySender(factory, kafkaProducerConfig, tracer);
+    }
+
+    /**
+     * Verifies that the Kafka record is created as expected when sending telemetry data with QoS 0.
+     */
+    @Test
+    public void testSendTelemetryCreatesCorrectRecordWithQoS0() {
+
+        // GIVEN a telemetry sender
+        final QoS qos = QoS.AT_MOST_ONCE;
+        final String payload = "the-payload";
+
+        // WHEN sending telemetry data with QoS 0
+        sender.sendTelemetry(tenant, device, qos, "the-content-type", Buffer.buffer(payload), null, null);
+
+        // THEN the producer record is created from the given values...
+        final ProducerRecord<String, Buffer> actual = TestHelper.getUnderlyingMockProducer(factory, "telemetry")
+                .history().get(0);
+
+        assertThat(actual.key()).isEqualTo(device.getDeviceId());
+        assertThat(actual.topic()).isEqualTo(new HonoTopic(HonoTopic.Type.TELEMETRY, tenant.getTenantId()).toString());
+        assertThat(actual.value().toString()).isEqualTo(payload);
+
+        // ...AND contains the standard headers
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("content-type", "the-content-type".getBytes()));
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("device_id", device.getDeviceId().getBytes()));
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("qos", Json.encode(qos.ordinal()).getBytes()));
+
+    }
+
+    /**
+     * Verifies that the Kafka record is created as expected when sending telemetry data with QoS 1.
+     */
+    @Test
+    public void testSendTelemetryCreatesCorrectRecordWithQoS1() {
+
+        // GIVEN a telemetry sender
+        final QoS qos = QoS.AT_LEAST_ONCE;
+        final String payload = "the-payload";
+
+        // WHEN sending telemetry data with QoS 1
+        sender.sendTelemetry(tenant, device, qos, "the-content-type", Buffer.buffer(payload), null, null);
+
+        // THEN the producer record is created from the given values...
+        final ProducerRecord<String, Buffer> actual = TestHelper.getUnderlyingMockProducer(factory, "telemetry")
+                .history().get(0);
+
+        assertThat(actual.key()).isEqualTo(device.getDeviceId());
+        assertThat(actual.topic()).isEqualTo(new HonoTopic(HonoTopic.Type.TELEMETRY, tenant.getTenantId()).toString());
+        assertThat(actual.value().toString()).isEqualTo(payload);
+
+        // ...AND contains the standard headers
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("content-type", "the-content-type".getBytes()));
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("device_id", device.getDeviceId().getBytes()));
+        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("qos", Json.encode(qos.ordinal()).getBytes()));
+
+    }
+
+    /**
+     * Verifies that the constructor throws a nullpointer exception if a parameter is {@code null}.
+     */
+    @Test
+    public void testThatConstructorThrowsOnMissingParameter() {
+        assertThrows(NullPointerException.class,
+                () -> new KafkaBasedTelemetrySender(null, kafkaProducerConfig, tracer));
+
+        assertThrows(NullPointerException.class, () -> new KafkaBasedTelemetrySender(factory, null, tracer));
+
+        assertThrows(NullPointerException.class,
+                () -> new KafkaBasedTelemetrySender(factory, kafkaProducerConfig, null));
+    }
+
+    /**
+     * Verifies that
+     * {@link KafkaBasedTelemetrySender#sendTelemetry(TenantObject, RegistrationAssertion, QoS, String, Buffer, Map, SpanContext)}
+     * throws a nullpointer exception if a mandatory parameter is {@code null}.
+     */
+    @Test
+    public void testThatSendTelemetryThrowsOnMissingMandatoryParameter() {
+        final QoS qos = QoS.AT_LEAST_ONCE;
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendTelemetry(null, device, qos, "the-content-type", null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendTelemetry(tenant, null, qos, "the-content-type", null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendTelemetry(tenant, device, null, "the-content-type", null, null, null));
+
+        assertThrows(NullPointerException.class,
+                () -> sender.sendTelemetry(tenant, device, qos, null, null, null, null));
+
+    }
+}

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/TestHelper.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/TestHelper.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import java.util.NoSuchElementException;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.eclipse.hono.kafka.client.CachingKafkaProducerFactory;
+import org.eclipse.hono.kafka.test.FakeProducer;
+
+import io.vertx.kafka.client.producer.KafkaProducer;
+
+/**
+ * A helper class for writing tests with the Kafka client.
+ */
+public class TestHelper {
+
+    private TestHelper() {
+    }
+
+    /**
+     * Gets the {@link MockProducer} for the given producer name from a factory.
+     *
+     * @param producerFactory The factory containing the {@link FakeProducer}.
+     * @param producerName The name under which the fake producer is cached in the factory.
+     * @param <K> The type for the record key serialization.
+     * @param <V> The type for the record value serialization.
+     * @return The mock producer.
+     *
+     * @throws NoSuchElementException if the given factory does not contain the expected producer (e.g. when the
+     *             producer got closed after a fatal error).
+     * @throws ClassCastException if the provided producer implementation is not an instance of {@link FakeProducer}.
+     */
+    public static <K, V> MockProducer<K, V> getUnderlyingMockProducer(
+            final CachingKafkaProducerFactory<K, V> producerFactory, final String producerName) {
+
+        final KafkaProducer<K, V> kafkaProducer = producerFactory.getProducer(producerName)
+                .orElseThrow(() -> new NoSuchElementException("no producer present in producer factory"));
+
+        return getMockProducerFromFakeProducer(kafkaProducer);
+    }
+
+    /**
+     * Gets the {@link MockProducer} from a given {@link FakeProducer}.
+     *
+     * @param fakeProducer The fake producer to get the mock producer from.
+     * @param <K> The type for the record key serialization.
+     * @param <V> The type for the record value serialization.
+     * @return The mock producer.
+     *
+     * @throws ClassCastException if the provided producer implementation is not an instance of {@link FakeProducer}.
+     */
+    public static <K, V> MockProducer<K, V> getMockProducerFromFakeProducer(
+            final KafkaProducer<K, V> fakeProducer) {
+
+        return ((FakeProducer<K, V>) fakeProducer).getMockProducer();
+    }
+
+}

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/EventSender.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/telemetry/EventSender.java
@@ -51,7 +51,7 @@ public interface EventSender extends Lifecycle {
      *         The future will be failed with a {@code org.eclipse.hono.client.ServerErrorException} if the data
      *         could not be sent. The error code contained in the exception indicates the
      *         cause of the failure.
-     * @throws NullPointerException if tenant or device are {@code null}.
+     * @throws NullPointerException if tenant, device or contentType are {@code null}.
      */
     Future<Void> sendEvent(
             TenantObject tenant,

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-clients-parent</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>hono-client-kafka-common</artifactId>
+
+    <name>Hono Client Kafka Common</name>
+    <description>Classes required for implementing Kafka based Hono clients</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-proton</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.jsonwebtoken</groupId>
+                    <artifactId>jjwt-jackson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.jsonwebtoken</groupId>
+                    <artifactId>jjwt-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.jsonwebtoken</groupId>
+                    <artifactId>jjwt-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-crypto</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-kafka-client</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>kafka-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-clients-parent</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>hono-client-kafka-common</artifactId>
 

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/CachingKafkaConsumerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/CachingKafkaConsumerFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.kafka.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+
+/**
+ * TODO.
+ *
+ * @param <K> The type for the record key serialization.
+ * @param <V> The type for the record value serialization.
+ */
+public class CachingKafkaConsumerFactory<K, V> implements KafkaConsumerFactory<K, V> {
+    private final Map<String, KafkaConsumer<K, V>> activeConsumers = new HashMap<>();
+    private final BiFunction<String, Map<String, String>, KafkaConsumer<K, V>> consumerInstanceSupplier;
+
+    /**
+     * Creates a new consumer factory.
+     * <p>
+     * Use {@link KafkaConsumerFactory#consumerFactory(Vertx)} to create consumers.
+     *
+     * @param consumerInstanceSupplier The function that provides new consumer instances.
+     */
+    public CachingKafkaConsumerFactory(
+            final BiFunction<String, Map<String, String>, KafkaConsumer<K, V>> consumerInstanceSupplier) {
+        this.consumerInstanceSupplier = consumerInstanceSupplier;
+    }
+
+    @Override
+    public KafkaConsumer<K, V> getOrCreateConsumer(final String consumerName,
+            final Map<String, String> config) {
+        activeConsumers.computeIfAbsent(consumerName, (name) -> {
+            final KafkaConsumer<K, V> consumer = consumerInstanceSupplier.apply(consumerName, config);
+            return consumer.exceptionHandler(t -> {
+                //TODO: check for errors and close
+                    closeConsumer(name);
+            });
+        });
+
+        return activeConsumers.get(consumerName);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * If a consumer with the given name exists, it is removed from the cache.
+     */
+    @Override
+    public Future<Void> closeConsumer(final String consumerName) {
+        final KafkaConsumer<K, V> consumer = activeConsumers.remove(consumerName);
+        if (consumer == null) {
+            return Future.succeededFuture();
+        } else {
+            final Promise<Void> promise = Promise.promise();
+            consumer.close(promise);
+            return promise.future();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> close() {
+        // TODO.
+        return CompositeFuture.all(activeConsumers
+                .keySet()
+                .stream()
+                .map(this::closeConsumer)
+                .collect(Collectors.toList())).mapEmpty();
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/CachingKafkaProducerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/CachingKafkaProducerFactory.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.producer.KafkaProducer;
+
+/**
+ * A factory for creating Kafka producers. Created producers are being cached.
+ * <p>
+ * This implementation provides no synchronization and should not be used by multiple threads. To create producers that
+ * can safely be shared between verticle instances, use {@link KafkaProducerFactory#sharedProducerFactory(Vertx)}.
+ * <p>
+ * Producers are closed and removed from the cache if they throw a {@link #isFatalError(Throwable) fatal exception}. A
+ * following invocation of {@link #getOrCreateProducer(String, Map)} will then return a new instance.
+ *
+ * @param <K> The type for the record key serialization.
+ * @param <V> The type for the record value serialization.
+ */
+public class CachingKafkaProducerFactory<K, V> implements KafkaProducerFactory<K, V> {
+
+    private final Map<String, KafkaProducer<K, V>> activeProducers = new HashMap<>();
+    private final BiFunction<String, Map<String, String>, KafkaProducer<K, V>> producerInstanceSupplier;
+
+    /**
+     * Creates a new producer factory.
+     * <p>
+     * Use {@link KafkaProducerFactory#sharedProducerFactory(Vertx)} to create producers that can safely be shared
+     * between verticle instances.
+     *
+     * @param producerInstanceSupplier The function that provides new producer instances.
+     */
+    public CachingKafkaProducerFactory(
+            final BiFunction<String, Map<String, String>, KafkaProducer<K, V>> producerInstanceSupplier) {
+        this.producerInstanceSupplier = producerInstanceSupplier;
+    }
+
+    /**
+     * Gets a producer for sending data to Kafka.
+     * <p>
+     * This method first tries to look up an already existing producer using the given name. If no producer exists yet,
+     * a new instance is created using the given factory and put to the cache.
+     * <p>
+     * The given config is ignored when an existing producers is returned.
+     *
+     * @param producerName The name to identify the producer.
+     * @param config The Kafka configuration with which the producer is to be created.
+     * @return an existing or new producer.
+     */
+    @Override
+    public KafkaProducer<K, V> getOrCreateProducer(final String producerName, final Map<String, String> config) {
+
+        activeProducers.computeIfAbsent(producerName, (name) -> {
+            final KafkaProducer<K, V> producer = producerInstanceSupplier.apply(producerName, config);
+            return producer.exceptionHandler(t -> {
+                if (isFatalError(t)) {
+                    closeProducer(name);
+                }
+            });
+        });
+
+        return activeProducers.get(producerName);
+    }
+
+    /**
+     * Gets an existing producer.
+     *
+     * @param producerName The name to look up the producer.
+     * @return The producer or {@code null} if the cache does not contain the name.
+     */
+    public Optional<KafkaProducer<K, V>> getProducer(final String producerName) {
+        return Optional.ofNullable(activeProducers.get(producerName));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * If a producer with the given name exists, it is removed from the cache.
+     */
+    @Override
+    public Future<Void> closeProducer(final String producerName) {
+        final KafkaProducer<K, V> producer = activeProducers.remove(producerName);
+        if (producer == null) {
+            return Future.succeededFuture();
+        } else {
+            final Promise<Void> promise = Promise.promise();
+            producer.close(promise);
+            return promise.future();
+        }
+    }
+
+    /**
+     * Checks if the given throwable indicates a fatal producer error.
+     *
+     * @param error The error to be checked.
+     * @return {@code true} if error is an instance of one of the following ({@code false} otherwise):
+     *         <ul>
+     *         <li>{@link ProducerFencedException}</li>
+     *         <li>{@link OutOfOrderSequenceException}</li>
+     *         <li>{@link AuthorizationException}</li>
+     *         <li>{@link UnsupportedVersionException}</li>
+     *         <li>{@link UnsupportedForMessageFormatException}.</li>
+     *         </ul>
+     */
+    public static boolean isFatalError(final Throwable error) {
+        return error instanceof ProducerFencedException
+                || error instanceof OutOfOrderSequenceException
+                || error instanceof AuthorizationException
+                || error instanceof UnsupportedVersionException
+                || error instanceof UnsupportedForMessageFormatException;
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/HonoTopic.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/HonoTopic.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.Objects;
+
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.TelemetryConstants;
+
+/**
+ * Identifier for Hono's topics. The Kafka topic string is obtained by {@link #toString()}.
+ */
+public final class HonoTopic {
+
+    private static final String SEPARATOR = ".";
+    private static final String NAMESPACE = "hono" + SEPARATOR;
+
+    private final String topicString;
+
+    /**
+     * Creates a new topic from the given topic type and tenant ID.
+     *
+     * @param type The type of the topic.
+     * @param tenantId The ID of the tenant that the topic belongs to.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public HonoTopic(final Type type, final String tenantId) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(tenantId);
+
+        topicString = type.prefix + tenantId;
+    }
+
+    /**
+     * Creates a topic instance from the string representation.
+     *
+     * @param topicString The string to create a topic from.
+     * @return The topic or {@code null} if the string does not contain a valid Hono topic.
+     */
+    public static HonoTopic fromString(final String topicString) {
+        if (topicString.startsWith(Type.TELEMETRY.prefix)) {
+            return new HonoTopic(Type.TELEMETRY, topicString.substring(Type.TELEMETRY.prefix.length()));
+        } else if (topicString.startsWith(Type.EVENT.prefix)) {
+            return new HonoTopic(Type.EVENT, topicString.substring(Type.EVENT.prefix.length()));
+        } else if (topicString.startsWith(Type.COMMAND.prefix)) {
+            return new HonoTopic(Type.COMMAND, topicString.substring(Type.COMMAND.prefix.length()));
+        } else if (topicString.startsWith(Type.COMMAND_RESPONSE.prefix)) {
+            return new HonoTopic(Type.COMMAND_RESPONSE, topicString.substring(Type.COMMAND_RESPONSE.prefix.length()));
+        }
+        return null;
+    }
+
+    /**
+     * Returns the string representation of the topic as used by the Kafka client.
+     *
+     * @return The topic as a string.
+     */
+    @Override
+    public String toString() {
+        return topicString;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final HonoTopic honoTopic = (HonoTopic) o;
+        return topicString.equals(honoTopic.topicString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicString);
+    }
+
+    /**
+     * The type of a Hono specific Kafka topic.
+     */
+    public enum Type {
+
+        TELEMETRY(NAMESPACE + TelemetryConstants.TELEMETRY_ENDPOINT + SEPARATOR),
+        EVENT(NAMESPACE + EventConstants.EVENT_ENDPOINT + SEPARATOR),
+        COMMAND(NAMESPACE + CommandConstants.COMMAND_ENDPOINT + SEPARATOR),
+        COMMAND_RESPONSE(NAMESPACE + CommandConstants.COMMAND_RESPONSE_ENDPOINT + SEPARATOR);
+
+        final String prefix;
+
+        Type(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String toString() {
+            return name().toLowerCase();
+        }
+
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/HonoTopic.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/HonoTopic.java
@@ -28,6 +28,7 @@ public final class HonoTopic {
     private static final String NAMESPACE = "hono" + SEPARATOR;
 
     private final String topicString;
+    private final String tenantId;
 
     /**
      * Creates a new topic from the given topic type and tenant ID.
@@ -40,6 +41,7 @@ public final class HonoTopic {
         Objects.requireNonNull(type);
         Objects.requireNonNull(tenantId);
 
+        this.tenantId = tenantId;
         topicString = type.prefix + tenantId;
     }
 
@@ -56,10 +58,30 @@ public final class HonoTopic {
             return new HonoTopic(Type.EVENT, topicString.substring(Type.EVENT.prefix.length()));
         } else if (topicString.startsWith(Type.COMMAND.prefix)) {
             return new HonoTopic(Type.COMMAND, topicString.substring(Type.COMMAND.prefix.length()));
+        } else if (topicString.startsWith(Type.COMMAND_INTERNAL.prefix)) {
+            return new HonoTopic(Type.COMMAND_INTERNAL, topicString.substring(Type.COMMAND_INTERNAL.prefix.length()));
         } else if (topicString.startsWith(Type.COMMAND_RESPONSE.prefix)) {
             return new HonoTopic(Type.COMMAND_RESPONSE, topicString.substring(Type.COMMAND_RESPONSE.prefix.length()));
         }
         return null;
+    }
+
+    /**
+     * Get the tenantId from the HonoTopic.
+     *
+     * @return The tenantId from the HonoTopic.
+     */
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Get the separator used for the HonoTopic.
+     *
+     * @return the topic separator.
+     */
+    public static String getSeparator() {
+        return SEPARATOR;
     }
 
     /**
@@ -97,6 +119,7 @@ public final class HonoTopic {
         TELEMETRY(NAMESPACE + TelemetryConstants.TELEMETRY_ENDPOINT + SEPARATOR),
         EVENT(NAMESPACE + EventConstants.EVENT_ENDPOINT + SEPARATOR),
         COMMAND(NAMESPACE + CommandConstants.COMMAND_ENDPOINT + SEPARATOR),
+        COMMAND_INTERNAL(NAMESPACE + CommandConstants.INTERNAL_COMMAND_ENDPOINT + SEPARATOR),
         COMMAND_RESPONSE(NAMESPACE + CommandConstants.COMMAND_RESPONSE_ENDPOINT + SEPARATOR);
 
         final String prefix;

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaConsumerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaConsumerConfigProperties.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configuration properties for Kafka consumers.
+ * <p>
+ * This class is intended to be as agnostic to the provided properties as possible in order to be forward-compatible
+ * with changes in new versions of the Kafka client. It only sets a couple of properties that are important for Hono to
+ * provide the expected quality of service.
+ *
+ * @see <a href="https://kafka.apache.org/documentation/#consumerconfigs">Kafka Consumer Configs</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/kafka">Documentation of Hono's Kafka-based APIs</a>
+ */
+// TODO check link to Hono documentation after the API specs are on master
+public class KafkaConsumerConfigProperties {
+
+    private final Logger log = LoggerFactory.getLogger(KafkaConsumerConfigProperties.class);
+
+    private Map<String, String> consumerConfig;
+    private String clientId;
+
+    /**
+     * Sets the Kafka consumer config properties to be used.
+     *
+     * @param consumerConfig The config properties.
+     * @throws NullPointerException if the config is {@code null}.
+     */
+    public void setConsumerConfig(final Map<String, String> consumerConfig) {
+        this.consumerConfig = Objects.requireNonNull(consumerConfig);
+    }
+
+    /**
+     * Sets the client ID that is passed to the Kafka server to allow application specific server-side request logging.
+     * <p>
+     * If the config set in {@link #setConsumerConfig(Map)} already contains a value for key {@code client.id}, that one
+     * will be used and the parameter here will be ignored.
+     *
+     * @param clientId The client ID to set.
+     * @throws NullPointerException if the client ID is {@code null}.
+     */
+    public final void setClientId(final String clientId) {
+        this.clientId = Objects.requireNonNull(clientId);
+    }
+
+    /**
+     * Gets the Kafka consumer configuration to which additional properties were applied. The following properties are
+     * set here to the given configuration:
+     * <ul>
+     * <li>{@code key.deserializer=org.apache.kafka.common.serialization.StringDeserializer}: defines how message keys
+     * are deserialized</li>
+     * <li>{@code value.deserializer=io.vertx.kafka.client.serialization.BufferDeserializer}: defines how message values
+     * are deserialized</li>
+     * <li>{@code client.id} if the property is not already present in the configuration and a value has been set with
+     * {@link #setClientId(String)}, this value will be taken</li>
+     * </ul>
+     *
+     * @return a copy of the consumer configuration with the applied properties an empty map if no consumer
+     *         configuration was set with {@link #setConsumerConfig(Map)}.
+     */
+    public Map<String, String> getConsumerConfig() {
+
+        if (consumerConfig == null) {
+            return Collections.emptyMap();
+        }
+
+        final HashMap<String, String> newConfig = new HashMap<>(consumerConfig);
+
+        overrideConsumerConfigProperty(newConfig, ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringDeserializer");
+
+        overrideConsumerConfigProperty(newConfig, ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                "io.vertx.kafka.client.serialization.BufferDeserializer");
+
+        if (clientId != null) {
+            newConfig.putIfAbsent(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
+        }
+
+        return newConfig;
+    }
+
+    private void overrideConsumerConfigProperty(final Map<String, String> config, final String key,
+            final String value) {
+
+        log.trace("Setting Kafka consumer config property [{}={}]", key, value);
+        final Object oldValue = config.put(key, value);
+        if (oldValue != null) {
+            log.debug("Provided Kafka consumer configuration contains property [{}={}], changing it to [{}]", key,
+                    oldValue, value);
+        }
+
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaConsumerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaConsumerFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.kafka.client;
+
+import java.util.Map;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+
+/**
+ * A factory for creating Kafka consumers.
+ *
+ * @param <K> The type for the record key serialization.
+ * @param <V> The type for the record value serialization.
+ */
+public interface KafkaConsumerFactory<K, V> {
+
+    /**
+     * Creates a new factory which produces {@link io.vertx.kafka.client.consumer.KafkaConsumer#create(Vertx, Map)}.
+     * <p>
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param <K> The type for the record key serialization.
+     * @param <V> The type for the record value serialization.
+     * @return An instance of the factory.
+     */
+    static <K, V> KafkaConsumerFactory<K, V> consumerFactory(final Vertx vertx) {
+        return new CachingKafkaConsumerFactory<>((name, config) -> KafkaConsumer.create(vertx, config));
+    }
+
+    /**
+     * Gets a consumer for consuming data from a Kafka cluster.
+     * <p>
+     * The consumer returned may be either newly created or it may be an existing consumer for the given consumer name.
+     * The config parameter might be ignored if an existing consumer is returned.
+     *
+     * @param consumerName The name to identify the consumer.
+     * @param config The Kafka configuration with which the consumer is to be created.
+     * @return an existing or new consumer.
+     */
+    KafkaConsumer<K, V> getOrCreateConsumer(String consumerName, Map<String, String> config);
+
+    /**
+     * Closes the consumer with the given consumer name if it exists.
+     *
+     * @param consumerName The name of the consumer to remove.
+     * @return A future that is completed when the close operation completed or a succeeded future if no consumer
+     *         existed with the given name.
+     */
+    Future<Void> closeConsumer(String consumerName);
+
+    /**
+     * Closes all the active consumers in this factory.
+     *
+     * @return A future indicating the outcome.
+     *         If the future succeeds if all the active consumers have been successfully closed.
+     *         Otherwise the future will fail.
+     */
+    Future<Void> close();
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaProducerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaProducerConfigProperties.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configuration properties for Kafka producers.
+ * <p>
+ * This class is intended to be as agnostic to the provided properties as possible in order to be forward-compatible
+ * with changes in new versions of the Kafka client. It only sets a couple of properties that are important for Hono to
+ * provide the expected quality of service.
+ *
+ * @see <a href="https://kafka.apache.org/documentation/#producerconfigs">Kafka Producer Configs</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/kafka">Documentation of Hono's Kafka-based APIs</a>
+ */
+// TODO check link to Hono documentation after the API specs are on master
+public class KafkaProducerConfigProperties {
+
+    private final Logger log = LoggerFactory.getLogger(KafkaProducerConfigProperties.class);
+
+    private Map<String, String> producerConfig;
+    private String clientId;
+
+    /**
+     * Sets the Kafka producer config properties to be used.
+     *
+     * @param producerConfig The config properties.
+     * @throws NullPointerException if the config is {@code null}.
+     */
+    public void setProducerConfig(final Map<String, String> producerConfig) {
+        this.producerConfig = Objects.requireNonNull(producerConfig);
+    }
+
+    /**
+     * Sets the client ID that is passed to the Kafka server to allow application specific server-side request logging.
+     * <p>
+     * If the config set in {@link #setProducerConfig(Map)} already contains a value for key {@code client.id}, that one
+     * will be used and the parameter here will be ignored.
+     *
+     * @param clientId The client ID to set.
+     * @throws NullPointerException if the client ID is {@code null}.
+     */
+    public final void setClientId(final String clientId) {
+        this.clientId = Objects.requireNonNull(clientId);
+    }
+
+    /**
+     * Gets the Kafka producer configuration to which additional properties were applied. The following properties are
+     * set here to the given configuration:
+     * <ul>
+     * <li>{@code enable.idempotence=true}: enables idempotent producer behavior</li>
+     * <li>{@code key.serializer=org.apache.kafka.common.serialization.StringSerializer}: defines how message keys are
+     * serialized</li>
+     * <li>{@code value.serializer=io.vertx.kafka.client.serialization.BufferSerializer}: defines how message values are
+     * serialized</li>
+     *
+     * <li>{@code client.id} if the property is not already present in the configuration and a value has been set with
+     * {@link #setClientId(String)}, this value will be taken</li>
+     * </ul>
+     *
+     * @return a copy of the producer configuration with the applied properties or an empty map if no producer
+     *         configuration was set with {@link #setProducerConfig(Map)}.
+     * @see <a href="https://kafka.apache.org/documentation/#enable.idempotence">The Kafka documentation -
+     *      "Producer Configs" - enable.idempotence</a>
+     */
+    public Map<String, String> getProducerConfig() {
+
+        if (producerConfig == null) {
+            return Collections.emptyMap();
+        }
+
+        final HashMap<String, String> newConfig = new HashMap<>(producerConfig);
+
+        overrideProducerConfigProperty(newConfig, ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringSerializer");
+
+        overrideProducerConfigProperty(newConfig, ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "io.vertx.kafka.client.serialization.BufferSerializer");
+
+        overrideProducerConfigProperty(newConfig, ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+
+        if (clientId != null) {
+            newConfig.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, clientId);
+        }
+
+        return newConfig;
+    }
+
+    private void overrideProducerConfigProperty(final Map<String, String> config, final String key,
+            final String value) {
+
+        log.trace("Setting Kafka producer config property [{}={}]", key, value);
+        final Object oldValue = config.put(key, value);
+        if (oldValue != null) {
+            log.debug("Provided Kafka producer configuration contains property [{}={}], changing it to [{}]", key,
+                    oldValue, value);
+        }
+
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaProducerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/KafkaProducerFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import java.util.Map;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.producer.KafkaProducer;
+
+/**
+ * A factory for creating Kafka producers.
+ *
+ * @param <K> The type for the record key serialization.
+ * @param <V> The type for the record value serialization.
+ */
+public interface KafkaProducerFactory<K, V> {
+
+    /**
+     * Creates a new factory which produces {@link KafkaProducer#createShared(Vertx, String, Map) shared producers}.
+     * Shared producers
+     * can safely be shared between verticle instances.
+     * <p>
+     * Config must always be the same for the same key in {@link #getOrCreateProducer(String, Map)}.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param <K> The type for the record key serialization.
+     * @param <V> The type for the record value serialization.
+     * @return An instance of the factory.
+     */
+    static <K, V> KafkaProducerFactory<K, V> sharedProducerFactory(final Vertx vertx) {
+        return new CachingKafkaProducerFactory<>((name, config) -> KafkaProducer.createShared(vertx, name, config));
+    }
+
+    /**
+     * Gets a producer for sending data to Kafka.
+     * <p>
+     * The producer returned may be either newly created or it may be an existing producer for the given producer name.
+     * The config parameter might be ignored if an existing producer is returned.
+     *
+     * @param producerName The name to identify the producer.
+     * @param config The Kafka configuration with which the producer is to be created.
+     * @return an existing or new producer.
+     */
+    KafkaProducer<K, V> getOrCreateProducer(String producerName, Map<String, String> config);
+
+    /**
+     * Closes the producer with the given producer name if it exists.
+     *
+     * @param producerName The name of the producer to remove.
+     * @return A future that is completed when the close operation completed or a succeeded future if no producer
+     *         existed with the given name.
+     */
+    Future<Void> closeProducer(String producerName);
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaHeaderInjectAdapter.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaHeaderInjectAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client.tracing;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+import io.opentracing.propagation.TextMap;
+import io.vertx.kafka.client.producer.KafkaHeader;
+
+/**
+ * An adapter for injecting properties as a new {@link KafkaHeader} to a list of Vert.x Kafka producer headers.
+ *
+ */
+public final class KafkaHeaderInjectAdapter implements TextMap {
+
+    private final List<KafkaHeader> headers;
+
+    /**
+     * Creates an adapter for a list of {@link KafkaHeader} objects.
+     *
+     * @param headers The list of {@link KafkaHeader} objects.
+     */
+    public KafkaHeaderInjectAdapter(final List<KafkaHeader> headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void put(final String key, final String value) {
+        headers.add(KafkaHeader.header(key, value));
+    }
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaTracingHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaTracingHelper.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client.tracing;
+
+import java.util.Objects;
+
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.tracing.TracingHelper;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopSpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.IntTag;
+import io.opentracing.tag.Tags;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.RecordMetadata;
+
+/**
+ * A helper class providing Kafka-specific utility methods for interacting with the OpenTracing API.
+ *
+ */
+// TODO align with Kafka tracing support in Vert.x 4.0
+public final class KafkaTracingHelper {
+
+    /**
+     * An OpenTracing tag that contains the offset of a Kafka record.
+     */
+    public static final LongTag TAG_OFFSET = new LongTag("offset");
+
+    /**
+     * An OpenTracing tag that contains the partition of a Kafka record.
+     */
+    public static final IntTag TAG_PARTITION = new IntTag("partition");
+
+    /**
+     * An OpenTracing tag that contains the timestamp of a Kafka record.
+     */
+    public static final LongTag TAG_TIMESTAMP = new LongTag("timestamp");
+
+    private KafkaTracingHelper() {
+        // prevent instantiation
+    }
+
+    /**
+     * Creates a new <em>OpenTracing</em> span to trace producing messages to Kafka.
+     * <p>
+     * The returned span will already contain the following tags:
+     * <ul>
+     * <li>{@link Tags#COMPONENT} - set to <em>hono-client-kafka</em></li>
+     * <li>{@link Tags#MESSAGE_BUS_DESTINATION} - set to {@code To_<topic>}</li>
+     * <li>{@link Tags#SPAN_KIND} - set to {@link Tags#SPAN_KIND_PRODUCER}</li>
+     * <li>{@link Tags#PEER_SERVICE} - set to <em>kafka</em></li>
+     * </ul>
+     *
+     * @param tracer The Tracer to use.
+     * @param topic The topic from which the operation name is derived.
+     * @param referenceType The type of reference towards the span context.
+     * @param parent The span context to set as parent and to derive the sampling priority from (may be null).
+     * @return The new span.
+     * @throws NullPointerException if tracer or topic is {@code null}.
+     */
+    public static Span newProducerSpan(final Tracer tracer, final HonoTopic topic, final String referenceType,
+            final SpanContext parent) {
+        Objects.requireNonNull(tracer);
+        Objects.requireNonNull(topic);
+        Objects.requireNonNull(referenceType);
+
+        return TracingHelper.buildSpan(tracer, parent, "To_" + topic.toString(), referenceType)
+                .ignoreActiveSpan()
+                .withTag(Tags.COMPONENT.getKey(), "hono-client-kafka")
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
+                .withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), topic.toString())
+                .withTag(Tags.PEER_SERVICE.getKey(), "kafka")
+                .start();
+    }
+
+    /**
+     * Sets tags from record metadata.
+     * <p>
+     * It sets the following tags:
+     * <ul>
+     * <li>{@link #TAG_OFFSET}</li>
+     * <li>{@link #TAG_PARTITION}</li>
+     * <li>{@link #TAG_TIMESTAMP}</li>
+     * </ul>
+     * <p>
+     * <em>It does not set the topic, as this is expected to be already already set.</em>
+     *
+     * @param span The span to set the tags on.
+     * @param recordMetadata The record metadata.
+     */
+    public static void setRecordMetadataTags(final Span span, final RecordMetadata recordMetadata) {
+
+        TAG_OFFSET.set(span, recordMetadata.getOffset());
+        TAG_PARTITION.set(span, recordMetadata.getPartition());
+        TAG_TIMESTAMP.set(span, recordMetadata.getTimestamp());
+    }
+
+    /**
+     * Injects a {@code SpanContext} into a Kafka record.
+     * <p>
+     * The span context will be added as a Kafka producer header.
+     *
+     * @param tracer The Tracer to use for injecting the context.
+     * @param record The Kafka record to inject the context into.
+     * @param spanContext The context to inject or {@code null} if no context is available.
+     * @throws NullPointerException if tracer or record is {@code null}.
+     */
+    public static void injectSpanContext(final Tracer tracer, final KafkaProducerRecord<String, Buffer> record,
+            final SpanContext spanContext) {
+
+        Objects.requireNonNull(tracer);
+        Objects.requireNonNull(record);
+
+        if (spanContext != null && !(spanContext instanceof NoopSpanContext)) {
+            tracer.inject(spanContext, Format.Builtin.TEXT_MAP, new KafkaHeaderInjectAdapter(record.headers()));
+        }
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/LongTag.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/LongTag.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client.tracing;
+
+import io.opentracing.Span;
+import io.opentracing.tag.AbstractTag;
+
+/**
+ * An OpenTracing tag type for {@code long} values.
+ */
+public class LongTag extends AbstractTag<Long> {
+
+    /**
+     * Creates an instance for the given key.
+     *
+     * @param tagKey The tag key.
+     */
+    public LongTag(final String tagKey) {
+        super(tagKey);
+    }
+
+    @Override
+    public void set(final Span span, final Long tagValue) {
+
+    }
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/CachingKafkaProducerFactoryTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/CachingKafkaProducerFactoryTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.eclipse.hono.kafka.test.FakeProducer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.producer.KafkaProducer;
+
+/**
+ * Verifies behavior of {@link CachingKafkaProducerFactory}.
+ */
+public class CachingKafkaProducerFactoryTest {
+
+    private static final String PRODUCER_NAME = "test-producer";
+
+    private final Map<String, String> config = new HashMap<>();
+
+    private CachingKafkaProducerFactory<String, Buffer> factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new CachingKafkaProducerFactory<>((name, config1) -> new FakeProducer<>());
+
+        config.put("bootstrap.servers", "localhost:9092");
+        config.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        config.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    }
+
+    /**
+     * Verifies that getOrCreateProducer() creates a producers and adds it to the cache.
+     */
+    @Test
+    public void testThatProducerIsAddedToCache() {
+
+        assertThat(factory.getProducer(PRODUCER_NAME)).isEmpty();
+
+        final KafkaProducer<String, Buffer> createProducer = factory.getOrCreateProducer(PRODUCER_NAME, config);
+        assertThat(createProducer).isNotNull();
+
+        final Optional<KafkaProducer<String, Buffer>> actual = factory.getProducer(PRODUCER_NAME);
+        assertThat(actual).isNotEmpty();
+        assertThat(actual.get()).isEqualTo(createProducer);
+
+    }
+
+    /**
+     * Verifies that {@link CachingKafkaProducerFactory#closeProducer(String)} closes the producer and removes it from
+     * the cache.
+     */
+    @Test
+    public void testRemoveProducerClosesAndRemovesFromCache() {
+        final String producerName1 = "first-producer";
+        final String producerName2 = "second-producer";
+
+        // GIVEN a factory that contains two producers
+        final KafkaProducer<String, Buffer> producer1 = factory.getOrCreateProducer(producerName1, config);
+        final KafkaProducer<String, Buffer> producer2 = factory.getOrCreateProducer(producerName2, config);
+        assertThat(producer2).isNotNull();
+
+        // WHEN removing one producer
+        factory.closeProducer(producerName1);
+
+        // THEN the producer is closed...
+        assertThat(((FakeProducer<String, Buffer>) producer1).getMockProducer().closed()).isTrue();
+        // ...AND removed from the cache
+        assertThat(factory.getProducer(producerName1)).isEmpty();
+        // ...AND the second producers is still present and open
+        assertThat(factory.getProducer(producerName2)).isNotEmpty();
+        assertThat(((FakeProducer<String, Buffer>) producer2).getMockProducer().closed()).isFalse();
+
+    }
+
+    /**
+     * Verifies that {@link CachingKafkaProducerFactory#isFatalError(Throwable)} returns true for the expected exception
+     * types.
+     */
+    @Test
+    public void testIsFatalError() {
+
+        assertThat(CachingKafkaProducerFactory.isFatalError(new ProducerFencedException("test"))).isTrue();
+        assertThat(CachingKafkaProducerFactory.isFatalError(new OutOfOrderSequenceException("test"))).isTrue();
+        assertThat(CachingKafkaProducerFactory.isFatalError(new AuthorizationException("test"))).isTrue();
+        assertThat(CachingKafkaProducerFactory.isFatalError(new UnsupportedVersionException("test"))).isTrue();
+        assertThat(CachingKafkaProducerFactory.isFatalError(new UnsupportedForMessageFormatException("test"))).isTrue();
+
+        assertThat(CachingKafkaProducerFactory.isFatalError(new KafkaException("test"))).isFalse();
+    }
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/HonoTopicTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/HonoTopicTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link HonoTopic}.
+ */
+public class HonoTopicTest {
+
+    /**
+     * Verifies that the toString method returns the expected string.
+     */
+    @Test
+    public void testToString() {
+        final String tenantId = "the-tenant";
+
+        final HonoTopic telemetry = new HonoTopic(HonoTopic.Type.TELEMETRY, tenantId);
+        assertThat(telemetry.toString()).isEqualTo("hono.telemetry." + tenantId);
+
+        final HonoTopic event = new HonoTopic(HonoTopic.Type.EVENT, tenantId);
+        assertThat(event.toString()).isEqualTo("hono.event." + tenantId);
+
+        final HonoTopic command = new HonoTopic(HonoTopic.Type.COMMAND, tenantId);
+        assertThat(command.toString()).isEqualTo("hono.command." + tenantId);
+
+        final HonoTopic commandResponse = new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId);
+        assertThat(commandResponse.toString()).isEqualTo("hono.command_response." + tenantId);
+
+    }
+
+    /**
+     * Verifies that the fromString method creates the the expected topic object.
+     */
+    @Test
+    public void testFromString() {
+        final String tenantId = "the-tenant";
+
+        final HonoTopic telemetry = HonoTopic.fromString("hono.telemetry." + tenantId);
+        assertThat(telemetry).isNotNull();
+        assertThat(telemetry.toString()).isEqualTo(HonoTopic.Type.TELEMETRY.prefix + tenantId);
+
+        final HonoTopic event = HonoTopic.fromString("hono.event." + tenantId);
+        assertThat(event).isNotNull();
+        assertThat(event.toString()).isEqualTo(HonoTopic.Type.EVENT.prefix + tenantId);
+
+        final HonoTopic command = HonoTopic.fromString("hono.command." + tenantId);
+        assertThat(command).isNotNull();
+        assertThat(command.toString()).isEqualTo(HonoTopic.Type.COMMAND.prefix + tenantId);
+
+        final HonoTopic commandResponse = HonoTopic.fromString("hono.command_response." + tenantId);
+        assertThat(commandResponse).isNotNull();
+        assertThat(commandResponse.toString()).isEqualTo(HonoTopic.Type.COMMAND_RESPONSE.prefix + tenantId);
+
+    }
+
+    /**
+     * Verifies that the fromString method returns {@code null} for unknown topic strings.
+     */
+    @Test
+    public void testThatFromStringReturnsNullForUnknownTopicString() {
+
+        assertThat(HonoTopic.fromString("bumlux.telemetry.tenant")).isNull();
+        assertThat(HonoTopic.fromString("hono.bumlux.tenant")).isNull();
+        assertThat(HonoTopic.fromString("hono.telemetry-tenant")).isNull();
+    }
+
+    /**
+     * Verifies that the equals method works as expected.
+     */
+    @Test
+    public void testEquals() {
+
+        assertThat(new HonoTopic(HonoTopic.Type.EVENT, "foo"))
+                .isEqualTo(new HonoTopic(HonoTopic.Type.EVENT, "foo"));
+
+        assertThat(new HonoTopic(HonoTopic.Type.EVENT, "foo"))
+                .isNotEqualTo(new HonoTopic(HonoTopic.Type.EVENT, "bar"));
+
+        assertThat(new HonoTopic(HonoTopic.Type.EVENT, "foo"))
+                .isNotEqualTo(new HonoTopic(HonoTopic.Type.COMMAND, "foo"));
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/KafkaConsumerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/KafkaConsumerConfigPropertiesTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link KafkaConsumerConfigProperties}.
+ */
+public class KafkaConsumerConfigPropertiesTest {
+
+    /**
+     * Verifies that trying to set a {@code null} config throws a Nullpointer exception.
+     */
+    @Test
+    public void testThatConfigCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaConsumerConfigProperties().setConsumerConfig(null));
+    }
+
+    /**
+     * Verifies that trying to set a {@code null} client ID throws a Nullpointer exception.
+     */
+    @Test
+    public void testThatClientIdCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaConsumerConfigProperties().setClientId(null));
+    }
+
+    /**
+     * Verifies that properties provided with {@link KafkaConsumerConfigProperties#setConsumerConfig(Map)} are returned
+     * in {@link KafkaConsumerConfigProperties#getConsumerConfig()}.
+     */
+    @Test
+    public void testThatGetConsumerConfigReturnsGivenProperties() {
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        config.setConsumerConfig(Collections.singletonMap("foo", "bar"));
+
+        assertThat(config.getConsumerConfig().get("foo")).isEqualTo("bar");
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setClientId(String)} is applied when it
+     * is not present in the configuration.
+     */
+    @Test
+    public void testThatGetConsumerConfigReturnsAdaptedConfig() {
+
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key.deserializer", "foo");
+        properties.put("value.deserializer", "bar");
+        properties.put("enable.idempotence", "baz");
+
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        config.setConsumerConfig(properties);
+
+        final Map<String, String> consumerConfig = config.getConsumerConfig();
+
+        assertThat(consumerConfig.get("key.deserializer"))
+                .isEqualTo("org.apache.kafka.common.serialization.StringDeserializer");
+        assertThat(consumerConfig.get("value.deserializer"))
+                .isEqualTo("io.vertx.kafka.client.serialization.BufferDeserializer");
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setClientId(String)} is applied when it
+     * is NOT present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsApplied() {
+        final String clientId = "the-client";
+
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        config.setConsumerConfig(Collections.emptyMap());
+        config.setClientId(clientId);
+
+        assertThat(config.getConsumerConfig().get("client.id")).isEqualTo(clientId);
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setClientId(String)} is NOT applied
+     * when it is present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
+        final String userProvidedClientId = "custom-client";
+
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        config.setConsumerConfig(Collections.singletonMap("client.id", userProvidedClientId));
+        config.setClientId("other-client");
+
+        assertThat(config.getConsumerConfig().get("client.id")).isEqualTo(userProvidedClientId);
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/KafkaProducerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/KafkaProducerConfigPropertiesTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link KafkaProducerConfigProperties}.
+ */
+public class KafkaProducerConfigPropertiesTest {
+
+    /**
+     * Verifies that trying to set a {@code null} config throws a Nullpointer exception.
+     */
+    @Test
+    public void testThatConfigCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaProducerConfigProperties().setProducerConfig(null));
+    }
+
+    /**
+     * Verifies that trying to set a {@code null} client ID throws a Nullpointer exception.
+     */
+    @Test
+    public void testThatClientIdCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaProducerConfigProperties().setClientId(null));
+    }
+
+    /**
+     * Verifies that properties provided with {@link KafkaProducerConfigProperties#setProducerConfig(Map)} are returned
+     * in {@link KafkaProducerConfigProperties#getProducerConfig()}.
+     */
+    @Test
+    public void testThatGetProducerConfigReturnsGivenProperties() {
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setProducerConfig(Collections.singletonMap("foo", "bar"));
+
+        assertThat(config.getProducerConfig().get("foo")).isEqualTo("bar");
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setClientId(String)} is applied when it
+     * is not present in the configuration.
+     */
+    @Test
+    public void testThatGetProducerConfigReturnsAdaptedConfig() {
+
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key.serializer", "foo");
+        properties.put("value.serializer", "bar");
+        properties.put("enable.idempotence", "baz");
+
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setProducerConfig(properties);
+
+        final Map<String, String> producerConfig = config.getProducerConfig();
+
+        assertThat(producerConfig.get("key.serializer"))
+                .isEqualTo("org.apache.kafka.common.serialization.StringSerializer");
+        assertThat(producerConfig.get("value.serializer"))
+                .isEqualTo("io.vertx.kafka.client.serialization.BufferSerializer");
+        assertThat(producerConfig.get("enable.idempotence")).isEqualTo("true");
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setClientId(String)} is applied when it
+     * is NOT present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsApplied() {
+        final String clientId = "the-client";
+
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setProducerConfig(Collections.emptyMap());
+        config.setClientId(clientId);
+
+        assertThat(config.getProducerConfig().get("client.id")).isEqualTo(clientId);
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setClientId(String)} is NOT applied
+     * when it is present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
+        final String userProvidedClientId = "custom-client";
+
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setProducerConfig(Collections.singletonMap("client.id", userProvidedClientId));
+        config.setClientId("other-client");
+
+        assertThat(config.getProducerConfig().get("client.id")).isEqualTo(userProvidedClientId);
+    }
+
+}

--- a/clients/kafka-common/src/test/resources/logback-test.xml
+++ b/clients/kafka-common/src/test/resources/logback-test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+
+  <!-- 
+    This is the logging configuration that is used by the
+    locally executing integration test cases.
+
+    Any changes made here will be reflected on the next test
+    execution.
+   -->
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.apache.kafka" level="ERROR"/>
+
+</configuration>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>hono-client-adapter-amqp</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-adapter-kafka</artifactId>
+    </dependency>
+    <dependency>
      <groupId>org.eclipse.hono</groupId>
      <artifactId>hono-client</artifactId>
     </dependency>

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -727,7 +727,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     public ClientConfigProperties commandConsumerFactoryConfig() {
         final ClientConfigProperties config = Optional.ofNullable(getCommandConsumerFactoryConfigDefaults())
                 .orElseGet(ClientConfigProperties::new);
-        setConfigServerRoleIfUnknown(config, "Command & Control");
+        setConfigServerRoleIfUnknown(config, "Command_Control");
         setDefaultConfigNameIfNotSet(config);
         return config;
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -36,6 +36,8 @@ import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient;
 import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
 import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
+import org.eclipse.hono.adapter.client.telemetry.kafka.KafkaBasedEventSender;
+import org.eclipse.hono.adapter.client.telemetry.kafka.KafkaBasedTelemetrySender;
 import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
@@ -45,6 +47,8 @@ import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.config.ServerConfig;
 import org.eclipse.hono.config.VertxProperties;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.client.KafkaProducerFactory;
 import org.eclipse.hono.service.cache.SpringCacheProvider;
 import org.eclipse.hono.service.monitoring.ConnectionEventProducer;
 import org.eclipse.hono.service.monitoring.ConnectionEventProducerConfig;
@@ -83,6 +87,7 @@ import io.opentracing.contrib.tracerresolver.TracerResolver;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
@@ -136,14 +141,24 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
             adapter.setCommandConsumerFactory(commandConsumerFactory(adapterProperties, samplerFactory, commandRouterClient));
         }
 
+        final KafkaProducerConfigProperties kafkaProducerConfig = kafkaProducerConfig();
+        if (kafkaProducerConfig.getProducerConfig().isEmpty()) {
+            // look up via bean factory is not possible because EventSender and TelemetrySender are implemented by
+            // ProtonBasedDownstreamSender
+            adapter.setEventSender(downstreamEventSender(samplerFactory, adapterProperties));
+            adapter.setTelemetrySender(downstreamTelemetrySender(samplerFactory, adapterProperties));
+        } else {
+            final KafkaProducerFactory<String, Buffer> kafkaProducerFactory = kafkaProducerFactory();
+            adapter.setEventSender(downstreamEventKafkaSender(kafkaProducerFactory, kafkaProducerConfig));
+            adapter.setTelemetrySender(downstreamTelemetryKafkaSender(kafkaProducerFactory, kafkaProducerConfig));
+        }
+
         adapter.setCommandResponseSender(commandResponseSender(samplerFactory, adapterProperties));
         Optional.ofNullable(connectionEventProducer())
             .ifPresent(adapter::setConnectionEventProducer);
         adapter.setCredentialsClient(credentialsClient(samplerFactory, adapterProperties));
-        adapter.setEventSender(downstreamEventSender(samplerFactory, adapterProperties));
         adapter.setHealthCheckServer(healthCheckServer());
         adapter.setRegistrationClient(registrationClient);
-        adapter.setTelemetrySender(downstreamTelemetrySender(samplerFactory, adapterProperties));
         adapter.setTenantClient(tenantClient(samplerFactory, adapterProperties));
         adapter.setTracer(getTracer());
         resourceLimitChecks.ifPresent(adapter::setResourceLimitChecks);
@@ -228,6 +243,21 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     }
 
     /**
+     * Exposes configuration properties for accessing the Kafka cluster as a Spring bean.
+     *
+     * @return The properties.
+     */
+    @ConfigurationProperties(prefix = "hono.kafka")
+    @Bean
+    public KafkaProducerConfigProperties kafkaProducerConfig() {
+        final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+        if (getAdapterName() != null) {
+            configProperties.setClientId(getAdapterName());
+        }
+        return configProperties;
+    }
+
+    /**
      * Gets the default client properties, on top of which the configured properties will be loaded, to be then provided
      * via {@link #downstreamSenderConfig()}.
      * <p>
@@ -296,6 +326,47 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     }
 
     /**
+     * Exposes a factory for creating producers for sending downstream messages via the Kafka cluster.
+     *
+     * @return The factory.
+     */
+    @Bean
+    @Scope("prototype")
+    public KafkaProducerFactory<String, Buffer> kafkaProducerFactory() {
+        return KafkaProducerFactory.sharedProducerFactory(vertx());
+    }
+
+    /**
+     * Exposes a client for sending telemetry messages via <em>Kafka</em> as a Spring bean.
+     *
+     * @return The client.
+     * @param kafkaProducerFactory The producer factory to use.
+     * @param kafkaProducerConfig The producer configuration to use.
+     */
+    @Bean
+    @Scope("prototype")
+    public TelemetrySender downstreamTelemetryKafkaSender(
+            final KafkaProducerFactory<String, Buffer> kafkaProducerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig) {
+        return new KafkaBasedTelemetrySender(kafkaProducerFactory, kafkaProducerConfig, getTracer());
+    }
+
+    /**
+     * Exposes a client for sending events via <em>Kafka</em> as a Spring bean.
+     *
+     * @return The client.
+     * @param kafkaProducerFactory The producer factory to use.
+     * @param kafkaProducerConfig The producer configuration to use.
+     */
+    @Bean
+    @Scope("prototype")
+    public EventSender downstreamEventKafkaSender(
+            final KafkaProducerFactory<String, Buffer> kafkaProducerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig) {
+        return new KafkaBasedEventSender(kafkaProducerFactory, kafkaProducerConfig, getTracer());
+    }
+
+    /**
      * Exposes configuration properties for accessing the registration service as a Spring bean.
      *
      * @return The properties.
@@ -335,7 +406,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
     public DeviceRegistrationClient registrationClient(
-            final SendMessageSampler.Factory samplerFactory, 
+            final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
 
         return new ProtonBasedDeviceRegistrationClient(
@@ -483,7 +554,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     @Qualifier(TenantConstants.TENANT_ENDPOINT)
     @Scope("prototype")
     public TenantClient tenantClient(
-            final SendMessageSampler.Factory samplerFactory, 
+            final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
 
         return new ProtonBasedTenantClient(

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractProtocolAdapterBase.java
@@ -194,6 +194,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     public final void setTelemetrySender(final TelemetrySender sender) {
         this.telemetrySender = Objects.requireNonNull(sender);
+        log.info("using TelemetrySender implementation [{}]", sender.getClass().getName());
     }
 
     /**
@@ -213,6 +214,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      */
     public final void setEventSender(final EventSender sender) {
         this.eventSender = Objects.requireNonNull(sender);
+        log.info("using EventSender implementation [{}]", sender.getClass().getName());
     }
 
     /**

--- a/services/command-router/pom.xml
+++ b/services/command-router/pom.xml
@@ -47,6 +47,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-adapter-amqp</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-adapter-kafka</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.commandrouter.impl.kafka;
+
+import java.net.HttpURLConnection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.eclipse.hono.adapter.client.telemetry.kafka.AbstractKafkaBasedMessageSender;
+import org.eclipse.hono.client.CommandTargetMapper;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.commandrouter.CommandConsumerFactory;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaConsumerConfigProperties;
+import org.eclipse.hono.kafka.client.KafkaConsumerFactory;
+import org.eclipse.hono.kafka.client.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.client.KafkaProducerFactory;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.DeviceConnectionConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * A factory for creating clients for the <em>Kafka messaging infrastructure</em> to receive commands.
+ * <p>
+ * The factory uses tenant-scoped topics, created (if not already existing for the tenant) when
+ * {@link CommandConsumerFactory#createCommandConsumer(String, SpanContext)} is invoked.
+ * <p>
+ * Command messages are first received on the tenant-scoped topic. It is then determined which protocol adapter instance
+ * can handle the command. The command is then forwarded to the Kafka cluster on an topic containing that adapter
+ * instance id.
+ */
+public class KafkaBasedCommandConsumerFactoryImpl extends AbstractKafkaBasedMessageSender
+        implements CommandConsumerFactory {
+
+    /**
+     * A logger to be shared with subclasses.
+     */
+    // TODO the topic should follow the hono topic convention hono.command.<tenant-id> and check how HonoTopic can be
+    // adapted for that
+    private static final Pattern topicPatternForIncomingCommands = Pattern.compile(Pattern.quote(
+            "hono" + HonoTopic.getSeparator() + CommandConstants.COMMAND_ENDPOINT + HonoTopic.getSeparator()) + ".*");
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+    private final String componentName;
+    private final KafkaConsumerFactory<String, Buffer> kafkaConsumerFactory;
+    private final KafkaConsumerConfigProperties kafkaConsumerConfig;
+    private CommandTargetMapper commandTargetMapper;
+
+    /**
+     * Creates a new factory to process commands via the Kafka cluster.
+     *
+     * @param componentName Then name of the component.
+     * @param kafkaProducerFactory The producer factory for creating Kafka producers for sending messages.
+     * @param kafkaProducerConfig The Kafka producer configuration.
+     * @param kafkaConsumerFactory The consumer factory for creating Kafka consumers for consuming messages.
+     * @param kafkaConsumerConfig The Kafka Consumer configuration.
+     * @param tracer The tracer instance.
+     */
+    public KafkaBasedCommandConsumerFactoryImpl(
+            final String componentName,
+            final KafkaProducerFactory<String, Buffer> kafkaProducerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfig,
+            final KafkaConsumerFactory<String, Buffer> kafkaConsumerFactory,
+            final KafkaConsumerConfigProperties kafkaConsumerConfig,
+            final Tracer tracer) {
+        super(kafkaProducerFactory, componentName, kafkaProducerConfig.getProducerConfig(), tracer);
+        this.componentName = componentName;
+        this.kafkaConsumerFactory = Objects.requireNonNull(kafkaConsumerFactory);
+        this.kafkaConsumerConfig = Objects.requireNonNull(kafkaConsumerConfig);
+    }
+
+    @Override
+    public void initialize(final CommandTargetMapper commandTargetMapper) {
+        this.commandTargetMapper = Objects.requireNonNull(commandTargetMapper);
+    }
+
+    @Override
+    public Future<Void> createCommandConsumer(final String tenantId, final SpanContext spanContext) {
+        // The consumer is created already in start method as it uses topic pattern (irrespective of tenant-id) to
+        // subscribe.
+        return Future.succeededFuture();
+    }
+
+    @Override
+    public Future<Void> start() {
+        final Promise<Void> subscriptionPromise = Promise.promise();
+        final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig();
+
+        consumerConfig.computeIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, k -> componentName);
+        kafkaConsumerFactory.getOrCreateConsumer(componentName, consumerConfig)
+                .subscribe(topicPatternForIncomingCommands, subscriptionPromise)
+                .handler(this::mapAndDelegateIncomingCommandMessage);
+
+        return subscriptionPromise.future()
+                .map(ok -> {
+                    log.info("Kafka consumer subscribed to the topic [{}]", topicPatternForIncomingCommands);
+                    return null;
+                });
+    }
+
+    @Override
+    public Future<Void> stop() {
+        return CompositeFuture.all(super.stop(), kafkaConsumerFactory.closeConsumer(componentName))
+                .mapEmpty();
+    }
+
+    private void mapAndDelegateIncomingCommandMessage(final KafkaConsumerRecord<String, Buffer> incomingCommandRecord) {
+        Objects.requireNonNull(incomingCommandRecord);
+
+        final Command command = Command.from(incomingCommandRecord);
+        final Span currentSpan = tracer.buildSpan("map and delegate command")
+                .ignoreActiveSpan()
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                .withTag(TracingHelper.TAG_TENANT_ID, command.getTenantId())
+                .withTag(TracingHelper.TAG_DEVICE_ID, command.getDeviceId())
+                .start();
+
+        log.debug("map and delegate command [commandTargetMapper: {}]", commandTargetMapper);
+        if (!command.isValid()) {
+            log.debug("command is invalid");
+            TracingHelper.logError(currentSpan, "command is invalid");
+            return;
+        }
+
+        commandTargetMapper
+                .getTargetGatewayAndAdapterInstance(command.getTenantId(), command.getDeviceId(), currentSpan.context())
+                .onSuccess(result -> {
+                    final String targetAdapterInstanceId = result
+                            .getString(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID);
+                    final String targetDeviceId = result.getString(DeviceConnectionConstants.FIELD_PAYLOAD_DEVICE_ID);
+                    final String gatewayId = targetDeviceId.equals(command.getDeviceId()) ? null : targetDeviceId;
+                    forwardCommand(command, gatewayId, targetAdapterInstanceId, incomingCommandRecord.value(),
+                            currentSpan);
+                    // TODO to explore options for committing manually based on the QoS once the command is
+                    // successfully forwarded
+                })
+                .onFailure(cause -> {
+                    final String errorMsg;
+                    if (ServiceInvocationException.extractStatusCode(cause) == HttpURLConnection.HTTP_NOT_FOUND) {
+                        errorMsg = "no target adapter instance found for command with device id "
+                                + command.getDeviceId();
+                    } else {
+                        errorMsg = "error getting target gateway and adapter instance for command with device id"
+                                + command.getDeviceId();
+                    }
+                    log.debug(errorMsg, cause);
+                    TracingHelper.logError(currentSpan, errorMsg, cause);
+                }).onComplete(ok -> currentSpan.finish());
+    }
+
+    private Future<Void> forwardCommand(final Command command,
+            final String gatewayId,
+            final String targetAdapterInstanceId,
+            final Buffer commandPayload,
+            final Span span) {
+        //TODO to make HonoTopic generic and not just mention the second argument as tenantId.
+        final HonoTopic topic = new HonoTopic(HonoTopic.Type.COMMAND_INTERNAL, targetAdapterInstanceId);
+        final Map<String, Object> msgProperties = Optional.ofNullable(gatewayId)
+                .map(id -> Map.<String, Object>of(MessageHelper.APP_PROPERTY_GATEWAY_ID, id))
+                .orElse(null);
+
+        log.debug("forwarding a command [tenantId: {}, deviceId: {}, topic: {}]", command.getTenantId(),
+                command.getDeviceId(), topic.toString());
+        return send(topic, command.getTenantId(), command.getDeviceId(), QoS.AT_LEAST_ONCE, command.getContentType(),
+                commandPayload, msgProperties, span.context())
+                        .onFailure(cause -> {
+                            log.debug("Error forwarding command", cause);
+                            TracingHelper.logError(span, "Error forwarding command", cause);
+                        });
+    }
+
+    private static class Command {
+        private String tenantId;
+        private String deviceId;
+        private final String contentType = "text/plain";
+        private boolean valid = false;
+
+        private Command(final KafkaConsumerRecord<String, Buffer> commandRecord) {
+            Optional.ofNullable(commandRecord)
+                    .ifPresent(command -> {
+                        final HonoTopic commandTopic = HonoTopic.fromString(command.topic());
+                        if (Objects.nonNull(commandTopic) && Objects.nonNull(commandTopic.getTenantId())) {
+                            tenantId = commandTopic.getTenantId();
+                        }
+                        Optional.ofNullable(commandRecord.key())
+                                .ifPresent(id -> deviceId = id);
+                        if (Objects.nonNull(deviceId) && Objects.nonNull(tenantId)) {
+                            valid = true;
+                        }
+                    });
+            // Check content-type and other required values.
+        }
+
+        private static Command from(final KafkaConsumerRecord<String, Buffer> commandRecord) {
+            return new Command(commandRecord);
+        }
+
+        private String getTenantId() {
+            return tenantId;
+        }
+
+        private String getDeviceId() {
+            return deviceId;
+        }
+
+        private String getContentType() {
+            return contentType;
+        }
+
+        private boolean isValid() {
+            return valid;
+        }
+    }
+}

--- a/site/documentation/content/admin-guide/common-config.md
+++ b/site/documentation/content/admin-guide/common-config.md
@@ -48,6 +48,13 @@ Protocol adapters require a connection to the *AMQP 1.0 Messaging Network* in or
 The connection to the messaging network is configured according to [Hono Client Configuration]({{< relref "hono-client-configuration.md" >}})
 with `HONO_MESSAGING` being used as `${PREFIX}`. Since there are no responses being received, the properties for configuring response caching can be ignored.
 
+### Kafka based Messaging Configuration
+
+Alternatively, protocol adapters can be configured to publish messages to an *Apache Kafka&reg; cluster* instead of 
+an AMQP Messaging Network. 
+
+The Kafka client is configured according to [Hono Kafka Client Configuration]({{< relref "hono-kafka-client-configuration.md" >}}).
+
 ### Command & Control Connection Configuration
 
 Protocol adapters require an additional connection to the *AMQP 1.0 Messaging Network* in order to receive

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -1,0 +1,44 @@
++++
+title = "Hono Kafka Client Configuration"
+weight = 342
++++
+
+Protocol adapters can be configured to use Kafka for the messaging. The Kafka client used there can be configured with 
+environment variables and/or command line options.
+
+## Producer Configuration Properties
+
+The `org.eclipse.hono.kafka.client.CachingKafkaProducerFactory` factory can be used to create Kafka producers for Hono's Kafka based APIs. 
+The producers created by the factory are configured with instances of the class `org.eclipse.hono.kafka.client.KafkaProducerConfigProperties`
+which can be used to programmatically configure a producer. 
+
+The configuration needs to be provided in the form `HONO_KAFKA_PRODUCERCONFIG_${PROPERTY}` as an environment variable or
+as a command line option in the form `hono.kafka.producerConfig.${property}`, where `${PROPERTY}` respectively 
+`${property}` is any of the Kafka client's [producer properties](https://kafka.apache.org/documentation/#producerconfigs). 
+The provided configuration is passed directly to the Kafka producer without Hono parsing or validating it.
+The following table shows which properties _are_ changed by Hono.
+
+| Environment Variable<br>Command Line Option | Mandatory Value | Description |
+| :------------------------------------------ | :-------------- | :---------- |
+| `HONO_KAFKA_PRODUCERCONFIG_KEY_SERIALIZER`<br>`--hono.kafka.producerConfig.key.serializer` | `org.apache.kafka.common.serialization.StringSerializer` | The record keys in Hono are always strings. Any other specified value is ignored. |
+| `HONO_KAFKA_PRODUCERCONFIG_VALUE_SERIALIZER`<br>`--hono.kafka.producerConfig.value.serializer` | `io.vertx.kafka.client.serialization.BufferSerializer` | The record values in Hono are always byte arrays.  Any other specified value is ignored. |
+| `HONO_KAFKA_PRODUCERCONFIG_ENABLE_IDEMPOTENCE`<br>`--hono.kafka.producerConfig.enable.idempotence` | `true` | The Hono Kafka client uses only idempotent producers.  Any other specified value is ignored. |
+
+{{% note title="Enable Kafka based Messaging" %}}
+The Kafka client requires the property `bootstrap.servers` to be provided. This variable is the minimal configuration 
+required to enable Kafka based messaging.
+{{% /note %}}
+
+### Using TLS
+
+The factory can be configured to use TLS for
+
+* authenticating the brokers in the Kafka cluster during connection establishment and
+* (optionally) authenticating to the broker using a client certificate
+
+To use this, a Kafka Producer configuration as described in 
+[Kafka documentation - section "Security"](https://kafka.apache.org/documentation/#security_configclients) needs to be provided. 
+The properties must be prefixed with `HONO_KAFKA_PRODUCERCONFIG_` respectively `hono.kafka.producerConfig.` as shown in 
+[Producer Configuration Properties]({{< relref "#producer-configuration-properties" >}}).
+The complete reference of available properties and the possible values is available in 
+[Kafka documentation - section "Producer Configs"](https://kafka.apache.org/documentation/#producerconfigs).

--- a/test-utils/kafka-test-utils/pom.xml
+++ b/test-utils/kafka-test-utils/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.hono</groupId>
     <artifactId>test-utils</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-test-utils</artifactId>
 

--- a/test-utils/kafka-test-utils/pom.xml
+++ b/test-utils/kafka-test-utils/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) 2020 Contributors to the Eclipse Foundation
-   
+
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
-   
+
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License 2.0 which is available at
     http://www.eclipse.org/legal/epl-2.0
-   
+
     SPDX-License-Identifier: EPL-2.0
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -16,37 +16,27 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eclipse.hono</groupId>
-    <artifactId>hono-bom</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
-    <relativePath>../bom</relativePath>
+    <artifactId>test-utils</artifactId>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
+  <artifactId>kafka-test-utils</artifactId>
 
-  <artifactId>hono-clients-parent</artifactId>
-  <packaging>pom</packaging>
-
-  <name>Hono Clients</name>
-  <description>Client role specific libraries for accessing Hono's remote APIs</description>
-
-  <modules>
-    <module>adapter</module>
-    <module>adapter-amqp</module>
-    <module>adapter-kafka</module>
-    <module>kafka-common</module>
-  </modules>
+  <name>Hono Kafka Test Utils</name>
+  <description>Helper classes for implementing tests that use a Kafka client.</description>
 
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-legal</artifactId>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-kafka-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jboss.jandex</groupId>
-        <artifactId>jandex-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>
+

--- a/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/FakeProducer.java
+++ b/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/FakeProducer.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.kafka.client.common.PartitionInfo;
+import io.vertx.kafka.client.common.impl.Helper;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.KafkaWriteStream;
+import io.vertx.kafka.client.producer.RecordMetadata;
+
+/**
+ * This is a fake Kafka producer. It provides the Vert.x abstraction for the {@link MockProducer} of Kafka's client.
+ * <p>
+ * This does not support every Vert.x <em>stream</em> related operation.
+ * <p>
+ * <b>Usage Example:</b>
+ * <pre>
+ * {@code
+ *     final FakeProducer<String, String> fakeProducer = new FakeProducer<>();
+ *
+ *     final Handler<AsyncResult<RecordMetadata>> resultHandler = asyncResult -> {
+ *         if (asyncResult.succeeded()) {
+ *             System.out.println("Record produced successfully to topic: " + asyncResult.result().getTopic());
+ *         } else {
+ *             System.out.println("Sending record failed: " + asyncResult.cause().getMessage());
+ *         }
+ *     };
+ *
+ *     // send two records
+ *     fakeProducer.send(new KafkaProducerRecordImpl<>("my-topic", "first message"), resultHandler);
+ *     fakeProducer.send(new KafkaProducerRecordImpl<>("my-topic", "second message"), resultHandler);
+ *
+ *     final MockProducer<String, String> mockProducer = fakeProducer.getMockProducer();
+ *
+ *     // completes the result handler of the first record successfully
+ *     mockProducer.completeNext();
+ *     // fails the result handler of the second record
+ *     mockProducer.errorNext(new KafkaException("something went wrong"));
+ *
+ *     // inspect the sent records
+ *     final ProducerRecord<String, String> firstRecord = mockProducer.history().get(0);
+ *     System.out.println(firstRecord);
+ *
+ *     final ProducerRecord<String, String> secondRecord = mockProducer.history().get(1);
+ *     System.out.println(secondRecord);
+ *
+ *     // clean the history...
+ *     mockProducer.clear();
+ *     // ... or close it if you are done
+ *     mockProducer.close();
+ * }
+ * </pre>
+ *
+ * @param <K> The type for the record key serialization.
+ * @param <V> The type for the record value serialization.
+ */
+public class FakeProducer<K, V> implements KafkaProducer<K, V> {
+
+    private final MockProducer<K, V> producer;
+    private Handler<Throwable> exceptionHandler;
+
+    /**
+     * Creates a fake producer with a new instance of {@link MockProducer#MockProducer()}.
+     */
+    public FakeProducer() {
+        producer = new MockProducer<>();
+    }
+
+    /**
+     * Creates a fake producer with the given mock producer instance.
+     *
+     * @param producer The mock producer to be used.
+     */
+    public FakeProducer(final MockProducer<K, V> producer) {
+        this.producer = producer;
+    }
+
+    /**
+     * Gets the underlying {@link MockProducer}.
+     *
+     * @return the mock producer.
+     */
+    public MockProducer<K, V> getMockProducer() {
+        return producer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KafkaProducer<K, V> exceptionHandler(final Handler<Throwable> handler) {
+        this.exceptionHandler = handler;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KafkaProducer<K, V> write(final KafkaProducerRecord<K, V> kafkaProducerRecord) {
+        write(kafkaProducerRecord, null);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation simply returns {@code this}.
+     */
+    @Override
+    public KafkaProducer<K, V> setWriteQueueMaxSize(final int i) {
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation always returns {@code false}.
+     */
+    @Override
+    public boolean writeQueueFull() {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation simply returns {@code this}.
+     */
+    @Override
+    public KafkaProducer<K, V> drainHandler(final Handler<Void> handler) {
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KafkaProducer<K, V> write(final KafkaProducerRecord<K, V> data, final Handler<AsyncResult<Void>> handler) {
+        Handler<AsyncResult<RecordMetadata>> mdHandler = null;
+        if (handler != null) {
+            mdHandler = ar -> handler.handle(ar.mapEmpty());
+        }
+        send(data, mdHandler);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void end() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void end(final Handler<AsyncResult<Void>> handler) {
+        if (handler != null) {
+            handler.handle(Future.succeededFuture());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KafkaProducer<K, V> send(final KafkaProducerRecord<K, V> record) {
+        send(record, null);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KafkaProducer<K, V> send(final KafkaProducerRecord<K, V> record,
+            final Handler<AsyncResult<RecordMetadata>> handler) {
+
+        try {
+            producer.send(record.record(), (metadata, err) -> {
+                if (err != null) {
+                    if (exceptionHandler != null) {
+                        exceptionHandler.handle(err);
+                    }
+                    if (handler != null) {
+                        handler.handle(Future.failedFuture(err));
+                    }
+                } else if (handler != null) {
+                    handler.handle(Future.succeededFuture(Helper.from(metadata)));
+                }
+            });
+        } catch (final Exception e) {
+            if (exceptionHandler != null) {
+                exceptionHandler.handle(e);
+            }
+
+            if (handler != null) {
+                handler.handle(Future.failedFuture(e));
+            }
+        }
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KafkaProducer<K, V> partitionsFor(final String topic,
+            final Handler<AsyncResult<List<PartitionInfo>>> handler) {
+
+        final List<org.apache.kafka.common.PartitionInfo> partitionInfoList = producer.partitionsFor(topic);
+
+        final List<PartitionInfo> partitions = partitionInfoList.stream().map(kafkaPartitionInfo -> new PartitionInfo()
+                .setInSyncReplicas(
+                        Stream.of(kafkaPartitionInfo.inSyncReplicas()).map(Helper::from).collect(Collectors.toList()))
+                .setLeader(Helper.from(kafkaPartitionInfo.leader()))
+                .setPartition(kafkaPartitionInfo.partition())
+                .setReplicas(Stream.of(kafkaPartitionInfo.replicas()).map(Helper::from).collect(Collectors.toList()))
+                .setTopic(kafkaPartitionInfo.topic())).collect(Collectors.toList());
+
+        handler.handle(Future.succeededFuture(partitions));
+
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KafkaProducer<K, V> flush(final Handler<Void> completionHandler) {
+        producer.flush();
+        if (completionHandler != null) {
+            completionHandler.handle(null);
+        }
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        close(0L, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close(final Handler<AsyncResult<Void>> completionHandler) {
+        close(0L, completionHandler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close(final long timeout, final Handler<AsyncResult<Void>> completionHandler) {
+        producer.close();
+        if (completionHandler != null) {
+            completionHandler.handle(Future.succeededFuture());
+        }
+    }
+
+    /**
+     * Not implemented.
+     *
+     * @throws UnsupportedOperationException always.
+     */
+    @Override
+    public KafkaWriteStream<K, V> asStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Producer<K, V> unwrap() {
+        return producer;
+    }
+}

--- a/test-utils/kafka-test-utils/src/test/java/org/eclipse/hono/kafka/test/FakeProducerTest.java
+++ b/test-utils/kafka-test-utils/src/test/java/org/eclipse/hono/kafka/test/FakeProducerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.kafka.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Handler;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.impl.KafkaProducerRecordImpl;
+
+/**
+ * Verifies the behavior of {@link FakeProducer}.
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 1, timeUnit = TimeUnit.SECONDS)
+public class FakeProducerTest {
+
+    private static final String TOPIC = "the-topic";
+    private static final String KEY = "the-key";
+    private static final String VALUE = "the-value";
+    private static final Long TIMESTAMP = 1234L;
+    private static final Integer PARTITION = 11;
+
+    private FakeProducer<String, String> fakeProducer;
+    private KafkaProducerRecord<String, String> producerRecord;
+
+    @BeforeEach
+    void setUp() {
+        fakeProducer = new FakeProducer<>();
+
+        producerRecord = new KafkaProducerRecordImpl<>(TOPIC, KEY, VALUE, TIMESTAMP, PARTITION);
+    }
+
+    /**
+     * Verifies that the default constructor actually creates a mock producer.
+     */
+    @Test
+    public void testThatDefaultConstructorCreatesAMockProducer() {
+        assertThat(new FakeProducer<>().getMockProducer()).isInstanceOf(MockProducer.class);
+    }
+
+    /**
+     * Verifies that the mock producer provided to {@link FakeProducer#FakeProducer(MockProducer)} is used.
+     */
+    @Test
+    public void testThatMockProducerProvidedToConstructorIsUsed() {
+
+        final MockProducer<String, String> mockProducer = new MockProducer<>(true, new StringSerializer(),
+                new StringSerializer());
+        assertThat(new FakeProducer<>(mockProducer).getMockProducer()).isSameAs(mockProducer);
+
+    }
+
+    /**
+     * Verifies that {@link FakeProducer#send(KafkaProducerRecord, Handler)} sends the producer record with the mock
+     * producer.
+     */
+    @Test
+    public void testThatProducerRecordIsSend() {
+
+        // GIVEN a fake producer
+
+        // WHEN sending a record
+        fakeProducer.send(producerRecord, ar -> {
+        });
+
+        // THEN the record is send with the mock producer
+        final ProducerRecord<String, String> sent = fakeProducer.getMockProducer().history().get(0);
+        assertThat(sent.topic()).isEqualTo(TOPIC);
+        assertThat(sent.key()).isEqualTo(KEY);
+        assertThat(sent.value()).isEqualTo(VALUE);
+        assertThat(sent.timestamp()).isEqualTo(TIMESTAMP);
+        assertThat(sent.partition()).isEqualTo(PARTITION);
+    }
+
+    /**
+     * Verifies that {@link FakeProducer#send(KafkaProducerRecord, Handler)} completes the handler.
+     */
+    @Test
+    public void testThatSendCompletesSuccessfully() {
+
+        // GIVEN a fake producer that sends a record
+        fakeProducer.send(producerRecord, ar -> {
+            // THEN the handler completes successfully
+            assertThat(ar.succeeded()).isTrue();
+        });
+
+        // WHEN completing the send operation
+        fakeProducer.getMockProducer().completeNext();
+    }
+
+    /**
+     * Verifies that an error in {@link FakeProducer#send(KafkaProducerRecord, Handler)} fails the handler.
+     */
+    @Test
+    public void testThatSendWithErrorFailsTheHandler() {
+
+        final RuntimeException expected = new RuntimeException("foo");
+
+        // GIVEN a fake producer that sends a record
+        fakeProducer.send(producerRecord, ar -> {
+            // THEN the handler completes with the expected exception
+            assertThat(ar.failed()).isTrue();
+            assertThat(ar.cause()).isSameAs(expected);
+        });
+
+        // WHEN failing the send operation with an exception
+        fakeProducer.getMockProducer().errorNext(expected);
+    }
+
+    /**
+     * Verifies that if an exception handler is set, it gets called when
+     * {@link FakeProducer#send(KafkaProducerRecord, Handler)} fails.
+     */
+    @Test
+    public void testThatExceptionHandlerIsCalledOnError() {
+
+        final RuntimeException expected = new RuntimeException("foo");
+
+        // GIVEN a fake producer with an exception handler set that sends a record
+        fakeProducer
+                .exceptionHandler(error -> {
+                    // THEN the handler completes with the expected exception
+                    assertThat(error).isSameAs(expected);
+                })
+                .send(producerRecord, null);
+
+        // WHEN failing the send operation with an exception
+        fakeProducer.getMockProducer().errorNext(expected);
+    }
+
+    /**
+     * Verifies that {@link FakeProducer#close(long, Handler)} closes the mock producer.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatFakeProducerIsClosed(final VertxTestContext ctx) {
+
+        final FakeProducer<String, String> fake = new FakeProducer<>();
+        fake.close(0L, ctx.succeeding(response -> ctx.verify(() -> {
+            assertThat(fake.getMockProducer().closed()).isTrue();
+            ctx.completeNow();
+        })));
+
+    }
+
+}

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -30,6 +30,7 @@
   <modules>
     <module>core-test-utils</module>
     <module>service-base-test-utils</module>
+      <module>kafka-test-utils</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
This draft PR provides a prototype of the command router component that uses Kafka as the messaging infrastructure. The aim of this draft PR is to provide a preview and a prototype to test various command & control scenarios using Kafka. This is an very early stage and hence it is not ready for review or merge. This draft uses Kafka clients from PR #2303 


- North bound applications should use the Kafka topic `hono.command.<tenant-Id>` with `deviceId` as the key to send commands.
- This Kafka based command router subscribes to receive those commands using a topic pattern `hono.command.*`. 
- The Kafka consumer in these command router instances have the same group id to ensure that a command is received by only one of the command router instances.
- On receiving a command, this router finds out to which adapter the device/gateway is connected to. Then forwards the command to the topic `hono.command_internal.<adapterInstanceId>`.


In order to deploy and tryout please follow the below steps:
1. You can also deploy a kafka cluster in _minikube_ as mentioned in the [PR #2216](https://github.com/eclipse/hono/pull/2216#issuecomment-730255279).

2. Use the helm charts workaround from the [IoT packages branch](https://github.com/bosch-io/packages/tree/%232273_Workaround_Kafka_based_command_router) to deploy Hono with this command router component.
      `helm install --dependency-update -n hono --set honoImagesTag=1.6.0-SNAPSHOT  eclipse-hono ./hono`

3. Ensure that a device (e.g. _4711_ belonging to the tenant _DEFAULT_TENANT_) is subscribed to receive commands.

4. Send commands to the device _4711_ using the below kafka command. Ensure that the command messages are prefixed with the _deviceId_ as key. Example: **4711:turnOnLight**

```
kubectl run kafka-producer -ti --image=strimzi/kafka:0.19.0-kafka-2.5.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --broker-list hono-kafka-bootstrap:9092  --property "parse.key=true" --property "key.separator=:" --topic hono.command.DEFAULT_TENANT
```
5. Use the below command to subscribe to the Kafka topic `hono.command_internal.<replace with adapter instance id>` to receive those commands. Make sure to use the correct adapter instance id in the above mentioned topic. Here is an example topic `hono.command_internal.Hono_adapter-http-vertx-Command_Control-1294e794-6dd0-4fbf-b908-d8b0dc0dd939` to demonstrate how it looks like.
```
kubectl run kafka-consumer -ti --image=strimzi/kafka:0.19.0-kafka-2.5.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server hono-kafka-bootstrap:9092  --topic hono.command_internal.<replace with adapter instance id>
```