### PR TITLE
Invoke assertRegistration before sending command to gateway

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -868,6 +868,17 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                 }
                 return checkMessageLimit(tenantObject, command.getPayloadSize(), commandContext.getTracingContext());
             }).compose(success -> {
+                // in case of a gateway having subscribed for a specific device,
+                // check the via-gateways, ensuring that the gateway may act on behalf of the device at this point in time
+                if (authenticatedDevice != null && !authenticatedDevice.getDeviceId().equals(sourceAddress.getResourceId())) {
+                    return getRegistrationAssertion(
+                            authenticatedDevice.getTenantId(),
+                            sourceAddress.getResourceId(),
+                            authenticatedDevice,
+                            commandContext.getTracingContext());
+                }
+                return Future.succeededFuture();
+            }).compose(success -> {
                 onCommandReceived(tenantTracker.result(), sender, commandContext);
                 return Future.succeededFuture();
             }).otherwise(failure -> {

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -806,6 +806,17 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "malformed command message"));
                 }
             }).compose(success -> {
+                // in case of a gateway having subscribed for a specific device,
+                // check the via-gateways, ensuring that the gateway may act on behalf of the device at this point in time
+                if (subscription.isGatewaySubscriptionForSpecificDevice()) {
+                    return getRegistrationAssertion(
+                            authenticatedDevice.getTenantId(),
+                            subscription.getDeviceId(),
+                            authenticatedDevice,
+                            commandContext.getTracingContext());
+                }
+                return Future.succeededFuture();
+            }).compose(success -> {
                 addMicrometerSample(commandContext, timer);
                 onCommandReceived(tenantTracker.result(), mqttEndpoint, subscription, commandContext, cmdHandler);
                 return Future.succeededFuture();

--- a/client/src/main/java/org/eclipse/hono/client/impl/MappingAndDelegatingCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/MappingAndDelegatingCommandHandler.java
@@ -170,7 +170,6 @@ public class MappingAndDelegatingCommandHandler {
         // note that the command might be invalid here - a matching local handler to reject it (and report metrics) shall be found in that case
         final Command originalCommand = originalCommandContext.getCommand();
 
-        // determine last used gateway device id
         LOG.trace("determine command target gateway/adapter for [{}]", originalCommand);
         final Future<JsonObject> commandTargetFuture = commandTargetMapper.getTargetGatewayAndAdapterInstance(tenantId,
                 originalDeviceId, originalCommandContext.getTracingContext());


### PR DESCRIPTION
Only done if gateway has subscribed specifically for the device the command is targeted at.

Not needed if command is forwarded to a gateway that has subscribed to commands for all its devices.
In that case the command is explicitly mapped to the gateway via the DeviceConnection API `getCommandHandlingAdapterInstances(tenant, deviceId, viaGateways, spanContext)` method, using the up-to-date via-gateway information.
(A gateway having subscribed specifically for the device is handled in the DeviceConnection service, as if the device had subscribed directly. The assignment to the gateway is only done in the target adapter instance logic in that case.)

I wanted to add integration tests here, clearing the via-gateways in the device registration data after a command subscription was done. But I don't see a way to circumvent usage of a cached device registration entry in that case (still containing the via-gateway), therefore the test would need to wait for 5min in between for the entry to expire.