### PR TITLE
Drop dependency on ProtocolAdpaterProperties

### DIFF
--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
@@ -28,7 +28,6 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.impl.CachingClientFactory;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.MessageHelper;
@@ -78,7 +77,12 @@ public abstract class AbstractRequestResponseServiceClient<T, R extends RequestR
      *
      * @param connection The connection to the service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param deviceDefaultsEnabled {@code true} if the default properties registered for devices
+     *                              should be included in messages being sent.
+     * @param jmsVendorPropsEnabled {@code true} if <em>Vendor Properties</em> as defined by <a
+     *                              href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
+     *                              Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
+     *                              in messages being sent.
      * @param clientFactory The factory to use for creating links to the service.
      * @param responseCache The cache to use for service responses.
      * @throws NullPointerException if any of the parameters other than responseCache are {@code null}.
@@ -86,11 +90,12 @@ public abstract class AbstractRequestResponseServiceClient<T, R extends RequestR
     protected AbstractRequestResponseServiceClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig,
+            final boolean deviceDefaultsEnabled,
+            final boolean jmsVendorPropsEnabled,
             final CachingClientFactory<RequestResponseClient<R>> clientFactory,
             final Cache<Object, R> responseCache) {
 
-        super(connection, samplerFactory, adapterConfig);
+        super(connection, samplerFactory, deviceDefaultsEnabled, jmsVendorPropsEnabled);
         this.clientFactory = Objects.requireNonNull(clientFactory);
         this.responseCache = Optional.ofNullable(responseCache).orElse(null);
     }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClient.java
@@ -77,12 +77,6 @@ public abstract class AbstractRequestResponseServiceClient<T, R extends RequestR
      *
      * @param connection The connection to the service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param deviceDefaultsEnabled {@code true} if the default properties registered for devices
-     *                              should be included in messages being sent.
-     * @param jmsVendorPropsEnabled {@code true} if <em>Vendor Properties</em> as defined by <a
-     *                              href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
-     *                              Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
-     *                              in messages being sent.
      * @param clientFactory The factory to use for creating links to the service.
      * @param responseCache The cache to use for service responses.
      * @throws NullPointerException if any of the parameters other than responseCache are {@code null}.
@@ -90,12 +84,10 @@ public abstract class AbstractRequestResponseServiceClient<T, R extends RequestR
     protected AbstractRequestResponseServiceClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final boolean deviceDefaultsEnabled,
-            final boolean jmsVendorPropsEnabled,
             final CachingClientFactory<RequestResponseClient<R>> clientFactory,
             final Cache<Object, R> responseCache) {
 
-        super(connection, samplerFactory, deviceDefaultsEnabled, jmsVendorPropsEnabled);
+        super(connection, samplerFactory);
         this.clientFactory = Objects.requireNonNull(clientFactory);
         this.responseCache = Optional.ofNullable(responseCache).orElse(null);
     }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractServiceClient.java
@@ -56,63 +56,20 @@ public abstract class AbstractServiceClient implements ConnectionLifecycle<HonoC
      */
     protected final SendMessageSampler.Factory samplerFactory;
 
-    private final boolean deviceDefaultsEnabled;
-    private final boolean jmsVendorPropsEnabled;
-
     /**
      * Creates a new client.
      *
      * @param connection The connection to the Hono service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param deviceDefaultsEnabled {@code true} if the default properties registered for devices
-     *                              should be included in messages being sent.
-     * @param jmsVendorPropsEnabled {@code true} if <em>Vendor Properties</em> as defined by <a
-     *                              href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
-     *                              Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
-     *                              in messages being sent.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     protected AbstractServiceClient(
             final HonoConnection connection,
-            final SendMessageSampler.Factory samplerFactory,
-            final boolean deviceDefaultsEnabled,
-            final boolean jmsVendorPropsEnabled) {
+            final SendMessageSampler.Factory samplerFactory) {
 
         this.connection = Objects.requireNonNull(connection);
         this.connection.addDisconnectListener(con -> onDisconnect());
         this.samplerFactory = Objects.requireNonNull(samplerFactory);
-        this.deviceDefaultsEnabled = deviceDefaultsEnabled;
-        this.jmsVendorPropsEnabled = jmsVendorPropsEnabled;
-    }
-
-    /**
-     * Checks if <em>default</em> values registered for a device should be used
-     * to augment messages published by the device.
-     * <p>
-     * Default values that can be registered for devices include:
-     * <ul>
-     * <li><em>content-type</em> - the default content type to set on a downstream message
-     * if the device did not specify a content type when it published the message. This
-     * is particularly useful for defining a content type for devices connected via MQTT
-     * which does not provide a standard way of setting a content type.</li>
-     * </ul>
-     *
-     * @return {@code true} if default values should be used.
-     */
-    protected final boolean isDeviceDefaultsEnabled() {
-        return deviceDefaultsEnabled;
-    }
-
-    /**
-     * Checks if <em>Vendor Properties</em> as defined by <a
-     * href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
-     * Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
-     * in messages being sent.
-     *
-     * @return {@code true} if the properties should be included.
-     */
-    protected final boolean isJmsVendorPropsEnabled() {
-        return jmsVendorPropsEnabled;
     }
 
     /**

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/AbstractServiceClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,7 +22,6 @@ import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ReconnectListener;
 import org.eclipse.hono.client.SendMessageSampler;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Lifecycle;
 import org.slf4j.Logger;
@@ -56,28 +55,64 @@ public abstract class AbstractServiceClient implements ConnectionLifecycle<HonoC
      * The factory for creating <em>send message</em> samplers.
      */
     protected final SendMessageSampler.Factory samplerFactory;
-    /**
-     * The protocol adapter configuration.
-     */
-    protected final ProtocolAdapterProperties adapterConfig;
+
+    private final boolean deviceDefaultsEnabled;
+    private final boolean jmsVendorPropsEnabled;
 
     /**
      * Creates a new client.
      *
      * @param connection The connection to the Hono service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param deviceDefaultsEnabled {@code true} if the default properties registered for devices
+     *                              should be included in messages being sent.
+     * @param jmsVendorPropsEnabled {@code true} if <em>Vendor Properties</em> as defined by <a
+     *                              href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
+     *                              Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
+     *                              in messages being sent.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     protected AbstractServiceClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
+            final boolean deviceDefaultsEnabled,
+            final boolean jmsVendorPropsEnabled) {
 
         this.connection = Objects.requireNonNull(connection);
         this.connection.addDisconnectListener(con -> onDisconnect());
         this.samplerFactory = Objects.requireNonNull(samplerFactory);
-        this.adapterConfig = Objects.requireNonNull(adapterConfig);
+        this.deviceDefaultsEnabled = deviceDefaultsEnabled;
+        this.jmsVendorPropsEnabled = jmsVendorPropsEnabled;
+    }
+
+    /**
+     * Checks if <em>default</em> values registered for a device should be used
+     * to augment messages published by the device.
+     * <p>
+     * Default values that can be registered for devices include:
+     * <ul>
+     * <li><em>content-type</em> - the default content type to set on a downstream message
+     * if the device did not specify a content type when it published the message. This
+     * is particularly useful for defining a content type for devices connected via MQTT
+     * which does not provide a standard way of setting a content type.</li>
+     * </ul>
+     *
+     * @return {@code true} if default values should be used.
+     */
+    protected final boolean isDeviceDefaultsEnabled() {
+        return deviceDefaultsEnabled;
+    }
+
+    /**
+     * Checks if <em>Vendor Properties</em> as defined by <a
+     * href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
+     * Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
+     * in messages being sent.
+     *
+     * @return {@code true} if the properties should be included.
+     */
+    protected final boolean isJmsVendorPropsEnabled() {
+        return jmsVendorPropsEnabled;
     }
 
     /**

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
@@ -51,21 +51,13 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
      *
      * @param connection The connection to the Hono service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param deviceDefaultsEnabled {@code true} if the default properties registered for devices
-     *                              should be included in messages being sent.
-     * @param jmsVendorPropsEnabled {@code true} if <em>Vendor Properties</em> as defined by <a
-     *                              href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
-     *                              Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
-     *                              in messages being sent.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     protected SenderCachingServiceClient(
             final HonoConnection connection,
-            final SendMessageSampler.Factory samplerFactory,
-            final boolean deviceDefaultsEnabled,
-            final boolean jmsVendorPropsEnabled) {
+            final SendMessageSampler.Factory samplerFactory) {
 
-        this(connection, samplerFactory, deviceDefaultsEnabled, jmsVendorPropsEnabled, true);
+        this(connection, samplerFactory, true);
     }
 
     /**
@@ -73,12 +65,6 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
      *
      * @param connection The connection to the Hono service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param deviceDefaultsEnabled {@code true} if the default properties registered for devices
-     *                              should be included in messages being sent.
-     * @param jmsVendorPropsEnabled {@code true} if <em>Vendor Properties</em> as defined by <a
-     *                              href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
-     *                              Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
-     *                              in messages being sent.
      * @param isTenantSpecificLink If the links created for this client are tenant-specific, leading
      *            them to get closed when a tenant timeout occurs.
      * @throws NullPointerException if any of the parameters is {@code null}.
@@ -86,11 +72,9 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
     protected SenderCachingServiceClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final boolean deviceDefaultsEnabled,
-            final boolean jmsVendorPropsEnabled,
             final boolean isTenantSpecificLink) {
 
-        super(connection, samplerFactory, deviceDefaultsEnabled, jmsVendorPropsEnabled);
+        super(connection, samplerFactory);
         this.clientFactory = new CachingClientFactory<>(connection.getVertx(), GenericSenderLink::isOpen);
         if (isTenantSpecificLink) {
             connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/SenderCachingServiceClient.java
@@ -22,7 +22,6 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.amqp.GenericSenderLink;
 import org.eclipse.hono.client.impl.CachingClientFactory;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.AddressHelper;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
@@ -52,15 +51,21 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
      *
      * @param connection The connection to the Hono service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param deviceDefaultsEnabled {@code true} if the default properties registered for devices
+     *                              should be included in messages being sent.
+     * @param jmsVendorPropsEnabled {@code true} if <em>Vendor Properties</em> as defined by <a
+     *                              href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
+     *                              Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
+     *                              in messages being sent.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     protected SenderCachingServiceClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
+            final boolean deviceDefaultsEnabled,
+            final boolean jmsVendorPropsEnabled) {
 
-        this(connection, samplerFactory, adapterConfig, true);
+        this(connection, samplerFactory, deviceDefaultsEnabled, jmsVendorPropsEnabled, true);
     }
 
     /**
@@ -68,7 +73,12 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
      *
      * @param connection The connection to the Hono service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param deviceDefaultsEnabled {@code true} if the default properties registered for devices
+     *                              should be included in messages being sent.
+     * @param jmsVendorPropsEnabled {@code true} if <em>Vendor Properties</em> as defined by <a
+     *                              href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
+     *                              Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
+     *                              in messages being sent.
      * @param isTenantSpecificLink If the links created for this client are tenant-specific, leading
      *            them to get closed when a tenant timeout occurs.
      * @throws NullPointerException if any of the parameters is {@code null}.
@@ -76,10 +86,11 @@ public abstract class SenderCachingServiceClient extends AbstractServiceClient {
     protected SenderCachingServiceClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig,
+            final boolean deviceDefaultsEnabled,
+            final boolean jmsVendorPropsEnabled,
             final boolean isTenantSpecificLink) {
 
-        super(connection, samplerFactory, adapterConfig);
+        super(connection, samplerFactory, deviceDefaultsEnabled, jmsVendorPropsEnabled);
         this.clientFactory = new CachingClientFactory<>(connection.getVertx(), GenericSenderLink::isOpen);
         if (isTenantSpecificLink) {
             connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandResponseSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandResponseSender.java
@@ -52,7 +52,7 @@ public class ProtonBasedCommandResponseSender extends AbstractServiceClient impl
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
-        super(connection, samplerFactory, adapterConfig);
+        super(connection, samplerFactory, adapterConfig.isDefaultsEnabled(), adapterConfig.isJmsVendorPropsEnabled());
     }
 
     private Future<GenericSenderLink> createSender(final String tenantId, final String replyId) {

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandResponseSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandResponseSender.java
@@ -40,6 +40,8 @@ import io.vertx.proton.ProtonHelper;
  */
 public class ProtonBasedCommandResponseSender extends AbstractServiceClient implements CommandResponseSender {
 
+    private final boolean jmsVendorPropsEnabled;
+
     /**
      * Creates a new sender for a connection.
      *
@@ -52,7 +54,8 @@ public class ProtonBasedCommandResponseSender extends AbstractServiceClient impl
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
-        super(connection, samplerFactory, adapterConfig.isDefaultsEnabled(), adapterConfig.isJmsVendorPropsEnabled());
+        super(connection, samplerFactory);
+        this.jmsVendorPropsEnabled = adapterConfig.isJmsVendorPropsEnabled();
     }
 
     private Future<GenericSenderLink> createSender(final String tenantId, final String replyId) {
@@ -81,6 +84,9 @@ public class ProtonBasedCommandResponseSender extends AbstractServiceClient impl
                 null));
         MessageHelper.addTenantId(msg, response.getTenantId());
         MessageHelper.addDeviceId(msg, response.getDeviceId());
+        if (jmsVendorPropsEnabled) {
+            MessageHelper.addJmsVendorProperties(msg);
+        }
         return msg;
     }
 

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClient.java
@@ -67,8 +67,6 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
             final ProtocolAdapterProperties adapterConfig) {
         super(connection,
                 samplerFactory,
-                adapterConfig.isDefaultsEnabled(),
-                adapterConfig.isJmsVendorPropsEnabled(),
                 new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
                 null);
         connection.getVertx().eventBus().consumer(

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -65,9 +65,14 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
-        super(connection, samplerFactory, adapterConfig, new CachingClientFactory<>(
-                connection.getVertx(), RequestResponseClient::isOpen), null);
-        connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
+        super(connection,
+                samplerFactory,
+                adapterConfig.isDefaultsEnabled(),
+                adapterConfig.isJmsVendorPropsEnabled(),
+                new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
+                null);
+        connection.getVertx().eventBus().consumer(
+                Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
                 this::handleTenantTimeout);
     }
 

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClient.java
@@ -27,7 +27,6 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.impl.CachingClientFactory;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CommandRouterConstants;
@@ -58,13 +57,11 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
      *
      * @param connection The connection to the Command Router service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public ProtonBasedCommandRouterClient(
             final HonoConnection connection,
-            final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
+            final SendMessageSampler.Factory samplerFactory) {
         super(connection,
                 samplerFactory,
                 new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterCommandConsumerFactoryImpl.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterCommandConsumerFactoryImpl.java
@@ -78,7 +78,7 @@ public class ProtonBasedCommandRouterCommandConsumerFactoryImpl extends Abstract
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
             final CommandRouterClient commandRouterClient) {
-        super(connection, samplerFactory, false, false);
+        super(connection, samplerFactory);
         this.commandRouterClient = Objects.requireNonNull(commandRouterClient);
 
         adapterInstanceId = getAdapterInstanceId(connection.getConfig().getName());

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterCommandConsumerFactoryImpl.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterCommandConsumerFactoryImpl.java
@@ -31,7 +31,6 @@ import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Strings;
 
@@ -72,16 +71,14 @@ public class ProtonBasedCommandRouterCommandConsumerFactoryImpl extends Abstract
      *
      * @param connection The connection to the AMQP network.
      * @param samplerFactory The sampler factory to use.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @param commandRouterClient The client to use for accessing the command router service.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public ProtonBasedCommandRouterCommandConsumerFactoryImpl(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig,
             final CommandRouterClient commandRouterClient) {
-        super(connection, samplerFactory, adapterConfig);
+        super(connection, samplerFactory, false, false);
         this.commandRouterClient = Objects.requireNonNull(commandRouterClient);
 
         adapterInstanceId = getAdapterInstanceId(connection.getConfig().getName());

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDelegatingCommandConsumerFactory.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDelegatingCommandConsumerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,7 +29,6 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory;
 import org.eclipse.hono.client.ProtocolAdapterCommandConsumerFactory.CommandHandlingAdapterInfoAccess;
 import org.eclipse.hono.client.SendMessageSampler.Factory;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.RegistrationAssertion;
 
 import io.opentracing.SpanContext;
@@ -59,7 +58,6 @@ public class ProtonBasedDelegatingCommandConsumerFactory extends AbstractService
      *
      * @param connection The connection to the AMQP 1.0 Messaging Network.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @param deviceConnectionClient The client to use for accessing the Device Connection service.
      * @param deviceRegistrationClient The client to use for accessing the Device Registration service.
      * @param tracer The OpenTracing tracer to use for tracking the processing of messages.
@@ -68,12 +66,11 @@ public class ProtonBasedDelegatingCommandConsumerFactory extends AbstractService
     public ProtonBasedDelegatingCommandConsumerFactory(
             final HonoConnection connection,
             final Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig,
             final DeviceConnectionClient deviceConnectionClient,
             final DeviceRegistrationClient deviceRegistrationClient,
             final Tracer tracer) {
 
-        super(connection, samplerFactory, adapterConfig);
+        super(connection, samplerFactory, false, false);
 
         Objects.requireNonNull(deviceConnectionClient);
         Objects.requireNonNull(deviceRegistrationClient);

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDelegatingCommandConsumerFactory.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDelegatingCommandConsumerFactory.java
@@ -70,7 +70,7 @@ public class ProtonBasedDelegatingCommandConsumerFactory extends AbstractService
             final DeviceRegistrationClient deviceRegistrationClient,
             final Tracer tracer) {
 
-        super(connection, samplerFactory, false, false);
+        super(connection, samplerFactory);
 
         Objects.requireNonNull(deviceConnectionClient);
         Objects.requireNonNull(deviceRegistrationClient);

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
@@ -29,7 +29,6 @@ import org.eclipse.hono.client.SendMessageSampler.Factory;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.impl.CachingClientFactory;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
@@ -64,13 +63,11 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseSe
      *
      * @param connection The connection to the Device Connection service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public ProtonBasedDeviceConnectionClient(
             final HonoConnection connection,
-            final Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
+            final Factory samplerFactory) {
 
         super(connection,
                 samplerFactory,

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -72,9 +72,14 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseSe
             final Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
 
-        super(connection, samplerFactory, adapterConfig, new CachingClientFactory<>(
-                connection.getVertx(), RequestResponseClient::isOpen), null);
-        connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
+        super(connection,
+                samplerFactory,
+                adapterConfig.isDefaultsEnabled(),
+                adapterConfig.isJmsVendorPropsEnabled(),
+                new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
+                null);
+        connection.getVertx().eventBus().consumer(
+                Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
                 this::handleTenantTimeout);
     }
 

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
@@ -74,8 +74,6 @@ public class ProtonBasedDeviceConnectionClient extends AbstractRequestResponseSe
 
         super(connection,
                 samplerFactory,
-                adapterConfig.isDefaultsEnabled(),
-                adapterConfig.isJmsVendorPropsEnabled(),
                 new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
                 null);
         connection.getVertx().eventBus().consumer(

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandSender.java
@@ -55,7 +55,7 @@ public class ProtonBasedInternalCommandSender extends SenderCachingServiceClient
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public ProtonBasedInternalCommandSender(final HonoConnection connection) {
-        super(connection, SendMessageSampler.Factory.noop(), false, false, false);
+        super(connection, SendMessageSampler.Factory.noop(), false);
     }
 
     @Override

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandSender.java
@@ -30,7 +30,6 @@ import org.eclipse.hono.adapter.client.command.InternalCommandSender;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
@@ -56,7 +55,7 @@ public class ProtonBasedInternalCommandSender extends SenderCachingServiceClient
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public ProtonBasedInternalCommandSender(final HonoConnection connection) {
-        super(connection, SendMessageSampler.Factory.noop(), new ProtocolAdapterProperties(), false);
+        super(connection, SendMessageSampler.Factory.noop(), false, false, false);
     }
 
     @Override

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -26,7 +26,6 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.impl.CachingClientFactory;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
@@ -64,14 +63,12 @@ public class ProtonBasedCredentialsClient extends AbstractRequestResponseService
      *
      * @param connection The connection to the Credentials service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @param responseCache The cache to use for service responses or {@code null} if responses should not be cached.
      * @throws NullPointerException if any of the parameters other than the response cache are {@code null}.
      */
     public ProtonBasedCredentialsClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig,
             final Cache<Object, CredentialsResult<CredentialsObject>> responseCache) {
 
         super(connection,

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -76,8 +76,6 @@ public class ProtonBasedCredentialsClient extends AbstractRequestResponseService
 
         super(connection,
                 samplerFactory,
-                adapterConfig.isDefaultsEnabled(),
-                adapterConfig.isJmsVendorPropsEnabled(),
                 new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
                 responseCache);
         connection.getVertx().eventBus().consumer(

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -74,9 +74,14 @@ public class ProtonBasedCredentialsClient extends AbstractRequestResponseService
             final ProtocolAdapterProperties adapterConfig,
             final Cache<Object, CredentialsResult<CredentialsObject>> responseCache) {
 
-        super(connection, samplerFactory, adapterConfig, new CachingClientFactory<>(
-                connection.getVertx(), RequestResponseClient::isOpen), responseCache);
-        connection.getVertx().eventBus().consumer(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
+        super(connection,
+                samplerFactory,
+                adapterConfig.isDefaultsEnabled(),
+                adapterConfig.isJmsVendorPropsEnabled(),
+                new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
+                responseCache);
+        connection.getVertx().eventBus().consumer(
+                Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
                 this::handleTenantTimeout);
     }
 

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
@@ -78,8 +78,6 @@ public class ProtonBasedDeviceRegistrationClient extends AbstractRequestResponse
 
         super(connection,
                 samplerFactory,
-                adapterConfig.isDefaultsEnabled(),
-                adapterConfig.isJmsVendorPropsEnabled(),
                 new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
                 responseCache);
         connection.getVertx().eventBus().consumer(

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
@@ -76,8 +76,12 @@ public class ProtonBasedDeviceRegistrationClient extends AbstractRequestResponse
             final ProtocolAdapterProperties adapterConfig,
             final Cache<Object, RegistrationResult> responseCache) {
 
-        super(connection, samplerFactory, adapterConfig, new CachingClientFactory<>(
-                connection.getVertx(), RequestResponseClient::isOpen), responseCache);
+        super(connection,
+                samplerFactory,
+                adapterConfig.isDefaultsEnabled(),
+                adapterConfig.isJmsVendorPropsEnabled(),
+                new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
+                responseCache);
         connection.getVertx().eventBus().consumer(
                 Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT,
                 this::handleTenantTimeout);

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
@@ -29,7 +29,6 @@ import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.impl.CachingClientFactory;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;
@@ -66,14 +65,12 @@ public class ProtonBasedDeviceRegistrationClient extends AbstractRequestResponse
      *
      * @param connection The connection to the Device Registration service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @param responseCache The cache to use for service responses or {@code null} if responses should not be cached.
      * @throws NullPointerException if any of the parameters other than the response cache are {@code null}.
      */
     public ProtonBasedDeviceRegistrationClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig,
             final Cache<Object, RegistrationResult> responseCache) {
 
         super(connection,

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
@@ -32,7 +32,6 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.impl.CachingClientFactory;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.Pair;
@@ -72,14 +71,12 @@ public final class ProtonBasedTenantClient extends AbstractRequestResponseServic
      *
      * @param connection The connection to the service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @param responseCache The cache to use for service responses or {@code null} if responses should not be cached.
      * @throws NullPointerException if any of the parameters other than the response cache are {@code null}.
      */
     public ProtonBasedTenantClient(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig,
             final Cache<Object, TenantResult<TenantObject>> responseCache) {
         super(connection,
                 samplerFactory,

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
@@ -81,8 +81,12 @@ public final class ProtonBasedTenantClient extends AbstractRequestResponseServic
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig,
             final Cache<Object, TenantResult<TenantObject>> responseCache) {
-        super(connection, samplerFactory, adapterConfig, new CachingClientFactory<>(
-                connection.getVertx(), RequestResponseClient::isOpen), responseCache);
+        super(connection,
+                samplerFactory,
+                adapterConfig.isDefaultsEnabled(),
+                adapterConfig.isJmsVendorPropsEnabled(),
+                new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
+                responseCache);
     }
 
     /**

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
@@ -83,8 +83,6 @@ public final class ProtonBasedTenantClient extends AbstractRequestResponseServic
             final Cache<Object, TenantResult<TenantObject>> responseCache) {
         super(connection,
                 samplerFactory,
-                adapterConfig.isDefaultsEnabled(),
-                adapterConfig.isJmsVendorPropsEnabled(),
                 new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen),
                 responseCache);
     }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
@@ -26,7 +26,6 @@ import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
@@ -49,14 +48,20 @@ public class ProtonBasedDownstreamSender extends SenderCachingServiceClient impl
      *
      * @param connection The connection to the Hono service.
      * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
-     * @param adapterConfig The protocol adapter's configuration properties.
+     * @param deviceDefaultsEnabled {@code true} if the default properties registered for devices
+     *                              should be included in messages being sent.
+     * @param jmsVendorPropsEnabled {@code true} if <em>Vendor Properties</em> as defined by <a
+     *                              href="https://www.oasis-open.org/committees/download.php/60574/amqp-bindmap-jms-v1.0-wd09.pdf">
+     *                              Advanced Message Queuing Protocol (AMQP) JMS Mapping Version 1.0, Chapter 4</a> should be included
+     *                              in messages being sent.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public ProtonBasedDownstreamSender(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
-        super(connection, samplerFactory, adapterConfig);
+            final boolean deviceDefaultsEnabled,
+            final boolean jmsVendorPropsEnabled) {
+        super(connection, samplerFactory, deviceDefaultsEnabled, jmsVendorPropsEnabled);
     }
 
     /**
@@ -138,8 +143,8 @@ public class ProtonBasedDownstreamSender extends SenderCachingServiceClient impl
                 tenant,
                 props,
                 device.getDefaults(),
-                adapterConfig.isDefaultsEnabled(),
-                adapterConfig.isJmsVendorPropsEnabled());
+                isDeviceDefaultsEnabled(),
+                isJmsVendorPropsEnabled());
     }
 
     /**

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
@@ -43,6 +43,9 @@ import io.vertx.core.buffer.Buffer;
  */
 public class ProtonBasedDownstreamSender extends SenderCachingServiceClient implements TelemetrySender, EventSender {
 
+    private final boolean deviceDefaultsEnabled;
+    private final boolean jmsVendorPropsEnabled;
+
     /**
      * Creates a new sender for a connection.
      *
@@ -61,7 +64,9 @@ public class ProtonBasedDownstreamSender extends SenderCachingServiceClient impl
             final SendMessageSampler.Factory samplerFactory,
             final boolean deviceDefaultsEnabled,
             final boolean jmsVendorPropsEnabled) {
-        super(connection, samplerFactory, deviceDefaultsEnabled, jmsVendorPropsEnabled);
+        super(connection, samplerFactory);
+        this.deviceDefaultsEnabled = deviceDefaultsEnabled;
+        this.jmsVendorPropsEnabled = jmsVendorPropsEnabled;
     }
 
     /**
@@ -143,8 +148,8 @@ public class ProtonBasedDownstreamSender extends SenderCachingServiceClient impl
                 tenant,
                 props,
                 device.getDefaults(),
-                isDeviceDefaultsEnabled(),
-                isJmsVendorPropsEnabled());
+                deviceDefaultsEnabled,
+                jmsVendorPropsEnabled);
     }
 
     /**

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClientTest.java
@@ -28,7 +28,6 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
 import org.eclipse.hono.client.impl.CachingClientFactory;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.CacheDirective;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,7 +64,8 @@ class AbstractRequestResponseServiceClientTest {
         client = new AbstractRequestResponseServiceClient<>(
                 AmqpClientUnitTestHelper.mockHonoConnection(vertx, props),
                 SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties(),
+                true,
+                false,
                 new CachingClientFactory<>(vertx, v -> true),
                 cache) {
 

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/amqp/AbstractRequestResponseServiceClientTest.java
@@ -64,8 +64,6 @@ class AbstractRequestResponseServiceClientTest {
         client = new AbstractRequestResponseServiceClient<>(
                 AmqpClientUnitTestHelper.mockHonoConnection(vertx, props),
                 SendMessageSampler.Factory.noop(),
-                true,
-                false,
                 new CachingClientFactory<>(vertx, v -> true),
                 cache) {
 

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClientTest.java
@@ -33,7 +33,6 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CacheDirective;
@@ -97,7 +96,7 @@ public class ProtonBasedCommandRouterClientTest {
                 .thenReturn(Future.succeededFuture(receiver));
         when(connection.createSender(anyString(), any(ProtonQoS.class), VertxMockSupport.anyHandler()))
             .thenReturn(Future.succeededFuture(sender));
-        client = new ProtonBasedCommandRouterClient(connection, SendMessageSampler.Factory.noop(), new ProtocolAdapterProperties());
+        client = new ProtonBasedCommandRouterClient(connection, SendMessageSampler.Factory.noop());
     }
 
     /**

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClientTest.java
@@ -33,7 +33,6 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CacheDirective;
@@ -101,8 +100,7 @@ public class ProtonBasedDeviceConnectionClientTest {
 
         client = new ProtonBasedDeviceConnectionClient(
                 connection,
-                SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties());
+                SendMessageSampler.Factory.noop());
     }
 
     /**

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClientTest.java
@@ -34,7 +34,6 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CacheDirective;
@@ -127,7 +126,6 @@ class ProtonBasedCredentialsClientTest {
         client = new ProtonBasedCredentialsClient(
                 connection,
                 SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties(),
                 cache);
     }
 

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClientTest.java
@@ -33,7 +33,6 @@ import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CacheDirective;
@@ -127,7 +126,6 @@ class ProtonBasedDeviceRegistrationClientTest {
         client = new ProtonBasedDeviceRegistrationClient(
                 connection,
                 SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties(),
                 cache);
     }
 

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClientTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClientTest.java
@@ -37,7 +37,6 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CacheDirective;
@@ -122,7 +121,6 @@ class ProtonBasedTenantClientTest {
         client = new ProtonBasedTenantClient(
                 connection,
                 SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties(),
                 cache);
     }
 

--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSenderTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSenderTest.java
@@ -31,7 +31,6 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.Constants;
@@ -77,14 +76,13 @@ public class ProtonBasedDownstreamSenderTest {
         when(vertx.eventBus()).thenReturn(mock(EventBus.class));
 
         final ClientConfigProperties clientConfigProperties = new ClientConfigProperties();
-        final ProtocolAdapterProperties adapterConfig = new ProtocolAdapterProperties();
         connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx, clientConfigProperties, tracer);
         when(connection.isConnected()).thenReturn(Future.succeededFuture());
         when(connection.isConnected(anyLong())).thenReturn(Future.succeededFuture());
         protonSender = AmqpClientUnitTestHelper.mockProtonSender();
         when(connection.createSender(anyString(), any(), any())).thenReturn(Future.succeededFuture(protonSender));
 
-        sender = new ProtonBasedDownstreamSender(connection, SendMessageSampler.Factory.noop(), adapterConfig);
+        sender = new ProtonBasedDownstreamSender(connection, SendMessageSampler.Factory.noop(), true, false);
     }
 
     /**

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
@@ -243,7 +243,6 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         return new ProtonBasedTenantClient(
                 HonoConnection.newConnection(vertx, tenantServiceClientConfig(), tracer),
                 messageSamplerFactory,
-                protocolAdapterProperties,
                 tenantResponseCache());
     }
 
@@ -269,7 +268,6 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         return new ProtonBasedDeviceRegistrationClient(
                 HonoConnection.newConnection(vertx, registrationServiceClientConfig(), tracer),
                 messageSamplerFactory,
-                protocolAdapterProperties,
                 registrationResponseCache());
     }
 
@@ -295,7 +293,6 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         return new ProtonBasedCredentialsClient(
                 HonoConnection.newConnection(vertx, credentialsServiceClientConfig(), tracer),
                 messageSamplerFactory,
-                protocolAdapterProperties,
                 credentialsResponseCache());
     }
 
@@ -313,8 +310,7 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
     protected CommandRouterClient commandRouterClient() {
         return new ProtonBasedCommandRouterClient(
                 HonoConnection.newConnection(vertx, commandRouterServiceClientConfig(), tracer),
-                messageSamplerFactory,
-                protocolAdapterProperties);
+                messageSamplerFactory);
     }
 
     private RequestResponseClientConfigProperties deviceConnectionServiceClientConfig() {
@@ -333,8 +329,7 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         if (config.deviceConnection.isHostConfigured()) {
             return new ProtonBasedDeviceConnectionClient(
                     HonoConnection.newConnection(vertx, deviceConnectionServiceClientConfig(), tracer),
-                    messageSamplerFactory,
-                    protocolAdapterProperties);
+                    messageSamplerFactory);
         } else {
             final RemoteCacheManager cacheManager = new RemoteCacheManager(
                     deviceConnectionCacheConfig.getConfigurationBuilder().build(),

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractProtocolAdapterApplication.java
@@ -367,7 +367,8 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         return new ProtonBasedDownstreamSender(
                 HonoConnection.newConnection(vertx, downstreamSenderConfig(), tracer),
                 messageSamplerFactory,
-                protocolAdapterProperties);
+                protocolAdapterProperties.isDefaultsEnabled(),
+                protocolAdapterProperties.isJmsVendorPropsEnabled());
     }
 
     private ClientConfigProperties commandConsumerFactoryConfig() {
@@ -404,7 +405,6 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         return new ProtonBasedDelegatingCommandConsumerFactory(
                 commandConsumerConnection(),
                 messageSamplerFactory,
-                protocolAdapterProperties,
                 deviceConnectionClient,
                 deviceRegistrationClient,
                 tracer);
@@ -424,7 +424,6 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         return new ProtonBasedCommandRouterCommandConsumerFactoryImpl(
                 commandConsumerConnection(),
                 messageSamplerFactory,
-                protocolAdapterProperties,
                 commandRouterClient);
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -125,7 +125,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
         Objects.requireNonNull(adapterProperties);
         Objects.requireNonNull(samplerFactory);
 
-        final DeviceRegistrationClient registrationClient = registrationClient(samplerFactory, adapterProperties);
+        final DeviceRegistrationClient registrationClient = registrationClient(samplerFactory);
         try {
             // look up client via bean factory in order to take advantage of conditional bean instantiation based
             // on config properties
@@ -161,10 +161,10 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
         adapter.setCommandResponseSender(commandResponseSender(samplerFactory, adapterProperties));
         Optional.ofNullable(connectionEventProducer())
             .ifPresent(adapter::setConnectionEventProducer);
-        adapter.setCredentialsClient(credentialsClient(samplerFactory, adapterProperties));
+        adapter.setCredentialsClient(credentialsClient(samplerFactory));
         adapter.setHealthCheckServer(healthCheckServer());
         adapter.setRegistrationClient(registrationClient);
-        adapter.setTenantClient(tenantClient(samplerFactory, adapterProperties));
+        adapter.setTenantClient(tenantClient(samplerFactory));
         adapter.setTracer(getTracer());
         resourceLimitChecks.ifPresent(adapter::setResourceLimitChecks);
     }
@@ -416,20 +416,17 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
      * Exposes a client for accessing the <em>Device Registration</em> API as a Spring bean.
      *
      * @param samplerFactory The sampler factory to use.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @return The client.
      */
     @Bean
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
     public DeviceRegistrationClient registrationClient(
-            final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
+            final SendMessageSampler.Factory samplerFactory) {
 
         return new ProtonBasedDeviceRegistrationClient(
                 registrationServiceConnection(),
                 samplerFactory,
-                adapterConfig,
                 registrationCache());
     }
 
@@ -489,20 +486,17 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
      * Exposes a client for accessing the <em>Credentials</em> API as a Spring bean.
      *
      * @param samplerFactory The sampler factory to use.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @return The client.
      */
     @Bean
     @Qualifier(CredentialsConstants.CREDENTIALS_ENDPOINT)
     @Scope("prototype")
     public CredentialsClient credentialsClient(
-            final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
+            final SendMessageSampler.Factory samplerFactory) {
 
         return new ProtonBasedCredentialsClient(
                 credentialsServiceConnection(),
                 samplerFactory,
-                adapterConfig,
                 credentialsCache());
     }
 
@@ -562,20 +556,17 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
      * Exposes a client for accessing the <em>Tenant</em> API as a Spring bean.
      *
      * @param samplerFactory The sampler factory to use.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @return The client.
      */
     @Bean
     @Qualifier(TenantConstants.TENANT_ENDPOINT)
     @Scope("prototype")
     public TenantClient tenantClient(
-            final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
+            final SendMessageSampler.Factory samplerFactory) {
 
         return new ProtonBasedTenantClient(
                 tenantServiceConnection(),
                 samplerFactory,
-                adapterConfig,
                 tenantCache());
     }
 
@@ -649,7 +640,6 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
      * Exposes a client for accessing the <em>Device Connection</em> API as a Spring bean.
      *
      * @param samplerFactory The sampler factory to use.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @return The client.
      */
     @Bean
@@ -657,13 +647,11 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     @Scope("prototype")
     @ConditionalOnProperty(prefix = "hono.device-connection", name = "host")
     public DeviceConnectionClient deviceConnectionClient(
-            final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
+            final SendMessageSampler.Factory samplerFactory) {
 
         return new ProtonBasedDeviceConnectionClient(
                 deviceConnectionServiceConnection(),
-                samplerFactory,
-                adapterConfig);
+                samplerFactory);
     }
 
     /**
@@ -713,7 +701,6 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
      * Exposes a client for accessing the <em>Command Router</em> API as a Spring bean.
      *
      * @param samplerFactory The sampler factory to use.
-     * @param adapterConfig The protocol adapter's configuration properties.
      * @return The client.
      */
     @Bean
@@ -721,13 +708,11 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     @Scope("prototype")
     @ConditionalOnProperty(prefix = "hono.command-router", name = "host")
     public CommandRouterClient commandRouterClient(
-            final SendMessageSampler.Factory samplerFactory,
-            final ProtocolAdapterProperties adapterConfig) {
+            final SendMessageSampler.Factory samplerFactory) {
 
         return new ProtonBasedCommandRouterClient(
                 commandRouterServiceConnection(),
-                samplerFactory,
-                adapterConfig);
+                samplerFactory);
     }
 
     /**

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -132,7 +132,6 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
             final DeviceConnectionClient deviceConnectionClient = context.getBean(DeviceConnectionClient.class);
             adapter.setCommandRouterClient(new DeviceConnectionClientAdapter(deviceConnectionClient));
             adapter.setCommandConsumerFactory(commandConsumerFactory(
-                    adapterProperties,
                     samplerFactory,
                     deviceConnectionClient,
                     registrationClient));
@@ -142,7 +141,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
             // Device Connection nor Command Router client have been configured anyway
             final CommandRouterClient commandRouterClient = context.getBean(CommandRouterClient.class);
             adapter.setCommandRouterClient(commandRouterClient);
-            adapter.setCommandConsumerFactory(commandConsumerFactory(adapterProperties, samplerFactory, commandRouterClient));
+            adapter.setCommandConsumerFactory(commandConsumerFactory(samplerFactory, commandRouterClient));
         }
 
         final KafkaProducerConfigProperties kafkaProducerConfig = kafkaProducerConfig();
@@ -308,7 +307,11 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     public TelemetrySender downstreamTelemetrySender(
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
-        return new ProtonBasedDownstreamSender(downstreamConnection(), samplerFactory, adapterConfig);
+        return new ProtonBasedDownstreamSender(
+                downstreamConnection(),
+                samplerFactory,
+                adapterConfig.isDefaultsEnabled(),
+                adapterConfig.isJmsVendorPropsEnabled());
     }
 
     /**
@@ -328,7 +331,11 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     public EventSender downstreamEventSender(
             final SendMessageSampler.Factory samplerFactory,
             final ProtocolAdapterProperties adapterConfig) {
-        return new ProtonBasedDownstreamSender(downstreamConnection(), samplerFactory, adapterConfig);
+        return new ProtonBasedDownstreamSender(
+                downstreamConnection(),
+                samplerFactory,
+                adapterConfig.isDefaultsEnabled(),
+                adapterConfig.isJmsVendorPropsEnabled());
     }
 
     /**
@@ -764,7 +771,6 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     }
 
     CommandConsumerFactory commandConsumerFactory(
-            final ProtocolAdapterProperties adapterProperties,
             final SendMessageSampler.Factory samplerFactory,
             final DeviceConnectionClient deviceConnectionClient,
             final DeviceRegistrationClient registrationClient) {
@@ -774,14 +780,12 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
         return new ProtonBasedDelegatingCommandConsumerFactory(
                 commandConsumerConnection(),
                 samplerFactory,
-                adapterProperties,
                 deviceConnectionClient,
                 registrationClient,
                 getTracer());
     }
 
     CommandConsumerFactory commandConsumerFactory(
-            final ProtocolAdapterProperties adapterProperties,
             final SendMessageSampler.Factory samplerFactory,
             final CommandRouterClient commandRouterClient) {
 
@@ -790,7 +794,6 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
         return new ProtonBasedCommandRouterCommandConsumerFactoryImpl(
                 commandConsumerConnection(),
                 samplerFactory,
-                adapterProperties,
                 commandRouterClient);
     }
 

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/ApplicationConfig.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/ApplicationConfig.java
@@ -272,16 +272,14 @@ public class ApplicationConfig {
      * Exposes a factory for creating clients for receiving upstream commands
      * via the AMQP Messaging Network.
      *
-     * @param config The component's configuration properties.
      * @return The factory.
      */
     @Bean
     @Scope("prototype")
-    public CommandConsumerFactory commandConsumerFactory(final CommandRouterServiceConfigProperties config) {
+    public CommandConsumerFactory commandConsumerFactory() {
         return new ProtonBasedCommandConsumerFactoryImpl(
                 commandConsumerConnection(),
-                SendMessageSampler.Factory.noop(),
-                config);
+                SendMessageSampler.Factory.noop());
     }
 
     /**

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/ApplicationConfig.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/ApplicationConfig.java
@@ -312,18 +312,16 @@ public class ApplicationConfig {
     /**
      * Exposes a client for accessing the <em>Device Registration</em> API as a Spring bean.
      *
-     * @param config The component's configuration properties.
      * @return The client.
      */
     @Bean
     @Qualifier(RegistrationConstants.REGISTRATION_ENDPOINT)
     @Scope("prototype")
-    public DeviceRegistrationClient registrationClient(final CommandRouterServiceConfigProperties config) {
+    public DeviceRegistrationClient registrationClient() {
 
         return new ProtonBasedDeviceRegistrationClient(
                 registrationServiceConnection(),
                 SendMessageSampler.Factory.noop(),
-                config,
                 Caches.newCaffeineCache(registrationClientConfig()));
     }
 

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
@@ -78,7 +78,7 @@ public class ProtonBasedCommandConsumerFactoryImpl extends AbstractServiceClient
     public ProtonBasedCommandConsumerFactoryImpl(
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory) {
-        super(connection, samplerFactory, false, false);
+        super(connection, samplerFactory);
     }
 
     @Override

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
@@ -28,7 +28,6 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.commandrouter.CommandConsumerFactory;
-import org.eclipse.hono.commandrouter.CommandRouterServiceConfigProperties;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.util.AddressHelper;
 import org.eclipse.hono.util.CommandConstants;
@@ -74,14 +73,12 @@ public class ProtonBasedCommandConsumerFactoryImpl extends AbstractServiceClient
      *
      * @param connection The connection to the AMQP network.
      * @param samplerFactory The sampler factory to use.
-     * @param config The component's configuration properties.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public ProtonBasedCommandConsumerFactoryImpl(
             final HonoConnection connection,
-            final SendMessageSampler.Factory samplerFactory,
-            final CommandRouterServiceConfigProperties config) {
-        super(connection, samplerFactory, config);
+            final SendMessageSampler.Factory samplerFactory) {
+        super(connection, samplerFactory, false, false);
     }
 
     @Override

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisionerConfigProperties.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisionerConfigProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,21 +12,18 @@
  *******************************************************************************/
 package org.eclipse.hono.deviceregistry.service.device;
 
-import org.eclipse.hono.config.ProtocolAdapterProperties;
-import org.eclipse.hono.util.RegistrationConstants;
-
 /**
  * Configuration properties for Hono's gateway-based auto-provisioning.
  */
-public class AutoProvisionerConfigProperties extends ProtocolAdapterProperties {
+public class AutoProvisionerConfigProperties {
 
     /**
      * Delay in milliseconds before trying to send the auto-provisioning notification if the initial attempt
      * to send the event hasn't completed yet.
      * <p>
      * This will only be invoked for requests that have <i>not</i> triggered the auto-provisioning,
-     * but instead have found the {@link RegistrationConstants#FIELD_AUTO_PROVISIONING_NOTIFICATION_SENT} flag
-     * in the device data to be {@code false}. Assuming that such a request has occurred very shortly after
+     * but instead have found the {@link org.eclipse.hono.util.RegistrationConstants#FIELD_AUTO_PROVISIONING_NOTIFICATION_SENT}
+     * flag in the device data to be {@code false}. Assuming that such a request has occurred very shortly after
      * the auto-provisioning, with the notification event still in the process of getting sent, the intention
      * here is to wait some time til the event was most probably sent. After the delay, the flag is checked
      * again and only if the flag is still {@code false}, meaning there was possibly an error sending the event

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,6 +14,7 @@
 
 package org.eclipse.hono.deviceregistry.file;
 
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
@@ -147,11 +148,12 @@ public class FileBasedServiceConfig {
      */
     @Bean
     @Scope("prototype")
-    public ProtonBasedDownstreamSender protonBasedDownstreamSender(final Vertx vertx, final Tracer tracer) {
+    public EventSender eventSender(final Vertx vertx, final Tracer tracer) {
         return new ProtonBasedDownstreamSender(
                 downstreamConnection(vertx, tracer),
                 SendMessageSampler.Factory.noop(),
-                autoProvisionerConfigProperties());
+                true,
+                true);
     }
 
     /**
@@ -230,7 +232,7 @@ public class FileBasedServiceConfig {
         autoProvisioner.setVertx(vertx);
         autoProvisioner.setTracer(tracer);
         autoProvisioner.setTenantInformationService(tenantInformationService());
-        autoProvisioner.setEventSender(protonBasedDownstreamSender(vertx, tracer));
+        autoProvisioner.setEventSender(eventSender(vertx, tracer));
         autoProvisioner.setConfig(autoProvisionerConfigProperties());
 
         registrationService.setAutoProvisioner(autoProvisioner);

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.deviceregistry.jdbc;
 import java.io.IOException;
 import java.util.Optional;
 
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
@@ -366,11 +367,12 @@ public class ApplicationConfig {
      */
     @Bean
     @Scope("prototype")
-    public ProtonBasedDownstreamSender protonBasedDownstreamSender(final Vertx vertx, final Tracer tracer) {
+    public EventSender eventSender(final Vertx vertx, final Tracer tracer) {
         return new ProtonBasedDownstreamSender(
                 downstreamConnection(vertx, tracer),
                 SendMessageSampler.Factory.noop(),
-                autoProvisionerConfigProperties());
+                true,
+                true);
     }
 
     /**
@@ -436,7 +438,7 @@ public class ApplicationConfig {
         autoProvisioner.setDeviceManagementService(registrationManagementService());
         autoProvisioner.setVertx(vertx);
         autoProvisioner.setTracer(tracer);
-        autoProvisioner.setEventSender(protonBasedDownstreamSender(vertx, tracer));
+        autoProvisioner.setEventSender(eventSender(vertx, tracer));
         autoProvisioner.setConfig(autoProvisionerConfigProperties());
 
         registrationService.setAutoProvisioner(autoProvisioner);

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.deviceregistry.mongodb;
 
 import java.util.Optional;
 
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.adapter.client.telemetry.amqp.ProtonBasedDownstreamSender;
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
@@ -302,11 +303,12 @@ public class ApplicationConfig {
      */
     @Bean
     @Scope("prototype")
-    public ProtonBasedDownstreamSender protonBasedDownstreamSender(final Vertx vertx, final Tracer tracer) {
+    public EventSender eventSender(final Vertx vertx, final Tracer tracer) {
         return new ProtonBasedDownstreamSender(
                 downstreamConnection(vertx, tracer),
                 SendMessageSampler.Factory.noop(),
-                autoProvisionerConfigProperties());
+                true,
+                true);
     }
 
     /**
@@ -378,7 +380,7 @@ public class ApplicationConfig {
         autoProvisioner.setTracer(tracer);
         autoProvisioner.setDeviceManagementService(service);
         autoProvisioner.setTenantInformationService(tenantInformationService);
-        autoProvisioner.setEventSender(protonBasedDownstreamSender(vertx, tracer));
+        autoProvisioner.setEventSender(eventSender(vertx, tracer));
         autoProvisioner.setConfig(autoProvisionerConfigProperties());
 
         service.setAutoProvisioner(autoProvisioner);

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsAmqpIT.java
@@ -16,7 +16,6 @@ import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedCredentialsClient;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,7 +48,6 @@ public class CredentialsAmqpIT extends CredentialsApiTests {
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
                 SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties(),
                 null);
 
         client.start().onComplete(ctx.completing());

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionAmqpIT.java
@@ -16,7 +16,6 @@ import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
 import org.eclipse.hono.adapter.client.command.amqp.ProtonBasedDeviceConnectionClient;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -50,8 +49,7 @@ public class DeviceConnectionAmqpIT extends DeviceConnectionApiTests {
                         IntegrationTestSupport.getDeviceConnectionServiceProperties(
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
-                SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties());
+                SendMessageSampler.Factory.noop());
 
         client.start().onComplete(ctx.completing());
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationAmqpIT.java
@@ -17,7 +17,6 @@ import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedDeviceRegistrationClient;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -52,7 +51,6 @@ public class DeviceRegistrationAmqpIT extends DeviceRegistrationApiTests {
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
                 SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties(),
                 null);
         registrationClient.start().onComplete(ctx.completing());
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantAmqpIT.java
@@ -17,7 +17,6 @@ import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.adapter.client.registry.amqp.ProtonBasedTenantClient;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
-import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,7 +55,6 @@ public class TenantAmqpIT extends TenantApiTests {
                                 IntegrationTestSupport.TENANT_ADMIN_USER,
                                 IntegrationTestSupport.TENANT_ADMIN_PWD)),
                 SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties(),
                 null);
 
         allTenantClient.start()
@@ -71,7 +69,6 @@ public class TenantAmqpIT extends TenantApiTests {
                                 IntegrationTestSupport.HONO_USER,
                                 IntegrationTestSupport.HONO_PWD)),
                 SendMessageSampler.Factory.noop(),
-                new ProtocolAdapterProperties(),
                 null);
 
         defaultTenantClient.start()


### PR DESCRIPTION
Mayn classes of the adapter-amqp module required a
ProtocolAdapterProperties instance in their constructors. However, some
classes will also be used outside the context of a protocol adapter. In
such cases, it seems odd to provide a properties instance which does not
actually represent the configuration of a protocol adapter.

The base classes for implementing AMQP based clients have been changed
to require simple booleans instead of the ProtocolAdapterProperties in
their constructors. The concrete client implementations have been
updated accordingly.