### PR TITLE
#2469 Adding getTimeUntilDisconnectNotification() to DownstreamMessage

### DIFF
--- a/clients/application/src/main/java/org/eclipse/hono/application/client/DownstreamMessage.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/DownstreamMessage.java
@@ -144,8 +144,7 @@ public interface DownstreamMessage<T extends MessageContext> extends Message<T> 
 
             if (tenantId != null && deviceId != null) {
                 final TimeUntilDisconnectNotification notification =
-                        new TimeUntilDisconnectNotification(tenantId, deviceId, ttd,
-                                TimeUntilDisconnectNotification.getReadyUntilInstantFromTtd(ttd, creationTime), creationTime);
+                        new TimeUntilDisconnectNotification(tenantId, deviceId, ttd, creationTime);
                 return Optional.of(notification);
             }
         }

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/DownstreamMessage.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/DownstreamMessage.java
@@ -16,7 +16,6 @@ package org.eclipse.hono.application.client;
 import java.time.Instant;
 import java.util.Optional;
 
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 
@@ -137,7 +136,7 @@ public interface DownstreamMessage<T extends MessageContext> extends Message<T> 
 
         if (ttd == null) {
             return Optional.empty();
-        } else if (ttd == 0 || MessageHelper.isDeviceCurrentlyConnected(ttd,
+        } else if (ttd == 0 || TimeUntilDisconnectNotification.isDeviceCurrentlyConnected(ttd,
                 creationTime != null ? creationTime.toEpochMilli() : null)) {
             final String tenantId = getTenantId();
             final String deviceId = getDeviceId();

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -790,57 +790,6 @@ public final class MessageHelper {
     }
 
     /**
-     * Checks if a device is currently connected to a protocol adapter.
-     * <p>
-     * If this method returns {@code true} an attempt could be made to send a command to the device.
-     * <p>
-     * This method uses the message's creation time and TTD value to determine the point in time
-     * until which the device will remain connected.
-     *
-     * @param msg The message that is checked for a TTD value.
-     * @return {@code true} if the TTD value contained in the message indicates that the device will
-     *         stay connected for some additional time.
-     * @throws NullPointerException If msg is {@code null}.
-     */
-    public static boolean isDeviceCurrentlyConnected(final Message msg) {
-        Objects.requireNonNull(msg);
-
-        return isDeviceCurrentlyConnected(getTimeUntilDisconnect(msg), msg.getCreationTime());
-    }
-
-
-    /**
-     * Checks if a device is currently connected to a protocol adapter.
-     * <p>
-     * If this method returns {@code true} an attempt could be made to send a command to the device.
-     * <p>
-     * This method uses the message's creation time and TTD value to determine the point in time
-     * until which the device will remain connected.
-     *
-     * @param ttd The TTD value.
-     * @param creationTime The creation time of the message. If {@code null} the device is considered as disconnected.
-     * @return {@code true} if the TTD value contained in the message indicates that the device will
-     *         stay connected for some additional time.
-     */
-    public static boolean isDeviceCurrentlyConnected(final Integer ttd, final Long creationTime) {
-
-        return Optional.ofNullable(ttd).map(ttdValue -> {
-            if (ttdValue == MessageHelper.TTD_VALUE_UNLIMITED) {
-                return true;
-            } else if (ttdValue == 0) {
-                return false;
-            } else {
-                if (creationTime == null) {
-                    return false;
-                }
-
-                final Instant creationTimeInstant = Instant.ofEpochMilli(creationTime);
-                return Instant.now().isBefore(creationTimeInstant.plusSeconds(ttdValue));
-            }
-        }).orElse(false);
-    }
-
-    /**
      * Sets the payload of an AMQP message using a <em>Data</em> section.
      * <p>
      * The message's <em>content-type</em> will be set to {@link #CONTENT_TYPE_APPLICATION_JSON}.

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -803,15 +803,39 @@ public final class MessageHelper {
      * @throws NullPointerException If msg is {@code null}.
      */
     public static boolean isDeviceCurrentlyConnected(final Message msg) {
+        Objects.requireNonNull(msg);
 
-        return Optional.ofNullable(MessageHelper.getTimeUntilDisconnect(msg)).map(ttd -> {
-            if (ttd == MessageHelper.TTD_VALUE_UNLIMITED) {
+        return isDeviceCurrentlyConnected(getTimeUntilDisconnect(msg), msg.getCreationTime());
+    }
+
+
+    /**
+     * Checks if a device is currently connected to a protocol adapter.
+     * <p>
+     * If this method returns {@code true} an attempt could be made to send a command to the device.
+     * <p>
+     * This method uses the message's creation time and TTD value to determine the point in time
+     * until which the device will remain connected.
+     *
+     * @param ttd The TTD value.
+     * @param creationTime The creation time of the message. If {@code null} the device is considered as disconnected.
+     * @return {@code true} if the TTD value contained in the message indicates that the device will
+     *         stay connected for some additional time.
+     */
+    public static boolean isDeviceCurrentlyConnected(final Integer ttd, final Long creationTime) {
+
+        return Optional.ofNullable(ttd).map(ttdValue -> {
+            if (ttdValue == MessageHelper.TTD_VALUE_UNLIMITED) {
                 return true;
-            } else if (ttd == 0) {
+            } else if (ttdValue == 0) {
                 return false;
             } else {
-                final Instant creationTime = Instant.ofEpochMilli(msg.getCreationTime());
-                return Instant.now().isBefore(creationTime.plusSeconds(ttd));
+                if (creationTime == null) {
+                    return false;
+                }
+
+                final Instant creationTimeInstant = Instant.ofEpochMilli(creationTime);
+                return Instant.now().isBefore(creationTimeInstant.plusSeconds(ttdValue));
             }
         }).orElse(false);
     }

--- a/core/src/main/java/org/eclipse/hono/util/TimeUntilDisconnectNotification.java
+++ b/core/src/main/java/org/eclipse/hono/util/TimeUntilDisconnectNotification.java
@@ -49,7 +49,7 @@ public final class TimeUntilDisconnectNotification {
      * @param creationTime The Instant that points to when the notification message was created at the client (adapter).
      * @throws NullPointerException If readyUntil is null.
      */
-    private TimeUntilDisconnectNotification(final String tenantId, final String deviceId, final Integer ttd,
+    public TimeUntilDisconnectNotification(final String tenantId, final String deviceId, final Integer ttd,
                                             final Instant readyUntil, final Instant creationTime) {
         Objects.requireNonNull(readyUntil);
 
@@ -166,9 +166,20 @@ public final class TimeUntilDisconnectNotification {
         return Optional.empty();
     }
 
-    private static Instant getReadyUntilInstantFromTtd(final Integer ttd, final Instant startingFrom) {
+    /**
+     * Calculates the instant until which the device is ready based on the given point of time.
+     *
+     * @param ttd The TTD of the device.
+     * @param startingFrom The point of time used as the start for the calculation. If {@code null}, the device is
+     *                     considered as never ready, meaning {@link Instant#MIN} is returned.
+     *
+     * @return The instant until the device is ready.
+     */
+    public static Instant getReadyUntilInstantFromTtd(final Integer ttd, final Instant startingFrom) {
         if (ttd == MessageHelper.TTD_VALUE_UNLIMITED) {
             return Instant.MAX;
+        } else if (startingFrom == null) {
+            return Instant.MIN;
         } else {
             return startingFrom.plusSeconds(ttd);
         }

--- a/core/src/main/java/org/eclipse/hono/util/TimeUntilDisconnectNotification.java
+++ b/core/src/main/java/org/eclipse/hono/util/TimeUntilDisconnectNotification.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.util;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.qpid.proton.message.Message;
@@ -146,7 +147,7 @@ public final class TimeUntilDisconnectNotification {
 
         if (ttd == null) {
             return Optional.empty();
-        } else if (ttd == 0 || MessageHelper.isDeviceCurrentlyConnected(msg)) {
+        } else if (ttd == 0 || isDeviceCurrentlyConnected(msg)) {
             final String tenantId = MessageHelper.getTenantIdAnnotation(msg);
             final String deviceId = MessageHelper.getDeviceId(msg);
 
@@ -183,5 +184,55 @@ public final class TimeUntilDisconnectNotification {
             final long milliseconds = getReadyUntil().minusMillis(Instant.now().toEpochMilli()).toEpochMilli();
             return (milliseconds > 0 ? milliseconds : 0);
         }
+    }
+
+    /**
+     * Checks if a device is currently connected to a protocol adapter.
+     * <p>
+     * If this method returns {@code true} an attempt could be made to send a command to the device.
+     * <p>
+     * This method uses the message's creation time and TTD value to determine the point in time
+     * until which the device will remain connected.
+     *
+     * @param ttd The TTD value.
+     * @param creationTime The creation time of the message. If {@code null} the device is considered as disconnected.
+     * @return {@code true} if the TTD value contained in the message indicates that the device will
+     *         stay connected for some additional time.
+     */
+    public static boolean isDeviceCurrentlyConnected(final Integer ttd, final Long creationTime) {
+
+        return Optional.ofNullable(ttd).map(ttdValue -> {
+            if (ttdValue == MessageHelper.TTD_VALUE_UNLIMITED) {
+                return true;
+            } else if (ttdValue == 0) {
+                return false;
+            } else {
+                if (creationTime == null) {
+                    return false;
+                }
+
+                final Instant creationTimeInstant = Instant.ofEpochMilli(creationTime);
+                return Instant.now().isBefore(creationTimeInstant.plusSeconds(ttdValue));
+            }
+        }).orElse(false);
+    }
+
+    /**
+     * Checks if a device is currently connected to a protocol adapter.
+     * <p>
+     * If this method returns {@code true} an attempt could be made to send a command to the device.
+     * <p>
+     * This method uses the message's creation time and TTD value to determine the point in time
+     * until which the device will remain connected.
+     *
+     * @param msg The message that is checked for a TTD value.
+     * @return {@code true} if the TTD value contained in the message indicates that the device will
+     *         stay connected for some additional time.
+     * @throws NullPointerException If msg is {@code null}.
+     */
+    public static boolean isDeviceCurrentlyConnected(final Message msg) {
+        Objects.requireNonNull(msg);
+
+        return isDeviceCurrentlyConnected(MessageHelper.getTimeUntilDisconnect(msg), msg.getCreationTime());
     }
 }


### PR DESCRIPTION
This is done as preparation for adapting ITs to Kafka. When ITs are based upon DownstreamMessage, `DownstreamMessage#getTimeUntilDisconnectNotification ` can be used to obtain the time until disconnect notification instead of `TimeUntilDisconnectNotification.fromMessage(msg)`.