### PR TITLE
[#2170] Support upload of client certificate for X.509 credentials

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioning.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/AutoProvisioning.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -83,7 +83,7 @@ public final class AutoProvisioning {
 
                     // 2. set the certificate credential
                     final String authId = clientCertificate.getSubjectX500Principal().getName(X500Principal.RFC2253);
-                    final X509CertificateCredential certCredential = new X509CertificateCredential(authId, List.of(new X509CertificateSecret()));
+                    final var certCredential = X509CertificateCredential.fromSubjectDn(authId, List.of(new X509CertificateSecret()));
                     certCredential.setEnabled(true).setComment(comment);
 
                     final String deviceId = r.getPayload().getId();

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -746,7 +746,7 @@ components:
                type: string
                description: |
                   The subject DN of the trusted root certificate in
-                  the format defined by RFC 2253.
+                  the format defined by [RFC 2253](https://tools.ietf.org/html/rfc2253#section-2).
                   CAs of the *same* tenant may share the same subject DN, for example
                   allowing for the definition of overlapping validity periods.
                   However, CAs of *different* tenants must not share the same
@@ -1159,9 +1159,6 @@ components:
       CommonCredentials:
          type: object
          additionalProperties: false
-         required:
-            - auth-id
-            - type
          properties:
             "type":
                type: string
@@ -1179,6 +1176,8 @@ components:
             - $ref: '#/components/schemas/CommonCredentials'
             - type: object
               required:
+                 - type
+                 - auth-id
                  - secrets
               additionalProperties: false
               properties:
@@ -1203,6 +1202,8 @@ components:
             - $ref: '#/components/schemas/CommonCredentials'
             - type: object
               required:
+                 - type
+                 - auth-id
                  - secrets
               additionalProperties: false
               properties:
@@ -1224,7 +1225,7 @@ components:
             - $ref: '#/components/schemas/CommonCredentials'
             - type: object
               required:
-                 - secrets
+                 - type
               additionalProperties: false
               properties:
                  "type":
@@ -1232,12 +1233,30 @@ components:
                     pattern: "x509-cert"
                  "auth-id":
                     type: string
-                    description: The *subject DN* of the public key contained in the device's X.509 certificate.
+                    description: |
+                       The *subject DN* of the public key contained in the device's X.509 certificate.
+                       The value MUST be formatted according to the rules defined in
+                       [RFC 2253](https://tools.ietf.org/html/rfc2253#section-2).
                  "secrets":
                     type: array
                     items:
                        $ref: '#/components/schemas/X509CertificateSecret'
+                    description: |
+                       A secret containing the X.509 certificate's validity period.
                     minItems: 1
+                    maxItems: 1
+                 "cert":
+                    type: string
+                    format: byte
+                    writeOnly: true
+                    description: |
+                       The Base64 encoded binary DER encoding of the device's X.509 client certificate.
+                       This property can be used as a convenient alternative to specifying the certificate's
+                       meta data in the *auth-id* and *secrets* explicitly.
+                       When provided in a request body, implementors of this API MUST extract the subject DN
+                       from the certificate's public key and store its value properly formatted to the *auth-id*
+                       property. The certificate's validity period MUST be stored in a single secret.
+                       The certificate itself must then be discarded.
 
       CommonSecret:
          type: object

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -29,6 +29,11 @@ title = "Release Notes"
   This should reduce the load on the Tenant service significantly in scenarios where devices of the same
   tenant connect to an adapter at a high rate, e.g. in when re-connecting after one or more adapter pods have
   crashed.
+* The Device Registry Management API's *update credentials* operation has been extended to allow specifying the
+  *auth-id* and validity period implicitly by means of including a (Base64 encoded) client certificate in the new
+  *cert* property. This can be used instead of specifying the client certificate's subject DN and public key's
+  validity period explicitly in the *auth-id* and *secrets* properties. This should make setting the correct *auth-id*
+  value much less error prone.
 
 ### Fixes & Enhancements
 

--- a/tests/src/test/java/org/eclipse/hono/tests/DeviceRegistryHttpClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/DeviceRegistryHttpClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -1055,7 +1055,7 @@ public final class DeviceRegistryHttpClient {
                 .compose(ok -> {
 
                     final String authId = deviceCert.getSubjectDN().getName();
-                    final X509CertificateCredential credential = new X509CertificateCredential(authId, List.of(new X509CertificateSecret()));
+                    final var credential = X509CertificateCredential.fromSubjectDn(authId, List.of(new X509CertificateSecret()));
 
                     return addCredentials(tenantId, deviceId, Collections.singleton(credential));
 

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -267,7 +267,7 @@ public class MqttConnectionIT extends MqttTestBase {
                 }).compose(ok -> helper.registry.registerDevice(tenantId, deviceId))
                 .compose(ok -> {
                     final String authId = new X500Principal("CN=4711").getName(X500Principal.RFC2253);
-                    final X509CertificateCredential credential = new X509CertificateCredential(authId, List.of(new X509CertificateSecret()));
+                    final var credential = X509CertificateCredential.fromSubjectDn(authId, List.of(new X509CertificateSecret()));
                     return helper.registry.addCredentials(tenantId, deviceId, Collections.singleton(credential));
                 })
                 // WHEN the device tries to connect using a client certificate with an unknown subject DN

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -131,7 +131,7 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
 
         final PskCredential pskCredential = IntegrationTestSupport.createPskCredentials("psk-id", "psk-key");
 
-        final X509CertificateCredential x509Credential = new X509CertificateCredential(
+        final var x509Credential = X509CertificateCredential.fromSubjectDn(
                 "emailAddress=foo@bar.com, CN=foo, O=bar",
                 List.of(new X509CertificateSecret()));
         x509Credential.setComment("non-standard attribute type");
@@ -525,7 +525,7 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
         final List<CommonCredential> credentialsListToAdd = new ArrayList<>();
         credentialsListToAdd.add(pskCredentials);
         credentialsListToAdd.add(hashedPasswordCredential);
-        credentialsListToAdd.add(new X509CertificateCredential("CN=Acme", List.of(new X509CertificateSecret())));
+        credentialsListToAdd.add(X509CertificateCredential.fromSubjectDn("CN=Acme", List.of(new X509CertificateSecret())));
         for (int i = 0; i < 3; i++) {
 
             final GenericSecret secret = new GenericSecret();


### PR DESCRIPTION
The Device Registry Management API's "update credentials" operation has
been extended to allow specifying the auth-id and validity period
implicitly by means of including a (Base64 encoded) client certificate
in the new "cert" property. This can be used instead of specifying the
client certificate's subject DN and public key's validity period
explicitly in the "auth-id" and "secrets" properties. This should make
setting the correct "auth-id" value much less error prone.

Fixes #2170
