### PR TITLE
[#2402] Use the messaging system configured on the tenant

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -228,7 +228,7 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         Optional.ofNullable(connectionEventProducer())
             .ifPresent(adapter::setConnectionEventProducer);
         adapter.setCredentialsClient(credentialsClient());
-        adapter.setEventSender(downstreamSender());
+        adapter.setAmqpEventSender(downstreamSender());
         adapter.setHealthCheckServer(healthCheckServer);
         adapter.setRegistrationClient(registrationClient);
         adapter.setResourceLimitChecks(resourceLimitChecks);

--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -232,7 +232,7 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
         adapter.setHealthCheckServer(healthCheckServer);
         adapter.setRegistrationClient(registrationClient);
         adapter.setResourceLimitChecks(resourceLimitChecks);
-        adapter.setTelemetrySender(downstreamSender());
+        adapter.setAmqpTelemetrySender(downstreamSender());
         adapter.setTenantClient(tenantClient());
         adapter.setTracer(tracer);
     }

--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
@@ -175,7 +175,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
             final KafkaProducerFactory<String, Buffer> kafkaProducerFactory = kafkaProducerFactory();
             adapter.setKafkaEventSender(
                     downstreamEventKafkaSender(kafkaProducerFactory, kafkaProducerConfig, adapterProperties));
-            adapter.setTelemetrySender(
+            adapter.setKafkaTelemetrySender(
                     downstreamTelemetryKafkaSender(kafkaProducerFactory, kafkaProducerConfig, adapterProperties));
             //set the kafka based command response sender
             adapter.setCommandResponseSender(kafkaBasedCommandResponseSender(kafkaProducerFactory, kafkaProducerConfig));
@@ -183,7 +183,7 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
 
         if (downstreamSenderConfig() != null) { // TODO proper check if AMQP network configured
             adapter.setAmqpEventSender(downstreamEventSender(samplerFactory, adapterProperties));
-            adapter.setTelemetrySender(downstreamTelemetrySender(samplerFactory, adapterProperties));
+            adapter.setAmqpTelemetrySender(downstreamTelemetrySender(samplerFactory, adapterProperties));
             //set the proton based command response sender
             adapter.setCommandResponseSender(protonBasedCommandResponseSender(samplerFactory, adapterProperties));
         }

--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
@@ -173,16 +173,16 @@ public abstract class AbstractAdapterConfig extends AdapterConfigurationSupport 
         final KafkaProducerConfigProperties kafkaProducerConfig = kafkaProducerConfig();
         if (kafkaProducerConfig.isConfigured()) {
             final KafkaProducerFactory<String, Buffer> kafkaProducerFactory = kafkaProducerFactory();
-            adapter.setEventSender(
+            adapter.setKafkaEventSender(
                     downstreamEventKafkaSender(kafkaProducerFactory, kafkaProducerConfig, adapterProperties));
             adapter.setTelemetrySender(
                     downstreamTelemetryKafkaSender(kafkaProducerFactory, kafkaProducerConfig, adapterProperties));
             //set the kafka based command response sender
             adapter.setCommandResponseSender(kafkaBasedCommandResponseSender(kafkaProducerFactory, kafkaProducerConfig));
-        } else {
-            // look up via bean factory is not possible because EventSender and TelemetrySender are implemented by
-            // ProtonBasedDownstreamSender
-            adapter.setEventSender(downstreamEventSender(samplerFactory, adapterProperties));
+        }
+
+        if (downstreamSenderConfig() != null) { // TODO proper check if AMQP network configured
+            adapter.setAmqpEventSender(downstreamEventSender(samplerFactory, adapterProperties));
             adapter.setTelemetrySender(downstreamTelemetrySender(samplerFactory, adapterProperties));
             //set the proton based command response sender
             adapter.setCommandResponseSender(protonBasedCommandResponseSender(samplerFactory, adapterProperties));

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -1050,13 +1050,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         if (commandRouterClient instanceof ServiceClient) {
             ((ServiceClient) commandRouterClient).registerReadinessChecks(handler);
         }
-        if (telemetrySenders.getAmqpSender() instanceof ServiceClient) {
-            ((ServiceClient) telemetrySenders.getAmqpSender()).registerReadinessChecks(handler);
-        }
-        if (eventSenders.getAmqpSender() instanceof ServiceClient) {
-            ((ServiceClient) eventSenders.getAmqpSender()).registerReadinessChecks(handler);
-        }
-        // TODO come up with ideas for readiness checks for the Kafka producers
+        telemetrySenders.registerReadinessChecks(handler);
+        eventSenders.registerReadinessChecks(handler);
     }
 
     /**
@@ -1087,12 +1082,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         if (commandRouterClient instanceof ServiceClient) {
             ((ServiceClient) commandRouterClient).registerLivenessChecks(handler);
         }
-        if (telemetrySenders.getAmqpSender() instanceof ServiceClient) {
-            ((ServiceClient) telemetrySenders.getAmqpSender()).registerLivenessChecks(handler);
-        }
-        if (eventSenders.getAmqpSender() instanceof ServiceClient) {
-            ((ServiceClient) eventSenders.getAmqpSender()).registerLivenessChecks(handler);
-        }
+        telemetrySenders.registerLivenessChecks(handler);
+        eventSenders.registerLivenessChecks(handler);
     }
 
     /**

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -56,7 +56,6 @@ import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TelemetryExecutionContext;
-import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 
 import io.micrometer.core.instrument.Timer.Sample;
@@ -103,8 +102,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     private ConnectionEventProducer connectionEventProducer;
     private CredentialsClient credentialsClient;
     private DeviceRegistrationClient registrationClient;
-    private EventSender amqpEventSender;
-    private EventSender kafkaEventSender;
+    private final MultiMessagingSenders<EventSender> eventSenders = new MultiMessagingSenders<>();
     private ResourceLimitChecks resourceLimitChecks = new NoopResourceLimitChecks();
     private TelemetrySender telemetrySender;
     private TenantClient tenantClient;
@@ -202,7 +200,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @throws NullPointerException if the sender is {@code null}.
      */
     public final void setAmqpEventSender(final EventSender amqpEventSender) {
-        this.amqpEventSender = Objects.requireNonNull(amqpEventSender);
+        Objects.requireNonNull(amqpEventSender);
+        eventSenders.setAmqpSender(amqpEventSender);
         log.info("setting AMQP-based EventSender");
     }
 
@@ -213,7 +212,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @throws NullPointerException if the sender is {@code null}.
      */
     public final void setKafkaEventSender(final EventSender kafkaEventSender) {
-        this.kafkaEventSender = Objects.requireNonNull(kafkaEventSender);
+        Objects.requireNonNull(kafkaEventSender);
+        eventSenders.setKafkaSender(kafkaEventSender);
         log.info("setting Kafka-based EventSender");
     }
 
@@ -224,43 +224,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      * @return The sender.
      */
     public final EventSender getEventSender(final TenantObject tenant) {
-
-        // check if configured on the tenant
-        final EventSender tenantConfiguredEventSender = getTenantConfiguredEventSender(tenant);
-        if (tenantConfiguredEventSender != null) {
-            return tenantConfiguredEventSender;
-        }
-
-        // TODO add adapter config property to determine which should be used as the default?
-
-        // not configured -> check if only one set
-        if (amqpEventSender == null && kafkaEventSender != null) {
-            return kafkaEventSender;
-        } else if (kafkaEventSender == null && amqpEventSender != null) {
-            return amqpEventSender;
-        }
-
-        // both senders are present -> fallback to default
-        return amqpEventSender;
-    }
-
-    private EventSender getTenantConfiguredEventSender(final TenantObject tenant) {
-        final JsonObject ext = Optional.ofNullable(tenant.getProperty(TenantConstants.FIELD_EXT, JsonObject.class))
-                .orElse(new JsonObject());
-        final String tenantConfig = ext.getString(TenantConstants.FIELD_EXT_MESSAGING_TYPE);
-
-        if (TenantConstants.MESSAGING_TYPE_KAFKA.equals(tenantConfig)) {
-            if (kafkaEventSender == null) {
-                throw new IllegalStateException("Tenant configured messaging [kafka] not present");
-            }
-            return kafkaEventSender;
-        } else if (TenantConstants.MESSAGING_TYPE_AMQP.equals(tenantConfig)) {
-            if (amqpEventSender == null) {
-                throw new IllegalStateException("Tenant configured messaging [amqp] not present");
-            }
-            return amqpEventSender;
-        }
-        return null;
+        return eventSenders.getSenderForTenantOrDefault(tenant);
     }
 
     /**
@@ -452,7 +416,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             result.fail(new IllegalStateException("Tenant client must be set"));
         } else if (telemetrySender == null) {
             result.fail(new IllegalStateException("Telemetry message sender must be set"));
-        } else if (amqpEventSender == null && kafkaEventSender == null) {
+        } else if (eventSenders.isUnconfigured()) {
             result.fail(new IllegalStateException("An event sender must be set"));
         } else if (registrationClient == null) {
             result.fail(new IllegalStateException("Device Registration client must be set"));
@@ -469,8 +433,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
             log.info("using ResourceLimitChecks [{}]", resourceLimitChecks.getClass().getName());
 
             startServiceClient(telemetrySender, "Telemetry");
-            startServiceClient(amqpEventSender, "AMQP-Event");
-            startServiceClient(kafkaEventSender, "Kafka-Event");
+            startServiceClient(eventSenders.getAmqpSender(), "AMQP-Event");
+            startServiceClient(eventSenders.getKafkaSender(), "Kafka-Event");
             startServiceClient(tenantClient, "Tenant service");
             startServiceClient(registrationClient, "Device Registration service");
             startServiceClient(credentialsClient, "Credentials service");
@@ -523,8 +487,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         results.add(stopServiceClient(commandConsumerFactory));
         results.add(stopServiceClient(commandResponseSender));
         results.add(stopServiceClient(commandRouterClient));
-        results.add(stopServiceClient(amqpEventSender));
-        results.add(stopServiceClient(kafkaEventSender));
+        results.add(stopServiceClient(eventSenders.getAmqpSender()));
+        results.add(stopServiceClient(eventSenders.getKafkaSender()));
         results.add(stopServiceClient(telemetrySender));
         return CompositeFuture.all(results);
     }
@@ -1073,9 +1037,10 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         if (telemetrySender instanceof ServiceClient) {
             ((ServiceClient) telemetrySender).registerReadinessChecks(handler);
         }
-        if (amqpEventSender instanceof ServiceClient) {
-            ((ServiceClient) amqpEventSender).registerReadinessChecks(handler);
+        if (eventSenders.getAmqpSender() instanceof ServiceClient) {
+            ((ServiceClient) eventSenders.getAmqpSender()).registerReadinessChecks(handler);
         }
+        // TODO come up with ideas for readiness checks for the Kafka producers
     }
 
     /**
@@ -1109,8 +1074,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         if (telemetrySender instanceof ServiceClient) {
             ((ServiceClient) telemetrySender).registerLivenessChecks(handler);
         }
-        if (amqpEventSender instanceof ServiceClient) {
-            ((ServiceClient) amqpEventSender).registerLivenessChecks(handler);
+        if (eventSenders.getAmqpSender() instanceof ServiceClient) {
+            ((ServiceClient) eventSenders.getAmqpSender()).registerLivenessChecks(handler);
         }
     }
 

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
@@ -16,10 +16,12 @@ package org.eclipse.hono.adapter;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.hono.adapter.client.util.ServiceClient;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
 
 /**
  * Encapsulates the Kafka-based and the AMQP-based sender for a message type.
@@ -133,4 +135,24 @@ class MultiMessagingSenders<T> {
         }
         return null;
     }
+
+    /**
+     * Registers liveness checks for the AMQP sender.
+     */
+    public void registerLivenessChecks(final HealthCheckHandler handler) {
+        if (amqpSender instanceof ServiceClient) {
+            ((ServiceClient) amqpSender).registerLivenessChecks(handler);
+        }
+    }
+
+    /**
+     * Registers readiness checks for the AMQP sender.
+     */
+    public void registerReadinessChecks(final HealthCheckHandler handler) {
+        if (amqpSender instanceof ServiceClient) {
+            ((ServiceClient) amqpSender).registerReadinessChecks(handler);
+        }
+        // TODO come up with ideas for readiness checks for the Kafka producers
+    }
+
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
@@ -88,8 +88,13 @@ class MultiMessagingSenders<T> {
      * @param tenant The tenant for which to send messages.
      * @return The sender that is configured at the tenant or, if this is missing and only one of the senders is set,
      *         that one, otherwise, the AMQP-based sender.
+     * @throws IllegalStateException if no no sender is set.
      */
     public final T getSenderForTenantOrDefault(final TenantObject tenant) {
+
+        if (isUnconfigured()) {
+            throw new IllegalStateException("No sender present");
+        }
 
         // check if configured on the tenant
         final T tenantConfiguredEventSender = getTenantConfiguredEventSender(tenant);

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
@@ -24,9 +24,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * Encapsulates the Kafka-based and the AMQP-based sender for a message type.
  *
- * @param <T> The sender type (intended to be one of {@link org.eclipse.hono.adapter.client.telemetry.EventSender},
- *            {@link org.eclipse.hono.adapter.client.telemetry.TelemetrySender}, or
- *            {@link org.eclipse.hono.adapter.client.command.CommandResponseSender}).
+ * @param <T> The sender type.
  */
 class MultiMessagingSenders<T> {
 
@@ -82,6 +80,10 @@ class MultiMessagingSenders<T> {
 
     /**
      * Gets the client to be used for sending messages downstream.
+     * <p>
+     * The property to determine the messaging type is expected in the {@link TenantConstants#FIELD_EXT_MESSAGING_TYPE}
+     * inside of the {@link TenantConstants#FIELD_EXT} property of the tenant. Valid values are
+     * {@link TenantConstants#MESSAGING_TYPE_AMQP} or {@link TenantConstants#MESSAGING_TYPE_KAFKA}.
      *
      * @param tenant The tenant for which to send messages.
      * @return The sender that is configured at the tenant or, if this is missing and only one of the senders is set,

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantObject;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Encapsulates the Kafka-based and the AMQP-based sender for a message type.
+ *
+ * @param <T> The sender type (intended to be one of {@link org.eclipse.hono.adapter.client.telemetry.EventSender},
+ *            {@link org.eclipse.hono.adapter.client.telemetry.TelemetrySender}, or
+ *            {@link org.eclipse.hono.adapter.client.command.CommandResponseSender}).
+ */
+class MultiMessagingSenders<T> {
+
+    private T amqpSender;
+    private T kafkaSender;
+
+    /**
+     * Sets the AMQP-based sender.
+     *
+     * @param amqpSender The sender.
+     * @throws NullPointerException if amqpSender is {@code null}.
+     */
+    public void setAmqpSender(final T amqpSender) {
+        this.amqpSender = Objects.requireNonNull(amqpSender);
+    }
+
+    /**
+     * Sets the Kafka-based sender.
+     *
+     * @param kafkaSender The sender.
+     * @throws NullPointerException if kafkaSender is {@code null}.
+     */
+    public void setKafkaSender(final T kafkaSender) {
+        this.kafkaSender = Objects.requireNonNull(kafkaSender);
+    }
+
+    /**
+     * Gets the AMQP-based sender.
+     *
+     * @return The sender or {@code null}.
+     */
+    public T getAmqpSender() {
+        return amqpSender;
+    }
+
+    /**
+     * Gets the Kafka-based sender.
+     *
+     * @return The sender or {@code null}.
+     */
+    public T getKafkaSender() {
+        return kafkaSender;
+    }
+
+    /**
+     * Checks if none of the senders are set.
+     *
+     * @return true if both senders are {code null}.
+     */
+    public boolean isUnconfigured() {
+        return amqpSender == null && kafkaSender == null;
+    }
+
+    /**
+     * Gets the client to be used for sending messages downstream.
+     *
+     * @param tenant The tenant for which to send messages.
+     * @return The sender that is configured at the tenant or, if this is missing and only one of the senders is set,
+     *         that one, otherwise, the AMQP-based sender.
+     */
+    public final T getSenderForTenantOrDefault(final TenantObject tenant) {
+
+        // check if configured on the tenant
+        final T tenantConfiguredEventSender = getTenantConfiguredEventSender(tenant);
+        if (tenantConfiguredEventSender != null) {
+            return tenantConfiguredEventSender;
+        }
+
+        // TODO add adapter config property to determine which should be used as the default?
+
+        // not configured -> check if only one set
+        if (amqpSender == null && kafkaSender != null) {
+            return kafkaSender;
+        } else if (kafkaSender == null && amqpSender != null) {
+            return amqpSender;
+        }
+
+        // both senders are present -> fallback to default
+        return amqpSender;
+    }
+
+    private T getTenantConfiguredEventSender(final TenantObject tenant) {
+        final JsonObject ext = Optional.ofNullable(tenant.getProperty(TenantConstants.FIELD_EXT, JsonObject.class))
+                .orElse(new JsonObject());
+        final String tenantConfig = ext.getString(TenantConstants.FIELD_EXT_MESSAGING_TYPE);
+
+        if (TenantConstants.MESSAGING_TYPE_KAFKA.equals(tenantConfig)) {
+            if (kafkaSender == null) {
+                throw new IllegalStateException("Tenant configured messaging [kafka] not present");
+            }
+            return kafkaSender;
+        } else if (TenantConstants.MESSAGING_TYPE_AMQP.equals(tenantConfig)) {
+            if (amqpSender == null) {
+                throw new IllegalStateException("Tenant configured messaging [amqp] not present");
+            }
+            return amqpSender;
+        }
+        return null;
+    }
+}

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/MultiMessagingSendersTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/MultiMessagingSendersTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests verifying behavior of {@link MultiMessagingSenders}.
+ *
+ */
+public class MultiMessagingSendersTest {
+
+    private final String tenant = "tenant";
+    private final Map<String, String> extensionFieldKafka = Map.of(TenantConstants.FIELD_EXT_MESSAGING_TYPE,
+            TenantConstants.MESSAGING_TYPE_KAFKA);
+    private final Map<String, String> extensionFieldAmqp = Map.of(TenantConstants.FIELD_EXT_MESSAGING_TYPE,
+            TenantConstants.MESSAGING_TYPE_AMQP);
+    private final EventSender amqpSender = mock(EventSender.class);
+    private final EventSender kafkaSender = mock(EventSender.class);
+    private final MultiMessagingSenders<EventSender> underTest = new MultiMessagingSenders<>();
+
+    /**
+     * Verifies that {@link MultiMessagingSenders#isUnconfigured()} returns {@code true} if no sender is set and
+     * {@code false} otherwise.
+     */
+    @Test
+    public void isUnconfigured() {
+        assertThat(underTest.isUnconfigured()).isTrue();
+
+        underTest.setAmqpSender(amqpSender);
+        assertThat(underTest.isUnconfigured()).isFalse();
+    }
+
+    /**
+     * Verifies that when the messaging to be used is configured for a tenant, then this is used.
+     */
+    @Test
+    public void testGetSenderConfiguredOnTenant() {
+
+        underTest.setKafkaSender(kafkaSender);
+        underTest.setAmqpSender(amqpSender);
+
+        assertThat(underTest.getSenderForTenantOrDefault(TenantObject.from(tenant, true).setProperty(
+                TenantConstants.FIELD_EXT, extensionFieldKafka))).isEqualTo(kafkaSender);
+
+        assertThat(underTest.getSenderForTenantOrDefault(TenantObject.from(tenant, true).setProperty(
+                TenantConstants.FIELD_EXT, extensionFieldAmqp))).isEqualTo(amqpSender);
+
+    }
+
+    /**
+     * Verifies that when no messaging type is configured for a tenant and only the Kafka sender is set, then this one
+     * is used.
+     */
+    @Test
+    public void testGetSenderOnlyKafkaSenderSet() {
+        underTest.setKafkaSender(kafkaSender);
+
+        assertThat(underTest.getSenderForTenantOrDefault(TenantObject.from(tenant, true))).isEqualTo(kafkaSender);
+    }
+
+    /**
+     * Verifies that when no messaging type is configured for a tenant and only the AMQP sender is set, then this one is
+     * used.
+     */
+    @Test
+    public void testGetSenderOnlyAmqpSenderSet() {
+        underTest.setAmqpSender(amqpSender);
+
+        assertThat(underTest.getSenderForTenantOrDefault(TenantObject.from(tenant, true))).isEqualTo(amqpSender);
+    }
+
+    /**
+     * Verifies that when no messaging type is configured for a tenant and both senders are set, then the AMQP sender is
+     * used.
+     */
+    @Test
+    public void testGetSenderDefault() {
+        underTest.setKafkaSender(kafkaSender);
+        underTest.setAmqpSender(amqpSender);
+
+        assertThat(underTest.getSenderForTenantOrDefault(TenantObject.from(tenant, true))).isEqualTo(amqpSender);
+    }
+
+    /**
+     * Verifies that the invocation of {@link MultiMessagingSenders#getSenderForTenantOrDefault(TenantObject)} throws an
+     * {@link IllegalArgumentException} if no sender has been set.
+     */
+    @Test
+    public void testGetSenderThrowsIfNoSenderSet() {
+        Assertions.assertThatIllegalStateException()
+                .isThrownBy(() -> underTest.getSenderForTenantOrDefault(TenantObject.from(tenant, true)));
+    }
+
+}

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -1142,7 +1142,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                     final Map<String, Object> props = getDownstreamMessageProperties(context);
 
                     if (context.getEndpoint() == EndpointType.TELEMETRY) {
-                        return getTelemetrySender().sendTelemetry(
+                        return getTelemetrySender(tenantValidationTracker.result()).sendTelemetry(
                                 tenantValidationTracker.result(),
                                 tokenFuture.result(),
                                 context.getRequestedQos(),

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -1151,7 +1151,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                                 props,
                                 currentSpan.context());
                     } else {
-                        return getEventSender().sendEvent(
+                        return getEventSender(tenantValidationTracker.result()).sendEvent(
                                 tenantValidationTracker.result(),
                                 tokenFuture.result(),
                                 context.getMessageContentType(),

--- a/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
@@ -870,6 +870,9 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         givenAnAdapter(properties);
         adapter.setConnectionEventProducer(connectionEventProducer);
 
+        // with an enabled tenant
+        givenAConfiguredTenant(TEST_TENANT_ID, true);
+
         // WHEN a device connects
         final Device authenticatedDevice = new Device(TEST_TENANT_ID, TEST_DEVICE);
         final Record record = new RecordImpl();

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -748,7 +748,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                                 props,
                                 currentSpan.context());
                     } else {
-                        sendResult = getTelemetrySender().sendTelemetry(
+                        sendResult = getTelemetrySender(tenantValidationTracker.result()).sendTelemetry(
                                 tenantTracker.result(),
                                 tokenTracker.result(),
                                 context.getRequestedQos(),

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -740,7 +740,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                     }
                     final Future<Void> sendResult;
                     if (endpoint == EndpointType.EVENT) {
-                        sendResult = getEventSender().sendEvent(
+                        sendResult = getEventSender(tenantValidationTracker.result()).sendEvent(
                                 tenantTracker.result(),
                                 tokenTracker.result(),
                                 contentType,

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -969,7 +969,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
 
         adapter.setTenantClient(tenantClient);
         adapter.setAmqpEventSender(eventSender);
-        adapter.setTelemetrySender(telemetrySender);
+        adapter.setAmqpTelemetrySender(telemetrySender);
         adapter.setRegistrationClient(registrationClient);
         if (complete) {
             adapter.setCredentialsClient(credentialsClient);

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapterTest.java
@@ -968,7 +968,7 @@ public class AbstractVertxBasedCoapAdapterTest extends ProtocolAdapterTestSuppor
         adapter.setResourceLimitChecks(resourceLimitChecks);
 
         adapter.setTenantClient(tenantClient);
-        adapter.setEventSender(eventSender);
+        adapter.setAmqpEventSender(eventSender);
         adapter.setTelemetrySender(telemetrySender);
         adapter.setRegistrationClient(registrationClient);
         if (complete) {

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -700,7 +700,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
             } else {
                 // unsettled
                 return CompositeFuture.all(
-                        getTelemetrySender().sendTelemetry(
+                        getTelemetrySender(tenantValidationTracker.result()).sendTelemetry(
                                 tenantTracker.result(),
                                 tokenTracker.result(),
                                 ctx.getRequestedQos(),

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/AbstractVertxBasedHttpProtocolAdapter.java
@@ -688,7 +688,7 @@ public abstract class AbstractVertxBasedHttpProtocolAdapter<T extends HttpProtoc
                 ctx.getTimeToLive()
                     .ifPresent(ttl -> props.put(MessageHelper.SYS_HEADER_PROPERTY_TTL, ttl.toSeconds()));
                 return CompositeFuture.all(
-                        getEventSender().sendEvent(
+                        getEventSender(tenantValidationTracker.result()).sendEvent(
                                 tenantTracker.result(),
                                 tokenTracker.result(),
                                 contentType,

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -859,7 +859,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             customizeDownstreamMessageProperties(props, ctx);
 
             if (endpoint == EndpointType.EVENT) {
-                return getEventSender().sendEvent(
+                return getEventSender(tenantObject).sendEvent(
                         tenantObject,
                         tokenTracker.result(),
                         ctx.contentType(),

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -867,7 +867,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                         props,
                         currentSpan.context());
             } else {
-                return getTelemetrySender().sendTelemetry(
+                return getTelemetrySender(tenantObject).sendTelemetry(
                         tenantObject,
                         tokenTracker.result(),
                         ctx.getRequestedQos(),

--- a/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/TenantConstants.java
@@ -167,6 +167,21 @@ public final class TenantConstants extends RequestResponseApiConstants {
     public static final String FIELD_TRACING_SAMPLING_MODE_PER_AUTH_ID = "sampling-mode-per-auth-id";
 
     /**
+     * The name of the property that defines the messaging type to be used for a tenant.
+     */
+    public static final String FIELD_EXT_MESSAGING_TYPE = "messaging-type";
+
+    /**
+     * The messaging type AMQP.
+     */
+    public static final String MESSAGING_TYPE_AMQP = "amqp";
+
+    /**
+     * The messaging type Kafka.
+     */
+    public static final String MESSAGING_TYPE_KAFKA = "kafka";
+
+    /**
      * The name of the Tenant API endpoint.
      */
     public static final String TENANT_ENDPOINT = "tenant";

--- a/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterTestSupport.java
+++ b/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterTestSupport.java
@@ -200,7 +200,7 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
         adapter.setCommandResponseSender(commandResponseSender);
         adapter.setCredentialsClient(credentialsClient);
         adapter.setCommandRouterClient(commandRouterClient);
-        adapter.setEventSender(eventSender);
+        adapter.setAmqpEventSender(eventSender);
         adapter.setRegistrationClient(registrationClient);
         adapter.setTelemetrySender(telemetrySender);
         adapter.setTenantClient(tenantClient);
@@ -352,7 +352,7 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
                 any(),
                 any(),
                 any())).thenReturn(outcome.future());
-        this.adapter.setEventSender(this.eventSender);
+        this.adapter.setAmqpEventSender(this.eventSender);
         return this.eventSender;
     }
 

--- a/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterTestSupport.java
+++ b/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterTestSupport.java
@@ -202,7 +202,7 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
         adapter.setCommandRouterClient(commandRouterClient);
         adapter.setAmqpEventSender(eventSender);
         adapter.setRegistrationClient(registrationClient);
-        adapter.setTelemetrySender(telemetrySender);
+        adapter.setAmqpTelemetrySender(telemetrySender);
         adapter.setTenantClient(tenantClient);
     }
 
@@ -320,7 +320,7 @@ public abstract class ProtocolAdapterTestSupport<C extends ProtocolAdapterProper
                 any(),
                 any(),
                 any())).thenReturn(outcome.future());
-        this.adapter.setTelemetrySender(this.telemetrySender);
+        this.adapter.setAmqpTelemetrySender(this.telemetrySender);
         return this.telemetrySender;
     }
 


### PR DESCRIPTION
This PR belongs to #2402. It adds support for selecting the messaging system at the tenant level. 
Protocol adapters start AMQP-based event senders *and* Kafka-based event senders (if the configuration for both is provided). At the tenant, a new property is added to select which messaging to use.