### PR TITLE
[#2273] Add KafkaBasedInternalCommandConsumer

### DIFF
--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -1,0 +1,239 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.kafka;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.adapter.client.command.CommandHandlerWrapper;
+import org.eclipse.hono.adapter.client.command.CommandHandlers;
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.tracing.KafkaTracingHelper;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.MessageHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.kafka.admin.NewTopic;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * A Kafka based consumer to receive commands forwarded by the Command Router on the internal command topic.
+ *
+ */
+public class KafkaBasedInternalCommandConsumer implements Lifecycle {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaBasedInternalCommandConsumer.class);
+
+    private static final int NUM_PARTITIONS = 1;
+    private static final short REPLICATION_FACTOR = 1; // TODO use value from adapter configuration instead.
+    private static final String CLIENT_NAME = "internal-cmd";
+
+    private final String adapterInstanceId;
+    private final CommandHandlers commandHandlers;
+    private final Tracer tracer;
+    private final KafkaAdminClient adminClient;
+    private final KafkaConsumer<String, Buffer> consumer;
+
+    /**
+     * Creates a consumer.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param consumerConfigProperties The Kafka consumer config properties.
+     * @param adminClientConfigProperties The Kafka admin client config properties.
+     * @param adapterInstanceId The adapter instance id.
+     * @param commandHandlers The command handlers to choose from for handling a received command.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public KafkaBasedInternalCommandConsumer(
+            final Vertx vertx,
+            final KafkaAdminClientConfigProperties adminClientConfigProperties,
+            final KafkaConsumerConfigProperties consumerConfigProperties,
+            final String adapterInstanceId,
+            final CommandHandlers commandHandlers,
+            final Tracer tracer) {
+        Objects.requireNonNull(vertx);
+        Objects.requireNonNull(adminClientConfigProperties);
+        Objects.requireNonNull(consumerConfigProperties);
+        this.adapterInstanceId = Objects.requireNonNull(adapterInstanceId);
+        this.commandHandlers = Objects.requireNonNull(commandHandlers);
+        this.tracer = Objects.requireNonNull(tracer);
+
+        final Map<String, String> adminClientConfig = adminClientConfigProperties.getAdminClientConfig(CLIENT_NAME);
+        adminClient = KafkaAdminClient.create(vertx, adminClientConfig);
+
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig(CLIENT_NAME);
+        // TODO configure offset/commit handling
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, adapterInstanceId);
+        consumer = KafkaConsumer.create(vertx, consumerConfig, String.class, Buffer.class);
+    }
+
+    /**
+     * Creates a consumer.
+     * <p>
+     * To be used for unit tests.
+     *
+     * @param kafkaAdminClient The Kafka admin client to use.
+     * @param kafkaConsumer The Kafka consumer to use.
+     * @param adapterInstanceId The adapter instance id.
+     * @param commandHandlers The command handlers to choose from for handling a received command.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    KafkaBasedInternalCommandConsumer(
+            final KafkaAdminClient kafkaAdminClient,
+            final KafkaConsumer<String, Buffer> kafkaConsumer,
+            final String adapterInstanceId,
+            final CommandHandlers commandHandlers,
+            final Tracer tracer) {
+        this.adminClient = Objects.requireNonNull(kafkaAdminClient);
+        this.consumer = Objects.requireNonNull(kafkaConsumer);
+        this.adapterInstanceId = Objects.requireNonNull(adapterInstanceId);
+        this.commandHandlers = Objects.requireNonNull(commandHandlers);
+        this.tracer = Objects.requireNonNull(tracer);
+    }
+
+    @Override
+    public Future<Void> start() {
+        // trigger creation of adapter specific topic and consumer
+        return createTopic().compose(v -> subscribeToTopic());
+    }
+
+    private Future<Void> createTopic() {
+        final Promise<Void> promise = Promise.promise();
+        final String topicName = getTopicName();
+        adminClient.createTopics(List.of(new NewTopic(topicName, NUM_PARTITIONS, REPLICATION_FACTOR)), promise.future());
+        return promise.future()
+                .onSuccess(v -> LOG.debug("created topic [{}]", topicName))
+                .onFailure(thr -> LOG.error("error creating topic [{}]", topicName, thr));
+    }
+
+    private Future<Void> subscribeToTopic() {
+        consumer.handler(this::handleCommandMessage);
+        consumer.exceptionHandler(thr -> {
+            LOG.error("consumer error occurred", thr);
+        });
+        consumer.partitionsRevokedHandler(this::onPartitionsRevoked);
+        final Promise<Void> partitionAssignedPromise = Promise.promise();
+        consumer.partitionsAssignedHandler(partitionsSet -> {
+            LOG.debug("partitions assigned: [{}]", getPartitionsString(partitionsSet));
+            partitionAssignedPromise.tryComplete();
+        });
+        final String topicName = getTopicName();
+        final Promise<Void> subscribedPromise = Promise.promise();
+        consumer.subscribe(topicName, subscribedPromise);
+
+        return CompositeFuture.all(subscribedPromise.future(), partitionAssignedPromise.future())
+                .map((Void) null)
+                .onComplete(ar -> consumer.partitionsAssignedHandler(this::onPartitionsAssigned))
+                .onSuccess(v -> LOG.debug("subscribed and got partition assignment for topic [{}]", topicName))
+                .onFailure(thr -> LOG.error("error subscribing to topic [{}]", topicName, thr));
+    }
+
+    private void onPartitionsAssigned(final Set<TopicPartition> partitionsSet) {
+        LOG.debug("partitions assigned: [{}]", getPartitionsString(partitionsSet));
+    }
+
+    private void onPartitionsRevoked(final Set<TopicPartition> partitionsSet) {
+        LOG.debug("partitions revoked: [{}]", getPartitionsString(partitionsSet));
+    }
+
+    private String getPartitionsString(final Collection<TopicPartition> partitionsSet) {
+        return partitionsSet.stream()
+                .map(topicPartition -> Integer.toString(topicPartition.getPartition()))
+                .collect(Collectors.joining(", "));
+    }
+
+    private String getTopicName() {
+        return new HonoTopic(HonoTopic.Type.COMMAND_INTERNAL, adapterInstanceId).toString();
+    }
+
+    @Override
+    public Future<Void> stop() {
+        final String topicName = getTopicName();
+        final Promise<Void> adminClientClosePromise = Promise.promise();
+        LOG.debug("stop: delete topic [{}]", topicName);
+        adminClient.deleteTopics(List.of(topicName), ar -> {
+            if (ar.failed()) {
+                LOG.warn("error deleting topic [{}]", topicName, ar.cause());
+            }
+            adminClient.close(adminClientClosePromise);
+        });
+        adminClientClosePromise.future().onComplete(ar -> LOG.debug("admin client closed"));
+
+        final Promise<Void> consumerClosePromise = Promise.promise();
+        LOG.debug("stop: close consumer");
+        consumer.close(consumerClosePromise);
+        consumerClosePromise.future().onComplete(ar -> LOG.debug("consumer closed"));
+        return CompositeFuture.all(adminClientClosePromise.future(), consumerClosePromise.future())
+                .mapEmpty();
+    }
+
+    void handleCommandMessage(final KafkaConsumerRecord<String, Buffer> record) {
+
+        final KafkaBasedCommand command;
+        try {
+            command = KafkaBasedCommand.fromRoutedCommandRecord(record);
+        } catch (final IllegalArgumentException e) {
+            LOG.debug("command record is invalid", e);
+            return;
+        }
+        final CommandHandlerWrapper commandHandler = commandHandlers.getCommandHandler(command.getTenant(),
+                command.getGatewayOrDeviceId());
+        if (commandHandler != null && commandHandler.getGatewayId() != null) {
+            // Gateway information set in command handler means a gateway has subscribed for commands for a specific device.
+            // This information isn't getting set in the record (by the Command Router) and therefore has to be adopted manually here.
+            command.setGatewayId(commandHandler.getGatewayId());
+        }
+
+        final SpanContext spanContext = KafkaTracingHelper.extractSpanContext(tracer, record);
+        final Span currentSpan = CommandContext.createSpan(tracer, command, spanContext);
+        currentSpan.setTag(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId);
+
+        final CommandContext commandContext = new KafkaBasedCommandContext(command, currentSpan);
+
+        if (commandHandler != null) {
+            LOG.trace("using [{}] for received command [{}]", commandHandler, command);
+            // command.isValid() check not done here - it is to be done in the command handler
+            commandHandler.handleCommand(commandContext);
+        } else {
+            LOG.info("no command handler found for command with device id {}, gateway id {} [tenant-id: {}]",
+                    command.getDeviceId(), command.getGatewayId(), command.getTenant());
+            TracingHelper.logError(currentSpan, "no command handler found for command");
+            commandContext.release();
+        }
+    }
+
+}

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandConsumerTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandConsumerTest.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.adapter.client.command.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.adapter.client.command.CommandHandlers;
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.MessageHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
+
+/**
+ * Tests verifying behavior of {@link KafkaBasedInternalCommandConsumer}.
+ *
+ */
+public class KafkaBasedInternalCommandConsumerTest {
+
+    private KafkaBasedInternalCommandConsumer internalCommandConsumer;
+    private CommandHandlers commandHandlers;
+
+    /**
+     * Sets up fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+        final KafkaAdminClient kafkaAdminClient = mock(KafkaAdminClient.class);
+        @SuppressWarnings("unchecked")
+        final KafkaConsumer<String, Buffer> kafkaConsumer = mock(KafkaConsumer.class);
+        final String adapterInstanceId = "adapterInstanceId";
+        final Span span = TracingMockSupport.mockSpan();
+        final Tracer tracer = TracingMockSupport.mockTracer(span);
+        commandHandlers = new CommandHandlers();
+        internalCommandConsumer = new KafkaBasedInternalCommandConsumer(
+                kafkaAdminClient,
+                kafkaConsumer,
+                adapterInstanceId,
+                commandHandlers,
+                tracer);
+    }
+
+    /**
+     * Verifies that the consumer handles a command record with missing subject by invoking the matching handler.
+     */
+    @Test
+    void testHandleCommandMessageWithInvalidRecord() {
+        // command record with missing subject header
+        final String tenantId = "myTenant";
+        final String deviceId = "4711";
+
+        final List<KafkaHeader> headers = List.of(KafkaHeader.header(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId),
+                KafkaHeader.header(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId));
+        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(deviceId, headers);
+
+        final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
+        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler);
+
+        internalCommandConsumer.handleCommandMessage(commandRecord);
+
+        final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(commandHandler).handle(commandContextCaptor.capture());
+        assertThat(commandContextCaptor.getValue()).isNotNull();
+        // assert that command is not valid
+        assertThat(commandContextCaptor.getValue().getCommand().isValid()).isFalse();
+        assertThat(commandContextCaptor.getValue().getCommand().getInvalidCommandReason()).contains("subject");
+
+    }
+
+    /**
+     * Verifies that the consumer handles a valid message by invoking the matching command handler.
+     */
+    @Test
+    void testHandleCommandMessageWithHandlerForDevice() {
+        final String tenantId = "myTenant";
+        final String deviceId = "4711";
+        final String subject = "subject";
+
+        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(deviceId,
+                getHeaders(tenantId, deviceId, subject));
+
+        final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
+        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler);
+
+        internalCommandConsumer.handleCommandMessage(commandRecord);
+
+        final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(commandHandler).handle(commandContextCaptor.capture());
+        assertThat(commandContextCaptor.getValue()).isNotNull();
+        assertThat(commandContextCaptor.getValue().getCommand().isValid()).isTrue();
+    }
+
+    /**
+     * Verifies that the consumer handles a valid message, targeted at a gateway, by invoking the matching command
+     * handler.
+     */
+    @Test
+    void testHandleCommandMessageWithHandlerForGateway() {
+        final String tenantId = "myTenant";
+        final String deviceId = "4711";
+        final String gatewayId = "gw-1";
+        final String subject = "subject";
+
+        final List<KafkaHeader> headers = new ArrayList<>(getHeaders(tenantId, deviceId, subject));
+        headers.add(KafkaHeader.header(MessageHelper.APP_PROPERTY_CMD_VIA, gatewayId));
+
+        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(deviceId, headers);
+
+        final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
+        commandHandlers.putCommandHandler(tenantId, gatewayId, null, commandHandler);
+
+        internalCommandConsumer.handleCommandMessage(commandRecord);
+
+        final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(commandHandler).handle(commandContextCaptor.capture());
+        assertThat(commandContextCaptor.getValue()).isNotNull();
+        assertThat(commandContextCaptor.getValue().getCommand().isValid()).isTrue();
+        // assert that command is directed at the gateway
+        assertThat(commandContextCaptor.getValue().getCommand().getGatewayId()).isEqualTo(gatewayId);
+        assertThat(commandContextCaptor.getValue().getCommand().getDeviceId()).isEqualTo(deviceId);
+    }
+
+    /**
+     * Verifies that the consumer handles a valid message, for which the matching command handler is associated
+     * with a gateway, by invoking the handler and adopting the gateway identifier in the command object.
+     */
+    @Test
+    void testHandleCommandMessageWithHandlerForGatewayAndSpecificDevice() {
+        final String tenantId = "myTenant";
+        final String deviceId = "4711";
+        final String gatewayId = "gw-1";
+        final String subject = "subject";
+
+        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(deviceId,
+                getHeaders(tenantId, deviceId, subject));
+
+        final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
+        commandHandlers.putCommandHandler(tenantId, deviceId, gatewayId, commandHandler);
+
+        internalCommandConsumer.handleCommandMessage(commandRecord);
+
+        final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
+        verify(commandHandler).handle(commandContextCaptor.capture());
+        assertThat(commandContextCaptor.getValue()).isNotNull();
+        assertThat(commandContextCaptor.getValue().getCommand().isValid()).isTrue();
+        // assert that command is directed at the gateway
+        assertThat(commandContextCaptor.getValue().getCommand().getGatewayId()).isEqualTo(gatewayId);
+        assertThat(commandContextCaptor.getValue().getCommand().getDeviceId()).isEqualTo(deviceId);
+    }
+
+    private List<KafkaHeader> getHeaders(final String tenantId, final String deviceId, final String subject) {
+        return List.of(
+                KafkaHeader.header(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId),
+                KafkaHeader.header(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId),
+                KafkaHeader.header(MessageHelper.SYS_PROPERTY_SUBJECT, subject)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private KafkaConsumerRecord<String, Buffer> getCommandRecord(final String key, final List<KafkaHeader> headers) {
+        final String adapterInstanceId = "the-adapter-instance-id";
+        final String topic = new HonoTopic(HonoTopic.Type.COMMAND_INTERNAL, adapterInstanceId).toString();
+        final KafkaConsumerRecord<String, Buffer> consumerRecord = mock(KafkaConsumerRecord.class);
+        when(consumerRecord.headers()).thenReturn(headers);
+        when(consumerRecord.topic()).thenReturn(topic);
+        when(consumerRecord.key()).thenReturn(key);
+        return consumerRecord;
+    }
+}

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandRouterCommandConsumerFactory.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandRouterCommandConsumerFactory.java
@@ -86,7 +86,9 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
      */
     public void registerInternalCommandConsumer(
             final BiFunction<String, CommandHandlers, Lifecycle> internalCommandConsumerSupplier) {
-        internalCommandConsumers.add(internalCommandConsumerSupplier.apply(adapterInstanceId, commandHandlers));
+        final Lifecycle consumer = internalCommandConsumerSupplier.apply(adapterInstanceId, commandHandlers);
+        log.info("register internal command consumer {}", consumer.getClass().getSimpleName());
+        internalCommandConsumers.add(consumer);
     }
 
     /**

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/HonoTopicTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/HonoTopicTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 public class HonoTopicTest {
 
     private final String tenantId = "the-tenant";
+    private final String adapterInstanceId = "the-adapter-instance-id";
 
     /**
      * Verifies that the toString method returns the expected string.
@@ -42,6 +43,9 @@ public class HonoTopicTest {
         final HonoTopic commandResponse = new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId);
         assertThat(commandResponse.toString()).isEqualTo("hono.command_response." + tenantId);
 
+        final HonoTopic commandInternal = new HonoTopic(HonoTopic.Type.COMMAND_INTERNAL, adapterInstanceId);
+        assertThat(commandInternal.toString()).isEqualTo("hono.command_internal." + adapterInstanceId);
+
     }
 
     /**
@@ -58,13 +62,20 @@ public class HonoTopicTest {
 
         assertTopicProperties(HonoTopic.fromString("hono.command_response." + tenantId), HonoTopic.Type.COMMAND_RESPONSE);
 
+        assertTopicProperties(HonoTopic.fromString("hono.command_internal." + adapterInstanceId), HonoTopic.Type.COMMAND_INTERNAL);
+
     }
 
     private void assertTopicProperties(final HonoTopic actual, final HonoTopic.Type expectedType) {
         assertThat(actual).isNotNull();
-        assertThat(actual.getTenantId()).isEqualTo(tenantId);
+        if (expectedType == HonoTopic.Type.COMMAND_INTERNAL) {
+            assertThat(actual.getSuffix()).isEqualTo(adapterInstanceId);
+            assertThat(actual.toString()).isEqualTo(expectedType.prefix + adapterInstanceId);
+        } else {
+            assertThat(actual.getTenantId()).isEqualTo(tenantId);
+            assertThat(actual.toString()).isEqualTo(expectedType.prefix + tenantId);
+        }
         assertThat(actual.getType()).isEqualTo(expectedType);
-        assertThat(actual.toString()).isEqualTo(expectedType.prefix + tenantId);
     }
 
     /**
@@ -114,6 +125,10 @@ public class HonoTopicTest {
         assertThat(HonoTopic.Type.COMMAND_RESPONSE.endpoint).isEqualTo("command_response");
         assertThat(HonoTopic.Type.COMMAND_RESPONSE.prefix).isEqualTo("hono.command_response.");
         assertThat(HonoTopic.Type.COMMAND_RESPONSE.toString()).isEqualTo("command_response");
+
+        assertThat(HonoTopic.Type.COMMAND_INTERNAL.endpoint).isEqualTo("command_internal");
+        assertThat(HonoTopic.Type.COMMAND_INTERNAL.prefix).isEqualTo("hono.command_internal.");
+        assertThat(HonoTopic.Type.COMMAND_INTERNAL.toString()).isEqualTo("command_internal");
 
     }
 


### PR DESCRIPTION
This is for #2273.
Adds a Kafka consumer used in protocol adapters for receiving commands forwarded by the Command Router component.