### PR TITLE
Also check connection when checking for open link

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -40,6 +40,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.HonoProtonHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RequestResponseApiConstants;
 import org.eclipse.hono.util.RequestResponseResult;
@@ -961,7 +962,7 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
      */
     @Override
     public final boolean isOpen() {
-        return sender != null && sender.isOpen() && receiver != null && receiver.isOpen();
+        return HonoProtonHelper.isLinkOpenAndConnected(sender) && HonoProtonHelper.isLinkOpenAndConnected(receiver);
     }
 
     @Override

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.hono.util.AddressHelper;
 import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.HonoProtonHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -201,7 +202,7 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
         final Span currentSpan = newChildSpan(null, command);
         TracingHelper.setDeviceTags(currentSpan, getTenantId(), deviceId);
 
-        if (sender.isOpen()) {
+        if (HonoProtonHelper.isLinkOpenAndConnected(sender)) {
             final Promise<BufferResult> responseTracker = Promise.promise();
             final Message request = ProtonHelper.message();
 

--- a/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -38,6 +38,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.AddressHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.HonoProtonHelper;
 import org.eclipse.hono.util.Strings;
 
 import io.opentracing.SpanContext;
@@ -342,7 +343,7 @@ public class ProtocolAdapterCommandConsumerFactoryImpl extends AbstractHonoClien
                         @SuppressWarnings("rawtypes")
                         final List<Future> consumerCreationFutures = new ArrayList<>();
                         // recreate adapter specific consumer
-                        if (adapterSpecificConsumer == null || !adapterSpecificConsumer.isOpen()) {
+                        if (!HonoProtonHelper.isLinkOpenAndConnected(adapterSpecificConsumer)) {
                             log.debug("recreate adapter specific command consumer link");
                             consumerCreationFutures.add(createAdapterSpecificConsumer());
                         }

--- a/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
+++ b/client/src/test/java/org/eclipse/hono/client/impl/HonoClientUnitTestHelper.java
@@ -27,9 +27,12 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonLink;
 import io.vertx.proton.ProtonQoS;
 import io.vertx.proton.ProtonReceiver;
 import io.vertx.proton.ProtonSender;
+import io.vertx.proton.ProtonSession;
 
 /**
  * Helper class that provides mocks for objects that are needed by unit tests using a Hono client.
@@ -42,7 +45,8 @@ public final class HonoClientUnitTestHelper {
     }
 
     /**
-     * Creates a mocked Proton sender which always returns {@code true} when its isOpen method is called.
+     * Creates a mocked Proton sender which always returns {@code true} when its isOpen method is called
+     * and whose connection is not disconnected.
      *
      * @return The mocked sender.
      */
@@ -52,12 +56,14 @@ public final class HonoClientUnitTestHelper {
         when(sender.isOpen()).thenReturn(Boolean.TRUE);
         when(sender.getQoS()).thenReturn(ProtonQoS.AT_LEAST_ONCE);
         when(sender.getTarget()).thenReturn(mock(Target.class));
+        mockLinkConnection(sender);
 
         return sender;
     }
 
     /**
-     * Creates a mocked Proton receiver which always returns {@code true} when its isOpen method is called.
+     * Creates a mocked Proton receiver which always returns {@code true} when its isOpen method is called
+     * and whose connection is not disconnected.
      *
      * @return The mocked receiver.
      */
@@ -65,8 +71,17 @@ public final class HonoClientUnitTestHelper {
 
         final ProtonReceiver receiver = mock(ProtonReceiver.class);
         when(receiver.isOpen()).thenReturn(Boolean.TRUE);
+        mockLinkConnection(receiver);
 
         return receiver;
+    }
+
+    private static void mockLinkConnection(final ProtonLink<?> link) {
+        final ProtonConnection connection = mock(ProtonConnection.class);
+        when(connection.isDisconnected()).thenReturn(false);
+        final ProtonSession session = mock(ProtonSession.class);
+        when(session.getConnection()).thenReturn(connection);
+        when(link.getSession()).thenReturn(session);
     }
 
     /**

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/RequestResponseClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/amqp/RequestResponseClient.java
@@ -36,6 +36,7 @@ import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.amqp.AbstractHonoClient;
 import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.HonoProtonHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RequestResponseResult;
 import org.eclipse.hono.util.TriTuple;
@@ -627,7 +628,7 @@ public class RequestResponseClient<R extends RequestResponseResult<?>> extends A
      * from the peer.
      */
     public final boolean isOpen() {
-        return sender != null && sender.isOpen() && receiver != null && receiver.isOpen();
+        return HonoProtonHelper.isLinkOpenAndConnected(sender) && HonoProtonHelper.isLinkOpenAndConnected(receiver);
     }
 
     /**

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandConsumer.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandConsumer.java
@@ -28,6 +28,7 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.HonoProtonHelper;
 import org.eclipse.hono.util.Lifecycle;
 import org.eclipse.hono.util.MessageHelper;
 import org.slf4j.Logger;
@@ -157,7 +158,7 @@ public class ProtonBasedInternalCommandConsumer extends AbstractServiceClient im
             connection.isConnected(getDefaultConnectionCheckTimeout())
                     .compose(res -> {
                         // recreate adapter specific consumer
-                        if (adapterSpecificConsumer == null || !adapterSpecificConsumer.isOpen()) {
+                        if (!HonoProtonHelper.isLinkOpenAndConnected(adapterSpecificConsumer)) {
                             log.debug("recreate adapter specific command consumer link");
                             return createAdapterSpecificConsumer();
                         }

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/AbstractRequestResponseEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/AbstractRequestResponseEndpoint.java
@@ -252,7 +252,7 @@ public abstract class AbstractRequestResponseEndpoint<T extends ServiceConfigPro
                         })
                         .map(amqpMessage -> {
                             Tags.HTTP_STATUS.set(currentSpan, MessageHelper.getStatus(amqpMessage));
-                            if (sender.isOpen()) {
+                            if (HonoProtonHelper.isLinkOpenAndConnected(sender)) {
                                 final ProtonDelivery responseDelivery = sender.send(amqpMessage);
                                 //TODO handle send exception
                                 logger.debug("sent response message to client  [correlation-id: {}, content-type: {}]",

--- a/test-utils/client-test-utils/src/main/java/org/eclipse/hono/client/amqp/test/AmqpClientUnitTestHelper.java
+++ b/test-utils/client-test-utils/src/main/java/org/eclipse/hono/client/amqp/test/AmqpClientUnitTestHelper.java
@@ -34,10 +34,13 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonLink;
 import io.vertx.proton.ProtonMessageHandler;
 import io.vertx.proton.ProtonQoS;
 import io.vertx.proton.ProtonReceiver;
 import io.vertx.proton.ProtonSender;
+import io.vertx.proton.ProtonSession;
 
 /**
  * Helper class that provides mocks for objects that are needed by unit tests for
@@ -80,7 +83,8 @@ public final class AmqpClientUnitTestHelper {
     }
 
     /**
-     * Creates a mocked Proton sender which always returns {@code true} when its isOpen method is called.
+     * Creates a mocked Proton sender which always returns {@code true} when its isOpen method is called
+     * and whose connection is not disconnected.
      *
      * @return The mocked sender.
      */
@@ -90,12 +94,14 @@ public final class AmqpClientUnitTestHelper {
         when(sender.isOpen()).thenReturn(Boolean.TRUE);
         when(sender.getQoS()).thenReturn(ProtonQoS.AT_LEAST_ONCE);
         when(sender.getTarget()).thenReturn(mock(Target.class));
+        mockLinkConnection(sender);
 
         return sender;
     }
 
     /**
-     * Creates a mocked Proton receiver which always returns {@code true} when its isOpen method is called.
+     * Creates a mocked Proton receiver which always returns {@code true} when its isOpen method is called
+     * and whose connection is not disconnected.
      *
      * @return The mocked receiver.
      */
@@ -103,8 +109,17 @@ public final class AmqpClientUnitTestHelper {
 
         final ProtonReceiver receiver = mock(ProtonReceiver.class);
         when(receiver.isOpen()).thenReturn(Boolean.TRUE);
+        mockLinkConnection(receiver);
 
         return receiver;
+    }
+
+    private static void mockLinkConnection(final ProtonLink<?> link) {
+        final ProtonConnection connection = mock(ProtonConnection.class);
+        when(connection.isDisconnected()).thenReturn(false);
+        final ProtonSession session = mock(ProtonSession.class);
+        when(session.getConnection()).thenReturn(connection);
+        when(link.getSession()).thenReturn(session);
     }
 
     /**


### PR DESCRIPTION
This serves as an extra safeguard against using a link whose underlying connection was already disconnected.
Relates to #2472.