### PR TITLE
Fix queue full handling

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/ResourceLimitExceededException.java
+++ b/client/src/main/java/org/eclipse/hono/client/ResourceLimitExceededException.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client;
+
+import java.net.HttpURLConnection;
+
+/**
+ * A {@link ServerErrorException} indicating that a request message was not processed
+ * because the client's resource limits have been exceeded.
+ * <p>
+ * Possible causes include the maximum capacity of a message queue being reached.
+ */
+public class ResourceLimitExceededException extends ServerErrorException {
+
+    /**
+     * Resource key for the error message.
+     */
+    public static final String MESSAGE_KEY = "SERVER_ERROR_RESOURCE_LIMIT_EXCEEDED";
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new exception.
+     * <p>
+     * The exception will have a <em>503: Unavailable</em> status code
+     * and its client facing error message will be set to the localized message
+     * with the key defined in {@link #MESSAGE_KEY}.
+     */
+    public ResourceLimitExceededException() {
+        this(null);
+    }
+
+    /**
+     * Creates a new exception.
+     * <p>
+     * The exception will have a <em>503: Unavailable</em> status code
+     * and its client facing error message will be set to the localized message
+     * with the key defined in {@link #MESSAGE_KEY}.
+     *
+     * @param message The (internal) detail message of the problem or {@code null}
+     *                if no detail message is available.
+     */
+    public ResourceLimitExceededException(final String message) {
+        super(HttpURLConnection.HTTP_UNAVAILABLE, message);
+        setClientFacingMessageWithKey(MESSAGE_KEY);
+    }
+}

--- a/client/src/main/java/org/eclipse/hono/client/StatusCodeMapper.java
+++ b/client/src/main/java/org/eclipse/hono/client/StatusCodeMapper.java
@@ -162,7 +162,7 @@ public abstract class StatusCodeMapper {
         Objects.requireNonNull(condition);
 
         if (AmqpError.RESOURCE_LIMIT_EXCEEDED.equals(condition)) {
-            return new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, description);
+            return new ResourceLimitExceededException(description);
         } else if (AmqpError.UNAUTHORIZED_ACCESS.equals(condition)) {
             return new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN, description);
         } else if (AmqpError.INTERNAL_ERROR.equals(condition)) {

--- a/client/src/main/resources/org/eclipse/hono/client/ServiceInvocationException_messages.properties
+++ b/client/src/main/resources/org/eclipse/hono/client/ServiceInvocationException_messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -19,4 +19,5 @@ CLIENT_ERROR_MESSAGE_UNDELIVERABLE=consumer declared message as undeliverable, i
 # ServerErrorException
 SERVER_ERROR_MESSAGE_NOT_PROCESSED=consumer didn't process the message
 SERVER_ERROR_NO_CONSUMER=no consumer available
+SERVER_ERROR_RESOURCE_LIMIT_EXCEEDED=consumer rejected the message because a resource limit was exceeded, possibly a (tenant-specific) queue size limit
 SERVER_ERROR_SEND_MESSAGE_TIMEOUT=consumer failed to indicate in time whether it has processed the message

--- a/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/AbstractRequestResponseClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,23 +30,26 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
+import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.Target;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.cache.ExpiringValueCache;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
+import org.eclipse.hono.client.ResourceLimitExceededException;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CacheDirective;
-import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,10 +128,12 @@ public class AbstractRequestResponseClientTest  {
                 "get",
                 Buffer.buffer("hello"),
                 ctx.failing(t -> {
-                    // THEN the message is not sent
-                    verify(sender, never()).send(any(Message.class));
-                    // and the request result handler is failed with a 503
-                    assertFailureCause(ctx, span, t, HttpURLConnection.HTTP_UNAVAILABLE);
+                    ctx.verify(() -> {
+                        // THEN the message is not sent
+                        verify(sender, never()).send(any(Message.class));
+                        // and the request result handler is failed with a 503
+                        assertFailureCause(span, t, HttpURLConnection.HTTP_UNAVAILABLE);
+                    });
                     ctx.completeNow();
                 }),
                 span);
@@ -164,13 +169,39 @@ public class AbstractRequestResponseClientTest  {
     }
 
     /**
-     * Verifies that the client fails the result handler if the peer rejects
-     * the request message.
+     * Verifies that the sender fails with an 503 error code if the peer rejects
+     * a message with an "amqp:resource-limit-exceeded" error.
      *
      * @param ctx The vert.x test context.
      */
     @Test
-    public void testCreateAndSendRequestFailsOnRejectedMessage(final VertxTestContext ctx) {
+    public void testCreateAndSendRequestFailsForResourceLimitExceeded(final VertxTestContext ctx) {
+        testCreateAndSendRequestFailsOnRejectedMessage(
+                ctx,
+                AmqpError.RESOURCE_LIMIT_EXCEEDED,
+                t -> assertThat(t).isInstanceOf(ResourceLimitExceededException.class)
+                    .extracting("clientFacingMessage").isNotNull());
+    }
+
+    /**
+     * Verifies that the sender fails with an 400 error code if the peer rejects
+     * a message with an arbitrary error condition.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateAndSendRequestFailsForArbitraryError(final VertxTestContext ctx) {
+        testCreateAndSendRequestFailsOnRejectedMessage(
+                ctx,
+                Symbol.getSymbol("arbitrary-error"),
+                t -> assertThat(t).isInstanceOf(ServiceInvocationException.class)
+                    .extracting("errorCode").isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST));
+    }
+
+    private void testCreateAndSendRequestFailsOnRejectedMessage(
+            final VertxTestContext ctx,
+            final Symbol errorCondition,
+            final Consumer<Throwable> failureAssertions) {
 
         // GIVEN a request-response client that times out requests after 200 ms
         client.setRequestTimeout(200);
@@ -181,14 +212,16 @@ public class AbstractRequestResponseClientTest  {
                 "get",
                 payload.toBuffer(),
                 ctx.failing(t -> {
-                    // THEN the result handler is failed with a 400 status code
-                    assertFailureCause(ctx, span, t, HttpURLConnection.HTTP_BAD_REQUEST);
+                    ctx.verify(() -> {
+                        // THEN the result handler is failed with the expected error
+                        failureAssertions.accept(t);
+                    });
                     ctx.completeNow();
                 }),
                 span);
         // and the peer rejects the message
         final Rejected rejected = new Rejected();
-        rejected.setError(ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, "request message is malformed"));
+        rejected.setError(ProtonHelper.condition(errorCondition, "request message cannot be processed"));
         final ProtonDelivery delivery = mock(ProtonDelivery.class);
         when(delivery.getRemoteState()).thenReturn(rejected);
         @SuppressWarnings("unchecked")
@@ -282,8 +315,10 @@ public class AbstractRequestResponseClientTest  {
                 Buffer.buffer("hello"),
                 ctx.failing(t -> {
                     // THEN the request fails immediately with a 503
-                    verify(sender, never()).send(any(Message.class), VertxMockSupport.anyHandler());
-                    assertFailureCause(ctx, span, t, HttpURLConnection.HTTP_UNAVAILABLE);
+                    ctx.verify(() -> {
+                        verify(sender, never()).send(any(Message.class), VertxMockSupport.anyHandler());
+                        assertFailureCause(span, t, HttpURLConnection.HTTP_UNAVAILABLE);
+                    });
                     ctx.completeNow();
                 }),
                 span);
@@ -504,7 +539,6 @@ public class AbstractRequestResponseClientTest  {
     }
 
     private void assertFailureCause(
-            final VertxTestContext ctx,
             final Span span,
             final Throwable cause,
             final int expectedErrorCode) {

--- a/client/src/test/java/org/eclipse/hono/client/impl/EventSenderImplTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/EventSenderImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.client.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -22,14 +23,21 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.HttpURLConnection;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
+import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.DownstreamSender;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.ResourceLimitExceededException;
 import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.junit.jupiter.api.BeforeEach;
@@ -99,10 +107,32 @@ public class EventSenderImplTest {
     }
 
     /**
-     * Verifies that the sender fails if the peer does not accept a message.
+     * Verifies that the sender fails with an 503 error code if the peer rejects
+     * a message with an "amqp:resource-limit-exceeded" error.
      */
     @Test
-    public void testSendMessageFailsForRejectedOutcome() {
+    public void testSendMessageFailsForResourceLimitExceeded() {
+        testSendMessageFailsForRejectedOutcome(
+                AmqpError.RESOURCE_LIMIT_EXCEEDED,
+                t -> assertThat(t).isInstanceOf(ResourceLimitExceededException.class)
+                    .extracting("clientFacingMessage").isNotNull());
+    }
+
+    /**
+     * Verifies that the sender fails with an 400 error code if the peer rejects
+     * a message with an arbitrary error condition.
+     */
+    @Test
+    public void testSendMessageFailsForArbitraryError() {
+        testSendMessageFailsForRejectedOutcome(
+                Symbol.getSymbol("arbitrary-error"),
+                t -> assertThat(t).isInstanceOf(ServiceInvocationException.class)
+                    .extracting("errorCode").isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST));
+    }
+
+    private void testSendMessageFailsForRejectedOutcome(
+            final Symbol errorCondition,
+            final Consumer<Throwable> failureAssertions) {
 
         // GIVEN a sender that has credit
         when(sender.sendQueueFull()).thenReturn(Boolean.FALSE);
@@ -122,12 +152,19 @@ public class EventSenderImplTest {
         assertFalse(result.isComplete());
 
         // and the result fails once the peer rejects the message
+        final ErrorCondition condition = new ErrorCondition();
+        condition.setCondition(errorCondition);
+        final Rejected error = new Rejected();
+        error.setError(condition);
         final ProtonDelivery rejected = mock(ProtonDelivery.class);
         when(rejected.remotelySettled()).thenReturn(Boolean.TRUE);
-        when(rejected.getRemoteState()).thenReturn(new Rejected());
+        when(rejected.getRemoteState()).thenReturn(error);
         handlerRef.get().handle(rejected);
 
-        assertFalse(result.succeeded());
+        // the request is failed
+        assertThat(result.failed()).isTrue();
+        // with the expected error
+        failureAssertions.accept(result.cause());
     }
 
     /**

--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericSenderLink.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericSenderLink.java
@@ -29,6 +29,7 @@ import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.Modified;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
@@ -40,6 +41,7 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.SendMessageTimeoutException;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.AddressHelper;
@@ -487,7 +489,7 @@ public class GenericSenderLink extends AbstractHonoClient {
         if (Rejected.class.isInstance(remoteState)) {
             final Rejected rejected = (Rejected) remoteState;
             e = Optional.ofNullable(rejected.getError())
-                    .map(error -> new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, error.getDescription()))
+                    .map(StatusCodeMapper::fromTransferError)
                     .orElseGet(() -> new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST));
         } else if (Released.class.isInstance(remoteState)) {
             e = new MessageNotProcessedException();

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -42,6 +42,9 @@ title = "Release Notes"
   registered for a device. This has been fixed.
 * The Mongo DB based registry container would have failed to start if the connection to the Mongo DB could not
   be established quickly enough. This has been fixed by decoupling the creation of indices from the start up process.
+* The protocol adapters erroneously indicated a client related error to devices if the downstream AMQP container
+  rejected a message with an `amqp:resource-limit-exceeded` error condition. This has been fixed so that the adapters
+  now correctly indicate a server related problem instead.
 
 ### Deprecations
 

--- a/tests/src/test/resources/amqp/logback-spring.xml
+++ b/tests/src/test/resources/amqp/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -31,12 +31,14 @@
   <springProfile name="trace">
     <logger name="org.eclipse.hono.adapter" level="TRACE"/>
     <logger name="org.eclipse.hono.client" level="TRACE"/>
+    <logger name="org.eclipse.hono.client.amqp" level="TRACE"/>
     <logger name="org.eclipse.hono.client.impl" level="TRACE"/>
   </springProfile>
 
   <springProfile name="dev">
     <logger name="org.eclipse.hono.adapter" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client.amqp" level="DEBUG"/>
     <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
     <logger name="org.eclipse.hono.service.auth.device" level="DEBUG"/>

--- a/tests/src/test/resources/coap/logback-spring.xml
+++ b/tests/src/test/resources/coap/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -31,6 +31,7 @@
   <springProfile name="trace">
     <logger name="org.eclipse.hono.adapter" level="TRACE"/>
     <logger name="org.eclipse.hono.client" level="TRACE"/>
+    <logger name="org.eclipse.hono.client.amqp" level="TRACE"/>
     <logger name="org.eclipse.hono.connection" level="TRACE"/>
     <logger name="org.eclipse.hono.service" level="TRACE"/>
   </springProfile>
@@ -38,6 +39,7 @@
   <springProfile name="dev">
     <logger name="org.eclipse.hono.adapter" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client.amqp" level="DEBUG"/>
     <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
     <logger name="org.eclipse.hono.service" level="DEBUG"/>

--- a/tests/src/test/resources/http/logback-spring.xml
+++ b/tests/src/test/resources/http/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -31,6 +31,7 @@
   <springProfile name="trace">
     <logger name="org.eclipse.hono.adapter" level="TRACE"/>
     <logger name="org.eclipse.hono.client" level="TRACE"/>
+    <logger name="org.eclipse.hono.client.amqp" level="TRACE"/>
     <logger name="org.eclipse.hono.connection" level="TRACE"/>
     <logger name="org.eclipse.hono.service" level="TRACE"/>
   </springProfile>
@@ -38,6 +39,7 @@
   <springProfile name="dev">
     <logger name="org.eclipse.hono.adapter" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client.amqp" level="DEBUG"/>
     <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
     <logger name="org.eclipse.hono.service" level="DEBUG"/>

--- a/tests/src/test/resources/mqtt/logback-spring.xml
+++ b/tests/src/test/resources/mqtt/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -31,6 +31,7 @@
   <springProfile name="trace">
     <logger name="org.eclipse.hono.adapter" level="TRACE"/>
     <logger name="org.eclipse.hono.client" level="TRACE"/>
+    <logger name="org.eclipse.hono.client.amqp" level="TRACE"/>
     <logger name="org.eclipse.hono.connection" level="TRACE"/>
     <logger name="org.eclipse.hono.service" level="TRACE"/>
   </springProfile>
@@ -38,6 +39,7 @@
   <springProfile name="dev">
     <logger name="org.eclipse.hono.adapter" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
+    <logger name="org.eclipse.hono.client.amqp" level="DEBUG"/>
     <logger name="org.eclipse.hono.client.impl.AbstractRequestResponseClient" level="DEBUG"/>
     <logger name="org.eclipse.hono.connection" level="DEBUG"/>
     <logger name="org.eclipse.hono.service" level="DEBUG"/>


### PR DESCRIPTION
The AMQP based adapter client has been changed to throw a
ServerErrorException with a status code of 503 in case a downstream AMQP
container rejects a message with error condition
amqp:resource-limit-exceeded.

This allows protocol adapters to notify devices accordingly.