### PR TITLE
[#2273] Improve createCommandConsumer() in Command Router

### DIFF
--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandConsumer.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandConsumer.java
@@ -146,8 +146,7 @@ public class ProtonBasedInternalCommandConsumer extends AbstractServiceClient im
             // command.isValid() check not done here - it is to be done in the command handler
             commandHandler.handleCommand(commandContext);
         } else {
-            LOG.info("no command handler found for command with device id {}, gateway id {} [tenant-id: {}]",
-                    command.getDeviceId(), command.getGatewayId(), command.getTenant());
+            LOG.info("no command handler found for command [{}]", command);
             TracingHelper.logError(currentSpan, "no command handler found for command");
             commandContext.release();
         }

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandSender.java
@@ -36,8 +36,8 @@ import io.vertx.kafka.client.producer.KafkaHeader;
 
 /**
  * A Kafka based sender for sending commands to an internal command topic
- * (<em>hono.command_internal.adapterInstanceId</em>). The corresponding protocol 
- * adapter consumes commands by subscribing to this topic.
+ * (<em>hono.command_internal.${adapterInstanceId}</em>).
+ * Protocol adapters consume commands by subscribing to this topic.
  */
 public class KafkaBasedInternalCommandSender extends AbstractKafkaBasedMessageSender implements InternalCommandSender {
 

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/AbstractMappingAndDelegatingCommandHandler.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/AbstractMappingAndDelegatingCommandHandler.java
@@ -29,8 +29,8 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.Future;
 
 /**
- * Handler for mapping the received commands and forwarding using
- * {@link org.eclipse.hono.adapter.client.command.InternalCommandSender}.
+ * Handler for mapping received commands to the corresponding target protocol adapter instance
+ * and forwarding them using the {@link org.eclipse.hono.adapter.client.command.InternalCommandSender}.
  */
 public abstract class AbstractMappingAndDelegatingCommandHandler implements Lifecycle {
 

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -12,10 +12,19 @@
  *******************************************************************************/
 package org.eclipse.hono.commandrouter.impl.kafka;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedInternalCommandSender;
@@ -30,34 +39,48 @@ import org.slf4j.LoggerFactory;
 
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.common.PartitionInfo;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.kafka.client.common.impl.Helper;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 
 /**
  * A factory for creating clients for the <em>Kafka messaging infrastructure</em> to receive commands.
  * <p>
- * This factory uses wild-card based topic pattern to subscribe for commands, which receives the command 
+ * This factory uses a wild-card based topic pattern to subscribe for commands, which receives the command
  * messages irrespective of the tenants.
  * <p>
- * Command messages are first received by the kafka based consumer. It is then determined which protocol adapter instance
- * can handle the command. The command is then forwarded to the Kafka cluster on an topic containing that adapter
- * instance id.
+ * Command messages are first received by the Kafka consumer on the tenant-specific topic. It is then determined
+ * which protocol adapter instance can handle the command. The command is then forwarded to the Kafka cluster on
+ * a topic containing that adapter instance id.
  */
 public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFactory {
-    private static final Logger log = LoggerFactory.getLogger(KafkaBasedCommandConsumerFactoryImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaBasedCommandConsumerFactoryImpl.class);
+
     private static final Pattern COMMANDS_TOPIC_PATTERN = Pattern
             .compile(Pattern.quote(HonoTopic.Type.COMMAND.prefix) + ".*");
+    private static final long WAIT_FOR_REBALANCE_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
 
     private final AtomicBoolean initialized = new AtomicBoolean(false);
     private final KafkaConsumer<String, Buffer> kafkaConsumer;
     private final KafkaBasedInternalCommandSender internalCommandSender;
     private final Tracer tracer;
+    private final Vertx vertx;
+    /**
+     * Currently subscribed topics, i.e. the topics matching COMMANDS_TOPIC_PATTERN.
+     * Note that these are not (necessarily) the topics that this particular kafkaConsumer
+     * here will receive messages for.
+     */
+    private Set<String> subscribedTopics = new HashSet<>();
+    private final AtomicReference<Promise<Void>> onSubscribedTopicsNextUpdated = new AtomicReference<>();
 
-    private CommandTargetMapper commandTargetMapper;
     private KafkaBasedMappingAndDelegatingCommandHandler commandHandler;
 
     /**
@@ -76,54 +99,97 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
             final KafkaProducerConfigProperties kafkaProducerConfig,
             final KafkaConsumerConfigProperties kafkaConsumerConfig,
             final Tracer tracer) {
-        Objects.requireNonNull(vertx);
+        this.vertx = Objects.requireNonNull(vertx);
         Objects.requireNonNull(kafkaProducerFactory);
         Objects.requireNonNull(kafkaProducerConfig);
         Objects.requireNonNull(kafkaConsumerConfig);
-        Objects.requireNonNull(tracer);
+        this.tracer = Objects.requireNonNull(tracer);
 
         this.internalCommandSender = new KafkaBasedInternalCommandSender(kafkaProducerFactory, kafkaProducerConfig, tracer);
         final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig("cmd-router");
         consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "cmd-router-group");
         this.kafkaConsumer = KafkaConsumer.create(vertx, consumerConfig, String.class, Buffer.class);
-        this.tracer = tracer;
     }
 
     @Override
     public void initialize(final CommandTargetMapper commandTargetMapper) {
         Objects.requireNonNull(commandTargetMapper);
-        this.commandTargetMapper = commandTargetMapper;
+        commandHandler = new KafkaBasedMappingAndDelegatingCommandHandler(commandTargetMapper, internalCommandSender,
+                tracer);
         initialized.set(true);
     }
 
     @Override
     public Future<Void> start() {
-        final Promise<Void> subscriptionPromise = Promise.promise();
-        final Promise<Void> partitionsAssignedPromise = Promise.promise();
-
         if (!initialized.get()) {
             return Future.failedFuture("not initialized");
         }
 
-        commandHandler = new KafkaBasedMappingAndDelegatingCommandHandler(commandTargetMapper, internalCommandSender,
-                tracer);
-        //TODO in the next iteration: handling of offsets and commits. 
+        //TODO in the next iteration: handling of offsets and commits.
         // And if required, to use a consumer(at most once) class similar to the AbstractAtLeastOnceKafkaConsumer
         kafkaConsumer
                 .handler(commandHandler::mapAndDelegateIncomingCommandMessage)
-                .partitionsAssignedHandler(ok -> partitionsAssignedPromise.tryComplete())
-                .exceptionHandler(error -> log.error("consumer error occurred", error))
-                .subscribe(COMMANDS_TOPIC_PATTERN, subscriptionPromise);
+                .partitionsAssignedHandler(this::onPartitionsAssigned)
+                .partitionsRevokedHandler(this::onPartitionsRevoked)
+                .exceptionHandler(error -> LOG.error("consumer error occurred", error));
 
-        return commandHandler.start()
-                .compose(ok -> CompositeFuture.all(subscriptionPromise.future(), partitionsAssignedPromise.future()))
+        return CompositeFuture.all(commandHandler.start(), subscribeAndWaitForRebalanceAndTopicsUpdate())
                 .map(ok -> {
-                    log.debug("subscribed to topic pattern [{}]", COMMANDS_TOPIC_PATTERN);
+                    LOG.debug("subscribed to topic pattern [{}], matching {} topics", COMMANDS_TOPIC_PATTERN, subscribedTopics.size());
                     return null;
                 });
     }
 
-    @Override 
+    private Future<Void> subscribeAndWaitForRebalanceAndTopicsUpdate() {
+        final Promise<Void> subscribedTopicsPromise = onSubscribedTopicsNextUpdated
+                .updateAndGet(promise -> promise == null ? Promise.promise() : promise);
+        final Promise<Void> subscriptionPromise = Promise.promise();
+        kafkaConsumer.subscribe(COMMANDS_TOPIC_PATTERN, subscriptionPromise);
+        vertx.setTimer(WAIT_FOR_REBALANCE_TIMEOUT, ar -> {
+            if (!subscribedTopicsPromise.future().isComplete()) {
+                final String errorMsg = "timed out waiting for rebalance and update of subscribed topics";
+                LOG.error(errorMsg);
+                subscribedTopicsPromise.tryFail(errorMsg);
+            }
+        });
+        return CompositeFuture.all(subscriptionPromise.future(), subscribedTopicsPromise.future()).mapEmpty();
+    }
+
+    private void onPartitionsAssigned(final Set<TopicPartition> partitionsSet) {
+        LOG.debug("partitions assigned: [{}]", getPartitionsDebugString(partitionsSet));
+        // update subscribedTopics (subscription() will return the actual topics, not the topic pattern)
+        kafkaConsumer.subscription(ar -> {
+            if (ar.succeeded()) {
+                subscribedTopics = new HashSet<>(ar.result());
+            } else {
+                LOG.warn("failed to get subscription", ar.cause());
+            }
+            Optional.ofNullable(onSubscribedTopicsNextUpdated.getAndSet(null))
+                    .ifPresent(promise -> {
+                        if (ar.succeeded()) {
+                            promise.tryComplete();
+                        } else {
+                            promise.tryFail(ar.cause());
+                        }
+                    });
+        });
+    }
+
+    private void onPartitionsRevoked(final Set<TopicPartition> partitionsSet) {
+        LOG.debug("partitions revoked: [{}]", getPartitionsDebugString(partitionsSet));
+    }
+
+    private String getPartitionsDebugString(final Set<TopicPartition> partitionsSet) {
+        if (partitionsSet.size() <= 20) {
+            // return detailed info
+            return partitionsSet.stream()
+                    .map(topicPartition -> String.format("'%s' -> %s", topicPartition.getTopic(), topicPartition.getPartition()))
+                    .collect(Collectors.joining(", "));
+        }
+        return partitionsSet.size() + " topic partitions";
+    }
+
+    @Override
     public Future<Void> stop() {
         final Promise<Void> consumerClosePromise = Promise.promise();
 
@@ -135,8 +201,75 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
 
     @Override
     public Future<Void> createCommandConsumer(final String tenantId, final SpanContext context) {
-        // The consumer is created already in start method as it uses topic pattern (irrespective of tenant-id) to
-        // subscribe.
-        return Future.succeededFuture();
+
+        final String topic = new HonoTopic(HonoTopic.Type.COMMAND, tenantId).toString();
+        // check whether tenant topic exists and its existence has been applied to the wildcard subscription yet;
+        // use previously updated topics list (less costly than invoking kafkaConsumer.subscription() here)
+        if (subscribedTopics.contains(topic)) {
+            LOG.debug("createCommandConsumer: topic is already subscribed [{}]", topic);
+            return Future.succeededFuture();
+        }
+
+        final Promise<List<PartitionInfo>> topicCheckFuture = Promise.promise();
+        // check whether tenant topic has been created since the last rebalance
+        // and if not, potentially create it here implicitly
+        // (partitionsFor() will create the topic if it doesn't exist, provided "auto.create.topics.enable" is true)
+        partitionsFor(topic, topicCheckFuture);
+        return topicCheckFuture.future()
+                .onFailure(thr -> LOG.error("createCommandConsumer: error getting partitions for topic [{}]", topic, thr))
+                .compose(partitions -> {
+                    LOG.debug("createCommandConsumer: got partitions for topic [{}]: {}", topic, partitions.size());
+                    if (partitions.isEmpty()) {
+                        return Future.failedFuture("topic does not exist: " + topic);
+                    }
+                    // again check topics in case rebalance happened in between
+                    if (subscribedTopics.contains(topic)) {
+                        return Future.succeededFuture();
+                    }
+                    // the topic list of a wildcard subscription only gets refreshed periodically by default (interval is defined by "metadata.max.age.ms");
+                    // therefore enforce a refresh here by again subscribing to the topic pattern
+                    return subscribeAndWaitForRebalanceAndTopicsUpdate();
+                })
+                .onSuccess(ar -> LOG.debug("createCommandConsumer: done with refreshing topic subscription"));
+    }
+
+    /**
+     * This method is adapted from {@code io.vertx.kafka.client.consumer.impl.KafkaConsumerImpl#partitionsFor(String, Handler)}
+     * and fixes an NPE in case {@code KafkaConsumer#partitionsFor(String)} returns {@code null}
+     * (happens if "auto.create.topics.enable" is false).
+     * <p>
+     * This method will become obsolete when updating to a Kafka client in which https://issues.apache.org/jira/browse/KAFKA-12260
+     * ("PartitionsFor should not return null value") is solved.
+     * TODO remove this method once updated Kafka client is used
+     */
+    private KafkaConsumer<String, Buffer> partitionsFor(final String topic, final Handler<AsyncResult<List<PartitionInfo>>> handler) {
+        kafkaConsumer.asStream().partitionsFor(topic, done -> {
+
+            if (done.succeeded()) {
+                if (done.result() == null) {
+                    handler.handle(Future.succeededFuture(List.of()));
+                } else {
+                    final List<PartitionInfo> partitions = new ArrayList<>();
+                    for (final org.apache.kafka.common.PartitionInfo kafkaPartitionInfo: done.result()) {
+
+                        final PartitionInfo partitionInfo = new PartitionInfo();
+                        partitionInfo
+                                .setInSyncReplicas(
+                                        Stream.of(kafkaPartitionInfo.inSyncReplicas()).map(Helper::from).collect(Collectors.toList()))
+                                .setLeader(Helper.from(kafkaPartitionInfo.leader()))
+                                .setPartition(kafkaPartitionInfo.partition())
+                                .setReplicas(
+                                        Stream.of(kafkaPartitionInfo.replicas()).map(Helper::from).collect(Collectors.toList()))
+                                .setTopic(kafkaPartitionInfo.topic());
+
+                        partitions.add(partitionInfo);
+                    }
+                    handler.handle(Future.succeededFuture(partitions));
+                }
+            } else {
+                handler.handle(Future.failedFuture(done.cause()));
+            }
+        });
+        return kafkaConsumer;
     }
 }


### PR DESCRIPTION
Ensure that once createCommandConsumer() in the Kafka-based CommandConsumerFactory succeeds, the relevant Kafka topic exists and is in the list of subscribed topics of the consumer.