### PR TITLE
Refactor integration tests

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
+++ b/client/src/main/java/org/eclipse/hono/client/ApplicationClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -66,7 +66,9 @@ public interface ApplicationClientFactory extends ConnectionLifecycle<HonoConnec
      *         The future will fail if the link cannot be established, e.g. because this factory
      *         is not connected.
      * @throws NullPointerException if any of the parameters is {@code null}.
+     * @deprecated Use {@code org.eclipse.hono.application.client.amqp.AmqpApplicationClientFactory} instead.
      */
+    @Deprecated
     Future<MessageConsumer> createTelemetryConsumer(
             String tenantId,
             BiConsumer<ProtonDelivery, Message> telemetryConsumer,
@@ -86,7 +88,9 @@ public interface ApplicationClientFactory extends ConnectionLifecycle<HonoConnec
      *         The future will fail if the link cannot be established, e.g. because this factory
      *         is not connected.
      * @throws NullPointerException if any of the parameters is {@code null}.
+     * @deprecated Use {@code org.eclipse.hono.application.client.amqp.AmqpApplicationClientFactory} instead.
      */
+    @Deprecated
     Future<MessageConsumer> createTelemetryConsumer(
             String tenantId,
             Consumer<Message> telemetryConsumer,
@@ -107,7 +111,9 @@ public interface ApplicationClientFactory extends ConnectionLifecycle<HonoConnec
      *         The future will fail if the link cannot be established, e.g. because this factory
      *         is not connected.
      * @throws NullPointerException if any of the parameters is {@code null}.
+     * @deprecated Use {@code org.eclipse.hono.application.client.amqp.AmqpApplicationClientFactory} instead.
      */
+    @Deprecated
     Future<MessageConsumer> createEventConsumer(
             String tenantId,
             BiConsumer<ProtonDelivery, Message> eventConsumer,
@@ -128,7 +134,9 @@ public interface ApplicationClientFactory extends ConnectionLifecycle<HonoConnec
      *         The future will fail if the link cannot be established, e.g. because this factory
      *         is not connected.
      * @throws NullPointerException if any of the parameters is {@code null}.
+     * @deprecated Use {@code org.eclipse.hono.application.client.amqp.AmqpApplicationClientFactory} instead.
      */
+    @Deprecated
     Future<MessageConsumer> createEventConsumer(
             String tenantId,
             BiConsumer<ProtonDelivery, Message> eventConsumer,
@@ -147,7 +155,9 @@ public interface ApplicationClientFactory extends ConnectionLifecycle<HonoConnec
      *         The future will fail if the link cannot be established, e.g. because this factory
      *         is not connected.
      * @throws NullPointerException if any of the parameters is {@code null}.
+     * @deprecated Use {@code org.eclipse.hono.application.client.amqp.AmqpApplicationClientFactory} instead.
      */
+    @Deprecated
     Future<MessageConsumer> createEventConsumer(
             String tenantId,
             Consumer<Message> eventConsumer,

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -64,9 +64,9 @@ title = "Release Notes"
   classes have been deprecated to further reduce the dependency on Spring Boot. Clients should use
   `org.eclipse.hono.service.cache.CaffeineCacheProvider` and `org.eclipse.hono.service.cache.CaffeineBasedExpiringValueCache`
   instead.
-* The public interfaces of the legacy `client` module have been deprecated. Client code should be
-  adapted to use the corresponding interfaces and implementations from the `clients/adapter` and
-  `clients/adapter-amqp` modules instead.
+* Most of the public interfaces of the legacy `client` module have been deprecated. Client code should be
+  adapted to use the corresponding interfaces and implementations from the `clients/adapter`, `clients/adapter-amqp`
+  and `clients/application-amqp` modules instead.
 * The Authentication server's `HONO_AUTH_SVC_PERMISSIONS_PATH` configuration property has been changed to no
   longer accept generic Spring resource URIs. The value is now required to be a file system path. The path
   may still contain a `file://` prefix in order to not break existing configurations. However, users are encouraged

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -239,6 +239,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       <artifactId>hono-client-adapter-amqp</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-application-amqp</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryAmqpIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,14 +12,15 @@
  *******************************************************************************/
 package org.eclipse.hono.tests.amqp;
 
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.proton.ProtonQoS;
 
@@ -36,13 +37,14 @@ public class TelemetryAmqpIT extends AmqpUploadTestBase {
     }
 
     @Override
-    protected Future<MessageConsumer> createConsumer(final String tenantId, final Consumer<Message> messageConsumer) {
-        return helper.applicationClientFactory.createTelemetryConsumer(tenantId, messageConsumer, close -> {});
+    protected Future<MessageConsumer> createConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
+        return helper.amqpApplicationClient.createTelemetryConsumer(tenantId, messageConsumer, close -> {});
     }
 
     @Override
     protected String getEndpointName() {
         return TELEMETRY_ENDPOINT;
     }
-
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,23 +17,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
-import org.apache.qpid.proton.message.Message;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
-import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
-import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -50,9 +50,16 @@ public class EventCoapIT extends CoapTestBase {
     private static final String PUT_URI_TEMPLATE = POST_URI + "/%s/%s";
 
     @Override
-    protected Future<MessageConsumer> createConsumer(final String tenantId, final Consumer<Message> messageConsumer) {
+    protected Future<MessageConsumer> createConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
 
-        return helper.applicationClientFactory.createEventConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.amqpApplicationClient.createEventConsumer(tenantId, messageConsumer, remoteClose -> {});
+    }
+
+    @Override
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
+        assertThat(msg.getMessageContext().getRawMessage().isDurable()).isTrue();
     }
 
     @Override
@@ -68,14 +75,6 @@ public class EventCoapIT extends CoapTestBase {
     @Override
     protected Type getMessageType() {
         return Type.CON;
-    }
-
-    @Override
-    protected void assertAdditionalMessageProperties(final VertxTestContext ctx, final Message msg) {
-        // assert that events are marked as "durable"
-        ctx.verify(() -> {
-            assertThat(msg.isDurable()).isTrue();
-        });
     }
 
     /**
@@ -114,7 +113,7 @@ public class EventCoapIT extends CoapTestBase {
                     createConsumer(tenantId, msg -> {
                         // THEN verify that the event message has been received by the consumer
                         logger.debug("event message has been received by the consumer");
-                        ctx.verify(() -> assertThat(MessageHelper.getPayloadAsString(msg)).isEqualTo(messagePayload));
+                        ctx.verify(() -> assertThat(msg.getPayload().toString()).isEqualTo(messagePayload));
                         ctx.completeNow();
                     });
                 })

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,9 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
-import org.apache.qpid.proton.message.Message;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
@@ -27,7 +25,9 @@ import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.elements.exception.ConnectorException;
-import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.QoS;
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
@@ -53,9 +54,11 @@ public class TelemetryCoapIT extends CoapTestBase {
     private static final String PUT_URI_TEMPLATE = POST_URI + "/%s/%s";
 
     @Override
-    protected Future<MessageConsumer> createConsumer(final String tenantId, final Consumer<Message> messageConsumer) {
+    protected Future<MessageConsumer> createConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
 
-        return helper.applicationClientFactory.createTelemetryConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.amqpApplicationClient.createTelemetryConsumer(tenantId, messageConsumer, remoteClose -> {});
     }
 
     @Override

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,20 +18,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.HttpURLConnection;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
-import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
@@ -55,16 +55,16 @@ public class EventHttpIT extends HttpTestBase {
     }
 
     @Override
-    protected Future<MessageConsumer> createConsumer(final String tenantId, final Consumer<Message> messageConsumer) {
+    protected Future<MessageConsumer> createConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
 
-        return helper.applicationClientFactory.createEventConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.amqpApplicationClient.createEventConsumer(tenantId, messageConsumer, remoteClose -> {});
     }
 
     @Override
-    protected void assertAdditionalMessageProperties(final Message msg) {
-        // assert that events are marked as "durable"
-
-        assertThat(msg.isDurable()).isTrue();
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
+        assertThat(msg.getMessageContext().getRawMessage().isDurable()).isTrue();
     }
 
     /**
@@ -136,7 +136,7 @@ public class EventHttpIT extends HttpTestBase {
                     createConsumer(tenantId, msg -> {
                         // THEN verify that the event message has been received by the consumer
                         logger.debug("event message has been received by the consumer");
-                        ctx.verify(() -> assertThat(MessageHelper.getPayloadAsString(msg)).isEqualTo(messagePayload));
+                        ctx.verify(() -> assertThat(msg.getPayload().toString()).isEqualTo(messagePayload));
                         ctx.completeNow();
                     });
                 })

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,10 +20,10 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
-import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.junit5.VertxExtension;
@@ -87,15 +88,16 @@ public class EventMqttIT extends MqttPublishTestBase {
     }
 
     @Override
-    protected Future<MessageConsumer> createConsumer(final String tenantId, final Consumer<Message> messageConsumer) {
+    protected Future<MessageConsumer> createConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
 
-        return helper.applicationClientFactory.createEventConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.amqpApplicationClient.createEventConsumer(tenantId, messageConsumer, remoteClose -> {});
     }
 
     @Override
-    protected void assertAdditionalMessageProperties(final VertxTestContext ctx, final Message msg) {
-        // assert that events are marked as "durable"
-        ctx.verify(() -> assertThat(msg.isDurable()).isTrue());
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
+        assertThat(msg.getMessageContext().getRawMessage().isDurable()).isTrue();
     }
 
     /**
@@ -192,7 +194,7 @@ public class EventMqttIT extends MqttPublishTestBase {
                 createConsumer(tenantId, msg -> {
                     // THEN verify that the event message has been received by the consumer
                     LOGGER.debug("event message has been received by the consumer");
-                    ctx.verify(() -> assertThat(MessageHelper.getPayloadAsString(msg)).isEqualTo(messagePayload));
+                    ctx.verify(() -> assertThat(msg.getPayload().toString()).isEqualTo(messagePayload));
                     ctx.completeNow();
                 });
             } else {

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,16 +13,16 @@
 
 package org.eclipse.hono.tests.mqtt;
 
-import java.util.function.Consumer;
-
-import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.junit5.VertxExtension;
@@ -107,8 +107,10 @@ public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
     }
 
     @Override
-    protected Future<MessageConsumer> createConsumer(final String tenantId, final Consumer<Message> messageConsumer) {
+    protected Future<MessageConsumer> createConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
 
-        return helper.applicationClientFactory.createTelemetryConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.amqpApplicationClient.createTelemetryConsumer(tenantId, messageConsumer, remoteClose -> {});
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,15 +13,15 @@
 
 package org.eclipse.hono.tests.mqtt;
 
-import java.util.function.Consumer;
-
-import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.junit5.VertxExtension;
@@ -66,8 +66,10 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
     }
 
     @Override
-    protected Future<MessageConsumer> createConsumer(final String tenantId, final Consumer<Message> messageConsumer) {
+    protected Future<MessageConsumer> createConsumer(
+            final String tenantId,
+            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
 
-        return helper.applicationClientFactory.createTelemetryConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.amqpApplicationClient.createTelemetryConsumer(tenantId, messageConsumer, remoteClose -> {});
     }
 }

--- a/tests/src/test/resources/logback-test-include-dev.xml
+++ b/tests/src/test/resources/logback-test-include-dev.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -17,6 +17,8 @@
    -->
 <included>
   <logger name="org.eclipse.hono" level="DEBUG"/>
+  <logger name="org.eclipse.hono.application.client" level="DEBUG"/>
+  <logger name="org.eclipse.hono.application.client.amqp" level="DEBUG"/>
   <logger name="org.eclipse.hono.client" level="DEBUG"/>
   <logger name="org.eclipse.hono.client.impl" level="DEBUG"/>
   <logger name="org.eclipse.hono.client.impl.HonoConnectionImpl" level="DEBUG"/>

--- a/tests/src/test/resources/logback-test-include-trace.xml
+++ b/tests/src/test/resources/logback-test-include-trace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -17,6 +17,8 @@
  -->
 <included>
   <logger name="org.eclipse.hono" level="TRACE"/>
+  <logger name="org.eclipse.hono.application.client" level="TRACE"/>
+  <logger name="org.eclipse.hono.application.client.amqp" level="TRACE"/>
   <logger name="org.eclipse.hono.client" level="TRACE"/>
   <logger name="org.eclipse.hono.client.impl" level="TRACE"/>
   <logger name="org.eclipse.hono.client.impl.HonoConnectionImpl" level="TRACE"/>


### PR DESCRIPTION
This is for #2392
The integration tests now use the new application client for consuming
downstream telemetry and event messages.