### PR TITLE
Fix internal method name in MultiMessagingSenders

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/MultiMessagingSenders.java
@@ -99,9 +99,9 @@ class MultiMessagingSenders<T> {
         }
 
         // check if configured on the tenant
-        final T tenantConfiguredEventSender = getTenantConfiguredEventSender(tenant);
-        if (tenantConfiguredEventSender != null) {
-            return tenantConfiguredEventSender;
+        final T tenantConfiguredSender = getTenantConfiguredSender(tenant);
+        if (tenantConfiguredSender != null) {
+            return tenantConfiguredSender;
         }
 
         // TODO add adapter config property to determine which should be used as the default?
@@ -117,7 +117,7 @@ class MultiMessagingSenders<T> {
         return amqpSender;
     }
 
-    private T getTenantConfiguredEventSender(final TenantObject tenant) {
+    private T getTenantConfiguredSender(final TenantObject tenant) {
         final JsonObject ext = Optional.ofNullable(tenant.getProperty(TenantConstants.FIELD_EXT, JsonObject.class))
                 .orElse(new JsonObject());
         final String tenantConfig = ext.getString(TenantConstants.FIELD_EXT_MESSAGING_TYPE);


### PR DESCRIPTION
Fixes a wrong name of a private method inside the class `MultiMessagingSenders` (it is not only for event senders but also for other senders).