### PR TITLE
[#2387] Do not use legacy client's DownstreamSender in new client

### DIFF
--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/DownstreamSenderLink.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/DownstreamSenderLink.java
@@ -171,6 +171,11 @@ public class DownstreamSenderLink extends AbstractHonoClient {
         return closeLinks();
     }
 
+    /**
+     * Checks if the wrapped sender link is open.
+     *
+     * @return {@code true} if the link is open and can be used to send messages.
+     */
     public final boolean isOpen() {
         return sender.isOpen();
     }
@@ -234,7 +239,7 @@ public class DownstreamSenderLink extends AbstractHonoClient {
 
         Objects.requireNonNull(message);
         Objects.requireNonNull(currentSpan);
-        Objects.requireNonNull(sender);
+        Objects.requireNonNull(sendOperation);
 
         Tags.MESSAGE_BUS_DESTINATION.set(currentSpan, getMessageAddress(message));
         TracingHelper.TAG_QOS.set(currentSpan, sender.getQoS().toString());
@@ -408,7 +413,7 @@ public class DownstreamSenderLink extends AbstractHonoClient {
                         final Rejected rejected = (Rejected) remoteState;
                         e = Optional.ofNullable(rejected.getError())
                                 .map(error -> new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, error.getDescription()))
-                                .orElse(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
+                                .orElseGet(() -> new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
                     } else if (Released.class.isInstance(remoteState)) {
                         e = new MessageNotProcessedException();
                     } else if (Modified.class.isInstance(remoteState)) {

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/DownstreamSenderLink.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/DownstreamSenderLink.java
@@ -1,0 +1,535 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.amqp;
+
+import java.net.HttpURLConnection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Modified;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.MessageNotProcessedException;
+import org.eclipse.hono.client.MessageUndeliverableException;
+import org.eclipse.hono.client.NoConsumerException;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.SendMessageTimeoutException;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.AddressHelper;
+import org.eclipse.hono.util.MessageHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.log.Fields;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * A wrapper around a vertx-proton based AMQP sender link.
+ * Exposes methods for sending messages using {@linkplain #send(Message, Span) AT_MOST_ONCE}
+ * and {@linkplain #sendAndWaitForOutcome(Message, Span) AT_LEAST_ONCE} delivery semantics.
+ */
+public class DownstreamSenderLink extends AbstractHonoClient {
+
+    private static final AtomicLong MESSAGE_COUNTER = new AtomicLong();
+    private static final Logger log = LoggerFactory.getLogger(DownstreamSenderLink.class);
+
+    private final String tenantId;
+    private final String targetAddress;
+    private final SendMessageSampler sampler;
+
+    /**
+     * Creates a new sender.
+     *
+     * @param connection The connection to use for interacting with the server.
+     * @param sender The sender link to send messages over.
+     * @param tenantId The identifier of the tenant that the
+     *           devices belong to which have published the messages
+     *           that this sender is used to send downstream.
+     * @param sampler The sampler for sending messages.
+     * @param targetAddress The target address to send the messages to.
+     * @throws NullPointerException if any of the parameters except targetAddress is {@code null}.
+     */
+    protected DownstreamSenderLink(
+            final HonoConnection connection,
+            final ProtonSender sender,
+            final String tenantId,
+            final String targetAddress,
+            final SendMessageSampler sampler) {
+
+        super(connection);
+        this.sender = Objects.requireNonNull(sender);
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.targetAddress = targetAddress;
+        this.sampler = Objects.requireNonNull(sampler);
+        if (sender.isOpen()) {
+            this.offeredCapabilities = Optional.ofNullable(sender.getRemoteOfferedCapabilities())
+                    .map(caps -> Collections.unmodifiableList(Arrays.asList(caps)))
+                    .orElse(Collections.emptyList());
+        }
+    }
+
+    /**
+     * Creates a new AMQP sender link for publishing messages to Hono's south bound API endpoints.
+     *
+     * @param con The connection to the Hono server.
+     * @param endpoint The endpoint to send messages to.
+     * @param tenantId The tenant that the events will be published for.
+     * @param sampler The sampler to use.
+     * @param remoteCloseHook The handler to invoke when the link is closed by the peer (may be {@code null}). The
+     *            sender's target address is provided as an argument to the handler.
+     * @return A future indicating the outcome.
+     * @throws NullPointerException if any of the parameters except remoteCloseHook is {@code null}.
+     */
+    public static Future<DownstreamSenderLink> create(
+            final HonoConnection con,
+            final String endpoint,
+            final String tenantId,
+            final SendMessageSampler sampler,
+            final Handler<String> remoteCloseHook) {
+
+        Objects.requireNonNull(con);
+        Objects.requireNonNull(endpoint);
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(sampler);
+
+        return create(con, endpoint, tenantId, null, sampler, remoteCloseHook);
+    }
+
+    /**
+     * Creates a new AMQP sender link for publishing messages to Hono's south bound API endpoints.
+     *
+     * @param con The connection to the Hono server.
+     * @param endpoint The endpoint to send messages to.
+     * @param tenantId The tenant that the messages' origin device belongs to.
+     * @param resourceId The resource ID to include in a downstream message's address (may be {@code null}).
+     * @param sampler The sampler to use.
+     * @param remoteCloseHook The handler to invoke when the link is closed by the peer (may be {@code null}). The
+     *            sender's target address is provided as an argument to the handler.
+     * @return A future indicating the outcome.
+     * @throws NullPointerException if any of the parameters except remoteCloseHook and resource ID are {@code null}.
+     */
+    public static Future<DownstreamSenderLink> create(
+            final HonoConnection con,
+            final String endpoint,
+            final String tenantId,
+            final String resourceId,
+            final SendMessageSampler sampler,
+            final Handler<String> remoteCloseHook) {
+
+        Objects.requireNonNull(con);
+        Objects.requireNonNull(endpoint);
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(sampler);
+
+        final String targetAddress = AddressHelper.getTargetAddress(endpoint, tenantId, resourceId, con.getConfig());
+        return con.createSender(targetAddress, ProtonQoS.AT_LEAST_ONCE, remoteCloseHook)
+                .map(sender -> new DownstreamSenderLink(con, sender, tenantId, targetAddress, sampler));
+    }
+
+    /**
+     * Closes the link.
+     *
+     * @return A succeeded future indicating that the link has been closed.
+     */
+    public final Future<Void> close() {
+        log.debug("closing sender ...");
+        return closeLinks();
+    }
+
+    public final boolean isOpen() {
+        return sender.isOpen();
+    }
+
+    /**
+     * Sends an AMQP 1.0 message to the endpoint configured for this link.
+     *
+     * @param message The message to send.
+     * @param currentSpan The <em>OpenTracing</em> span used to trace the sending of the message.
+     *              The span will be finished by this method and will contain an error log if
+     *              the message has not been accepted by the peer.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the message has been sent to the endpoint.
+     *         The delivery contained in the future represents the delivery state at the time
+     *         the future has been succeeded, i.e. for telemetry data it will be locally
+     *         <em>unsettled</em> without any outcome yet. For events it will be locally
+     *         and remotely <em>settled</em> and will contain the <em>accepted</em> outcome.
+     *         <p>
+     *         The future will be failed with a {@link ServerErrorException} if the message
+     *         could not be sent due to a lack of credit.
+     *         If an event is sent which cannot be processed by the peer the future will
+     *         be failed with either a {@code ServerErrorException} or a {@link ClientErrorException}
+     *         depending on the reason for the failure to process the message.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public final Future<ProtonDelivery> send(final Message message, final Span currentSpan) {
+
+        return checkForCreditAndSend(message, currentSpan, this::sendMessage);
+    }
+
+    /**
+     * Sends an AMQP 1.0 message to the endpoint configured for this link and waits for the
+     * disposition indicating the outcome of the transfer.
+     *
+     * @param message The message to send.
+     * @param currentSpan The <em>OpenTracing</em> span used to trace the sending of the message.
+     *              The span will be finished by this method and will contain an error log if
+     *              the message has not been accepted by the peer.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the message has been accepted (and settled)
+     *         by the peer.
+     *         <p>
+     *         The future will be failed with a {@link ServerErrorException} if the message
+     *         could not be sent due to a lack of credit.
+     *         If an event is sent which cannot be processed by the peer the future will
+     *         be failed with either a {@code ServerErrorException} or a {@link ClientErrorException}
+     *         depending on the reason for the failure to process the message.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public Future<ProtonDelivery> sendAndWaitForOutcome(final Message message, final Span currentSpan) {
+
+        return checkForCreditAndSend(message, currentSpan, this::sendMessageAndWaitForOutcome);
+    }
+
+    private Future<ProtonDelivery> checkForCreditAndSend(
+            final Message message,
+            final Span currentSpan,
+            final BiFunction<Message, Span, Future<ProtonDelivery>> sendOperation) {
+
+        Objects.requireNonNull(message);
+        Objects.requireNonNull(currentSpan);
+        Objects.requireNonNull(sender);
+
+        Tags.MESSAGE_BUS_DESTINATION.set(currentSpan, getMessageAddress(message));
+        TracingHelper.TAG_QOS.set(currentSpan, sender.getQoS().toString());
+        Tags.SPAN_KIND.set(currentSpan, Tags.SPAN_KIND_PRODUCER);
+        TracingHelper.setDeviceTags(currentSpan, tenantId, MessageHelper.getDeviceId(message));
+        TracingHelper.injectSpanContext(connection.getTracer(), currentSpan.context(), message);
+
+        return connection.executeOnContext(result -> {
+            if (sender.sendQueueFull()) {
+                final ServerErrorException e = new NoConsumerException("no credit available");
+                logMessageSendingError("error sending message [ID: {}, address: {}], no credit available (drain={})",
+                        message.getMessageId(), getMessageAddress(message), sender.getDrain());
+                TracingHelper.TAG_CREDIT.set(currentSpan, 0);
+                logError(currentSpan, e);
+                currentSpan.finish();
+                result.fail(e);
+                this.sampler.queueFull(this.tenantId);
+            } else {
+                sendOperation.apply(message, currentSpan).onComplete(result);
+            }
+        });
+    }
+
+    /**
+     * Sends an AMQP 1.0 message to the peer this client is configured for.
+     *
+     * @param message The message to send.
+     * @param currentSpan The <em>OpenTracing</em> span used to trace the sending of the message.
+     *              The span will be finished by this method and will contain an error log if
+     *              the message has not been accepted by the peer.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will succeed if the message has been sent to the peer.
+     *         The delivery contained in the future will represent the delivery
+     *         state at the time the future has been succeeded, i.e. it will be
+     *         locally <em>unsettled</em> without any outcome yet.
+     *         <p>
+     *         The future will be failed with a {@link ServiceInvocationException} if the
+     *         message could not be sent.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    private Future<ProtonDelivery> sendMessage(final Message message, final Span currentSpan) {
+
+        Objects.requireNonNull(message);
+        Objects.requireNonNull(currentSpan);
+
+        final String messageId = String.format("%s-%d", getClass().getSimpleName(), MESSAGE_COUNTER.getAndIncrement());
+        message.setMessageId(messageId);
+        logMessageIdAndSenderInfo(currentSpan, messageId);
+
+        final SendMessageSampler.Sample sample = this.sampler.start(this.tenantId);
+
+        final AtomicReference<ProtonDelivery> deliveryRef = new AtomicReference<>();
+        final ClientConfigProperties config = connection.getConfig();
+        final AtomicBoolean timeoutReached = new AtomicBoolean(false);
+        final Long timerId = config.getSendMessageTimeout() > 0
+                ? connection.getVertx().setTimer(config.getSendMessageTimeout(), id -> {
+                    if (timeoutReached.compareAndSet(false, true)) {
+                        final ServerErrorException exception = new SendMessageTimeoutException(
+                                "waiting for delivery update timed out after " + config.getSendMessageTimeout() + "ms");
+                        logMessageSendingError(
+                                "waiting for delivery update timed out for message [ID: {}, address: {}] after {}ms",
+                                messageId, getMessageAddress(message), connection.getConfig().getSendMessageTimeout());
+                        // settle and release the delivery - this ensures that the message isn't considered "in flight"
+                        // anymore in the AMQP messaging network and that it doesn't count towards the link capacity
+                        // (it would be enough to just settle the delivery without an outcome but that cannot be done with proton-j as of now)
+                        Optional.ofNullable(deliveryRef.get())
+                                .ifPresent(delivery -> ProtonHelper.released(delivery, true));
+                        TracingHelper.logError(currentSpan, exception.getMessage());
+                        Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_UNAVAILABLE);
+                        currentSpan.finish();
+                        sample.timeout();
+                    }
+                })
+                : null;
+
+        final ProtonDelivery delivery = sender.send(message, deliveryUpdated -> {
+            if (timerId != null) {
+                connection.getVertx().cancelTimer(timerId);
+            }
+            final DeliveryState remoteState = deliveryUpdated.getRemoteState();
+            sample.completed(remoteState);
+            if (timeoutReached.get()) {
+                log.debug("ignoring received delivery update for message [ID: {}, address: {}]: waiting for the update has already timed out",
+                        messageId, getMessageAddress(message));
+            } else if (deliveryUpdated.remotelySettled()) {
+                logUpdatedDeliveryState(currentSpan, message, deliveryUpdated);
+            } else {
+                logMessageSendingError("peer did not settle message [ID: {}, address: {}, remote state: {}], failing delivery",
+                        messageId, getMessageAddress(message), remoteState.getClass().getSimpleName());
+                TracingHelper.logError(currentSpan, new ServerErrorException(
+                        HttpURLConnection.HTTP_INTERNAL_ERROR,
+                        "peer did not settle message, failing delivery"));
+            }
+            currentSpan.finish();
+        });
+        deliveryRef.set(delivery);
+        log.trace("sent AT_MOST_ONCE message [ID: {}, address: {}], remaining credit: {}, queued messages: {}",
+                messageId, getMessageAddress(message), sender.getCredit(), sender.getQueued());
+
+        return Future.succeededFuture(delivery);
+    }
+
+    /**
+     * Sends an AMQP 1.0 message to the peer this client is configured for
+     * and waits for the outcome of the transfer.
+     *
+     * @param message The message to send.
+     * @param currentSpan The <em>OpenTracing</em> span used to trace the sending of the message.
+     *              The span will be finished by this method and will contain an error log if
+     *              the message has not been accepted by the peer.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will succeed if the message has been accepted (and settled)
+     *         by the peer.
+     *         <p>
+     *         The future will be failed with a {@link ServiceInvocationException} if the
+     *         message could not be sent or has not been accepted by the peer or if no delivery update
+     *         was received from the peer within the configured timeout period
+     *         (see {@link ClientConfigProperties#getSendMessageTimeout()}).
+     * @throws NullPointerException if either of the parameters is {@code null}.
+     */
+    private Future<ProtonDelivery> sendMessageAndWaitForOutcome(final Message message, final Span currentSpan) {
+
+        Objects.requireNonNull(message);
+        Objects.requireNonNull(currentSpan);
+
+        final AtomicReference<ProtonDelivery> deliveryRef = new AtomicReference<>();
+        final Promise<ProtonDelivery> result = Promise.promise();
+        final String messageId = String.format("%s-%d", getClass().getSimpleName(), MESSAGE_COUNTER.getAndIncrement());
+        message.setMessageId(messageId);
+        logMessageIdAndSenderInfo(currentSpan, messageId);
+
+        final SendMessageSampler.Sample sample = this.sampler.start(this.tenantId);
+
+        final Long timerId = connection.getConfig().getSendMessageTimeout() > 0
+                ? connection.getVertx().setTimer(connection.getConfig().getSendMessageTimeout(), id -> {
+                    if (!result.future().isComplete()) {
+                        final ServerErrorException exception = new SendMessageTimeoutException(
+                                "waiting for delivery update timed out after "
+                                        + connection.getConfig().getSendMessageTimeout() + "ms");
+                        logMessageSendingError("waiting for delivery update timed out for message [ID: {}, address: {}] after {}ms",
+                                messageId, getMessageAddress(message), connection.getConfig().getSendMessageTimeout());
+                        // settle and release the delivery - this ensures that the message isn't considered "in flight"
+                        // anymore in the AMQP messaging network and that it doesn't count towards the link capacity
+                        // (it would be enough to just settle the delivery without an outcome but that cannot be done with proton-j as of now)
+                        Optional.ofNullable(deliveryRef.get())
+                                .ifPresent(delivery -> ProtonHelper.released(delivery, true));
+                        result.fail(exception);
+                        sample.timeout();
+                    }
+                })
+                : null;
+
+        deliveryRef.set(sender.send(message, deliveryUpdated -> {
+            if (timerId != null) {
+                connection.getVertx().cancelTimer(timerId);
+            }
+            final DeliveryState remoteState = deliveryUpdated.getRemoteState();
+            if (result.future().isComplete()) {
+                log.debug("ignoring received delivery update for message [ID: {}, address: {}]: waiting for the update has already timed out",
+                        messageId, getMessageAddress(message));
+            } else if (deliveryUpdated.remotelySettled()) {
+                logUpdatedDeliveryState(currentSpan, message, deliveryUpdated);
+                sample.completed(remoteState);
+                if (Accepted.class.isInstance(remoteState)) {
+                    result.complete(deliveryUpdated);
+                } else {
+                    ServiceInvocationException e = null;
+                    if (Rejected.class.isInstance(remoteState)) {
+                        final Rejected rejected = (Rejected) remoteState;
+                        e = Optional.ofNullable(rejected.getError())
+                                .map(error -> new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, error.getDescription()))
+                                .orElse(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
+                    } else if (Released.class.isInstance(remoteState)) {
+                        e = new MessageNotProcessedException();
+                    } else if (Modified.class.isInstance(remoteState)) {
+                        final Modified modified = (Modified) deliveryUpdated.getRemoteState();
+                        if (modified.getUndeliverableHere()) {
+                            e = new MessageUndeliverableException();
+                        } else {
+                            e = new MessageNotProcessedException();
+                        }
+                    }
+                    result.fail(e);
+                }
+            } else {
+                logMessageSendingError("peer did not settle message [ID: {}, address: {}, remote state: {}], failing delivery",
+                        messageId, getMessageAddress(message), remoteState.getClass().getSimpleName());
+                final ServiceInvocationException e = new ServerErrorException(
+                        HttpURLConnection.HTTP_INTERNAL_ERROR,
+                        "peer did not settle message, failing delivery");
+                result.fail(e);
+            }
+        }));
+        log.trace("sent AT_LEAST_ONCE message [ID: {}, address: {}], remaining credit: {}, queued messages: {}",
+                messageId, getMessageAddress(message), sender.getCredit(), sender.getQueued());
+
+        return result.future()
+                .onSuccess(delivery -> Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_ACCEPTED))
+                .onFailure(t -> {
+                    TracingHelper.logError(currentSpan, t);
+                    Tags.HTTP_STATUS.set(currentSpan, ServiceInvocationException.extractStatusCode(t));
+                })
+                .onComplete(r -> currentSpan.finish());
+    }
+
+    /**
+     * Creates a log entry in the given span with the message id and information about the sender (credits, QOS).
+     *
+     * @param currentSpan The current span to log to.
+     * @param messageId The message id.
+     * @throws NullPointerException if currentSpan is {@code null}.
+     */
+    protected final void logMessageIdAndSenderInfo(final Span currentSpan, final String messageId) {
+        final Map<String, Object> details = new HashMap<>(2);
+        details.put(TracingHelper.TAG_MESSAGE_ID.getKey(), messageId);
+        details.put(TracingHelper.TAG_CREDIT.getKey(), sender.getCredit());
+        currentSpan.log(details);
+    }
+
+    /**
+     * Creates a log entry in the given span with information about the message delivery outcome given in the delivery
+     * parameter. Sets the {@link Tags#HTTP_STATUS} as well.
+     * <p>
+     * Also corresponding log output is created.
+     *
+     * @param currentSpan The current span to log to.
+     * @param message The message.
+     * @param delivery The updated delivery.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected final void logUpdatedDeliveryState(final Span currentSpan, final Message message, final ProtonDelivery delivery) {
+        Objects.requireNonNull(currentSpan);
+        final String messageId = message.getMessageId() != null ? message.getMessageId().toString() : "";
+        final String messageAddress = getMessageAddress(message);
+        final DeliveryState remoteState = delivery.getRemoteState();
+        if (Accepted.class.isInstance(remoteState)) {
+            log.trace("message [ID: {}, address: {}] accepted by peer", messageId, messageAddress);
+            currentSpan.log("message accepted by peer");
+            Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_ACCEPTED);
+        } else {
+            final Map<String, Object> events = new HashMap<>();
+            if (Rejected.class.isInstance(remoteState)) {
+                final Rejected rejected = (Rejected) delivery.getRemoteState();
+                Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_BAD_REQUEST);
+                if (rejected.getError() == null) {
+                    logMessageSendingError("message [ID: {}, address: {}] rejected by peer", messageId, messageAddress);
+                    events.put(Fields.MESSAGE, "message rejected by peer");
+                } else {
+                    logMessageSendingError("message [ID: {}, address: {}] rejected by peer: {}, {}", messageId,
+                            messageAddress, rejected.getError().getCondition(), rejected.getError().getDescription());
+                    events.put(Fields.MESSAGE, String.format("message rejected by peer: %s, %s",
+                            rejected.getError().getCondition(), rejected.getError().getDescription()));
+                }
+            } else if (Released.class.isInstance(remoteState)) {
+                logMessageSendingError("message [ID: {}, address: {}] not accepted by peer, remote state: {}",
+                        messageId, messageAddress, remoteState.getClass().getSimpleName());
+                Tags.HTTP_STATUS.set(currentSpan, HttpURLConnection.HTTP_UNAVAILABLE);
+                events.put(Fields.MESSAGE, "message not accepted by peer, remote state: " + remoteState);
+            } else if (Modified.class.isInstance(remoteState)) {
+                final Modified modified = (Modified) delivery.getRemoteState();
+                logMessageSendingError("message [ID: {}, address: {}] not accepted by peer, remote state: {}",
+                        messageId, messageAddress, modified);
+                Tags.HTTP_STATUS.set(currentSpan, modified.getUndeliverableHere() ? HttpURLConnection.HTTP_NOT_FOUND
+                        : HttpURLConnection.HTTP_UNAVAILABLE);
+                events.put(Fields.MESSAGE, "message not accepted by peer, remote state: " + remoteState);
+            }
+            TracingHelper.logError(currentSpan, events);
+        }
+    }
+
+    /**
+     * Gets the address that a message is targeted at.
+     *
+     * @param message The message.
+     * @return The message's address or the targetAddress passed in to the constructor
+     *         if the message has no address.
+     * @throws NullPointerException if message is {@code null}.
+     */
+    private String getMessageAddress(final Message message) {
+        Objects.requireNonNull(message);
+        return Optional.ofNullable(message.getAddress()).orElse(targetAddress);
+    }
+
+    /**
+     * Logs an error that occurred when sending a message.
+     * <p>
+     * This method logs on DEBUG level by default. Subclasses may override this
+     * method to use a different log level.
+     *
+     * @param format The log format string.
+     * @param arguments The arguments of the format string.
+     */
+    private void logMessageSendingError(final String format, final Object... arguments) {
+        log.debug(format, arguments);
+    }
+}

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/DownstreamSenderLinkTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/DownstreamSenderLinkTest.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.adapter.client.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.MessageHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.Span;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * Tests verifying behavior of {@link DownstreamSenderLink}.
+ *
+ */
+public class DownstreamSenderLinkTest {
+
+    private Vertx vertx;
+    private ProtonSender sender;
+    private ClientConfigProperties config;
+    private HonoConnection connection;
+    private DownstreamSenderLink messageSender;
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+
+        vertx = mock(Vertx.class);
+        sender = AmqpClientUnitTestHelper.mockProtonSender();
+        config = new ClientConfigProperties();
+        connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx, config);
+        messageSender = new DownstreamSenderLink(connection, sender, "tenant", "telemetry/tenant", SendMessageSampler.noop());
+    }
+
+    /**
+     * Verifies that the sender does not wait for the peer to settle and
+     * accept a message before succeeding.
+     */
+    @Test
+    public void testSendSucceedsForRejectedOutcome() {
+
+        // GIVEN a sender that has credit
+        when(sender.sendQueueFull()).thenReturn(Boolean.FALSE);
+
+        // WHEN trying to send a message
+        final Span span = mock(Span.class);
+        final Message message = ProtonHelper.message("some payload");
+        message.setContentType("text/plain");
+        MessageHelper.addDeviceId(message, "device");
+        final Future<ProtonDelivery> result = messageSender.send(message, span);
+
+        // which gets rejected by the peer
+        final ArgumentCaptor<Handler<ProtonDelivery>> deliveryUpdateHandler = VertxMockSupport.argumentCaptorHandler();
+        verify(sender).send(any(Message.class), deliveryUpdateHandler.capture());
+        final ProtonDelivery rejected = mock(ProtonDelivery.class);
+        when(rejected.remotelySettled()).thenReturn(Boolean.TRUE);
+        when(rejected.getRemoteState()).thenReturn(new Rejected());
+        deliveryUpdateHandler.getValue().handle(rejected);
+
+        // THEN the resulting future is succeeded nevertheless
+        assertThat(result.succeeded()).isTrue();
+        // and the span has been finished
+        verify(span).finish();
+    }
+
+    /**
+     * Verifies that sending a message with AT_MOST_ONCE QoS fails if no credit is available.
+     */
+    @Test
+    public void testSendFailsOnLackOfCredit() {
+
+        // GIVEN a sender that has credit
+        when(sender.sendQueueFull()).thenReturn(Boolean.TRUE);
+
+        // WHEN trying to send a message
+        final Span span = mock(Span.class);
+        final Message msg = ProtonHelper.message("telemetry/tenant", "hello");
+        final Future<ProtonDelivery> result = messageSender.send(msg, span);
+
+        // THEN the message is not sent
+        assertThat(result.failed()).isTrue();
+        verify(sender, never()).send(any(Message.class), VertxMockSupport.anyHandler());
+        // but the span has been finished
+        verify(span).finish();
+    }
+
+    /**
+     * Verifies that the sender waits for the peer to settle and
+     * accept a message before succeeding the returned future.
+     */
+    @Test
+    public void testSendAndWaitForOutcomeWaitsForAcceptedOutcome() {
+
+        // GIVEN a sender that has credit
+        when(sender.sendQueueFull()).thenReturn(Boolean.FALSE);
+
+        // WHEN trying to send a message
+        final Span span = mock(Span.class);
+        final Message message = ProtonHelper.message("some payload");
+        message.setContentType("text/plain");
+        MessageHelper.addDeviceId(message, "device");
+        final Future<ProtonDelivery> result = messageSender.sendAndWaitForOutcome(message, span);
+
+        // THEN the message has been sent
+        final ArgumentCaptor<Handler<ProtonDelivery>> deliveryUpdateHandler = VertxMockSupport.argumentCaptorHandler();
+        verify(sender).send(any(Message.class), deliveryUpdateHandler.capture());
+        // but the result is not completed
+        assertThat(result.isComplete()).isFalse();
+
+        // until the message gets accepted by the peer
+        final ProtonDelivery accepted = mock(ProtonDelivery.class);
+        when(accepted.remotelySettled()).thenReturn(Boolean.TRUE);
+        when(accepted.getRemoteState()).thenReturn(new Accepted());
+        deliveryUpdateHandler.getValue().handle(accepted);
+
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    /**
+     * Verifies that the sender fails if the peer does not accept a message.
+     */
+    @Test
+    public void testSendAndWaitForOutcomeFailsForRejectedOutcome() {
+
+        // GIVEN a sender that has credit
+        when(sender.sendQueueFull()).thenReturn(Boolean.FALSE);
+
+        // WHEN trying to send a message
+        final Span span = mock(Span.class);
+        final Message message = ProtonHelper.message("some payload");
+        message.setContentType("text/plain");
+        MessageHelper.addDeviceId(message, "device");
+        final Future<ProtonDelivery> result = messageSender.sendAndWaitForOutcome(message, span);
+
+        // THEN the message has been sent
+        final ArgumentCaptor<Handler<ProtonDelivery>> deliveryUpdateHandler = VertxMockSupport.argumentCaptorHandler();
+        verify(sender).send(any(Message.class), deliveryUpdateHandler.capture());
+        // but the request is not completed
+        assertThat(result.isComplete()).isFalse();
+
+        // and when the peer rejects the message
+        final ProtonDelivery rejected = mock(ProtonDelivery.class);
+        when(rejected.remotelySettled()).thenReturn(Boolean.TRUE);
+        when(rejected.getRemoteState()).thenReturn(new Rejected());
+        deliveryUpdateHandler.getValue().handle(rejected);
+
+        // the request is failed
+        assertThat(result.failed()).isTrue();
+    }
+
+
+    /**
+     * Verifies that the sender fails if no credit is available.
+     */
+    @Test
+    public void testSendAndWaitForOutcomeFailsOnLackOfCredit() {
+
+        // GIVEN a sender that has credit
+        when(sender.sendQueueFull()).thenReturn(Boolean.TRUE);
+
+        // WHEN trying to send a message
+        final Span span = mock(Span.class);
+        final Message msg = ProtonHelper.message("telemetry/tenant", "hello");
+        final Future<ProtonDelivery> result = messageSender.sendAndWaitForOutcome(msg, span);
+
+        // THEN the message is not sent
+        assertThat(result.failed()).isTrue();
+        verify(sender, never()).send(any(Message.class), VertxMockSupport.anyHandler());
+        // but the span has been finished
+        verify(span).finish();
+    }
+
+    /**
+     * Verifies that a timeout occurring while a message is sent doesn't cause the corresponding 
+     * OpenTracing span to stay unfinished.
+     */
+    @Test
+    public void testSendFinishesSpanOnTimeout() {
+
+        // GIVEN a sender that won't receive a delivery update on sending a message 
+        // and directly triggers the timeout handler
+        when(sender.send(any(Message.class), VertxMockSupport.anyHandler())).thenReturn(mock(ProtonDelivery.class));
+        VertxMockSupport.runTimersImmediately(vertx);
+
+        // WHEN sending a message
+        final Message message = mock(Message.class);
+        final Span span = mock(Span.class);
+        messageSender.send(message, span);
+
+        // THEN the given Span will nonetheless be finished.
+        verify(span).finish();
+    }
+}


### PR DESCRIPTION
The ProtonBasedDownstreamSender and ProtonBasedCommandResponseSender
have been refactored to use a wrapper around a sender link to forward
messages downstream which no longer depends on the legacy client.

Fixes #2387
