### PR TITLE
Add KafkaAdminClientConfigProperties class

### DIFF
--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/AbstractKafkaConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/AbstractKafkaConfigProperties.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Common configuration properties for Kafka clients.
+ */
+public abstract class AbstractKafkaConfigProperties {
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Common client config properties.
+     */
+    protected Map<String, String> commonClientConfig;
+    /**
+     * Client id prefix to be applied if no {@code client.id} property is set in the common
+     * or specific client config properties.
+     */
+    protected String defaultClientIdPrefix;
+
+    /**
+     * Sets the common Kafka client config properties to be used.
+     *
+     * @param commonClientConfig The config properties.
+     * @throws NullPointerException if the config is {@code null}.
+     */
+    public final void setCommonClientConfig(final Map<String, String> commonClientConfig) {
+        this.commonClientConfig = Objects.requireNonNull(commonClientConfig);
+    }
+
+    /**
+     * Sets the prefix for the client ID that is passed to the Kafka server to allow application specific server-side
+     * request logging.
+     * <p>
+     * If the common or specific client config already contains a value for key {@code client.id}, that one
+     * will be used and the parameter here will be ignored.
+     *
+     * @param clientId The client ID prefix to set.
+     * @throws NullPointerException if the client ID is {@code null}.
+     */
+    public final void setDefaultClientIdPrefix(final String clientId) {
+        this.defaultClientIdPrefix = Objects.requireNonNull(clientId);
+    }
+
+    /**
+     * Overrides a property in the given map.
+     *
+     * @param config The map to set the property in.
+     * @param key The key of the property.
+     * @param value The property value.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected final void overrideConfigProperty(final Map<String, String> config, final String key, final String value) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+
+        log.trace("setting Kafka config property [{}={}]", key, value);
+        final Object oldValue = config.put(key, value);
+        if (oldValue != null) {
+            log.debug("provided Kafka configuration contains property [{}={}], changing it to [{}]", key,
+                    oldValue, value);
+        }
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigProperties.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+
+/**
+ * Configuration properties for Kafka admin clients.
+ * <p>
+ * This class is intended to be as agnostic to the provided properties as possible in order to be forward-compatible
+ * with changes in new versions of the Kafka client.
+ *
+ * @see <a href="https://kafka.apache.org/documentation/#adminclientconfigs">Kafka AdminClient Configs</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/telemetry-kafka">Telemetry API for Kafka Specification</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/event-kafka">Event API for Kafka Specification</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">Command &amp; Control API for Kafka Specification</a>
+ */
+public class KafkaAdminClientConfigProperties extends AbstractKafkaConfigProperties {
+
+    private Map<String, String> adminClientConfig;
+
+    /**
+     * Sets the Kafka admin client config properties to be used.
+     *
+     * @param adminConfig The config properties.
+     * @throws NullPointerException if the config is {@code null}.
+     */
+    public final void setAdminClientConfig(final Map<String, String> adminConfig) {
+        this.adminClientConfig = Objects.requireNonNull(adminConfig);
+    }
+
+    /**
+     * Checks if a configuration has been set.
+     *
+     * @return true if configuration is present.
+     */
+    public final boolean isConfigured() {
+        return commonClientConfig != null || adminClientConfig != null;
+    }
+
+    /**
+     * Gets the Kafka admin client configuration to which additional properties were applied. The following properties are
+     * set here to the given configuration:
+     * <ul>
+     * <li>{@code client.id} if the property is not already present in the configuration and a value has been set with
+     * {@link #setDefaultClientIdPrefix(String)}, this value will be taken</li>
+     * </ul>
+     *
+     * @return a copy of the admin client configuration with the applied properties or an empty map if neither an admin
+     *         client configuration was set with {@link #setAdminClientConfig(Map)} nor common configuration properties were
+     *         set with {@link #setCommonClientConfig(Map)}.
+     */
+    public final Map<String, String> getAdminClientConfig() {
+
+        if (commonClientConfig == null && adminClientConfig == null) {
+            return Collections.emptyMap();
+        }
+
+        final Map<String, String> newConfig = new HashMap<>();
+        if (commonClientConfig != null) {
+            newConfig.putAll(commonClientConfig);
+        }
+        if (adminClientConfig != null) {
+            newConfig.putAll(adminClientConfig);
+        }
+
+        if (defaultClientIdPrefix != null) {
+            newConfig.putIfAbsent(AdminClientConfig.CLIENT_ID_CONFIG, defaultClientIdPrefix);
+        }
+        return newConfig;
+    }
+
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
@@ -19,31 +19,27 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
 
 /**
  * Configuration properties for Kafka consumers.
  * <p>
  * This class is intended to be as agnostic to the provided properties as possible in order to be forward-compatible
- * with changes in new versions of the Kafka client. It only sets a couple of properties that are important for Hono to
- * provide the expected quality of service.
+ * with changes in new versions of the Kafka client.
  *
  * @see <a href="https://kafka.apache.org/documentation/#consumerconfigs">Kafka Consumer Configs</a>
  * @see <a href="https://www.eclipse.org/hono/docs/api/telemetry-kafka">Telemetry API for Kafka Specification</a>
  * @see <a href="https://www.eclipse.org/hono/docs/api/event-kafka">Event API for Kafka Specification</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">Command &amp; Control API for Kafka Specification</a>
  */
-public class KafkaConsumerConfigProperties {
+public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties {
 
     /**
      * The default amount of time (milliseconds) to wait for records when polling records.
      */
     public static final long DEFAULT_POLL_TIMEOUT = 100L; // ms
 
-    private final Logger log = LoggerFactory.getLogger(KafkaConsumerConfigProperties.class);
-
     private Map<String, String> consumerConfig;
-    private String clientId;
     private long pollTimeout = DEFAULT_POLL_TIMEOUT;
 
     /**
@@ -52,21 +48,8 @@ public class KafkaConsumerConfigProperties {
      * @param consumerConfig The config properties.
      * @throws NullPointerException if the config is {@code null}.
      */
-    public void setConsumerConfig(final Map<String, String> consumerConfig) {
+    public final void setConsumerConfig(final Map<String, String> consumerConfig) {
         this.consumerConfig = Objects.requireNonNull(consumerConfig);
-    }
-
-    /**
-     * Sets the client ID that is passed to the Kafka server to allow application specific server-side request logging.
-     * <p>
-     * If the config set in {@link #setConsumerConfig(Map)} already contains a value for key {@code client.id}, that one
-     * will be used and the parameter here will be ignored.
-     *
-     * @param clientId The client ID to set.
-     * @throws NullPointerException if the client ID is {@code null}.
-     */
-    public final void setClientId(final String clientId) {
-        this.clientId = Objects.requireNonNull(clientId);
     }
 
     /**
@@ -74,8 +57,8 @@ public class KafkaConsumerConfigProperties {
      *
      * @return true if configuration is present.
      */
-    public boolean isConfigured() {
-        return consumerConfig != null;
+    public final boolean isConfigured() {
+        return commonClientConfig != null || consumerConfig != null;
     }
 
     /**
@@ -87,28 +70,35 @@ public class KafkaConsumerConfigProperties {
      * <li>{@code value.deserializer=io.vertx.kafka.client.serialization.BufferDeserializer}: defines how message values
      * are deserialized</li>
      * <li>{@code client.id} if the property is not already present in the configuration and a value has been set with
-     * {@link #setClientId(String)}, this value will be taken</li>
+     * {@link #setDefaultClientIdPrefix(String)}, this value will be taken</li>
      * </ul>
      *
-     * @return a copy of the consumer configuration with the applied properties an empty map if no consumer
-     *         configuration was set with {@link #setConsumerConfig(Map)}.
+     * @return a copy of the consumer configuration with the applied properties or an empty map if neither a consumer
+     *         client configuration was set with {@link #setConsumerConfig(Map)} nor common configuration properties were
+     *         set with {@link #setCommonClientConfig(Map)}.
      */
-    public Map<String, String> getConsumerConfig() {
+    public final Map<String, String> getConsumerConfig() {
 
-        if (consumerConfig == null) {
+        if (commonClientConfig == null && consumerConfig == null) {
             return Collections.emptyMap();
         }
 
-        final HashMap<String, String> newConfig = new HashMap<>(consumerConfig);
+        final Map<String, String> newConfig = new HashMap<>();
+        if (commonClientConfig != null) {
+            newConfig.putAll(commonClientConfig);
+        }
+        if (consumerConfig != null) {
+            newConfig.putAll(consumerConfig);
+        }
 
-        overrideConsumerConfigProperty(newConfig, ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+        overrideConfigProperty(newConfig, ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.StringDeserializer");
 
-        overrideConsumerConfigProperty(newConfig, ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+        overrideConfigProperty(newConfig, ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
                 "io.vertx.kafka.client.serialization.BufferDeserializer");
 
-        if (clientId != null) {
-            newConfig.putIfAbsent(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
+        if (defaultClientIdPrefix != null) {
+            newConfig.putIfAbsent(ConsumerConfig.CLIENT_ID_CONFIG, defaultClientIdPrefix);
         }
 
         return newConfig;
@@ -122,7 +112,7 @@ public class KafkaConsumerConfigProperties {
      * @param pollTimeoutMillis The maximum number of milliseconds to wait.
      * @throws IllegalArgumentException if poll timeout is negative.
      */
-    public void setPollTimeout(final long pollTimeoutMillis) {
+    public final void setPollTimeout(final long pollTimeoutMillis) {
         if (pollTimeoutMillis < 0) {
             throw new IllegalArgumentException("poll timeout must not be negative");
         } else {
@@ -137,20 +127,8 @@ public class KafkaConsumerConfigProperties {
      *
      * @return The maximum number of milliseconds to wait.
      */
-    public long getPollTimeout() {
+    public final long getPollTimeout() {
         return pollTimeout;
-    }
-
-    private void overrideConsumerConfigProperty(final Map<String, String> config, final String key,
-            final String value) {
-
-        log.trace("Setting Kafka consumer config property [{}={}]", key, value);
-        final Object oldValue = config.put(key, value);
-        if (oldValue != null) {
-            log.debug("Provided Kafka consumer configuration contains property [{}={}], changing it to [{}]", key,
-                    oldValue, value);
-        }
-
     }
 
 }

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigPropertiesTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the behavior of {@link KafkaAdminClientConfigProperties}.
+ */
+public class KafkaAdminClientConfigPropertiesTest {
+
+    /**
+     * Verifies that trying to set a {@code null} config throws a {@link NullPointerException}.
+     */
+    @Test
+    public void testThatConfigCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaAdminClientConfigProperties().setAdminClientConfig(null));
+    }
+
+    /**
+     * Verifies that trying to set a {@code null} client ID throws a {@link NullPointerException}.
+     */
+    @Test
+    public void testThatClientIdCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaAdminClientConfigProperties().setDefaultClientIdPrefix(null));
+    }
+
+    /**
+     * Verifies that properties provided with {@link KafkaAdminClientConfigProperties#setAdminClientConfig(Map)} are returned
+     * in {@link KafkaAdminClientConfigProperties#getAdminClientConfig()}.
+     */
+    @Test
+    public void testThatGetAdminClientConfigReturnsGivenProperties() {
+        final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
+        config.setAdminClientConfig(Collections.singletonMap("foo", "bar"));
+
+        assertThat(config.getAdminClientConfig().get("foo")).isEqualTo("bar");
+    }
+
+    /**
+     * Verifies that properties provided with {@link KafkaAdminClientConfigProperties#setAdminClientConfig(Map)} and
+     * {@link AbstractKafkaConfigProperties#setCommonClientConfig(Map)} are returned
+     * in {@link KafkaAdminClientConfigProperties#getAdminClientConfig()}, with the admin client config properties having
+     * precedence.
+     */
+    @Test
+    public void testThatGetAdminClientConfigReturnsGivenPropertiesWithCommonProperties() {
+        final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
+        config.setCommonClientConfig(Map.of("foo", "toBeOverridden", "common", "commonValue"));
+        config.setAdminClientConfig(Collections.singletonMap("foo", "bar"));
+
+        assertThat(config.getAdminClientConfig().get("foo")).isEqualTo("bar");
+        assertThat(config.getAdminClientConfig().get("common")).isEqualTo("commonValue");
+    }
+
+    /**
+     * Verifies that {@link KafkaAdminClientConfigProperties#isConfigured()} returns false if no configuration has been
+     * set, and true otherwise.
+     */
+    @Test
+    public void testIsConfiguredMethod() {
+
+        assertThat(new KafkaAdminClientConfigProperties().isConfigured()).isFalse();
+
+        final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
+        config.setAdminClientConfig(Collections.singletonMap("foo", "bar"));
+        assertThat(config.isConfigured()).isTrue();
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaAdminClientConfigProperties#setDefaultClientIdPrefix(String)} is applied when it
+     * is NOT present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsApplied() {
+        final String clientId = "the-client";
+
+        final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
+        config.setAdminClientConfig(Collections.emptyMap());
+        config.setDefaultClientIdPrefix(clientId);
+
+        assertThat(config.getAdminClientConfig().get("client.id")).isEqualTo(clientId);
+    }
+
+    /**
+     * Verifies that the client ID set with {@link KafkaAdminClientConfigProperties#setDefaultClientIdPrefix(String)} is NOT applied
+     * when it is present in the configuration.
+     */
+    @Test
+    public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
+        final String userProvidedClientId = "custom-client";
+
+        final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
+        config.setAdminClientConfig(Collections.singletonMap("client.id", userProvidedClientId));
+        config.setDefaultClientIdPrefix("other-client");
+
+        assertThat(config.getAdminClientConfig().get("client.id")).isEqualTo(userProvidedClientId);
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaProducerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaProducerConfigPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class KafkaProducerConfigPropertiesTest {
 
     /**
-     * Verifies that trying to set a {@code null} config throws a Nullpointer exception.
+     * Verifies that trying to set a {@code null} config throws a {@link NullPointerException}.
      */
     @Test
     public void testThatConfigCanNotBeSetToNull() {
@@ -36,11 +36,11 @@ public class KafkaProducerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that trying to set a {@code null} client ID throws a Nullpointer exception.
+     * Verifies that trying to set a {@code null} client ID throws a {@link NullPointerException}.
      */
     @Test
     public void testThatClientIdCanNotBeSetToNull() {
-        assertThrows(NullPointerException.class, () -> new KafkaProducerConfigProperties().setClientId(null));
+        assertThrows(NullPointerException.class, () -> new KafkaProducerConfigProperties().setDefaultClientIdPrefix(null));
     }
 
     /**
@@ -53,6 +53,22 @@ public class KafkaProducerConfigPropertiesTest {
         config.setProducerConfig(Collections.singletonMap("foo", "bar"));
 
         assertThat(config.getProducerConfig().get("foo")).isEqualTo("bar");
+    }
+
+    /**
+     * Verifies that properties provided with {@link KafkaProducerConfigProperties#setProducerConfig(Map)} and
+     * {@link org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties#setCommonClientConfig(Map)} are returned
+     * in {@link KafkaProducerConfigProperties#getProducerConfig()}, with the producer config properties having
+     * precedence.
+     */
+    @Test
+    public void testThatGetProducerConfigReturnsGivenPropertiesWithCommonProperties() {
+        final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
+        config.setCommonClientConfig(Map.of("foo", "toBeOverridden", "common", "commonValue"));
+        config.setProducerConfig(Collections.singletonMap("foo", "bar"));
+
+        assertThat(config.getProducerConfig().get("foo")).isEqualTo("bar");
+        assertThat(config.getProducerConfig().get("common")).isEqualTo("commonValue");
     }
 
     /**
@@ -70,8 +86,8 @@ public class KafkaProducerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setClientId(String)} is applied when it
-     * is not present in the configuration.
+     * Verifies that properties returned in {@link KafkaProducerConfigProperties#getProducerConfig()} contain
+     * the predefined entries, overriding any corresponding properties given in {@link KafkaProducerConfigProperties#setProducerConfig(Map)}.
      */
     @Test
     public void testThatGetProducerConfigReturnsAdaptedConfig() {
@@ -94,7 +110,7 @@ public class KafkaProducerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setClientId(String)} is applied when it
+     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setDefaultClientIdPrefix(String)} is applied when it
      * is NOT present in the configuration.
      */
     @Test
@@ -103,13 +119,13 @@ public class KafkaProducerConfigPropertiesTest {
 
         final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
         config.setProducerConfig(Collections.emptyMap());
-        config.setClientId(clientId);
+        config.setDefaultClientIdPrefix(clientId);
 
         assertThat(config.getProducerConfig().get("client.id")).isEqualTo(clientId);
     }
 
     /**
-     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setClientId(String)} is NOT applied
+     * Verifies that the client ID set with {@link KafkaProducerConfigProperties#setDefaultClientIdPrefix(String)} is NOT applied
      * when it is present in the configuration.
      */
     @Test
@@ -118,7 +134,7 @@ public class KafkaProducerConfigPropertiesTest {
 
         final KafkaProducerConfigProperties config = new KafkaProducerConfigProperties();
         config.setProducerConfig(Collections.singletonMap("client.id", userProvidedClientId));
-        config.setClientId("other-client");
+        config.setDefaultClientIdPrefix("other-client");
 
         assertThat(config.getProducerConfig().get("client.id")).isEqualTo(userProvidedClientId);
     }

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class KafkaConsumerConfigPropertiesTest {
 
     /**
-     * Verifies that trying to set a {@code null} config throws a Nullpointer exception.
+     * Verifies that trying to set a {@code null} config throws a {@link NullPointerException}.
      */
     @Test
     public void testThatConfigCanNotBeSetToNull() {
@@ -36,15 +36,15 @@ public class KafkaConsumerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that trying to set a {@code null} client ID throws a Nullpointer exception.
+     * Verifies that trying to set a {@code null} client ID throws a {@link NullPointerException}.
      */
     @Test
     public void testThatClientIdCanNotBeSetToNull() {
-        assertThrows(NullPointerException.class, () -> new KafkaConsumerConfigProperties().setClientId(null));
+        assertThrows(NullPointerException.class, () -> new KafkaConsumerConfigProperties().setDefaultClientIdPrefix(null));
     }
 
     /**
-     * Verifies that trying to set a negative poll timeout throws a IllegalArgumentException.
+     * Verifies that trying to set a negative poll timeout throws an {@link IllegalArgumentException}.
      */
     @Test
     public void testThatPollTimeoutCanNotBeSetToNull() {
@@ -64,6 +64,22 @@ public class KafkaConsumerConfigPropertiesTest {
     }
 
     /**
+     * Verifies that properties provided with {@link KafkaConsumerConfigProperties#setConsumerConfig(Map)} and
+     * {@link org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties#setCommonClientConfig(Map)} are returned
+     * in {@link KafkaConsumerConfigProperties#getConsumerConfig()}, with the consumer config properties having
+     * precedence.
+     */
+    @Test
+    public void testThatGetConsumerConfigReturnsGivenPropertiesWithCommonProperties() {
+        final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
+        config.setCommonClientConfig(Map.of("foo", "toBeOverridden", "common", "commonValue"));
+        config.setConsumerConfig(Collections.singletonMap("foo", "bar"));
+
+        assertThat(config.getConsumerConfig().get("foo")).isEqualTo("bar");
+        assertThat(config.getConsumerConfig().get("common")).isEqualTo("commonValue");
+    }
+
+    /**
      * Verifies that {@link KafkaConsumerConfigProperties#isConfigured()} returns false if no configuration has been
      * set, and true otherwise.
      */
@@ -78,8 +94,8 @@ public class KafkaConsumerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setClientId(String)} is applied when it
-     * is not present in the configuration.
+     * Verifies that properties returned in {@link KafkaConsumerConfigProperties#getConsumerConfig()} ()} contain
+     * the predefined entries, overriding any corresponding properties given in {@link KafkaConsumerConfigProperties#setConsumerConfig(Map)}.
      */
     @Test
     public void testThatGetConsumerConfigReturnsAdaptedConfig() {
@@ -101,7 +117,7 @@ public class KafkaConsumerConfigPropertiesTest {
     }
 
     /**
-     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setClientId(String)} is applied when it
+     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setDefaultClientIdPrefix(String)} is applied when it
      * is NOT present in the configuration.
      */
     @Test
@@ -110,13 +126,13 @@ public class KafkaConsumerConfigPropertiesTest {
 
         final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
         config.setConsumerConfig(Collections.emptyMap());
-        config.setClientId(clientId);
+        config.setDefaultClientIdPrefix(clientId);
 
         assertThat(config.getConsumerConfig().get("client.id")).isEqualTo(clientId);
     }
 
     /**
-     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setClientId(String)} is NOT applied
+     * Verifies that the client ID set with {@link KafkaConsumerConfigProperties#setDefaultClientIdPrefix(String)} is NOT applied
      * when it is present in the configuration.
      */
     @Test
@@ -125,7 +141,7 @@ public class KafkaConsumerConfigPropertiesTest {
 
         final KafkaConsumerConfigProperties config = new KafkaConsumerConfigProperties();
         config.setConsumerConfig(Collections.singletonMap("client.id", userProvidedClientId));
-        config.setClientId("other-client");
+        config.setDefaultClientIdPrefix("other-client");
 
         assertThat(config.getConsumerConfig().get("client.id")).isEqualTo(userProvidedClientId);
     }

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractAdapterConfig.java
@@ -42,8 +42,10 @@ import org.eclipse.hono.adapter.client.telemetry.kafka.KafkaBasedTelemetrySender
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
@@ -252,7 +254,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     }
 
     /**
-     * Exposes configuration properties for accessing the Kafka cluster as a Spring bean.
+     * Exposes configuration properties for a producer accessing the Kafka cluster as a Spring bean.
      *
      * @return The properties.
      */
@@ -261,7 +263,37 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
     public KafkaProducerConfigProperties kafkaProducerConfig() {
         final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
         if (getAdapterName() != null) {
-            configProperties.setClientId(getAdapterName());
+            configProperties.setDefaultClientIdPrefix(getAdapterName());
+        }
+        return configProperties;
+    }
+
+    /**
+     * Exposes configuration properties for a consumer accessing the Kafka cluster as a Spring bean.
+     *
+     * @return The properties.
+     */
+    @ConfigurationProperties(prefix = "hono.kafka")
+    @Bean
+    public KafkaConsumerConfigProperties kafkaConsumerConfig() {
+        final KafkaConsumerConfigProperties configProperties = new KafkaConsumerConfigProperties();
+        if (getAdapterName() != null) {
+            configProperties.setDefaultClientIdPrefix(getAdapterName());
+        }
+        return configProperties;
+    }
+
+    /**
+     * Exposes configuration properties for an admin client accessing the Kafka cluster as a Spring bean.
+     *
+     * @return The properties.
+     */
+    @ConfigurationProperties(prefix = "hono.kafka")
+    @Bean
+    public KafkaAdminClientConfigProperties kafkaAdminClientConfig() {
+        final KafkaAdminClientConfigProperties configProperties = new KafkaAdminClientConfigProperties();
+        if (getAdapterName() != null) {
+            configProperties.setDefaultClientIdPrefix(getAdapterName());
         }
         return configProperties;
     }

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -45,7 +45,85 @@ The factory can be configured to use TLS for
 
 To use this, a Kafka Producer configuration as described in 
 [Kafka documentation - section "Security"](https://kafka.apache.org/documentation/#security_configclients) needs to be provided. 
-The properties must be prefixed with `HONO_KAFKA_PRODUCERCONFIG_` respectively `hono.kafka.producerConfig.` as shown in 
+The properties must be prefixed with `HONO_KAFKA_PRODUCERCONFIG_` and `hono.kafka.producerConfig.` respectively as shown in 
 [Producer Configuration Properties]({{< relref "#producer-configuration-properties" >}}).
 The complete reference of available properties and the possible values is available in 
 [Kafka documentation - section "Producer Configs"](https://kafka.apache.org/documentation/#producerconfigs).
+
+## Consumer Configuration Properties
+
+Consumers for Hono's Kafka based APIs are configured with instances of the class `org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties`
+which can be used to programmatically configure a consumer.
+
+The configuration needs to be provided in the form `HONO_KAFKA_CONSUMERCONFIG_${PROPERTY}` as an environment variable or
+as a command line option in the form `hono.kafka.consumerConfig.${property}`, where `${PROPERTY}` respectively
+`${property}` is any of the Kafka client's [consumer properties](https://kafka.apache.org/documentation/#consumerconfigs).
+The provided configuration is passed directly to the Kafka consumer without Hono parsing or validating it.
+
+The following properties can _not_ be set using this mechanism because the protocol adapters use fixed values instead.
+
+| Kafka Consumer Config Property | Fixed Value |
+| :----------------------------- | :---------- |
+| `key.deserializer` | `org.apache.kafka.common.serialization.StringDeserializer` |
+| `value.deserializer` | `io.vertx.kafka.client.serialization.BufferDeserializer` |
+
+{{% note title="Enable Kafka based Messaging" %}}
+The Kafka client requires the property `bootstrap.servers` to be provided. This variable is the minimal configuration
+required to enable Kafka based messaging.
+{{% /note %}}
+
+### Using TLS
+
+The factory can be configured to use TLS for
+
+* authenticating the brokers in the Kafka cluster during connection establishment and
+* (optionally) authenticating to the broker using a client certificate
+
+To use this, a Kafka Consumer configuration as described in
+[Kafka documentation - section "Security"](https://kafka.apache.org/documentation/#security_configclients) needs to be provided.
+The properties must be prefixed with `HONO_KAFKA_CONSUMERCONFIG_` and `hono.kafka.consumerConfig.` respectively as shown in
+[Consumer Configuration Properties]({{< relref "#consumer-configuration-properties" >}}).
+The complete reference of available properties and the possible values is available in
+[Kafka documentation - section "Consumer Configs"](https://kafka.apache.org/documentation/#consumerconfigs).
+
+
+## Admin Client Configuration Properties
+
+Admin clients for Hono's Kafka based APIs are configured with instances of the class `org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties`
+which can be used to programmatically configure an admin client.
+
+The configuration needs to be provided in the form `HONO_KAFKA_ADMINCLIENTCONFIG_${PROPERTY}` as an environment variable or
+as a command line option in the form `hono.kafka.adminClientConfig.${property}`, where `${PROPERTY}` respectively
+`${property}` is any of the Kafka client's [admin client properties](https://kafka.apache.org/documentation/#adminclientconfigs).
+The provided configuration is passed directly to the Kafka admin client without Hono parsing or validating it.
+
+{{% note title="Enable Kafka based Messaging" %}}
+The Kafka client requires the property `bootstrap.servers` to be provided. This variable is the minimal configuration
+required to enable Kafka based messaging.
+{{% /note %}}
+
+### Using TLS
+
+The factory can be configured to use TLS for
+
+* authenticating the brokers in the Kafka cluster during connection establishment and
+* (optionally) authenticating to the broker using a client certificate
+
+To use this, a Kafka admin client configuration as described in
+[Kafka documentation - section "Security"](https://kafka.apache.org/documentation/#security_configclients) needs to be provided.
+The properties must be prefixed with `HONO_KAFKA_ADMINCLIENTCONFIG_` and `hono.kafka.adminClientConfig.` respectively as shown in
+[Admin Client Configuration Properties]({{< relref "#admin-client-configuration-properties" >}}).
+The complete reference of available properties and the possible values is available in
+[Kafka documentation - section "Admin Configs"](https://kafka.apache.org/documentation/#adminclientconfigs).
+
+## Common Configuration Properties
+
+Configuration properties that are common to all the client types described above can be put in a common configuration section.
+This will avoid having to define duplicate configuration properties for the different client types.
+
+Relevant properties are `bootstrap.servers` and the properties related to the TLS configuration (see chapters above).
+
+The properties must be prefixed with `HONO_KAFKA_COMMONCLIENTCONFIG_` and `hono.kafka.commonClientConfig.` respectively.
+
+A property with the same name defined in the configuration of one of the specific client types above will have precedence
+over the common property.


### PR DESCRIPTION
Also provide a way to define common config properties used in all the producer, consumer and admin client types.