### PR TITLE
[#2478] Extend the northbound application client to support sending commands asynchronously

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
@@ -151,7 +151,7 @@ public class AppConfiguration {
     public ApplicationClient<KafkaMessageContext> kafkaApplicationClient(
             final Vertx vertx,
             final KafkaConsumerConfigProperties kafkaConsumerConfigProperties,
-            final KafkaProducerFactory producerFactory,
+            final KafkaProducerFactory<String, Buffer> producerFactory,
             final KafkaProducerConfigProperties kafkaProducerConfigProperties) {
         return new KafkaApplicationClientImpl(vertx, kafkaConsumerConfigProperties, producerFactory,
                 kafkaProducerConfigProperties);

--- a/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
@@ -144,7 +144,7 @@ public class AppConfiguration {
      * @param kafkaConsumerConfigProperties The consumer configuration properties.
      * @param producerFactory The factory to use for creating Kafka producers.
      * @param kafkaProducerConfigProperties The producer configuration properties.
-     * @return The factory.
+     * @return The client.
      */
     @Profile("kafka")
     @Bean

--- a/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/AppConfiguration.java
@@ -20,6 +20,8 @@ import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
 import org.eclipse.hono.application.client.kafka.impl.KafkaApplicationClientImpl;
 import org.eclipse.hono.client.ApplicationClientFactory;
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -29,6 +31,7 @@ import org.springframework.context.annotation.Profile;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.dns.AddressResolverOptions;
 
 /**
@@ -87,6 +90,29 @@ public class AppConfiguration {
     }
 
     /**
+     * Exposes Kafka producer configuration properties as a Spring bean.
+     *
+     * @return The properties.
+     */
+    @ConfigurationProperties(prefix = "hono.kafka")
+    @Profile("kafka")
+    @Bean
+    public KafkaProducerConfigProperties kafkaProducerConfig() {
+        return new KafkaProducerConfigProperties();
+    }
+
+    /**
+     * Exposes a factory for creating producers for sending messages via the Kafka cluster.
+     *
+     * @return The factory.
+     */
+    @Profile("kafka")
+    @Bean
+    public KafkaProducerFactory<String, Buffer> kafkaProducerFactory() {
+        return KafkaProducerFactory.sharedProducerFactory(vertx());
+    }
+
+    /**
      * Exposes a factory for creating clients for Hono's northbound APIs as a Spring bean.
      *
      * @return The factory.
@@ -116,13 +142,18 @@ public class AppConfiguration {
      *
      * @param vertx The vertx instance to be used.
      * @param kafkaConsumerConfigProperties The consumer configuration properties.
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param kafkaProducerConfigProperties The producer configuration properties.
      * @return The factory.
      */
     @Profile("kafka")
     @Bean
     public ApplicationClient<KafkaMessageContext> kafkaApplicationClient(
             final Vertx vertx,
-            final KafkaConsumerConfigProperties kafkaConsumerConfigProperties) {
-        return new KafkaApplicationClientImpl(vertx, kafkaConsumerConfigProperties);
+            final KafkaConsumerConfigProperties kafkaConsumerConfigProperties,
+            final KafkaProducerFactory producerFactory,
+            final KafkaProducerConfigProperties kafkaProducerConfigProperties) {
+        return new KafkaApplicationClientImpl(vertx, kafkaConsumerConfigProperties, producerFactory,
+                kafkaProducerConfigProperties);
     }
 }

--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/AbstractHonoClient.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/AbstractHonoClient.java
@@ -14,17 +14,16 @@
 package org.eclipse.hono.client.amqp;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import org.apache.qpid.proton.amqp.Symbol;
-import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.MessageHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,29 +146,12 @@ public abstract class AbstractHonoClient {
      *
      * @param msg The Proton message. Must not be null.
      * @param properties The map containing application properties.
-     * @throws NullPointerException if the message passed in is null.
+     * @throws NullPointerException if the message passed in is {@code null}.
      * @throws IllegalArgumentException if the properties contain any value that AMQP 1.0 disallows.
      */
     protected static final void setApplicationProperties(final Message msg, final Map<String, ?> properties) {
-        if (properties != null) {
-            final Map<String, Object> propsToAdd = new HashMap<>();
-            // check the three types not allowed by AMQP 1.0 spec for application properties (list, map and array)
-            for (final Map.Entry<String, ?> entry: properties.entrySet()) {
-                if (entry.getValue() != null) {
-                    if (entry.getValue() instanceof List) {
-                        throw new IllegalArgumentException(String.format("Application property %s can't be a List", entry.getKey()));
-                    } else if (entry.getValue() instanceof Map) {
-                        throw new IllegalArgumentException(String.format("Application property %s can't be a Map", entry.getKey()));
-                    } else if (entry.getValue().getClass().isArray()) {
-                        throw new IllegalArgumentException(String.format("Application property %s can't be an Array", entry.getKey()));
-                    }
-                }
-                propsToAdd.put(entry.getKey(), entry.getValue());
-            }
+        Objects.requireNonNull(msg);
 
-            final ApplicationProperties applicationProperties = new ApplicationProperties(propsToAdd);
-            msg.setApplicationProperties(applicationProperties);
-        }
+        MessageHelper.setApplicationProperties(msg, properties);
     }
-
 }

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClient.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClient.java
@@ -24,9 +24,8 @@ import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.DisconnectListener;
 import org.eclipse.hono.client.HonoConnection;
-import org.eclipse.hono.client.ReconnectListener;
+import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.amqp.GenericReceiverLink;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
@@ -47,7 +46,7 @@ import io.vertx.proton.ProtonHelper;
  * event and command response messages.
  *
  */
-public class ProtonBasedApplicationClient implements AmqpApplicationClient {
+public class ProtonBasedApplicationClient extends ProtonBasedCommandSender implements AmqpApplicationClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProtonBasedApplicationClient.class);
 
@@ -61,7 +60,8 @@ public class ProtonBasedApplicationClient implements AmqpApplicationClient {
      * @throws NullPointerException if connection is {@code null}.
      */
     public ProtonBasedApplicationClient(final HonoConnection connection) {
-        this.connection = Objects.requireNonNull(connection);
+        super(connection, SendMessageSampler.Factory.noop());
+        this.connection = connection;
     }
 
     /**
@@ -88,38 +88,6 @@ public class ProtonBasedApplicationClient implements AmqpApplicationClient {
     public final void disconnect(final Handler<AsyncResult<Void>> completionHandler) {
         LOG.info("disconnecting from Hono endpoint");
         connection.disconnect(completionHandler);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public final Future<Void> isConnected() {
-        return connection.isConnected();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public final Future<Void> isConnected(final long waitForCurrentConnectAttemptTimeout) {
-        return connection.isConnected(waitForCurrentConnectAttemptTimeout);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public final void addDisconnectListener(final DisconnectListener<HonoConnection> listener) {
-        connection.addDisconnectListener(listener);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public final void addReconnectListener(final ReconnectListener<HonoConnection> listener) {
-        connection.addReconnectListener(listener);
     }
 
     /**

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.application.client.amqp;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.application.client.CommandSender;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.SenderCachingServiceClient;
+import org.eclipse.hono.util.AddressHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.proton.ProtonHelper;
+
+/**
+ * A vertx-proton based client for sending commands.
+ *
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control/">
+ *      Command &amp; Control API for AMQP 1.0 Specification</a>
+ */
+public class ProtonBasedCommandSender extends SenderCachingServiceClient implements CommandSender {
+
+    /**
+     * Creates a new vertx-proton based command sender.
+     *
+     * @param connection The connection to the Hono server.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @throws NullPointerException if any of the parameters except the closeHandler is {@code null}.
+     */
+    public ProtonBasedCommandSender(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory) {
+        super(connection, samplerFactory);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if tenantId, deviceId, command, correlationId or replyId is {@code null}.
+     */
+    @Override
+    public Future<Void> sendAsyncCommand(final String tenantId, final String deviceId, final String command,
+            final String contentType, final Buffer data, final String correlationId, final String replyId,
+            final Map<String, Object> properties, final SpanContext context) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(command);
+        Objects.requireNonNull(correlationId);
+        Objects.requireNonNull(replyId);
+
+        return getOrCreateSenderLink(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId)
+                .recover(thr -> Future.failedFuture(StatusCodeMapper.toServerError(thr)))
+                .compose(sender -> {
+                    final String targetAddress = AddressHelper
+                            .getTargetAddress(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, deviceId,
+                                    connection.getConfig());
+                    final Message msg = createMessage(tenantId, deviceId, command, contentType, data, correlationId,
+                            replyId, targetAddress, properties);
+                    return sender.sendAndWaitForOutcome(msg, newChildSpan(context, "send Command " + command));
+                })
+                .mapEmpty();
+    }
+
+    private static Message createMessage(final String tenantId, final String deviceId, final String command,
+            final String contentType, final Buffer data, final String correlationId, final String replyId,
+            final String targetAddress, final Map<String, Object> properties) {
+        final Message msg = ProtonHelper.message();
+
+        MessageHelper.setCreationTime(msg);
+        msg.setAddress(targetAddress);
+        msg.setReplyTo(
+                String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, replyId));
+        MessageHelper.setApplicationProperties(msg, properties);
+        msg.setCorrelationId(correlationId);
+        msg.setSubject(command);
+        MessageHelper.setPayload(msg, contentType, data);
+        MessageHelper.addTenantId(msg, tenantId);
+        MessageHelper.addDeviceId(msg, deviceId);
+
+        return msg;
+    }
+}

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
@@ -74,7 +74,7 @@ public class ProtonBasedCommandSender extends SenderCachingServiceClient impleme
                                     connection.getConfig());
                     final Message msg = createMessage(tenantId, deviceId, command, contentType, data, correlationId,
                             replyId, targetAddress, properties);
-                    return sender.sendAndWaitForOutcome(msg, newChildSpan(context, "send command " + command));
+                    return sender.sendAndWaitForOutcome(msg, newChildSpan(context, "send command"));
                 })
                 .mapEmpty();
     }

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
@@ -74,7 +74,7 @@ public class ProtonBasedCommandSender extends SenderCachingServiceClient impleme
                                     connection.getConfig());
                     final Message msg = createMessage(tenantId, deviceId, command, contentType, data, correlationId,
                             replyId, targetAddress, properties);
-                    return sender.sendAndWaitForOutcome(msg, newChildSpan(context, "send Command " + command));
+                    return sender.sendAndWaitForOutcome(msg, newChildSpan(context, "send command " + command));
                 })
                 .mapEmpty();
     }

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClientTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClientTest.java
@@ -48,6 +48,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -56,6 +57,7 @@ import io.vertx.proton.ProtonHelper;
 import io.vertx.proton.ProtonMessageHandler;
 import io.vertx.proton.ProtonQoS;
 import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
 
 
 /**
@@ -64,7 +66,7 @@ import io.vertx.proton.ProtonReceiver;
  */
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
-class ProtonBasedApplicationClientFactoryTest {
+class ProtonBasedApplicationClientTest {
 
     private HonoConnection connection;
     private ProtonBasedApplicationClient client;
@@ -75,7 +77,9 @@ class ProtonBasedApplicationClientFactoryTest {
     @BeforeEach
     void setUp() {
         final var vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
         connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx);
+        when(connection.getVertx()).thenReturn(vertx);
         final ProtonReceiver receiver = AmqpClientUnitTestHelper.mockProtonReceiver();
         when(connection.createReceiver(
                 anyString(),
@@ -84,6 +88,8 @@ class ProtonBasedApplicationClientFactoryTest {
                 anyInt(),
                 anyBoolean(),
                 VertxMockSupport.anyHandler())).thenReturn(Future.succeededFuture(receiver));
+        final ProtonSender sender = AmqpClientUnitTestHelper.mockProtonSender();
+        when(connection.createSender(anyString(), any(), any())).thenReturn(Future.succeededFuture(sender));
         client = new ProtonBasedApplicationClient(connection);
     }
 

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClientTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedApplicationClientTest.java
@@ -79,7 +79,6 @@ class ProtonBasedApplicationClientTest {
         final var vertx = mock(Vertx.class);
         when(vertx.eventBus()).thenReturn(mock(EventBus.class));
         connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx);
-        when(connection.getVertx()).thenReturn(vertx);
         final ProtonReceiver receiver = AmqpClientUnitTestHelper.mockProtonReceiver();
         when(connection.createReceiver(
                 anyString(),

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.application.client.kafka.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.application.client.CommandSender;
+import org.eclipse.hono.client.kafka.HonoTopic;
+import org.eclipse.hono.client.kafka.KafkaMessageHelper;
+import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
+import org.eclipse.hono.util.MessageHelper;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A Kafka based client for sending commands.
+ *
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">
+ *      Command &amp; Control API for Kafka Specification</a>
+ */
+public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender implements CommandSender {
+
+    /**
+     * Creates a new Kafka-based command sender.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param config          The Kafka producer configuration properties to use.
+     * @param tracer          The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public KafkaBasedCommandSender(
+            final KafkaProducerFactory<String, Buffer> producerFactory,
+            final KafkaProducerConfigProperties config,
+            final Tracer tracer) {
+        super(producerFactory, "command-sender", config, tracer);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * The replyId is not used in the Kafka based implementation. It can be set to {@code null}.
+     * If set it will be ignored.
+     *
+     * @throws NullPointerException if tenantId, deviceId, command or correlationId is {@code null}.
+     */
+    @Override
+    public Future<Void> sendAsyncCommand(
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final String contentType,
+            final Buffer data,
+            final String correlationId,
+            final String replyId,
+            final Map<String, Object> properties,
+            final SpanContext context) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(command);
+        Objects.requireNonNull(correlationId);
+
+        final HonoTopic topic = new HonoTopic(HonoTopic.Type.COMMAND, tenantId);
+        final Map<String, Object> headerProperties = getHeaderProperties(deviceId, command, contentType, correlationId,
+                properties);
+        return sendAndWaitForOutcome(topic.toString(), tenantId, deviceId, data, headerProperties, context);
+    }
+
+    private Map<String, Object> getHeaderProperties(final String deviceId, final String subject,
+            final String contentType, final String correlationId, final Map<String, Object> properties) {
+        final Map<String, Object> props = Optional.ofNullable(properties)
+                .orElse(new HashMap<>());
+
+        props.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId);
+        props.put(MessageHelper.SYS_PROPERTY_SUBJECT, subject);
+        props.put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE,
+                Objects.nonNull(contentType) ? contentType : MessageHelper.CONTENT_TYPE_OCTET_STREAM);
+        props.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, correlationId);
+        props.put(KafkaMessageHelper.HEADER_RESPONSE_REQUIRED, true);
+
+        return props;
+    }
+}

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -88,7 +88,8 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender imp
             final String contentType, final String correlationId, final boolean responseRequired,
             final Map<String, Object> properties) {
         final Map<String, Object> props = Optional.ofNullable(properties)
-                .orElse(new HashMap<>());
+                .map(HashMap::new)
+                .orElseGet(HashMap::new);
 
         props.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId);
         props.put(MessageHelper.SYS_PROPERTY_SUBJECT, subject);

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -80,12 +80,13 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender imp
 
         final HonoTopic topic = new HonoTopic(HonoTopic.Type.COMMAND, tenantId);
         final Map<String, Object> headerProperties = getHeaderProperties(deviceId, command, contentType, correlationId,
-                properties);
+                true, properties);
         return sendAndWaitForOutcome(topic.toString(), tenantId, deviceId, data, headerProperties, context);
     }
 
     private Map<String, Object> getHeaderProperties(final String deviceId, final String subject,
-            final String contentType, final String correlationId, final Map<String, Object> properties) {
+            final String contentType, final String correlationId, final boolean responseRequired,
+            final Map<String, Object> properties) {
         final Map<String, Object> props = Optional.ofNullable(properties)
                 .orElse(new HashMap<>());
 
@@ -94,7 +95,7 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender imp
         props.put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE,
                 Objects.nonNull(contentType) ? contentType : MessageHelper.CONTENT_TYPE_OCTET_STREAM);
         props.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, correlationId);
-        props.put(KafkaMessageHelper.HEADER_RESPONSE_REQUIRED, true);
+        props.put(KafkaMessageHelper.HEADER_RESPONSE_REQUIRED, responseRequired);
 
         return props;
     }

--- a/clients/application/pom.xml
+++ b/clients/application/pom.xml
@@ -104,6 +104,39 @@
         </exclusion>
       </exclusions>
     </dependency>
-
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-proton</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.security</groupId>
+          <artifactId>spring-security-crypto</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-noop</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.jsonwebtoken</groupId>
+          <artifactId>jjwt-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.jsonwebtoken</groupId>
+          <artifactId>jjwt-jackson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/ApplicationClient.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/ApplicationClient.java
@@ -22,7 +22,7 @@ import io.vertx.core.Handler;
  *
  * @param <T> The type of context that messages are being received in.
  */
-public interface ApplicationClient<T extends MessageContext> {
+public interface ApplicationClient<T extends MessageContext> extends CommandSender {
 
     /**
      * Creates a client for consuming data from Hono's north bound <em>Telemetry API</em>.

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.application.client;
+
+import java.util.Map;
+
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.util.Lifecycle;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A client for sending commands.
+ *
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control/">
+ *      Command &amp; Control API for AMQP 1.0 Specification</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">
+ *      Command &amp; Control API for Kafka Specification</a>
+ */
+public interface CommandSender extends Lifecycle {
+
+    /**
+     * Sends an async command to a device, i.e. there is no immediate response expected from the device, but
+     * asynchronously via a separate consumer.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload any data for it. The device also needs
+     * to be connected for a successful delivery.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The command name.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @param correlationId The identifier to use for correlating the response with the request. Note: This parameter is
+     *            security sensitive. To ensure secure request response mapping choose correlationId carefully, e.g.
+     *            {@link java.util.UUID#randomUUID()}.
+     * @param replyId An arbitrary string which will be used to create the reply-to address to be included in commands
+     *            sent to devices of the tenant. If the messaging network specific Command &amp; Control implementation does
+     *            not require a replyId, the specified value will be ignored.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         If the command was accepted, the future will succeed.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the command could not be forwarded
+     *         upstream.
+     * @throws NullPointerException if tenantId, deviceId, command or correlationId is {@code null}.
+     *                              Also if the replyId is {@code null} provided that the messaging 
+     *                              network specific Command &amp; Control implementation requires it.
+     */
+    default Future<Void> sendAsyncCommand(
+            String tenantId,
+            String deviceId,
+            String command,
+            Buffer data,
+            String correlationId,
+            String replyId) {
+        return sendAsyncCommand(tenantId, deviceId, command, null, data, correlationId, replyId, null);
+    }
+
+    /**
+     * Sends an async command to a device, i.e. there is no immediate response expected from the device, but
+     * asynchronously via a separate consumer.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload any data for it. The device also needs
+     * to be connected for a successful delivery.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The command name.
+     * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @param correlationId The identifier to use for correlating the response with the request. Note: This parameter is
+     *            security sensitive. To ensure secure request response mapping choose correlationId carefully, e.g.
+     *            {@link java.util.UUID#randomUUID()}.
+     * @param replyId An arbitrary string which will be used to create the reply-to address to be included in commands
+     *            sent to devices of the tenant. If the messaging network specific Command &amp; Control implementation does
+     *            not require a replyId, the specified value will be ignored.
+     * @param properties The headers to include in the command message as AMQP application properties.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         If the command was accepted, the future will succeed.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the command could not be forwarded
+     *         upstream.
+     * @throws NullPointerException if tenantId, deviceId, command or correlationId is {@code null}.
+     *                              Also if the replyId is {@code null} provided that the messaging 
+     *                              network specific Command &amp; Control implementation requires it.
+     */
+    default Future<Void> sendAsyncCommand(
+            String tenantId,
+            String deviceId,
+            String command,
+            String contentType,
+            Buffer data,
+            String correlationId,
+            String replyId,
+            Map<String, Object> properties) {
+        return sendAsyncCommand(tenantId, deviceId, command, contentType, data, correlationId, replyId, properties,
+                null);
+    }
+
+    /**
+     * Sends an async command to a device, i.e. there is no immediate response expected from the device, but
+     * asynchronously via a separate consumer.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload any data for it. The device also needs
+     * to be connected for a successful delivery.
+     * <p>
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The command name.
+     * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @param correlationId The identifier to use for correlating the response with the request. Note: This parameter is
+     *            security sensitive. To ensure secure request response mapping choose correlationId carefully, e.g.
+     *            {@link java.util.UUID#randomUUID()}.
+     * @param replyId An arbitrary string which will be used to create the reply-to address to be included in commands
+     *            sent to devices of the tenant. If the messaging network specific Command &amp; Control implementation does
+     *            not require a replyId, the specified value will be ignored.
+     * @param properties The headers to include in the command message as AMQP application properties.
+     * @param context The currently active OpenTracing span context that is used to trace the execution of this
+     *            operation or {@code null} if no span is currently active.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         If the command was accepted, the future will succeed.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the command could not be forwarded
+     *         upstream.
+     * @throws NullPointerException if tenantId, deviceId, command or correlationId is {@code null}.
+     *                              Also if the replyId is {@code null} provided that the messaging 
+     *                              network specific Command &amp; Control implementation requires it.
+     */
+    Future<Void> sendAsyncCommand(
+            String tenantId,
+            String deviceId,
+            String command,
+            String contentType,
+            Buffer data,
+            String correlationId,
+            String replyId,
+            Map<String, Object> properties,
+            SpanContext context);
+
+}

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
@@ -59,12 +59,12 @@ public interface CommandSender extends Lifecycle {
      *                              network specific Command &amp; Control implementation requires it.
      */
     default Future<Void> sendAsyncCommand(
-            String tenantId,
-            String deviceId,
-            String command,
-            Buffer data,
-            String correlationId,
-            String replyId) {
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final Buffer data,
+            final String correlationId,
+            final String replyId) {
         return sendAsyncCommand(tenantId, deviceId, command, null, data, correlationId, replyId, null);
     }
 
@@ -98,14 +98,14 @@ public interface CommandSender extends Lifecycle {
      *                              network specific Command &amp; Control implementation requires it.
      */
     default Future<Void> sendAsyncCommand(
-            String tenantId,
-            String deviceId,
-            String command,
-            String contentType,
-            Buffer data,
-            String correlationId,
-            String replyId,
-            Map<String, Object> properties) {
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final String contentType,
+            final Buffer data,
+            final String correlationId,
+            final String replyId,
+            final Map<String, Object> properties) {
         return sendAsyncCommand(tenantId, deviceId, command, contentType, data, correlationId, replyId, properties,
                 null);
     }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaMessageHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaMessageHelper.java
@@ -34,6 +34,11 @@ import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
  */
 public final class KafkaMessageHelper {
 
+    /**
+     * The name of the boolean Kafka record header that defines whether a response is required for the command.
+     */
+    public static final String HEADER_RESPONSE_REQUIRED = "response-required";
+
     private KafkaMessageHelper() {
     }
 


### PR DESCRIPTION
This PR is for #2478. It extends the northbound application client to support sending commands asynchronously.  Support for sending one-way/synchronous commands and consuming command responses will be addressed in the next PRs. 

This PR has been implemented on top of code from PR #2497 and that should be merged first.