### PR TITLE
Do not delete images from Hugo theme when building docs locally

### DIFF
--- a/site/build-site.bat
+++ b/site/build-site.bat
@@ -27,8 +27,6 @@ IF NOT EXIST themes\hugo-universal-theme (
 )
 cd themes\hugo-universal-theme
 git checkout 1.1.1
-ECHO Remove images from theme
-DEL /Q static\img\*
 cd ..\..
 
 IF NOT "%~1"==""  (

--- a/site/build-site.sh
+++ b/site/build-site.sh
@@ -34,8 +34,6 @@ fi
 cd themes/hugo-universal-theme
 git fetch
 git checkout 1.1.1
-echo "Remove images from theme" # We do not need the pictures. Removing them, so they don't get deployed
-rm static/img/*
 cd ../..
 
 echo "Going to build homepage in directory: $TARGET"


### PR DESCRIPTION
A recent change in the build scripts for the documentation causes that on each build images of the Hugo theme are deleted. While this step makes sense in the Jenkins pipeline, it is not necessary for local builds. Because the images are simply deleted from a directory under version control, this is always displayed as changes in my IDE, which is unnecessarily annoying. So just stopping to delete the files in the local builds is the simplest solution.