### PR TITLE
Use Testcontainers for running MongoDB registry unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -43,13 +43,6 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - name: Cache embedded MongoDB for unit tests
-      uses: actions/cache@v2
-      with:
-        path: ~/.embedmongo/**/*.tgz
-        key: ${{ runner.os }}-mongodb-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-mongodb-
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -35,7 +35,6 @@
     <californium.version>2.6.0</californium.version>
     <commons-cli.version>1.2</commons-cli.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.14.0</dispatch-router.image.name>
-    <flapdoodle.version>2.2.0</flapdoodle.version>
     <guava.version>28.0-jre</guava.version>
     <gson.version>2.8.5</gson.version>
     <h2.version>1.4.200</h2.version>
@@ -57,7 +56,7 @@
     <mchange-commons.version>0.2.15</mchange-commons.version>
     <micrometer.version>1.6.2</micrometer.version>
     <mockito.version>3.6.28</mockito.version>
-    <mongodb.version>4.0.20</mongodb.version>
+    <mongodb-image.name>mongo:4.2.11</mongodb-image.name>
     <netty.version>4.1.49.Final</netty.version>
     <netty.tcnative.version>2.0.30.Final</netty.tcnative.version>
     <opentracing.version>0.33.0</opentracing.version>
@@ -567,6 +566,18 @@
         <version>${jaeger.version}</version>
         <scope>runtime</scope>
       </dependency>
+      <dependency>
+        <groupId>io.jaegertracing</groupId>
+        <artifactId>jaeger-core</artifactId>
+        <version>${jaeger.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.jaegertracing</groupId>
+        <artifactId>jaeger-thrift</artifactId>
+        <version>${jaeger.version}</version>
+        <scope>runtime</scope>
+      </dependency>
 
       <!-- Infinispan -->
       <dependency>
@@ -824,12 +835,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>de.flapdoodle.embed</groupId>
-        <artifactId>de.flapdoodle.embed.mongo</artifactId>
-        <version>${flapdoodle.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
         <version>${qpid-jms.version}</version>
@@ -872,29 +877,10 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-bom</artifactId>
-        <version>${testcontainers.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-query-dsl</artifactId>
         <version>${infinispan.version}</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.jaegertracing</groupId>
-        <artifactId>jaeger-core</artifactId>
-        <version>${jaeger.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.jaegertracing</groupId>
-        <artifactId>jaeger-thrift</artifactId>
-        <version>${jaeger.version}</version>
-        <scope>runtime</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/services/device-registry-jdbc/pom.xml
+++ b/services/device-registry-jdbc/pom.xml
@@ -65,6 +65,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -33,14 +33,6 @@
       <artifactId>hono-service-device-registry-base</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-service-device-registry-base</artifactId>
-      <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-mongo-client</artifactId>
     </dependency>
@@ -49,8 +41,17 @@
       <artifactId>vertx-auth-mongo</artifactId>
     </dependency>
     <dependency>
-      <groupId>de.flapdoodle.embed</groupId>
-      <artifactId>de.flapdoodle.embed.mongo</artifactId>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-service-device-registry-base</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mongodb</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -58,95 +59,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.github.joelittlejohn.embedmongo</groupId>
-        <artifactId>embedmongo-maven-plugin</artifactId>
-        <version>0.4.2</version>
-        <executions>
-          <execution>
-            <id>start-mongodb</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>start</goal>
-            </goals>
-            <configuration>
-              <randomPort>true</randomPort>
-              <!-- optional, default is false, if true allocates a random port and overrides embedmongo.port -->
-
-              <version>${mongodb.version}</version>
-              <!-- optional, default 2.2.1 -->
-
-              <features>ONLY_WITH_SSL, ONLY_WINDOWS_2008_SERVER, NO_HTTP_INTERFACE_ARG</features>
-              <!-- optional, default is none. Enables flapdoodle.embed.mongo features, for example to build Windows 
-                download URLs since 3.6 -->
-
-              <!-- databaseDirectory>/tmp/mongotest</databaseDirectory -->
-              <!-- optional, default is a new dir in java.io.tmpdir -->
-
-              <logging>none</logging>
-              <!-- optional (file|console|none), default console -->
-
-              <logFile>${project.build.directory}/myfile.log</logFile>
-              <!-- optional, can be used when logging=file, default is ./embedmongo.log -->
-
-              <logFileEncoding>utf-8</logFileEncoding>
-              <!-- optional, can be used when logging=file, default is utf-8 -->
-
-              <bindIp>127.0.0.1</bindIp>
-              <!-- optional, default is to listen on all interfaces -->
-
-              <!-- downloadPath>http://internal-mongo-repo/</downloadPath -->
-              <!-- optional, default is http://fastdl.mongodb.org/ -->
-
-              <unixSocketPrefix>${user.home}/.embedmongo</unixSocketPrefix>
-              <!-- optional, default is /tmp -->
-
-              <storageEngine>wiredTiger</storageEngine>
-              <!--optional, one of wiredTiger or mmapv1 (default is mmapv1) -->
-
-              <skip>false</skip>
-              <!-- optional, skips this plugin entirely, use on the command line like -Dembedmongo.skip -->
-
-            </configuration>
-          </execution>
-          <execution>
-            <id>stop-mongodb</id>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>stop</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <skip>true</skip>
+          <systemProperties>
+            <mongoDbImageName>${mongodb-image.name}</mongoDbImageName>
+          </systemProperties>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <includes>
-            <include>**/*Test.java</include>
-          </includes>
-          <systemPropertyVariables>
-            <mongodb.port>${embedmongo.port}</mongodb.port>
-            <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
-            <!-- javax.net.debug>ssl:handshake</javax.net.debug -->
-          </systemPropertyVariables>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-tests</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -204,15 +123,6 @@
     </profile>
 
     <profile>
-      <id>jaeger</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.jaegertracing</groupId>
-          <artifactId>jaeger-client</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
       <id>docker-push-image</id>
       <build>
         <plugins>
@@ -232,6 +142,17 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>jaeger</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.jaegertracing</groupId>
+          <artifactId>jaeger-client</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+
   </profiles>
 
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -456,7 +456,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                   <build>
                     <skip>${hono.mongodb.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>mongo:${mongodb.version}</from>
+                    <from>${mongodb-image.name}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>


### PR DESCRIPTION
The flapdoodle library used for starting an embedded Mongo DB before
running the unit tests of the Mongo DB based registry doesn't support
Mongo DB versions > 4.0.
The testcontainers framework provides more flexibility in that regard.
