### PR TITLE
Use response-required instead of response-expected command header

### DIFF
--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandTest.java
@@ -71,7 +71,7 @@ public class KafkaBasedCommandTest {
         final String subject = "doThis";
 
         final List<KafkaHeader> headers = new ArrayList<>(getHeaders(deviceId, subject, correlationId));
-        headers.add(KafkaHeader.header(KafkaBasedCommand.HEADER_RESPONSE_EXPECTED, "true"));
+        headers.add(KafkaHeader.header(KafkaBasedCommand.HEADER_RESPONSE_REQUIRED, "true"));
         final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(topic, deviceId, headers);
         final KafkaBasedCommand cmd = KafkaBasedCommand.from(commandRecord);
         assertTrue(cmd.isValid());
@@ -109,12 +109,12 @@ public class KafkaBasedCommandTest {
     }
 
     /**
-     * Verifies that a command can be created from a valid record that has no <em>response-expected</em>
+     * Verifies that a command can be created from a valid record that has no <em>response-required</em>
      * and no <em>correlation-id</em> header.
      * Verifies that the command reports that it is a one-way command.
      */
     @Test
-    public void testFromRecordSucceedsWithoutResponseExpectedAndCorrelationId() {
+    public void testFromRecordSucceedsWithoutResponseRequiredAndCorrelationId() {
         final String topic = new HonoTopic(HonoTopic.Type.COMMAND, Constants.DEFAULT_TENANT).toString();
         final String deviceId = "4711";
         final String subject = "doThis";
@@ -131,17 +131,17 @@ public class KafkaBasedCommandTest {
     }
 
     /**
-     * Verifies that a valid command cannot be created from a record that has the <em>response-expected</em>
+     * Verifies that a valid command cannot be created from a record that has the <em>response-required</em>
      * header set to "true" but has no <em>correlation-id</em> header.
      */
     @Test
-    public void testFromRecordFailsForMissingCorrelationIdWithResponseExpected() {
+    public void testFromRecordFailsForMissingCorrelationIdWithResponseRequired() {
         final String topic = new HonoTopic(HonoTopic.Type.COMMAND, Constants.DEFAULT_TENANT).toString();
         final String deviceId = "4711";
         final String subject = "doThis";
 
         final List<KafkaHeader> headers = new ArrayList<>(getHeaders(deviceId, subject));
-        headers.add(KafkaHeader.header(KafkaBasedCommand.HEADER_RESPONSE_EXPECTED, "true"));
+        headers.add(KafkaHeader.header(KafkaBasedCommand.HEADER_RESPONSE_REQUIRED, "true"));
         final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(topic, deviceId, headers);
         final KafkaBasedCommand cmd = KafkaBasedCommand.from(commandRecord);
         assertFalse(cmd.isValid());

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/Command.java
@@ -25,7 +25,7 @@ import io.vertx.core.buffer.Buffer;
 public interface Command {
 
     /**
-     * Checks if this command is a <em>one-way</em> command (meaning there is no response expected).
+     * Checks if this command is a <em>one-way</em> command (meaning there is no response required).
      *
      * @return {@code true} if this is a one-way command.
      */

--- a/site/documentation/content/api/command-and-control-kafka/index.md
+++ b/site/documentation/content/api/command-and-control-kafka/index.md
@@ -60,7 +60,7 @@ The command message MAY contain arbitrary payload, set as message value, to be s
 For that, the Business Application connects to the *Kafka Cluster* and writes a message to the tenant-specific topic `hono.command.${tenant_id}` where `${tenant_id}` is the ID of the tenant that the client wants to send the command for.
 The Business Application can consume the corresponding command response from the `hono.command_response.${tenant_id}` topic.
 
-In contrast to a one-way command, a request/response command contains a *response-expected* header with value `true` and a *correlation-id* header, providing the identifier that is used to correlate a response message to the original request.
+In contrast to a one-way command, a request/response command contains a *response-required* header with value `true` and a *correlation-id* header, providing the identifier that is used to correlate a response message to the original request.
 
 **Preconditions**
 
@@ -86,7 +86,7 @@ The following table provides an overview of the headers the *Business Applicatio
 | :------------------ | :-------: | :-------- | :---------- |
 | *correlation-id*    | yes       | *string*  | The identifier used to correlate a response message to the original request. It is used as the *correlation-id* header in the response. |
 | *device_id*         | yes       | *string*  | The identifier of the device that the command is targeted at. |
-| *response-expected* | yes       | *boolean* | MUST be set with a value of `true`, meaning that a response from the device is expected for the command. |
+| *response-required* | yes       | *boolean* | MUST be set with a value of `true`, meaning that the device is required to send a response for the command. |
 | *subject*           | yes       | *string*  | The name of the command to be executed by the device. |
 | *content-type*      | no        | *string*  | If present, MUST contain a *Media Type* as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046) which describes the semantics and format of the command's input data contained in the message payload. However, not all protocol adapters will support this property as not all transport protocols provide means to convey this information, e.g. MQTT 3.1.1 has no notion of message headers. |
 


### PR DESCRIPTION
Rename the Kafka record header used for request/response commands. 

The new name better reflects the need for a response to be sent by the device because otherwise the sending application has to consider the execution of the command to have failed. The new name is also in line with the corresponding name in Eclipse Ditto.
