### PR TITLE
Move HTTP adapter base classes to HTTP adapter module

### DIFF
--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AuthHandlerTools.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AuthHandlerTools.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,7 +12,7 @@
  */
 
 
-package org.eclipse.hono.service.http;
+package org.eclipse.hono.adapter.http;
 
 import java.util.Optional;
 
@@ -47,7 +47,8 @@ public final class AuthHandlerTools {
      * <p>
      * Note that the routing context is failed with just the exception, no status
      * code. Setting the status code on the response corresponding to the exception
-     * is to be done in the failure handler, e.g. as implemented in the {@link DefaultFailureHandler}.
+     * is to be done in the failure handler, e.g. as implemented in the
+     * {@link org.eclipse.hono.service.http.DefaultFailureHandler}.
      *
      * @param ctx The routing context.
      * @param exception The cause of failure to process the request.

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandler.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,12 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.service.http;
+package org.eclipse.hono.adapter.http;
 
 import java.util.Objects;
 
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
+import org.eclipse.hono.service.http.HttpContext;
+import org.eclipse.hono.service.http.HttpUtils;
 
 import io.opentracing.Tracer;
 import io.vertx.core.AsyncResult;

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoChainAuthHandler.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoChainAuthHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,11 +12,12 @@
  */
 
 
-package org.eclipse.hono.service.http;
+package org.eclipse.hono.adapter.http;
 
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
+import org.eclipse.hono.service.http.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoHttpAuthHandler.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HonoHttpAuthHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,12 +12,14 @@
  */
 
 
-package org.eclipse.hono.service.http;
+package org.eclipse.hono.adapter.http;
 
 import java.util.Objects;
 
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
+import org.eclipse.hono.service.http.HttpContext;
+import org.eclipse.hono.service.http.TracingHandler;
 import org.eclipse.hono.tracing.TracingHelper;
 
 import io.opentracing.Tracer;

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAuthProviderAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAuthProviderAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,13 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.service.http;
+package org.eclipse.hono.adapter.http;
 
 import java.util.Objects;
 
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.ExecutionContextAuthHandler;
 import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
+import org.eclipse.hono.service.http.HttpContext;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/X509AuthHandler.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/X509AuthHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.service.http;
+package org.eclipse.hono.adapter.http;
 
 import java.net.HttpURLConnection;
 import java.security.cert.Certificate;
@@ -23,6 +23,8 @@ import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
 import org.eclipse.hono.service.auth.device.SubjectDnCredentials;
 import org.eclipse.hono.service.auth.device.X509Authentication;
+import org.eclipse.hono.service.http.HttpContext;
+import org.eclipse.hono.service.http.TracingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,7 +18,10 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
+import org.eclipse.hono.adapter.http.HonoBasicAuthHandler;
+import org.eclipse.hono.adapter.http.HonoChainAuthHandler;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
+import org.eclipse.hono.adapter.http.X509AuthHandler;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
@@ -27,11 +30,8 @@ import org.eclipse.hono.service.auth.device.TenantServiceBasedX509Authentication
 import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
 import org.eclipse.hono.service.auth.device.X509AuthProvider;
-import org.eclipse.hono.service.http.HonoBasicAuthHandler;
-import org.eclipse.hono.service.http.HonoChainAuthHandler;
 import org.eclipse.hono.service.http.HttpContext;
 import org.eclipse.hono.service.http.HttpUtils;
-import org.eclipse.hono.service.http.X509AuthHandler;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandlerTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/HonoBasicAuthHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.service.http;
+package org.eclipse.hono.adapter.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,6 +35,7 @@ import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.auth.device.AbstractDeviceCredentials;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
+import org.eclipse.hono.service.http.HttpContext;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/HonoChainAuthHandlerTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/HonoChainAuthHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.service.http;
+package org.eclipse.hono.adapter.http;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,6 +34,7 @@ import org.eclipse.hono.service.auth.DeviceUser;
 import org.eclipse.hono.service.auth.device.AbstractDeviceCredentials;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.PreCredentialsValidationHandler;
+import org.eclipse.hono.service.http.HttpContext;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.AsyncResult;

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/X509AuthHandlerTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/X509AuthHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,7 +12,7 @@
  */
 
 
-package org.eclipse.hono.service.http;
+package org.eclipse.hono.adapter.http;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -43,6 +43,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.SubjectDnCredentials;
 import org.eclipse.hono.service.auth.device.X509Authentication;
+import org.eclipse.hono.service.http.TracingHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
+++ b/adapters/lora-vertx/src/main/java/org/eclipse/hono/adapter/lora/impl/LoraProtocolAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,6 +20,9 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
+import org.eclipse.hono.adapter.http.HonoBasicAuthHandler;
+import org.eclipse.hono.adapter.http.HonoChainAuthHandler;
+import org.eclipse.hono.adapter.http.X509AuthHandler;
 import org.eclipse.hono.adapter.lora.LoraConstants;
 import org.eclipse.hono.adapter.lora.LoraMessage;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
@@ -35,12 +38,9 @@ import org.eclipse.hono.service.auth.device.TenantServiceBasedX509Authentication
 import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
 import org.eclipse.hono.service.auth.device.X509AuthProvider;
-import org.eclipse.hono.service.http.HonoBasicAuthHandler;
-import org.eclipse.hono.service.http.HonoChainAuthHandler;
 import org.eclipse.hono.service.http.HttpContext;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.service.http.TracingHandler;
-import org.eclipse.hono.service.http.X509AuthHandler;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;

--- a/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
+++ b/adapters/sigfox-vertx/src/main/java/org/eclipse/hono/adapter/sigfox/impl/SigfoxProtocolAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,13 +21,13 @@ import java.util.Optional;
 import org.eclipse.hono.adapter.client.command.Command;
 import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.adapter.http.AbstractVertxBasedHttpProtocolAdapter;
+import org.eclipse.hono.adapter.http.HonoBasicAuthHandler;
+import org.eclipse.hono.adapter.http.HonoChainAuthHandler;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.service.auth.device.DeviceCredentialsAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordAuthProvider;
 import org.eclipse.hono.service.auth.device.UsernamePasswordCredentials;
-import org.eclipse.hono.service.http.HonoBasicAuthHandler;
-import org.eclipse.hono.service.http.HonoChainAuthHandler;
 import org.eclipse.hono.service.http.HttpContext;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.tracing.TracingHelper;

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -55,7 +55,6 @@ import org.eclipse.hono.service.base.jdbc.store.tenant.ManagementStore;
 import org.eclipse.hono.service.base.jdbc.store.tenant.Stores;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.credentials.DelegatingCredentialsAmqpEndpoint;
-import org.eclipse.hono.service.http.HonoBasicAuthHandler;
 import org.eclipse.hono.service.http.HttpEndpoint;
 import org.eclipse.hono.service.http.HttpServiceConfigProperties;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
@@ -90,6 +89,7 @@ import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.jdbc.JDBCAuth;
 import io.vertx.ext.jdbc.JDBCClient;
 import io.vertx.ext.web.handler.AuthHandler;
+import io.vertx.ext.web.handler.BasicAuthHandler;
 
 /**
  * Spring Boot configuration for the JDBC based device registry application.
@@ -590,7 +590,7 @@ public class ApplicationConfig {
      * Creates a new instance of an auth handler to provide basic authentication for the 
      * HTTP based Device Registry Management endpoint.
      * <p>
-     * This creates an instance of the {@link HonoBasicAuthHandler} with the auth provider returned by
+     * This method creates a {@link BasicAuthHandler} using the auth provider returned by
      * {@link #authProvider()} if the property corresponding to {@link HttpServiceConfigProperties#isAuthenticationRequired()}
      * is set to {@code true}.
      *
@@ -604,10 +604,9 @@ public class ApplicationConfig {
     @Scope("prototype")
     public AuthHandler createAuthHandler(final HttpServiceConfigProperties httpServiceConfigProperties) {
         if (httpServiceConfigProperties != null && httpServiceConfigProperties.isAuthenticationRequired()) {
-            return new HonoBasicAuthHandler(
+            return BasicAuthHandler.create(
                     authProvider(),
-                    httpServerProperties().getRealm(),
-                    tracer());
+                    httpServerProperties().getRealm());
         }
         return null;
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -45,7 +45,6 @@ import org.eclipse.hono.service.VertxBasedHealthCheckServer;
 import org.eclipse.hono.service.amqp.AmqpEndpoint;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.credentials.DelegatingCredentialsAmqpEndpoint;
-import org.eclipse.hono.service.http.HonoBasicAuthHandler;
 import org.eclipse.hono.service.http.HttpEndpoint;
 import org.eclipse.hono.service.http.HttpServiceConfigProperties;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
@@ -78,6 +77,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.mongo.MongoAuth;
 import io.vertx.ext.mongo.MongoClient;
 import io.vertx.ext.web.handler.AuthHandler;
+import io.vertx.ext.web.handler.BasicAuthHandler;
 
 /**
  * Spring Boot configuration for the mongodb based device registry application.
@@ -499,7 +499,7 @@ public class ApplicationConfig {
      * Creates a new instance of an auth handler to provide basic authentication for the 
      * HTTP based Device Registry Management endpoint.
      * <p>
-     * This creates an instance of the {@link HonoBasicAuthHandler} with an auth provider of type
+     * This method creates a {@link BasicAuthHandler} using an auth provider of type
      * {@link MongoAuth} if the property corresponding to {@link HttpServiceConfigProperties#isAuthenticationRequired()}
      * is set to {@code true}.
      *
@@ -513,10 +513,9 @@ public class ApplicationConfig {
     @Scope("prototype")
     public AuthHandler createAuthHandler(final HttpServiceConfigProperties httpServiceConfigProperties) {
         if (httpServiceConfigProperties.isAuthenticationRequired()) {
-            return new HonoBasicAuthHandler(
+            return BasicAuthHandler.create(
                     MongoAuth.create(mongoClient(), new JsonObject()),
-                    httpServerProperties().getRealm(),
-                    tracer());
+                    httpServerProperties().getRealm());
         }
         return null;
     }


### PR DESCRIPTION
There are several classes in the service-base module which are only
relevant to HTTP based protocol adapters. These classes have therefore
been moved to the HTTP adapter base module.

This is also the first step towards splitting up the service-base module into a service-base and an adapter-base module. The latter is supposed to contain classes only which are useful for implementing protocol adapters while the former will be useful for implementing both (plain) services and protocol adapters. This way we will be able to more precisely define the service component's (transitive) dependencies, e.g. protocol adapters will have a dependency on the Infinispan based client while the Authentication server won't. In a further step, the service-base and adapter-base modules will then be refined to service-base, service-base-spring and service-base-quarkus on the one hand and adapter-base, adapter-base-spring and adapter-base-quarkus on the other hand. This will allow to keep Spring Boot dependencies separate from Quarkus dependencies when adding Quarkus based service implementations.