### PR TITLE
[#2392] Add implementation of AMQP based application client factory

### DIFF
--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericReceiverLink.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericReceiverLink.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.amqp;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.HonoConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+
+/**
+ * A wrapper around a vertx-proton based AMQP receiver link.
+ */
+public class GenericReceiverLink extends AbstractHonoClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GenericReceiverLink.class);
+
+    private GenericReceiverLink(final HonoConnection connection, final ProtonReceiver receiver) {
+        super(connection);
+        this.receiver = Objects.requireNonNull(receiver);
+    }
+
+    /**
+     * Creates a new receiver link for a source address.
+     *
+     * @param con The connection to the server.
+     * @param sourceAddress The address to receive messages from.
+     * @param messageConsumer The consumer to invoke with each message received.
+     * @param autoAccept {@code true} if received deliveries should be automatically accepted (and settled)
+     *                   after the message handler runs for them, if no other disposition has been applied
+     *                   during handling. NOTE: When using {@code false} here, make sure that deliveries are
+     *                   quickly updated and settled, so that the messages don't remain <em>in flight</em>
+     *                   for long.
+     * @param closeHook The handler to invoke when the link is closed by the peer (may be {@code null}).
+     * @return A future indicating the outcome.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static Future<GenericReceiverLink> create(
+            final HonoConnection con,
+            final String sourceAddress,
+            final BiConsumer<ProtonDelivery, Message> messageConsumer,
+            final boolean autoAccept,
+            final Handler<String> closeHook) {
+
+        Objects.requireNonNull(con);
+        Objects.requireNonNull(sourceAddress);
+        Objects.requireNonNull(messageConsumer);
+
+        final int preFetchSize = con.getConfig().getInitialCredits();
+        return con.createReceiver(
+                sourceAddress,
+                ProtonQoS.AT_LEAST_ONCE,
+                messageConsumer::accept,
+                preFetchSize,
+                autoAccept,
+                closeHook)
+                .map(receiver -> new GenericReceiverLink(con, receiver));
+    }
+
+    /**
+     * Closes the link.
+     *
+     * @return A succeeded future indicating that the link has been closed.
+     */
+    public final Future<Void> close() {
+        LOG.debug("closing receiver ...");
+        return closeLinks();
+    }
+}

--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericReceiverLink.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericReceiverLink.java
@@ -50,9 +50,9 @@ public class GenericReceiverLink extends AbstractHonoClient {
      *                   during handling. NOTE: When using {@code false} here, make sure that deliveries are
      *                   quickly updated and settled, so that the messages don't remain <em>in flight</em>
      *                   for long.
-     * @param closeHook The handler to invoke when the link is closed by the peer (may be {@code null}).
+     * @param closeHook An (optional) handler to invoke when the link is closed by the peer.
      * @return A future indicating the outcome.
-     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws NullPointerException if any of the parameters except close hook are {@code null}.
      */
     public static Future<GenericReceiverLink> create(
             final HonoConnection con,

--- a/clients/application-amqp/pom.xml
+++ b/clients/application-amqp/pom.xml
@@ -37,5 +37,11 @@
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-amqp-common</artifactId>
     </dependency>
+
+    <!--  testing -->
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>client-test-utils</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/AmqpApplicationClientFactory.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/AmqpApplicationClientFactory.java
@@ -13,11 +13,78 @@
 
 package org.eclipse.hono.application.client.amqp;
 
+import java.util.function.Function;
+
 import org.eclipse.hono.application.client.ApplicationClientFactory;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.util.Lifecycle;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 
 /**
  * A factory for creating clients for Hono's AMQP-based north bound APIs.
  */
 public interface AmqpApplicationClientFactory extends ApplicationClientFactory<AmqpMessageContext>, Lifecycle {
+
+    /**
+     * Creates a client for consuming messages from Hono's north bound <em>Telemetry API</em>.
+     * <p>
+     * The messages passed in to the provided consumer will be acknowledged automatically if the future
+     * returned by the consumer is succeeded.
+     *
+     * @param tenantId The tenant to consume messages for.
+     * @param messageHandler The handler to invoke with every message received. The future returned
+     *                        will be succeeded if the message has been processed successfully.
+     *                        It will be failed if an error occurred while processing the message.
+     *                        <p>
+     *                        Implementors are encouraged to specify in detail the types of exceptions that the
+     *                        future might be failed with, what kind of problem they indicate and what the
+     *                        consequences regarding the underlying messaging infrastructure will be.
+     * @param closeHandler An (optional) handler to be invoked when the consumer is being closed by the peer.
+     *                     The handler will be invoked with an exception indicating the cause of the consumer
+     *                     being closed or {@code null} if unknown.
+     *                     <p>
+     *                     Implementors are encouraged to specify in detail the types of exceptions that might
+     *                     be passed in, what kind of problem they indicate and what the consequences regarding the
+     *                     underlying messaging infrastructure will be.
+     * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
+     *         cannot be started.
+     * @throws NullPointerException if any of tenant ID or message handler are {@code null}.
+     */
+    Future<MessageConsumer> createTelemetryConsumer(
+            String tenantId,
+            Function<DownstreamMessage<AmqpMessageContext>, Future<Void>> messageHandler,
+            Handler<Throwable> closeHandler);
+
+    /**
+     * Creates a client for consuming messages from Hono's north bound <em>Event API</em>.
+     * <p>
+     * The messages passed in to the provided consumer will be acknowledged automatically if the future
+     * returned by the consumer is succeeded.
+     *
+     * @param tenantId The tenant to consume messages for.
+     * @param messageHandler The handler to invoke with every message received. The future returned
+     *                        will be succeeded if the message has been processed successfully.
+     *                        It will be failed if an error occurred while processing the message.
+     *                        <p>
+     *                        Implementors are encouraged to specify in detail the types of exceptions that the
+     *                        future might be failed with, what kind of problem they indicate and what the
+     *                        consequences regarding the underlying messaging infrastructure will be.
+     * @param closeHandler An (optional) handler to be invoked when the consumer is being closed by the peer.
+     *                     The handler will be invoked with an exception indicating the cause of the consumer
+     *                     being closed or {@code null} if unknown.
+     *                     <p>
+     *                     Implementors are encouraged to specify in detail the types of exceptions that might
+     *                     be passed in, what kind of problem they indicate and what the consequences regarding the
+     *                     underlying messaging infrastructure will be.
+     * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
+     *         cannot be started.
+     * @throws NullPointerException if any of tenant ID or message handler are {@code null}.
+     */
+    Future<MessageConsumer> createEventConsumer(
+            String tenantId,
+            Function<DownstreamMessage<AmqpMessageContext>, Future<Void>> messageHandler,
+            Handler<Throwable> closeHandler);
 }

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/AmqpApplicationClientFactory.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/AmqpApplicationClientFactory.java
@@ -18,7 +18,8 @@ import java.util.function.Function;
 import org.eclipse.hono.application.client.ApplicationClientFactory;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.client.ConnectionLifecycle;
+import org.eclipse.hono.client.HonoConnection;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -26,7 +27,7 @@ import io.vertx.core.Handler;
 /**
  * A factory for creating clients for Hono's AMQP-based north bound APIs.
  */
-public interface AmqpApplicationClientFactory extends ApplicationClientFactory<AmqpMessageContext>, Lifecycle {
+public interface AmqpApplicationClientFactory extends ApplicationClientFactory<AmqpMessageContext>, ConnectionLifecycle<HonoConnection> {
 
     /**
      * Creates a client for consuming messages from Hono's north bound <em>Telemetry API</em>.

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/AmqpMessageContext.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/AmqpMessageContext.java
@@ -15,36 +15,51 @@ package org.eclipse.hono.application.client.amqp;
 
 import java.util.Objects;
 
+import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.application.client.MessageContext;
 
 import io.vertx.proton.ProtonDelivery;
 
 /**
- * The context of a AMQP message.
+ * The context that an AMQP message has been received in.
  * <p>
- * It provides access to the {@link ProtonDelivery} object of the message.
+ * Provides access to the raw message and the delivery that it is associated with.
  */
 public class AmqpMessageContext implements MessageContext {
 
     private final ProtonDelivery delivery;
-
+    private final Message message;
     /**
      * Creates a context.
      *
      * @param delivery The delivery of the message.
-     * @throws NullPointerException if delivery is {@code null}.
+     * @param message The raw AMQP message.
+     * @throws NullPointerException any of the parameters are {@code null}.
      */
-    public AmqpMessageContext(final ProtonDelivery delivery) {
+    public AmqpMessageContext(final ProtonDelivery delivery, final Message message) {
         Objects.requireNonNull(delivery);
+        Objects.requireNonNull(message);
         this.delivery = delivery;
+        this.message = message;
     }
 
     /**
      * Gets the proton delivery of the message.
+     * <p>
+     * The delivery can be used to manually settle messages with a particular outcome.
      *
      * @return The delivery.
      */
     public final ProtonDelivery getDelivery() {
         return delivery;
+    }
+
+    /**
+     * Gets the AMQP message.
+     *
+     * @return The raw message.
+     */
+    public final Message getRawMessage() {
+        return message;
     }
 }

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClientFactory.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClientFactory.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.application.client.amqp;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.amqp.GenericReceiverLink;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.TelemetryConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+
+
+/**
+ * A vertx-proton based factory for creating clients to Hono's north bound APIs.
+ *
+ */
+public class ProtonBasedApplicationClientFactory implements AmqpApplicationClientFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProtonBasedApplicationClientFactory.class);
+
+    private final HonoConnection connection;
+
+    /**
+     * @param connection The connection to use for accessing Hono's north bound (AMQP 1.0 based)
+     *                   API endpoints.
+     * @throws NullPointerException if connection is {@code null}.
+     */
+    public ProtonBasedApplicationClientFactory(final HonoConnection connection) {
+        this.connection = Objects.requireNonNull(connection);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The outcome of the underlying connection's {@link HonoConnection#connect()} method.
+     */
+    @Override
+    public Future<Void> start() {
+        LOG.info("connecting to Hono endpoint");
+        return connection.connect().mapEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The outcome of the underlying connection's {@link HonoConnection#shutdown(Handler)} method.
+     */
+    @Override
+    public Future<Void> stop() {
+        LOG.info("shutting down connection to Hono endpoint");
+        final Promise<Void> result = Promise.promise();
+        connection.shutdown(result);
+        return result.future();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The {@link DownstreamMessage#getMessageContext()} method of the message passed in to the
+     * provided handler will return an {@link AmqpMessageContext} instance.
+     * Its {@link AmqpMessageContext#getDelivery()} method can be used to manually update
+     * the underlying AMQP transfer's disposition.
+     * <p>
+     * Otherwise, the transfer will be settled
+     * <ul>
+     * <li>with the <em>rejected</em> outcome if the {@link Handler#handle(Object)} method throws
+     * a {@link ClientErrorException},</li>
+     * <li>with the <em>released</em> outcome if the {@link Handler#handle(Object)} method throws
+     * an exception other than {@link ClientErrorException} or</li>
+     * <li>with the <em>accepted</em> outcome otherwise.</li>
+     * </ul>
+     */
+    @Override
+    public Future<MessageConsumer> createTelemetryConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageHandler,
+            final Handler<Throwable> closeHandler) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(messageHandler);
+
+        final String sourceAddress = String.format("%s/%s", TelemetryConstants.TELEMETRY_ENDPOINT, tenantId);
+        return createConsumer(sourceAddress, messageHandler, closeHandler);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The {@link DownstreamMessage#getMessageContext()} method of the message passed in to the
+     * provided handler will return an {@link AmqpMessageContext} instance.
+     * Its {@link AmqpMessageContext#getDelivery()} method can be used to manually update
+     * the underlying AMQP transfer's disposition.
+     * <p>
+     * Otherwise, the transfer will be settled
+     * <ul>
+     * <li>with the <em>rejected</em> outcome if the {@link Handler#handle(Object)} method throws
+     * a {@link ClientErrorException},</li>
+     * <li>with the <em>released</em> outcome if the {@link Handler#handle(Object)} method throws
+     * an exception other than {@link ClientErrorException} or</li>
+     * <li>with the <em>accepted</em> outcome otherwise.</li>
+     * </ul>
+     */
+    @Override
+    public Future<MessageConsumer> createEventConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageHandler,
+            final Handler<Throwable> closeHandler) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(messageHandler);
+
+        final String sourceAddress = String.format("%s/%s", EventConstants.EVENT_ENDPOINT, tenantId);
+        return createConsumer(sourceAddress, messageHandler, closeHandler);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The {@link DownstreamMessage#getMessageContext()} method of the message passed in to the
+     * provided handler will return an {@link AmqpMessageContext} instance.
+     * Its {@link AmqpMessageContext#getDelivery()} method can be used to manually update
+     * the underlying AMQP transfer's disposition.
+     * <p>
+     * Otherwise, the transfer will be settled
+     * <ul>
+     * <li>with the <em>rejected</em> outcome if the returned future is failed with
+     * a {@link ClientErrorException},</li>
+     * <li>with the <em>released</em> outcome if the returned future is failed with
+     * an exception other than {@link ClientErrorException} or</li>
+     * <li>with the <em>accepted</em> outcome if the returned future is succeeded.</li>
+     * </ul>
+     */
+    @Override
+    public Future<MessageConsumer> createTelemetryConsumer(
+            final String tenantId,
+            final Function<DownstreamMessage<AmqpMessageContext>, Future<Void>> messageHandler,
+            final Handler<Throwable> closeHandler) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(messageHandler);
+
+        final String sourceAddress = String.format("%s/%s", TelemetryConstants.TELEMETRY_ENDPOINT, tenantId);
+        return createAsyncConsumer(sourceAddress, messageHandler, closeHandler);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The {@link DownstreamMessage#getMessageContext()} method of the message passed in to the
+     * provided handler will return an {@link AmqpMessageContext} instance.
+     * Its {@link AmqpMessageContext#getDelivery()} method can be used to manually update
+     * the underlying AMQP transfer's disposition.
+     * <p>
+     * Otherwise, the transfer will be settled
+     * <ul>
+     * <li>with the <em>rejected</em> outcome if the returned future is failed with
+     * a {@link ClientErrorException},</li>
+     * <li>with the <em>released</em> outcome if the returned future is failed with
+     * an exception other than {@link ClientErrorException} or</li>
+     * <li>with the <em>accepted</em> outcome if the returned future is succeeded.</li>
+     * </ul>
+     */
+    @Override
+    public Future<MessageConsumer> createEventConsumer(
+            final String tenantId,
+            final Function<DownstreamMessage<AmqpMessageContext>, Future<Void>> messageHandler,
+            final Handler<Throwable> closeHandler) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(messageHandler);
+
+        final String sourceAddress = String.format("%s/%s", EventConstants.EVENT_ENDPOINT, tenantId);
+        return createAsyncConsumer(sourceAddress, messageHandler, closeHandler);
+    }
+
+    private Future<MessageConsumer> createConsumer(
+            final String sourceAddress,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageHandler,
+            final Handler<Throwable> closeHandler) {
+
+        return GenericReceiverLink.create(
+                connection,
+                sourceAddress,
+                (delivery, message) -> {
+                    try {
+                        final var msg = ProtonBasedDownstreamMessage.from(message, delivery);
+                        messageHandler.handle(msg);
+                        if (!delivery.isSettled()) {
+                            LOG.debug("client provided message handler did not settle message, auto-accepting ...");
+                            ProtonHelper.accepted(delivery, true);
+                        }
+                    } catch (final Throwable t) {
+                        handleException(t, delivery);
+                    }
+                },
+                false,
+                s -> Optional.ofNullable(closeHandler).ifPresent(h -> h.handle(null)))
+            .map(recv -> new MessageConsumer() {
+                public Future<Void> close() {
+                    return recv.close();
+                };
+            });
+    }
+
+    private Future<MessageConsumer> createAsyncConsumer(
+            final String sourceAddress,
+            final Function<DownstreamMessage<AmqpMessageContext>, Future<Void>> messageHandler,
+            final Handler<Throwable> closeHandler) {
+
+        return GenericReceiverLink.create(
+                connection,
+                sourceAddress,
+                (delivery, message) -> {
+                    try {
+                        final var msg = ProtonBasedDownstreamMessage.from(message, delivery);
+                        messageHandler.apply(msg)
+                            .onSuccess(ok -> {
+                                if (!delivery.isSettled()) {
+                                    LOG.debug("client provided message handler did not settle message, auto-accepting ...");
+                                    ProtonHelper.accepted(delivery, true);
+                                }
+                            })
+                            .onFailure(t -> {
+                                handleException(t, delivery);
+                            });
+                    } catch (final Throwable t) {
+                        handleException(t, delivery);
+                    }
+                },
+                false,
+                s -> Optional.ofNullable(closeHandler).ifPresent(h -> h.handle(null)))
+            .map(recv -> new MessageConsumer() {
+                public Future<Void> close() {
+                    return recv.close();
+                };
+            });
+    }
+
+    private void handleException(final Throwable error, final ProtonDelivery delivery) {
+        LOG.debug("client provided message handler threw exception [local state: {}, settled: {}]",
+                Optional.ofNullable(delivery.getLocalState()).map(s -> s.getType().name()).orElse(null),
+                delivery.isSettled(),
+                error);
+        if (!delivery.isSettled()) {
+            // settle with outcome based on thrown exception
+            final var localState = getDeliveryState(error);
+            LOG.debug("settling transfer [local state: {}]", localState.getType().name());
+            delivery.disposition(localState, true);
+        }
+    }
+
+    private DeliveryState getDeliveryState(final Throwable t) {
+        if (t instanceof ClientErrorException) {
+            final var rejected = new Rejected();
+            rejected.setError(ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, t.getMessage()));
+            return rejected;
+        } else {
+            return new Released();
+        }
+    }
+}

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.application.client.amqp;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageProperties;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.ResourceIdentifier;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.proton.ProtonDelivery;
+
+
+/**
+ * A wrapper around a vertx-proton AMQP {@link Message}.
+ *
+ */
+public final class ProtonBasedDownstreamMessage implements DownstreamMessage<AmqpMessageContext> {
+
+    private final Message message;
+    private final AmqpMessageContext context;
+    private final MessageProperties properties;
+
+    private ProtonBasedDownstreamMessage(final Message msg, final ProtonDelivery delivery) {
+
+        Objects.requireNonNull(msg);
+        Objects.requireNonNull(delivery);
+
+        this.message = msg;
+        this.context = new AmqpMessageContext(delivery, msg);
+        final var props = Collections.unmodifiableMap(Optional.ofNullable(msg.getApplicationProperties())
+                        .map(ApplicationProperties::getValue)
+                        .orElse(Map.of()));
+        this.properties = new MessageProperties() {
+
+            @Override
+            public Map<String, Object> getPropertiesMap() {
+                return props;
+            }
+        };
+    }
+
+    /**
+     * Creates a new instance from a proton message.
+     *
+     * @param msg The proton message to wrap.
+     * @param delivery The delivery that the message is associated with.
+     * @return The new instance.
+     * @throws NullPointerException if message is {@code null}.
+     */
+    public static ProtonBasedDownstreamMessage from(final Message msg, final ProtonDelivery delivery) {
+        return new ProtonBasedDownstreamMessage(msg, delivery);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTenantId() {
+        return Optional.ofNullable(message.getAddress())
+                .map(ResourceIdentifier::fromString)
+                .map(ResourceIdentifier::getTenantId)
+                .orElseThrow(() -> new IllegalStateException("message has no proper address"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDeviceId() {
+        return MessageHelper.getDeviceId(message);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return An unmodifiable view on the message's application properties.
+     */
+    @Override
+    public MessageProperties getProperties() {
+        return properties;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getContentType() {
+        return message.getContentType();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AmqpMessageContext getMessageContext() {
+        return context;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The QoS level determined from the message's {@value MessageHelper#APP_PROPERTY_QOS}
+     *         application property value or {@link QoS#AT_MOST_ONCE} if the message has no such
+     *         property or its value is neither 0 nor 1.
+     */
+    @Override
+    public QoS getQos() {
+        return Optional.ofNullable(MessageHelper.getQoS(message))
+                .map(QoS::from)
+                .orElse(QoS.AT_MOST_ONCE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Buffer getPayload() {
+        return MessageHelper.getPayload(message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Instant getCreationTime() {
+        return Optional.ofNullable(message.getCreationTime())
+                .map(Instant::ofEpochMilli)
+                .orElse(null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getTimeTillDisconnect() {
+        return MessageHelper.getTimeUntilDisconnect(message);
+    }
+}

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
@@ -145,9 +145,7 @@ public final class ProtonBasedDownstreamMessage implements DownstreamMessage<Amq
      */
     @Override
     public Instant getCreationTime() {
-        return Optional.ofNullable(message.getCreationTime())
-                .map(Instant::ofEpochMilli)
-                .orElse(null);
+        return message.getCreationTime() == 0L ? null : Instant.ofEpochMilli(message.getCreationTime());
     }
 
     /**

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessage.java
@@ -67,7 +67,7 @@ public final class ProtonBasedDownstreamMessage implements DownstreamMessage<Amq
      * @param msg The proton message to wrap.
      * @param delivery The delivery that the message is associated with.
      * @return The new instance.
-     * @throws NullPointerException if message is {@code null}.
+     * @throws NullPointerException if message or delivery are {@code null}.
      */
     public static ProtonBasedDownstreamMessage from(final Message msg, final ProtonDelivery delivery) {
         return new ProtonBasedDownstreamMessage(msg, delivery);

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClientFactoryTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClientFactoryTest.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.application.client.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Modified;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonMessageHandler;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+
+
+/**
+ * Tests verifying behavior of {@link ProtonBasedApplicationClientFactory}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+class ProtonBasedApplicationClientFactoryTest {
+
+    private ProtonReceiver receiver;
+    private HonoConnection connection;
+    private ProtonBasedApplicationClientFactory client;
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    void setUp() {
+        final var vertx = mock(Vertx.class);
+        connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx);
+        receiver = AmqpClientUnitTestHelper.mockProtonReceiver();
+        when(connection.createReceiver(
+                anyString(),
+                any(ProtonQoS.class),
+                any(ProtonMessageHandler.class),
+                anyInt(),
+                anyBoolean(),
+                VertxMockSupport.anyHandler())).thenReturn(Future.succeededFuture(receiver));
+
+        client = new ProtonBasedApplicationClientFactory(connection);
+    }
+
+    /**
+     * Verifies that starting the client triggers the underlying connection to be established.
+     *
+     * @param ctx The vertx test context.
+     */
+    @Test
+    void testStartTriggersConnectionEstablishment(final VertxTestContext ctx) {
+        when(connection.connect()).thenReturn(Future.succeededFuture(connection));
+        client.start().onComplete(ctx.succeeding(ok -> {
+            ctx.verify(() -> verify(connection).connect());
+            ctx.completeNow();
+        }));
+    }
+
+    /**
+     * Verifies that stopping the client shuts down the underlying connection.
+     */
+    @Test
+    void testStopShutsDownConnection() {
+        final var result = client.stop();
+        assertThat(result.isComplete()).isFalse();
+        final ArgumentCaptor<Handler<AsyncResult<Void>>> shutdownHandler = VertxMockSupport.argumentCaptorHandler();
+        verify(connection).shutdown(shutdownHandler.capture());
+        shutdownHandler.getValue().handle(Future.succeededFuture());
+        assertThat(result.succeeded()).isTrue();
+    }
+
+    /**
+     * Verifies that the message consumer created by the factory catches an exception
+     * thrown by the client provided handler and releases the message.
+     *
+     * @param ctx The vertx test context.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCreateTelemetryConsumerReleasesMessageOnException(final VertxTestContext ctx) {
+
+        // GIVEN a client provided message handler that throws an exception on
+        // each message received
+        final Handler<DownstreamMessage<AmqpMessageContext>> consumer = VertxMockSupport.mockHandler();
+        doThrow(new IllegalArgumentException("message does not contain required properties"),
+                new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST))
+            .when(consumer).handle(any(DownstreamMessage.class));
+
+        client.createTelemetryConsumer("tenant", consumer, t -> {})
+            .onComplete(ctx.succeeding(mc -> {
+                final ArgumentCaptor<ProtonMessageHandler> messageHandler = ArgumentCaptor.forClass(ProtonMessageHandler.class);
+                ctx.verify(() -> {
+                    verify(connection).createReceiver(
+                            eq("telemetry/tenant"),
+                            eq(ProtonQoS.AT_LEAST_ONCE),
+                            messageHandler.capture(),
+                            anyInt(),
+                            anyBoolean(),
+                            VertxMockSupport.anyHandler());
+
+                    final var msg = ProtonHelper.message();
+                    // WHEN a message is received and the client provided consumer
+                    // throws an IllegalArgumentException
+                    var delivery = mock(ProtonDelivery.class);
+                    messageHandler.getValue().handle(delivery, msg);
+                    // THEN the message is forwarded to the client provided handler
+                    verify(consumer).handle(any(DownstreamMessage.class));
+                    // AND the AMQP message is being released
+                    verify(delivery).disposition(any(Released.class), eq(Boolean.TRUE));
+
+                    // WHEN a message is received and the client provided consumer
+                    // throws a ClientErrorException
+                    delivery = mock(ProtonDelivery.class);
+                    messageHandler.getValue().handle(delivery, msg);
+                    // THEN the message is forwarded to the client provided handler
+                    verify(consumer, times(2)).handle(any(DownstreamMessage.class));
+                    // AND the AMQP message is being rejected
+                    verify(delivery).disposition(any(Rejected.class), eq(Boolean.TRUE));
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that the message consumer created by the factory allows the client provided handler
+     * to manually perform a disposition update for a received message.
+     *
+     * @param ctx The vertx test context.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCreateTelemetryConsumerSupportsManualDispositionHandling(final VertxTestContext ctx) {
+
+        // GIVEN a client provided message handler that manually settles messages
+        final Handler<DownstreamMessage<AmqpMessageContext>> consumer = VertxMockSupport.mockHandler();
+
+        // WHEN creating a telemetry consumer
+        client.createTelemetryConsumer("tenant", consumer, t -> {})
+            .onComplete(ctx.succeeding(mc -> {
+                final ArgumentCaptor<ProtonMessageHandler> messageHandler = ArgumentCaptor.forClass(ProtonMessageHandler.class);
+                ctx.verify(() -> {
+                    verify(connection).createReceiver(
+                            eq("telemetry/tenant"),
+                            eq(ProtonQoS.AT_LEAST_ONCE),
+                            messageHandler.capture(),
+                            anyInt(),
+                            anyBoolean(),
+                            VertxMockSupport.anyHandler());
+                    final var delivery = mock(ProtonDelivery.class);
+                    final var msg = ProtonHelper.message();
+                    // over which a message is being received
+                    messageHandler.getValue().handle(delivery, msg);
+                    // THEN the message is forwarded to the client provided handler
+                    final ArgumentCaptor<DownstreamMessage<AmqpMessageContext>> downstreamMessage = ArgumentCaptor.forClass(DownstreamMessage.class);
+                    verify(consumer).handle(downstreamMessage.capture());
+                    final var messageContext = downstreamMessage.getValue().getMessageContext();
+                    ProtonHelper.modified(messageContext.getDelivery(), true, true, true);
+                    // AND the AMQP message is being settled with the modified outcome
+                    verify(delivery).disposition(any(Modified.class), eq(Boolean.TRUE));
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that the message consumer created by the factory settles an event with the
+     * accepted outcome if the client provided handler does not throw an exception.
+     *
+     * @param ctx The vertx test context.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCreateEventConsumerAcceptsMessage(final VertxTestContext ctx) {
+
+        // GIVEN a client provided message handler
+        final Handler<DownstreamMessage<AmqpMessageContext>> consumer = VertxMockSupport.mockHandler();
+
+        // WHEN creating an event consumer
+        client.createEventConsumer("tenant", consumer, t -> {})
+            .onComplete(ctx.succeeding(mc -> {
+                final ArgumentCaptor<ProtonMessageHandler> messageHandler = ArgumentCaptor.forClass(ProtonMessageHandler.class);
+                ctx.verify(() -> {
+                    verify(connection).createReceiver(
+                            eq("event/tenant"),
+                            eq(ProtonQoS.AT_LEAST_ONCE),
+                            messageHandler.capture(),
+                            anyInt(),
+                            anyBoolean(),
+                            VertxMockSupport.anyHandler());
+                    final var delivery = mock(ProtonDelivery.class);
+                    when(delivery.isSettled()).thenReturn(Boolean.FALSE);
+                    final var msg = ProtonHelper.message();
+                    // over which a message is being received
+                    messageHandler.getValue().handle(delivery, msg);
+                    // THEN the message is forwarded to the client provided handler
+                    verify(consumer).handle(any(DownstreamMessage.class));
+                    // AND the AMQP message is being accepted
+                    verify(delivery).disposition(any(Accepted.class), eq(Boolean.TRUE));
+                });
+                ctx.completeNow();
+            }));
+    }
+
+}

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessageTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedDownstreamMessageTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.application.client.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.ResourceIdentifier;
+import org.eclipse.hono.util.TelemetryConstants;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.proton.ProtonDelivery;
+
+
+/**
+ * Tests verifying the behavior of {@link ProtonBasedDownstreamMessage}.
+ *
+ */
+class ProtonBasedDownstreamMessageTest {
+
+    /**
+     * Verifies that the downstream message provides access to the wrapped
+     * AMQP message's properties.
+     */
+    @Test
+    void testPropertiesAreCorrectlyRetrievedFromMessage() {
+
+        final var now = Instant.now().toEpochMilli();
+        final var delivery = mock(ProtonDelivery.class);
+        final var msg = MessageHelper.newMessage(
+                ResourceIdentifier.from(TelemetryConstants.TELEMETRY_ENDPOINT, "tenant", "device"),
+                "text/plain",
+                Buffer.buffer("hello"),
+                TenantObject.from("tenant"),
+                Map.of(
+                        MessageHelper.APP_PROPERTY_QOS, 1,
+                        "other", "property"),
+                Map.of(),
+                false,
+                false);
+        msg.setCreationTime(now);
+        MessageHelper.addTimeUntilDisconnect(msg, 22);
+
+        final var downstreamMessage = ProtonBasedDownstreamMessage.from(msg, delivery);
+        assertThat(downstreamMessage.getContentType()).isEqualTo("text/plain");
+        assertThat(downstreamMessage.getCreationTime()).isEqualTo(Instant.ofEpochMilli(now));
+        assertThat(downstreamMessage.getDeviceId()).isEqualTo("device");
+        assertThat(downstreamMessage.getMessageContext().getDelivery()).isEqualTo(delivery);
+        assertThat(downstreamMessage.getPayload().toString()).isEqualTo("hello");
+        assertThat(downstreamMessage.getProperties().getPropertiesMap())
+            .containsEntry("other", "property");
+        assertThat(downstreamMessage.getQos()).isEqualTo(QoS.AT_LEAST_ONCE);
+        assertThat(downstreamMessage.getTenantId()).isEqualTo("tenant");
+        assertThat(downstreamMessage.getTimeTillDisconnect()).isEqualTo(22);
+        assertThat(downstreamMessage.isSenderConnected()).isTrue();
+        assertThat(downstreamMessage.isSenderConnected(Instant.now().plusSeconds(60))).isFalse();
+    }
+}

--- a/clients/application-amqp/src/test/resources/logback-test.xml
+++ b/clients/application-amqp/src/test/resources/logback-test.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<!DOCTYPE configuration>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.eclipse.hono.application.client" level="WARN"/>
+  <logger name="org.eclipse.hono.application.client.amqp" level="WARN"/>
+
+</configuration>

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/DownstreamMessage.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/DownstreamMessage.java
@@ -112,7 +112,7 @@ public interface DownstreamMessage<T extends MessageContext> extends Message<T> 
     default boolean isSenderConnected(final Instant now) {
 
         final int ttd = Optional.ofNullable(getTimeTillDisconnect()).orElse(0);
-        switch (getTimeTillDisconnect()) {
+        switch (ttd) {
         case -1: return true;
         case 0: return false;
         default:

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -318,7 +318,7 @@ public final class MessageHelper {
      * @return The property value or {@code null} if not set.
      * @throws NullPointerException if message is {@code null}.
      */
-    public static int getQoS(final Message msg) {
+    public static Integer getQoS(final Message msg) {
         return getApplicationProperty(msg.getApplicationProperties(), APP_PROPERTY_QOS, Integer.class);
     }
 

--- a/core/src/main/java/org/eclipse/hono/util/QoS.java
+++ b/core/src/main/java/org/eclipse/hono/util/QoS.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,4 +20,18 @@ public enum QoS {
 
     AT_MOST_ONCE,
     AT_LEAST_ONCE;
+
+    /**
+     * Gets the quality of service corresponding to a given integer.
+     *
+     * @param code The code to get the qos for.
+     * @return {@link #AT_MOST_ONCE} if code is 0, {@link #AT_LEAST_ONCE} if code is 1, otherwise {@code null}.
+     */
+    public static QoS from(final int code) {
+        switch (code) {
+        case 0: return AT_MOST_ONCE;
+        case 1: return AT_LEAST_ONCE;
+        default: return null;
+        }
+    }
 }


### PR DESCRIPTION
This adds a vertx-proton based implementation of #2392
In a next PR I will refactor the integration tests to use the new application client factory.

@b-abel would you mind to also take a look?