### PR TITLE
Introduce response caching at Tenant service client level

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/TenantClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/TenantClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,8 +25,10 @@ import io.vertx.core.Future;
  * <p>
  * See Hono's <a href="https://www.eclipse.org/hono/docs/api/tenant">
  * Tenant API specification</a> for a description of the result codes returned.
- * </p>
+ *
+ * @deprecated Use {@code org.eclipse.hono.adapter.client.registry.TenantClient} instead.
  */
+@Deprecated
 public interface TenantClient extends RequestResponseClient {
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/TenantClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/TenantClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,7 +22,9 @@ import io.vertx.core.Future;
 /**
  * A factory for creating clients for Hono's Tenant API.
  *
+ * @deprecated Use {@code org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient} instead.
  */
+@Deprecated
 public interface TenantClientFactory extends ConnectionLifecycle<HonoConnection> {
 
     /**

--- a/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/TenantClientImpl.java
@@ -56,7 +56,9 @@ import io.vertx.proton.ProtonSender;
 /**
  * A Vertx-Proton based client for Hono's Tenant API.
  *
+ * @deprecated Use {@code org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient} instead.
  */
+@Deprecated
 public class TenantClientImpl extends AbstractRequestResponseClient<TenantResult<TenantObject>>
         implements TenantClient {
 

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractHonoClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractHonoClient.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.amqp;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * A base class for implementing Hono API clients.
+ * <p>
+ * Holds a sender and a receiver to an AMQP 1.0 server and provides
+ * support for closing these links gracefully.
+ */
+public abstract class AbstractHonoClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractHonoClient.class);
+
+    /**
+     * The connection to the server.
+     */
+    protected final HonoConnection connection;
+
+    /**
+     * The vertx-proton object used for sending messages to the server.
+     */
+    protected ProtonSender sender;
+    /**
+     * The vertx-proton object used for receiving messages from the server.
+     */
+    protected ProtonReceiver receiver;
+    /**
+     * The capabilities offered by the peer.
+     */
+    protected List<Symbol> offeredCapabilities = Collections.emptyList();
+
+    /**
+     * Creates a client for a connection.
+     *
+     * @param connection The connection to use.
+     * @throws NullPointerException if connection is {@code null}.
+     */
+    protected AbstractHonoClient(final HonoConnection connection) {
+        this.connection = Objects.requireNonNull(connection);
+    }
+
+    /**
+     * Marks an <em>OpenTracing</em> span as erroneous and logs an exception.
+     * <p>
+     * This method does <em>not</em> finish the span.
+     *
+     * @param span The span to mark.
+     * @param error The exception that has occurred. If the exception is a
+     *              {@link ServiceInvocationException} then a {@link Tags#HTTP_STATUS}
+     *              tag is added containing the exception's error code property value.
+     * @throws NullPointerException if error is {@code null}.
+     */
+    protected final void logError(final Span span, final Throwable error) {
+        if (span != null) {
+            if (ServiceInvocationException.class.isInstance(error)) {
+                final ServiceInvocationException e = (ServiceInvocationException) error;
+                Tags.HTTP_STATUS.set(span, e.getErrorCode());
+            }
+            TracingHelper.logError(span, error);
+        }
+    }
+
+    /**
+     * Checks if this client supports a certain capability.
+     * <p>
+     * The result of this method should only be considered reliable
+     * if this client is open.
+     *
+     * @param capability The capability to check support for.
+     * @return {@code true} if the capability is included in the list of
+     *         capabilities that the peer has offered during link
+     *         establishment, {@code false} otherwise.
+     */
+    public final boolean supportsCapability(final Symbol capability) {
+        if (capability == null) {
+            return false;
+        } else {
+            return offeredCapabilities.contains(capability);
+        }
+    }
+
+    /**
+     * Closes this client's sender and receiver links to Hono.
+     * Link resources will be freed after the links are closed.
+     *
+     * @return A succeeded future indicating that the links have been closed.
+     */
+    protected final Future<Void> closeLinks() {
+
+        final Promise<Void> result = Promise.promise();
+        final Handler<Void> closeReceiver = s -> {
+            if (receiver != null) {
+                LOG.debug("locally closing receiver link [{}]", receiver.getSource().getAddress());
+            }
+            connection.closeAndFree(receiver, receiverClosed -> result.complete());
+        };
+
+        if (sender != null) {
+            LOG.debug("locally closing sender link [{}]", sender.getTarget().getAddress());
+            connection.closeAndFree(sender, senderClosed -> closeReceiver.handle(null));
+        } else if (receiver != null) {
+            closeReceiver.handle(null);
+        } else {
+            result.complete();
+        }
+        return result.future();
+    }
+
+    /**
+     * Set the application properties for a Proton Message but do a check for all properties first if they only contain
+     * values that the AMQP 1.0 spec allows.
+     *
+     * @param msg The Proton message. Must not be null.
+     * @param properties The map containing application properties.
+     * @throws NullPointerException if the message passed in is null.
+     * @throws IllegalArgumentException if the properties contain any value that AMQP 1.0 disallows.
+     */
+    protected static final void setApplicationProperties(final Message msg, final Map<String, ?> properties) {
+        if (properties != null) {
+            final Map<String, Object> propsToAdd = new HashMap<>();
+            // check the three types not allowed by AMQP 1.0 spec for application properties (list, map and array)
+            for (final Map.Entry<String, ?> entry: properties.entrySet()) {
+                if (entry.getValue() != null) {
+                    if (entry.getValue() instanceof List) {
+                        throw new IllegalArgumentException(String.format("Application property %s can't be a List", entry.getKey()));
+                    } else if (entry.getValue() instanceof Map) {
+                        throw new IllegalArgumentException(String.format("Application property %s can't be a Map", entry.getKey()));
+                    } else if (entry.getValue().getClass().isArray()) {
+                        throw new IllegalArgumentException(String.format("Application property %s can't be an Array", entry.getKey()));
+                    }
+                }
+                propsToAdd.put(entry.getKey(), entry.getValue());
+            }
+
+            final ApplicationProperties applicationProperties = new ApplicationProperties(propsToAdd);
+            msg.setApplicationProperties(applicationProperties);
+        }
+    }
+
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
@@ -1,0 +1,369 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.adapter.client.amqp;
+
+import java.net.HttpURLConnection;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.cache.CacheProvider;
+import org.eclipse.hono.cache.ExpiringValueCache;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.impl.CachingClientFactory;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RequestResponseResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A vertx-proton based parent class for the implementation of API clients that follow the request response pattern.
+ * <p>
+ * Provides support for caching response messages from a service in an {@link ExpiringValueCache}.
+ *
+ * @param <R> The type of response this client expects the peer to return.
+ * @param <T> The type of object contained in the peer's response.
+ *
+ */
+public abstract class AbstractRequestResponseServiceClient<T, R extends RequestResponseResult<T>> extends AbstractServiceClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractRequestResponseServiceClient.class);
+    private static final int[] CACHEABLE_STATUS_CODES = new int[] {
+                            HttpURLConnection.HTTP_OK,
+                            HttpURLConnection.HTTP_NOT_AUTHORITATIVE,
+                            HttpURLConnection.HTTP_PARTIAL,
+                            HttpURLConnection.HTTP_MULT_CHOICE,
+                            HttpURLConnection.HTTP_MOVED_PERM,
+                            HttpURLConnection.HTTP_GONE
+    };
+
+    /**
+     * Contains the AMQP link sender/receiver link pairs for invoking the service.
+     */
+    protected final CachingClientFactory<RequestResponseClient<R>> clientFactory;
+    /**
+     * A cache to use for responses received from the service.
+     */
+    private final ExpiringValueCache<Object, R> responseCache;
+
+    /**
+     * Creates a request-response client.
+     *
+     * @param connection The connection to the service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param clientFactory The factory to use for creating links to the service.
+     * @param cacheProvider The provider to use for creating cache instances for service responses.
+     * @throws NullPointerException if any of the parameters other than cacheProvider are {@code null}.
+     */
+    protected AbstractRequestResponseServiceClient(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig,
+            final CachingClientFactory<RequestResponseClient<R>> clientFactory,
+            final CacheProvider cacheProvider) {
+
+        super(connection, samplerFactory, adapterConfig);
+        this.clientFactory = Objects.requireNonNull(clientFactory);
+        if (cacheProvider == null) {
+            this.responseCache = null;
+        } else {
+            this.responseCache = cacheProvider.getCache("responses");
+        }
+    }
+
+    /**
+     * Gets the key to use for caching the client for a tenant.
+     *
+     * @param tenantId The tenant.
+     * @return The key.
+     * @throws NullPointerException if tenant ID is {@code null}.
+     */
+    protected abstract String getKey(String tenantId);
+
+    /**
+     * Removes a client for a tenant from the cache.
+     *
+     * @param tenantId The tenant to remove the client for.
+     * @throws NullPointerException if tenant ID is {@code null}.
+     */
+    protected void removeClient(final String tenantId) {
+        clientFactory.removeClient(getKey(tenantId));
+    }
+
+    /**
+     * Removes a client for a tenant from the cache and closes it.
+     *
+     * @param msg The message containing the identifier of the tenant to remove and close the client for.
+     * @throws NullPointerException if message is {@code null}.
+     */
+    protected void handleTenantTimeout(final io.vertx.core.eventbus.Message<Object> msg) {
+        Optional.ofNullable(msg.body())
+            .filter(String.class::isInstance)
+            .map(String.class::cast)
+            .map(this::getKey)
+            .ifPresent(k -> clientFactory.removeClient(k, RequestResponseClient::close));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Clears the state of the client factory.
+     */
+    @Override
+    protected void onDisconnect() {
+        clientFactory.clearState();
+    }
+
+    /**
+     * Checks if an AMQP message contains the result of the successful invocation
+     * of an operation.
+     *
+     * @param status The status code from the message.
+     * @param contentType A media type describing the payload or {@code null} if unknown.
+     * @param payload The payload from the response (may be {@code null}).
+     * @return {@code true} if 200 =&lt; status &lt; 300 and the message contains a JSON
+     *                      payload.
+     */
+    protected final boolean isSuccessResponse(
+            final int status,
+            final String contentType,
+            final Buffer payload) {
+
+        return StatusCodeMapper.isSuccessful(status) && payload != null
+                && MessageHelper.CONTENT_TYPE_APPLICATION_JSON.equalsIgnoreCase(contentType);
+    }
+
+    /**
+     * Maps an AMQP message to the response type.
+     * <p>
+     * This method invokes {@link #getResult(int, String, Buffer, CacheDirective, ApplicationProperties)}
+     * to perform the actual mapping.
+     *
+     * @param message The message.
+     * @return The response object.
+     * @throws NullPointerException if message is {@code null}.
+     */
+    protected final R getRequestResponseResult(final Message message) {
+
+        final Integer status = MessageHelper.getStatus(message);
+        if (status == null) {
+            LOG.debug("response message has no status code application property [reply-to: {}, correlation ID: {}]",
+                    message.getReplyTo(), message.getCorrelationId());
+            return null;
+        } else {
+            final CacheDirective cacheDirective = CacheDirective.from(MessageHelper.getCacheDirective(message));
+            return getResult(
+                    status,
+                    message.getContentType(),
+                    MessageHelper.getPayload(message),
+                    cacheDirective,
+                    message.getApplicationProperties());
+        }
+    }
+
+
+    /**
+     * Creates a result object from the status and payload of a response received from the endpoint.
+     *
+     * @param status The status of the response.
+     * @param contentType A media type describing the payload or {@code null} if unknown.
+     * @param payload The representation of the payload (may be {@code null}).
+     * @param cacheDirective Restrictions regarding the caching of the payload (may be {@code null}).
+     * @param applicationProperties Arbitrary properties conveyed in the response message's
+     *                              <em>application-properties</em>.
+     * @return The result object.
+     */
+    protected abstract R getResult(
+            int status,
+            String contentType,
+            Buffer payload,
+            CacheDirective cacheDirective,
+            ApplicationProperties applicationProperties);
+
+    /**
+     * Gets the default value for the period of time after which an entry in the response cache
+     * is considered invalid.
+     * <p>
+     * The value is derived from the configuration properties as follows:
+     * <ol>
+     * <li>if the properties are of type {@link RequestResponseClientConfigProperties}
+     * then the value of its <em>responseCacheDefaultTimeout</em> property is used</li>
+     * <li>otherwise the {@linkplain RequestResponseClientConfigProperties#DEFAULT_RESPONSE_CACHE_TIMEOUT
+     * default timeout value} is used</li>
+     * </ol>
+     *
+     * @return The timeout period in seconds.
+     */
+    protected final long getResponseCacheDefaultTimeout() {
+        if (connection.getConfig() instanceof RequestResponseClientConfigProperties) {
+            return ((RequestResponseClientConfigProperties) connection.getConfig()).getResponseCacheDefaultTimeout();
+        } else {
+            return RequestResponseClientConfigProperties.DEFAULT_RESPONSE_CACHE_TIMEOUT;
+        }
+    }
+
+    /**
+     * Checks if this client supports caching of results.
+     *
+     * @return {@code true} if caching is supported.
+     */
+    protected final boolean isCachingEnabled() {
+        return responseCache != null;
+    }
+
+    private boolean isCacheableStatusCode(final int code) {
+        return Arrays.binarySearch(CACHEABLE_STATUS_CODES, code) >= 0;
+    }
+
+    /**
+     * Gets a response from the cache.
+     * <p>
+     * Sets a tag on the given span according to whether there was a cache hit.
+     *
+     * @param key The key to get the response for.
+     * @param currentSpan The span to mark (may be {@code null}).
+     * @return A succeeded future containing the response from the cache
+     *         or a failed future if no response exists for the key
+     *         or the response is expired.
+     * @throws NullPointerException if key is {@code null}.
+     */
+    protected Future<R> getResponseFromCache(final Object key, final Span currentSpan) {
+
+        Objects.requireNonNull(key);
+
+        if (isCachingEnabled()) {
+            final R result = responseCache.get(key);
+            if (currentSpan != null) {
+                TracingHelper.TAG_CACHE_HIT.set(currentSpan, result != null);
+            }
+            if (result == null) {
+                return Future.failedFuture("cache miss");
+            } else {
+                return Future.succeededFuture(result);
+            }
+        } else {
+            return Future.failedFuture(new IllegalStateException("no cache configured"));
+        }
+    }
+
+    /**
+     * Adds a response to the cache.
+     * <p>
+     * If no cache is configured then this method does nothing.
+     * <p>
+     * Otherwise
+     * <ol>
+     * <li>if the response does not contain any cache directive and the response's status code is
+     * one of the codes defined by <a href="https://tools.ietf.org/html/rfc2616#section-13.4">
+     * RFC 2616, Section 13.4 Response Cacheability</a>, the response is put to the cache using
+     * the default timeout returned by {@link #getResponseCacheDefaultTimeout()},</li>
+     * <li>else if the response contains a <em>max-age</em> directive, the response
+     * is put to the cache using the max age from the directive,</li>
+     * <li>else if the response contains a <em>no-cache</em> directive, the response
+     * is not put to the cache.</li>
+     * </ol>
+     *
+     * @param key The key to use for the response.
+     * @param response The response to put to the cache.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected final void addToCache(final Object key, final R response) {
+
+        if (isCachingEnabled()) {
+
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(response);
+
+            final CacheDirective cacheDirective = Optional.ofNullable(response.getCacheDirective())
+                    .orElseGet(() -> {
+                        if (isCacheableStatusCode(response.getStatus())) {
+                            return CacheDirective.maxAgeDirective(getResponseCacheDefaultTimeout());
+                        } else {
+                            return CacheDirective.noCacheDirective();
+                        }
+                    });
+
+            if (cacheDirective.isCachingAllowed()) {
+                if (cacheDirective.getMaxAge() > 0) {
+                    responseCache.put(key, response, Duration.ofSeconds(cacheDirective.getMaxAge()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Applies the given mapper function to the result of the given Future if it succeeded.
+     * <p>
+     * Makes sure that the given Span is finished when the given Future is completed.
+     * Also sets the {@code Tags.HTTP_STATUS} tag on the span and logs error information if there was an error.
+     *
+     * @param result The Future supplying the <em>RequestResponseResult</em> that the mapper will be applied on.
+     * @param resultMapper The mapper function.
+     * @param currentSpan The OpenTracing Span to use.
+     * @return The Future with the result of applying the mapping function or with the error from the given Future.
+     * @throws NullPointerException if either of the parameters is {@code null}.
+     */
+    protected final Future<T> mapResultAndFinishSpan(
+            final Future<R> result,
+            final Function<R, T> resultMapper,
+            final Span currentSpan) {
+
+        return result.recover(t -> {
+            Tags.HTTP_STATUS.set(currentSpan, ServiceInvocationException.extractStatusCode(t));
+            TracingHelper.logError(currentSpan, t);
+            return Future.failedFuture(t);
+        }).map(resultValue -> {
+            if (resultValue != null) {
+                Tags.HTTP_STATUS.set(currentSpan, resultValue.getStatus());
+                if (resultValue.isError()) {
+                    Tags.ERROR.set(currentSpan, Boolean.TRUE);
+                }
+            } else {
+                Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_ACCEPTED);
+            }
+            return resultMapper.apply(resultValue);
+        }).onComplete(o -> currentSpan.finish());
+    }
+
+    /**
+     * Creates a new map containing the {@link MessageHelper#APP_PROPERTY_DEVICE_ID}
+     * key with the given identifier as value.
+     *
+     * @param deviceId The device identifier.
+     * @return The map.
+     */
+    protected final Map<String, Object> createDeviceIdProperties(final String deviceId) {
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId);
+        return properties;
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/RequestResponseClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/RequestResponseClient.java
@@ -1,0 +1,642 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.adapter.client.amqp;
+
+import java.net.HttpURLConnection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Modified;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RequestResponseResult;
+import org.eclipse.hono.util.TriTuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * A vertx-proton based client for invoking operations on AMQP 1.0 based service endpoints.
+ * <p>
+ * The client holds a sender and a receiver link for sending request messages and receiving
+ * response messages.
+ *
+ * @param <R> The type of result this client expects the service to return.
+ *
+ */
+public class RequestResponseClient<R extends RequestResponseResult<?>> extends AbstractHonoClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RequestResponseClient.class);
+
+    /**
+     * The target address of the sender link used to send requests to the service.
+     */
+    private final String linkTargetAddress;
+    /**
+     * The source address of the receiver link used to receive responses from the service.
+     */
+    private final String replyToAddress;
+    private final SendMessageSampler sampler;
+    private final Map<Object, TriTuple<Promise<R>, Function<Message, R>, Span>> replyMap = new HashMap<>();
+    private final String endpointName;
+    private final String tenantId;
+    private long requestTimeoutMillis;
+
+    /**
+     * Creates a request-response client.
+     * <p>
+     * The created instance's sender link's target address is set to
+     * <em>${endpointName}[/${tenantId}]</em> and the receiver link's source
+     * address is set to <em>${endpointName}[/${tenantId}]/${UUID}</em>
+     * (where ${UUID} is a generated UUID).
+     * <p>
+     * The latter address is also used as the value of the <em>reply-to</em>
+     * property of all request messages sent by this client.
+     * <p>
+     * The client will be ready to use after invoking {@link #createLinks()} or
+     * {@link #createLinks(Handler, Handler)} only.
+     *
+     * @param connection The connection to the service.
+     * @param endpointName The name of the endpoint to send request messages to.
+     * @param tenantId The tenant that the client should be scoped to or {@code null} if the
+     *                 client should not be scoped to a tenant.
+     * @param sampler The sampler to use.
+     * @throws NullPointerException if any of the parameters except tenantId is {@code null}.
+     */
+    private RequestResponseClient(
+            final HonoConnection connection,
+            final String endpointName,
+            final String tenantId,
+            final SendMessageSampler sampler) {
+
+        this(connection, endpointName, tenantId, UUID.randomUUID().toString(), sampler);
+    }
+
+    /**
+     * Creates a request-response client.
+     * <p>
+     * The created instance's sender link's target address is set to
+     * <em>${endpointName}[/${tenantId}]</em> and the receiver link's source
+     * address is set to <em>${endpointName}[/${tenantId}]/${replyId}</em>.
+     * <p>
+     * The latter address is also used as the value of the <em>reply-to</em>
+     * property of all request messages sent by this client.
+     * <p>
+     * The client will be ready to use after invoking {@link #createLinks()} or
+     * {@link #createLinks(Handler, Handler)} only.
+     *
+     * @param connection The connection to the service.
+     * @param endpointName The name of the endpoint to send request messages to.
+     * @param tenantId The tenant that the client should be scoped to or {@code null} if the
+     *                 client should not be scoped to a tenant.
+     * @param replyId The replyId to use in the reply-to address.
+     * @param sampler The sampler to use.
+     * @throws NullPointerException if any of the parameters except tenantId is {@code null}.
+     */
+    private RequestResponseClient(
+            final HonoConnection connection,
+            final String endpointName,
+            final String tenantId,
+            final String replyId,
+            final SendMessageSampler sampler) {
+
+        super(connection);
+        this.endpointName = Objects.requireNonNull(endpointName);
+        Objects.requireNonNull(replyId);
+        this.sampler = Objects.requireNonNull(sampler);
+        this.requestTimeoutMillis = connection.getConfig().getRequestTimeout();
+        if (tenantId == null) {
+            this.linkTargetAddress = endpointName;
+            this.replyToAddress = String.format("%s/%s", endpointName, replyId);
+        } else {
+            this.linkTargetAddress = String.format("%s/%s", endpointName, tenantId);
+            this.replyToAddress = String.format("%s/%s/%s", endpointName, tenantId, replyId);
+        }
+        this.tenantId = tenantId;
+    }
+
+    /**
+     * Creates a request-response client for an endpoint.
+     * <p>
+     * The client has a sender and a receiver link opened to the service
+     * endpoint. The sender link's target address is set to
+     * <em>${endpointName}[/${tenantId}]</em> and the receiver link's source
+     * address is set to <em>${endpointName}[/${tenantId}]/${UUID}</em>
+     * (where ${UUID} is a generated UUID).
+     * <p>
+     * The latter address is also used as the value of the <em>reply-to</em>
+     * property of all request messages sent by the client.
+     *
+     * @param <T> The type of response that the client expects the service to return.
+     * @param connection The connection to the service.
+     * @param endpointName The name of the endpoint to send request messages to.
+     * @param tenantId The tenant that the client should be scoped to or {@code null} if the
+     *                 client should not be scoped to a tenant.
+     * @param sampler The sampler to use.
+     * @param senderCloseHook A handler to invoke if the peer closes the sender link unexpectedly (may be {@code null}).
+     * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly (may be {@code null}).
+     * @return A future indicating the outcome of creating the client. The future will be failed
+     *         with a {@link org.eclipse.hono.client.ServiceInvocationException} if the links
+     *         cannot be opened.
+     * @throws NullPointerException if any of the parameters except tenantId is {@code null}.
+     */
+    public static <T extends RequestResponseResult<?>> Future<RequestResponseClient<T>> forEndpoint(
+            final HonoConnection connection,
+            final String endpointName,
+            final String tenantId,
+            final SendMessageSampler sampler,
+            final Handler<String> senderCloseHook,
+            final Handler<String> receiverCloseHook) {
+
+        final RequestResponseClient<T> result = new RequestResponseClient<>(connection, endpointName, tenantId, sampler);
+        return result.createLinks(senderCloseHook, receiverCloseHook).map(result);
+    }
+
+    /**
+     * Gets the default value for the period of time after which an entry in the response cache
+     * is considered invalid.
+     * <p>
+     * The value is derived from the configuration properties as follows:
+     * <ol>
+     * <li>if the properties are of type {@link RequestResponseClientConfigProperties}
+     * then the value of its <em>responseCacheDefaultTimeout</em> property is used</li>
+     * <li>otherwise the {@linkplain RequestResponseClientConfigProperties#DEFAULT_RESPONSE_CACHE_TIMEOUT
+     * default timeout value} is used</li>
+     * </ol>
+     *
+     * @return The timeout period in seconds.
+     */
+    protected final long getResponseCacheDefaultTimeout() {
+        if (connection.getConfig() instanceof RequestResponseClientConfigProperties) {
+            return ((RequestResponseClientConfigProperties) connection.getConfig()).getResponseCacheDefaultTimeout();
+        } else {
+            return RequestResponseClientConfigProperties.DEFAULT_RESPONSE_CACHE_TIMEOUT;
+        }
+    }
+
+    /**
+     * Sets the period of time after which any requests are considered to have timed out.
+     * <p>
+     * The client will fail the result handler passed in to any of the operations if no response
+     * has been received from the peer after the given amount of time.
+     * <p>
+     * When setting this property to 0, requests do not time out at all. Note that this will
+     * allow for unanswered requests piling up in the client, which eventually may cause the
+     * client to run out of memory.
+     * <p>
+     * The default value of this property is 200 milliseconds.
+     *
+     * @param timoutMillis The number of milliseconds after which a request is considered to have timed out.
+     * @throws IllegalArgumentException if the value is &lt; 0
+     */
+    public final void setRequestTimeout(final long timoutMillis) {
+
+        if (timoutMillis < 0) {
+            throw new IllegalArgumentException("request timeout must be >= 0");
+        } else {
+            this.requestTimeoutMillis = timoutMillis;
+        }
+    }
+
+    /**
+     * Build a unique messageId for a request that serves as an identifier for a new message.
+     *
+     * @return The unique messageId;
+     */
+    private String createMessageId() {
+        return String.format("%s-client-%s", endpointName, UUID.randomUUID());
+    }
+
+    /**
+     * Creates the sender and receiver links to the peer for sending requests
+     * and receiving responses.
+     *
+     * @return A future indicating the outcome. The future will succeed if the links
+     *         have been created.
+     */
+    public final Future<Void> createLinks() {
+        return createLinks(null, null);
+    }
+
+    /**
+     * Creates the sender and receiver links to the peer for sending requests
+     * and receiving responses.
+     *
+     * @param senderCloseHook A handler to invoke if the peer closes the sender link unexpectedly (may be {@code null}).
+     * @param receiverCloseHook A handler to invoke if the peer closes the receiver link unexpectedly (may be {@code null}).
+     * @return A future indicating the outcome. The future will succeed if the links
+     *         have been created.
+     */
+    public final Future<Void> createLinks(
+            final Handler<String> senderCloseHook,
+            final Handler<String> receiverCloseHook) {
+
+        return createReceiver(replyToAddress, receiverCloseHook)
+                .compose(recv -> {
+                    this.receiver = recv;
+                    return createSender(linkTargetAddress, senderCloseHook);
+                })
+                .compose(sender -> {
+                    LOG.debug("request-response client for peer [{}] created", connection.getConfig().getHost());
+                    this.offeredCapabilities = Optional.ofNullable(sender.getRemoteOfferedCapabilities())
+                            .map(caps -> Collections.unmodifiableList(Arrays.asList(caps)))
+                            .orElse(Collections.emptyList());
+                    this.sender = sender;
+                    return Future.succeededFuture();
+                });
+    }
+
+    private Future<ProtonSender> createSender(final String targetAddress, final Handler<String> closeHook) {
+
+        return connection.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, closeHook);
+    }
+
+    private Future<ProtonReceiver> createReceiver(final String sourceAddress, final Handler<String> closeHook) {
+
+        return connection.createReceiver(sourceAddress, ProtonQoS.AT_LEAST_ONCE, this::handleResponse, closeHook);
+    }
+
+    /**
+     * Handles a response received from the peer.
+     * <p>
+     * In particular, this method tries to correlate the message with a previous request
+     * using the message's <em>correlation-id</em> and, if successful, the delivery is <em>accepted</em>
+     * and the message is passed to the handler registered with the original request.
+     * <p>
+     * If the response cannot be correlated to a request, e.g. because the request has timed
+     * out, then the delivery is <em>released</em> and the message is silently discarded.
+     *
+     * @param delivery The handle for accessing the message's disposition.
+     * @param message The response message.
+     */
+    private void handleResponse(final ProtonDelivery delivery, final Message message) {
+
+        // the tuple from the reply map contains
+        // 1. the handler for processing the response and
+        // 2. the function for mapping the raw AMQP message to the response type
+        // 3. the Opentracing span covering the execution
+        final TriTuple<Promise<R>, Function<Message, R>, Span> handler = replyMap.remove(message.getCorrelationId());
+
+        if (handler == null) {
+            LOG.debug("discarding unexpected response [reply-to: {}, correlation ID: {}]",
+                    replyToAddress, message.getCorrelationId());
+            ProtonHelper.rejected(delivery, true);
+        } else {
+            final R response = handler.two().apply(message);
+            final Span span = handler.three();
+            if (response == null) {
+                LOG.debug("discarding malformed response [reply-to: {}, correlation ID: {}]",
+                        replyToAddress, message.getCorrelationId());
+                handler.one().handle(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR,
+                        "cannot process response from service [" + endpointName + "]")));
+                ProtonHelper.released(delivery, true);
+            } else {
+                LOG.debug("received response [reply-to: {}, subject: {}, correlation ID: {}, status: {}, cache-directive: {}]",
+                        replyToAddress, message.getSubject(), message.getCorrelationId(), response.getStatus(), response.getCacheDirective());
+                if (span != null) {
+                    span.log("response from peer accepted");
+                }
+                handler.one().handle(Future.succeededFuture(response));
+                ProtonHelper.accepted(delivery, true);
+            }
+        }
+    }
+
+
+    /**
+     * Cancels an outstanding request with a given result.
+     *
+     * @param correlationId The identifier of the request to cancel.
+     * @param result The result to pass to the result handler registered for the correlation ID.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws IllegalArgumentException if the result is succeeded.
+     */
+    private void cancelRequest(final Object correlationId, final AsyncResult<R> result) {
+
+        Objects.requireNonNull(correlationId);
+        Objects.requireNonNull(result);
+
+        if (result.succeeded()) {
+            throw new IllegalArgumentException("result must be failed");
+        } else {
+            Optional.ofNullable(replyMap.remove(correlationId))
+                .ifPresent(handler -> {
+                    LOG.debug("canceling request [target: {}, correlation ID: {}]: {}",
+                            linkTargetAddress, correlationId, result.cause().getMessage());
+                    handler.one().handle(result);
+                });
+        }
+    }
+
+    /**
+     * Creates an AMQP message for a subject and address.
+     * <p>
+     * The message can be extended by arbitrary application properties passed in.
+     *
+     * @param subject The subject system property of the message.
+     * @param address The address of the message, put in the <em>to</em> property.
+     * @param appProperties The map containing arbitrary application properties.
+     *                      Maybe null if no application properties are needed.
+     * @return The message constructed from the provided parameters.
+     * @throws NullPointerException if the subject is {@code null}.
+     * @throws IllegalArgumentException if the application properties contain values of types that are not
+     *                                  {@linkplain AbstractHonoClient#setApplicationProperties(Message, Map)
+     *                                  supported by AMQP 1.0}.
+     */
+    private Message createMessage(
+            final String subject,
+            final String address,
+            final Map<String, Object> appProperties) {
+
+        Objects.requireNonNull(subject);
+        final Message msg = ProtonHelper.message();
+        AbstractHonoClient.setApplicationProperties(msg, appProperties);
+        msg.setAddress(address);
+        msg.setReplyTo(replyToAddress);
+        msg.setMessageId(createMessageId());
+        msg.setSubject(subject);
+        return msg;
+    }
+
+    /**
+     * Creates a request message for a payload and headers and sends it to the peer.
+     * <p>
+     * This method uses the sender link's target address as the value for the message's
+     * <em>to</em> property.
+     * <p>
+     * This method first checks if the sender has any credit left. If not, a failed future is returned immediately.
+     * Otherwise, the request message is sent and a timer is started which fails the returned future,
+     * if no response is received within <em>requestTimeoutMillis</em> milliseconds.
+     * <p>
+     * In case of an error the {@code Tags.HTTP_STATUS} tag of the span is set accordingly.
+     * However, the span is never finished by this method.
+     *
+     * @param action The operation that the request is supposed to trigger/invoke.
+     * @param properties The headers to include in the request message as AMQP application properties.
+     * @param payload The payload to include in the request message as an AMQP Value section.
+     * @param contentType The content type of the payload.
+     * @param responseMapper A function mapping a raw AMQP message to the response type.
+     * @param currentSpan The <em>Opentracing</em> span used to trace the request execution.
+     * @return A future indicating the outcome of the operation.
+     *         The future will be failed with a {@link ServerErrorException} if the request cannot be sent to
+     *         the remote service, e.g. because there is no connection to the service or there are no credits
+     *         available for sending the request or the request timed out.
+     * @throws NullPointerException if any of action, response mapper or currentSpan is {@code null}.
+     * @throws IllegalArgumentException if the properties contain any non-primitive typed values.
+     * @see AbstractHonoClient#setApplicationProperties(Message, Map)
+     */
+    public final Future<R> createAndSendRequest(
+            final String action,
+            final Map<String, Object> properties,
+            final Buffer payload,
+            final String contentType,
+            final Function<Message, R> responseMapper,
+            final Span currentSpan) {
+
+        return createAndSendRequest(
+                action,
+                linkTargetAddress,
+                properties,
+                payload,
+                contentType,
+                responseMapper,
+                currentSpan);
+    }
+
+    /**
+     * Creates a request message for a payload and headers and sends it to the peer.
+     * <p>
+     * This method first checks if the sender has any credit left. If not, a failed future is returned immediately.
+     * Otherwise, the request message is sent and a timer is started which fails the returned future,
+     * if no response is received within <em>requestTimeoutMillis</em> milliseconds.
+     * <p>
+     * In case of an error the {@code Tags.HTTP_STATUS} tag of the span is set accordingly.
+     * However, the span is never finished by this method.
+     *
+     * @param action The operation that the request is supposed to trigger/invoke.
+     * @param address The address to send the message to.
+     * @param properties The headers to include in the request message as AMQP application properties.
+     * @param payload The payload to include in the request message as an AMQP Value section.
+     * @param contentType The content type of the payload.
+     * @param responseMapper A function mapping a raw AMQP message to the response type.
+     * @param currentSpan The <em>Opentracing</em> span used to trace the request execution.
+     * @return A future indicating the outcome of the operation.
+     *         The future will be failed with a {@link ServerErrorException} if the request cannot be sent to
+     *         the remote service, e.g. because there is no connection to the service or there are no credits
+     *         available for sending the request or the request timed out.
+     * @throws NullPointerException if any of action, response mapper or currentSpan is {@code null}.
+     * @throws IllegalArgumentException if the properties contain any non-primitive typed values.
+     * @see AbstractHonoClient#setApplicationProperties(Message, Map)
+     */
+    private Future<R> createAndSendRequest(
+            final String action,
+            final String address,
+            final Map<String, Object> properties,
+            final Buffer payload,
+            final String contentType,
+            final Function<Message, R> responseMapper,
+            final Span currentSpan) {
+
+        Objects.requireNonNull(action);
+        Objects.requireNonNull(currentSpan);
+        Objects.requireNonNull(responseMapper);
+
+        if (isOpen()) {
+            final Message request = createMessage(action, address, properties);
+            MessageHelper.setPayload(request, contentType, payload);
+            return sendRequest(request, responseMapper, currentSpan);
+        } else {
+             return Future.failedFuture(new ServerErrorException(
+                    HttpURLConnection.HTTP_UNAVAILABLE, "sender and/or receiver link is not open"));
+        }
+    }
+
+    /**
+     * Sends a request message via this client's sender link to the peer.
+     * <p>
+     * This method first checks if the sender has any credit left. If not, the result handler is failed immediately.
+     * Otherwise, the request message is sent and a timer is started which fails the result handler,
+     * if no response is received within <em>requestTimeoutMillis</em> milliseconds.
+     * <p>
+     * The given span is never finished by this method.
+     *
+     * @param request The message to send.
+     * @param responseMapper A function mapping a raw AMQP message to the response type.
+     * @param currentSpan The <em>Opentracing</em> span used to trace the request execution.
+     * @return A future indicating the outcome of the operation.
+     *         The future will be failed with a {@link ServerErrorException} if the request cannot be sent to
+     *         the remote service, e.g. because there is no connection to the service or there are no credits
+     *         available for sending the request or the request timed out.
+     */
+    private Future<R> sendRequest(
+            final Message request,
+            final Function<Message, R> responseMapper,
+            final Span currentSpan) {
+
+        final String requestTargetAddress = Optional.ofNullable(request.getAddress()).orElse(linkTargetAddress);
+        Tags.MESSAGE_BUS_DESTINATION.set(currentSpan, requestTargetAddress);
+        Tags.SPAN_KIND.set(currentSpan, Tags.SPAN_KIND_CLIENT);
+        Tags.HTTP_METHOD.set(currentSpan, request.getSubject());
+        if (tenantId != null) {
+            currentSpan.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
+        }
+
+        return connection.executeOnContext((Promise<R> res) -> {
+
+            if (sender.sendQueueFull()) {
+
+                LOG.debug("cannot send request to peer, no credit left for link [link target: {}]", linkTargetAddress);
+                res.fail(new ServerErrorException(
+                        HttpURLConnection.HTTP_UNAVAILABLE, "no credit available for sending request"));
+
+                sampler.queueFull(tenantId);
+
+            } else {
+
+                final Map<String, Object> details = new HashMap<>(3);
+                final Object correlationId = Optional.ofNullable(request.getCorrelationId()).orElse(request.getMessageId());
+                if (correlationId instanceof String) {
+                    details.put(TracingHelper.TAG_CORRELATION_ID.getKey(), correlationId);
+                }
+                details.put(TracingHelper.TAG_CREDIT.getKey(), sender.getCredit());
+                details.put(TracingHelper.TAG_QOS.getKey(), sender.getQoS().toString());
+                currentSpan.log(details);
+
+                final TriTuple<Promise<R>, Function<Message, R>, Span> handler = TriTuple.of(res, responseMapper, currentSpan);
+                TracingHelper.injectSpanContext(connection.getTracer(), currentSpan.context(), request);
+                replyMap.put(correlationId, handler);
+
+                final SendMessageSampler.Sample sample = sampler.start(tenantId);
+
+                sender.send(request, deliveryUpdated -> {
+                    final Promise<R> failedResult = Promise.promise();
+                    final DeliveryState remoteState = deliveryUpdated.getRemoteState();
+                    sample.completed(remoteState);
+                    if (Rejected.class.isInstance(remoteState)) {
+                        final Rejected rejected = (Rejected) remoteState;
+                        if (rejected.getError() != null) {
+                            LOG.debug("service did not accept request [target address: {}, subject: {}, correlation ID: {}]: {}",
+                                    requestTargetAddress, request.getSubject(), correlationId, rejected.getError());
+                            failedResult.fail(StatusCodeMapper.from(rejected.getError()));
+                            cancelRequest(correlationId, failedResult.future());
+                        } else {
+                            LOG.debug("service did not accept request [target address: {}, subject: {}, correlation ID: {}]",
+                                    requestTargetAddress, request.getSubject(), correlationId);
+                            failedResult.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
+                            cancelRequest(correlationId, failedResult.future());
+                        }
+                    } else if (Accepted.class.isInstance(remoteState)) {
+                        LOG.trace("service has accepted request [target address: {}, subject: {}, correlation ID: {}]",
+                                requestTargetAddress, request.getSubject(), correlationId);
+                        currentSpan.log("request accepted by peer");
+                        // if no reply-to is set, the request is assumed to be one-way (no response is expected)
+                        if (request.getReplyTo() == null) {
+                            if (replyMap.remove(correlationId) != null) {
+                                res.complete();
+                            } else {
+                                LOG.trace("accepted request won't be acted upon, request already cancelled [target address: {}, subject: {}, correlation ID: {}]",
+                                        requestTargetAddress, request.getSubject(), correlationId);
+                            }
+                        }
+                    } else if (Released.class.isInstance(remoteState)) {
+                        LOG.debug("service did not accept request [target address: {}, subject: {}, correlation ID: {}], remote state: {}",
+                                requestTargetAddress, request.getSubject(), correlationId, remoteState);
+                        failedResult.fail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE));
+                        cancelRequest(correlationId, failedResult.future());
+                    } else if (Modified.class.isInstance(remoteState)) {
+                        LOG.debug("service did not accept request [target address: {}, subject: {}, correlation ID: {}], remote state: {}",
+                                requestTargetAddress, request.getSubject(), correlationId, remoteState);
+                        final Modified modified = (Modified) deliveryUpdated.getRemoteState();
+                        failedResult.fail(modified.getUndeliverableHere() ? new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)
+                                : new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE));
+                        cancelRequest(correlationId, failedResult.future());
+                    } else if (remoteState == null) {
+                        // possible scenario here: sender link got closed while waiting on the delivery update
+                        final String furtherInfo = !sender.isOpen() ? ", sender link was closed in between" : "";
+                        LOG.warn("got undefined delivery state for service request{} [target address: {}, subject: {}, correlation ID: {}]",
+                                furtherInfo, requestTargetAddress, request.getSubject(), correlationId);
+                        failedResult.fail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE));
+                        cancelRequest(correlationId, failedResult.future());
+                    }
+                });
+                if (requestTimeoutMillis > 0) {
+                    connection.getVertx().setTimer(requestTimeoutMillis, tid -> {
+                        cancelRequest(correlationId, Future.failedFuture(new ServerErrorException(
+                                HttpURLConnection.HTTP_UNAVAILABLE, "request timed out after " + requestTimeoutMillis + "ms")));
+                        sample.timeout();
+                    });
+                }
+                if (LOG.isDebugEnabled()) {
+                    final String deviceId = MessageHelper.getDeviceId(request);
+                    if (deviceId == null) {
+                        LOG.debug("sent request [target address: {}, subject: {}, correlation ID: {}] to service",
+                                requestTargetAddress, request.getSubject(), correlationId);
+                    } else {
+                        LOG.debug("sent request [target address: {}, subject: {}, correlation ID: {}, device ID: {}] to service",
+                                requestTargetAddress, request.getSubject(), correlationId, deviceId);
+                    }
+                }
+            }
+          });
+    }
+
+    /**
+     * Checks if this client's sender and receiver links are open.
+     *
+     * @return {@code true} if a request can be sent to and a response can be received
+     * from the peer.
+     */
+    public final boolean isOpen() {
+        return sender != null && sender.isOpen() && receiver != null && receiver.isOpen();
+    }
+
+    /**
+     * Closes the links.
+     *
+     * @return A succeeded future indicating that the links have been closed.
+     */
+    public final Future<Void> close() {
+
+        LOG.debug("closing request-response client ...");
+        return closeLinks();
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
@@ -14,31 +14,52 @@
 
 package org.eclipse.hono.adapter.client.registry.amqp;
 
+import java.net.HttpURLConnection;
+import java.util.Objects;
+import java.util.function.Supplier;
+
 import javax.security.auth.x500.X500Principal;
 
-import org.eclipse.hono.adapter.client.amqp.AbstractRequestResponseClient;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.eclipse.hono.adapter.client.amqp.AbstractRequestResponseServiceClient;
+import org.eclipse.hono.adapter.client.amqp.RequestResponseClient;
 import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.cache.CacheProvider;
+import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.impl.CachingClientFactory;
-import org.eclipse.hono.client.impl.TenantClientImpl;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.Pair;
+import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantConstants.TenantAction;
 import org.eclipse.hono.util.TenantObject;
 import org.eclipse.hono.util.TenantResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import io.opentracing.tag.StringTag;
 import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
 
 
 /**
  * A vertx-proton based client of Hono's Tenant service.
  *
  */
-public final class ProtonBasedTenantClient extends AbstractRequestResponseClient<TenantResult<TenantObject>> implements TenantClient {
+public final class ProtonBasedTenantClient extends AbstractRequestResponseServiceClient<TenantObject, TenantResult<TenantObject>> implements TenantClient {
 
-    private final CachingClientFactory<org.eclipse.hono.client.TenantClient> tenantClientFactory;
+    private static final Logger LOG = LoggerFactory.getLogger(ProtonBasedTenantClient.class);
+    private static final StringTag TAG_SUBJECT_DN = new StringTag("subject_dn");
 
     /**
      * Creates a new client for a connection.
@@ -54,56 +75,124 @@ public final class ProtonBasedTenantClient extends AbstractRequestResponseClient
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig,
             final CacheProvider cacheProvider) {
-        super(connection, samplerFactory, adapterConfig, cacheProvider);
-        this.tenantClientFactory = new CachingClientFactory<>(connection.getVertx(), c -> c.isOpen());
+        super(connection, samplerFactory, adapterConfig, new CachingClientFactory<>(
+                connection.getVertx(), RequestResponseClient::isOpen), cacheProvider);
     }
 
-    private Future<org.eclipse.hono.client.TenantClient> getOrCreateTenantClient() {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getKey(final String tenantId) {
+        // there is one client for all tenant IDs only
+        return TenantConstants.TENANT_ENDPOINT;
+    }
+
+    private Future<RequestResponseClient<TenantResult<TenantObject>>> getOrCreateClient() {
 
         return connection.isConnected(getDefaultConnectionCheckTimeout())
                 .compose(v -> connection.executeOnContext(result -> {
-                    tenantClientFactory.getOrCreateClient(
-                            TenantClientImpl.getTargetAddress(),
-                            () -> TenantClientImpl.create(
-                                    responseCacheProvider,
-                                    connection,
-                                    samplerFactory.create(TenantConstants.TENANT_ENDPOINT),
-                                    this::removeTenantClient,
-                                    this::removeTenantClient),
+                    clientFactory.getOrCreateClient(
+                            TenantConstants.TENANT_ENDPOINT,
+                            () -> {
+                                return RequestResponseClient.forEndpoint(
+                                        connection,
+                                        TenantConstants.TENANT_ENDPOINT,
+                                        null,
+                                        samplerFactory.create(TenantConstants.TENANT_ENDPOINT),
+                                        this::removeClient,
+                                        this::removeClient);
+                            },
                             result);
                 }));
     }
 
-    private void removeTenantClient(final String tenantId) {
-        // the tenantId is not relevant for this client, so ignore it
-        tenantClientFactory.removeClient(TenantClientImpl.getTargetAddress());
+    @Override
+    protected TenantResult<TenantObject> getResult(
+            final int status,
+            final String contentType,
+            final Buffer payload,
+            final CacheDirective cacheDirective,
+            final ApplicationProperties applicationProperties) {
+
+        if (isSuccessResponse(status, contentType, payload)) {
+            try {
+                return TenantResult.from(
+                        status,
+                        Json.decodeValue(payload, TenantObject.class),
+                        cacheDirective,
+                        applicationProperties);
+            } catch (final DecodeException e) {
+                LOG.warn("received malformed payload from Tenant service", e);
+                return TenantResult.from(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null, applicationProperties);
+            }
+        } else {
+            return TenantResult.from(status, null, null, applicationProperties);
+        }
     }
 
     /**
      * {@inheritDoc}
-     *
-     * Clears the state of the client factory.
      */
     @Override
-    protected void onDisconnect() {
-        tenantClientFactory.clearState();
+    public Future<TenantObject> get(final String tenantId, final SpanContext parent) {
+
+        Objects.requireNonNull(tenantId);
+
+        final var responseCacheKey = Pair.of(TenantAction.get, tenantId);
+        final Span span = newChildSpan(parent, "get Tenant by ID");
+        span.setTag(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
+        return get(
+                responseCacheKey,
+                () -> new JsonObject().put(TenantConstants.FIELD_PAYLOAD_TENANT_ID, tenantId),
+                span);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public Future<TenantObject> get(final String tenantId, final SpanContext context) {
-        return getOrCreateTenantClient()
-                .compose(client -> client.get(tenantId, context));
+    public Future<TenantObject> get(final X500Principal subjectDn, final SpanContext parent) {
+
+        Objects.requireNonNull(subjectDn);
+
+        final String subjectDnRfc2253 = subjectDn.getName(X500Principal.RFC2253);
+        final var responseCacheKey = Pair.of(TenantAction.get, subjectDn);
+        final Span span = newChildSpan(parent, "get Tenant by subject DN");
+        TAG_SUBJECT_DN.set(span, subjectDnRfc2253);
+        return get(
+                responseCacheKey,
+                () -> new JsonObject().put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, subjectDnRfc2253),
+                span);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Future<TenantObject> get(final X500Principal subjectDn, final SpanContext context) {
-        return getOrCreateTenantClient()
-                .compose(client -> client.get(subjectDn, context));
+    private <T> Future<TenantObject> get(
+            final Pair<TenantAction, T> responseCacheKey,
+            final Supplier<JsonObject> payloadSupplier,
+            final Span currentSpan) {
+
+        final Future<TenantResult<TenantObject>> resultTracker = getResponseFromCache(responseCacheKey, currentSpan)
+                .recover(cacheMiss -> getOrCreateClient()
+                        .compose(client -> client.createAndSendRequest(
+                                    TenantAction.get.toString(),
+                                    null,
+                                    payloadSupplier.get().toBuffer(),
+                                    RegistrationConstants.CONTENT_TYPE_APPLICATION_JSON,
+                                    this::getRequestResponseResult,
+                                    currentSpan))
+                        .map(tenantResult -> {
+                            addToCache(responseCacheKey, tenantResult);
+                            return tenantResult;
+                        }));
+        return mapResultAndFinishSpan(resultTracker, tenantResult -> {
+            switch (tenantResult.getStatus()) {
+            case HttpURLConnection.HTTP_OK:
+                return tenantResult.getPayload();
+            case HttpURLConnection.HTTP_NOT_FOUND:
+                throw new ClientErrorException(tenantResult.getStatus(), "no such tenant");
+            default:
+                throw StatusCodeMapper.from(tenantResult);
+            }
+        }, currentSpan);
     }
 }

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClientTest.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.amqp;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.eclipse.hono.cache.CacheProvider;
+import org.eclipse.hono.cache.ExpiringValueCache;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.impl.CachingClientFactory;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.util.CacheDirective;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+
+
+/**
+ * Tests verifying the behavior of {@link AbstractRequestResponseServiceClient}.
+ *
+ */
+class AbstractRequestResponseServiceClientTest {
+
+    private static final int DEFAULT_CACHE_TIMEOUT_SECONDS = 100;
+    private AbstractRequestResponseServiceClient<Buffer, SimpleRequestResponseResult> client;
+    private Vertx vertx;
+    private CacheProvider cacheProvider;
+    private ExpiringValueCache<Object, Object> cache;
+
+    /**
+     * Sets up the fixture.
+     */
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+
+        vertx = mock(Vertx.class);
+        cache = mock(ExpiringValueCache.class);
+        cacheProvider = mock(CacheProvider.class);
+        when(cacheProvider.getCache(anyString())).thenReturn(cache);
+        final var props = new RequestResponseClientConfigProperties();
+        props.setResponseCacheDefaultTimeout(DEFAULT_CACHE_TIMEOUT_SECONDS);
+
+        client = new AbstractRequestResponseServiceClient<>(
+                AmqpClientUnitTestHelper.mockHonoConnection(vertx, props),
+                SendMessageSampler.Factory.noop(),
+                new ProtocolAdapterProperties(),
+                new CachingClientFactory<>(vertx, v -> true),
+                cacheProvider) {
+
+            @Override
+            protected SimpleRequestResponseResult getResult(
+                    final int status,
+                    final String contentType,
+                    final Buffer payload,
+                    final CacheDirective cacheDirective,
+                    final ApplicationProperties applicationProperties) {
+                return SimpleRequestResponseResult.from(status, payload, cacheDirective, applicationProperties);
+            }
+
+            @Override
+            protected String getKey(final String tenantId) {
+                return "test-" + tenantId;
+            }
+        };
+    }
+
+    /**
+     * Verifies that the client puts a response from a service to the cache
+     * using the default cache timeout if the response does not contain a
+     * <em>no-cache</em> cache directive.
+     */
+    @Test
+    public void testCreateAndSendRequestAddsResponseToCache() {
+
+        // GIVEN a response without a cache directive and status code 200
+        final var response = SimpleRequestResponseResult.from(
+                200,
+                Buffer.buffer("ok"),
+                null,
+                null);
+
+        // WHEN adding the response to the cache
+        client.addToCache("key", response);
+
+        // THEN the response has been put to the cache with the default timeout
+        verify(cache).put(
+                eq("key"),
+                eq(response),
+                eq(Duration.ofSeconds(DEFAULT_CACHE_TIMEOUT_SECONDS)));
+    }
+
+    /**
+     * Verifies that the client puts a response from a service to the cache
+     * using the max age indicated by the response's <em>max-age</em> cache directive.
+     */
+    @Test
+    public void testAddToCacheConsidersMaxAge() {
+
+        // GIVEN a response with a max-age directive
+        final var response = SimpleRequestResponseResult.from(
+                200,
+                Buffer.buffer("ok"),
+                CacheDirective.maxAgeDirective(Duration.ofMinutes(5)),
+                null);
+
+        // WHEN adding the response to the cache
+        client.addToCache("key", response);
+
+        // THEN the response has been put to the cache
+        verify(cache).put(eq("key"), eq(response), eq(Duration.ofMinutes(5)));
+    }
+
+    /**
+     * Verifies that the client does not put a response from a service to the cache
+     * if the response contains a <em>no-cache</em> cache directive.
+     */
+    @Test
+    public void testAddToCacheDoesNotAddResponseToCache() {
+
+        // GIVEN a response with a no-cache directive
+        final var response = SimpleRequestResponseResult.from(
+                200,
+                Buffer.buffer("ok"),
+                CacheDirective.noCacheDirective(),
+                null);
+
+        // WHEN adding the response to the cache
+        client.addToCache("key", response);
+
+        // THEN the response is not put to the cache
+        verify(cache, never()).put(anyString(), any(SimpleRequestResponseResult.class), any(Duration.class));
+    }
+
+    /**
+     * Verifies that the client does not put a response from a service to the cache
+     * that does not contain any cache directive but has a <em>non-cacheable</em> status code.
+     */
+    @Test
+    public void testAddToCacheDoesNotAddNonCacheableResponseToCache() {
+
+        // GIVEN a response with no cache directive and a 404 status code
+        final var response = SimpleRequestResponseResult.from(
+                404,
+                Buffer.buffer("ok"),
+                null,
+                null);
+
+        // WHEN adding the response to the cache
+        client.addToCache("key", response);
+
+        // THEN the response is not put to the cache
+        verify(cache, never()).put(anyString(), any(SimpleRequestResponseResult.class), any(Duration.class));
+    }
+}

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/RequestResponseClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/RequestResponseClientTest.java
@@ -1,0 +1,379 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.MessageHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonMessageHandler;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+
+/**
+ * Tests verifying behavior of {@link RequestResponseClient}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class RequestResponseClientTest  {
+
+    private Future<RequestResponseClient<SimpleRequestResponseResult>> client;
+    private Vertx vertx;
+    private HonoConnection connection;
+    private ProtonReceiver receiver;
+    private ProtonSender sender;
+    private RequestResponseClientConfigProperties clientConfig;
+    private Span span;
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+
+        span = TracingMockSupport.mockSpan();
+        final Tracer tracer = TracingMockSupport.mockTracer(span);
+
+        final EventBus eventBus = mock(EventBus.class);
+        vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(eventBus);
+        receiver = AmqpClientUnitTestHelper.mockProtonReceiver();
+        sender = AmqpClientUnitTestHelper.mockProtonSender();
+
+        clientConfig = new RequestResponseClientConfigProperties();
+        connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx, clientConfig, tracer);
+        when(connection.isConnected(anyLong())).thenReturn(Future.succeededFuture());
+        when(connection.createReceiver(anyString(), any(ProtonQoS.class), any(ProtonMessageHandler.class), VertxMockSupport.anyHandler()))
+                .thenReturn(Future.succeededFuture(receiver));
+        when(connection.createSender(anyString(), any(ProtonQoS.class), VertxMockSupport.anyHandler()))
+            .thenReturn(Future.succeededFuture(sender));
+
+        client = RequestResponseClient.forEndpoint(
+                connection,
+                "ep",
+                "tenant",
+                SendMessageSampler.noop(),
+                VertxMockSupport.mockHandler(),
+                VertxMockSupport.mockHandler());
+    }
+
+    private void assertFailureCause(
+            final Span span,
+            final Throwable cause,
+            final int expectedErrorCode) {
+
+        assertEquals(
+                expectedErrorCode,
+                ((ServiceInvocationException) cause).getErrorCode());
+        verify(span, never()).finish();
+    }
+
+    private Message verifySenderSend() {
+        final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(sender).send(messageCaptor.capture(), VertxMockSupport.anyHandler());
+        return messageCaptor.getValue();
+    }
+
+    private ProtonMessageHandler verifyResponseHandlerSet() {
+        final ArgumentCaptor<ProtonMessageHandler> messageHandler = ArgumentCaptor.forClass(ProtonMessageHandler.class);
+        verify(connection).createReceiver(anyString(), any(ProtonQoS.class), messageHandler.capture(), VertxMockSupport.anyHandler());
+        return messageHandler.getValue();
+    }
+
+    /**
+     * Verifies that the client fails the handler for sending a request message
+     * with a 503 {@link ServerErrorException} if the link to the peer has no credit left.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateAndSendRequestFailsIfSendQueueFull(final VertxTestContext ctx) {
+
+        // GIVEN a request-response client with a full send queue
+        when(sender.sendQueueFull()).thenReturn(Boolean.TRUE);
+
+        // WHEN sending a request message
+        client
+            .compose(c -> c.createAndSendRequest(
+                "get",
+                null,
+                Buffer.buffer("hello"),
+                "text/plain",
+                SimpleRequestResponseResult::from,
+                span))
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> {
+                    // THEN the message is not sent
+                    verify(sender, never()).send(any(Message.class), VertxMockSupport.anyHandler());
+                    // and the request result handler is failed with a 503
+                    assertFailureCause(span, t, HttpURLConnection.HTTP_UNAVAILABLE);
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that the client creates and sends a message based on provided headers and payload
+     * and sets a timer for canceling the request if no response is received.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateAndSendRequestSendsProperRequestMessage(final VertxTestContext ctx) {
+
+        // WHEN sending a request message with some headers and payload
+        final JsonObject payload = new JsonObject().put("key", "value");
+        final Map<String, Object> props = Map.of("test-key", "test-value");
+        client
+            .onComplete(ctx.succeeding(c -> {
+                c.createAndSendRequest(
+                        "get",
+                        props,
+                        payload.toBuffer(),
+                        "application/json",
+                        SimpleRequestResponseResult::from,
+                        span);
+            }));
+
+        // THEN the message is sent and the message being sent contains the headers as application properties
+        final Message request = verifySenderSend();
+        assertThat(request).isNotNull();
+        assertThat(request.getBody()).isNotNull();
+        assertThat(request.getBody()).isInstanceOf(Data.class);
+        final Buffer body = MessageHelper.getPayload(request);
+        assertThat(body.getBytes()).isEqualTo(payload.toBuffer().getBytes());
+        assertThat(request.getApplicationProperties()).isNotNull();
+        assertThat(request.getApplicationProperties().getValue().get("test-key")).isEqualTo("test-value");
+        // and a timer has been set to time out the request
+        verify(vertx).setTimer(eq(clientConfig.getRequestTimeout()), VertxMockSupport.anyHandler());
+        ctx.completeNow();
+    }
+
+    /**
+     * Verifies that the client fails the result handler if the peer rejects
+     * the request message.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateAndSendRequestFailsOnRejectedMessage(final VertxTestContext ctx) {
+
+        // WHEN sending a request message with some payload
+        final JsonObject payload = new JsonObject().put("key", "value");
+        client
+            .compose(c -> c.createAndSendRequest(
+                    "get",
+                    null,
+                    payload.toBuffer(),
+                    "application/json",
+                    SimpleRequestResponseResult::from,
+                    span))
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> {
+                    // THEN the result handler is failed with a 400 status code
+                    assertFailureCause(span, t, HttpURLConnection.HTTP_BAD_REQUEST);
+                    // and a timer has been set to time out the request
+                    verify(vertx).setTimer(eq(clientConfig.getRequestTimeout()), VertxMockSupport.anyHandler());
+                });
+                ctx.completeNow();
+            }));
+
+        // and the peer rejects the message
+        final Rejected rejected = new Rejected();
+        rejected.setError(ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, "request message is malformed"));
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        when(delivery.getRemoteState()).thenReturn(rejected);
+        final ArgumentCaptor<Handler<ProtonDelivery>> dispositionHandlerCaptor = VertxMockSupport.argumentCaptorHandler();
+        verify(sender).send(any(Message.class), dispositionHandlerCaptor.capture());
+        dispositionHandlerCaptor.getValue().handle(delivery);
+    }
+
+    /**
+     * Verifies that the client returns the service's response message that correlates with the request.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateAndSendRequestReturnsCorrespondingResponseMessage(final VertxTestContext ctx) {
+
+        // WHEN sending a request message to the peer without a timeout set
+        client
+            .map(c -> {
+                c.setRequestTimeout(0);
+                return c;
+            })
+            .compose(c -> c.createAndSendRequest(
+                "request",
+                null,
+                Buffer.buffer("hello"),
+                "text/plain",
+                SimpleRequestResponseResult::from,
+                span))
+            .onComplete(ctx.succeeding(s -> {
+                ctx.verify(() -> {
+                    // THEN the response is passed to the handler registered with the request
+                    assertEquals(200, s.getStatus());
+                    assertEquals("payload", s.getPayload().toString());
+                    // and no response time-out handler has been set
+                    verify(vertx, never()).setTimer(anyLong(), VertxMockSupport.anyHandler());
+                });
+                ctx.completeNow();
+            }));
+
+        // WHEN a response is received for the request
+        final Message request = verifySenderSend();
+        final ProtonMessageHandler responseHandler = verifyResponseHandlerSet();
+        final Message response = ProtonHelper.message("payload");
+        response.setCorrelationId(request.getMessageId());
+        MessageHelper.addProperty(response, MessageHelper.APP_PROPERTY_STATUS, 200);
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        responseHandler.handle(delivery, response);
+    }
+
+    /**
+     * Verifies that the client cancels and fails a request for which no response
+     * has been received after a certain amount of time. The request is then
+     * failed with a {@link ServerErrorException} with a 503 status code.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateAndSendRequestReturnsFailedFutureIfRequestTimesOut(final VertxTestContext ctx) {
+
+        // WHEN no response is received for a request sent to the peer
+        VertxMockSupport.runTimersImmediately(vertx);
+
+        client.compose(c -> c.createAndSendRequest(
+                "request",
+                null,
+                Buffer.buffer("hello"),
+                "text/plain",
+                SimpleRequestResponseResult::from,
+                span))
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> {
+                    // THEN the request handler is failed
+                    assertEquals(
+                            HttpURLConnection.HTTP_UNAVAILABLE,
+                            ((ServerErrorException) t).getErrorCode());
+                    verify(span, never()).finish();
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that a response handler is immediately failed with a
+     * {@link ServerErrorException} when the sender link is not open (yet).
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateAndSendRequestFailsIfSenderIsNotOpen(final VertxTestContext ctx) {
+
+        // GIVEN a client whose sender is not open
+        when(sender.isOpen()).thenReturn(Boolean.FALSE);
+
+        // WHEN sending a request
+        client.compose(c -> c.createAndSendRequest(
+                "get",
+                null,
+                Buffer.buffer("hello"),
+                "text/plain",
+                SimpleRequestResponseResult::from,
+                span))
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> {
+                    // THEN the request fails immediately with a 503
+                    verify(sender, never()).send(any(Message.class), VertxMockSupport.anyHandler());
+                    assertFailureCause(span, t, HttpURLConnection.HTTP_UNAVAILABLE);
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that a response handler is immediately failed with a
+     * {@link ServerErrorException} when the receiver link is not open (yet).
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateAndSendRequestFailsIfReceiverIsNotOpen(final VertxTestContext ctx) {
+
+        // GIVEN a client whose receiver is not open
+        when(receiver.isOpen()).thenReturn(Boolean.FALSE);
+
+        // WHEN sending a request
+        client.compose(c -> c.createAndSendRequest(
+                "get",
+                null,
+                Buffer.buffer("hello"),
+                "text/plain",
+                SimpleRequestResponseResult::from,
+                span))
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> {
+                    // THEN the request fails immediately with a 503
+                    verify(sender, never()).send(any(Message.class), VertxMockSupport.anyHandler());
+                    assertFailureCause(span, t, HttpURLConnection.HTTP_UNAVAILABLE);
+                });
+                ctx.completeNow();
+            }));
+    }
+}

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/SimpleRequestResponseResult.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/SimpleRequestResponseResult.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.amqp;
+
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RequestResponseResult;
+
+import io.vertx.core.buffer.Buffer;
+
+
+/**
+ * A result that contains a status code and a string payload.
+ *
+ */
+public final class SimpleRequestResponseResult extends RequestResponseResult<Buffer> {
+
+    private SimpleRequestResponseResult(
+            final int status,
+            final Buffer payload,
+            final CacheDirective directive,
+            final ApplicationProperties applicationProperties) {
+        super(status, payload, directive, applicationProperties);
+    }
+
+    /**
+     * Creates a new instance for a status code and payload.
+     *
+     * @param status The status code.
+     * @param payload The payload.
+     * @param cacheDirective Restrictions regarding the caching of the payload by
+     *                       the receiver of the result (may be {@code null}).
+     * @param applicationProperties Arbitrary properties conveyed in the response message's
+     *                              <em>application-properties</em>.
+     * @return The instance.
+     */
+    public static SimpleRequestResponseResult from(
+            final int status,
+            final Buffer payload,
+            final CacheDirective cacheDirective,
+            final ApplicationProperties applicationProperties) {
+        return new SimpleRequestResponseResult(status, payload, cacheDirective, applicationProperties);
+    }
+
+    /**
+     * Creates a new instance for a message.
+     *
+     * @param message The message.
+     * @return The instance.
+     */
+    public static SimpleRequestResponseResult from(final Message message) {
+        return from(
+                MessageHelper.getStatus(message),
+                MessageHelper.getPayload(message),
+                CacheDirective.from(MessageHelper.getCacheDirective(message)),
+                message.getApplicationProperties());
+    }
+
+}

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedTenantCommandRouterClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedTenantCommandRouterClientTest.java
@@ -39,7 +39,6 @@ import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -103,7 +102,7 @@ public class ProtonBasedTenantCommandRouterClientTest {
                     ctx.completeNow();
                 }));
 
-        final Message sentMessage = verifySenderSend();
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         final Message response = createNoContentResponseMessage(sentMessage.getMessageId());
         client.doHandleResponse(mock(ProtonDelivery.class), response);
     }
@@ -127,7 +126,7 @@ public class ProtonBasedTenantCommandRouterClientTest {
                     ctx.completeNow();
                 }));
 
-        final Message sentMessage = verifySenderSend();
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         final Message response = createNoContentResponseMessage(sentMessage.getMessageId());
         client.doHandleResponse(mock(ProtonDelivery.class), response);
     }
@@ -151,7 +150,7 @@ public class ProtonBasedTenantCommandRouterClientTest {
                     ctx.completeNow();
                 }));
 
-        final Message sentMessage = verifySenderSend();
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         final Message response = createNoContentResponseMessage(sentMessage.getMessageId());
         client.doHandleResponse(mock(ProtonDelivery.class), response);
     }
@@ -251,7 +250,7 @@ public class ProtonBasedTenantCommandRouterClientTest {
                     ctx.completeNow();
                 }));
 
-        final Message sentMessage = verifySenderSend();
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         final Message response = ProtonHelper.message();
         MessageHelper.addProperty(response, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_PRECON_FAILED);
         MessageHelper.addCacheDirective(response, CacheDirective.maxAgeDirective(60));
@@ -372,7 +371,7 @@ public class ProtonBasedTenantCommandRouterClientTest {
         client.setLastKnownGatewayForDevice(deviceId, gatewayId, span.context());
 
         // THEN the message being sent contains the device ID in its properties
-        final Message sentMessage = verifySenderSend();
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         assertThat(MessageHelper.getDeviceId(sentMessage)).isEqualTo(deviceId);
         assertThat(MessageHelper.getApplicationProperty(sentMessage.getApplicationProperties(),
                 MessageHelper.APP_PROPERTY_GATEWAY_ID, String.class))
@@ -395,7 +394,7 @@ public class ProtonBasedTenantCommandRouterClientTest {
         client.registerCommandConsumer(deviceId, "adapterInstanceId", null, span.context());
 
         // THEN the message being sent contains the device ID in its properties
-        final Message sentMessage = verifySenderSend();
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         assertThat(MessageHelper.getDeviceId(sentMessage)).isEqualTo(deviceId);
         assertThat(MessageHelper.getApplicationProperty(sentMessage.getApplicationProperties(),
                 MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, String.class))
@@ -423,7 +422,7 @@ public class ProtonBasedTenantCommandRouterClientTest {
                 Duration.ofSeconds(lifespanSeconds), span.context());
 
         // THEN the message being sent contains the device ID in its properties
-        final Message sentMessage = verifySenderSend();
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         assertThat(MessageHelper.getDeviceId(sentMessage)).isEqualTo(deviceId);
         assertThat(MessageHelper.getApplicationProperty(sentMessage.getApplicationProperties(),
                 MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, String.class))
@@ -450,7 +449,7 @@ public class ProtonBasedTenantCommandRouterClientTest {
         client.unregisterCommandConsumer(deviceId, adapterInstanceId, span.context());
 
         // THEN the message being sent contains the device ID in its properties
-        final Message sentMessage = verifySenderSend();
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
         assertThat(MessageHelper.getDeviceId(sentMessage)).isEqualTo(deviceId);
         assertThat(MessageHelper.getApplicationProperty(sentMessage.getApplicationProperties(),
                 MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, String.class))
@@ -466,11 +465,5 @@ public class ProtonBasedTenantCommandRouterClientTest {
         MessageHelper.addCacheDirective(response, CacheDirective.maxAgeDirective(60));
         response.setCorrelationId(correlationId);
         return response;
-    }
-
-    private Message verifySenderSend() {
-        final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
-        verify(sender).send(messageCaptor.capture(), VertxMockSupport.anyHandler());
-        return messageCaptor.getValue();
     }
 }

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClientTest.java
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.client.registry.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.client.amqp.AmqpClientUnitTestHelper;
+import org.eclipse.hono.cache.CacheProvider;
+import org.eclipse.hono.cache.ExpiringValueCache;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantObject;
+import org.eclipse.hono.util.TenantResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonMessageHandler;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+
+/**
+ * Tests verifying behavior of {@link ProtonBasedTenantClient}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+class ProtonBasedTenantClientTest {
+
+    private HonoConnection connection;
+    private ProtonSender sender;
+    private ProtonReceiver receiver;
+    private ProtonBasedTenantClient client;
+    private ExpiringValueCache<Object, Object> cache;
+    private CacheProvider cacheProvider;
+    private Span span;
+
+    /**
+     * Sets up the fixture.
+     */
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    public void setUp() {
+
+        span = TracingMockSupport.mockSpan();
+        final Tracer tracer = TracingMockSupport.mockTracer(span);
+
+        final Vertx vertx = mock(Vertx.class);
+        receiver = AmqpClientUnitTestHelper.mockProtonReceiver();
+        sender = AmqpClientUnitTestHelper.mockProtonSender();
+
+        final RequestResponseClientConfigProperties config = new RequestResponseClientConfigProperties();
+        connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx, config, tracer);
+        when(connection.isConnected(anyLong())).thenReturn(Future.succeededFuture());
+        when(connection.createReceiver(anyString(), any(ProtonQoS.class), any(ProtonMessageHandler.class), VertxMockSupport.anyHandler()))
+                .thenReturn(Future.succeededFuture(receiver));
+        when(connection.createSender(anyString(), any(ProtonQoS.class), VertxMockSupport.anyHandler()))
+            .thenReturn(Future.succeededFuture(sender));
+
+        cache = mock(ExpiringValueCache.class);
+        cacheProvider = mock(CacheProvider.class);
+        when(cacheProvider.getCache(anyString())).thenReturn(cache);
+    }
+
+    private static JsonObject newTenantResult(final String tenantId) {
+
+        final JsonObject returnObject = new JsonObject().
+                put(TenantConstants.FIELD_PAYLOAD_TENANT_ID, tenantId).
+                put(TenantConstants.FIELD_ENABLED, true);
+        return returnObject;
+    }
+
+    private void givenAClient(final CacheProvider cacheProvider) {
+        client = new ProtonBasedTenantClient(
+                connection,
+                SendMessageSampler.Factory.noop(),
+                new ProtocolAdapterProperties(),
+                cacheProvider);
+    }
+
+    /**
+     * Verifies that the client retrieves registration information from the
+     * Device Registration service if no cache is configured.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testGetTenantInvokesServiceIfNoCacheConfigured(final VertxTestContext ctx) {
+
+        // GIVEN an adapter with no cache configured
+        givenAClient(null);
+        final JsonObject tenantResult = newTenantResult("tenant");
+
+        // WHEN getting tenant information by ID
+        client.get("tenant", span.context()).onComplete(ctx.succeeding(tenant -> {
+            ctx.verify(() -> {
+                // THEN the registration information has been retrieved from the service
+                verify(cache, never()).get(any());
+                assertThat(tenant).isNotNull();
+                assertThat(tenant.getTenantId()).isEqualTo("tenant");
+                // and not been put to the cache
+                verify(cache, never()).put(any(), any(TenantResult.class), any(Duration.class));
+                // and the span is finished
+                verify(span).finish();
+            });
+            ctx.completeNow();
+        }));
+
+        final Message request = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
+        final Message response = ProtonHelper.message();
+        MessageHelper.addProperty(response, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        MessageHelper.addCacheDirective(response, CacheDirective.maxAgeDirective(60));
+        response.setCorrelationId(request.getMessageId());
+        MessageHelper.setPayload(response, MessageHelper.CONTENT_TYPE_APPLICATION_JSON, tenantResult.toBuffer());
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        AmqpClientUnitTestHelper.assertReceiverLinkCreated(connection).handle(delivery, response);
+    }
+
+    /**
+     * Verifies that on a cache miss the adapter retrieves tenant information
+     * from the Tenant service and puts it to the cache.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testGetTenantAddsInfoToCacheOnCacheMiss(final VertxTestContext ctx) {
+
+        // GIVEN an adapter with an empty cache
+        givenAClient(cacheProvider);
+        when(cache.get(any())).thenReturn(null);
+        final JsonObject tenantResult = newTenantResult("tenant");
+
+        // WHEN getting tenant information
+        client.get("tenant", span.context()).onComplete(ctx.succeeding(tenant -> {
+            ctx.verify(() -> {
+                // THEN the tenant result has been added to the cache
+                final var responseCacheKey = ArgumentCaptor.forClass(Object.class);
+                verify(cache).get(responseCacheKey.capture());
+                assertThat(tenant).isNotNull();
+                assertThat(tenant.getTenantId()).isEqualTo("tenant");
+                verify(cache).put(eq(responseCacheKey.getValue()), any(TenantResult.class), any(Duration.class));
+                // and the span is finished
+                verify(span).finish();
+            });
+            ctx.completeNow();
+        }));
+
+        final Message request = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
+        final Message response = ProtonHelper.message();
+        MessageHelper.addProperty(response, MessageHelper.APP_PROPERTY_STATUS, HttpURLConnection.HTTP_OK);
+        MessageHelper.addCacheDirective(response, CacheDirective.maxAgeDirective(60));
+        response.setCorrelationId(request.getMessageId());
+        MessageHelper.setPayload(response, MessageHelper.CONTENT_TYPE_APPLICATION_JSON, tenantResult.toBuffer());
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        AmqpClientUnitTestHelper.assertReceiverLinkCreated(connection).handle(delivery, response);
+    }
+
+    /**
+     * Verifies that tenant information is taken from the cache if a cache is configured and the
+     * cache contains an entry for the given tenant.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testGetTenantReturnsValueFromCache(final VertxTestContext ctx) {
+
+        // GIVEN a client with a cache containing a tenant
+        givenAClient(cacheProvider);
+        // but no connection to the service
+        when(sender.isOpen()).thenReturn(false);
+        when(connection.isConnected(anyLong()))
+            .thenReturn(Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)));
+
+        final JsonObject tenantJsonObject = newTenantResult("tenant");
+        final TenantResult<TenantObject> tenantResult = client.getResult(
+                HttpURLConnection.HTTP_OK, "application/json", tenantJsonObject.toBuffer(), null, null);
+
+        when(cache.get(any())).thenReturn(tenantResult);
+
+        // WHEN getting tenant information
+        client.get("tenant", span.context()).onComplete(ctx.succeeding(result -> {
+            ctx.verify(() -> {
+                // THEN the tenant information is read from the cache
+                verify(cache).get(any());
+                assertThat(result).isEqualTo(tenantResult.getPayload());
+                // and no request message is sent to the service
+                verify(sender, never()).send(any(Message.class), VertxMockSupport.anyHandler());
+                // and the span is finished
+                verify(span).finish();
+            });
+            ctx.completeNow();
+        }));
+    }
+
+    /**
+     * Verifies that the client fails if the Tenant service cannot be reached
+     * because the sender link has no credit left.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testGetTenantFailsIfSenderHasNoCredit(final VertxTestContext ctx) {
+
+        // GIVEN a client with no credit left 
+        givenAClient(cacheProvider);
+        when(sender.sendQueueFull()).thenReturn(true);
+
+        // WHEN getting tenant information
+        client.get("tenant", span.context()).onComplete(ctx.failing(t -> {
+            ctx.verify(() -> {
+                // THEN the invocation fails and the span is marked as erroneous
+                verify(span).setTag(eq(Tags.ERROR.getKey()), eq(Boolean.TRUE));
+                // and the span is finished
+                verify(span).finish();
+                assertThat(t).isInstanceOf(ServerErrorException.class)
+                    .extracting("errorCode").isEqualTo(HttpURLConnection.HTTP_UNAVAILABLE);
+            });
+            ctx.completeNow();
+        }));
+    }
+
+    /**
+     * Verifies that the client includes the required information in the request
+     * message sent to the Tenant service.
+     */
+    @Test
+    public void testGetTenantByCaUsesRFC2253SubjectDn() {
+
+        // GIVEN a client
+        givenAClient(cacheProvider);
+
+        // WHEN getting tenant information for a subject DN
+        final X500Principal dn = new X500Principal("CN=ca, OU=Hono, O=Eclipse");
+        client.get(dn, span.context());
+
+        // THEN the message being sent contains the subject DN in RFC 2253 format in the
+        // payload
+        final Message request = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
+        final JsonObject payload = MessageHelper.getJsonPayload(request);
+        assertThat(payload.getString(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN)).isEqualTo("CN=ca,OU=Hono,O=Eclipse");
+    }
+
+    /**
+     * Verifies that the client includes the required information in the request
+     * message sent to the Tenant service.
+     */
+    @Test
+    public void testGetTenantIncludesRequiredInformationInRequest() {
+
+        // GIVEN a client without a cache
+        givenAClient(null);
+
+        // WHEN getting tenant information
+        client.get("tenant", span.context());
+
+        // THEN the message being sent contains the tenant ID as search criteria
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
+        assertThat(MessageHelper.getTenantId(sentMessage)).isNull();
+        assertThat(sentMessage.getMessageId()).isNotNull();
+        assertThat(sentMessage.getSubject()).isEqualTo(TenantConstants.TenantAction.get.toString());
+        assertThat(MessageHelper.getJsonPayload(sentMessage).getString(TenantConstants.FIELD_PAYLOAD_TENANT_ID)).isEqualTo("tenant");
+    }
+}


### PR DESCRIPTION
This is the first step of #2381 

Responses from the Tenant service are now being stored in a cache that
is independent from the life cycle of the underlying connection to the
service.
