### PR TITLE
Make inclusion of tenant ID configurable

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1417,26 +1417,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         Objects.requireNonNull(cmdSubscriptionsManager);
 
         final Command command = commandContext.getCommand();
-
-        // build topic string; examples:
-        // command///req/xyz/light (authenticated device)
-        // command///req//light (authenticated device, one-way)
-        // command/DEFAULT_TENANT/4711/req/xyz/light (unauthenticated device)
-        // command//4712/req/xyz/light (authenticated gateway)
-
-        final String topicTenantId = subscription.isAuthenticated() ? "" : subscription.getTenant();
-        final String topicDeviceId = command.isTargetedAtGateway() ? command.getOriginalDeviceId()
-                : subscription.isAuthenticated() ? "" : subscription.getDeviceId();
-        final String topicCommandRequestId = command.isOneWay() ? "" : command.getRequestId();
-
-        final String publishTopic = String.format(
-                "%s/%s/%s/%s/%s/%s",
-                subscription.getEndpoint(),
-                topicTenantId,
-                topicDeviceId,
-                subscription.getRequestPart(),
-                topicCommandRequestId,
-                command.getName());
+        final String publishTopic = subscription.getCommandPublishTopic(command);
         Tags.MESSAGE_BUS_DESTINATION.set(commandContext.getTracingSpan(), publishTopic);
         TracingHelper.TAG_QOS.set(commandContext.getTracingSpan(), subscription.getQos().name());
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -2,7 +2,6 @@
 title = "Release Notes"
 +++
 
-
 ## 1.6.0 (not yet released)
 
 ### New Features
@@ -11,6 +10,8 @@ title = "Release Notes"
   This can be enabled by configuring protocol adapters to use Hono's new Kafka-based
   client. Please refer to [Hono Kafka Client Configuration]({{% doclink "/admin-guide/hono-kafka-client-configuration/" %}})
   for details.
+* The MQTT adapter now allows clients to indicate whether they want the target device's tenant and/or device IDs
+  to be included in the topic used when publishing commands.
 
 ## 1.5.0
 


### PR DESCRIPTION
This addresses #2363 

The MQTT adapter now supports a tenant specific boolean configuration
property that allows to always include the tenant ID in the topic name
used for publishing command messages.

This can be used to allow protocol gateways to determine a device's
tenant from the topic name.
