### PR TITLE
[#8] Commit offsets when the Kafka consumer is interrupted.

### DIFF
--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClientFactory.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClientFactory.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.application.client.kafka;
 import org.eclipse.hono.application.client.ApplicationClientFactory;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerCommitException;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerPollException;
 
@@ -44,12 +45,14 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
      * <p>
      * Errors can happen when polling, in message processing, and when committing the offset to Kafka. If a {@code poll}
      * operation fails, the consumer will be closed and the close handler will be passed a
-     * {@link KafkaConsumerPollException} indicating the cause. If the provided message handler throws an exception, the
+     * {@link KafkaConsumerPollException} indicating the cause. The provided message handler may throw
+     * a{@link ServerErrorException} to indicate a transient error. If the message handler throws another exception, the
      * consumer will be closed and the exception will be passed to the close handler. If the offset commit fails, the
      * consumer will be closed and the close handler will be passed a {@link KafkaConsumerCommitException}.
      *
      * @param tenantId The tenant to consume data for.
-     * @param messageHandler The handler to invoke with every message received. The handler should not throw exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
+     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
      * @param closeHandler The handler invoked when the consumer is closed due to an error.
      * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
      *         cannot be started.
@@ -83,7 +86,8 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
      * consumer will be closed and the close handler will be passed a {@link KafkaConsumerCommitException}.
      *
      * @param tenantId The tenant to consume data for.
-     * @param messageHandler The handler to invoke with every message received. The handler should not throw exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
+     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
      * @param closeHandler The handler invoked when the consumer is closed due to an error.
      * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
      *         cannot be started.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClientFactory.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClientFactory.java
@@ -16,7 +16,6 @@ package org.eclipse.hono.application.client.kafka;
 import org.eclipse.hono.application.client.ApplicationClientFactory;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerCommitException;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerPollException;
 
@@ -45,14 +44,14 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
      * <p>
      * Errors can happen when polling, in message processing, and when committing the offset to Kafka. If a {@code poll}
      * operation fails, the consumer will be closed and the close handler will be passed a
-     * {@link KafkaConsumerPollException} indicating the cause. The provided message handler may throw
-     * a{@link ServerErrorException} to indicate a transient error. If the message handler throws another exception, the
-     * consumer will be closed and the exception will be passed to the close handler. If the offset commit fails, the
-     * consumer will be closed and the close handler will be passed a {@link KafkaConsumerCommitException}.
+     * {@link KafkaConsumerPollException} indicating the cause. If the provided the message handler throws a runtime
+     * exception, the current offsets are committed and the failed message will be polled again with the next batch of
+     * records. If the offset commit fails, the consumer will be closed and the close handler will be passed a
+     * {@link KafkaConsumerCommitException}.
      *
      * @param tenantId The tenant to consume data for.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
-     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. If the handler throws a
+     *            runtime exception, it will be invoked again with the message.
      * @param closeHandler The handler invoked when the consumer is closed due to an error.
      * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
      *         cannot be started.
@@ -81,13 +80,14 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
      * <p>
      * Errors can happen when polling, in message processing, and when committing the offset to Kafka. If a {@code poll}
      * operation fails, the consumer will be closed and the close handler will be passed a
-     * {@link KafkaConsumerPollException} indicating the cause. If the provided message handler throws an exception, the
-     * consumer will be closed and the exception will be passed to the close handler. If the offset commit fails, the
-     * consumer will be closed and the close handler will be passed a {@link KafkaConsumerCommitException}.
+     * {@link KafkaConsumerPollException} indicating the cause. If the provided the message handler throws a runtime
+     * exception, the current offsets are committed and the failed message will be polled again with the next batch of
+     * records. If the offset commit fails, the consumer will be closed and the close handler will be passed a
+     * {@link KafkaConsumerCommitException}.
      *
      * @param tenantId The tenant to consume data for.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
-     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. If the handler throws a
+     *            runtime exception, it will be invoked again with the message.
      * @param closeHandler The handler invoked when the consumer is closed due to an error.
      * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
      *         cannot be started.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClientFactory.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClientFactory.java
@@ -30,9 +30,10 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
     /**
      * Creates a client for consuming data from Hono's north bound <em>Telemetry API</em>.
      * <p>
-     * The messages passed in to the consumer will be acknowledged automatically if the message handler does not throw
-     * an exception. <b> NB: Be very careful about throwing exceptions in the message handler, after that no more
-     * telemetry messages will be consumed for the client until the problem is fixed!</b>
+     * The messages passed in to the consumer will be acknowledged automatically when the message handler completes. <b>
+     * The message handler is expected to handle processing errors internally and should not deliberately throw
+     * exceptions.</b> Any exception in the message handler will stop the consumption permanently, because a new
+     * consumer will try to consume the same message again and will then get the same exception.
      * <p>
      * If a fatal error occurs, the consumer will be closed and the close-handler, if it is not {@code null}, invoked
      * with an exception indicating the cause. There are error cases that might disappear later on and where it makes
@@ -44,11 +45,11 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
      * Errors can happen when polling, in message processing, and when committing the offset to Kafka. If a {@code poll}
      * operation fails, the consumer will be closed and the close handler will be passed a
      * {@link KafkaConsumerPollException} indicating the cause. If the provided message handler throws an exception, the
-     * consumer will be closed without invoking the close handler. If the offset commit fails, the consumer will be
-     * closed and the close handler will be passed a {@link KafkaConsumerCommitException}.
+     * consumer will be closed and the exception will be passed to the close handler. If the offset commit fails, the
+     * consumer will be closed and the close handler will be passed a {@link KafkaConsumerCommitException}.
      *
      * @param tenantId The tenant to consume data for.
-     * @param messageHandler The handler to invoke with every message received.
+     * @param messageHandler The handler to invoke with every message received. The handler should not throw exceptions.
      * @param closeHandler The handler invoked when the consumer is closed due to an error.
      * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
      *         cannot be started.
@@ -63,9 +64,10 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
     /**
      * Creates a client for consuming data from Hono's north bound <em>Event API</em>.
      * <p>
-     * The messages passed in to the consumer will be acknowledged automatically if the message handler does not throw
-     * an exception. <b> NB: Be very careful about throwing exceptions in the message handler, after that no more event
-     * messages will be consumed for the client until the problem is fixed!</b>
+     * The messages passed in to the consumer will be acknowledged automatically when the message handler completes. <b>
+     * The message handler is expected to handle processing errors internally and should not deliberately throw
+     * exceptions.</b> Any exception in the message handler will stop the consumption permanently, because a new
+     * consumer will try to consume the same message again and will then get the same exception.
      * <p>
      * If a fatal error occurs, the consumer will be closed and the close-handler, if it is not {@code null}, invoked
      * with an exception indicating the cause. There are error cases that might disappear later on and where it makes
@@ -77,11 +79,11 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
      * Errors can happen when polling, in message processing, and when committing the offset to Kafka. If a {@code poll}
      * operation fails, the consumer will be closed and the close handler will be passed a
      * {@link KafkaConsumerPollException} indicating the cause. If the provided message handler throws an exception, the
-     * consumer will be closed without invoking the close handler. If the offset commit fails, the consumer will be
-     * closed and the close handler will be passed a {@link KafkaConsumerCommitException}.
+     * consumer will be closed and the exception will be passed to the close handler. If the offset commit fails, the
+     * consumer will be closed and the close handler will be passed a {@link KafkaConsumerCommitException}.
      *
      * @param tenantId The tenant to consume data for.
-     * @param messageHandler The handler to invoke with every message received.
+     * @param messageHandler The handler to invoke with every message received. The handler should not throw exceptions.
      * @param closeHandler The handler invoked when the consumer is closed due to an error.
      * @return A future that will complete with the consumer once it is ready. The future will fail if the consumer
      *         cannot be started.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClientFactory.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClientFactory.java
@@ -30,10 +30,8 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
     /**
      * Creates a client for consuming data from Hono's north bound <em>Telemetry API</em>.
      * <p>
-     * The messages passed in to the consumer will be acknowledged automatically when the message handler completes. <b>
-     * The message handler is expected to handle processing errors internally and should not deliberately throw
-     * exceptions.</b> Any exception in the message handler will stop the consumption permanently, because a new
-     * consumer will try to consume the same message again and will then get the same exception.
+     * The messages passed in to the consumer will be acknowledged automatically if the message handler does not throw
+     * an exception.
      * <p>
      * If a fatal error occurs, the consumer will be closed and the close-handler, if it is not {@code null}, invoked
      * with an exception indicating the cause. There are error cases that might disappear later on and where it makes
@@ -44,7 +42,7 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
      * <p>
      * Errors can happen when polling, in message processing, and when committing the offset to Kafka. If a {@code poll}
      * operation fails, the consumer will be closed and the close handler will be passed a
-     * {@link KafkaConsumerPollException} indicating the cause. If the provided the message handler throws a runtime
+     * {@link KafkaConsumerPollException} indicating the cause. If the provided message handler throws a runtime
      * exception, the current offsets are committed and the failed message will be polled again with the next batch of
      * records. If the offset commit fails, the consumer will be closed and the close handler will be passed a
      * {@link KafkaConsumerCommitException}.
@@ -66,10 +64,8 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
     /**
      * Creates a client for consuming data from Hono's north bound <em>Event API</em>.
      * <p>
-     * The messages passed in to the consumer will be acknowledged automatically when the message handler completes. <b>
-     * The message handler is expected to handle processing errors internally and should not deliberately throw
-     * exceptions.</b> Any exception in the message handler will stop the consumption permanently, because a new
-     * consumer will try to consume the same message again and will then get the same exception.
+     * The messages passed in to the consumer will be acknowledged automatically if the message handler does not throw
+     * an exception.
      * <p>
      * If a fatal error occurs, the consumer will be closed and the close-handler, if it is not {@code null}, invoked
      * with an exception indicating the cause. There are error cases that might disappear later on and where it makes
@@ -80,7 +76,7 @@ public interface KafkaApplicationClientFactory extends ApplicationClientFactory<
      * <p>
      * Errors can happen when polling, in message processing, and when committing the offset to Kafka. If a {@code poll}
      * operation fails, the consumer will be closed and the close handler will be passed a
-     * {@link KafkaConsumerPollException} indicating the cause. If the provided the message handler throws a runtime
+     * {@link KafkaConsumerPollException} indicating the cause. If the provided message handler throws a runtime
      * exception, the current offsets are committed and the failed message will be polled again with the next batch of
      * records. If the offset commit fails, the consumer will be closed and the close handler will be passed a
      * {@link KafkaConsumerCommitException}.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/DownstreamMessageConsumer.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/DownstreamMessageConsumer.java
@@ -39,7 +39,8 @@ public abstract class DownstreamMessageConsumer
      *
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param topic The Kafka topic to consume records from.
-     * @param messageHandler The handler to be invoked for each message created from a record.
+     * @param messageHandler The handler to be invoked for each message created from a record. The handler should not
+     *            throw exceptions.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @param pollTimeout The maximal number of milliseconds to wait for messages during a poll operation.
      * @throws NullPointerException if any of the parameters is {@code null}.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/DownstreamMessageConsumer.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/DownstreamMessageConsumer.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
-import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.consumer.AbstractAtLeastOnceKafkaConsumer;
 
 import io.vertx.core.Future;
@@ -40,8 +39,8 @@ public abstract class DownstreamMessageConsumer
      *
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param topic The Kafka topic to consume records from.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
-     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. If the handler throws a
+     *            runtime exception, it will be invoked again with the message.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @param pollTimeout The maximal number of milliseconds to wait for messages during a poll operation.
      * @throws NullPointerException if any of the parameters is {@code null}.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/DownstreamMessageConsumer.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/DownstreamMessageConsumer.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.consumer.AbstractAtLeastOnceKafkaConsumer;
 
 import io.vertx.core.Future;
@@ -39,8 +40,8 @@ public abstract class DownstreamMessageConsumer
      *
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param topic The Kafka topic to consume records from.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler should not
-     *            throw exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
+     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @param pollTimeout The maximal number of milliseconds to wait for messages during a poll operation.
      * @throws NullPointerException if any of the parameters is {@code null}.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/EventConsumer.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/EventConsumer.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
-import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 
@@ -47,8 +46,8 @@ public class EventConsumer extends DownstreamMessageConsumer {
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param config The Kafka consumer configuration properties to use.
      * @param tenantId The tenant to consume events for.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
-     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. If the handler throws a
+     *            runtime exception, it will be invoked again with the message.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @return a future indicating the outcome. When {@link #start()} completes successfully, the future will be
      *         completed with the consumer. Otherwise the future will fail with the cause.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/EventConsumer.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/EventConsumer.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 
@@ -46,8 +47,8 @@ public class EventConsumer extends DownstreamMessageConsumer {
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param config The Kafka consumer configuration properties to use.
      * @param tenantId The tenant to consume events for.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler should not
-     *            throw exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
+     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @return a future indicating the outcome. When {@link #start()} completes successfully, the future will be
      *         completed with the consumer. Otherwise the future will fail with the cause.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/EventConsumer.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/EventConsumer.java
@@ -46,7 +46,8 @@ public class EventConsumer extends DownstreamMessageConsumer {
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param config The Kafka consumer configuration properties to use.
      * @param tenantId The tenant to consume events for.
-     * @param messageHandler The handler to be invoked for each message created from a record.
+     * @param messageHandler The handler to be invoked for each message created from a record. The handler should not
+     *            throw exceptions.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @return a future indicating the outcome. When {@link #start()} completes successfully, the future will be
      *         completed with the consumer. Otherwise the future will fail with the cause.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaDownstreamMessage.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaDownstreamMessage.java
@@ -55,6 +55,7 @@ public class KafkaDownstreamMessage implements DownstreamMessage<KafkaMessageCon
      *
      * @param record The record.
      * @throws NullPointerException if the record is {@code null}.
+     * @throws IllegalArgumentException if the topic does not contain a tenant id.
      */
     public KafkaDownstreamMessage(final KafkaConsumerRecord<String, Buffer> record) {
         Objects.requireNonNull(record);

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/TelemetryConsumer.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/TelemetryConsumer.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
-import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 
@@ -47,8 +46,8 @@ public class TelemetryConsumer extends DownstreamMessageConsumer {
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param config The Kafka consumer configuration properties to use.
      * @param tenantId The tenant to consume telemetry data for.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
-     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. If the handler throws a
+     *            runtime exception, it will be invoked again with the message.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @return a future indicating the outcome. When {@link #start()} completes successfully, the future will be
      *         completed with the consumer. Otherwise the future will fail with the cause.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/TelemetryConsumer.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/TelemetryConsumer.java
@@ -46,7 +46,8 @@ public class TelemetryConsumer extends DownstreamMessageConsumer {
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param config The Kafka consumer configuration properties to use.
      * @param tenantId The tenant to consume telemetry data for.
-     * @param messageHandler The handler to be invoked for each message created from a record.
+     * @param messageHandler The handler to be invoked for each message created from a record. The handler should not
+     *            throw exceptions.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @return a future indicating the outcome. When {@link #start()} completes successfully, the future will be
      *         completed with the consumer. Otherwise the future will fail with the cause.

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/TelemetryConsumer.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/TelemetryConsumer.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 
@@ -46,8 +47,8 @@ public class TelemetryConsumer extends DownstreamMessageConsumer {
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param config The Kafka consumer configuration properties to use.
      * @param tenantId The tenant to consume telemetry data for.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler should not
-     *            throw exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
+     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @return a future indicating the outcome. When {@link #start()} completes successfully, the future will be
      *         completed with the consumer. Otherwise the future will fail with the cause.

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -319,8 +319,7 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
 
     private void closeAndCallHandler(final Throwable exception) {
         LOG.error("Closing consumer with cause", exception);
-        closeHandler.handle(exception);
-        closeConsumer();
+        closeConsumer().onComplete(v -> closeHandler.handle(exception));
     }
 
     private Future<Void> tryCommitAndClose() {

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -246,7 +246,7 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
                     addToCurrentOffsets(record);
                 } catch (final RuntimeException messageHandlingError) {
                     LOG.debug("Message handler failed", messageHandlingError);
-                    // will commit the offset of the failed record and then resume polling (will include failed record)
+                    // resume with committing the current offsets and then polling (failed record will be polled again)
                     break;
                 }
             }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -262,6 +262,10 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
     }
 
     private Future<Void> commit(final boolean retry) {
+        if (offsetsToBeCommitted.isEmpty()) {
+            return Future.succeededFuture();
+        }
+
         final Promise<Void> commitPromise = Promise.promise();
         kafkaConsumer.commit(commitPromise);
         return commitPromise.future()
@@ -283,6 +287,11 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
     }
 
     private Future<Map<TopicPartition, OffsetAndMetadata>> commitCurrentOffsets() {
+        if (offsetsToBeCommitted.isEmpty()) {
+            LOG.debug("no offsets to commit");
+            return Future.succeededFuture();
+        }
+
         LOG.debug("committing the current offsets");
         LOG.trace("committing offsets: {}", offsetsToBeCommitted);
 

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -247,6 +247,7 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
                 } catch (final RuntimeException messageHandlingError) {
                     LOG.debug("Message handler failed", messageHandlingError);
                     // will commit the offset of the failed record and then resume polling (will include failed record)
+                    break;
                 }
             }
             commit(true).compose(ok -> poll()).onSuccess(this::handleBatch);

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -77,9 +77,9 @@ import io.vertx.kafka.client.consumer.OffsetAndMetadata;
  */
 public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
 
-    // TODO add unit test
-
     private static final Logger LOG = LoggerFactory.getLogger(AbstractAtLeastOnceKafkaConsumer.class);
+
+    boolean stopped = false; // visible for testing
 
     private final KafkaConsumer<String, Buffer> kafkaConsumer;
     private final Set<String> topics;
@@ -88,7 +88,6 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
     private final Handler<Throwable> closeHandler;
     private final Duration pollTimeout;
     private final Map<TopicPartition, OffsetAndMetadata> offsetsToBeCommitted = new HashMap<>();
-    private boolean stopped = true;
 
     /**
      * Creates a new consumer.

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -63,8 +63,8 @@ import io.vertx.kafka.client.consumer.OffsetAndMetadata;
  * future. For subsequent {@code poll} operations, the Kafka consumer will be closed and the close handler will be
  * passed a {@link KafkaConsumerPollException}.
  * <p>
- * If the provided the message handler throws a runtime exception, the current offsets are committed and the failed
- * message will be polled again with the next batch of records.
+ * If the provided message handler throws a runtime exception, the current offsets are committed and the failed message
+ * will be polled again with the next batch of records.
  * <p>
  * If {@link KafkaConsumer#commit(Handler)} times out, the commit will be retried once. If the retry fails or the commit
  * fails with another exception, the Kafka consumer will be closed and the close handler will be passed a

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -67,7 +67,7 @@ import io.vertx.kafka.client.consumer.OffsetAndMetadata;
  * throws an unexpected exception, the Kafka consumer will be closed and the exception will be passed to the close
  * handler. <b>The message handler is expected to handle processing errors internally and should not deliberately throw
  * exceptions.</b> Any exception in the message processing will stop the consumption permanently, because a new consumer
- * will try to consume the same message again will then get the same exception.
+ * will try to consume the same message again and will then get the same exception.
  * <p>
  * If {@link KafkaConsumer#commit(Handler)} times out, the commit will be retried once. If the retry fails or the commit
  * fails with another exception, the Kafka consumer will be closed and the close handler will be passed a

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.common.errors.TimeoutException;
-import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.util.Lifecycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,21 +56,15 @@ import io.vertx.kafka.client.consumer.OffsetAndMetadata;
  * ERROR CASES:
  * <p>
  * Errors can happen when polling, in message processing, and when committing the offset to Kafka.
- *
  * If a fatal error occurs, the underlying Kafka consumer will be closed and the close-handler invoked with an exception
  * indicating the cause. Therefore, the provided Kafka consumer must not be used anywhere else.
  * <p>
  * If {@link KafkaConsumer#poll(Duration, Handler)} fails during the start, {@link #start()} will return a failed
  * future. For subsequent {@code poll} operations, the Kafka consumer will be closed and the close handler will be
  * passed a {@link KafkaConsumerPollException}.
- *
  * <p>
- * If the message processing fails because either {@link #createMessage(KafkaConsumerRecord)} or the message handler
- * throws an unexpected exception, the Kafka consumer will be closed and the exception will be passed to the close
- * handler. <b>The message handler may throw a{@link ServerErrorException} to indicate a transient error.</b> In this
- * case the consumer will not be closed, instead the current offsets are committed and the failed message will be polled
- * again with the next batch of records. Any other exceptions in the message processing will stop the consumption
- * permanently, because a new consumer will try to consume the same message again and will then get the same exception.
+ * If the provided the message handler throws a runtime exception, the current offsets are committed and the failed
+ * message will be polled again with the next batch of records.
  * <p>
  * If {@link KafkaConsumer#commit(Handler)} times out, the commit will be retried once. If the retry fails or the commit
  * fails with another exception, the Kafka consumer will be closed and the close handler will be passed a
@@ -98,8 +91,8 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
      *
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param topic The Kafka topic to consume records from.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
-     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. If the handler throws a
+     *            runtime exception, the record will be polled again.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @param pollTimeout The maximal number of milliseconds to wait for messages during a poll operation.
      * @throws NullPointerException if any of the parameters is {@code null}.
@@ -120,8 +113,8 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
      *
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param topics The Kafka topics to consume records from.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
-     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. If the handler throws a
+     *            runtime exception, the record will be polled again.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @param pollTimeout The maximal number of milliseconds to wait for messages during a poll operation.
      * @throws NullPointerException if any of the parameters is {@code null}.
@@ -142,8 +135,8 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
      *
      * @param kafkaConsumer The Kafka consumer to be exclusively used by this instance to consume records.
      * @param topicPattern The pattern of Kafka topic names to consume records from.
-     * @param messageHandler The handler to be invoked for each message created from a record. The handler may throw a
-     *            {@link ServerErrorException} to indicate a transient error but should not throw any other exceptions.
+     * @param messageHandler The handler to be invoked for each message created from a record. If the handler throws a
+     *            runtime exception, the record will be polled again.
      * @param closeHandler The handler to be invoked when the Kafka consumer has been closed due to an error.
      * @param pollTimeout The maximal number of milliseconds to wait for messages during a poll operation.
      * @throws NullPointerException if any of the parameters is {@code null}.
@@ -251,14 +244,15 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
                 try {
                     messageHandler.handle(message);
                     addToCurrentOffsets(record);
-                } catch (final ServerErrorException serverErrorException) {
-                    LOG.debug("Message handler failed", serverErrorException);
-                    // will commit the offset of the failed record and then poll again
+                } catch (final RuntimeException messageHandlingError) {
+                    LOG.debug("Message handler failed", messageHandlingError);
+                    // will commit the offset of the failed record and then resume polling (will include failed record)
                 }
             }
             commit(true).compose(ok -> poll()).onSuccess(this::handleBatch);
         } catch (final Exception ex) {
             LOG.error("Consumer failed, closing", ex);
+            // indicates an unexpected programming error and ensures that the consumer does not silently stop consuming
             tryCommitAndClose().onComplete(v -> closeHandler.handle(ex));
         }
     }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -48,7 +48,7 @@ import io.vertx.kafka.client.consumer.OffsetAndMetadata;
  * handled by the message handler.
  * <p>
  * The consumer starts consuming when {@link #start()} is invoked. It needs to be closed by invoking {@link #stop()} to
- * release the resources.
+ * release the resources. A stopped instance cannot be started again.
  * <p>
  * </p>
  * ERROR CASES:
@@ -188,6 +188,10 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
      */
     @Override
     public Future<Void> start() {
+
+        if (stopped) {
+            return Future.failedFuture("consumer already stopped"); // the underlying Kafka consumer cannot be reopened
+        }
 
         final Promise<Void> promise = Promise.promise();
         if (topics != null) {

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumerKafkaMockConsumerTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumerKafkaMockConsumerTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+
+/**
+ * Verifies the behavior of {@link AbstractAtLeastOnceKafkaConsumer} with tests using {@link MockConsumer}.
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class AbstractAtLeastOnceKafkaConsumerKafkaMockConsumerTest {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(AbstractAtLeastOnceKafkaConsumerKafkaMockConsumerTest.class);
+
+    private static final String TOPIC = "test.topic";
+    private static final int PARTITION = 0;
+    private final TopicPartition topicPartition = new TopicPartition(TOPIC, PARTITION);
+
+    private MockConsumer<String, Buffer> mockConsumer;
+    private KafkaConsumer<String, Buffer> vertxKafkaConsumer;
+
+    @BeforeEach
+    void setUp(final Vertx vertx) {
+        mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        vertxKafkaConsumer = KafkaConsumer.create(vertx, mockConsumer);
+
+    }
+
+    /**
+     * Verifies that the underlying Kafka consumer is closed when {@link AbstractAtLeastOnceKafkaConsumer#stop()} is
+     * invoked.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatStopClosesConsumer(final VertxTestContext ctx) {
+        final AbstractAtLeastOnceKafkaConsumer<JsonObject> underTest = new TestConsumer(vertxKafkaConsumer, TOPIC);
+        underTest.start()
+                .onComplete(ctx.succeeding(started -> underTest.stop()
+                        .onComplete(ctx.succeeding(stopped -> ctx.verify(() -> {
+
+                            assertThat(underTest.stopped).isTrue();
+                            assertThat(mockConsumer.closed()).isTrue();
+
+                            ctx.completeNow();
+                        })))));
+    }
+
+    /**
+     * Verifies that when {@link AbstractAtLeastOnceKafkaConsumer#stop()} is invoked, the consumer cannot be started
+     * again. This is important because the underlying Kafka consumer cannot be restarted.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatStartFailsIfConsumerIsAlreadyStopped(final VertxTestContext ctx) {
+        // GIVEN a started consumer
+        final AbstractAtLeastOnceKafkaConsumer<JsonObject> underTest = new TestConsumer(vertxKafkaConsumer, TOPIC);
+        underTest.start()
+                // WHEN stopping
+                .onComplete(ctx.succeeding(started -> underTest.stop()
+                        .onComplete(ctx.succeeding(stopped -> {
+                            // THEN it cannot be started again
+                            underTest.start().onComplete(ctx.failing(cause -> ctx.verify(() -> {
+                                assertThat(cause).hasMessage("consumer already stopped");
+                                ctx.completeNow();
+                            })));
+                        }))));
+    }
+
+    /**
+     * Verifies that when {@link AbstractAtLeastOnceKafkaConsumer#start()} fails, if it cannot successfully poll
+     * messages from Kafka.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatStartFailsIfFirstPollFails(final VertxTestContext ctx) {
+        final AuthenticationException authenticationException = new AuthenticationException("auth failed");
+
+        // WHEN the initial poll operation fails
+        mockConsumer.setPollException(authenticationException);
+
+        // GIVEN a started consumer
+        new TestConsumer(vertxKafkaConsumer, TOPIC).start()
+                // THEN the start fails
+                .onComplete(ctx.failing(cause -> ctx.verify(() -> {
+
+                    assertThat(cause).isInstanceOf(KafkaConsumerPollException.class);
+                    assertThat(cause.getCause()).isEqualTo(authenticationException);
+
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that when an error occurs during message polling, the consumer is closed and the close handler invoked
+     * with the error.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatPollErrorClosesConsumer(final VertxTestContext ctx) {
+        final AtomicReference<TestConsumer> testConsumerRef = new AtomicReference<>();
+        final KafkaException pollError = new KafkaException("error");
+
+        final TestConsumer testConsumer = TestConsumer.createWithCloseHandler(vertxKafkaConsumer, TOPIC,
+                cause -> ctx.verify(() -> {
+
+                    // THEN the test consumer is closed...
+                    assertThat(testConsumerRef.get().stopped).isTrue();
+                    assertThat(mockConsumer.closed()).isTrue();
+                    // ...AND the close handler is invoked with a KafkaConsumerPollException, containing the cause
+                    assertThat(cause).isInstanceOf(KafkaConsumerPollException.class);
+                    assertThat(cause.getCause()).isEqualTo(pollError);
+
+                    ctx.completeNow();
+                }));
+
+        testConsumerRef.set(testConsumer);
+
+        // GIVEN a started test consumer
+        testConsumer.start()
+                .onComplete(ctx.succeeding(v -> {
+
+                    // WHEN polling fails after the first poll operation
+                    mockConsumer.setPollException(pollError);
+                }));
+
+    }
+
+    /**
+     * Verifies that the consumer polls multiple batches of messages, processes them in right order and commits the
+     * offset after processing of a batch finished.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatConsumedMessagesAreProcessedInOrder(final VertxTestContext ctx) {
+        final int numberOfBatches = 11;
+        final int recordsPerBatch = 20;
+
+        final AtomicInteger expectedOffset = new AtomicInteger();
+
+        final Handler<JsonObject> messageHandler = msg -> {
+            final Long currentOffset = msg.getLong(TestConsumer.RECORD_OFFSET);
+            ctx.verify(() -> {
+
+                // THEN the messages are processed in order
+                LOG.debug("current offset: {}, expected offset: {}", currentOffset, expectedOffset.get());
+                assertThat(currentOffset).isEqualTo(expectedOffset.getAndIncrement());
+
+                final boolean firstMessageInBatch = currentOffset % recordsPerBatch == 0;
+                if (firstMessageInBatch) {
+                    // ... AND commit points to the first message of the batch (you commit the NEXT offset to be read)
+                    assertThat(getCommittedOffset(topicPartition)).isEqualTo(currentOffset);
+                }
+            });
+
+            if (currentOffset == (recordsPerBatch * (numberOfBatches - 1))) { // last batch started
+                ctx.completeNow(); // we don't know when the last commit finished, but we verified committing already
+            }
+        };
+
+        // GIVEN a started consumer
+        TestConsumer.createWithMessageHandler(vertxKafkaConsumer, TOPIC, messageHandler).start()
+                .onComplete(ctx.succeeding(v -> {
+
+                    // WHEN consuming multiple batches of of records
+                    mockConsumer.updateBeginningOffsets(Map.of(topicPartition, ((long) 0))); // define start offset
+                    mockConsumer.rebalance(Collections.singletonList(topicPartition)); // trigger partition assignment
+                    for (int i = 0; i < numberOfBatches; i++) {
+                        scheduleBatch(i * recordsPerBatch, recordsPerBatch);
+                    }
+
+                }));
+    }
+
+    private long getCommittedOffset(final TopicPartition topicPartition) {
+        final long committedOffset;
+
+        final Map<TopicPartition, OffsetAndMetadata> committed = mockConsumer.committed(Set.of(topicPartition));
+        if (committed.isEmpty()) {
+            LOG.debug("no offset committed yet for topic-partition [{}]", topicPartition);
+            committedOffset = 0;
+        } else {
+            committedOffset = committed.get(topicPartition).offset();
+            LOG.debug("committed offset for topic-partition [{}] is {}", topicPartition, committedOffset);
+        }
+        return committedOffset;
+    }
+
+    private void scheduleBatch(final int startOffset, final int recordsToAdd) {
+        mockConsumer.schedulePollTask(() -> {
+            for (int j = startOffset; j < startOffset + recordsToAdd; j++) {
+                mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, PARTITION, j, null, Buffer.buffer()));
+            }
+        });
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumerMockitoTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumerMockitoTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.kafka.consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -103,10 +104,10 @@ public class AbstractAtLeastOnceKafkaConsumerMockitoTest {
 
         // WHEN committing fails
         doAnswer(invocation -> {
-            final Promise<Void> promise = invocation.getArgument(0);
+            final Promise<Void> promise = invocation.getArgument(1);
             promise.handle(Future.failedFuture(commitError));
             return 1L;
-        }).when(mockKafkaConsumer).commit(VertxMockSupport.anyHandler());
+        }).when(mockKafkaConsumer).commit(anyMap(), VertxMockSupport.anyHandler());
 
         final Handler<Throwable> closeHandler = cause -> ctx.verify(() -> {
 
@@ -201,16 +202,10 @@ public class AbstractAtLeastOnceKafkaConsumerMockitoTest {
                 });
 
         doAnswer(invocation -> {
-            final Promise<Void> promise = invocation.getArgument(0);
-            promise.handle(Future.succeededFuture());
-            return 1L;
-        }).when(mockKafkaConsumer).commit(VertxMockSupport.anyHandler());
-
-        doAnswer(invocation -> {
             final Promise<Map<TopicPartition, OffsetAndMetadata>> promise = invocation.getArgument(1);
             promise.handle(Future.succeededFuture());
             return 1L;
-        }).when(mockKafkaConsumer).commit(any(), VertxMockSupport.anyHandler());
+        }).when(mockKafkaConsumer).commit(anyMap(), VertxMockSupport.anyHandler());
 
         doAnswer(invocation -> {
             final Promise<Void> promise = invocation.getArgument(0);

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumerMockitoTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumerMockitoTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.internal.verification.VerificationModeFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
+import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordsImpl;
+
+/**
+ * Verifies the behavior of {@link AbstractAtLeastOnceKafkaConsumer} with test cases that are not supported by
+ * {@link MockConsumer}. Uses Mockito.
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class AbstractAtLeastOnceKafkaConsumerMockitoTest {
+
+    private static final String TOPIC = "test.topic";
+    private static final int PARTITION = 0;
+
+    /**
+     * Verifies that {@link AbstractAtLeastOnceKafkaConsumer#start()} subscribes for the topic and polls for the first
+     * batch of messages.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatStartSubscribesAndPolls(final VertxTestContext ctx) {
+
+        final KafkaConsumer<String, Buffer> mockKafkaConsumer = mockVertxKafkaConsumer(0, 1);
+        final AbstractAtLeastOnceKafkaConsumer<JsonObject> underTest = new TestConsumer(mockKafkaConsumer, TOPIC);
+        underTest.start()
+                .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+
+                    verify(mockKafkaConsumer).subscribe(eq(Set.of(TOPIC)), VertxMockSupport.anyHandler());
+                    verify(mockKafkaConsumer, VerificationModeFactory.atLeastOnce()).poll(any(),
+                            VertxMockSupport.anyHandler());
+
+                    ctx.completeNow();
+                })));
+    }
+
+    /**
+     * Verifies that when an error occurs during message committing, the consumer is closed and the close handler
+     * invoked with the error.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testThatCommitErrorClosesConsumer(final VertxTestContext ctx) {
+        final AtomicReference<TestConsumer> testConsumerRef = new AtomicReference<>();
+        final KafkaException commitError = new KafkaException("commit failed");
+
+        final KafkaConsumer<String, Buffer> mockKafkaConsumer = mockVertxKafkaConsumer(0, 0);
+
+        // WHEN committing fails
+        doAnswer(invocation -> {
+            final Promise<Void> promise = invocation.getArgument(0);
+            promise.handle(Future.failedFuture(commitError));
+            return 1L;
+        }).when(mockKafkaConsumer).commit(VertxMockSupport.anyHandler());
+
+        final Handler<Throwable> closeHandler = cause -> ctx.verify(() -> {
+
+            // THEN the test consumer is closed...
+            assertThat(testConsumerRef.get().stopped).isTrue();
+            // ...AND the close handler is invoked with a KafkaConsumerCommitException, containing the cause
+            assertThat(cause).isInstanceOf(KafkaConsumerCommitException.class);
+            assertThat(cause.getCause()).isEqualTo(commitError);
+
+            ctx.completeNow();
+        });
+
+        final TestConsumer testConsumer = TestConsumer.createWithCloseHandler(mockKafkaConsumer, TOPIC, closeHandler);
+        testConsumerRef.set(testConsumer);
+
+        // GIVEN a started test consumer
+        testConsumer.start();
+
+    }
+
+    /**
+     * Verifies that when an error occurs during message processing, the consumer is closed, the current offset
+     * committed and the close handler invoked with the error.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testMessageProcessingError(final VertxTestContext ctx) {
+
+        final int startOffset = 50;
+        final int corruptMessageOffset = 100;
+
+        final IllegalStateException unexpectedError = new IllegalStateException("this should not have happened");
+
+        final AtomicLong committedOffset = new AtomicLong();
+
+        final KafkaConsumer<String, Buffer> mockKafkaConsumer = mockVertxKafkaConsumer(startOffset,
+                corruptMessageOffset);
+
+        doAnswer(invocation -> {
+            final Map<io.vertx.kafka.client.common.TopicPartition, io.vertx.kafka.client.consumer.OffsetAndMetadata> offsets = invocation
+                    .getArgument(0);
+            committedOffset
+                    .set(offsets.get(new io.vertx.kafka.client.common.TopicPartition(TOPIC, PARTITION)).getOffset());
+
+            final Promise<Map<TopicPartition, OffsetAndMetadata>> promise = invocation.getArgument(1);
+            promise.handle(Future.succeededFuture());
+            return 1L;
+        }).when(mockKafkaConsumer).commit(any(), VertxMockSupport.anyHandler());
+
+        final AtomicReference<TestConsumer> testConsumerRef = new AtomicReference<>();
+        final TestConsumer testConsumer = new TestConsumer(mockKafkaConsumer, TOPIC,
+                msg -> {
+                    // WHEN message processing fails
+                    if (msg.getInteger(TestConsumer.RECORD_OFFSET) == corruptMessageOffset) {
+                        throw unexpectedError;
+                    }
+                }, cause -> ctx.verify(() -> {
+
+                    // THEN the offset is committed...
+                    assertThat(committedOffset.get()).isEqualTo(corruptMessageOffset);
+                    // ... AND the test consumer is closed...
+                    assertThat(testConsumerRef.get().stopped).isTrue();
+                    // ...AND the close handler is invoked with the exception
+                    assertThat(cause).isEqualTo(unexpectedError);
+
+                    ctx.completeNow();
+                }));
+        testConsumerRef.set(testConsumer);
+
+        testConsumer.start();
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private KafkaConsumer<String, Buffer> mockVertxKafkaConsumer(final int startOffset, final int lastOffset) {
+
+        final KafkaConsumer<String, Buffer> mockKafkaConsumer = mock(KafkaConsumer.class);
+
+        when(mockKafkaConsumer.subscribe(anySet(), VertxMockSupport.anyHandler()))
+                .thenAnswer(invocationOnMock -> {
+                    final Promise<Void> promise = invocationOnMock.getArgument(1);
+                    promise.handle(Future.succeededFuture());
+                    return mockKafkaConsumer;
+                });
+
+        when(mockKafkaConsumer.subscribe(any(Pattern.class), VertxMockSupport.anyHandler()))
+                .thenAnswer(invocationOnMock -> {
+                    final Promise<Void> promise = invocationOnMock.getArgument(1);
+                    promise.handle(Future.succeededFuture());
+                    return mockKafkaConsumer;
+                });
+
+        doAnswer(invocation -> {
+            final Promise<Void> promise = invocation.getArgument(0);
+            promise.handle(Future.succeededFuture());
+            return 1L;
+        }).when(mockKafkaConsumer).commit(VertxMockSupport.anyHandler());
+
+        doAnswer(invocation -> {
+            final Promise<Map<TopicPartition, OffsetAndMetadata>> promise = invocation.getArgument(1);
+            promise.handle(Future.succeededFuture());
+            return 1L;
+        }).when(mockKafkaConsumer).commit(any(), VertxMockSupport.anyHandler());
+
+        doAnswer(invocation -> {
+            final Promise<Void> promise = invocation.getArgument(0);
+            promise.handle(Future.succeededFuture());
+            return 1L;
+        }).when(mockKafkaConsumer).close(VertxMockSupport.anyHandler());
+
+        final List<ConsumerRecord<String, Buffer>> recordList = new ArrayList<>();
+        for (int i = startOffset; i < lastOffset + 1; i++) {
+            recordList.add(new ConsumerRecord<>(TOPIC, PARTITION, i, null, Buffer.buffer()));
+        }
+        final TopicPartition topicPartition = new TopicPartition(TOPIC, PARTITION);
+        final Map<TopicPartition, List<ConsumerRecord<String, Buffer>>> pollResult = Map.of(topicPartition, recordList);
+
+        doAnswer(invocation -> {
+            final Promise<KafkaConsumerRecords<String, Buffer>> task = invocation.getArgument(1);
+            task.handle(Future.succeededFuture(new KafkaConsumerRecordsImpl<>(new ConsumerRecords<>(pollResult))));
+            return 1L;
+        }).when(mockKafkaConsumer).poll(any(Duration.class), VertxMockSupport.anyHandler());
+
+        return mockKafkaConsumer;
+
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/TestConsumer.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/TestConsumer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.consumer;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * A {@link AbstractAtLeastOnceKafkaConsumer} implementation for tests.
+ */
+public class TestConsumer extends AbstractAtLeastOnceKafkaConsumer<JsonObject> {
+
+    public static final String RECORD_VALUE = "value";
+    public static final String RECORD_KEY = "key";
+    public static final String RECORD_TOPIC = "topic";
+    public static final String RECORD_OFFSET = "offset";
+    public static final String RECORD_PARTITION = "partition";
+
+    /**
+     * Creates a new test consumer with empty message and close handlers.
+     *
+     * @param kafkaConsumer The Kafka consumer to be used.
+     * @param topic The topic to consume from.
+     */
+    public TestConsumer(final KafkaConsumer<String, Buffer> kafkaConsumer, final String topic) {
+        this(kafkaConsumer, topic, m -> {
+        }, t -> {
+        });
+    }
+
+    /**
+     * Creates a new test consumer.
+     *
+     * @param kafkaConsumer The Kafka consumer to be used.
+     * @param topic The topic to consume from.
+     * @param messageHandler The message handler to set.
+     * @param closeHandler The close handler to set.
+     */
+    public TestConsumer(final KafkaConsumer<String, Buffer> kafkaConsumer, final String topic,
+            final Handler<JsonObject> messageHandler, final Handler<Throwable> closeHandler) {
+        super(kafkaConsumer, topic, messageHandler, closeHandler, KafkaConsumerConfigProperties.DEFAULT_POLL_TIMEOUT);
+    }
+
+    /**
+     * Creates a new test consumer with an empty close handler.
+     *
+     * @param kafkaConsumer The Kafka consumer to be used.
+     * @param topic The topic to consume from.
+     * @param messageHandler The message handler to set.
+     * @return the new test consumer.
+     */
+    public static TestConsumer createWithMessageHandler(final KafkaConsumer<String, Buffer> kafkaConsumer,
+            final String topic, final Handler<JsonObject> messageHandler) {
+        return new TestConsumer(kafkaConsumer, topic, messageHandler, cause -> {
+        });
+    }
+
+    /**
+     * Creates a new test consumer with an empty message handler.
+     *
+     * @param kafkaConsumer The Kafka consumer to be used.
+     * @param topic The topic to consume from.
+     * @param closeHandler The close handler to set.
+     * @return the new test consumer.
+     */
+    public static TestConsumer createWithCloseHandler(final KafkaConsumer<String, Buffer> kafkaConsumer,
+            final String topic, final Handler<Throwable> closeHandler) {
+        return new TestConsumer(kafkaConsumer, topic, msg -> {
+        }, closeHandler);
+    }
+
+    @Override
+    protected JsonObject createMessage(final KafkaConsumerRecord<String, Buffer> record) {
+        final JsonObject jsonObject = new JsonObject();
+        jsonObject.put(RECORD_TOPIC, record.topic());
+        jsonObject.put(RECORD_KEY, record.key());
+        jsonObject.put(RECORD_VALUE, record.value().toString());
+        jsonObject.put(RECORD_OFFSET, record.offset());
+        jsonObject.put(RECORD_PARTITION, record.partition());
+        return jsonObject;
+    }
+}


### PR DESCRIPTION
This change aims to reduce the cases where the same Kafka record is consumed a second time.

If an error occurs while processing a message or when the consumer is stopped, the offsets for the already processed messages from the current batch are now committed. This is to prevent all messages from being processed again. Especially in case of errors during message processing, the same messages could otherwise be consumed again and again.