### PR TITLE
[#8] Add Kafka receiver to CLI.

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -67,6 +67,10 @@
       <artifactId>javax.annotation-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-kafka-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <version>${spring-boot.version}</version>
@@ -84,6 +88,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>core-test-utils</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,9 +16,11 @@ package org.eclipse.hono.cli;
 import org.eclipse.hono.client.ApplicationClientFactory;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.config.ClientConfigProperties;
+import org.eclipse.hono.kafka.client.KafkaConsumerConfigProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
@@ -65,6 +67,18 @@ public class AppConfiguration {
     public ClientConfigProperties honoClientConfig() {
         final ClientConfigProperties config = new ClientConfigProperties();
         return config;
+    }
+
+    /**
+     * Exposes Kafka consumer configuration properties as a Spring bean.
+     *
+     * @return The properties.
+     */
+    @ConfigurationProperties(prefix = "hono.kafka")
+    @Profile("receiver-kafka")
+    @Bean
+    public KafkaConsumerConfigProperties honoKafkaClientConfig() {
+        return new KafkaConsumerConfigProperties();
     }
 
     /**

--- a/cli/src/main/java/org/eclipse/hono/cli/app/KafkaReceiver.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/KafkaReceiver.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.cli.app;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+
+import org.eclipse.hono.cli.AbstractCliClient;
+import org.eclipse.hono.kafka.client.HonoTopic;
+import org.eclipse.hono.kafka.client.KafkaConsumerConfigProperties;
+import org.eclipse.hono.util.Strings;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * A command line client for receiving messages from via Hono's north bound Kafka-based Telemetry and/or Event APIs.
+ * <p>
+ * Messages are output to stdout.
+ * <p>
+ * Note that this example intentionally does not support Command &amp; Control and rather is the most simple version of
+ * a receiver for downstream data.
+ */
+@Component
+@Profile("receiver-kafka")
+public class KafkaReceiver extends AbstractCliClient {
+
+    private static final String TYPE_TELEMETRY = "telemetry";
+    private static final String TYPE_EVENT = "event";
+    private static final String TYPE_ALL = "all";
+
+    @Value(value = "${tenant.id}")
+    protected String tenantId;
+
+    /**
+     * The type of messages to create a consumer for.
+     */
+    @Value(value = "${message.type}")
+    protected String messageType;
+
+    @Value(value = "${print.verbose:true}")
+    protected Boolean isPrintVerbose;
+
+    private KafkaConsumerConfigProperties config;
+
+    @Autowired
+    public void setConfig(final KafkaConsumerConfigProperties config) {
+        this.config = config;
+    }
+
+    /**
+     * Starts this component.
+     *
+     * @return A future indicating the outcome of the startup process.
+     */
+    @PostConstruct
+    Future<Void> start() {
+        return createConsumer()
+                .onComplete(this::handleCreateConsumerStatus);
+    }
+
+    private Future<Void> createConsumer() {
+
+        if (Strings.isNullOrEmpty(tenantId)) {
+            return Future.failedFuture("tenant id is not set");
+        }
+
+        final Set<String> topics = getTopics();
+        if (topics.isEmpty()) {
+            return Future.failedFuture(String.format(
+                    "Invalid message type [\"%s\"]. Valid types are \"telemetry\", \"event\" or \"all\"", messageType));
+        }
+
+        final KafkaConsumer<String, Buffer> consumer = KafkaConsumer.create(vertx, config.getConsumerConfig(),
+                String.class, Buffer.class);
+
+        consumer.handler(this::logMessage);
+        final Promise<Void> promise = Promise.promise();
+        consumer.subscribe(topics, promise);
+        return promise.future();
+    }
+
+    private Set<String> getTopics() {
+        final Set<String> topics = new HashSet<>();
+        if (messageType.equals(TYPE_TELEMETRY) || messageType.equals(TYPE_ALL)) {
+            topics.add(new HonoTopic(HonoTopic.Type.TELEMETRY, tenantId).toString());
+        }
+
+        if (messageType.equals(TYPE_EVENT) || messageType.equals(TYPE_ALL)) {
+            topics.add(new HonoTopic(HonoTopic.Type.EVENT, tenantId).toString());
+        }
+        return topics;
+    }
+
+    private void handleCreateConsumerStatus(final AsyncResult<Void> startup) {
+        if (startup.succeeded()) {
+            log.info("Receiver [tenant: {}, mode: {}] subscribed successfully, hit ctrl-c to exit", tenantId,
+                    messageType);
+        } else {
+            log.error("Error occurred during initialization of receiver: {}", startup.cause().getMessage());
+            vertx.close();
+        }
+    }
+
+    /**
+     * Handle received message.
+     *
+     * Write log messages to stdout.
+     *
+     * @param record The Kafka consumer record.
+     */
+    private void logMessage(final KafkaConsumerRecord<String, Buffer> record) {
+
+        if (isPrintVerbose) {
+            logVerbosely(record);
+        } else {
+            log.info("received message [topic: {}, key: {}]: {}", record.topic(), record.key(), record.value());
+        }
+
+    }
+
+    private void logVerbosely(final KafkaConsumerRecord<String, Buffer> record) {
+        final long timestamp = record.timestamp();
+        final LocalDateTime time = LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault());
+
+        final StringBuilder stringBuilder = new StringBuilder();
+        record.headers().forEach(h -> {
+            stringBuilder.append("    ");
+            stringBuilder.append(h.key());
+            stringBuilder.append("=");
+            stringBuilder.append(h.value());
+            stringBuilder.append("\n");
+        });
+        final String headers = stringBuilder.toString();
+
+        log.info(
+                "topic: {}, partition: {}, offset: {}, timestamp: {} ({})\n  Headers:\n{}  Key:\n    {}\n  Value:\n    {}",
+                record.topic(), record.partition(), record.offset(), timestamp, time, headers, record.key(),
+                record.value());
+
+    }
+
+}

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -39,6 +39,23 @@ message:
 ---
 
 spring:
+  profiles: receiver-kafka
+
+hono:
+  kafka:
+    consumerConfig:
+      bootstrap.servers: localhost:9092
+      group.id: hono-cli
+
+message:
+  type: all
+
+print:
+  verbose: true
+
+---
+
+spring:
   profiles: statistic
 
 statistic:

--- a/cli/src/main/resources/logback-spring.xml
+++ b/cli/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -44,4 +44,7 @@
 
     <logger name="io.vertx.proton.impl" level="INFO"/>
     <logger name="io.vertx.core.net.impl" level="INFO"/>
+
+    <logger name="org.apache.kafka.common" level="WARN"/>
+    <logger name="org.apache.kafka.clients" level="ERROR"/>
 </configuration>

--- a/cli/src/test/java/org/eclipse/hono/cli/app/KafkaReceiverTest.java
+++ b/cli/src/test/java/org/eclipse/hono/cli/app/KafkaReceiverTest.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.cli.app;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.hono.kafka.client.KafkaConsumerConfigProperties;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Test cases verifying the behavior of {@code KafkaReceiver}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+public class KafkaReceiverTest {
+
+    private KafkaReceiver receiver;
+
+    /**
+     * Sets up the receiver with mocks.
+     *
+     */
+    @BeforeEach
+    public void setup() {
+
+        final Vertx vertx = mock(Vertx.class);
+        final Context context = VertxMockSupport.mockContext(vertx);
+        when(vertx.getOrCreateContext()).thenReturn(context);
+
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "hono-cli");
+
+        config.setConsumerConfig(properties);
+
+        receiver = new KafkaReceiver();
+        receiver.setConfig(config);
+        receiver.setVertx(vertx);
+        receiver.tenantId = "TEST_TENANT";
+    }
+
+    /**
+     * Verifies that the receiver is started successfully with message.type=telemetry.
+     *
+     * @param context The vert.x test context.
+     */
+    @Test
+    public void testTelemetryStart(final VertxTestContext context) {
+        receiver.messageType = "telemetry";
+
+        receiver.start().onComplete(context.completing());
+    }
+
+    /**
+     * Verifies that the receiver is started successfully with message.type=event.
+     *
+     * @param context The vert.x test context.
+     */
+    @Test
+    public void testEventStart(final VertxTestContext context) {
+        receiver.messageType = "event";
+
+        receiver.start().onComplete(context.completing());
+    }
+
+    /**
+     * Verifies that the receiver is started successfully with message.type=all.
+     *
+     * @param context The vert.x test context.
+     */
+    @Test
+    public void testDefaultStart(final VertxTestContext context) {
+        receiver.messageType = "all";
+
+        receiver.start().onComplete(context.completing());
+
+    }
+
+    /**
+     * Verifies that the receiver fails to start when invalid value is passed to message.type.
+     *
+     * @param context The vert.x test context.
+     */
+    @Test
+    public void testInvalidTypeStart(final VertxTestContext context) {
+        receiver.messageType = "xxxxx";
+        receiver.start().onComplete(
+                context.failing(result -> context.completeNow()));
+    }
+
+    /**
+     * Verifies that the receiver fails to start when the tenant ID is not set.
+     *
+     * @param context The vert.x test context.
+     */
+    @Test
+    public void testThatStartFailsIfTenantIdIsEmpty(final VertxTestContext context) {
+        receiver.tenantId = "";
+        receiver.start().onComplete(
+                context.failing(result -> context.completeNow()));
+    }
+
+}

--- a/cli/src/test/resources/logback-test.xml
+++ b/cli/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2017, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -33,4 +33,6 @@
     <logger name="org.eclipse.hono.cli" level="INFO"/>
     <logger name="org.eclipse.hono.client" level="INFO"/>
     <logger name="org.eclipse.hono.util" level="INFO"/>
+
+    <logger name="org.apache.kafka" level="ERROR"/>
 </configuration>


### PR DESCRIPTION
This PR adds a receiver to the CLI that consumes telemetry data and events from Kafka. Please refer to "Start the Downstream Consumer" in https://github.com/eclipse/hono/pull/2216#issuecomment-730255279 for usage instructions.

This belongs to #8. 

