### PR TITLE
[#2402] Add interfaces to downstream senders.

### DIFF
--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/AmqpEventSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/AmqpEventSender.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.amqp;
+
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
+
+/**
+ * A client for publishing events originating from devices to downstream AMQP consumers.
+ */
+public interface AmqpEventSender extends EventSender {
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/AmqpTelemetrySender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/AmqpTelemetrySender.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.amqp;
+
+import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
+
+/**
+ * A client for publishing telemetry data originating from devices to downstream AMQP consumers.
+ */
+public interface AmqpTelemetrySender extends TelemetrySender {
+}

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/telemetry/amqp/ProtonBasedDownstreamSender.java
@@ -21,8 +21,6 @@ import java.util.Optional;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.adapter.client.amqp.SenderCachingServiceClient;
-import org.eclipse.hono.adapter.client.telemetry.EventSender;
-import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
@@ -41,7 +39,8 @@ import io.vertx.core.buffer.Buffer;
 /**
  * A vertx-proton based sender for telemetry messages and events.
  */
-public class ProtonBasedDownstreamSender extends SenderCachingServiceClient implements TelemetrySender, EventSender {
+public class ProtonBasedDownstreamSender extends SenderCachingServiceClient
+        implements AmqpTelemetrySender, AmqpEventSender {
 
     private final boolean deviceDefaultsEnabled;
     private final boolean jmsVendorPropsEnabled;

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSender.java
@@ -16,7 +16,6 @@ package org.eclipse.hono.adapter.client.telemetry.kafka;
 import java.util.Map;
 import java.util.Objects;
 
-import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerFactory;
@@ -34,7 +33,7 @@ import io.vertx.core.buffer.Buffer;
 /**
  * A client for publishing event messages to a Kafka cluster.
  */
-public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender implements EventSender {
+public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender implements KafkaEventSender {
 
     /**
      * Creates a new Kafka-based event sender.

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySender.java
@@ -16,7 +16,6 @@ package org.eclipse.hono.adapter.client.telemetry.kafka;
 import java.util.Map;
 import java.util.Objects;
 
-import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerFactory;
@@ -34,7 +33,7 @@ import io.vertx.core.buffer.Buffer;
 /**
  * A client for publishing telemetry messages to a Kafka cluster.
  */
-public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSender implements TelemetrySender {
+public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSender implements KafkaTelemetrySender {
 
     /**
      * Creates a new Kafka-based telemetry sender.

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaEventSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaEventSender.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
+
+/**
+ * A client for publishing events originating from devices to a Kafka cluster.
+ */
+public interface KafkaEventSender extends EventSender {
+}

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaTelemetrySender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaTelemetrySender.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.client.telemetry.kafka;
+
+import org.eclipse.hono.adapter.client.telemetry.TelemetrySender;
+
+/**
+ * A client for publishing telemetry data originating from devices to a Kafka cluster.
+ */
+public interface KafkaTelemetrySender extends TelemetrySender {
+}


### PR DESCRIPTION
This is a preparation step for #2402.
To allow the selection of the messaging network type on the tenant level, the Kafka-based senders, as well as the AMQP-based ones, need to be set on the protocol adapters. This PR adds interfaces that allow on the one hand to distinguish between AMQP- and Kafka-based senders and prevent on the other hand that the protocol adapters depend on the implementation classes.
