### PR TITLE
Replace usage of deprecated Command classes

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -41,7 +41,10 @@ import io.vertx.proton.ProtonHelper;
 
 /**
  * Handler for commands received at the protocol adapter instance specific address.
+ *
+ * @deprecated Use {@code org.eclipse.hono.adapter.client.command.amqp.ProtonBasedAdapterInstanceCommandHandler} instead.
  */
+@Deprecated
 public final class AdapterInstanceCommandHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(AdapterInstanceCommandHandler.class);

--- a/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -60,7 +60,10 @@ import io.vertx.proton.ProtonReceiver;
  * a consumer and corresponding command handler for the command message's target device or one of the device's
  * possible gateways. If found, that handler is either invoked directly, or, if it is on another protocol adapter
  * instance, the command message is sent to that protocol adapter instance to be handled there.
+ *
+ * @deprecated Use {@code org.eclipse.hono.adapter.client.command.amqp.ProtonBasedDelegatingCommandConsumerFactory} instead.
  */
+@Deprecated
 public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClientFactory implements ProtocolAdapterCommandConsumerFactory {
 
     private static final int RECREATE_CONSUMERS_DELAY = 20;

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedAdapterInstanceCommandHandler.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedAdapterInstanceCommandHandler.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import java.util.Objects;
+
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.adapter.client.command.CommandHandlerWrapper;
+import org.eclipse.hono.adapter.client.command.CommandHandlers;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.proton.ProtonDelivery;
+
+/**
+ * Handler for commands received at the protocol adapter instance specific address.
+ */
+public class ProtonBasedAdapterInstanceCommandHandler {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(ProtonBasedAdapterInstanceCommandHandler.class);
+
+    private final String adapterInstanceId;
+    private final Tracer tracer;
+
+    /**
+     * Creates a new ProtonBasedAdapterInstanceCommandHandler instance.
+     *
+     * @param tracer The tracer instance.
+     * @param adapterInstanceId The id of the protocol adapter instance that this handler is running in.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public ProtonBasedAdapterInstanceCommandHandler(final Tracer tracer,
+            final String adapterInstanceId) {
+        this.tracer = Objects.requireNonNull(tracer);
+        this.adapterInstanceId = Objects.requireNonNull(adapterInstanceId);
+    }
+
+    /**
+     * Handles a received command message.
+     *
+     * @param msg The command message.
+     * @param delivery The command message delivery.
+     * @param commandHandlers The container from which the device specific command handler for the command
+     *            is chosen and invoked.
+     * @throws NullPointerException If any of the parameters is {@code null}.
+     */
+    public void handleCommandMessage(final Message msg, final ProtonDelivery delivery, final CommandHandlers commandHandlers) {
+        Objects.requireNonNull(msg);
+        Objects.requireNonNull(delivery);
+        Objects.requireNonNull(commandHandlers);
+        // command could have been mapped to a gateway, but the original address stays the same in the message address in that case
+        final ResourceIdentifier resourceIdentifier = Strings.isNullOrEmpty(msg.getAddress()) ? null
+                : ResourceIdentifier.fromString(msg.getAddress());
+        if (resourceIdentifier == null || resourceIdentifier.getResourceId() == null) {
+            LOG.debug("address of command message is invalid: {}", msg.getAddress());
+            final Rejected rejected = new Rejected();
+            rejected.setError(new ErrorCondition(Constants.AMQP_BAD_REQUEST, "invalid command target address"));
+            delivery.disposition(rejected, true);
+            return;
+        }
+        final String tenantId = resourceIdentifier.getTenantId();
+        final String originalDeviceId = resourceIdentifier.getResourceId();
+        // fetch "via" property (if set)
+        final String gatewayIdFromMessage = MessageHelper.getApplicationProperty(msg.getApplicationProperties(),
+                MessageHelper.APP_PROPERTY_CMD_VIA, String.class);
+        final String targetDeviceId = gatewayIdFromMessage != null ? gatewayIdFromMessage : originalDeviceId;
+        final CommandHandlerWrapper commandHandler = commandHandlers.getCommandHandler(tenantId, targetDeviceId);
+
+        // Adopt gateway id from command handler if set;
+        // for that kind of command handler (gateway subscribing for specific device commands), the
+        // gateway information is not stored in the device connection service ("deviceConnectionService.setCommandHandlingAdapterInstance()" doesn't have an extra gateway id parameter);
+        // and therefore not set in the delegated command message
+        final String gatewayId = commandHandler != null && commandHandler.getGatewayId() != null
+                ? commandHandler.getGatewayId()
+                : gatewayIdFromMessage;
+
+        final ProtonBasedCommand command = new ProtonBasedCommand(msg, tenantId,
+                gatewayId != null ? gatewayId : originalDeviceId);
+
+        final SpanContext spanContext = TracingHelper.extractSpanContext(tracer, msg);
+        final Span currentSpan = org.eclipse.hono.client.impl.CommandConsumer.createSpan("handle command", tenantId,
+                originalDeviceId, gatewayId, tracer, spanContext);
+        currentSpan.setTag(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId);
+        command.logToSpan(currentSpan);
+
+        final CommandContext commandContext = new ProtonBasedCommandContext(command, delivery, currentSpan);
+
+        if (commandHandler != null) {
+            LOG.trace("using [{}] for received command [{}]", commandHandler, command);
+            // command.isValid() check not done here - it is to be done in the command handler
+            commandHandler.handleCommand(commandContext);
+        } else {
+            LOG.info("no command handler found for command with device id {}, gateway id {} [tenant-id: {}]",
+                    originalDeviceId, gatewayId, tenantId);
+            TracingHelper.logError(currentSpan, "no command handler found for command");
+            commandContext.release();
+        }
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandContext.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,32 +15,43 @@ package org.eclipse.hono.adapter.client.command.amqp;
 
 import java.util.Objects;
 
+import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.eclipse.hono.adapter.client.command.Command;
 import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.MapBasedExecutionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
+import io.vertx.proton.ProtonDelivery;
 import io.vertx.proton.ProtonHelper;
 
 /**
- * A wrapper around a legacy {@link org.eclipse.hono.client.CommandContext}.
+ * A context for passing around parameters relevant for processing a {@code Command} used in a vertx-proton based
+ * client.
  */
-public class ProtonBasedCommandContext implements CommandContext {
+public class ProtonBasedCommandContext extends MapBasedExecutionContext implements CommandContext {
 
-    private final org.eclipse.hono.client.CommandContext ctx;
+    private static final Logger LOG = LoggerFactory.getLogger(ProtonBasedCommandContext.class);
+
     private final ProtonBasedCommand command;
+    private final ProtonDelivery delivery;
 
     /**
      * Creates a new command context.
      *
-     * @param context The legacy command context to wrap.
-     * @throws NullPointerException if context is {@code null}.
+     * @param command The command to be processed.
+     * @param delivery The delivery corresponding to the message.
+     * @param span The OpenTracing span to use for tracking the processing of the command.
+     * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    public ProtonBasedCommandContext(final org.eclipse.hono.client.CommandContext context) {
-        this.ctx = Objects.requireNonNull(context);
-        this.command = new ProtonBasedCommand(context.getCommand());
+    public ProtonBasedCommandContext(final ProtonBasedCommand command, final ProtonDelivery delivery, final Span span) {
+        super(span);
+        this.command = Objects.requireNonNull(command);
+        this.delivery = Objects.requireNonNull(delivery);
     }
 
     @Override
@@ -55,47 +66,41 @@ public class ProtonBasedCommandContext implements CommandContext {
 
     @Override
     public void accept() {
-        ctx.accept();
+        final Span span = getTracingSpan();
+        LOG.trace("accepting command message [{}]", getCommand());
+        ProtonHelper.accepted(delivery, true);
+        span.log("accepted command for device");
+        span.finish();
     }
 
     @Override
     public void release() {
-        ctx.release();
+        final Span span = getTracingSpan();
+        ProtonHelper.released(delivery, true);
+        TracingHelper.logError(span, "released command for device");
+        span.finish();
     }
 
     @Override
     public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
-        ctx.modify(deliveryFailed, undeliverableHere);
+        final Span span = getTracingSpan();
+        ProtonHelper.modified(delivery, true, deliveryFailed, undeliverableHere);
+        TracingHelper.logError(span, "modified command for device"
+                + (deliveryFailed ? "; delivery failed" : "")
+                + (undeliverableHere ? "; undeliverable here" : ""));
+        span.finish();
     }
 
     @Override
     public void reject(final String cause) {
-        final ErrorCondition error = ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, cause);
-        ctx.reject(error);
+        final ErrorCondition errorCondition = ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, cause);
+        final Span span = getTracingSpan();
+        final Rejected rejected = new Rejected();
+        rejected.setError(errorCondition);
+        delivery.disposition(rejected, true);
+        TracingHelper.logError(span, "rejected command for device"
+                + (errorCondition.getDescription() != null ? "; error: " + errorCondition.getDescription() : ""));
+        span.finish();
     }
 
-    @Override
-    public <T> T get(final String key) {
-        return ctx.get(key);
-    }
-
-    @Override
-    public <T> T get(final String key, final T defaultValue) {
-        return ctx.get(key, defaultValue);
-    }
-
-    @Override
-    public void put(final String key, final Object value) {
-        ctx.put(key, value);
-    }
-
-    @Override
-    public SpanContext getTracingContext() {
-        return ctx.getTracingContext();
-    }
-
-    @Override
-    public Span getTracingSpan() {
-        return ctx.getTracingSpan();
-    }
 }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDelegatingCommandConsumerFactory.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDelegatingCommandConsumerFactory.java
@@ -149,9 +149,7 @@ public class ProtonBasedDelegatingCommandConsumerFactory extends AbstractService
         return factory.createCommandConsumer(
                 tenantId,
                 deviceId,
-                ctx -> {
-                    commandHandler.handle(new ProtonBasedCommandContext(ctx));
-                },
+                ctx -> commandHandler.handle(new ProtonBasedLegacyCommandContextWrapper(ctx)),
                 lifespan,
                 context)
                 .map(adapterCommandConsumer -> {
@@ -181,9 +179,7 @@ public class ProtonBasedDelegatingCommandConsumerFactory extends AbstractService
                 tenantId,
                 deviceId,
                 gatewayId,
-                ctx -> {
-                    commandHandler.handle(new ProtonBasedCommandContext(ctx));
-                },
+                ctx -> commandHandler.handle(new ProtonBasedLegacyCommandContextWrapper(ctx)),
                 lifespan,
                 context)
                 .map(adapterCommandConsumer -> {

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandContextWrapper.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandContextWrapper.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import java.util.Objects;
+
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.eclipse.hono.adapter.client.command.Command;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.util.Constants;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.vertx.proton.ProtonHelper;
+
+/**
+ * A wrapper around a legacy {@link org.eclipse.hono.client.CommandContext}.
+ */
+public class ProtonBasedLegacyCommandContextWrapper implements CommandContext {
+
+    private final org.eclipse.hono.client.CommandContext ctx;
+    private final ProtonBasedCommand command;
+
+    /**
+     * Creates a new command context.
+     *
+     * @param context The legacy command context to wrap.
+     * @throws NullPointerException if context is {@code null}.
+     */
+    public ProtonBasedLegacyCommandContextWrapper(final org.eclipse.hono.client.CommandContext context) {
+        this.ctx = Objects.requireNonNull(context);
+        this.command = new ProtonBasedCommand(context.getCommand());
+    }
+
+    @Override
+    public void logCommandToSpan(final Span span) {
+        command.logToSpan(span);
+    }
+
+    @Override
+    public Command getCommand() {
+        return command;
+    }
+
+    @Override
+    public void accept() {
+        ctx.accept();
+    }
+
+    @Override
+    public void release() {
+        ctx.release();
+    }
+
+    @Override
+    public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
+        ctx.modify(deliveryFailed, undeliverableHere);
+    }
+
+    @Override
+    public void reject(final String cause) {
+        final ErrorCondition error = ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, cause);
+        ctx.reject(error);
+    }
+
+    @Override
+    public <T> T get(final String key) {
+        return ctx.get(key);
+    }
+
+    @Override
+    public <T> T get(final String key, final T defaultValue) {
+        return ctx.get(key, defaultValue);
+    }
+
+    @Override
+    public void put(final String key, final Object value) {
+        ctx.put(key, value);
+    }
+
+    @Override
+    public SpanContext getTracingContext() {
+        return ctx.getTracingContext();
+    }
+
+    @Override
+    public Span getTracingSpan() {
+        return ctx.getTracingSpan();
+    }
+}

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedAdapterInstanceCommandHandlerTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedAdapterInstanceCommandHandlerTest.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.adapter.client.command.CommandHandlers;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.MessageHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+
+/**
+ * Tests verifying behavior of {@link ProtonBasedAdapterInstanceCommandHandler}.
+ *
+ */
+public class ProtonBasedAdapterInstanceCommandHandlerTest {
+
+
+    private ProtonBasedAdapterInstanceCommandHandler adapterInstanceCommandHandler;
+    private CommandHandlers commandHandlers;
+
+    /**
+     * Sets up fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+        final Span span = TracingMockSupport.mockSpan();
+        final Tracer tracer = TracingMockSupport.mockTracer(span);
+
+        final String adapterInstanceId = "adapterInstanceId";
+        adapterInstanceCommandHandler = new ProtonBasedAdapterInstanceCommandHandler(tracer, adapterInstanceId);
+        commandHandlers = new CommandHandlers();
+    }
+
+    @Test
+    void testHandleCommandMessageWithInvalidMessage() {
+        final Message msg = mock(Message.class);
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        adapterInstanceCommandHandler.handleCommandMessage(msg, delivery, commandHandlers);
+
+        final ArgumentCaptor<DeliveryState> deliveryStateCaptor = ArgumentCaptor.forClass(DeliveryState.class);
+        verify(delivery).disposition(deliveryStateCaptor.capture(), anyBoolean());
+        assertThat(deliveryStateCaptor.getValue()).isNotNull();
+        assertThat(deliveryStateCaptor.getValue()).isInstanceOf(Rejected.class);
+    }
+
+    @Test
+    void testHandleCommandMessageWithNoHandlerFound() {
+        final Message msg = mock(Message.class);
+        final String deviceId = "4711";
+        when(msg.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, deviceId));
+        final ProtonDelivery delivery = mock(ProtonDelivery.class);
+        adapterInstanceCommandHandler.handleCommandMessage(msg, delivery, commandHandlers);
+
+        final ArgumentCaptor<DeliveryState> deliveryStateCaptor = ArgumentCaptor.forClass(DeliveryState.class);
+        verify(delivery).disposition(deliveryStateCaptor.capture(), anyBoolean());
+        assertThat(deliveryStateCaptor.getValue()).isNotNull();
+        assertThat(deliveryStateCaptor.getValue()).isInstanceOf(Released.class);
+    }
+
+    @Test
+    void testHandleCommandMessageWithHandlerForDevice() {
+        final String deviceId = "4711";
+        final String correlationId = "the-correlation-id";
+        final Message message = ProtonHelper.message("input data");
+        message.setAddress(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, deviceId));
+        message.setSubject("doThis");
+        message.setCorrelationId(correlationId);
+
+        final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
+        commandHandlers.putCommandHandler(Constants.DEFAULT_TENANT, deviceId, null, commandHandler);
+
+        adapterInstanceCommandHandler.handleCommandMessage(message, mock(ProtonDelivery.class), commandHandlers);
+
+        final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(commandHandler).handle(commandContextCaptor.capture());
+        assertThat(commandContextCaptor.getValue()).isNotNull();
+        assertThat(commandContextCaptor.getValue().getCommand().getDeviceId()).isEqualTo(deviceId);
+    }
+
+    @Test
+    void testHandleCommandMessageWithHandlerForGateway() {
+        final String deviceId = "4711";
+        final String gatewayId = "gw-1";
+        final String correlationId = "the-correlation-id";
+        final Message message = ProtonHelper.message("input data");
+        message.setAddress(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, deviceId));
+        message.setSubject("doThis");
+        message.setCorrelationId(correlationId);
+        message.setApplicationProperties(
+                new ApplicationProperties(Collections.singletonMap(MessageHelper.APP_PROPERTY_CMD_VIA, gatewayId)));
+
+        final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
+        commandHandlers.putCommandHandler(Constants.DEFAULT_TENANT, gatewayId, null, commandHandler);
+
+        adapterInstanceCommandHandler.handleCommandMessage(message, mock(ProtonDelivery.class), commandHandlers);
+
+        final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(commandHandler).handle(commandContextCaptor.capture());
+        assertThat(commandContextCaptor.getValue()).isNotNull();
+        // assert that command is directed at the gateway
+        assertThat(commandContextCaptor.getValue().getCommand().getDeviceId()).isEqualTo(gatewayId);
+        assertThat(commandContextCaptor.getValue().getCommand().getOriginalDeviceId()).isEqualTo(deviceId);
+    }
+
+    @Test
+    void testHandleCommandMessageWithHandlerForGatewayAndSpecificDevice() {
+        final String deviceId = "4711";
+        final String gatewayId = "gw-1";
+        final String correlationId = "the-correlation-id";
+        final Message message = ProtonHelper.message("input data");
+        message.setAddress(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, deviceId));
+        message.setSubject("doThis");
+        message.setCorrelationId(correlationId);
+
+        final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
+        commandHandlers.putCommandHandler(Constants.DEFAULT_TENANT, deviceId, gatewayId, commandHandler);
+
+        adapterInstanceCommandHandler.handleCommandMessage(message, mock(ProtonDelivery.class), commandHandlers);
+
+        final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(commandHandler).handle(commandContextCaptor.capture());
+        assertThat(commandContextCaptor.getValue()).isNotNull();
+        // assert that command is directed at the gateway
+        assertThat(commandContextCaptor.getValue().getCommand().getDeviceId()).isEqualTo(gatewayId);
+        assertThat(commandContextCaptor.getValue().getCommand().getOriginalDeviceId()).isEqualTo(deviceId);
+    }
+
+}

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.adapter.client.command;
 
+import io.opentracing.Span;
 import io.vertx.core.buffer.Buffer;
 
 /**
@@ -144,4 +145,12 @@ public interface Command {
      * @throws IllegalStateException if this command is invalid.
      */
     String getCorrelationId();
+
+    /**
+     * Logs information about the command.
+     *
+     * @param span The span to log to.
+     * @throws NullPointerException if span is {@code null}.
+     */
+    void logToSpan(Span span);
 }

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandContext.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandContext.java
@@ -24,7 +24,7 @@ import io.opentracing.Span;
 public interface CommandContext extends ExecutionContext {
 
     /**
-     * The key under which the current CommandContext is stored.
+     * The key under which the current CommandContext is stored in an ExecutionContext container.
      */
     String KEY_COMMAND_CONTEXT = "command-context";
 

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandHandlerWrapper.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandHandlerWrapper.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command;
+
+import java.util.Objects;
+
+import io.vertx.core.Handler;
+
+/**
+ * Wraps a command handler to be used in a command consumer.
+ */
+public final class CommandHandlerWrapper {
+
+    private final String tenantId;
+    private final String deviceId;
+    private final String gatewayId;
+    private final Handler<CommandContext> commandHandler;
+
+    /**
+     * Creates a new CommandHandlerWrapper.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The identifier of the device or gateway that is the target of the commands being handled.
+     * @param gatewayId The identifier of the gateway in case the handler is used as part of the gateway
+     *                  subscribing specifically for commands for the given device, or {@code null} otherwise.
+     *                  (A gateway subscribing for commands for all devices, that it may act on behalf of, would mean
+     *                  using a {@code null} value here and providing the gateway id in the <em>deviceId</em>
+     *                  parameter.)
+     * @param commandHandler The command handler.
+     * @throws NullPointerException If tenantId, deviceId or commandHandler is {@code null}.
+     */
+    public CommandHandlerWrapper(final String tenantId, final String deviceId, final String gatewayId,
+                                 final Handler<CommandContext> commandHandler) {
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.deviceId = Objects.requireNonNull(deviceId);
+        this.gatewayId = gatewayId;
+        this.commandHandler = Objects.requireNonNull(commandHandler);
+    }
+
+    /**
+     * Gets the tenant identifier.
+     *
+     * @return The identifier.
+     */
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Gets the identifier of the device or gateway to handle commands for.
+     *
+     * @return The identifier.
+     */
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    /**
+     * Gets the identifier of the gateway in case the handler is used by a gateway having specifically subscribed for
+     * commands for the device returned by {@link #getDeviceId()}.
+     *
+     * @return The identifier or {@code null}.
+     */
+    public String getGatewayId() {
+        return gatewayId;
+    }
+
+    /**
+     * Invokes the command handler with the given command context.
+     *
+     * @param commandContext The command context to pass on to the command handler.
+     */
+    public void handleCommand(final CommandContext commandContext) {
+        commandHandler.handle(commandContext);
+    }
+
+    @Override
+    public String toString() {
+        return "CommandHandlerWrapper{" +
+                "tenantId='" + tenantId + '\'' +
+                ", deviceId='" + deviceId + '\'' +
+                (gatewayId != null ? (", gatewayId='" + gatewayId + '\'') : "") +
+                '}';
+    }
+}

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandHandlers.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandHandlers.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Handler;
+
+/**
+ * A container for command handlers associated with devices.
+ */
+public class CommandHandlers {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(CommandHandlers.class);
+
+    private final Map<String, CommandHandlerWrapper> commandHandlers = new HashMap<>();
+
+    /**
+     * Adds a handler for commands targeted at a device that is connected either directly or via a gateway.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The identifier of the device or gateway that is the target of the commands being handled.
+     * @param gatewayId The identifier of the gateway in case the handler gets added as part of the gateway
+     *                  subscribing specifically for commands of the given device, or {@code null} otherwise.
+     *                  (A gateway subscribing for commands of all devices, that it may act on behalf of, would mean
+     *                  using a {@code null} value here and providing the gateway id in the <em>deviceId</em>
+     *                  parameter.)
+     * @param commandHandler The command handler. The handler must invoke one of the terminal methods of the passed
+     *                       in {@link CommandContext} in order to settle the command message transfer and finish
+     *                       the trace span associated with the {@link CommandContext}.
+     * @return The replaced handler entry or {@code null} if there was none.
+     * @throws NullPointerException If any of tenantId, deviceId or commandHandler is {@code null}.
+     */
+    public CommandHandlerWrapper putCommandHandler(final String tenantId, final String deviceId,
+            final String gatewayId, final Handler<CommandContext> commandHandler) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(commandHandler);
+
+        return putCommandHandler(new CommandHandlerWrapper(tenantId, deviceId, gatewayId, commandHandler));
+    }
+
+    /**
+     * Adds a handler for commands targeted at a device that is connected either directly or via a gateway.
+     *
+     * @param commandHandlerWrapper The wrapper containing the command handler and device/gateway identifier.
+     * @return The replaced entry or {@code null} if there was none.
+     * @throws NullPointerException If commandHandlerWrapper is {@code null}.
+     */
+    public CommandHandlerWrapper putCommandHandler(final CommandHandlerWrapper commandHandlerWrapper) {
+        Objects.requireNonNull(commandHandlerWrapper);
+
+        final String key = getDeviceKey(commandHandlerWrapper);
+        if (commandHandlers.containsKey(key)) {
+            LOG.debug("replacing existing command handler [tenant-id: {}, device-id: {}]",
+                    commandHandlerWrapper.getTenantId(), commandHandlerWrapper.getDeviceId());
+        }
+        return commandHandlers.put(key, commandHandlerWrapper);
+    }
+
+    /**
+     * Gets a handler for the given device id.
+     * <p>
+     * When providing a gateway id as <em>deviceId</em> here, the handler is returned that handles
+     * commands for all devices that the gateway may act on behalf of, if such a handler was set before.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id to get the handler for.
+     * @return The handler or {@code null}.
+     * @throws NullPointerException If tenantId or deviceId is {@code null}.
+     */
+    public CommandHandlerWrapper getCommandHandler(final String tenantId, final String deviceId) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        return commandHandlers.get(getDeviceKey(tenantId, deviceId));
+    }
+
+    /**
+     * Gets the contained command handlers.
+     *
+     * @return The command handlers.
+     */
+    public Collection<CommandHandlerWrapper> getCommandHandlers() {
+        return commandHandlers.values();
+    }
+
+    /**
+     * Removes the handler for the given device id.
+     *
+     * @param tenantId The tenant id of the handler to remove.
+     * @param deviceId The device id of the handler to remove.
+     * @return {@code true} if the handler was removed.
+     * @throws NullPointerException If tenantId or deviceId is {@code null}.
+     */
+    public boolean removeCommandHandler(final String tenantId, final String deviceId) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        final CommandHandlerWrapper removedHandler = commandHandlers.remove(getDeviceKey(tenantId, deviceId));
+        LOG.trace("Removed handler for tenant {}, device {}: {}", tenantId, deviceId, removedHandler != null);
+        return removedHandler != null;
+    }
+
+    /**
+     * Removes the given handler.
+     *
+     * @param commandHandlerWrapper The handler to remove.
+     * @return {@code true} if the handler was removed.
+     * @throws NullPointerException If commandHandlerWrapper is {@code null}.
+     */
+    public boolean removeCommandHandler(final CommandHandlerWrapper commandHandlerWrapper) {
+        Objects.requireNonNull(commandHandlerWrapper);
+        final boolean removed = commandHandlers.remove(getDeviceKey(commandHandlerWrapper), commandHandlerWrapper);
+        LOG.trace("Removed {}: {}", commandHandlerWrapper, removed);
+        return removed;
+    }
+
+    private String getDeviceKey(final CommandHandlerWrapper commandHandlerWrapper) {
+        return getDeviceKey(commandHandlerWrapper.getTenantId(), commandHandlerWrapper.getDeviceId());
+    }
+
+    private String getDeviceKey(final String tenantId, final String deviceId) {
+        return String.format("%s/%s", tenantId, deviceId);
+    }
+
+}


### PR DESCRIPTION
The `AdapterInstanceCommandHandler` class has been marked as deprecated and a new corresponding class has been added, not using the deprecated Command(Context) classes anymore.