### PR TITLE
Add transport protocol agnostic interface for northbound Hono-Client

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -171,6 +171,21 @@
         <artifactId>client-device-connection-infinispan</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-application</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-application-amqp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-application-kafka</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Californium -->
       <dependency>

--- a/clients/application-amqp/pom.xml
+++ b/clients/application-amqp/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-application-amqp</artifactId>
+
+  <name>Hono Client for Business Applications (AMQP)</name>
+  <description>Clients for Hono's northbound AMQP-based APIs for implementing business applications</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-application</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-amqp-common</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/client/application/amqp/AmqpApplicationClientFactory.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/client/application/amqp/AmqpApplicationClientFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application.amqp;
+
+import java.util.function.Consumer;
+
+import org.eclipse.hono.client.application.ApplicationClientFactory;
+import org.eclipse.hono.client.application.DownstreamMessage;
+import org.eclipse.hono.client.application.MessageConsumer;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * A factory for creating clients for Hono's AMQP-based northbound APIs.
+ */
+public interface AmqpApplicationClientFactory extends ApplicationClientFactory {
+
+    /**
+     * Creates a client for consuming data from Hono's northbound <em>Telemetry API</em>.
+     *
+     * @param tenantId The tenant to consume data for.
+     * @param telemetryConsumer The handler to invoke with every message received.
+     * @param autoAccept {@code true} if received deliveries should be automatically accepted (and settled) after the
+     *            message handler runs for them, if no other disposition has been applied during handling. NOTE: When
+     *            using {@code false} here, make sure that deliveries (from {@link AmqpMessageContext#getDelivery()})
+     *            are quickly updated and settled, so that the messages don't remain <em>in flight</em> for long.
+     * @param closeHandler The handler invoked when the peer detaches the link.
+     * @return A future that will complete with the consumer once the link has been established. The future will fail if
+     *         the link cannot be established, e.g. because this factory is not connected.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<MessageConsumer<DownstreamMessage>> createTelemetryConsumer(
+            String tenantId,
+            Consumer<DownstreamMessage> telemetryConsumer,
+            boolean autoAccept,
+            Handler<Throwable> closeHandler);
+
+    /**
+     * Creates a client for consuming events from Hono's northbound <em>Event API</em>.
+     *
+     * @param tenantId The tenant to consume data for.
+     * @param eventConsumer The handler to invoke with every message received.
+     * @param autoAccept {@code true} if received deliveries should be automatically accepted (and settled) after the
+     *            message handler runs for them, if no other disposition has been applied during handling. NOTE: When
+     *            using {@code false} here, make sure that deliveries (from {@link AmqpMessageContext#getDelivery()})
+     *            are quickly updated and settled, so that the messages don't remain <em>in flight</em> for long.
+     * @param closeHandler The handler invoked when the peer detaches the link.
+     * @return A future that will complete with the consumer once the link has been established. The future will fail if
+     *         the link cannot be established, e.g. because this factory is not connected.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<MessageConsumer<DownstreamMessage>> createEventConsumer(
+            String tenantId,
+            Consumer<DownstreamMessage> eventConsumer,
+            boolean autoAccept,
+            Handler<Throwable> closeHandler);
+
+}

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/client/application/amqp/AmqpMessageContext.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/client/application/amqp/AmqpMessageContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application.amqp;
+
+import java.util.Objects;
+
+import org.eclipse.hono.client.application.MessageContext;
+
+import io.vertx.proton.ProtonDelivery;
+
+/**
+ * The context of a AMQP message.
+ * <p>
+ * It provides access to the {@link ProtonDelivery} object of the message.
+ */
+public class AmqpMessageContext implements MessageContext {
+
+    private final ProtonDelivery delivery;
+
+    /**
+     * Creates a context.
+     *
+     * @param delivery The delivery of the message.
+     * @throws NullPointerException if delivery is {@code null}.
+     */
+    public AmqpMessageContext(final ProtonDelivery delivery) {
+        Objects.requireNonNull(delivery);
+        this.delivery = delivery;
+    }
+
+    /**
+     * Gets the proton delivery of the message.
+     *
+     * @return The delivery.
+     */
+    public final ProtonDelivery getDelivery() {
+        return delivery;
+    }
+}

--- a/clients/application-kafka/pom.xml
+++ b/clients/application-kafka/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-application-kafka</artifactId>
+
+  <name>Hono Client for Business Applications (Kafka)</name>
+  <description>Clients for Hono's northbound Kafka-based APIs for implementing business applications</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-application</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-kafka-common</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/client/application/kafka/KafkaApplicationClientFactory.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/client/application/kafka/KafkaApplicationClientFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application.kafka;
+
+import org.eclipse.hono.client.application.ApplicationClientFactory;
+
+/**
+ * A factory for creating clients for Hono's Kafka-based northbound APIs.
+ */
+public interface KafkaApplicationClientFactory extends ApplicationClientFactory {
+
+}

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/client/application/kafka/KafkaMessageContext.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/client/application/kafka/KafkaMessageContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application.kafka;
+
+import java.util.Objects;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.eclipse.hono.client.application.MessageContext;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * The context of a Kafka message.
+ * <p>
+ * It provides access to the raw {@link ConsumerRecord}.
+ */
+public class KafkaMessageContext implements MessageContext {
+
+    private final ConsumerRecord<String, Buffer> record;
+
+    /**
+     * Creates a context.
+     *
+     * @param record The Kafka consumer record from which the message is created.
+     * @throws NullPointerException if record is {@code null}.
+     */
+    public KafkaMessageContext(final ConsumerRecord<String, Buffer> record) {
+        Objects.requireNonNull(record);
+        this.record = record;
+    }
+
+    /**
+     * Gets the raw Kafka consumer record from which the message is created.
+     *
+     * @return The consumer record.
+     */
+    public final ConsumerRecord<String, Buffer> getRecord() {
+        return record;
+    }
+}

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/client/application/kafka/KafkaMessageProperties.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/client/application/kafka/KafkaMessageProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.eclipse.hono.client.application.Message;
+import org.eclipse.hono.client.application.MessageProperties;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * The metadata of a {@link Message} created from a {@link ConsumerRecord}.
+ */
+public class KafkaMessageProperties implements MessageProperties {
+
+    private final Map<String, Object> properties = new HashMap<>();
+
+    /**
+     * Creates message properties from a Kafka consumer record.
+     *
+     * @param record The consumer record to extract the metadata from.
+     * @throws NullPointerException if record is {@code null}.
+     */
+    public KafkaMessageProperties(final ConsumerRecord<String, Buffer> record) {
+        Objects.requireNonNull(record);
+
+        record.headers().forEach(header -> properties.put(header.key(), header.value()));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The headers of the {@link ConsumerRecord}.
+     */
+    @Override
+    public final Map<String, Object> getPropertiesMap() {
+        return properties;
+    }
+
+}

--- a/clients/application/pom.xml
+++ b/clients/application/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-application</artifactId>
+
+  <name>Hono Client for Business Applications</name>
+  <description>Clients for Hono's northbound APIs that are required for implementing business applications</description>
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler-proxy</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-buffer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-proton</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.security</groupId>
+          <artifactId>spring-security-crypto</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-noop</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.jsonwebtoken</groupId>
+          <artifactId>jjwt-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.jsonwebtoken</groupId>
+          <artifactId>jjwt-jackson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/clients/application/src/main/java/org/eclipse/hono/client/application/ApplicationClientFactory.java
+++ b/clients/application/src/main/java/org/eclipse/hono/client/application/ApplicationClientFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application;
+
+import java.util.function.Consumer;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * A factory for creating clients for Hono's northbound APIs.
+ */
+public interface ApplicationClientFactory {
+
+    /**
+     * Creates a client for consuming data from Hono's northbound <em>Telemetry API</em>.
+     * <p>
+     * The messages passed in to the consumer will be acknowledged automatically if the consumer does not throw an
+     * exception.
+     *
+     * @param tenantId The tenant to consume data for.
+     * @param telemetryConsumer The handler to invoke with every message received.
+     * @param closeHandler The handler invoked when the consumer is closed (not when the closing was triggered by
+     *            calling {@link MessageConsumer#close()}). If the consumer is closed due to an error, the cause is
+     *            passed to the handler. Otherwise, the throwable is {@code null}.
+     * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
+     *         cannot be started.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<MessageConsumer<DownstreamMessage>> createTelemetryConsumer(
+            String tenantId,
+            Consumer<DownstreamMessage> telemetryConsumer,
+            Handler<Throwable> closeHandler);
+
+    /**
+     * Creates a client for consuming events from Hono's northbound <em>Event API</em>.
+     * <p>
+     * The messages passed in to the consumer will be acknowledged automatically if the consumer does not throw an
+     * exception.
+     *
+     * @param tenantId The tenant to consume data for.
+     * @param eventConsumer The handler to invoke with every message received.
+     * @param closeHandler The handler invoked when the consumer is closed (not when the closing was triggered by
+     *            calling {@link MessageConsumer#close()}). If the consumer is closed due to an error, the cause is
+     *            passed to the handler. Otherwise, the throwable is {@code null}.
+     * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
+     *         cannot be started.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<MessageConsumer<DownstreamMessage>> createEventConsumer(
+            String tenantId,
+            Consumer<DownstreamMessage> eventConsumer,
+            Handler<Throwable> closeHandler);
+
+    // TODO add methods for command & control
+
+}

--- a/clients/application/src/main/java/org/eclipse/hono/client/application/DownstreamMessage.java
+++ b/clients/application/src/main/java/org/eclipse/hono/client/application/DownstreamMessage.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application;
+
+import org.eclipse.hono.util.QoS;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A message of Hono's northbound APIs, flowing from the messaging system to the backend application.
+ */
+public interface DownstreamMessage extends Message {
+    /**
+     * Gets the tenant that sent the message.
+     *
+     * @return the tenant id.
+     */
+    String getTenantId();
+
+    /**
+     * Gets the device that sent the message.
+     *
+     * @return the device id.
+     */
+    String getDeviceId();
+
+    /**
+     * Gets the metadata of the message.
+     *
+     * @return the message properties.
+     */
+    MessageProperties getProperties();
+
+    /**
+     * Gets the content-type of the payload.
+     *
+     * @return the content-type.
+     */
+    String getContentType();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    MessageContext getMessageContext();
+
+    /**
+     * Gets the quality of service level that the device requested.
+     *
+     * @return The QoS.
+     */
+    QoS getQos();
+
+    /**
+     * Gets the payload of the message.
+     *
+     * @return the payload - may be {@code null}.
+     */
+    Buffer getPayload();
+}

--- a/clients/application/src/main/java/org/eclipse/hono/client/application/DownstreamMessageImpl.java
+++ b/clients/application/src/main/java/org/eclipse/hono/client/application/DownstreamMessageImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application;
+
+import java.util.Objects;
+
+import org.eclipse.hono.util.QoS;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A downstream message of Hono's northbound APIs.
+ */
+public class DownstreamMessageImpl implements DownstreamMessage {
+
+    private final String tenantId;
+    private final String deviceId;
+    private final MessageProperties properties;
+    private final String contentType;
+    private final MessageContext messageContext;
+    private final QoS qos;
+    private final Buffer payload;
+
+    /**
+     * Creates a downstream message.
+     *
+     * @param tenantId The tenant that sent the message.
+     * @param deviceId The device that sent the message.
+     * @param properties The metadata of the message.
+     * @param contentType The content type of the message payload.
+     * @param messageContext The context to be added to the message.
+     * @param qos The quality of service level that the device requested.
+     * @param payload The payload - may be {@code null}.
+     * @throws NullPointerException if any of the parameters, except payload, is {@code null}.
+     */
+    public DownstreamMessageImpl(final String tenantId, final String deviceId, final MessageProperties properties,
+            final String contentType, final MessageContext messageContext, final QoS qos, final Buffer payload) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(properties);
+        Objects.requireNonNull(contentType);
+        Objects.requireNonNull(messageContext);
+        Objects.requireNonNull(qos);
+
+        this.tenantId = tenantId;
+        this.deviceId = deviceId;
+        this.properties = properties;
+        this.contentType = contentType;
+        this.messageContext = messageContext;
+        this.qos = qos;
+        this.payload = payload;
+    }
+
+    @Override
+    public final String getTenantId() {
+        return tenantId;
+    }
+
+    @Override
+    public final String getDeviceId() {
+        return deviceId;
+    }
+
+    @Override
+    public final MessageProperties getProperties() {
+        return properties;
+    }
+
+    @Override
+    public final String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public final MessageContext getMessageContext() {
+        return messageContext;
+    }
+
+    @Override
+    public final QoS getQos() {
+        return qos;
+    }
+
+    @Override
+    public final Buffer getPayload() {
+        return payload;
+    }
+}

--- a/clients/application/src/main/java/org/eclipse/hono/client/application/Message.java
+++ b/clients/application/src/main/java/org/eclipse/hono/client/application/Message.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application;
+
+/**
+ * A message of Hono's northbound APIs, exchanged between the messaging system and the backend application.
+ */
+public interface Message {
+
+    /**
+     * Gets the message context which is specific for the messaging system in use.
+     *
+     * @return The context.
+     */
+    MessageContext getMessageContext();
+
+}

--- a/clients/application/src/main/java/org/eclipse/hono/client/application/MessageConsumer.java
+++ b/clients/application/src/main/java/org/eclipse/hono/client/application/MessageConsumer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application;
+
+import io.vertx.core.Future;
+
+/**
+ * A client that consumes messages from Hono's northbound APIs.
+ *
+ * @param <T> The type of messages consumed by this client.
+ */
+public interface MessageConsumer<T extends Message> {
+
+    /**
+     * Closes the client.
+     *
+     * @return A future indicating the outcome of the operation.
+     */
+    Future<Void> close();
+
+}

--- a/clients/application/src/main/java/org/eclipse/hono/client/application/MessageContext.java
+++ b/clients/application/src/main/java/org/eclipse/hono/client/application/MessageContext.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application;
+
+/**
+ * The message context wraps objects that are specific for the messaging system that is used to exchange a
+ * {@link Message} of Hono's northbound APIs.
+ */
+public interface MessageContext {
+
+}

--- a/clients/application/src/main/java/org/eclipse/hono/client/application/MessageProperties.java
+++ b/clients/application/src/main/java/org/eclipse/hono/client/application/MessageProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.application;
+
+import java.util.Map;
+
+/**
+ * The metadata of a {@link Message}.
+ * <p>
+ * Implementations for a specific messaging system may add different kinds of specific properties.
+ */
+public interface MessageProperties {
+
+    /**
+     * Gets the metadata properties.
+     *
+     * @return returns the message properties or an empty map if no properties set.
+     */
+    Map<String, Object> getPropertiesMap();
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/HonoTopic.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/HonoTopic.java
@@ -24,9 +24,6 @@ import org.eclipse.hono.util.TelemetryConstants;
  */
 public final class HonoTopic {
 
-    private static final String SEPARATOR = ".";
-    private static final String NAMESPACE = "hono" + SEPARATOR;
-
     private final Type type;
     private final String tenantId;
     private final String topicString;
@@ -44,7 +41,7 @@ public final class HonoTopic {
 
         this.type = type;
         this.tenantId = tenantId;
-        this.topicString = type.prefix + tenantId;
+        topicString = type.prefix + tenantId;
     }
 
     /**
@@ -125,15 +122,26 @@ public final class HonoTopic {
      */
     public enum Type {
 
-        TELEMETRY(NAMESPACE + TelemetryConstants.TELEMETRY_ENDPOINT + SEPARATOR),
-        EVENT(NAMESPACE + EventConstants.EVENT_ENDPOINT + SEPARATOR),
-        COMMAND(NAMESPACE + CommandConstants.COMMAND_ENDPOINT + SEPARATOR),
-        COMMAND_RESPONSE(NAMESPACE + CommandConstants.COMMAND_RESPONSE_ENDPOINT + SEPARATOR);
+        TELEMETRY(TelemetryConstants.TELEMETRY_ENDPOINT),
+        EVENT(EventConstants.EVENT_ENDPOINT),
+        COMMAND(CommandConstants.COMMAND_ENDPOINT),
+        COMMAND_RESPONSE(CommandConstants.COMMAND_RESPONSE_ENDPOINT);
 
-        final String prefix;
+        private static final String SEPARATOR = ".";
+        private static final String NAMESPACE = "hono";
 
-        Type(final String prefix) {
-            this.prefix = prefix;
+        /**
+         * The name of the endpoint (e.g. "event").
+         */
+        public final String endpoint;
+        /**
+         * The prefix of a Hono topic (e.g. "hono.event.").
+         */
+        public final String prefix;
+
+        Type(final String endpoint) {
+            this.endpoint = endpoint;
+            this.prefix = NAMESPACE + SEPARATOR + endpoint + SEPARATOR;
         }
 
         @Override

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaTracingHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/kafka/client/tracing/KafkaTracingHelper.java
@@ -80,7 +80,7 @@ public final class KafkaTracingHelper {
         Objects.requireNonNull(topic);
         Objects.requireNonNull(referenceType);
 
-        return TracingHelper.buildSpan(tracer, parent, "To_" + topic.toString(), referenceType)
+        return TracingHelper.buildSpan(tracer, parent, "To_" + topic.getType().endpoint, referenceType)
                 .ignoreActiveSpan()
                 .withTag(Tags.COMPONENT.getKey(), "hono-client-kafka")
                 .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/HonoTopicTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/HonoTopicTest.java
@@ -94,4 +94,27 @@ public class HonoTopicTest {
                 .isNotEqualTo(new HonoTopic(HonoTopic.Type.COMMAND, tenantId));
     }
 
+    /**
+     * Verifies the properties of the enum <em>Type</em>.
+     */
+    @Test
+    public void testType() {
+        assertThat(HonoTopic.Type.TELEMETRY.endpoint).isEqualTo("telemetry");
+        assertThat(HonoTopic.Type.TELEMETRY.prefix).isEqualTo("hono.telemetry.");
+        assertThat(HonoTopic.Type.TELEMETRY.toString()).isEqualTo("telemetry");
+
+        assertThat(HonoTopic.Type.EVENT.endpoint).isEqualTo("event");
+        assertThat(HonoTopic.Type.EVENT.prefix).isEqualTo("hono.event.");
+        assertThat(HonoTopic.Type.EVENT.toString()).isEqualTo("event");
+
+        assertThat(HonoTopic.Type.COMMAND.endpoint).isEqualTo("command");
+        assertThat(HonoTopic.Type.COMMAND.prefix).isEqualTo("hono.command.");
+        assertThat(HonoTopic.Type.COMMAND.toString()).isEqualTo("command");
+
+        assertThat(HonoTopic.Type.COMMAND_RESPONSE.endpoint).isEqualTo("command_response");
+        assertThat(HonoTopic.Type.COMMAND_RESPONSE.prefix).isEqualTo("hono.command_response.");
+        assertThat(HonoTopic.Type.COMMAND_RESPONSE.toString()).isEqualTo("command_response");
+
+    }
+
 }

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/HonoTopicTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/kafka/client/HonoTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,12 +22,13 @@ import org.junit.jupiter.api.Test;
  */
 public class HonoTopicTest {
 
+    private final String tenantId = "the-tenant";
+
     /**
      * Verifies that the toString method returns the expected string.
      */
     @Test
     public void testToString() {
-        final String tenantId = "the-tenant";
 
         final HonoTopic telemetry = new HonoTopic(HonoTopic.Type.TELEMETRY, tenantId);
         assertThat(telemetry.toString()).isEqualTo("hono.telemetry." + tenantId);
@@ -48,24 +49,22 @@ public class HonoTopicTest {
      */
     @Test
     public void testFromString() {
-        final String tenantId = "the-tenant";
 
-        final HonoTopic telemetry = HonoTopic.fromString("hono.telemetry." + tenantId);
-        assertThat(telemetry).isNotNull();
-        assertThat(telemetry.toString()).isEqualTo(HonoTopic.Type.TELEMETRY.prefix + tenantId);
+        assertTopicProperties(HonoTopic.fromString("hono.telemetry." + tenantId), HonoTopic.Type.TELEMETRY);
 
-        final HonoTopic event = HonoTopic.fromString("hono.event." + tenantId);
-        assertThat(event).isNotNull();
-        assertThat(event.toString()).isEqualTo(HonoTopic.Type.EVENT.prefix + tenantId);
+        assertTopicProperties(HonoTopic.fromString("hono.event." + tenantId), HonoTopic.Type.EVENT);
 
-        final HonoTopic command = HonoTopic.fromString("hono.command." + tenantId);
-        assertThat(command).isNotNull();
-        assertThat(command.toString()).isEqualTo(HonoTopic.Type.COMMAND.prefix + tenantId);
+        assertTopicProperties(HonoTopic.fromString("hono.command." + tenantId), HonoTopic.Type.COMMAND);
 
-        final HonoTopic commandResponse = HonoTopic.fromString("hono.command_response." + tenantId);
-        assertThat(commandResponse).isNotNull();
-        assertThat(commandResponse.toString()).isEqualTo(HonoTopic.Type.COMMAND_RESPONSE.prefix + tenantId);
+        assertTopicProperties(HonoTopic.fromString("hono.command_response." + tenantId), HonoTopic.Type.COMMAND_RESPONSE);
 
+    }
+
+    private void assertTopicProperties(final HonoTopic actual, final HonoTopic.Type expectedType) {
+        assertThat(actual).isNotNull();
+        assertThat(actual.getTenantId()).isEqualTo(tenantId);
+        assertThat(actual.getType()).isEqualTo(expectedType);
+        assertThat(actual.toString()).isEqualTo(expectedType.prefix + tenantId);
     }
 
     /**
@@ -85,14 +84,14 @@ public class HonoTopicTest {
     @Test
     public void testEquals() {
 
-        assertThat(new HonoTopic(HonoTopic.Type.EVENT, "foo"))
-                .isEqualTo(new HonoTopic(HonoTopic.Type.EVENT, "foo"));
+        assertThat(new HonoTopic(HonoTopic.Type.EVENT, tenantId))
+                .isEqualTo(new HonoTopic(HonoTopic.Type.EVENT, tenantId));
 
-        assertThat(new HonoTopic(HonoTopic.Type.EVENT, "foo"))
+        assertThat(new HonoTopic(HonoTopic.Type.EVENT, tenantId))
                 .isNotEqualTo(new HonoTopic(HonoTopic.Type.EVENT, "bar"));
 
-        assertThat(new HonoTopic(HonoTopic.Type.EVENT, "foo"))
-                .isNotEqualTo(new HonoTopic(HonoTopic.Type.COMMAND, "foo"));
+        assertThat(new HonoTopic(HonoTopic.Type.EVENT, tenantId))
+                .isNotEqualTo(new HonoTopic(HonoTopic.Type.COMMAND, tenantId));
     }
 
 }

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -33,6 +33,9 @@
     <module>adapter-kafka</module>
     <module>amqp-common</module>
     <module>kafka-common</module>
+    <module>application</module>
+    <module>application-kafka</module>
+    <module>application-amqp</module>
   </modules>
 
   <dependencies>


### PR DESCRIPTION
This adds an interface for clients to be used by northbound applications, which removes the dependency from AMQP-specific types and allows to easily switch between AMQP-based and Kafka-based messaging.
This currently only supports downstream messaging. Support for command & control is to be added later.
This is the first step of #2392. Implementations of this interface are subject of subsequent pull requests to keep this PR smaller.