### PR TITLE
Support gathering of code coverage information

### DIFF
--- a/adapter-base/pom.xml
+++ b/adapter-base/pom.xml
@@ -125,6 +125,10 @@
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -122,6 +122,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/client-device-connection-infinispan/pom.xml
+++ b/client-device-connection-infinispan/pom.xml
@@ -148,6 +148,10 @@
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -171,6 +171,10 @@
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -113,6 +113,10 @@
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -206,6 +206,10 @@
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,9 @@
       Additional tag which can be defined for custom builds
      -->
     <docker.image.additional.tag></docker.image.additional.tag>
+
+    <!-- skip acquisition of code coverage information when running unit tests by default -->
+    <jacoco.skip>true</jacoco.skip>
   </properties>
 
   <modules>
@@ -432,6 +435,42 @@
               <goals>
                 <goal>jandex</goal>
               </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.6</version>
+          <executions>
+          <execution>
+            <id>default-prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+            <execution>
+              <id>default_check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <rule>
+                    <element>CLASS</element>
+                    <excludes>
+                      <exclude>*Test</exclude>
+                      <exclude>*IT</exclude>
+                    </excludes>
+                  </rule>
+                </rules>
+              </configuration>
             </execution>
           </executions>
         </plugin>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -177,6 +177,10 @@
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -106,6 +106,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/site/documentation/content/dev-guide/building_hono.md
+++ b/site/documentation/content/dev-guide/building_hono.md
@@ -56,6 +56,21 @@ If you plan to build the Docker images more frequently, e.g. because you want to
 The first build might take several minutes because Docker will need to download all the base images that Hono is relying on. However, most of these will be cached by Docker so that subsequent builds will be running much faster.
 {{% /note %}}
 
+#### Gathering Code Coverage Information for Unit Tests
+
+Hono's unit tests can be configured to gather code coverage information during execution using the JaCoCo Maven plugin.
+The plugin is disabled by default and can be enabled by setting the *jacoco.skip* maven property to `false`:
+
+```sh
+# in the "hono" folder containing the source code
+mvn clean install -Djacoco.skip=false -Ddocker.host=tcp://${host}:${port} -Pbuild-docker-image,metrics-prometheus,jaeger
+```
+
+The plugin will produce a `target/jacoco.exec` file in each module which contains the (binary) coverage data.
+It will also produce XML data files under `target/site/jacoco` in each module.
+Tools like [SonarQube](https://docs.sonarqube.org/latest/analysis/coverage/) can be used to collect and properly format
+this data.
+
 #### Using custom Image Names
 
 The container images being created will have names based on the following pattern:


### PR DESCRIPTION
The build has been extended to support running the JaCoCo plugin for
gathering code coverage information when running unit tests.
By default, the plugin will be skipped. It can be activated by means of
setting the "jacoco.skip" Maven property to value "false".

This might be helpful for some downstream consumers of our code who need
some "proof-of-quality". We can also use this data to (sporadically)
asses whether we have some "blind spots" in our code that should be
tested more thoroughly.