### PR TITLE
Improve MQTT subscription handling

### DIFF
--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -920,6 +920,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         givenAnAdapter(properties);
         givenAnEventSenderForAnyTenant();
         final MqttEndpoint endpoint = mockEndpoint();
+        when(endpoint.isConnected()).thenReturn(true);
         when(endpoint.keepAliveTimeSeconds()).thenReturn(10); // 10 seconds
 
         // WHEN a device subscribes to commands
@@ -945,11 +946,12 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
         verify(endpoint).closeHandler(closeHookCaptor.capture());
         // which closes the command consumer when the device disconnects
         closeHookCaptor.getValue().handle(null);
+        when(endpoint.isConnected()).thenReturn(false);
         verify(commandConsumer).close(any());
         // and since closing the command consumer fails with a precon-failed exception
         // there is only one notification sent during consumer creation,
         assertEmptyNotificationHasBeenSentDownstream("tenant", "deviceId", -1);
-        //no 'disconnectedTtdEvent' event with TTD = 0
+        // no 'disconnectedTtdEvent' event with TTD = 0
         assertEmptyNotificationHasNotBeenSentDownstream("tenant", "deviceId", 0);
     }
 


### PR DESCRIPTION
As a preparation for #2064, the command subscription handling in the MQTT adapter has been refactored. 

Invalid subscriptions will now log an error entry in the tracing span, tracing when unsubscribing has been improved and proper handling of duplicate subscriptions (with same device id but different QoS or endpoint id) has been implemented. 
Also, an MQTT connection getting closed before the SUBACK can be sent will now prevent an event notification to be sent downstream.
