### PR TITLE
Use the new API for sending to internal command endpoint

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/Command.java
+++ b/client/src/main/java/org/eclipse/hono/client/Command.java
@@ -48,10 +48,10 @@ public final class Command {
     private final Optional<String> validationError;
     private final Message message;
     private final String tenantId;
-    private final String deviceId;
     private final String correlationId;
     private final String replyToId;
     private final String requestId;
+    private String deviceId;
 
     private Command(
             final Optional<String> validationError,
@@ -230,7 +230,8 @@ public final class Command {
     }
 
     /**
-     * Gets the device's identifier.
+     * Gets the identifier of the gateway or edge device that this command
+     * needs to be forwarded to for delivery.
      * <p>
      * In the case that the command got redirected to a gateway,
      * the id returned here is a gateway id. See {@link #getOriginalDeviceId()}
@@ -240,6 +241,18 @@ public final class Command {
      */
     public String getDeviceId() {
         return deviceId;
+    }
+
+    /**
+     * Sets the identifier of the gateway this command is to be sent to.
+     * <p>
+     * Using {@code null} as parameter means that the command is to be forwarded directly
+     * to the device given in the original command message, without using a gateway.
+     *
+     * @param gatewayId The gateway identifier.
+     */
+    public void setGatewayId(final String gatewayId) {
+        this.deviceId = Optional.ofNullable(gatewayId).orElseGet(this::getOriginalDeviceId);
     }
 
     /**
@@ -468,10 +481,10 @@ public final class Command {
         if (isValid()) {
             final String originalDeviceId = getOriginalDeviceId();
             if (!getDeviceId().equals(originalDeviceId)) {
-                return String.format("Command [name: %s, tenant-id: %s, device-id %s, original device-id %s, request-id: %s]",
+                return String.format("Command [name: %s, tenant-id: %s, gateway-id: %s, device-id: %s, request-id: %s]",
                         getName(), getTenant(), getDeviceId(), originalDeviceId, getRequestId());
             } else {
-                return String.format("Command [name: %s, tenant-id: %s, device-id %s, request-id: %s]",
+                return String.format("Command [name: %s, tenant-id: %s, device-id: %s, request-id: %s]",
                         getName(), getTenant(), getDeviceId(), getRequestId());
             }
         } else {

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
@@ -46,6 +46,9 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
 
     /**
      * Creates a new client.
+     * <p>
+     * The created sender links are expected to be tenant-specific and are closed
+     * when a tenant timeout occurs.
      *
      * @param connection The connection to the Hono service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
@@ -57,17 +60,49 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
 
+        this(connection, samplerFactory, adapterConfig, true);
+    }
+
+    /**
+     * Creates a new client.
+     *
+     * @param connection The connection to the Hono service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param isTenantSpecificLink If the links created for this client are tenant-specific, leading
+     *            them to get closed when a tenant timeout occurs.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected SenderCachingServiceClient(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory,
+            final ProtocolAdapterProperties adapterConfig,
+            final boolean isTenantSpecificLink) {
+
         super(connection, samplerFactory, adapterConfig);
         this.clientFactory = new CachingClientFactory<>(connection.getVertx(), GenericSenderLink::isOpen);
-        connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
-                this::handleTenantTimeout);
+        if (isTenantSpecificLink) {
+            connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
+                    this::handleTenantTimeout);
+        }
     }
 
     private void handleTenantTimeout(final Message<String> msg) {
-        List.of(AddressHelper.getTargetAddress(TelemetryConstants.TELEMETRY_ENDPOINT, msg.body(), null, connection.getConfig()),
-                AddressHelper.getTargetAddress(EventConstants.EVENT_ENDPOINT, msg.body(), null, connection.getConfig()))
+        final String tenantId = msg.body();
+        List.of(AddressHelper.getTargetAddress(TelemetryConstants.TELEMETRY_ENDPOINT, tenantId, null, connection.getConfig()),
+                AddressHelper.getTargetAddress(EventConstants.EVENT_ENDPOINT, tenantId, null, connection.getConfig()))
             .forEach(key -> Optional.ofNullable(clientFactory.getClient(key))
                     .ifPresent(client -> client.close().onComplete(r -> clientFactory.removeClient(key))));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Clears the state of the client factory.
+     */
+    @Override
+    protected void onDisconnect() {
+        clientFactory.clearState();
     }
 
     /**
@@ -108,6 +143,40 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
                                     endpoint,
                                     tenantId,
                                     samplerFactory.create(endpoint),
+                                    onSenderClosed -> removeClient(key)),
+                            result);
+                }));
+    }
+
+    /**
+     * Gets an existing or creates a new sender link.
+     * <p>
+     * This method first tries to look up an already existing
+     * link using the given key. If no link exists yet, a new
+     * instance is created using the given link target address
+     * and put to the cache.
+     * <p>
+     * This method is to be used for creating links that are
+     * independent of a particular tenant.
+     *
+     * @param address The target address of the link.
+     * @return A future indicating the outcome of the operation.
+     *         The future will be completed with the sender link
+     *         or will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}
+     *         if no sender link could be created.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected final Future<GenericSenderLink> getOrCreateSenderLink(final String address) {
+        Objects.requireNonNull(address);
+        return connection
+                .isConnected(getDefaultConnectionCheckTimeout())
+                .compose(v -> connection.executeOnContext(result -> {
+                    final String key = AddressHelper.rewrite(address, connection.getConfig());
+                    clientFactory.getOrCreateClient(
+                            key,
+                            () -> GenericSenderLink.create(
+                                    connection,
+                                    address,
                                     onSenderClosed -> removeClient(key)),
                             result);
                 }));

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommand.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommand.java
@@ -175,22 +175,6 @@ public final class ProtonBasedCommand implements Command {
     }
 
     /**
-     * Sets the identifier of the gateway this command is to be sent to.
-     * <p>
-     * A scenario where the gateway information isn't taken from the command message
-     * (see {@link #fromRoutedCommandMessage(Message)}) but instead needs to be set
-     * manually here would be the case of a gateway subscribing for commands targeted
-     * at a specific device. In that scenario, the Command Router does the routing
-     * based on the edge device identifier and only the target protocol adapter knows
-     * about the gateway association.
-     *
-     * @param gatewayId The gateway identifier.
-     */
-    public void setGatewayId(final String gatewayId) {
-        this.gatewayId = gatewayId;
-    }
-
-    /**
      * Gets the AMQP 1.0 message representing this command.
      *
      * @return The command message.
@@ -240,6 +224,23 @@ public final class ProtonBasedCommand implements Command {
     @Override
     public String getGatewayId() {
         return gatewayId;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A scenario where the gateway information isn't taken from the command message
+     * (see {@link #fromRoutedCommandMessage(Message)}) but instead needs to be set
+     * manually here would be the case of a gateway subscribing for commands targeted
+     * at a specific device. In that scenario, the Command Router does the routing
+     * based on the edge device identifier and only the target protocol adapter knows
+     * about the gateway association.
+     *
+     * @param gatewayId The gateway identifier.
+     */
+    @Override
+    public void setGatewayId(final String gatewayId) {
+        this.gatewayId = gatewayId;
     }
 
     @Override
@@ -293,7 +294,7 @@ public final class ProtonBasedCommand implements Command {
     public String toString() {
         if (isValid()) {
             if (isTargetedAtGateway()) {
-                return String.format("Command [name: %s, tenant-id: %s, device-id: %s, original device-id %s, request-id: %s]",
+                return String.format("Command [name: %s, tenant-id: %s, gateway-id: %s, device-id: %s, request-id: %s]",
                         getName(), tenantId, gatewayId, deviceId, requestId);
             } else {
                 return String.format("Command [name: %s, tenant-id: %s, device-id: %s, request-id: %s]",

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommand.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommand.java
@@ -190,6 +190,15 @@ public final class ProtonBasedCommand implements Command {
         this.gatewayId = gatewayId;
     }
 
+    /**
+     * Gets the AMQP 1.0 message representing this command.
+     *
+     * @return The command message.
+     */
+    Message getMessage() {
+        return message;
+    }
+
     @Override
     public boolean isOneWay() {
         return replyToId == null;
@@ -284,10 +293,10 @@ public final class ProtonBasedCommand implements Command {
     public String toString() {
         if (isValid()) {
             if (isTargetedAtGateway()) {
-                return String.format("Command [name: %s, tenant-id: %s, device-id %s, original device-id %s, request-id: %s]",
+                return String.format("Command [name: %s, tenant-id: %s, device-id: %s, original device-id %s, request-id: %s]",
                         getName(), tenantId, gatewayId, deviceId, requestId);
             } else {
-                return String.format("Command [name: %s, tenant-id: %s, device-id %s, request-id: %s]",
+                return String.format("Command [name: %s, tenant-id: %s, device-id: %s, request-id: %s]",
                         getName(), tenantId, deviceId, requestId);
             }
         } else {

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandContext.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandContext.java
@@ -17,7 +17,6 @@ import java.util.Objects;
 
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
-import org.eclipse.hono.adapter.client.command.Command;
 import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
@@ -60,7 +59,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
     }
 
     @Override
-    public Command getCommand() {
+    public ProtonBasedCommand getCommand() {
         return command;
     }
 

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandSender.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.command.amqp;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Modified;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.client.amqp.SenderCachingServiceClient;
+import org.eclipse.hono.adapter.client.command.Command;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.adapter.client.command.InternalCommandSender;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.vertx.core.Future;
+import io.vertx.proton.ProtonHelper;
+
+/**
+ * A vertx-proton based sender for command messages to the internal Command and Control API endpoint provided by
+ * protocol adapters.
+ */
+public class ProtonBasedInternalCommandSender extends SenderCachingServiceClient implements InternalCommandSender {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProtonBasedInternalCommandSender.class);
+
+    /**
+     * Creates a new sender for a connection.
+     *
+     * @param connection The connection to the Hono service.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public ProtonBasedInternalCommandSender(final HonoConnection connection) {
+        super(connection, SendMessageSampler.Factory.noop(), new ProtocolAdapterProperties(), false);
+    }
+
+    @Override
+    public Future<Void> sendCommand(final CommandContext commandContext, final String adapterInstanceId) {
+        Objects.requireNonNull(commandContext);
+        return getOrCreateSenderLink(getTargetAddress(adapterInstanceId))
+                .recover(thr -> Future.failedFuture(StatusCodeMapper.toServerError(thr)))
+                .compose(sender -> {
+                    final Span span = newChildSpan(commandContext.getTracingContext(), "delegate Command request");
+                    final Command command = commandContext.getCommand();
+                    final Message message = adoptOrCreateMessage(command);
+                    TracingHelper.setDeviceTags(span, command.getTenant(), command.getDeviceId());
+                    if (command.isTargetedAtGateway()) {
+                        MessageHelper.addProperty(message, MessageHelper.APP_PROPERTY_CMD_VIA, command.getGatewayId());
+                        TracingHelper.TAG_GATEWAY_ID.set(span, command.getGatewayId());
+                    }
+                    return sender.sendAndWaitForRawOutcome(message, span);
+                })
+                .map(delivery -> {
+                    final DeliveryState remoteState = delivery.getRemoteState();
+                    LOG.trace("command [{}] sent to downstream peer; remote state of delivery: {}",
+                            commandContext.getCommand(), remoteState);
+                    if (Accepted.class.isInstance(remoteState)) {
+                        commandContext.accept();
+                    } else if (Rejected.class.isInstance(remoteState)) {
+                        final Rejected rejected = (Rejected) remoteState;
+                        commandContext.reject(Optional.ofNullable(rejected.getError())
+                                .map(ErrorCondition::getDescription)
+                                .orElse(null));
+                    } else if (Released.class.isInstance(remoteState)) {
+                        commandContext.release();
+                    } else if (Modified.class.isInstance(remoteState)) {
+                        final Modified modified = (Modified) remoteState;
+                        commandContext.modify(modified.getDeliveryFailed(), modified.getUndeliverableHere());
+                    }
+                    return (Void) null;
+                })
+                .recover(thr -> {
+                    LOG.debug("failed to send command [{}] to downstream peer", commandContext.getCommand(), thr);
+                    TracingHelper.logError(commandContext.getTracingSpan(),
+                            "failed to send command message to downstream peer: " + thr);
+                    commandContext.release();
+                    return Future.succeededFuture();
+                });
+    }
+
+    /**
+     * Gets the AMQP <em>target</em> address to use for sending the delegated command messages to.
+     *
+     * @param adapterInstanceId The protocol adapter instance id.
+     * @return The target address.
+     * @throws NullPointerException if adapterInstanceId is {@code null}.
+     */
+    static String getTargetAddress(final String adapterInstanceId) {
+        return CommandConstants.INTERNAL_COMMAND_ENDPOINT + "/" + Objects.requireNonNull(adapterInstanceId);
+    }
+
+    private Message adoptOrCreateMessage(final Command command) {
+        final Message msg;
+        if (command instanceof ProtonBasedCommand) {
+            // copy and adapt original message
+            msg = MessageHelper.getShallowCopy(((ProtonBasedCommand) command).getMessage());
+        } else {
+            // create new message and adopt command properties
+            msg = ProtonHelper.message();
+            final byte[] payloadBytesOrNull = command.getPayload() != null ? command.getPayload().getBytes() : null;
+            MessageHelper.setPayload(msg, command.getContentType(), payloadBytesOrNull);
+            msg.setAddress(getCommandMessageAddress(command));
+            msg.setSubject(command.getName());
+            if (command.getContentType() != null) {
+                msg.setContentType(command.getContentType());
+            }
+        }
+        // explicitly set correlation id (possibly coming from the message-id property in case of a copied message)
+        if (command.getCorrelationId() != null) {
+            msg.setCorrelationId(command.getCorrelationId());
+        }
+        if (!command.isOneWay()) {
+            msg.setReplyTo(getReplyToAddress(command));
+        }
+        return msg;
+    }
+
+    private String getCommandMessageAddress(final Command command) {
+        // message address contains the "command" endpoint (the "command_internal" endpoint is used in the link address)
+        return String.format("%s/%s/%s", CommandConstants.COMMAND_ENDPOINT,
+                command.getTenant(), command.getDeviceId());
+    }
+
+    private String getReplyToAddress(final Command command) {
+        return command.isOneWay() ? null
+                : String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT,
+                command.getTenant(), command.getReplyToId());
+    }
+
+    @Override
+    public String toString() {
+        return ProtonBasedInternalCommandSender.class.getName()
+                + " via AMQP 1.0 Messaging Network";
+    }
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandWrapper.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandWrapper.java
@@ -92,6 +92,11 @@ public final class ProtonBasedLegacyCommandWrapper implements Command {
     }
 
     @Override
+    public void setGatewayId(final String gatewayId) {
+        command.setGatewayId(gatewayId);
+    }
+
+    @Override
     public String getName() {
         return command.getName();
     }

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommand.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommand.java
@@ -149,22 +149,6 @@ public final class KafkaBasedCommand implements Command {
         return RecordUtil.getStringHeaderValue(record.headers(), header);
     }
 
-    /**
-     * Sets the identifier of the gateway this command is to be sent to.
-     * <p>
-     * A scenario where the gateway information isn't taken from the command record
-     * (see {@link #fromRoutedCommandRecord(KafkaConsumerRecord)}) but instead needs
-     * to be set manually here would be the case of a gateway subscribing for commands
-     * targeted at a specific device. In that scenario, the Command Router does the
-     * routing based on the edge device identifier and only the target protocol adapter
-     * knows about the gateway association.
-     *
-     * @param gatewayId The gateway identifier.
-     */
-    public void setGatewayId(final String gatewayId) {
-        this.gatewayId = gatewayId;
-    }
-
     @Override
     public boolean isOneWay() {
         return correlationId == null;
@@ -206,6 +190,23 @@ public final class KafkaBasedCommand implements Command {
     @Override
     public String getGatewayId() {
         return gatewayId;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A scenario where the gateway information isn't taken from the command record
+     * (see {@link #fromRoutedCommandRecord(KafkaConsumerRecord)}) but instead needs
+     * to be set manually here would be the case of a gateway subscribing for commands
+     * targeted at a specific device. In that scenario, the Command Router does the
+     * routing based on the edge device identifier and only the target protocol adapter
+     * knows about the gateway association.
+     *
+     * @param gatewayId The gateway identifier.
+     */
+    @Override
+    public void setGatewayId(final String gatewayId) {
+        this.gatewayId = gatewayId;
     }
 
     @Override
@@ -260,10 +261,10 @@ public final class KafkaBasedCommand implements Command {
     public String toString() {
         if (isValid()) {
             if (isTargetedAtGateway()) {
-                return String.format("Command [name: %s, tenant-id: %s, gateway-id %s, device-id %s, request-id: %s]",
+                return String.format("Command [name: %s, tenant-id: %s, gateway-id: %s, device-id: %s, request-id: %s]",
                         getName(), tenantId, gatewayId, deviceId, requestId);
             } else {
-                return String.format("Command [name: %s, tenant-id: %s, device-id %s, request-id: %s]",
+                return String.format("Command [name: %s, tenant-id: %s, device-id: %s, request-id: %s]",
                         getName(), tenantId, deviceId, requestId);
             }
         } else {

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
@@ -93,6 +93,16 @@ public interface Command {
     String getGatewayId();
 
     /**
+     * Sets the identifier of the gateway this command is to be sent to.
+     * <p>
+     * Using {@code null} as parameter means that the command is to be forwarded directly
+     * to the device given in the original command message, without using a gateway.
+     *
+     * @param gatewayId The gateway identifier.
+     */
+    void setGatewayId(String gatewayId);
+
+    /**
      * Gets the name of this command.
      *
      * @return The name.

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/InternalCommandSender.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/InternalCommandSender.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.command;
+
+import org.eclipse.hono.util.Lifecycle;
+
+import io.vertx.core.Future;
+
+/**
+ * A client to send commands to the internal Command and Control API endpoint provided by protocol adapters.
+ */
+public interface InternalCommandSender extends Lifecycle {
+
+    /**
+     * Sends a command to the downstream peer, targeting the protocol adapter Command and Control API endpoint
+     * identified by the given protocol adapter instance id.
+     * <p>
+     * Note that the result of the send operation is getting applied to the command context here.
+     * That means implementations are required to invoke one of the given command context's
+     * {@link CommandContext#accept()}, {@link CommandContext#release()}, {@link CommandContext#modify(boolean, boolean)}
+     * or {@link CommandContext#reject(String)} methods based on the outcome of sending the command to the
+     * protocol adapter instance.
+     *
+     * @param commandContext The context of the command to send.
+     * @param adapterInstanceId The protocol adapter instance id to send the command to.
+     * @return A future that will be succeeded once the outcome of the send operation has been applied to
+     *         the command context.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<Void> sendCommand(CommandContext commandContext, String adapterInstanceId);
+}

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandler.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandler.java
@@ -20,6 +20,8 @@ import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.adapter.client.command.Command;
+import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedCommand;
 import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedCommandContext;
 import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedInternalCommandSender;
@@ -133,8 +135,8 @@ public class MappingAndDelegatingCommandHandler {
     }
 
     private void mapAndDelegateIncomingCommand(final String tenantId, final String deviceId,
-            final ProtonBasedCommandContext commandContext) {
-        final ProtonBasedCommand command = commandContext.getCommand();
+            final CommandContext commandContext) {
+        final Command command = commandContext.getCommand();
 
         // determine last used gateway device id
         LOG.trace("determine command target gateway/adapter for [{}]", command);

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandler.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandler.java
@@ -20,18 +20,14 @@ import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.Command;
-import org.eclipse.hono.client.CommandContext;
-import org.eclipse.hono.client.DelegatedCommandSender;
+import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedCommand;
+import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedCommandContext;
+import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedInternalCommandSender;
 import org.eclipse.hono.client.HonoConnection;
-import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.client.impl.CommandConsumer;
-import org.eclipse.hono.client.impl.DelegatedCommandSenderImpl;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.tracing.TracingHelper;
-import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
@@ -54,27 +50,22 @@ public class MappingAndDelegatingCommandHandler {
 
     private final HonoConnection connection;
     private final CommandTargetMapper commandTargetMapper;
-    private final CachingClientFactory<DelegatedCommandSender> delegatedCommandSenderFactory;
-    private final SendMessageSampler sampler;
+    private final ProtonBasedInternalCommandSender internalCommandSender;
 
     /**
      * Creates a new MappingAndDelegatingCommandHandler instance.
      *
      * @param connection The connection to the AMQP network.
      * @param commandTargetMapper The mapper component to determine the command target.
-     * @param sampler The sampler to use.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public MappingAndDelegatingCommandHandler(
             final HonoConnection connection,
-            final CommandTargetMapper commandTargetMapper,
-            final SendMessageSampler sampler) {
+            final CommandTargetMapper commandTargetMapper) {
         this.connection = Objects.requireNonNull(connection);
         this.commandTargetMapper = Objects.requireNonNull(commandTargetMapper);
-        this.sampler = sampler;
 
-        this.delegatedCommandSenderFactory = new CachingClientFactory<>(connection.getVertx(), s -> s.isOpen());
-        this.connection.addDisconnectListener(con -> delegatedCommandSenderFactory.clearState());
+        this.internalCommandSender = new ProtonBasedInternalCommandSender(connection);
     }
 
     /**
@@ -85,17 +76,17 @@ public class MappingAndDelegatingCommandHandler {
      * and delegates the command to the resulting protocol adapter instance.
      *
      * @param tenantId The tenant that the command target must belong to.
-     * @param originalMessageDelivery The delivery of the command message.
+     * @param messageDelivery The delivery of the command message.
      * @param message The command message.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public void mapAndDelegateIncomingCommandMessage(
             final String tenantId,
-            final ProtonDelivery originalMessageDelivery,
+            final ProtonDelivery messageDelivery,
             final Message message) {
 
         Objects.requireNonNull(tenantId);
-        Objects.requireNonNull(originalMessageDelivery);
+        Objects.requireNonNull(messageDelivery);
         Objects.requireNonNull(message);
 
         // this is the place where a command message on the "command/${tenant}" address arrives *first*
@@ -103,7 +94,7 @@ public class MappingAndDelegatingCommandHandler {
             LOG.debug("command message has no address");
             final Rejected rejected = new Rejected();
             rejected.setError(new ErrorCondition(Constants.AMQP_BAD_REQUEST, "missing command target address"));
-            originalMessageDelivery.disposition(rejected, true);
+            messageDelivery.disposition(rejected, true);
             return;
         }
         final ResourceIdentifier targetAddress = ResourceIdentifier.fromString(message.getAddress());
@@ -112,123 +103,76 @@ public class MappingAndDelegatingCommandHandler {
             LOG.debug("command message address contains invalid tenant [expected: {}, found: {}]", tenantId, targetAddress.getTenantId());
             final Rejected rejected = new Rejected();
             rejected.setError(new ErrorCondition(AmqpError.UNAUTHORIZED_ACCESS, "unauthorized to send command to tenant"));
-            originalMessageDelivery.disposition(rejected, true);
+            messageDelivery.disposition(rejected, true);
             return;
-        } else if (deviceId == null) {
+        } else if (Strings.isNullOrEmpty(deviceId)) {
             LOG.debug("invalid command message address: {}", message.getAddress());
             final Rejected rejected = new Rejected();
             rejected.setError(new ErrorCondition(Constants.AMQP_BAD_REQUEST, "invalid command target address"));
-            originalMessageDelivery.disposition(rejected, true);
+            messageDelivery.disposition(rejected, true);
             return;
         }
 
-        final Command command = Command.from(message, tenantId, deviceId);
+        final ProtonBasedCommand command = ProtonBasedCommand.from(message);
         if (command.isValid()) {
-            LOG.trace("received valid command message: [{}]", command);
+            LOG.trace("received valid command message: {}", command);
         } else {
             LOG.debug("received invalid command message: {}", command);
         }
         final SpanContext spanContext = TracingHelper.extractSpanContext(connection.getTracer(), message);
         final Span currentSpan = CommandConsumer.createSpan("map and delegate command", tenantId, deviceId, null,
                 connection.getTracer(), spanContext);
-        CommandConsumer.logReceivedCommandToSpan(command, currentSpan);
-        final CommandContext commandContext = CommandContext.from(command, originalMessageDelivery, currentSpan);
+        command.logToSpan(currentSpan);
+        final ProtonBasedCommandContext commandContext = new ProtonBasedCommandContext(command, messageDelivery, currentSpan);
         if (command.isValid()) {
             mapAndDelegateIncomingCommand(tenantId, deviceId, commandContext);
         } else {
             // command message is invalid
-            commandContext.reject(getMalformedMessageError());
+            commandContext.reject("malformed command message");
         }
     }
 
-    private void mapAndDelegateIncomingCommand(final String tenantId, final String originalDeviceId,
-            final CommandContext originalCommandContext) {
-        final Command originalCommand = originalCommandContext.getCommand();
+    private void mapAndDelegateIncomingCommand(final String tenantId, final String deviceId,
+            final ProtonBasedCommandContext commandContext) {
+        final ProtonBasedCommand command = commandContext.getCommand();
 
         // determine last used gateway device id
-        LOG.trace("determine command target gateway/adapter for [{}]", originalCommand);
+        LOG.trace("determine command target gateway/adapter for [{}]", command);
         final Future<JsonObject> commandTargetFuture = commandTargetMapper.getTargetGatewayAndAdapterInstance(tenantId,
-                originalDeviceId, originalCommandContext.getTracingContext());
+                deviceId, commandContext.getTracingContext());
 
-        commandTargetFuture.onComplete(commandTargetResult -> {
-            if (commandTargetResult.succeeded()) {
-                final String targetDeviceId = commandTargetResult.result().getString(DeviceConnectionConstants.FIELD_PAYLOAD_DEVICE_ID);
-                final String targetAdapterInstance = commandTargetResult.result().getString(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID);
+        commandTargetFuture.onComplete(cmdTargetResult -> {
+            if (cmdTargetResult.succeeded()) {
+                final String targetDeviceId = cmdTargetResult.result().getString(DeviceConnectionConstants.FIELD_PAYLOAD_DEVICE_ID);
+                final String targetAdapterInstance = cmdTargetResult.result().getString(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID);
 
-                final String targetGatewayId = targetDeviceId.equals(originalDeviceId) ? null : targetDeviceId;
-                final CommandContext commandContext = adaptCommandContextToGatewayIfNeeded(originalCommandContext, targetGatewayId);
-                delegateCommandMessageToAdapterInstance(targetAdapterInstance, commandContext);
+                final String targetGatewayId = targetDeviceId.equals(deviceId) ? null : targetDeviceId;
+                if (targetGatewayId == null) {
+                    LOG.trace("command not mapped to gateway, use original device id [{}]", command.getDeviceId());
+                } else {
+                    LOG.trace("determined target gateway [{}] for device [{}]", targetGatewayId, command.getDeviceId());
+                    commandContext.getTracingSpan().log("determined target gateway [" + targetGatewayId + "]");
+                    command.setGatewayId(targetGatewayId);
+                }
+                LOG.trace("delegate command to target adapter instance '{}' [command: {}]", targetAdapterInstance,
+                        commandContext.getCommand());
+                internalCommandSender.sendCommand(commandContext, targetAdapterInstance);
 
             } else {
-                if (commandTargetResult.cause() instanceof ServiceInvocationException
-                        && ((ServiceInvocationException) commandTargetResult.cause()).getErrorCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-                    LOG.debug("no target adapter instance found for command for device {}", originalDeviceId);
-                    TracingHelper.logError(originalCommandContext.getTracingSpan(),
-                            "no target adapter instance found for command with device id " + originalDeviceId);
+                if (cmdTargetResult.cause() instanceof ServiceInvocationException
+                        && ((ServiceInvocationException) cmdTargetResult.cause()).getErrorCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+                    LOG.debug("no target adapter instance found for command for device {}", deviceId);
+                    TracingHelper.logError(commandContext.getTracingSpan(),
+                            "no target adapter instance found for command with device id " + deviceId);
                 } else {
                     LOG.debug("error getting target gateway and adapter instance for command with device id {}",
-                            originalDeviceId, commandTargetResult.cause());
-                    TracingHelper.logError(originalCommandContext.getTracingSpan(),
-                            "error getting target gateway and adapter instance for command with device id " + originalDeviceId,
-                            commandTargetResult.cause());
+                            deviceId, cmdTargetResult.cause());
+                    TracingHelper.logError(commandContext.getTracingSpan(),
+                            "error getting target gateway and adapter instance for command with device id " + deviceId,
+                            cmdTargetResult.cause());
                 }
-                originalCommandContext.release();
+                commandContext.release();
             }
-        });
-    }
-
-    private ErrorCondition getMalformedMessageError() {
-        return new ErrorCondition(Constants.AMQP_BAD_REQUEST, "malformed command message");
-    }
-
-    private CommandContext adaptCommandContextToGatewayIfNeeded(final CommandContext originalCommandContext, final String gatewayId) {
-        final Command originalCommand = originalCommandContext.getCommand();
-        final String tenantId = originalCommand.getTenant();
-        final String originalDeviceId = originalCommand.getDeviceId();
-
-        final CommandContext commandContext;
-        if (gatewayId == null) {
-            LOG.trace("command not mapped to gateway, use original device id {}", originalDeviceId);
-            commandContext = originalCommandContext;
-        } else {
-            LOG.trace("determined target gateway {} for device {}", gatewayId, originalDeviceId);
-            originalCommandContext.getTracingSpan().log("determined target gateway " + gatewayId);
-            if (!originalCommand.isOneWay()) {
-                originalCommand.getCommandMessage().setReplyTo(String.format("%s/%s/%s",
-                        CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, originalCommand.getReplyToId()));
-            }
-            final Command command = Command.from(originalCommand.getCommandMessage(), tenantId, gatewayId);
-            commandContext = CommandContext.from(command, originalCommandContext.getDelivery(),
-                    originalCommandContext.getTracingSpan());
-        }
-        return commandContext;
-    }
-
-    private void delegateCommandMessageToAdapterInstance(final String targetAdapterInstance, final CommandContext commandContext) {
-        LOG.trace("delegate command to target adapter instance '{}' [command: {}]", targetAdapterInstance, commandContext.getCommand());
-        getOrCreateDelegatedCommandSender(targetAdapterInstance)
-                .compose(sender -> sender.sendCommandMessage(commandContext.getCommand(), commandContext.getTracingContext()))
-                .onComplete(ar -> {
-                    if (ar.succeeded()) {
-                        final ProtonDelivery delegatedMsgDelivery = ar.result();
-                        LOG.trace("command [{}] sent to downstream peer; remote state of delivery: {}",
-                                commandContext.getCommand(), delegatedMsgDelivery.getRemoteState());
-                        commandContext.disposition(delegatedMsgDelivery.getRemoteState());
-                    } else {
-                        LOG.debug("failed to send command [{}] to downstream peer", commandContext.getCommand(), ar.cause());
-                        TracingHelper.logError(commandContext.getTracingSpan(),
-                                "failed to send command message to downstream peer: " + ar.cause());
-                        commandContext.release();
-                    }
-                });
-    }
-
-    private Future<DelegatedCommandSender> getOrCreateDelegatedCommandSender(final String protocolAdapterInstanceId) {
-        return connection.executeOnContext(result -> {
-            delegatedCommandSenderFactory.getOrCreateClient(protocolAdapterInstanceId,
-                    () -> DelegatedCommandSenderImpl.create(connection, protocolAdapterInstanceId, sampler,
-                            onSenderClosed -> delegatedCommandSenderFactory.removeClient(protocolAdapterInstanceId)),
-                    result);
         });
     }
 

--- a/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/MappingAndDelegatingCommandHandlerTest.java
@@ -36,7 +36,6 @@ import org.apache.qpid.proton.amqp.transport.Target;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
-import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.test.VertxMockSupport;
@@ -99,7 +98,7 @@ public class MappingAndDelegatingCommandHandlerTest {
         commandTargetMapper = mock(CommandTargetMapper.class);
 
         mappingAndDelegatingCommandHandler = new MappingAndDelegatingCommandHandler(
-                connection, commandTargetMapper, SendMessageSampler.noop());
+                connection, commandTargetMapper);
     }
 
     /**


### PR DESCRIPTION
The Command Router now uses the new API for sending command messages to the target protocol adapter instance.