### PR TITLE
Add own CommandTargetMapper in Command Router

### DIFF
--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/ApplicationConfig.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/ApplicationConfig.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
-import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/CommandConsumerFactory.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/CommandConsumerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,6 @@
 
 package org.eclipse.hono.commandrouter;
 
-import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.Lifecycle;
 

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/CommandTargetMapper.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/CommandTargetMapper.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.commandrouter;
+
+import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.commandrouter.impl.CommandTargetMapperImpl;
+import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
+import org.eclipse.hono.util.DeviceConnectionConstants;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A component for determining where a incoming command message should be targeted at when processing the message in a
+ * protocol adapter.
+ * <p>
+ * This refers to finding the <em>protocol adapter instance</em> that a device or gateway has connected to in order to
+ * receive a command message. Furthermore, it is determined to which <em>gateway</em> a command is to be mapped to or
+ * whether it will be sent to the target device directly.
+ * <p>
+ * Note that if multiple gateways are connected and able to handle the incoming command message, it is up to the
+ * <em>CommandTargetMapper</em> implementation to choose just one.
+ * <p>
+ * The <em>CommandTargetMapper</em> will return a gateway id as target, if there is no command consumer registered
+ * specifically for the device id of the command, but instead there is a consumer registered for a gateway that may act
+ * on behalf of the device.
+ * <p>
+ * Note that this also means that if a <em>gateway</em> has registered itself as a command consumer for a <em>specific
+ * device</em> (instead of as a consumer for commands to <em>any</em> device that the gateway may handle), that gateway
+ * won't be returned here for that device. That kind of gateway mapping will occur when processing the command at the
+ * target protocol adapter instance.
+ */
+public interface CommandTargetMapper {
+
+    /**
+     * Creates a new {@link CommandTargetMapper} using the default implementation.
+     *
+     * @param tracer The tracer instance.
+     * @return The CommandTargetMapper instance.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    static CommandTargetMapper create(final Tracer tracer) {
+        return new CommandTargetMapperImpl(tracer);
+    }
+
+    /**
+     * Initializes the mapper with the given context.
+     *
+     * @param registrationClient The Device Registration service client.
+     * @param deviceConnectionInfo The Device Connection service client.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    void initialize(DeviceRegistrationClient registrationClient, DeviceConnectionInfo deviceConnectionInfo);
+
+    /**
+     * Determines the target protocol adapter instance for a command directed at the given device. Also determines
+     * whether the command should be mapped to a gateway.
+     * <p>
+     * The mapping to a gateway will be done if there is no command consumer registered specifically for the given
+     * device id, but instead there is a consumer registered for a gateway that may act on behalf of the device.
+     * <p>
+     * Note that this also means that if a <em>gateway</em> has registered itself as a command consumer specifically for
+     * the given device (instead of as a consumer for commands to <em>any</em> device that the gateway may handle), that
+     * gateway won't be returned here. That kind of gateway mapping will have to occur when processing the command at
+     * the target protocol adapter instance.
+     * <p>
+     * If there are multiple command subscriptions from gateways that may act on behalf of the device and if the device
+     * hasn't communicated via any of these gateways yet, this method chooses one of the possible combinations of
+     * gateway and adapter instance where that gateway has subscribed for commands.
+     * <p>
+     * The value of the returned future is a JSON object with the fields
+     * {@link DeviceConnectionConstants#FIELD_PAYLOAD_DEVICE_ID} and
+     * {@link DeviceConnectionConstants#FIELD_ADAPTER_INSTANCE_ID} set to the determined values. If the command is not
+     * mapped to a gateway here, the {@link DeviceConnectionConstants#FIELD_PAYLOAD_DEVICE_ID} contains the given device
+     * id itself.
+     * <p>
+     * Note that {@link #initialize(DeviceRegistrationClient, DeviceConnectionInfo)} has to have been called already,
+     * otherwise a failed future is returned.
+     *
+     * @param tenantId The tenant identifier.
+     * @param deviceId The device identifier.
+     * @param context The currently active OpenTracing span context or {@code null}.
+     * @return A succeeded Future containing the JSON object with target device/gateway and adapter instance; or a
+     *         failed Future with:
+     *         <ul>
+     *         <li>a {@link ClientErrorException} with status <em>Not Found</em> if no matching adapter instance was
+     *         found</li>
+     *         <li>or a {@link ServiceInvocationException} with an error code indicating the cause of the failure</li>
+     *         </ul>
+     * @throws NullPointerException if tenantId or deviceId is {@code null}.
+     */
+    Future<JsonObject> getTargetGatewayAndAdapterInstance(String tenantId, String deviceId, SpanContext context);
+
+}

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandTargetMapperImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandTargetMapperImpl.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.commandrouter.impl;
+
+import java.net.HttpURLConnection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.commandrouter.CommandTargetMapper;
+import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.DeviceConnectionConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A component for mapping an incoming command to the gateway (if applicable)
+ * and protocol adapter instance that can handle it.
+ */
+public class CommandTargetMapperImpl implements CommandTargetMapper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CommandTargetMapperImpl.class);
+
+    private final Tracer tracer;
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private DeviceRegistrationClient registrationClient;
+    private DeviceConnectionInfo deviceConnectionInfo;
+
+    /**
+     * Creates a new GatewayMapperImpl instance.
+     *
+     * @param tracer The tracer instance.
+     * @throws NullPointerException if tracer is {@code null}.
+     */
+    public CommandTargetMapperImpl(final Tracer tracer) {
+        this.tracer = Objects.requireNonNull(tracer);
+    }
+
+    @Override
+    public void initialize(final DeviceRegistrationClient registrationClient, final DeviceConnectionInfo deviceConnectionInfo) {
+        this.registrationClient = Objects.requireNonNull(registrationClient);
+        this.deviceConnectionInfo = Objects.requireNonNull(deviceConnectionInfo);
+        initialized.set(true);
+    }
+
+    @Override
+    public final Future<JsonObject> getTargetGatewayAndAdapterInstance(final String tenantId, final String deviceId,
+            final SpanContext context) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        if (!initialized.get()) {
+            LOG.error("not initialized");
+            return Future.failedFuture(new IllegalStateException("CommandTargetMapper not initialized"));
+        }
+        final Span span = TracingHelper
+                .buildChildSpan(tracer, context, "get target gateway and adapter instance",
+                        CommandTargetMapper.class.getSimpleName())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER)
+                .withTag(TracingHelper.TAG_TENANT_ID, tenantId)
+                .withTag(TracingHelper.TAG_DEVICE_ID, deviceId)
+                .start();
+
+        return registrationClient.assertRegistration(tenantId, deviceId, null, span.context())
+                .map(RegistrationAssertion::getAuthorizedGateways)
+                .recover(t -> {
+                    LOG.debug("Error retrieving gateways authorized to act on behalf of device [tenant-id: {}, device-id: {}]",
+                            tenantId, deviceId, t);
+                    return Future.failedFuture(t);
+                }).compose(viaGateways -> {
+                    return deviceConnectionInfo
+                            .getCommandHandlingAdapterInstances(tenantId, deviceId, new HashSet<>(viaGateways), span)
+                            .compose(resultJson -> determineTargetInstanceJson(resultJson, deviceId, viaGateways, span));
+                }).onFailure(t -> {
+                    LOG.debug("Error getting target gateway and adapter instance", t);
+                    TracingHelper.logError(span, t);
+                    Tags.HTTP_STATUS.set(span, ServiceInvocationException.extractStatusCode(t));
+                }).onComplete(ar -> span.finish());
+    }
+
+    private Future<JsonObject> determineTargetInstanceJson(final JsonObject adapterInstancesJson, final String deviceId,
+            final List<String> viaGateways, final Span span) {
+        final JsonArray instancesArray = adapterInstancesJson.getJsonArray(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCES);
+        if (instancesArray == null || instancesArray.isEmpty()) {
+            return createAndLogInternalServerErrorFuture(span, "Invalid result JSON; field '"
+                    + DeviceConnectionConstants.FIELD_ADAPTER_INSTANCES + "' is null or empty");
+        }
+
+        final JsonObject targetInstanceObject;
+        try {
+            if (instancesArray.size() == 1) {
+                targetInstanceObject = instancesArray.getJsonObject(0);
+            } else {
+                targetInstanceObject = chooseTargetGatewayAndAdapterInstance(instancesArray);
+            }
+        } catch (final ClassCastException e) {
+            return createAndLogInternalServerErrorFuture(span, "Invalid result JSON: " + e.toString());
+        }
+        final String targetDevice = targetInstanceObject.getString(DeviceConnectionConstants.FIELD_PAYLOAD_DEVICE_ID);
+        final String targetAdapterInstance = targetInstanceObject.getString(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID);
+        if (targetDevice == null || targetAdapterInstance == null) {
+            return createAndLogInternalServerErrorFuture(span, "Invalid result JSON, missing target device and/or adapter instance");
+        }
+        if (!targetDevice.equals(deviceId)) {
+            // target device is a gateway
+            if (!viaGateways.contains(targetDevice)) {
+                return createAndLogInternalServerErrorFuture(span,
+                        "Invalid result JSON, target gateway " + targetDevice + " is not in via gateways list");
+            }
+            span.setTag(MessageHelper.APP_PROPERTY_GATEWAY_ID, targetDevice);
+        }
+
+        final String choiceInfo = instancesArray.size() > 1 ? " chosen from " + instancesArray.size() + " entries" : "";
+        final String gatewayInfo = !targetDevice.equals(deviceId) ? " gateway '" + targetDevice + "' and" : "";
+        final String infoMsg = String.format("command target%s:%s adapter instance '%s'", choiceInfo, gatewayInfo, targetAdapterInstance);
+        LOG.debug(infoMsg);
+        span.log(infoMsg);
+
+        span.setTag(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, targetAdapterInstance);
+        return Future.succeededFuture(targetInstanceObject);
+    }
+
+    private Future<JsonObject> createAndLogInternalServerErrorFuture(final Span span, final String errorMessage) {
+        LOG.error(errorMessage);
+        TracingHelper.logError(span, errorMessage);
+        return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR));
+    }
+
+    /**
+     * Chooses the target gateway and adapter instance from the given list of entries.
+     * <p>
+     * This method returns first entry from the given list.
+     * <p>
+     * Subclasses may override this method in order to apply a different algorithm.
+     *
+     * @param instancesArray The JSON array containing the target gateway and adapter instance entries to choose from.
+     * @return The chosen JSON object.
+     */
+    protected JsonObject chooseTargetGatewayAndAdapterInstance(final JsonArray instancesArray) {
+        return instancesArray.getJsonObject(0);
+    }
+
+}

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandler.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,7 +22,6 @@ import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.Command;
 import org.eclipse.hono.client.CommandContext;
-import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.DelegatedCommandSender;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
@@ -30,6 +29,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.client.impl.CommandConsumer;
 import org.eclipse.hono.client.impl.DelegatedCommandSenderImpl;
+import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.hono.adapter.client.amqp.AbstractServiceClient;
-import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.SendMessageSampler;
@@ -31,6 +30,7 @@ import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.client.impl.CommandConsumer;
 import org.eclipse.hono.commandrouter.CommandConsumerFactory;
 import org.eclipse.hono.commandrouter.CommandRouterServiceConfigProperties;
+import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.util.AddressHelper;
 import org.eclipse.hono.util.CommandConstants;
 

--- a/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -35,10 +35,9 @@ import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.Target;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.CommandTargetMapper;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
-import org.eclipse.hono.commandrouter.impl.amqp.MappingAndDelegatingCommandHandler;
+import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CommandConstants;


### PR DESCRIPTION
Thereby removing usage of the deprecated `org.eclipse.hono.client.CommandTargetMapper` class.