### PR TITLE
Add integrations tests for Postgres in JDBC registry and fix issues

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -77,6 +77,7 @@
     <spring.version>5.2.11.RELEASE</spring.version>
     <spring-boot.version>2.2.11.RELEASE</spring-boot.version>
     <spring-security-crypto.version>5.2.7.RELEASE</spring-security-crypto.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
     <vertx.version>3.9.4</vertx.version>
     <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
     <wildfly-elytron.version>1.10.4.Final</wildfly-elytron.version>
@@ -876,6 +877,13 @@
         <artifactId>hamcrest-core</artifactId>
         <version>${hamcrest-core.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/SQL.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/SQL.java
@@ -44,6 +44,7 @@ import io.vertx.ext.sql.SQLConnection;
  * SQL helper methods.
  */
 public final class SQL {
+    public static String DIALECT_POSTGRESQL = "postgresql";
 
     private static final Logger log = LoggerFactory.getLogger(SQL.class);
 

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/DeviceStores.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/DeviceStores.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 
 import org.eclipse.hono.service.base.jdbc.config.JdbcDeviceStoreProperties;
 import org.eclipse.hono.service.base.jdbc.config.JdbcProperties;
+import org.eclipse.hono.service.base.jdbc.store.SQL;
 
 import io.opentracing.Tracer;
 import io.vertx.core.Vertx;
@@ -97,7 +98,8 @@ public final class DeviceStores {
             return new TableAdapterStore(
                     JdbcProperties.dataSource(vertx, properties),
                     tracer,
-                    Configurations.tableConfiguration(properties.getUrl(), credentials, registrations, groups));
+                    Configurations.tableConfiguration(properties.getUrl(), credentials, registrations, groups),
+                    SQL.getDatabaseDialect(properties.getUrl()));
 
         }
     }

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/TableManagementStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/TableManagementStore.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.service.base.jdbc.store.device;
 
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -229,7 +230,7 @@ public class TableManagementStore extends AbstractDeviceStore {
                         params.put("device_id", deviceDto.getDeviceId());
                         params.put("version", deviceDto.getVersion());
                         params.put("data", deviceDto.getDeviceJson());
-                        params.put("created", deviceDto.getCreationTime());
+                        params.put("created", Timestamp.from(deviceDto.getCreationTime()));
                         params.put("auto_provisioned", deviceDto.getDeviceStatus().isAutoProvisioned());
                     });
 
@@ -395,7 +396,7 @@ public class TableManagementStore extends AbstractDeviceStore {
                                             map.put("data", deviceDto.getDeviceJson());
                                             map.put("expected_version", version);
                                             map.put("next_version", deviceDto.getVersion());
-                                            map.put("updated_on", deviceDto.getUpdatedOn());
+                                            map.put("updated_on", Timestamp.from(deviceDto.getUpdatedOn()));
                                             map.put("auto_provisioning_notification_sent", deviceDto.getDeviceStatus().isAutoProvisioningNotificationSent());
                                         })
                                         .trace(this.tracer, span.context()).update(connection)

--- a/services/base-jdbc/src/main/resources/org/eclipse/hono/service/base/jdbc/store/device/base.postgresql.sql.yaml
+++ b/services/base-jdbc/src/main/resources/org/eclipse/hono/service/base/jdbc/store/device/base.postgresql.sql.yaml
@@ -43,3 +43,13 @@ insertCredentialEntry: |
       :auth_id,
       :data::jsonb
    )
+
+resolveGroups: |
+   SELECT
+      device_id
+   FROM
+      %3$s
+   WHERE
+      tenant_id=:tenant_id
+   AND
+      group_id in (select unnest((string_to_array(:group_ids,','))::varchar[]))

--- a/services/base-jdbc/src/main/resources/org/eclipse/hono/service/base/jdbc/store/tenant/base.sql.yaml
+++ b/services/base-jdbc/src/main/resources/org/eclipse/hono/service/base/jdbc/store/tenant/base.sql.yaml
@@ -24,7 +24,7 @@ readByTrustAnchor: |
    SELECT
       T.tenant_id as TENANT_ID,
       T.version as VERSION,
-      T.data as DATA,
+      T.data as DATA
    FROM
       %1$s as T
    INNER JOIN

--- a/services/base-jdbc/src/main/sql/postgresql/create.devices.sql
+++ b/services/base-jdbc/src/main/sql/postgresql/create.devices.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS device_registrations
+(
+    TENANT_ID VARCHAR(36) NOT NULL,
+    DEVICE_ID VARCHAR(256) NOT NULL,
+    VERSION   CHAR(36)     NOT NULL,
+
+    CREATED TIMESTAMP NOT NULL,
+    UPDATED_ON TIMESTAMP,
+
+    AUTO_PROVISIONED BOOLEAN,
+    AUTO_PROVISIONING_NOTIFICATION_SENT BOOLEAN,
+
+    DATA      JSONB,
+
+    PRIMARY KEY (TENANT_ID, DEVICE_ID)
+);
+
+CREATE TABLE IF NOT EXISTS device_credentials
+(
+    TENANT_ID VARCHAR(36) NOT NULL,
+    DEVICE_ID VARCHAR(256) NOT NULL,
+
+    TYPE      VARCHAR(64)  NOT NULL,
+    AUTH_ID   VARCHAR(256) NOT NULL,
+
+    DATA      JSONB,
+
+    PRIMARY KEY (TENANT_ID, TYPE, AUTH_ID),
+    FOREIGN KEY (TENANT_ID, DEVICE_ID) REFERENCES device_registrations (TENANT_ID, DEVICE_ID) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS device_groups
+(
+    TENANT_ID VARCHAR(36) NOT NULL,
+    DEVICE_ID VARCHAR(256) NOT NULL,
+    GROUP_ID  VARCHAR(256) NOT NULL,
+
+    PRIMARY KEY (TENANT_ID, DEVICE_ID, GROUP_ID),
+    FOREIGN KEY (TENANT_ID, DEVICE_ID) REFERENCES device_registrations (TENANT_ID, DEVICE_ID) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS device_states
+(
+    TENANT_ID           VARCHAR(36) NOT NULL,
+    DEVICE_ID           VARCHAR(256) NOT NULL,
+
+    LAST_KNOWN_GATEWAY  VARCHAR(256),
+    ADAPTER_INSTANCE_ID VARCHAR(256),
+
+    PRIMARY KEY (TENANT_ID, DEVICE_ID)
+);
+
+-- create indexes for non-primary key access paths
+
+CREATE INDEX idx_device_registrations_tenant ON device_registrations (TENANT_ID);
+
+CREATE INDEX idx_device_credentials_tenant ON device_credentials (TENANT_ID);
+CREATE INDEX idx_device_credentials_tenant_and_device ON device_credentials (TENANT_ID, DEVICE_ID);
+
+CREATE INDEX idx_device_states_tenant ON device_states (TENANT_ID);
+
+CREATE INDEX idx_device_member_of_tenant ON device_groups (TENANT_ID);
+CREATE INDEX idx_device_member_of_tenant_and_device ON device_groups (TENANT_ID, DEVICE_ID);

--- a/services/base-jdbc/src/main/sql/postgresql/create.tenants.sql
+++ b/services/base-jdbc/src/main/sql/postgresql/create.tenants.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS tenants
+(
+    TENANT_ID VARCHAR(36) NOT NULL,
+    VERSION   CHAR(36) NOT NULL,
+    DATA      TEXT,
+
+    PRIMARY KEY (TENANT_ID)
+);
+
+CREATE TABLE IF NOT EXISTS tenant_trust_anchors
+(
+    SUBJECT_DN VARCHAR(256) NOT NULL,
+    TENANT_ID  VARCHAR(36)     NOT NULL,
+    DATA       TEXT,
+
+    PRIMARY KEY (SUBJECT_DN),
+    FOREIGN KEY (TENANT_ID) REFERENCES tenants (TENANT_ID) ON DELETE CASCADE
+);
+
+-- create indexes for non-primary key access paths
+
+CREATE INDEX idx_tenant_trust_anchors_tenant ON tenant_trust_anchors (TENANT_ID);

--- a/services/device-registry-jdbc/pom.xml
+++ b/services/device-registry-jdbc/pom.xml
@@ -63,6 +63,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-service-device-registry-base</artifactId>
       <version>${project.version}</version>
@@ -86,6 +91,19 @@
             <org.eclipse.hono.service.base.jdbc.store.skipDumpingStatementConfiguration>true</org.eclipse.hono.service.base.jdbc.store.skipDumpingStatementConfiguration>
           </systemProperties>
         </configuration>
+        <executions>
+            <execution>
+                <id>postgresql-tests</id>
+                <goals>
+                    <goal>test</goal>
+                </goals>
+                <configuration>
+                    <systemProperties>
+                        <AbstractJdbcRegistryTest.databaseType>postgresql</AbstractJdbcRegistryTest.databaseType>
+                    </systemProperties>
+                </configuration>
+            </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Changes

* Adds DDL for Postgres and adapt queries  for Postgres syntax
* Provide workaround for the fact that vertx jdbc doesn't support arrays (https://stackoverflow.com/a/42295098 for details)
  * Pass array parameter as CSV string and parse in query using DB specific functions
* Run Postgres tests with TestContainers and Postgres Docker image
* Fix failing tests for PostgreSQL
