### PR TITLE
[#2381] Use expiring Caffeine cache

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/RequestResponseClientConfigProperties.java
+++ b/client/src/main/java/org/eclipse/hono/client/RequestResponseClientConfigProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -33,6 +33,10 @@ public class RequestResponseClientConfigProperties extends ClientConfigPropertie
      * The default timeout for cached responses in seconds until they are considered invalid.
      */
     public static final long DEFAULT_RESPONSE_CACHE_TIMEOUT = 600L;
+    /**
+     * The maximum period of time in seconds after which cached responses are considered invalid.
+     */
+    public static final long MAX_RESPONSE_CACHE_TIMEOUT = 24 * 60 * 60L; // 24h
 
     private int responseCacheMinSize = DEFAULT_RESPONSE_CACHE_MIN_SIZE;
     private long responseCacheMaxSize = DEFAULT_RESPONSE_CACHE_MAX_SIZE;
@@ -107,9 +111,9 @@ public class RequestResponseClientConfigProperties extends ClientConfigPropertie
     /**
      * Gets the default period of time after which cached responses are considered invalid.
      * <p>
-     * The default value of this property is {@link #DEFAULT_RESPONSE_CACHE_TIMEOUT}.
+     * The default value of this property is {@value #DEFAULT_RESPONSE_CACHE_TIMEOUT}.
      *
-     * @return The default timeout for cached responses.
+     * @return The timeout in seconds.
      */
     public final long getResponseCacheDefaultTimeout() {
         return responseCacheDefaultTimeout;
@@ -118,7 +122,8 @@ public class RequestResponseClientConfigProperties extends ClientConfigPropertie
     /**
      * Sets the default period of time after which cached responses should be considered invalid.
      * <p>
-     * The default value of this property is {@link #DEFAULT_RESPONSE_CACHE_TIMEOUT}.
+     * The default value of this property is {@value #DEFAULT_RESPONSE_CACHE_TIMEOUT}.
+     * The value of this property is capped at {@value #MAX_RESPONSE_CACHE_TIMEOUT}.
      *
      * @param timeout The timeout in seconds.
      * @throws IllegalArgumentException if timeout is &lt;= 0.
@@ -127,9 +132,8 @@ public class RequestResponseClientConfigProperties extends ClientConfigPropertie
         if (timeout <= 0) {
             throw new IllegalArgumentException("default cache timeout must be greater than zero");
         }
-        this.responseCacheDefaultTimeout = timeout;
+        this.responseCacheDefaultTimeout = Math.min(timeout, MAX_RESPONSE_CACHE_TIMEOUT);
     }
-
 
     /**
      * {@inheritDoc}

--- a/clients/adapter-amqp/pom.xml
+++ b/clients/adapter-amqp/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>vertx-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,6 @@
 package org.eclipse.hono.adapter.client.amqp;
 
 import java.net.HttpURLConnection;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,8 +22,6 @@ import java.util.function.Function;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.cache.CacheProvider;
-import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
@@ -39,6 +36,8 @@ import org.eclipse.hono.util.RequestResponseResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
+
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Future;
@@ -47,7 +46,7 @@ import io.vertx.core.buffer.Buffer;
 /**
  * A vertx-proton based parent class for the implementation of API clients that follow the request response pattern.
  * <p>
- * Provides support for caching response messages from a service in an {@link ExpiringValueCache}.
+ * Provides support for caching response messages from a service in a Caffeine Cache.
  *
  * @param <R> The type of response this client expects the peer to return.
  * @param <T> The type of object contained in the peer's response.
@@ -72,7 +71,7 @@ public abstract class AbstractRequestResponseServiceClient<T, R extends RequestR
     /**
      * A cache to use for responses received from the service.
      */
-    private final ExpiringValueCache<Object, R> responseCache;
+    private final Cache<Object, R> responseCache;
 
     /**
      * Creates a request-response client.
@@ -81,23 +80,19 @@ public abstract class AbstractRequestResponseServiceClient<T, R extends RequestR
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
      * @param adapterConfig The protocol adapter's configuration properties.
      * @param clientFactory The factory to use for creating links to the service.
-     * @param cacheProvider The provider to use for creating cache instances for service responses.
-     * @throws NullPointerException if any of the parameters other than cacheProvider are {@code null}.
+     * @param responseCache The cache to use for service responses.
+     * @throws NullPointerException if any of the parameters other than responseCache are {@code null}.
      */
     protected AbstractRequestResponseServiceClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig,
             final CachingClientFactory<RequestResponseClient<R>> clientFactory,
-            final CacheProvider cacheProvider) {
+            final Cache<Object, R> responseCache) {
 
         super(connection, samplerFactory, adapterConfig);
         this.clientFactory = Objects.requireNonNull(clientFactory);
-        if (cacheProvider == null) {
-            this.responseCache = null;
-        } else {
-            this.responseCache = cacheProvider.getCache("responses");
-        }
+        this.responseCache = Optional.ofNullable(responseCache).orElse(null);
     }
 
     /**
@@ -261,16 +256,13 @@ public abstract class AbstractRequestResponseServiceClient<T, R extends RequestR
         Objects.requireNonNull(key);
 
         if (isCachingEnabled()) {
-            final R result = responseCache.get(key);
-            if (currentSpan != null) {
-                TracingHelper.TAG_CACHE_HIT.set(currentSpan, result != null);
-            }
-            if (result == null) {
-                return Future.failedFuture("cache miss");
-            } else {
-                return Future.succeededFuture(result);
-            }
+            final R result = responseCache.getIfPresent(key);
+            TracingHelper.TAG_CACHE_HIT.set(currentSpan, result != null);
+            return Optional.ofNullable(result)
+                    .map(Future::succeededFuture)
+                    .orElse(Future.failedFuture("cache miss"));
         } else {
+            TracingHelper.TAG_CACHE_HIT.set(currentSpan, Boolean.FALSE);
             return Future.failedFuture(new IllegalStateException("no cache configured"));
         }
     }
@@ -303,19 +295,12 @@ public abstract class AbstractRequestResponseServiceClient<T, R extends RequestR
             Objects.requireNonNull(key);
             Objects.requireNonNull(response);
 
-            final CacheDirective cacheDirective = Optional.ofNullable(response.getCacheDirective())
-                    .orElseGet(() -> {
-                        if (isCacheableStatusCode(response.getStatus())) {
-                            return CacheDirective.maxAgeDirective(getResponseCacheDefaultTimeout());
-                        } else {
-                            return CacheDirective.noCacheDirective();
-                        }
-                    });
+            final boolean resultCanBeCached = Optional.ofNullable(response.getCacheDirective())
+                    .map(directive -> directive.isCachingAllowed())
+                    .orElse(isCacheableStatusCode(response.getStatus()));
 
-            if (cacheDirective.isCachingAllowed()) {
-                if (cacheDirective.getMaxAge() > 0) {
-                    responseCache.put(key, response, Duration.ofSeconds(cacheDirective.getMaxAge()));
-                }
+            if (resultCanBeCached) {
+                responseCache.put(key, response);
             }
         }
     }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
@@ -272,17 +272,16 @@ public abstract class AbstractRequestResponseServiceClient<T, R extends RequestR
      * <p>
      * If no cache is configured then this method does nothing.
      * <p>
-     * Otherwise
+     * Otherwise, the response is put to the cache if it either
      * <ol>
+     * <li>contains a cache directive other than the <em>no-cache</em> directive or</li>
      * <li>if the response does not contain any cache directive and the response's status code is
      * one of the codes defined by <a href="https://tools.ietf.org/html/rfc2616#section-13.4">
-     * RFC 2616, Section 13.4 Response Cacheability</a>, the response is put to the cache using
-     * the default timeout returned by {@link #getResponseCacheDefaultTimeout()},</li>
-     * <li>else if the response contains a <em>max-age</em> directive, the response
-     * is put to the cache using the max age from the directive,</li>
-     * <li>else if the response contains a <em>no-cache</em> directive, the response
-     * is not put to the cache.</li>
+     * RFC 2616, Section 13.4 Response Cacheability</a>.</li>
      * </ol>
+     * It is the cache implementation's responsibility to evict entries after a reasonable amount
+     * of time. The maxAge property of the cache directive contained in a response should be
+     * considered when determining the concrete amount of time.
      *
      * @param key The key to use for the response.
      * @param response The response to put to the cache.

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,7 +21,6 @@ import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.eclipse.hono.adapter.client.amqp.AbstractRequestResponseServiceClient;
 import org.eclipse.hono.adapter.client.amqp.RequestResponseClient;
 import org.eclipse.hono.adapter.client.registry.CredentialsClient;
-import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
@@ -38,6 +37,8 @@ import org.eclipse.hono.util.RequestResponseApiConstants;
 import org.eclipse.hono.util.TriTuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.Cache;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -64,18 +65,17 @@ public class ProtonBasedCredentialsClient extends AbstractRequestResponseService
      * @param connection The connection to the Credentials service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
      * @param adapterConfig The protocol adapter's configuration properties.
-     * @param cacheProvider The cache provider to use for creating a cache for service responses or
-     *                      {@code null} if responses should not be cached.
-     * @throws NullPointerException if any of the parameters other than the cache provider are {@code null}.
+     * @param responseCache The cache to use for service responses or {@code null} if responses should not be cached.
+     * @throws NullPointerException if any of the parameters other than the response cache are {@code null}.
      */
     public ProtonBasedCredentialsClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig,
-            final CacheProvider cacheProvider) {
+            final Cache<Object, CredentialsResult<CredentialsObject>> responseCache) {
 
         super(connection, samplerFactory, adapterConfig, new CachingClientFactory<>(
-                connection.getVertx(), RequestResponseClient::isOpen), cacheProvider);
+                connection.getVertx(), RequestResponseClient::isOpen), responseCache);
         connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
                 this::handleTenantTimeout);
     }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,7 +22,6 @@ import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.eclipse.hono.adapter.client.amqp.AbstractRequestResponseServiceClient;
 import org.eclipse.hono.adapter.client.amqp.RequestResponseClient;
 import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
-import org.eclipse.hono.cache.CacheProvider;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
@@ -41,6 +40,8 @@ import org.eclipse.hono.util.RegistrationResult;
 import org.eclipse.hono.util.TriTuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.Cache;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -66,18 +67,17 @@ public class ProtonBasedDeviceRegistrationClient extends AbstractRequestResponse
      * @param connection The connection to the Device Registration service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
      * @param adapterConfig The protocol adapter's configuration properties.
-     * @param cacheProvider The cache provider to use for creating a cache for service responses or
-     *                      {@code null} if responses should not be cached.
-     * @throws NullPointerException if any of the parameters other than the cache provider are {@code null}.
+     * @param responseCache The cache to use for service responses or {@code null} if responses should not be cached.
+     * @throws NullPointerException if any of the parameters other than the response cache are {@code null}.
      */
     public ProtonBasedDeviceRegistrationClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig,
-            final CacheProvider cacheProvider) {
+            final Cache<Object, RegistrationResult> responseCache) {
 
         super(connection, samplerFactory, adapterConfig, new CachingClientFactory<>(
-                connection.getVertx(), RequestResponseClient::isOpen), cacheProvider);
+                connection.getVertx(), RequestResponseClient::isOpen), responseCache);
         connection.getVertx().eventBus().consumer(
                 Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
                 this::handleTenantTimeout);

--- a/service-base/src/main/java/org/eclipse/hono/service/cache/Caches.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/cache/Caches.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.service.cache;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.RequestResponseResult;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+
+/**
+ * A helper class for creating Caffeine based cache instances.
+ *
+ */
+public final class Caches {
+
+    private Caches() {
+        // prevent instantiation
+    }
+
+    /**
+     * Creates a new Caffeine based cache.
+     * <p>
+     * The created cache will automatically expire values based on the maximum age
+     * set in the value's {@linkplain org.eclipse.hono.util.CacheDirective#getMaxAge() cache directive}.
+     * The cache size will be according to the given configuration's minimum and maximum
+     * response cache size properties.
+     *
+     * @param <V> The type of values that the cache supports.
+     * @param config The configuration to use for the cache.
+     * @return A new cache or {@code null} if the configured max cache size is &lt;= 0.
+     */
+    public static <V extends RequestResponseResult<?>> Cache<Object, V> newCaffeineCache(
+            final RequestResponseClientConfigProperties config) {
+
+        if (config.getResponseCacheMaxSize() <= 0) {
+            return null;
+        }
+
+        return Caffeine.newBuilder()
+                .initialCapacity(config.getResponseCacheMinSize())
+                .maximumSize(Math.max(config.getResponseCacheMinSize(), config.getResponseCacheMaxSize()))
+                .expireAfter(new Expiry<Object, V>() {
+
+                    private long getMaxAge(final CacheDirective directive) {
+                        return Optional.ofNullable(directive)
+                            .map(d -> {
+                                return Duration.ofSeconds(d.getMaxAge()).toNanos();
+                            })
+                            .orElse(config.getResponseCacheDefaultTimeout());
+                    }
+
+                    @Override
+                    public long expireAfterCreate(
+                            final Object key,
+                            final V value,
+                            final long currentTime) {
+
+                        return getMaxAge(value.getCacheDirective());
+                    }
+
+                    @Override
+                    public long expireAfterUpdate(
+                            final Object key,
+                            final V value,
+                            final long currentTime,
+                            final long currentDuration) {
+
+                        return getMaxAge(value.getCacheDirective());
+                    }
+
+                    @Override
+                    public long expireAfterRead(
+                            final Object key,
+                            final V value,
+                            final long currentTime,
+                            final long currentDuration) {
+
+                        return currentDuration;
+                    }
+                })
+                .build();
+    }
+}

--- a/service-base/src/main/java/org/eclipse/hono/service/cache/Caches.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/cache/Caches.java
@@ -62,9 +62,9 @@ public final class Caches {
                     private long getMaxAge(final CacheDirective directive) {
                         return Optional.ofNullable(directive)
                             .map(d -> {
-                                return Duration.ofSeconds(d.getMaxAge()).toNanos();
+                                return Duration.ofSeconds(Math.min(d.getMaxAge(), config.getResponseCacheDefaultTimeout())).toNanos();
                             })
-                            .orElse(config.getResponseCacheDefaultTimeout());
+                            .orElse(Duration.ofSeconds(config.getResponseCacheDefaultTimeout()).toNanos());
                     }
 
                     @Override

--- a/site/documentation/content/admin-guide/common-config.md
+++ b/site/documentation/content/admin-guide/common-config.md
@@ -83,6 +83,10 @@ where the `${PREFIX}` is set to `HONO_REGISTRATION`.
 The adapter caches the responses from the service according to the *cache directive* included in the response.
 If the response doesn't contain a *cache directive* no data will be cached.
 
+Note that the adapter uses a single cache for all responses from the service regardless of the tenant identifier.
+Consequently, the Device Registration Service client configuration's *responseCacheMinSize* and *responseCacheMaxSize* properties
+determine the overall number of responses that can be cached.
+
 ### Credentials Service Connection Configuration
 
 Protocol adapters require a connection to an implementation of Hono's [Credentials API]({{< relref "/api/credentials" >}}) in order to retrieve credentials stored for devices that needs to be authenticated. During connection establishment, the adapter uses the Credentials API to retrieve the credentials on record for the device and matches that with the credentials provided by a device.
@@ -92,6 +96,10 @@ where the `${PREFIX}` is set to `HONO_CREDENTIALS`.
 
 The adapter caches the responses from the service according to the *cache directive* included in the response.
 If the response doesn't contain a *cache directive* no data will be cached.
+
+Note that the adapter uses a single cache for all responses from the service regardless of the tenant identifier.
+Consequently, the Credentials Service client configuration's *responseCacheMinSize* and *responseCacheMaxSize* properties
+determine the overall number of responses that can be cached.
 
 <a name="device-connection-service-connection-configuration"></a>
 ### Device Connection Service Connection Configuration

--- a/site/documentation/content/admin-guide/hono-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-client-configuration.md
@@ -65,8 +65,11 @@ The clients created by a Hono client factory support the caching of responses re
 In order to enable caching, the `org.eclipse.hono.client.impl.HonoClientImpl` factory class needs to be configured with a cache manager using the *setCacheManager* method. Any specific client created by the factory will then cache responses to service invocations based on the following rules:
 
 1. If the response contains a `no-cache` directive, the response is not cached at all.
-2. Otherwise, if the response contains a `max-age` directive, the response is cached for the number of seconds specified by the directive.
-3. Otherwise, if the response message does not contain any of the above directives and the response's status code is one of the codes defined in [RFC 2616, Section 13.4 Response Cacheability](https://tools.ietf.org/html/rfc2616#section-13.4), the response is put to the cache using the default timeout defined by the `${PREFIX}_RESPONSECACHEDEFAULTTIMEOUT` variable as the maximum age.
+2. Otherwise, if the response contains a `max-age` directive, the response is cached for the number of seconds determined
+   as the minimum of the value contained in the directive and the value of the `${PREFIX}_RESPONSECACHEDEFAULTTIMEOUT` variable.
+3. Otherwise, if the response message does not contain any of the above directives and the response's status code is one
+   of the codes defined in [RFC 2616, Section 13.4 Response Cacheability](https://tools.ietf.org/html/rfc2616#section-13.4),
+   the response is put to the cache using the default timeout defined by the `${PREFIX}_RESPONSECACHEDEFAULTTIMEOUT` variable as the maximum age.
 
 The following table provides an overview of the configuration variables and corresponding command line options for configuring the Hono client's caching behavior.
 
@@ -74,7 +77,7 @@ The following table provides an overview of the configuration variables and corr
 | :------------------------------------------ | :-------: | :------------ | :------------|
 | `${PREFIX}_RESPONSECACHEMINSIZE`<br>`--${prefix}.responseCacheMinSize` | no | `20` | The minimum number of responses that can be cached. |
 | `${PREFIX}_RESPONSECACHEMAXSIZE`<br>`--${prefix}.responseCacheMaxSize` | no | `1000` | The maximum number of responses that can be cached. It is up to the particular cache implementation, how to deal with new cache entries once this limit has been reached. |
-| `${PREFIX}_RESPONSECACHEDEFAULTTIMEOUT`<br>`--${prefix}.responseCacheDefaultTimeout` | no | `600` | The default number of seconds after which cached responses should be considered invalid. |
+| `${PREFIX}_RESPONSECACHEDEFAULTTIMEOUT`<br>`--${prefix}.responseCacheDefaultTimeout` | no | `600` | The default number of seconds after which cached responses should be considered invalid. The value of this property serves as an upper boundary to the value conveyed in a `max-age` cache directive and is capped at `86400`, which corresponds to 24 hours. |
 
 ## Using TLS
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -12,6 +12,20 @@ title = "Release Notes"
   for details.
 * The MQTT adapter now allows clients to indicate whether they want the target device's tenant and/or device IDs
   to be included in the topic used when publishing commands.
+* The caching behavior of the protocol adapters' AMQP based registry clients has been changed. All adapter
+  Verticle instances now share a single cache instance *per service*. In particular, there is a single cache for
+  all responses returned by the Tenant, Device Registration and Credentials service respectively.
+  In addition, each cache is now being used for all responses to requests regardless of the tenant. Consequently, the
+  service client configurations' *responseCacheMinSize* and *responseCacheMaxSize* properties now determine
+  the overall number of responses that can be cached *per service*. In previous versions the properties determined
+  the number of entries *per client instance and tenant*. The new approach allows for better control over the maximum
+  amount of memory being used by the cache and should also increase cache hits when deploying multiple adapter
+  Verticle instances.
+  The `org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient` now makes sure that only a single
+  request to the Tenant service is issued when multiple (parallel) *get* method invocations run into a cache miss.
+  This should reduce the load on the Tenant service significantly in scenarios where devices of the same
+  tenant connect to an adapter at a high rate, e.g. in when re-connecting after one or more adapter pods have
+  crashed.
 
 ### Deprecations
 


### PR DESCRIPTION
The registry service clients have been changed to use a Caffeine based
cache instead of org.eclipse.hono.cache.ExpiringValueCache.
The Caffeine cache is configured to expire values based on the
CacheDirective's max age that is contained in the RequestResponseResult
typed values.

Also, a single cache instance is being used per service which is shared
between all client instances.

The ProtonBasedTenantClient has been changed to make sure that only a
single request is issued to the Tenant service when multiple (parallel)
method invocations result in cache misses.
