### PR TITLE
#2469 Adapt integration tests for telemetry and events to Kafka

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -408,6 +408,14 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
               <systemProperties>
                 <downstream.bootstrap.servers>${docker.host.address}:${kafka.port}</downstream.bootstrap.servers>
               </systemProperties>
+              <!--
+                TODO: Remove these exclusions as soon as Command and Control is implemented for Kafka.
+                Until then excluding these speeds up Kafka based integration test runs
+              -->
+              <excludes>
+                <exclude>**/CommandAndControlAmqpIT.java</exclude>
+                <exclude>**/CommandAndControlMqttIT.java</exclude>
+              </excludes>
             </configuration>
           </plugin>
         </plugins>

--- a/tests/src/test/java/org/eclipse/hono/tests/AmqpMessageContextConditionalVerifier.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/AmqpMessageContextConditionalVerifier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageContext;
+import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+
+
+/**
+ * A utility class encapsulating verifications which shall only be made on {@link AmqpMessageContext} based
+ * {@link DownstreamMessage}s.
+ */
+public final class AmqpMessageContextConditionalVerifier {
+
+    private AmqpMessageContextConditionalVerifier() {
+    }
+
+    /**
+     * Verify that the raw AMQP message of the given message's context is durable.
+     *
+     * @param msg The message to be verified.
+     */
+    public static void assertMessageIsDurable(final DownstreamMessage<? extends MessageContext> msg) {
+        if (msg.getMessageContext() instanceof AmqpMessageContext) {
+            final AmqpMessageContext amqpMessageContext = (AmqpMessageContext) msg.getMessageContext();
+            assertThat(amqpMessageContext.getRawMessage().isDurable()).isTrue();
+        }
+    }
+
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -909,18 +909,13 @@ public final class IntegrationTestSupport {
             legacyClientResult.complete();
         }
 
-        final Promise<Void> newClientResult = Promise.promise();
-        if (applicationClient instanceof AmqpApplicationClient) {
-            ((AmqpApplicationClient) applicationClient).disconnect(newClientResult);
-        } else {
-            newClientResult.complete();
-        }
+        final Future<Void> stopResult = applicationClient.stop();
 
         return CompositeFuture.all(
                 legacyClientResult.future()
                     .onSuccess(ok -> LOGGER.info("legacy client's connection to AMQP Messaging Network closed")),
-                newClientResult.future()
-                    .onSuccess(ok -> LOGGER.info("new client's connection to AMQP Messaging Network closed")))
+                stopResult
+                    .onSuccess(ok -> LOGGER.info("new client's connection to messaging network closed")))
                 .mapEmpty();
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -42,13 +42,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.eclipse.hono.application.client.ApplicationClient;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageContext;
+import org.eclipse.hono.application.client.MessageProperties;
 import org.eclipse.hono.application.client.amqp.AmqpApplicationClient;
 import org.eclipse.hono.application.client.amqp.ProtonBasedApplicationClient;
+import org.eclipse.hono.application.client.kafka.impl.KafkaApplicationClientImpl;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageTimeoutException;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.service.management.credentials.Credentials;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
@@ -486,13 +494,14 @@ public final class IntegrationTestSupport {
     /**
      * A client for connecting to Hono's north bound APIs
      * via the AMQP Messaging Network using the legacy client.
+     * Required as long as Command and Control is not fully implemented for Kafka.
      */
     public IntegrationTestApplicationClientFactory applicationClientFactory;
     /**
      * A client for connecting to Hono's north bound APIs
-     * via the AMQP Messaging Network using the new client.
+     * depending on the configured messaging network.
      */
-    public AmqpApplicationClient amqpApplicationClient;
+    public ApplicationClient<?> applicationClient;
 
     private final Set<String> tenantsToDelete = new HashSet<>();
     private final Map<String, Set<String>> devicesToDelete = new HashMap<>();
@@ -558,6 +567,35 @@ public final class IntegrationTestSupport {
         props.setHostnameVerificationRequired(false);
         props.setSecureProtocols(List.of("TLSv1.3"));
         return props;
+    }
+
+    /**
+     * Creates properties for connecting a consumer to Kafka.
+     *
+     * @return The properties or {@code null} if no connection to Kafka is configured.
+     */
+    public static KafkaConsumerConfigProperties getKafkaConsumerConfig() {
+        LOGGER.info("Configured to connect to Kafka on {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
+        final KafkaConsumerConfigProperties consumerConfig = new KafkaConsumerConfigProperties();
+        consumerConfig.setConsumerConfig(Map.of(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS,
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                ConsumerConfig.GROUP_ID_CONFIG, "its-" + UUID.randomUUID()));
+        return consumerConfig;
+    }
+
+    /**
+     * Creates properties for connecting a producer to Kafka.
+     *
+     * @return The properties or {@code null} if no connection to Kafka is configured.
+     */
+    public static KafkaProducerConfigProperties getKafkaProducerConfig() {
+        LOGGER.info("Configured to connect to Kafka on {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
+        final KafkaProducerConfigProperties consumerConfig = new KafkaProducerConfigProperties();
+        consumerConfig.setProducerConfig(Map.of(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS)
+        );
+        return consumerConfig;
     }
 
     /**
@@ -680,15 +718,18 @@ public final class IntegrationTestSupport {
     }
 
     /**
-     * Connects to the AMQP 1.0 Messaging Network.
+     * Connects to the messaging network, i.e. Kafka if configured, AMQP otherwise.
      * <p>
      * Also creates an HTTP client for accessing the Device Registry.
      *
      * @return A future indicating the outcome of the operation.
      */
     public Future<?> init() {
-
-        return init(getMessagingNetworkProperties());
+        if (getConfiguredMessagingType() == MessagingType.amqp) {
+            return init(getMessagingNetworkProperties());
+        } else {
+            return init(getKafkaConsumerConfig());
+        }
     }
 
     /**
@@ -704,7 +745,9 @@ public final class IntegrationTestSupport {
 
         initRegistryClient();
         applicationClientFactory = IntegrationTestApplicationClientFactory.create(HonoConnection.newConnection(vertx, downstreamProps));
-        amqpApplicationClient = new ProtonBasedApplicationClient(HonoConnection.newConnection(vertx, downstreamProps));
+        final AmqpApplicationClient protonBasedApplicationClientFactory =
+                new ProtonBasedApplicationClient(HonoConnection.newConnection(vertx, downstreamProps));
+        applicationClient = protonBasedApplicationClientFactory;
 
         return CompositeFuture.all(
                 applicationClientFactory.connect()
@@ -712,12 +755,31 @@ public final class IntegrationTestSupport {
                         LOGGER.info("connected to AMQP Messaging Network using legacy client [{}:{}]",
                                 downstreamProps.getHost(), downstreamProps.getPort());
                     }),
-                amqpApplicationClient.connect()
+                protonBasedApplicationClientFactory.connect()
                     .onSuccess(ok -> {
                         LOGGER.info("connected to AMQP Messaging Network using new client [{}:{}]",
                                 downstreamProps.getHost(), downstreamProps.getPort());
                     }))
                 .mapEmpty();
+    }
+
+    /**
+     * Connects to Kafka.
+     * <p>
+     * Also creates an HTTP client for accessing the Device Registry.
+     *
+     * @param kafkaDownstreamProps The properties for connecting to Kafka.
+     *
+     * @return A future indicating the outcome of the operation.
+     */
+    public Future<?> init(final KafkaConsumerConfigProperties kafkaDownstreamProps) {
+
+        initRegistryClient();
+
+        applicationClient = new KafkaApplicationClientImpl(vertx, kafkaDownstreamProps,
+                KafkaProducerFactory.sharedProducerFactory(vertx), getKafkaProducerConfig());
+
+        return Future.succeededFuture();
     }
 
     /**
@@ -841,9 +903,19 @@ public final class IntegrationTestSupport {
     public Future<?> disconnect() {
 
         final Promise<Void> legacyClientResult = Promise.promise();
-        applicationClientFactory.disconnect(legacyClientResult);
+        if (applicationClientFactory != null) {
+            applicationClientFactory.disconnect(legacyClientResult);
+        } else {
+            legacyClientResult.complete();
+        }
+
         final Promise<Void> newClientResult = Promise.promise();
-        amqpApplicationClient.disconnect(newClientResult);
+        if (applicationClient instanceof AmqpApplicationClient) {
+            ((AmqpApplicationClient) applicationClient).disconnect(newClientResult);
+        } else {
+            newClientResult.complete();
+        }
+
         return CompositeFuture.all(
                 legacyClientResult.future()
                     .onSuccess(ok -> LOGGER.info("legacy client's connection to AMQP Messaging Network closed")),
@@ -1079,7 +1151,7 @@ public final class IntegrationTestSupport {
                 .fail(new SendMessageTimeoutException("sending command timed out after " + requestTimeout + "ms")));
 
         // send the one way command upstream to the device
-        final Future<Void> sendOneWayCommandTracker = amqpApplicationClient
+        final Future<Void> sendOneWayCommandTracker = applicationClient
                 .sendOneWayCommand(tenantId, deviceId, command, contentType, payload, properties,
                         NoopSpan.INSTANCE.context())
                 .onComplete(ar -> {
@@ -1347,7 +1419,7 @@ public final class IntegrationTestSupport {
             final String deviceId) {
 
         final Checkpoint messagesReceived = ctx.checkpoint(2);
-        return amqpApplicationClient.createEventConsumer(
+        return applicationClient.createEventConsumer(
                 tenantId,
                 msg -> {
                     ctx.verify(() -> {
@@ -1355,9 +1427,7 @@ public final class IntegrationTestSupport {
 
                         if (msg.getContentType().equals(EventConstants.CONTENT_TYPE_DEVICE_PROVISIONING_NOTIFICATION)) {
                             assertThat(msg.getTenantId()).isEqualTo(tenantId);
-                            final var rawMessage = msg.getMessageContext().getRawMessage();
-                            assertThat(MessageHelper.getRegistrationStatus(rawMessage))
-                                    .isEqualTo(EventConstants.RegistrationStatus.NEW.name());
+                            assertThat(getRegistrationStatus(msg)).isEqualTo(EventConstants.RegistrationStatus.NEW.name());
                             messagesReceived.flag();
                         } else {
                             messagesReceived.flag();
@@ -1365,7 +1435,7 @@ public final class IntegrationTestSupport {
                     });
                 },
                 close -> {})
-            .compose(ok -> amqpApplicationClient.createTelemetryConsumer(
+            .compose(ok -> applicationClient.createTelemetryConsumer(
                     tenantId,
                     msg -> {
                         ctx.verify(() -> {
@@ -1376,5 +1446,10 @@ public final class IntegrationTestSupport {
                     },
                     close -> {}))
             .mapEmpty();
+    }
+
+    private static String getRegistrationStatus(final DownstreamMessage<? extends MessageContext> msg) {
+        final MessageProperties properties = msg.getProperties();
+        return properties.getProperty(MessageHelper.APP_PROPERTY_REGISTRATION_STATUS, String.class);
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
@@ -33,7 +33,7 @@ import org.apache.qpid.proton.message.Message;
 import org.assertj.core.api.Assertions;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.tenant.Tenant;
@@ -80,7 +80,7 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
      * @param messageConsumer The handler to invoke for every message received.
      * @return A future succeeding with the created consumer.
      */
-    protected abstract Future<MessageConsumer> createConsumer(String tenantId, Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer);
+    protected abstract Future<MessageConsumer> createConsumer(String tenantId, Handler<DownstreamMessage<? extends MessageContext>> messageConsumer);
 
     /**
      * Gets the endpoint name.
@@ -112,7 +112,7 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
      * @param msg The message to perform checks on.
      * @throws RuntimeException if any of the checks fail.
      */
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
         // empty
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -333,7 +333,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             context.runOnContext(go -> {
                 final String correlationId = String.valueOf(commandsSent.getAndIncrement());
                 final Buffer msg = Buffer.buffer("value: " + correlationId);
-                helper.amqpApplicationClient.sendAsyncCommand(
+                helper.applicationClient.sendAsyncCommand(
                         tenantId,
                         commandTargetDeviceId,
                         "setValue",
@@ -678,7 +678,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         final long commandTimeout = IntegrationTestSupport.getSendCommandTimeout();
 
         final VertxTestContext commandClientCreation = new VertxTestContext();
-        final Future<CommandClient> commandClient = helper.applicationClientFactory.getOrCreateCommandClient(tenantId, "test-client")
+        final Future<CommandClient> commandClient = helper.applicationClientFactory
+                .getOrCreateCommandClient(tenantId, "test-client")
                 .onSuccess(c -> c.setRequestTimeout(commandTimeout))
                 .onComplete(commandClientCreation.completing());
 
@@ -772,7 +773,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         final long commandTimeout = IntegrationTestSupport.getSendCommandTimeout();
 
         final VertxTestContext commandClientCreation = new VertxTestContext();
-        final Future<CommandClient> commandClient = helper.applicationClientFactory.getOrCreateCommandClient(tenantId, "test-client")
+        final Future<CommandClient> commandClient = helper.applicationClientFactory
+                .getOrCreateCommandClient(tenantId, "test-client")
                 .onSuccess(c -> c.setRequestTimeout(commandTimeout))
                 .onComplete(commandClientCreation.completing());
 

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/EventAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/EventAmqpIT.java
@@ -22,7 +22,8 @@ import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
+import org.eclipse.hono.tests.AmqpMessageContextConditionalVerifier;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.AmqpErrorException;
 import org.eclipse.hono.util.MessageHelper;
@@ -53,8 +54,8 @@ public class EventAmqpIT extends AmqpUploadTestBase {
     @Override
     protected Future<MessageConsumer> createConsumer(
             final String tenantId,
-            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
-        return helper.amqpApplicationClient.createEventConsumer(tenantId, messageConsumer, close -> {});
+            final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
+        return helper.applicationClient.createEventConsumer(tenantId, (Handler) messageConsumer, close -> {});
     }
 
     @Override
@@ -63,8 +64,8 @@ public class EventAmqpIT extends AmqpUploadTestBase {
     }
 
     @Override
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
-        assertThat(msg.getMessageContext().getRawMessage().isDurable()).isTrue();
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
+        AmqpMessageContextConditionalVerifier.assertMessageIsDurable(msg);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryAmqpIT.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Future;
@@ -39,8 +39,8 @@ public class TelemetryAmqpIT extends AmqpUploadTestBase {
     @Override
     protected Future<MessageConsumer> createConsumer(
             final String tenantId,
-            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
-        return helper.amqpApplicationClient.createTelemetryConsumer(tenantId, messageConsumer, close -> {});
+            final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
+        return helper.applicationClient.createTelemetryConsumer(tenantId, (Handler) messageConsumer, close -> {});
     }
 
     @Override

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import org.apache.qpid.proton.message.Message;
 import org.assertj.core.data.Index;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapHandler;
@@ -54,19 +53,20 @@ import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedSinglePskStore;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.CommandEndpointConfiguration.SubscriberRole;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistryManagementConstants;
-import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -244,7 +244,7 @@ public abstract class CoapTestBase {
      * @return A future succeeding with the created consumer.
      */
     protected abstract Future<MessageConsumer> createConsumer(
-            String tenantId, Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer);
+            String tenantId, Handler<DownstreamMessage<? extends MessageContext>> messageConsumer);
 
     /**
      * Gets the name of the resource that unauthenticated devices
@@ -326,7 +326,7 @@ public abstract class CoapTestBase {
      * @param msg The message to perform checks on.
      * @throws RuntimeException if any of the checks fail.
      */
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
         // empty
     }
 
@@ -492,7 +492,7 @@ public abstract class CoapTestBase {
             final VertxTestContext ctx,
             final String tenantId,
             final Supplier<Future<?>> warmUp,
-            final Consumer<Message> messageConsumer,
+            final Consumer<DownstreamMessage<? extends MessageContext>> messageConsumer,
             final Function<Integer, Future<OptionSet>> requestSender) throws InterruptedException {
         testUploadMessages(ctx, tenantId, warmUp, messageConsumer, requestSender, MESSAGES_TO_SEND, null);
     }
@@ -514,7 +514,7 @@ public abstract class CoapTestBase {
             final VertxTestContext ctx,
             final String tenantId,
             final Supplier<Future<?>> warmUp,
-            final Consumer<Message> messageConsumer,
+            final Consumer<DownstreamMessage<? extends MessageContext>> messageConsumer,
             final Function<Integer, Future<OptionSet>> requestSender,
             final int numberOfMessages,
             final QoS expectedQos) throws InterruptedException {
@@ -524,13 +524,12 @@ public abstract class CoapTestBase {
         final VertxTestContext setup = new VertxTestContext();
         createConsumer(tenantId, msg -> {
             ctx.verify(() -> {
-                final var rawMessage = msg.getMessageContext().getRawMessage();
-                logger.trace("received {}", rawMessage);
+                logger.trace("received {}", msg);
                 IntegrationTestSupport.assertTelemetryMessageProperties(msg, tenantId);
                 assertThat(msg.getQos()).isEqualTo(getExpectedQoS(expectedQos));
                 assertAdditionalMessageProperties(msg);
                 if (messageConsumer != null) {
-                    messageConsumer.accept(rawMessage);
+                    messageConsumer.accept(msg);
                 }
             });
             received.countDown();
@@ -737,6 +736,7 @@ public abstract class CoapTestBase {
      */
     @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("commandAndControlVariants")
+    @AssumeMessagingSystem(type = MessagingType.amqp) // TODO remove when Kafka C&C is implemented!
     public void testUploadMessagesWithTtdThatReplyWithCommand(
             final CoapCommandEndpointConfiguration endpointConfig,
             final VertxTestContext ctx) throws InterruptedException {
@@ -774,7 +774,7 @@ public abstract class CoapTestBase {
                 () -> warmUp(client, createCoapsOrCoapRequest(endpointConfig, deviceId, 0)),
                 msg -> {
 
-                    TimeUntilDisconnectNotification.fromMessage(msg)
+                    msg.getTimeUntilDisconnectNotification()
                         .map(notification -> {
                             logger.trace("received piggy backed message [ttd: {}]: {}", notification.getTtd(), msg);
                             ctx.verify(() -> {
@@ -879,6 +879,7 @@ public abstract class CoapTestBase {
     @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
     @MethodSource("commandAndControlVariants")
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    @AssumeMessagingSystem(type = MessagingType.amqp) // TODO remove when Kafka C&C is implemented!
     public void testUploadMessagesWithTtdThatReplyWithOneWayCommand(
             final CoapCommandEndpointConfiguration endpointConfig,
             final VertxTestContext ctx) throws InterruptedException {
@@ -907,9 +908,9 @@ public abstract class CoapTestBase {
         testUploadMessages(ctx, tenantId,
                 () -> warmUp(client, createCoapsRequest(Code.POST, getPostResource(), 0)),
                 msg -> {
-                    final Integer ttd = MessageHelper.getTimeUntilDisconnect(msg);
+                    final Integer ttd = msg.getTimeTillDisconnect();
                     logger.debug("north-bound message received {}, ttd: {}", msg, ttd);
-                    TimeUntilDisconnectNotification.fromMessage(msg).ifPresent(notification -> {
+                    msg.getTimeUntilDisconnectNotification().ifPresent(notification -> {
                         ctx.verify(() -> {
                             assertThat(notification.getTenantId()).isEqualTo(tenantId);
                             assertThat(notification.getDeviceId()).isEqualTo(subscribingDeviceId);

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
@@ -25,8 +25,9 @@ import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tests.AmqpMessageContextConditionalVerifier;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
 import org.junit.jupiter.api.Test;
@@ -52,14 +53,14 @@ public class EventCoapIT extends CoapTestBase {
     @Override
     protected Future<MessageConsumer> createConsumer(
             final String tenantId,
-            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
+            final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
 
-        return helper.amqpApplicationClient.createEventConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.applicationClient.createEventConsumer(tenantId, (Handler) messageConsumer, remoteClose -> {});
     }
 
     @Override
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
-        assertThat(msg.getMessageContext().getRawMessage().isDurable()).isTrue();
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
+        AmqpMessageContextConditionalVerifier.assertMessageIsDurable(msg);
     }
 
     @Override

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -27,7 +27,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.elements.exception.ConnectorException;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.QoS;
@@ -56,9 +56,10 @@ public class TelemetryCoapIT extends CoapTestBase {
     @Override
     protected Future<MessageConsumer> createConsumer(
             final String tenantId,
-            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
+            final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
 
-        return helper.amqpApplicationClient.createTelemetryConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.applicationClient
+                .createTelemetryConsumer(tenantId, (Handler) messageConsumer, remoteClose -> {});
     }
 
     @Override

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -21,8 +21,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tests.AmqpMessageContextConditionalVerifier;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
@@ -57,14 +58,14 @@ public class EventHttpIT extends HttpTestBase {
     @Override
     protected Future<MessageConsumer> createConsumer(
             final String tenantId,
-            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
+            final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
 
-        return helper.amqpApplicationClient.createEventConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.applicationClient.createEventConsumer(tenantId, (Handler) messageConsumer, remoteClose -> {});
     }
 
     @Override
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
-        assertThat(msg.getMessageContext().getRawMessage().isDurable()).isTrue();
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
+        AmqpMessageContextConditionalVerifier.assertMessageIsDurable(msg);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -23,8 +23,9 @@ import java.util.function.BiConsumer;
 
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tests.AmqpMessageContextConditionalVerifier;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
@@ -92,14 +93,14 @@ public class EventMqttIT extends MqttPublishTestBase {
     @Override
     protected Future<MessageConsumer> createConsumer(
             final String tenantId,
-            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
+            final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
 
-        return helper.amqpApplicationClient.createEventConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.applicationClient.createEventConsumer(tenantId, (Handler) messageConsumer, remoteClose -> {});
     }
 
     @Override
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
-        assertThat(msg.getMessageContext().getRawMessage().isDurable()).isTrue();
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
+        AmqpMessageContextConditionalVerifier.assertMessageIsDurable(msg);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
 
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.device.Device;
@@ -207,7 +207,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
      */
     protected abstract Future<MessageConsumer> createConsumer(
             String tenantId,
-            Handler<DownstreamMessage<AmqpMessageContext>> messageHandler);
+            Handler<DownstreamMessage<? extends MessageContext>> messageHandler);
 
     /**
      * Verifies that a number of messages published to Hono's MQTT adapter
@@ -532,7 +532,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
             final String tenantId,
             final Future<MqttConnAckMessage> connection,
             final Function<Buffer, Future<String>> sender,
-            final Function<Handler<DownstreamMessage<AmqpMessageContext>>, Future<MessageConsumer>> consumerSupplier,
+            final Function<Handler<DownstreamMessage<? extends MessageContext>>, Future<MessageConsumer>> consumerSupplier,
             final Function<MqttPublishMessage, Future<String>> errorMsgHandler,
             final String errorTopic)
             throws InterruptedException {
@@ -551,7 +551,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
                 ctx.failNow(new IllegalStateException("consumer received message although sending was supposed to fail"));
                 return;
             }
-            LOGGER.trace("received {}", msg.getMessageContext().getRawMessage());
+            LOGGER.trace("received {}", msg);
             ctx.verify(() -> {
                 IntegrationTestSupport.assertTelemetryMessageProperties(msg, tenantId);
                 assertThat(msg.getQos().ordinal()).isEqualTo(getQos().ordinal());
@@ -697,7 +697,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
      * @param msg The message to perform checks on.
      * @throws RuntimeException if any of the checks fail.
      */
-    protected void assertAdditionalMessageProperties(final DownstreamMessage<AmqpMessageContext> msg) {
+    protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
         // empty
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS0IT.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -112,8 +112,9 @@ public class TelemetryMqttQoS0IT extends MqttPublishTestBase {
     @Override
     protected Future<MessageConsumer> createConsumer(
             final String tenantId,
-            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
+            final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
 
-        return helper.amqpApplicationClient.createTelemetryConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.applicationClient
+                .createTelemetryConsumer(tenantId, (Handler) messageConsumer, remoteClose -> {});
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
@@ -21,12 +21,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
-import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
+import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.client.NoConsumerException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,9 +95,10 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
     @Override
     protected Future<MessageConsumer> createConsumer(
             final String tenantId,
-            final Handler<DownstreamMessage<AmqpMessageContext>> messageConsumer) {
+            final Handler<DownstreamMessage<? extends MessageContext>> messageConsumer) {
 
-        return helper.amqpApplicationClient.createTelemetryConsumer(tenantId, messageConsumer, remoteClose -> {});
+        return helper.applicationClient
+                .createTelemetryConsumer(tenantId, (Handler) messageConsumer, remoteClose -> {});
     }
 
     /**
@@ -106,6 +109,7 @@ public class TelemetryMqttQoS1IT extends MqttPublishTestBase {
      * @throws InterruptedException if the test fails.
      */
     @Test
+    @AssumeMessagingSystem(type = MessagingType.amqp)
     public void testUploadMessagesWithNoConsumerSendsErrors(final VertxTestContext ctx) throws InterruptedException {
 
         final String tenantId = helper.getRandomTenantId();


### PR DESCRIPTION
This PR adapts the telemetry and event based integration tests to the new `ApplicationClient` interface so that they can be executed with an AMQP 1.0 network _or_ Kafka.

All Command and Control specific tests are skipped for the Kafka profile. The goal is to have the Kafka ITs in a state where they can be executed successfully. 

Skipped Tests:
- CommandAndControlAmqpIT:*
- CommandAndControlMqttIT:*
- CoapTestBase:testUploadMessagesWithTtdThatReplyWithCommand
- CoapTestBase:testUploadMessagesWithTtdThatReplyWithOneWayCommand
- HttpTestBase:testHandleConcurrentUploadWithTtd
- HttpTestBase:testUploadMessagesWithTtdThatReplyWithCommand
- HttpTestBase:testUploadMessagesWithTtdThatReplyWithOneWayCommand

As soon as the Command and Control implementation is complete those tests can be included/migrated to the Kafka profile as well.