### PR TITLE
[#2393] Migrating to ProtonBasedDownstreamSender in AutoProvisioner.

### DIFF
--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -32,6 +32,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-adapter-amqp</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
     </dependency>

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisioner.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisioner.java
@@ -19,8 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.DownstreamSender;
-import org.eclipse.hono.client.DownstreamSenderFactory;
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
@@ -37,7 +36,7 @@ import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.Lifecycle;
 import org.eclipse.hono.util.MessageHelper;
-import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TenantObject;
 import org.eclipse.hono.util.TenantResult;
@@ -50,11 +49,9 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.opentracing.tag.Tags;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.proton.ProtonDelivery;
 
 /**
  * Implements gateway based auto-provisioning.
@@ -69,7 +66,7 @@ public class AutoProvisioner implements Lifecycle {
 
     private TenantInformationService tenantInformationService = new NoopTenantInformationService();
 
-    private DownstreamSenderFactory downstreamSenderFactory;
+    private ProtonBasedDownstreamSender protonBasedDownstreamSender;
 
     private Future<HonoConnection> connectionAttempt;
 
@@ -83,7 +80,7 @@ public class AutoProvisioner implements Lifecycle {
         // to start(). This results in an exception in the factory's connect() method.
         synchronized (this) {
             if (connectionAttempt == null) {
-                connectionAttempt = downstreamSenderFactory.connect().map(connection -> {
+                connectionAttempt = protonBasedDownstreamSender.connect().map(connection -> {
                     LOG.info("connected to AMQP network");
                     if (vertx == null && connection != null) {
                         vertx = connection.getVertx();
@@ -102,7 +99,7 @@ public class AutoProvisioner implements Lifecycle {
     @Override
     public final Future<Void> stop() {
         final Promise<Void> result = Promise.promise();
-        downstreamSenderFactory.disconnect(result);
+        protonBasedDownstreamSender.disconnect(result);
         return result.future();
     }
 
@@ -124,8 +121,8 @@ public class AutoProvisioner implements Lifecycle {
      * @throws NullPointerException if the factory is {@code null}.
      */
     @Autowired
-    public final void setDownstreamSenderFactory(final DownstreamSenderFactory factory) {
-        this.downstreamSenderFactory = Objects.requireNonNull(factory);
+    public final void setProtonBasedDownstreamSender(final ProtonBasedDownstreamSender factory) {
+        this.protonBasedDownstreamSender = Objects.requireNonNull(factory);
     }
 
     /**
@@ -181,7 +178,7 @@ public class AutoProvisioner implements Lifecycle {
         this.config = Objects.requireNonNull(config);
     }
 
-    private Future<ProtonDelivery> sendAutoProvisioningEvent(
+    private Future<Void> sendAutoProvisioningEvent(
             final String tenantId,
             final String deviceId,
             final String gatewayId,
@@ -195,16 +192,13 @@ public class AutoProvisioner implements Lifecycle {
         LOG.debug("sending auto-provisioning event for device [{}] created via gateway [{}] [tenant-id: {}]", deviceId, gatewayId, tenantId);
 
         final Future<TenantResult<TenantObject>> tenantTracker = tenantInformationService.getTenant(tenantId, span);
-        final Future<DownstreamSender> senderTracker = downstreamSenderFactory.getOrCreateEventSender(tenantId);
 
-        return CompositeFuture.all(tenantTracker, senderTracker).compose(ok -> {
+        return tenantTracker.compose(ok -> {
             if (tenantTracker.result().isError()) {
                 return Future.failedFuture(StatusCodeMapper.from(tenantTracker.result()));
             }
 
             final Map<String, Object> props = new HashMap<>();
-            props.put(MessageHelper.APP_PROPERTY_QOS, QoS.AT_LEAST_ONCE.ordinal());
-            props.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId);
             props.put(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
             props.put(MessageHelper.APP_PROPERTY_GATEWAY_ID, gatewayId);
             props.put(MessageHelper.APP_PROPERTY_REGISTRATION_STATUS, EventConstants.RegistrationStatus.NEW.name());
@@ -221,8 +215,12 @@ public class AutoProvisioner implements Lifecycle {
                     false,
                     false);
 
-            final DownstreamSender sender = senderTracker.result();
-            return sender.sendAndWaitForOutcome(msg, span.context())
+            return protonBasedDownstreamSender.sendEvent(tenantTracker.result().getPayload(),
+                        new RegistrationAssertion(deviceId),
+                        EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION,
+                        null,
+                        props,
+                        span.context())
                     .onFailure(t -> LOG.info("error sending auto-provisioning event for device [{}] created via gateway [{}] [tenant-id: {}]",
                             deviceId, gatewayId, tenantId));
         });

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisionerConfigProperties.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisionerConfigProperties.java
@@ -12,12 +12,13 @@
  *******************************************************************************/
 package org.eclipse.hono.deviceregistry.service.device;
 
+import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.RegistrationConstants;
 
 /**
  * Configuration properties for Hono's gateway-based auto-provisioning.
  */
-public class AutoProvisionerConfigProperties {
+public class AutoProvisionerConfigProperties extends ProtocolAdapterProperties {
 
     /**
      * Delay in milliseconds before trying to send the auto-provisioning notification if the initial attempt

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisionerTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisionerTest.java
@@ -107,7 +107,7 @@ class AutoProvisionerTest {
                 any(SpanContext.class)))
             .thenReturn(Future.succeededFuture());
 
-        autoProvisioner.setProtonBasedDownstreamSender(sender);
+        autoProvisioner.setEventSender(sender);
 
         when(deviceManagementService
                 .updateDevice(eq(Constants.DEFAULT_TENANT), eq(DEVICE_ID), any(Device.class), any(), any()))

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -230,7 +230,7 @@ public class FileBasedServiceConfig {
         autoProvisioner.setVertx(vertx);
         autoProvisioner.setTracer(tracer);
         autoProvisioner.setTenantInformationService(tenantInformationService());
-        autoProvisioner.setProtonBasedDownstreamSender(protonBasedDownstreamSender(vertx, tracer));
+        autoProvisioner.setEventSender(protonBasedDownstreamSender(vertx, tracer));
         autoProvisioner.setConfig(autoProvisionerConfigProperties());
 
         registrationService.setAutoProvisioner(autoProvisioner);

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.eclipse.hono.client.DownstreamSenderFactory;
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.deviceregistry.DeviceRegistryTestUtils;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
@@ -96,15 +96,15 @@ public class FileBasedRegistrationServiceTest implements RegistrationServiceTest
         autoProvisioner.setDeviceManagementService(registrationService);
         autoProvisioner.setConfig(new AutoProvisionerConfigProperties());
 
-        final DownstreamSenderFactory downstreamSenderFactoryMock = mock(DownstreamSenderFactory.class);
-        when(downstreamSenderFactoryMock.connect()).thenReturn(Future.succeededFuture());
+        final ProtonBasedDownstreamSender downstreamSender = mock(ProtonBasedDownstreamSender.class);
+        when(downstreamSender.connect()).thenReturn(Future.succeededFuture());
         doAnswer(invocation -> {
             final Handler<AsyncResult<Void>> handler = invocation.getArgument(0);
             handler.handle(Future.succeededFuture());
             return null;
-        }).when(downstreamSenderFactoryMock).disconnect(VertxMockSupport.anyHandler());
+        }).when(downstreamSender).disconnect(VertxMockSupport.anyHandler());
 
-        autoProvisioner.setDownstreamSenderFactory(downstreamSenderFactoryMock);
+        autoProvisioner.setProtonBasedDownstreamSender(downstreamSender);
 
         registrationService.setAutoProvisioner(autoProvisioner);
     }

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.deviceregistry.DeviceRegistryTestUtils;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
@@ -46,7 +46,6 @@ import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.management.device.Status;
 import org.eclipse.hono.service.registration.RegistrationService;
 import org.eclipse.hono.service.registration.RegistrationServiceTests;
-import org.eclipse.hono.test.VertxMockSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,15 +95,11 @@ public class FileBasedRegistrationServiceTest implements RegistrationServiceTest
         autoProvisioner.setDeviceManagementService(registrationService);
         autoProvisioner.setConfig(new AutoProvisionerConfigProperties());
 
-        final ProtonBasedDownstreamSender downstreamSender = mock(ProtonBasedDownstreamSender.class);
-        when(downstreamSender.connect()).thenReturn(Future.succeededFuture());
-        doAnswer(invocation -> {
-            final Handler<AsyncResult<Void>> handler = invocation.getArgument(0);
-            handler.handle(Future.succeededFuture());
-            return null;
-        }).when(downstreamSender).disconnect(VertxMockSupport.anyHandler());
+        final EventSender eventSender = mock(EventSender.class);
+        when(eventSender.start()).thenReturn(Future.succeededFuture());
+        when(eventSender.stop()).thenReturn(Future.succeededFuture());
 
-        autoProvisioner.setProtonBasedDownstreamSender(downstreamSender);
+        autoProvisioner.setEventSender(eventSender);
 
         registrationService.setAutoProvisioner(autoProvisioner);
     }

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -436,7 +436,7 @@ public class ApplicationConfig {
         autoProvisioner.setDeviceManagementService(registrationManagementService());
         autoProvisioner.setVertx(vertx);
         autoProvisioner.setTracer(tracer);
-        autoProvisioner.setProtonBasedDownstreamSender(protonBasedDownstreamSender(vertx, tracer));
+        autoProvisioner.setEventSender(protonBasedDownstreamSender(vertx, tracer));
         autoProvisioner.setConfig(autoProvisionerConfigProperties());
 
         registrationService.setAutoProvisioner(autoProvisioner);

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -16,10 +16,11 @@ package org.eclipse.hono.deviceregistry.jdbc;
 import java.io.IOException;
 import java.util.Optional;
 
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
-import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ServerConfig;
@@ -356,31 +357,34 @@ public class ApplicationConfig {
     /**
      * Exposes a factory for creating clients for the <em>AMQP Messaging Network</em> as a Spring bean.
      * <p>
-     * The factory is initialized with the connection provided by {@link #downstreamConnection(Vertx)}.
+     * The factory is initialized with the connection provided by {@link #downstreamConnection(Vertx, Tracer)}.
      *
      * @param vertx The vert.x instance to run on.
+     * @param tracer The tracer to be used.
      *
      * @return The factory.
      */
     @Bean
     @Scope("prototype")
-    public DownstreamSenderFactory downstreamSenderFactory(final Vertx vertx) {
-        return DownstreamSenderFactory.create(downstreamConnection(vertx));
+    public ProtonBasedDownstreamSender protonBasedDownstreamSender(final Vertx vertx, final Tracer tracer) {
+        return new ProtonBasedDownstreamSender(
+                downstreamConnection(vertx, tracer),
+                SendMessageSampler.Factory.noop(),
+                autoProvisionerConfigProperties());
     }
 
     /**
-     * Exposes the connection to the <em>AMQP Messaging Network</em> as a Spring bean.
-     * <p>
-     * The connection is configured with the properties provided by {@link #downstreamSenderFactoryConfig()}.
+     * Creates a new downstream sender for telemetry and event messages.
      *
      * @param vertx The vert.x instance to run on.
+     * @param tracer The tracer to be used.
      *
      * @return The connection.
      */
     @Bean
     @Scope("prototype")
-    public HonoConnection downstreamConnection(final Vertx vertx) {
-        return HonoConnection.newConnection(vertx, downstreamSenderFactoryConfig());
+    public HonoConnection downstreamConnection(final Vertx vertx, final Tracer tracer) {
+        return HonoConnection.newConnection(vertx, downstreamSenderConfig(), tracer);
     }
 
     /**
@@ -390,8 +394,16 @@ public class ApplicationConfig {
      */
     @ConfigurationProperties(prefix = "hono.messaging")
     @Bean
-    public ClientConfigProperties downstreamSenderFactoryConfig() {
+    public ClientConfigProperties downstreamSenderConfig() {
+        final ClientConfigProperties config = new ClientConfigProperties();
+        setDefaultConfigNameIfNotSet(config);
         return new ClientConfigProperties();
+    }
+
+    private void setDefaultConfigNameIfNotSet(final ClientConfigProperties config) {
+        if (config.getName() == null) {
+            config.setName("Device Registry");
+        }
     }
 
     /**
@@ -424,7 +436,7 @@ public class ApplicationConfig {
         autoProvisioner.setDeviceManagementService(registrationManagementService());
         autoProvisioner.setVertx(vertx);
         autoProvisioner.setTracer(tracer);
-        autoProvisioner.setDownstreamSenderFactory(downstreamSenderFactory(vertx));
+        autoProvisioner.setProtonBasedDownstreamSender(protonBasedDownstreamSender(vertx, tracer));
         autoProvisioner.setConfig(autoProvisionerConfigProperties());
 
         registrationService.setAutoProvisioner(autoProvisioner);

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -378,7 +378,7 @@ public class ApplicationConfig {
         autoProvisioner.setTracer(tracer);
         autoProvisioner.setDeviceManagementService(service);
         autoProvisioner.setTenantInformationService(tenantInformationService);
-        autoProvisioner.setProtonBasedDownstreamSender(protonBasedDownstreamSender(vertx, tracer));
+        autoProvisioner.setEventSender(protonBasedDownstreamSender(vertx, tracer));
         autoProvisioner.setConfig(autoProvisionerConfigProperties());
 
         service.setAutoProvisioner(autoProvisioner);

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -15,10 +15,11 @@ package org.eclipse.hono.deviceregistry.mongodb;
 
 import java.util.Optional;
 
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
-import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ServerConfig;
@@ -292,33 +293,36 @@ public class ApplicationConfig {
     }
 
     /**
-     * Exposes a factory for creating clients for the <em>AMQP Messaging Network</em> as a Spring bean.
-     * <p>
-     * The factory is initialized with the connection provided by {@link #downstreamConnection(Vertx)}.
+     * Creates a new downstream sender for telemetry and event messages.
      *
      * @param vertx The vert.x instance to run on.
+     * @param tracer The tracer to be used.
      *
      * @return The factory.
      */
     @Bean
     @Scope("prototype")
-    public DownstreamSenderFactory downstreamSenderFactory(final Vertx vertx) {
-        return DownstreamSenderFactory.create(downstreamConnection(vertx));
+    public ProtonBasedDownstreamSender protonBasedDownstreamSender(final Vertx vertx, final Tracer tracer) {
+        return new ProtonBasedDownstreamSender(
+                downstreamConnection(vertx, tracer),
+                SendMessageSampler.Factory.noop(),
+                autoProvisionerConfigProperties());
     }
 
     /**
      * Exposes the connection to the <em>AMQP Messaging Network</em> as a Spring bean.
      * <p>
-     * The connection is configured with the properties provided by {@link #downstreamSenderFactoryConfig()}.
+     * The connection is configured with the properties provided by {@link #downstreamSenderConfig()}.
      *
      * @param vertx The vert.x instance to run on.
+     * @param tracer The tracer to be used.
      *
      * @return The connection.
      */
     @Bean
     @Scope("prototype")
-    public HonoConnection downstreamConnection(final Vertx vertx) {
-        return HonoConnection.newConnection(vertx, downstreamSenderFactoryConfig());
+    public HonoConnection downstreamConnection(final Vertx vertx, final Tracer tracer) {
+        return HonoConnection.newConnection(vertx, downstreamSenderConfig(), tracer);
     }
 
     /**
@@ -328,8 +332,16 @@ public class ApplicationConfig {
      */
     @ConfigurationProperties(prefix = "hono.messaging")
     @Bean
-    public ClientConfigProperties downstreamSenderFactoryConfig() {
+    public ClientConfigProperties downstreamSenderConfig() {
+        final ClientConfigProperties config = new ClientConfigProperties();
+        setDefaultConfigNameIfNotSet(config);
         return new ClientConfigProperties();
+    }
+
+    private void setDefaultConfigNameIfNotSet(final ClientConfigProperties config) {
+        if (config.getName() == null) {
+            config.setName("Device Registry");
+        }
     }
 
     /**
@@ -366,7 +378,7 @@ public class ApplicationConfig {
         autoProvisioner.setTracer(tracer);
         autoProvisioner.setDeviceManagementService(service);
         autoProvisioner.setTenantInformationService(tenantInformationService);
-        autoProvisioner.setDownstreamSenderFactory(downstreamSenderFactory(vertx));
+        autoProvisioner.setProtonBasedDownstreamSender(protonBasedDownstreamSender(vertx, tracer));
         autoProvisioner.setConfig(autoProvisionerConfigProperties());
 
         service.setAutoProvisioner(autoProvisioner);

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.hono.client.DownstreamSenderFactory;
+import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
@@ -73,8 +73,8 @@ public class MongoDbBasedRegistrationServiceTest implements RegistrationServiceT
         vertx = Vertx.vertx();
         mongoClient = MongoDbTestUtils.getMongoClient(vertx, "hono-devices-test");
 
-        final DownstreamSenderFactory downstreamSenderFactoryMock = mock(DownstreamSenderFactory.class);
-        when(downstreamSenderFactoryMock.connect()).thenReturn(Future.succeededFuture());
+        final ProtonBasedDownstreamSender downstreamSender = mock(ProtonBasedDownstreamSender.class);
+        when(downstreamSender.connect()).thenReturn(Future.succeededFuture());
 
         registrationService = new MongoDbBasedRegistrationService(
                 vertx,
@@ -85,12 +85,12 @@ public class MongoDbBasedRegistrationServiceTest implements RegistrationServiceT
         final AutoProvisioner autoProvisioner = new AutoProvisioner();
         autoProvisioner.setConfig(new AutoProvisionerConfigProperties());
         autoProvisioner.setDeviceManagementService(registrationService);
-        autoProvisioner.setDownstreamSenderFactory(downstreamSenderFactoryMock);
+        autoProvisioner.setProtonBasedDownstreamSender(downstreamSender);
         doAnswer(invocation -> {
             final Handler<AsyncResult<Void>> handler = invocation.getArgument(0);
             handler.handle(Future.succeededFuture());
             return null;
-        }).when(downstreamSenderFactoryMock).disconnect(VertxMockSupport.anyHandler());
+        }).when(downstreamSender).disconnect(VertxMockSupport.anyHandler());
 
         registrationService.setAutoProvisioner(autoProvisioner);
 


### PR DESCRIPTION
This fixes #2393

Signed-off-by: Florian Kaltner <florian.kaltner@bosch.io>