### PR TITLE
[#2053] Adding release notes for gateway-based auto-provisioning and …

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/EventConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/EventConstants.java
@@ -40,7 +40,7 @@ public final class EventConstants {
     /**
      * The content type of the <em>device provisioning notification</em> event.
      */
-    public static final String CONTENT_TYPE_DEVICE_PROVISIONING_NOTIFICATION = "application/vnd.eclipse-device-provisioning-notification";
+    public static final String CONTENT_TYPE_DEVICE_PROVISIONING_NOTIFICATION = "application/vnd.eclipse-hono-device-provisioning-notification";
 
 
     /**

--- a/site/documentation/content/api/event/index.md
+++ b/site/documentation/content/api/event/index.md
@@ -142,7 +142,7 @@ The relevant properties are listed again in the following table:
 
 | Name                       | Mandatory        | Location                 | Type      | Description |
 | :------------------------- | :--------------: | :----------------------- | :-------- | :---------- |
-| *content-type*             | yes              | *properties*             | *symbol*  | MUST be set to *application/vnd.eclipse-device-provisioning-notification* |
+| *content-type*             | yes              | *properties*             | *symbol*  | MUST be set to *application/vnd.eclipse-hono-device-provisioning-notification* |
 | *hono_registration_status* | yes              | *application-properties* | *string*  | Contains NEW if the device has been newly provisioned. |
 | *tenant_id*                | yes              | *application-properties* | *string*  | The tenant id denoting the tenant of the device. |
 | *device_id*                | yes              | *application-properties* | *string*  | The id of the device. |

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -34,6 +34,12 @@ title = "Release Notes"
   *cert* property. This can be used instead of specifying the client certificate's subject DN and public key's
   validity period explicitly in the *auth-id* and *secrets* properties. This should make setting the correct *auth-id*
   value much less error prone.
+* Hono now supports *auto-provisioning* of devices that connect via gateway. 
+  For more information please refer to the 
+  [Device Provisioning]({{% doclink "/concepts/provisioning/#gateway-based-auto-provisioning" %}}) concept and to the 
+  [Device registry management API]({{% doclink "/api/management#/devices/createDeviceRegistration" %}}) on how to 
+  create a device registration for a gateway which is enabled for auto-provisioning.
+  
 
 ### Fixes & Enhancements
 


### PR DESCRIPTION
…fixing typo in event content type.

Signed-off-by: Florian Kaltner <florian.kaltner@bosch.io>