### PR TITLE
Fix -DskipTests not working for docker related tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
     <!--
       Needs to be set to true on platforms where no Docker daemon is available.
     -->
-    <no.docker>false</no.docker>
+    <skipDockerTests>${skipTests}</skipDockerTests>
 
     <!--
       Build images defined in modules with packaging type "pom".
@@ -516,7 +516,7 @@
       </activation>
       <properties>
         <!-- this will prevent (unit) tests from being run that require test containers -->
-        <no.docker>true</no.docker>
+        <skipDockerTests>true</skipDockerTests>
       </properties>
     </profile>
     <profile>

--- a/services/device-registry-jdbc/pom.xml
+++ b/services/device-registry-jdbc/pom.xml
@@ -99,7 +99,7 @@
               <goal>test</goal>
             </goals>
             <configuration>
-              <skipTests>${no.docker}</skipTests>
+              <skipTests>${skipDockerTests}</skipTests>
               <systemPropertyVariables>
                 <AbstractJdbcRegistryTest.databaseType>postgresql</AbstractJdbcRegistryTest.databaseType>
                 <AbstractJdbcRegistryTest.postgresqlImageName>${postgresql-image.name}</AbstractJdbcRegistryTest.postgresqlImageName>

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -62,7 +62,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <skipTests>${no.docker}</skipTests>
+          <skipTests>${skipDockerTests}</skipTests>
           <systemProperties>
             <mongoDbImageName>${mongodb-image.name}</mongoDbImageName>
           </systemProperties>


### PR DESCRIPTION
The "no.docker" property has been replaced by "skipDockerTests", initialized to the "skipTests" value by default.
This re-enables the possibility to skip all tests via the -DskipTests maven argument.