### PR TITLE
[#2477] Support time-to-live (TTL) header in Kafka-based clients

### DIFF
--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
@@ -137,13 +137,16 @@ public abstract class AbstractKafkaBasedDownstreamSender extends AbstractKafkaBa
         headerProperties.putIfAbsent(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, MessageHelper.CONTENT_TYPE_OCTET_STREAM);
 
         if (headerProperties.containsKey(MessageHelper.APP_PROPERTY_DEVICE_TTD)
-                && !headerProperties.containsKey(MessageHelper.SYS_PROPERTY_CREATION_TIME)) {
-            // TODO set this as creation time in the KafkaRecord?
+                || headerProperties.containsKey(MessageHelper.SYS_HEADER_PROPERTY_TTL)) {
 
-            // must match http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-timestamp
-            // as defined in https://www.eclipse.org/hono/docs/api/telemetry/#forward-telemetry-data
-            final long timestamp = Instant.now().toEpochMilli();
-            headerProperties.put(MessageHelper.SYS_PROPERTY_CREATION_TIME, timestamp);
+            if (!headerProperties.containsKey(MessageHelper.SYS_PROPERTY_CREATION_TIME)) {
+                // TODO set this as creation time in the KafkaRecord?
+
+                // must match http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-timestamp
+                // as defined in https://www.eclipse.org/hono/docs/api/telemetry/#forward-telemetry-data
+                final long timestamp = Instant.now().toEpochMilli();
+                headerProperties.put(MessageHelper.SYS_PROPERTY_CREATION_TIME, timestamp);
+            }
         }
 
         return headerProperties;

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaMessageHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaMessageHelper.java
@@ -95,7 +95,7 @@ public final class KafkaMessageHelper {
      *
      * @param headers The headers to be checked.
      * @return {@code true} if <em>ttl</em> and <em>creation-time</em> headers are present and the time-to-live is
-     *         already elapsed, {@code false}.
+     *         already elapsed, {@code false} otherwise.
      */
     public static boolean isTtlElapsed(final List<KafkaHeader> headers) {
         return getHeaderValue(headers, MessageHelper.SYS_HEADER_PROPERTY_TTL, Long.class)

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaMessageHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaMessageHelper.java
@@ -91,12 +91,11 @@ public final class KafkaMessageHelper {
     }
 
     /**
-     * Gets the {@link MessageHelper#SYS_HEADER_PROPERTY_TTL ttl} header from the given list of Kafka headers.
-     * <p>
-     * If the list contains multiple occurrences of the header, the value of its first occurrence is returned.
+     * Checks if a {@link MessageHelper#SYS_HEADER_PROPERTY_TTL ttl} header is present and the time already elapsed.
      *
-     * @param headers The headers to get the ttl from.
-     * @return The time-to-live (may be empty).
+     * @param headers The headers to be checked.
+     * @return {@code true} if <em>ttl</em> and <em>creation-time</em> headers are present and the time-to-live is
+     *         already elapsed, {@code false}.
      */
     public static boolean isTtlElapsed(final List<KafkaHeader> headers) {
         return getHeaderValue(headers, MessageHelper.SYS_HEADER_PROPERTY_TTL, Long.class)

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -240,7 +240,7 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
      * @param respectTtl The intended behaviour: if true, messages with elapsed ttl are silently dropped and the message
      *            handler not invoked.
      */
-    public void setRespectTtl(final boolean respectTtl) {
+    public final void setRespectTtl(final boolean respectTtl) {
         this.respectTtl = respectTtl;
     }
 

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaMessageHelperTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaMessageHelperTest.java
@@ -15,11 +15,11 @@ package org.eclipse.hono.client.kafka;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.eclipse.hono.client.kafka.KafkaMessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -146,4 +146,32 @@ public class KafkaMessageHelperTest {
 
         assertThat(KafkaMessageHelper.getQoS(headers)).isEqualTo(Optional.of(qos));
     }
+
+    /**
+     * Verifies that {@link KafkaMessageHelper#isTtlElapsed(List)} returns {@code false} if the TTL is still in the
+     * future.
+     */
+    @Test
+    public void testThatTtlIsNotElapsed() {
+        final long createTime = Instant.now().toEpochMilli();
+
+        headers.add(KafkaMessageHelper.createKafkaHeader("ttl", 5));
+        headers.add(KafkaMessageHelper.createKafkaHeader("creation-time", createTime));
+
+        assertThat(KafkaMessageHelper.isTtlElapsed(headers)).isFalse();
+    }
+
+    /**
+     * Verifies that {@link KafkaMessageHelper#isTtlElapsed(List)} returns {@code true} if the TTL is in the past.
+     */
+    @Test
+    public void testIsTtlElapsed() {
+        final long createTime = Instant.now().minusSeconds(6).toEpochMilli();
+
+        headers.add(KafkaMessageHelper.createKafkaHeader("ttl", 5));
+        headers.add(KafkaMessageHelper.createKafkaHeader("creation-time", createTime));
+
+        assertThat(KafkaMessageHelper.isTtlElapsed(headers)).isTrue();
+    }
+
 }


### PR DESCRIPTION
This PR adds support for time-to-live (TTL) headers to the Kafka-based clients. It fixes #2477.
