### PR TITLE
Upgrade to latest Quarkus version

### DIFF
--- a/adapters/base-quarkus/pom.xml
+++ b/adapters/base-quarkus/pom.xml
@@ -61,11 +61,6 @@
       <artifactId>quarkus-config-yaml</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${log4j.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.logmanager</groupId>
       <artifactId>log4j2-jboss-logmanager</artifactId>
     </dependency>

--- a/adapters/http-vertx-quarkus/src/main/resources/reflection-config.json
+++ b/adapters/http-vertx-quarkus/src/main/resources/reflection-config.json
@@ -19,5 +19,23 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "com.github.benmanes.caffeine.cache.SSMSA",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "com.github.benmanes.caffeine.cache.PSWMS",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]

--- a/adapters/mqtt-vertx-quarkus/src/main/resources/reflection-config.json
+++ b/adapters/mqtt-vertx-quarkus/src/main/resources/reflection-config.json
@@ -19,5 +19,23 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "com.github.benmanes.caffeine.cache.SSMSA",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "com.github.benmanes.caffeine.cache.PSWMS",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,7 +31,7 @@
     <artemis.image.name>quay.io/enmasse/artemis-base:2.13.0</artemis.image.name>
     <assertj-core.version>3.17.2</assertj-core.version>
     <c3p0.version>0.9.5.4</c3p0.version>
-    <caffeine.version>2.8.6</caffeine.version>
+    <caffeine.version>2.8.8</caffeine.version>
     <californium.version>2.6.0</californium.version>
     <commons-cli.version>1.2</commons-cli.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.14.0</dispatch-router.image.name>
@@ -68,7 +68,7 @@
     <protostream.version>4.3.2.Final</protostream.version>
     <proton.version>0.33.8</proton.version>
     <qpid-jms.version>0.55.0</qpid-jms.version>
-    <quarkus.platform.version>1.9.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.10.5.Final</quarkus.platform.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <rxjava.version>2.2.12</rxjava.version>
     <slf4j.version>1.7.28</slf4j.version>
@@ -901,6 +901,18 @@
                 <classifier>${classifier.spring.boot.artifact}</classifier>
                 <excludeArtifactIds>hono-legal,hono-demo-certs</excludeArtifactIds>
               </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${quarkus.platform.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>build</goal>
+              </goals>
             </execution>
           </executions>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -417,18 +417,6 @@
           <version>1.0.0</version>
         </plugin>
         <plugin>
-          <groupId>io.quarkus</groupId>
-          <artifactId>quarkus-maven-plugin</artifactId>
-          <version>1.9.2.Final</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>build</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <groupId>org.jboss.jandex</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
           <version>1.0.8</version>

--- a/site/documentation/content/dev-guide/building_hono.md
+++ b/site/documentation/content/dev-guide/building_hono.md
@@ -82,7 +82,7 @@ mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-native-image,metri
 {{% note title="Experimental" %}}
 Support for *native* images is an experimental feature. The `build-native-image` and the `build-docker-image` profiles are mutually exclusive.
 Using Jaeger tracing with native images doesn't work yet, i.e. the `jaeger` Maven profile must not be activated when building
-ntive images.
+native images.
 {{% /note %}}
 
 #### Pushing Images

--- a/site/documentation/content/dev-guide/building_hono.md
+++ b/site/documentation/content/dev-guide/building_hono.md
@@ -81,6 +81,8 @@ mvn clean install -Ddocker.host=tcp://${host}:${port} -Pbuild-native-image,metri
 
 {{% note title="Experimental" %}}
 Support for *native* images is an experimental feature. The `build-native-image` and the `build-docker-image` profiles are mutually exclusive.
+Using Jaeger tracing with native images doesn't work yet, i.e. the `jaeger` Maven profile must not be activated when building
+ntive images.
 {{% /note %}}
 
 #### Pushing Images
@@ -103,4 +105,5 @@ The source code for Hono comes with a test suite for integration testing. To tri
 mvn verify -Prun-tests
 ```
 
-The tests are executed against the Docker images of the Hono components. Because of that, it is necessary to build the respective images as described above before the execution of the tests. The respective `Readme.md` file in the folder `hono/tests` contains more information regarding the test suite.
+The tests are executed against the Docker images of the Hono components. Because of that, it is necessary to build the respective images as
+described above before the execution of the tests. The respective `Readme.md` file in the folder `hono/tests` contains more information regarding the test suite.


### PR DESCRIPTION
Upgraded to version 1.10.5. The Quarkus Caffeine extension no longer
registers all cache implementation classes for reflection during native
builds. Thus, the implementation classes required by Hono's adapters had
to be added manually to the reflection-config.json files.
See https://github.com/quarkusio/quarkus/issues/12961
