### PR TITLE
Refactor Command classes

### DIFF
--- a/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx/src/main/java/org/eclipse/hono/adapter/amqp/impl/VertxBasedAmqpProtocolAdapter.java
@@ -965,19 +965,19 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
             msg.setAddress(String.format("%s/%s/%s",
                     CommandConstants.COMMAND_ENDPOINT,
                     command.getTenant(),
-                    command.getOriginalDeviceId()));
+                    command.getDeviceId()));
             msg.setCorrelationId(command.getCorrelationId());
             msg.setSubject(command.getName());
             MessageHelper.setPayload(msg, command.getContentType(), command.getPayload());
 
             if (command.isTargetedAtGateway()) {
-                MessageHelper.addDeviceId(msg, command.getOriginalDeviceId());
+                MessageHelper.addDeviceId(msg, command.getDeviceId());
             }
             if (!command.isOneWay()) {
                 msg.setReplyTo(String.format("%s/%s/%s",
                         CommandConstants.COMMAND_RESPONSE_ENDPOINT,
                         command.getTenant(),
-                        Commands.getDeviceFacingReplyToId(command.getReplyToId(), command.getOriginalDeviceId())));
+                        Commands.getDeviceFacingReplyToId(command.getReplyToId(), command.getDeviceId())));
             }
 
             final Long timerId = getConfig().getSendMessageToDeviceTimeout() < 1 ? null

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -854,13 +854,13 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
 
         currentSpan.setTag(Constants.HEADER_COMMAND, command.getName());
         log.debug("adding command [name: {}, request-id: {}] to response for device [tenant-id: {}, device-id: {}]",
-                command.getName(), command.getRequestId(), command.getTenant(), command.getDeviceId());
+                command.getName(), command.getRequestId(), command.getTenant(), command.getGatewayOrDeviceId());
         commandContext.getTracingSpan().log("forwarding command to device in CoAP response");
 
         if (command.isTargetedAtGateway()) {
             options.addLocationPath(command.getTenant());
-            options.addLocationPath(command.getOriginalDeviceId());
-            currentSpan.setTag(Constants.HEADER_COMMAND_TARGET_DEVICE, command.getOriginalDeviceId());
+            options.addLocationPath(command.getDeviceId());
+            currentSpan.setTag(Constants.HEADER_COMMAND_TARGET_DEVICE, command.getDeviceId());
         }
         if (!command.isOneWay()) {
             options.addLocationPath(command.getRequestId());

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -924,15 +924,15 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
         response.putHeader(Constants.HEADER_COMMAND, command.getName());
         currentSpan.setTag(Constants.HEADER_COMMAND, command.getName());
         log.debug("adding command [name: {}, request-id: {}] to response for device [tenant-id: {}, device-id: {}]",
-                command.getName(), command.getRequestId(), command.getTenant(), command.getDeviceId());
+                command.getName(), command.getRequestId(), command.getTenant(), command.getGatewayOrDeviceId());
 
         if (!command.isOneWay()) {
             response.putHeader(Constants.HEADER_COMMAND_REQUEST_ID, command.getRequestId());
             currentSpan.setTag(Constants.HEADER_COMMAND_REQUEST_ID, command.getRequestId());
         }
         if (command.isTargetedAtGateway()) {
-            response.putHeader(Constants.HEADER_COMMAND_TARGET_DEVICE, command.getOriginalDeviceId());
-            currentSpan.setTag(Constants.HEADER_COMMAND_TARGET_DEVICE, command.getOriginalDeviceId());
+            response.putHeader(Constants.HEADER_COMMAND_TARGET_DEVICE, command.getDeviceId());
+            currentSpan.setTag(Constants.HEADER_COMMAND_TARGET_DEVICE, command.getDeviceId());
         }
 
         response.setStatusCode(HttpURLConnection.HTTP_OK);

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1450,7 +1450,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                 final Integer msgId = sentHandler.result();
                 if (command.isTargetedAtGateway()) {
                     log.debug("published command [packet-id: {}] to gateway [tenant-id: {}, gateway-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}, topic: {}]",
-                            msgId, subscription.getTenant(), subscription.getDeviceId(), command.getOriginalDeviceId(),
+                            msgId, subscription.getTenant(), subscription.getDeviceId(), command.getDeviceId(),
                             subscription.getClientId(), subscription.getQos(), publishTopic);
                 } else {
                     log.debug("published command [packet-id: {}] to device [tenant-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}, topic: {}]",
@@ -1465,7 +1465,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
 
                 if (command.isTargetedAtGateway()) {
                     log.debug("error publishing command to gateway [tenant-id: {}, gateway-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}, topic: {}]",
-                            subscription.getTenant(), subscription.getDeviceId(), command.getOriginalDeviceId(),
+                            subscription.getTenant(), subscription.getDeviceId(), command.getDeviceId(),
                             subscription.getClientId(), subscription.getQos(), publishTopic, sentHandler.cause());
                 } else {
                     log.debug("error publishing command to device [tenant-id: {}, device-id: {}, MQTT client-id: {}, QoS: {}, topic: {}]",

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/CommandSubscription.java
@@ -267,7 +267,7 @@ public final class CommandSubscription {
         Objects.requireNonNull(command);
 
         final String topicTenantId = containsTenantId ? getTenant() : "";
-        final String topicDeviceId = command.isTargetedAtGateway() ? command.getOriginalDeviceId()
+        final String topicDeviceId = command.isTargetedAtGateway() ? command.getDeviceId()
                 : containsDeviceId ? getDeviceId() : "";
         final String topicCommandRequestId = command.isOneWay() ? "" : command.getRequestId();
 

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/CommandSubscriptionTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/CommandSubscriptionTest.java
@@ -205,7 +205,7 @@ public class CommandSubscriptionTest {
         final Command command = mock(Command.class);
         when(command.isTargetedAtGateway()).thenReturn(false);
         when(command.getTenant()).thenReturn(device.getTenantId());
-        when(command.getDeviceId()).thenReturn(device.getDeviceId());
+        when(command.getGatewayOrDeviceId()).thenReturn(device.getDeviceId());
         when(command.getRequestId()).thenReturn("requestId");
         when(command.getName()).thenReturn("doSomething");
 
@@ -321,8 +321,9 @@ public class CommandSubscriptionTest {
         final Command command = mock(Command.class);
         when(command.isTargetedAtGateway()).thenReturn(true);
         when(command.getTenant()).thenReturn(gw.getTenantId());
-        when(command.getDeviceId()).thenReturn(gw.getDeviceId());
-        when(command.getOriginalDeviceId()).thenReturn(gatewayManagedDeviceId);
+        when(command.getGatewayId()).thenReturn(gw.getDeviceId());
+        when(command.getGatewayOrDeviceId()).thenReturn(gw.getDeviceId());
+        when(command.getDeviceId()).thenReturn(gatewayManagedDeviceId);
         when(command.getRequestId()).thenReturn("requestId");
         when(command.getName()).thenReturn("doSomething");
 

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -278,7 +278,7 @@ public final class SigfoxProtocolAdapter
     private Buffer convertToResponsePayload(final Command command) {
         final JsonObject payload = new JsonObject();
 
-        payload.put(command.getDeviceId(),
+        payload.put(command.getGatewayOrDeviceId(),
                 new JsonObject()
                         .put(DOWNLINK_DATA_FIELD,
                                 BaseEncoding

--- a/client/src/main/java/org/eclipse/hono/client/Command.java
+++ b/client/src/main/java/org/eclipse/hono/client/Command.java
@@ -221,31 +221,12 @@ public final class Command {
     }
 
     /**
-     * Gets the name of this command.
-     *
-     * @return The name.
-     * @throws IllegalStateException if this command is invalid.
-     */
-    public String getName() {
-        if (isValid()) {
-            return message.getSubject();
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
-    }
-
-    /**
      * Gets the tenant that the device belongs to.
      *
-     * @return The tenant identifier.
-     * @throws IllegalStateException if this command is invalid.
+     * @return The tenant identifier or {@code null} if the command is invalid and no tenant id is set.
      */
     public String getTenant() {
-        if (isValid()) {
-            return tenantId;
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
+        return tenantId;
     }
 
     /**
@@ -255,15 +236,10 @@ public final class Command {
      * the id returned here is a gateway id. See {@link #getOriginalDeviceId()}
      * for the original device id in that case.
      *
-     * @return The identifier.
-     * @throws IllegalStateException if this command is invalid.
+     * @return The identifier or {@code null} if the command is invalid and no device id is set.
      */
     public String getDeviceId() {
-        if (isValid()) {
-            return deviceId;
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
+        return deviceId;
     }
 
     /**
@@ -274,15 +250,10 @@ public final class Command {
      * from the original device id.
      *
      * @return {@code true} if the device id is a gateway id.
-     * @throws IllegalStateException if this command is invalid.
      */
     public boolean isTargetedAtGateway() {
-        if (isValid()) {
-            final String originalDeviceId = getOriginalDeviceId();
-            return originalDeviceId != null && !originalDeviceId.equals(getDeviceId());
-        } else {
-            throw new IllegalStateException("command is invalid");
-        }
+        final String originalDeviceId = getOriginalDeviceId();
+        return originalDeviceId != null && !originalDeviceId.equals(getDeviceId());
     }
 
     /**
@@ -292,12 +263,24 @@ public final class Command {
      * This id differs from {@link #getDeviceId()} if the command got redirected to a gateway
      * ({@link #getDeviceId()} returns the gateway id in that case).
      *
-     * @return The identifier.
-     * @throws IllegalStateException if this command is invalid.
+     * @return The identifier or {@code null} if the command is invalid and no device id is set.
      */
     public String getOriginalDeviceId() {
+        if (Strings.isNullOrEmpty(message.getAddress())) {
+            return null;
+        }
+        return ResourceIdentifier.fromString(message.getAddress()).getResourceId();
+    }
+
+    /**
+     * Gets the name of this command.
+     *
+     * @return The name.
+     * @throws IllegalStateException if this command is invalid.
+     */
+    public String getName() {
         if (isValid()) {
-            return ResourceIdentifier.fromString(message.getAddress()).getResourceId();
+            return message.getSubject();
         } else {
             throw new IllegalStateException("command is invalid");
         }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommand.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommand.java
@@ -117,7 +117,7 @@ public final class ProtonBasedCommand implements Command {
      * {@inheritDoc}
      */
     @Override
-    public String getDeviceId() {
+    public String getGatewayOrDeviceId() {
         return command.getDeviceId();
     }
 
@@ -133,8 +133,19 @@ public final class ProtonBasedCommand implements Command {
      * {@inheritDoc}
      */
     @Override
-    public String getOriginalDeviceId() {
+    public String getDeviceId() {
         return command.getOriginalDeviceId();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getGatewayId() {
+        if (!isValid()) {
+            throw new IllegalStateException("command is invalid");
+        }
+        return isTargetedAtGateway() ? getGatewayOrDeviceId() : null;
     }
 
     /**

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandContextWrapper.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandContextWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,7 +30,7 @@ import io.vertx.proton.ProtonHelper;
 public class ProtonBasedLegacyCommandContextWrapper implements CommandContext {
 
     private final org.eclipse.hono.client.CommandContext ctx;
-    private final ProtonBasedCommand command;
+    private final Command command;
 
     /**
      * Creates a new command context.
@@ -40,7 +40,7 @@ public class ProtonBasedLegacyCommandContextWrapper implements CommandContext {
      */
     public ProtonBasedLegacyCommandContextWrapper(final org.eclipse.hono.client.CommandContext context) {
         this.ctx = Objects.requireNonNull(context);
-        this.command = new ProtonBasedCommand(context.getCommand());
+        this.command = new ProtonBasedLegacyCommandWrapper(context.getCommand());
     }
 
     @Override

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandWrapper.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandWrapper.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.hono.adapter.client.command.Command;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.log.Fields;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A wrapper around a legacy {@link org.eclipse.hono.client.Command}.
+ *
+ */
+public final class ProtonBasedLegacyCommandWrapper implements Command {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProtonBasedLegacyCommandWrapper.class);
+
+    private final org.eclipse.hono.client.Command command;
+
+    /**
+     * Creates a new command as a wrapper around a legacy command.
+     *
+     * @param command The command to wrap.
+     * @throws NullPointerException if the command is {@code null}.
+     */
+    public ProtonBasedLegacyCommandWrapper(final org.eclipse.hono.client.Command command) {
+        this.command = Objects.requireNonNull(command);
+        if (Strings.isNullOrEmpty(command.getTenant()) || Strings.isNullOrEmpty(command.getOriginalDeviceId())) {
+            LOG.warn("given command expected to have a valid tenant/device id: {}", command);
+        }
+    }
+
+    @Override
+    public boolean isOneWay() {
+        return command.isOneWay();
+    }
+
+    @Override
+    public boolean isValid() {
+        return command.isValid();
+    }
+
+    @Override
+    public String getInvalidCommandReason() {
+        return command.getInvalidCommandReason();
+    }
+
+    @Override
+    public String getTenant() {
+        return command.getTenant();
+    }
+
+    @Override
+    public String getGatewayOrDeviceId() {
+        // the legacy command class associates getDeviceId() with the gateway or, if not set, original command target device.
+        return command.getDeviceId();
+    }
+
+    @Override
+    public boolean isTargetedAtGateway() {
+        return command.isTargetedAtGateway();
+    }
+
+    @Override
+    public String getDeviceId() {
+        return command.getOriginalDeviceId();
+    }
+
+    @Override
+    public String getGatewayId() {
+        return isTargetedAtGateway() ? getGatewayOrDeviceId() : null;
+    }
+
+    @Override
+    public String getName() {
+        return command.getName();
+    }
+
+    @Override
+    public String getRequestId() {
+        return command.getRequestId();
+    }
+
+    @Override
+    public Buffer getPayload() {
+        return command.getPayload();
+    }
+
+    @Override
+    public int getPayloadSize() {
+        return command.getPayloadSize();
+    }
+
+    @Override
+    public String getContentType() {
+        return command.getContentType();
+    }
+
+    @Override
+    public String getReplyToId() {
+        return command.getReplyToId();
+    }
+
+    @Override
+    public String getCorrelationId() {
+        return command.getCorrelationId();
+    }
+
+    @Override
+    public String toString() {
+        return command.toString();
+    }
+
+    @Override
+    public void logToSpan(final Span span) {
+        Objects.requireNonNull(span);
+        if (command.isValid()) {
+            TracingHelper.TAG_CORRELATION_ID.set(span, command.getCorrelationId());
+            final Map<String, String> items = new HashMap<>(5);
+            items.put(Fields.EVENT, "received command message");
+            items.put("to", command.getCommandMessage().getAddress());
+            items.put("reply-to", command.getCommandMessage().getReplyTo());
+            items.put("name", command.getName());
+            items.put("content-type", command.getContentType());
+            span.log(items);
+        } else {
+            TracingHelper.logError(span, "received invalid command message [" + command + "]");
+        }
+    }
+}

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedAdapterInstanceCommandHandlerTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedAdapterInstanceCommandHandlerTest.java
@@ -136,8 +136,8 @@ public class ProtonBasedAdapterInstanceCommandHandlerTest {
         verify(commandHandler).handle(commandContextCaptor.capture());
         assertThat(commandContextCaptor.getValue()).isNotNull();
         // assert that command is directed at the gateway
-        assertThat(commandContextCaptor.getValue().getCommand().getDeviceId()).isEqualTo(gatewayId);
-        assertThat(commandContextCaptor.getValue().getCommand().getOriginalDeviceId()).isEqualTo(deviceId);
+        assertThat(commandContextCaptor.getValue().getCommand().getGatewayId()).isEqualTo(gatewayId);
+        assertThat(commandContextCaptor.getValue().getCommand().getDeviceId()).isEqualTo(deviceId);
     }
 
     @Test
@@ -160,8 +160,8 @@ public class ProtonBasedAdapterInstanceCommandHandlerTest {
         verify(commandHandler).handle(commandContextCaptor.capture());
         assertThat(commandContextCaptor.getValue()).isNotNull();
         // assert that command is directed at the gateway
-        assertThat(commandContextCaptor.getValue().getCommand().getDeviceId()).isEqualTo(gatewayId);
-        assertThat(commandContextCaptor.getValue().getCommand().getOriginalDeviceId()).isEqualTo(deviceId);
+        assertThat(commandContextCaptor.getValue().getCommand().getGatewayId()).isEqualTo(gatewayId);
+        assertThat(commandContextCaptor.getValue().getCommand().getDeviceId()).isEqualTo(deviceId);
     }
 
 }

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandTest.java
@@ -1,0 +1,356 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.qpid.proton.amqp.messaging.AmqpSequence;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.amqp.messaging.Section;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.Constants;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.proton.ProtonHelper;
+
+/**
+ * Tests verifying behavior of {@link ProtonBasedCommand}.
+ *
+ */
+public class ProtonBasedCommandTest {
+
+    /**
+     * Verifies that a command can be created from a valid message.
+     */
+    @Test
+    public void testFromMessageSucceeds() {
+        final String replyToId = "the-reply-to-id";
+        final String correlationId = "the-correlation-id";
+        final Message message = ProtonHelper.message("input data");
+        message.setAddress(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        message.setSubject("doThis");
+        message.setCorrelationId(correlationId);
+        message.setReplyTo(String.format("%s/%s/%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final ProtonBasedCommand cmd = ProtonBasedCommand.from(message);
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getName()).isEqualTo("doThis");
+        assertThat(cmd.getTenant()).isEqualTo(Constants.DEFAULT_TENANT);
+        assertThat(cmd.getGatewayOrDeviceId()).isEqualTo("4711");
+        assertThat(cmd.getDeviceId()).isEqualTo("4711");
+        assertThat(cmd.getReplyToId()).isEqualTo(String.format("4711/%s", replyToId));
+        assertThat(cmd.getCorrelationId()).isEqualTo(correlationId);
+        assertFalse(cmd.isOneWay());
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message representing a routed command
+     * message with a <em>via</em> property containing a gateway identifier.
+     */
+    @Test
+    public void testFromRoutedCommandMessageSucceeds() {
+        final String gatewayId = "gw-1";
+        final String targetDeviceId = "4711";
+        final String replyToId = "the-reply-to-id";
+        final String correlationId = "the-correlation-id";
+        final Map<String, Object> applicationProperties = new HashMap<>();
+        applicationProperties.put("via", gatewayId);
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getApplicationProperties()).thenReturn(new ApplicationProperties(applicationProperties));
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final ProtonBasedCommand cmd = ProtonBasedCommand.fromRoutedCommandMessage(message);
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getName()).isEqualTo("doThis");
+        assertThat(cmd.getTenant()).isEqualTo(Constants.DEFAULT_TENANT);
+        assertThat(cmd.getGatewayOrDeviceId()).isEqualTo(gatewayId);
+        assertThat(cmd.getGatewayId()).isEqualTo(gatewayId);
+        assertThat(cmd.getDeviceId()).isEqualTo(targetDeviceId);
+        assertThat(cmd.getReplyToId()).isEqualTo(String.format("%s/%s", targetDeviceId, replyToId));
+        assertThat(cmd.getCorrelationId()).isEqualTo(correlationId);
+        assertFalse(cmd.isOneWay());
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message having no device-id as part of the reply-to address.
+     */
+    @Test
+    public void testForReplyToWithoutDeviceId() {
+        final String replyToId = "the-reply-to-id";
+        final String correlationId = "the-correlation-id";
+        final Message message = ProtonHelper.message("input data");
+        message.setAddress(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        message.setSubject("doThis");
+        message.setCorrelationId(correlationId);
+        message.setReplyTo(String.format("%s/%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, replyToId));
+        final ProtonBasedCommand cmd = ProtonBasedCommand.from(message);
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getReplyToId()).isEqualTo(replyToId);
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message having device-id as part of the reply-to address.
+     */
+    @Test
+    public void testForReplyToWithDeviceId() {
+        final String replyToId = "the-reply-to-id";
+        final String correlationId = "the-correlation-id";
+        final Message message = ProtonHelper.message("input data");
+        message.setAddress(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        message.setSubject("doThis");
+        message.setCorrelationId(correlationId);
+        message.setReplyTo(String.format("%s/%s/%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final ProtonBasedCommand cmd = ProtonBasedCommand.from(message);
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getReplyToId()).isEqualTo(String.format("4711/%s", replyToId));
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message that has an empty reply-to property.
+     * Verifies that the replyToId is {@code null} and the command reports that it is a one-way command.
+     */
+    @Test
+    public void testFromMessageSucceedsWithoutReplyTo() {
+        final String correlationId = "the-correlation-id";
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        final ProtonBasedCommand cmd = ProtonBasedCommand.from(message);
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getName()).isEqualTo("doThis");
+        assertThat(cmd.getCorrelationId()).isEqualTo(correlationId);
+        assertThat(cmd.getReplyToId()).isNull();
+        assertTrue(cmd.isOneWay());
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message that has an empty reply-to property
+     * and no message-id and correlation-id properties.
+     * Verifies that the replyToId is {@code null} and the command reports that it is a one-way command.
+     */
+    @Test
+    public void testFromMessageSucceedsWithoutReplyToAndCorrelationId() {
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getSubject()).thenReturn("doThis");
+        final ProtonBasedCommand cmd = ProtonBasedCommand.from(message);
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getName()).isEqualTo("doThis");
+        assertThat(cmd.getCorrelationId()).isNull();
+        assertThat(cmd.getReplyToId()).isNull();
+        assertTrue(cmd.isOneWay());
+    }
+
+    /**
+     * Verifies that a command can be created from a message with message id but no correlation id.
+     */
+    @Test
+    public void testFromMessageSucceedsWithMessageIdButNoCorrelationId() {
+        final String replyToId = "the-reply-to-id";
+        final String messageId = "the-message-id";
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getApplicationProperties()).thenReturn(null);
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getMessageId()).thenReturn(messageId);
+        when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final ProtonBasedCommand cmd = ProtonBasedCommand.from(message);
+        assertTrue(cmd.isValid());
+        assertThat(cmd.getCorrelationId()).isEqualTo(messageId);
+    }
+
+    /**
+     * Verifies that a command can be created from a valid message with no application properties is valid.
+     */
+    @Test
+    public void testFromMessageSucceedsWithNoApplicationProperties() {
+        final String replyToId = "the-reply-to-id";
+        final String correlationId = "the-correlation-id";
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getApplicationProperties()).thenReturn(null);
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final ProtonBasedCommand cmd = ProtonBasedCommand.from(message);
+        assertTrue(cmd.isValid());
+    }
+
+    /**
+     * Verifies that a valid command cannot be created from a message that has an unsupported body section.
+     */
+    @Test
+    public void testFromMessageFailsForUnsupportedMessageBody() {
+        final String replyToId = "the-reply-to-id";
+        final String correlationId = "the-correlation-id";
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getApplicationProperties()).thenReturn(null);
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+
+        Section body = new AmqpValue(5L);
+        when(message.getBody()).thenReturn(body);
+        ProtonBasedCommand command = ProtonBasedCommand.from(message);
+        assertFalse(command.isValid());
+        assertThat(command.getInvalidCommandReason()).contains("body");
+        // assert tenant/device information can be retrieved nonetheless
+        assertThat(command.getTenant()).isEqualTo(Constants.DEFAULT_TENANT);
+        assertThat(command.getGatewayOrDeviceId()).isEqualTo("4711");
+        assertThat(command.getDeviceId()).isEqualTo("4711");
+
+
+        body = new AmqpSequence(Collections.singletonList("test"));
+        when(message.getBody()).thenReturn(body);
+        command = ProtonBasedCommand.from(message);
+        assertFalse(command.isValid());
+        assertThat(command.getInvalidCommandReason()).contains("body");
+        // assert tenant/device information can be retrieved nonetheless
+        assertThat(command.getTenant()).isEqualTo(Constants.DEFAULT_TENANT);
+        assertThat(command.getGatewayOrDeviceId()).isEqualTo("4711");
+        assertThat(command.getDeviceId()).isEqualTo("4711");
+    }
+
+    /**
+     * Verifies that a valid command cannot be created from a message that neither
+     * contains a message nor correlation ID.
+     */
+    @Test
+    public void testFromMessageFailsForMissingCorrelationOrMessageId() {
+        final String replyToId = "the-reply-to-id";
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT, "4711", replyToId));
+        final ProtonBasedCommand command = ProtonBasedCommand.from(message);
+        assertFalse(command.isValid());
+        assertThat(command.getInvalidCommandReason()).contains("correlation-id");
+        // assert tenant/device information can be retrieved nonetheless
+        assertThat(command.getTenant()).isEqualTo(Constants.DEFAULT_TENANT);
+        assertThat(command.getGatewayOrDeviceId()).isEqualTo("4711");
+        assertThat(command.getDeviceId()).isEqualTo("4711");
+    }
+
+    /**
+     * Verifies that a command cannot be created from a message that contains
+     * a 'to' address without the device-id part.
+     */
+    @Test
+    public void testFromMessageFailsForMissingDeviceIdInAddress() {
+
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT));
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn("the-correlation-id");
+        assertThrows(IllegalArgumentException.class, () -> {
+            ProtonBasedCommand.from(message);
+        });
+    }
+
+    /**
+     * Verifies that a valid command cannot be created from a message that contains
+     * a reply-to address with the wrong tenant.
+     */
+    @Test
+    public void testFromMessageFailsForReplyToWithWrongTenant() {
+        final String correlationId = "the-correlation-id";
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        when(message.getReplyTo()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, "wrong_tenant", "4711"));
+        final ProtonBasedCommand command = ProtonBasedCommand.from(message);
+        assertFalse(command.isValid());
+        assertThat(command.getInvalidCommandReason()).contains("reply-to");
+        // assert tenant/device information can be retrieved nonetheless
+        assertThat(command.getTenant()).isEqualTo(Constants.DEFAULT_TENANT);
+        assertThat(command.getGatewayOrDeviceId()).isEqualTo("4711");
+        assertThat(command.getDeviceId()).isEqualTo("4711");
+    }
+
+    /**
+     * Verifies that a valid command cannot be created from a message that contains
+     * a reply-to address without a reply id.
+     */
+    @Test
+    public void testFromMessageFailsForReplyToWithoutReplyId() {
+        final String correlationId = "the-correlation-id";
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getSubject()).thenReturn("doThis");
+        when(message.getCorrelationId()).thenReturn(correlationId);
+        when(message.getReplyTo()).thenReturn(String.format("%s/%s",
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, Constants.DEFAULT_TENANT));
+        final ProtonBasedCommand command = ProtonBasedCommand.from(message);
+        assertFalse(command.isValid());
+        assertThat(command.getInvalidCommandReason()).contains("reply-to");
+        // assert tenant/device information can be retrieved nonetheless
+        assertThat(command.getTenant()).isEqualTo(Constants.DEFAULT_TENANT);
+        assertThat(command.getGatewayOrDeviceId()).isEqualTo("4711");
+        assertThat(command.getDeviceId()).isEqualTo("4711");
+    }
+
+    /**
+     * Verifies the return value of getInvalidCommandReason().
+     */
+    @Test
+    public void testGetInvalidCommandReason() {
+        final Message message = mock(Message.class);
+        when(message.getAddress()).thenReturn(String.format("%s/%s/%s",
+                CommandConstants.COMMAND_ENDPOINT, Constants.DEFAULT_TENANT, "4711"));
+        when(message.getReplyTo()).thenReturn("invalid-reply-to");
+        final ProtonBasedCommand command = ProtonBasedCommand.from(message);
+        assertFalse(command.isValid());
+        // verify the returned validation error contains all missing fields
+        assertThat(command.getInvalidCommandReason()).contains("subject");
+        assertThat(command.getInvalidCommandReason()).contains("correlation-id");
+        assertThat(command.getInvalidCommandReason()).contains("reply-to");
+    }
+}

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommand.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommand.java
@@ -169,7 +169,7 @@ public final class KafkaBasedCommand implements Command {
     }
 
     @Override
-    public String getDeviceId() {
+    public String getGatewayOrDeviceId() {
         requireValid();
         return deviceId;
     }
@@ -181,9 +181,15 @@ public final class KafkaBasedCommand implements Command {
     }
 
     @Override
-    public String getOriginalDeviceId() {
+    public String getDeviceId() {
         requireValid();
         return originalDeviceId;
+    }
+
+    @Override
+    public String getGatewayId() {
+        requireValid();
+        return isTargetedAtGateway() ? getGatewayOrDeviceId() : null;
     }
 
     @Override
@@ -232,8 +238,8 @@ public final class KafkaBasedCommand implements Command {
     public String toString() {
         if (isValid()) {
             if (isTargetedAtGateway()) {
-                return String.format("Command [name: %s, tenant-id: %s, device-id %s, original device-id %s, request-id: %s]",
-                        getName(), getTenant(), getDeviceId(), getOriginalDeviceId(), getRequestId());
+                return String.format("Command [name: %s, tenant-id: %s, gateway-id %s, device-id %s, request-id: %s]",
+                        getName(), getTenant(), getGatewayId(), getDeviceId(), getRequestId());
             } else {
                 return String.format("Command [name: %s, tenant-id: %s, device-id %s, request-id: %s]",
                         getName(), getTenant(), getDeviceId(), getRequestId());

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandTest.java
@@ -54,7 +54,6 @@ public class KafkaBasedCommandTest {
         assertTrue(cmd.isValid());
         assertThat(cmd.getName()).isEqualTo(subject);
         assertThat(cmd.getDeviceId()).isEqualTo(deviceId);
-        assertThat(cmd.getOriginalDeviceId()).isEqualTo(deviceId);
         assertThat(cmd.getCorrelationId()).isEqualTo(correlationId);
         assertFalse(cmd.isOneWay());
     }
@@ -76,8 +75,7 @@ public class KafkaBasedCommandTest {
         final KafkaBasedCommand cmd = KafkaBasedCommand.from(commandRecord, gatewayId);
         assertTrue(cmd.isValid());
         assertThat(cmd.getName()).isEqualTo(subject);
-        assertThat(cmd.getDeviceId()).isEqualTo(gatewayId);
-        assertThat(cmd.getOriginalDeviceId()).isEqualTo(targetDeviceId);
+        assertThat(cmd.getDeviceId()).isEqualTo(targetDeviceId);
         assertThat(cmd.getCorrelationId()).isEqualTo(correlationId);
         assertFalse(cmd.isOneWay());
     }

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
@@ -17,8 +17,10 @@ import io.opentracing.Span;
 import io.vertx.core.buffer.Buffer;
 
 /**
- * A message representing a Hono Command to be sent to a device.
- *
+ * A Hono command to be sent to a device.
+ * <p>
+ * The command may be invalid, in which case only tenant/device/gateway identifier and payload size information
+ * can be retrieved.
  */
 public interface Command {
 
@@ -45,18 +47,9 @@ public interface Command {
     String getInvalidCommandReason();
 
     /**
-     * Gets the name of this command.
-     *
-     * @return The name.
-     * @throws IllegalStateException if this command is invalid.
-     */
-    String getName();
-
-    /**
      * Gets the tenant that the device belongs to.
      *
      * @return The tenant identifier.
-     * @throws IllegalStateException if this command is invalid.
      */
     String getTenant();
 
@@ -70,7 +63,6 @@ public interface Command {
      * is returned.
      *
      * @return The identifier.
-     * @throws IllegalStateException if this command is invalid.
      */
     String getGatewayOrDeviceId();
 
@@ -82,7 +74,6 @@ public interface Command {
      * from the original device id.
      *
      * @return {@code true} if the device id is a gateway id.
-     * @throws IllegalStateException if this command is invalid.
      */
     boolean isTargetedAtGateway();
 
@@ -90,7 +81,6 @@ public interface Command {
      * Gets the identifier of the device that is supposed to execute the command.
      *
      * @return The identifier.
-     * @throws IllegalStateException if this command is invalid.
      */
     String getDeviceId();
 
@@ -99,9 +89,16 @@ public interface Command {
      * Otherwise {@code null} is returned.
      *
      * @return The identifier or {@code null}.
-     * @throws IllegalStateException if this command is invalid.
      */
     String getGatewayId();
+
+    /**
+     * Gets the name of this command.
+     *
+     * @return The name.
+     * @throws IllegalStateException if this command is invalid.
+     */
+    String getName();
 
     /**
      * Gets the request identifier of this command. Can be used to correlate this command

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
@@ -61,16 +61,18 @@ public interface Command {
     String getTenant();
 
     /**
-     * Gets the device's identifier.
+     * Gets the identifier of the gateway or edge device that this command
+     * needs to be forwarded to for delivery.
      * <p>
-     * In the case that the command got redirected to a gateway,
-     * the id returned here is a gateway id. See {@link #getOriginalDeviceId()}
-     * for the original device id in that case.
+     * If the command is to be sent to the target device directly, without
+     * using a gateway, the id returned here is the same as the one
+     * returned by {@link #getDeviceId()}. Otherwise, {@link #getGatewayId()}
+     * is returned.
      *
      * @return The identifier.
      * @throws IllegalStateException if this command is invalid.
      */
-    String getDeviceId();
+    String getGatewayOrDeviceId();
 
     /**
      * Checks whether the command is targeted at a gateway.
@@ -85,16 +87,21 @@ public interface Command {
     boolean isTargetedAtGateway();
 
     /**
-     * Gets the device identifier used in the original command. It is extracted from the
-     * <em>to</em> property of the command AMQP message.
-     * <p>
-     * This id differs from {@link #getDeviceId()} if the command got redirected to a gateway
-     * ({@link #getDeviceId()} returns the gateway id in that case).
+     * Gets the identifier of the device that is supposed to execute the command.
      *
      * @return The identifier.
      * @throws IllegalStateException if this command is invalid.
      */
-    String getOriginalDeviceId();
+    String getDeviceId();
+
+    /**
+     * Gets the gateway identifier if this command is to be sent via a gateway.
+     * Otherwise {@code null} is returned.
+     *
+     * @return The identifier or {@code null}.
+     * @throws IllegalStateException if this command is invalid.
+     */
+    String getGatewayId();
 
     /**
      * Gets the request identifier of this command. Can be used to correlate this command

--- a/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
+++ b/test-utils/service-base-test-utils/src/main/java/org/eclipse/hono/service/test/ProtocolAdapterTestSupport.java
@@ -267,8 +267,8 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
 
         final Command command = mock(Command.class);
         when(command.getTenant()).thenReturn(tenantId);
+        when(command.getGatewayOrDeviceId()).thenReturn(deviceId);
         when(command.getDeviceId()).thenReturn(deviceId);
-        when(command.getOriginalDeviceId()).thenReturn(deviceId);
         when(command.getName()).thenReturn(name);
         when(command.getContentType()).thenReturn(contentType);
         when(command.getPayload()).thenReturn(payload);


### PR DESCRIPTION
 Refactor device/gateway related Command methods:
`getDeviceId()` has been renamed to `getGatewayOrDeviceId()` and `getOriginalDeviceId()` has been renamed to `getDevice()`. Also a `getGatewayId()` method has been added.

Refactor Command classes:
The new `Command` class now requires tenant/device information to be set and returns this kind of information even if the
command is otherwise invalid. This makes it easier to choose the command handler for a potentially invalid command.
Usage of the legacy command class inside the` ProtonBasedCommand` has been removed.

For the review it may be easier to look at the 2 commits separately.