### PR TITLE
[#2456] Include an optional ID for a tenant's trust anchor

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/TrustedCertificateAuthority.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/TrustedCertificateAuthority.java
@@ -44,6 +44,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonInclude(value = Include.NON_NULL)
 public class TrustedCertificateAuthority {
+    @JsonProperty(RegistryManagementConstants.FIELD_ID)
+    private String id;
 
     private X500Principal subjectDn;
 
@@ -84,6 +86,26 @@ public class TrustedCertificateAuthority {
                 return false;
             }
         }
+    }
+
+    /**
+     * Gets the identifier of the trust anchor.
+     *
+     * @return the identifier of the trust anchor.
+     */
+    public final String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the identifier of the trust anchor.
+     *
+     * @param id the identifier of the trust anchor.
+     * @return A reference to this for fluent use.
+     */
+    public final TrustedCertificateAuthority setId(final String id) {
+        this.id = id;
+        return this;
     }
 
     /**

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/tenant/AbstractTenantServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/tenant/AbstractTenantServiceTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.tenant.Tenant;
@@ -408,13 +409,16 @@ public interface AbstractTenantServiceTest {
 
         final X500Principal subjectDn = new X500Principal("O=Eclipse, OU=Hono, CN=ca");
 
+        final String trustAnchorId = DeviceRegistryUtils.getUniqueIdentifier();
         final JsonArray expectedCaList = new JsonArray().add(new JsonObject()
+                .put(TenantConstants.FIELD_OBJECT_ID, trustAnchorId)
                 .put(TenantConstants.FIELD_PAYLOAD_SUBJECT_DN, subjectDn.getName(X500Principal.RFC2253))
                 .put(TenantConstants.FIELD_PAYLOAD_PUBLIC_KEY, "NOTAPUBLICKEY".getBytes(StandardCharsets.UTF_8))
                 .put(TenantConstants.FIELD_AUTO_PROVISIONING_ENABLED, false));
 
         final Tenant tenant = new Tenant()
                 .setTrustedCertificateAuthorities(List.of(new TrustedCertificateAuthority()
+                        .setId(trustAnchorId)
                         .setSubjectDn(subjectDn)
                         .setPublicKey("NOTAPUBLICKEY".getBytes(StandardCharsets.UTF_8))
                         .setNotBefore(Instant.now().minus(1, ChronoUnit.DAYS))

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantService.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.security.auth.x500.X500Principal;
 
+import org.eclipse.hono.deviceregistry.service.tenant.AbstractTenantManagementService;
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.deviceregistry.util.Versioned;
 import org.eclipse.hono.service.management.Id;
@@ -57,7 +58,7 @@ import io.vertx.core.json.JsonObject;
  * On startup this adapter loads all registered tenants from a file. On shutdown all tenants kept in memory are written
  * to the file.
  */
-public final class FileBasedTenantService implements TenantService, TenantManagementService, Lifecycle {
+public final class FileBasedTenantService extends AbstractTenantManagementService implements TenantService, TenantManagementService, Lifecycle {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileBasedTenantService.class);
 
@@ -385,15 +386,17 @@ public final class FileBasedTenantService implements TenantService, TenantManage
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public Future<OperationResult<Id>> createTenant(final Optional<String> tenantId, final Tenant tenantSpec,
+    protected Future<OperationResult<Id>> processCreateTenant(final String tenantId, final Tenant tenantSpec,
             final Span span) {
-
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(tenantSpec);
+        Objects.requireNonNull(span);
 
-        final String tenantIdValue = tenantId.orElseGet(this::generateTenantId);
-        return Future.succeededFuture(add(tenantIdValue, tenantSpec, span));
+        return Future.succeededFuture(add(tenantId, tenantSpec, span));
     }
 
     /**
@@ -439,22 +442,17 @@ public final class FileBasedTenantService implements TenantService, TenantManage
     }
 
     /**
-     * Updates the tenant information.
-     *
-     * @param tenantId The tenant to update
-     * @param tenantSpec The new tenant information
-     * @param expectedResourceVersion The version identifier of the tenant information to update.
-     * @return A future indicating the outcome of the operation.
-     * @throws NullPointerException if either of the input parameters is {@code null}.
+     * {@inheritDoc}
      */
     @Override
-    public Future<OperationResult<Void>> updateTenant(final String tenantId, final Tenant tenantSpec,
-            final Optional<String> expectedResourceVersion,
-            final Span span) {
+    protected Future<OperationResult<Void>> processUpdateTenant(final String tenantId, final Tenant tenantSpec,
+            final Optional<String> resourceVersion, final Span span) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(tenantSpec);
+        Objects.requireNonNull(resourceVersion);
+        Objects.requireNonNull(span);
 
-        return Future.succeededFuture(update(tenantId, tenantSpec, expectedResourceVersion, span));
+        return Future.succeededFuture(update(tenantId, tenantSpec, resourceVersion, span));
     }
 
     /**

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/TenantManagementServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/TenantManagementServiceImpl.java
@@ -42,8 +42,12 @@ public class TenantManagementServiceImpl extends AbstractTenantManagementService
         this.store = store;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public Future<OperationResult<Id>> createTenant(final String tenantId, final Tenant tenantObj, final Span span) {
+    public Future<OperationResult<Id>> processCreateTenant(final String tenantId, final Tenant tenantObj,
+            final Span span) {
 
         return this.store
 
@@ -77,8 +81,12 @@ public class TenantManagementServiceImpl extends AbstractTenantManagementService
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public Future<OperationResult<Void>> updateTenant(final String tenantId, final Tenant tenantObj, final Optional<String> resourceVersion, final Span span) {
+    public Future<OperationResult<Void>> processUpdateTenant(final String tenantId, final Tenant tenantObj,
+            final Optional<String> resourceVersion, final Span span) {
 
         return this.store
 

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -742,6 +742,14 @@ components:
          type: object
          additionalProperties: false
          properties:
+            "id":
+               type: string
+               required: false
+               description: |
+                  The identifier of the trust anchor. This identifier must be unique
+                  among a tenant's trust anchors. If this property is not provided,
+                  then the device registry assigns a unique identifier.
+               example: A user provided identifier could look like "DEFAULT_TENANT_CA_2021_2022".
             "subject-dn":
                type: string
                description: |

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -4,6 +4,12 @@ title = "Release Notes"
 
 ## 1.7.0 (not yet released)
 
+### New Features
+* The Device Registry Management API has been extended now to support an optional unique identifier 
+  for trust anchors belonging to a tenant. The file, JDBC and MongoDB based device registries
+  support this feature. Please refer to the
+  [Device registry management API]({{% doclink "/api/management#/tenants/" %}}) for details.
+
 ### Fixes & Enhancements
 
 * The common configuration property for setting the vert.x instance's max-event-loop-execute-time had erroneously

--- a/tests/src/test/java/org/eclipse/hono/tests/Tenants.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/Tenants.java
@@ -94,12 +94,40 @@ public final class Tenants {
             final Instant notBefore,
             final Instant notAfter) {
 
+        final TrustedCertificateAuthority trustAnchor = createTrustAnchor(null, subjectDn, publicKey, algorithm,
+                notBefore, notAfter);
+        return new Tenant().setTrustedCertificateAuthorities(List.of(trustAnchor));
+    }
+
+    /**
+     * Create a trust anchor.
+     *
+     * @param id The trust anchor ID.
+     * @param subjectDn The subject DN of the trust anchor.
+     * @param publicKey The public key for the anchor.
+     * @param algorithm The public key algorithm.
+     * @param notBefore The earliest instant that the trust anchor may be used.
+     * @param notAfter The latest instant that the trust anchor may be used.
+     *
+     * @return The trust anchor. Never returns {@code null}.
+     * @throws NullPointerException if any of the arguments other than algorithm are {@code null}.
+     */
+    public static TrustedCertificateAuthority createTrustAnchor(
+            final String id,
+            final String subjectDn,
+            final byte[] publicKey,
+            final String algorithm,
+            final Instant notBefore,
+            final Instant notAfter) {
+
         final var trustedCa = new TrustedCertificateAuthority()
                 .setSubjectDn(subjectDn)
                 .setPublicKey(publicKey)
                 .setNotBefore(notBefore)
                 .setNotAfter(notAfter);
-        Optional.ofNullable(algorithm).ifPresent(alg -> trustedCa.setKeyAlgorithm(alg));
-        return new Tenant().setTrustedCertificateAuthorities(List.of(trustedCa));
+        Optional.ofNullable(algorithm).ifPresent(trustedCa::setKeyAlgorithm);
+        Optional.ofNullable(id).ifPresent(trustedCa::setId);
+
+        return trustedCa;
     }
 }


### PR DESCRIPTION
Extend Device Registry Management API specification to include an optional identifier for a tenant's trust anchor.