### PR TITLE
[#2478] Pull up Kafka test helper class for reuse

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -876,6 +876,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>kafka-test-utils</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
         <version>${qpid-jms.version}</version>

--- a/clients/adapter-kafka/pom.xml
+++ b/clients/adapter-kafka/pom.xml
@@ -46,5 +46,10 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>kafka-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
@@ -22,10 +22,10 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.eclipse.hono.adapter.client.command.CommandResponse;
-import org.eclipse.hono.adapter.client.telemetry.kafka.TestHelper;
 import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,8 +72,8 @@ public class KafkaBasedCommandResponseSenderTest {
                 Buffer.buffer(payload),
                 contentType,
                 status);
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
         final KafkaBasedCommandResponseSender sender = new KafkaBasedCommandResponseSender(factory, kafkaProducerConfig,
                 tracer);
 

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
@@ -30,6 +30,7 @@ import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationAssertion;
@@ -83,8 +84,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
      */
     @Test
     public void testLifecycle() {
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
         final AbstractKafkaBasedDownstreamSender sender = newSender(factory);
 
         assertThat(factory.getProducer(PRODUCER_NAME)).isEmpty();
@@ -105,8 +106,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         // GIVEN a sender
         final String payload = "the-payload";
         final Map<String, Object> properties = Collections.singletonMap("foo", "bar");
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(KafkaClientUnitTestHelper.newProducerFactory(mockProducer));
 
         // WHEN sending a message
         sender.send(topic, tenant, device, qos, CONTENT_TYPE, Buffer.buffer(payload), properties, null)
@@ -121,7 +122,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
                         assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("foo", "bar".getBytes()));
 
                         // ...AND contains the standard headers
-                        TestHelper.assertStandardHeaders(actual, DEVICE_ID, CONTENT_TYPE, qos);
+                        KafkaClientUnitTestHelper.assertStandardHeaders(actual, DEVICE_ID, CONTENT_TYPE, qos);
                     });
                     ctx.completeNow();
                 }));
@@ -137,8 +138,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
 
         // GIVEN a sender sending a message
         final RuntimeException expectedError = new RuntimeException("boom");
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(false);
-        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(false);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(KafkaClientUnitTestHelper.newProducerFactory(mockProducer));
 
         sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null)
                 .onComplete(ctx.failing(t -> {
@@ -167,8 +168,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         final AuthorizationException expectedError = new AuthorizationException("go away");
 
         // GIVEN a sender sending a message
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(false);
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(false);
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
         newSender(factory).send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null)
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {
@@ -195,8 +196,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         final RuntimeException expectedError = new RuntimeException("foo");
 
         // GIVEN a sender sending a message
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(false);
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(false);
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
         newSender(factory).send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null)
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {
@@ -291,8 +292,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
             final Map<String, Object> properties, final RegistrationAssertion device, final TenantObject tenant,
             final VertxTestContext ctx) {
 
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        newSender(TestHelper.newProducerFactory(mockProducer))
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        newSender(KafkaClientUnitTestHelper.newProducerFactory(mockProducer))
                 .send(topic, tenant, device, qos, contentTypeParameter, null, properties, null)
                 .onComplete(ctx.succeeding(v -> {
                     ctx.verify(() -> {
@@ -312,8 +313,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
      */
     @Test
     public void testThatCreationTimeIsAddedWhenNotPresentAndTtdIsSet(final VertxTestContext ctx) {
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(KafkaClientUnitTestHelper.newProducerFactory(mockProducer));
 
         // GIVEN properties that contain a TTD
         final long ttd = 99L;
@@ -343,8 +344,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
      */
     @Test
     public void testThatCreationTimeIsAddedWhenNotPresentAndTtlIsSet(final VertxTestContext ctx) {
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(KafkaClientUnitTestHelper.newProducerFactory(mockProducer));
 
         // GIVEN properties that contain a TTL
         final long ttl = 99L;
@@ -373,8 +374,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
      */
     @Test
     public void testThatCreationTimeIsNotChanged(final VertxTestContext ctx) {
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(KafkaClientUnitTestHelper.newProducerFactory(mockProducer));
 
         // GIVEN properties that contain creation-time
         final long creationTime = 12345L;
@@ -403,8 +404,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
      */
     @Test
     public void testThatConstructorThrowsOnMissingParameter() {
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
 
         assertThrows(NullPointerException.class,
                 () -> new AbstractKafkaBasedDownstreamSender(null, PRODUCER_NAME, config, adapterConfig, tracer) {
@@ -434,8 +435,8 @@ public class AbstractKafkaBasedDownstreamSenderTest {
      */
     @Test
     public void testThatSendThrowsOnMissingMandatoryParameter() {
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final AbstractKafkaBasedDownstreamSender sender = newSender(TestHelper.newProducerFactory(mockProducer));
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final AbstractKafkaBasedDownstreamSender sender = newSender(KafkaClientUnitTestHelper.newProducerFactory(mockProducer));
 
         assertThrows(NullPointerException.class,
                 () -> sender.send(null, tenant, device, qos, CONTENT_TYPE, null, null, null));

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSenderTest.java
@@ -25,6 +25,7 @@ import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.TenantObject;
@@ -74,8 +75,8 @@ public class KafkaBasedEventSenderTest {
         // GIVEN a sender
         final String contentType = "the-content-type";
         final String payload = "the-payload";
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
         final KafkaBasedEventSender sender = new KafkaBasedEventSender(factory, kafkaProducerConfig, adapterConfig,
                 tracer);
 
@@ -92,7 +93,7 @@ public class KafkaBasedEventSenderTest {
                         assertThat(actual.value().toString()).isEqualTo(payload);
 
                         // ...AND contains the standard headers
-                        TestHelper.assertStandardHeaders(actual, device.getDeviceId(), contentType, QoS.AT_LEAST_ONCE);
+                        KafkaClientUnitTestHelper.assertStandardHeaders(actual, device.getDeviceId(), contentType, QoS.AT_LEAST_ONCE);
                     });
                     ctx.completeNow();
                 }));
@@ -105,8 +106,8 @@ public class KafkaBasedEventSenderTest {
      */
     @Test
     public void testThatConstructorThrowsOnMissingParameter() {
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper
-                .newProducerFactory(TestHelper.newMockProducer(true));
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper
+                .newProducerFactory(KafkaClientUnitTestHelper.newMockProducer(true));
 
         assertThrows(NullPointerException.class,
                 () -> new KafkaBasedEventSender(null, kafkaProducerConfig, adapterConfig, tracer));
@@ -125,8 +126,8 @@ public class KafkaBasedEventSenderTest {
      */
     @Test
     public void testThatSendEventThrowsOnMissingMandatoryParameter() {
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper
-                .newProducerFactory(TestHelper.newMockProducer(true));
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper
+                .newProducerFactory(KafkaClientUnitTestHelper.newMockProducer(true));
         final KafkaBasedEventSender sender = new KafkaBasedEventSender(factory, kafkaProducerConfig, adapterConfig,
                 tracer);
 

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
@@ -25,6 +25,7 @@ import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
+import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.TenantObject;
@@ -74,8 +75,8 @@ public class KafkaBasedTelemetrySenderTest {
         // GIVEN a telemetry sender
         final QoS qos = QoS.AT_MOST_ONCE;
         final String payload = "the-payload";
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
         final KafkaBasedTelemetrySender sender = new KafkaBasedTelemetrySender(factory, kafkaProducerConfig,
                 adapterConfig, tracer);
 
@@ -92,7 +93,8 @@ public class KafkaBasedTelemetrySenderTest {
                         assertThat(actual.value().toString()).isEqualTo(payload);
 
                         // ...AND contains the standard headers
-                        TestHelper.assertStandardHeaders(actual, device.getDeviceId(), "the-content-type", qos);
+                        KafkaClientUnitTestHelper
+                                .assertStandardHeaders(actual, device.getDeviceId(), "the-content-type", qos);
                     });
                     ctx.completeNow();
                 }));
@@ -111,8 +113,8 @@ public class KafkaBasedTelemetrySenderTest {
         final QoS qos = QoS.AT_LEAST_ONCE;
         final String contentType = "the-content-type";
         final String payload = "the-payload";
-        final MockProducer<String, Buffer> mockProducer = TestHelper.newMockProducer(true);
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper.newProducerFactory(mockProducer);
+        final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
         final KafkaBasedTelemetrySender sender = new KafkaBasedTelemetrySender(factory, kafkaProducerConfig,
                 adapterConfig, tracer);
 
@@ -129,7 +131,7 @@ public class KafkaBasedTelemetrySenderTest {
                         assertThat(actual.value().toString()).isEqualTo(payload);
 
                         // ...AND contains the standard headers
-                        TestHelper.assertStandardHeaders(actual, device.getDeviceId(), contentType, qos);
+                        KafkaClientUnitTestHelper.assertStandardHeaders(actual, device.getDeviceId(), contentType, qos);
                     });
                     ctx.completeNow();
                 }));
@@ -141,8 +143,8 @@ public class KafkaBasedTelemetrySenderTest {
      */
     @Test
     public void testThatConstructorThrowsOnMissingParameter() {
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper
-                .newProducerFactory(TestHelper.newMockProducer(true));
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper
+                .newProducerFactory(KafkaClientUnitTestHelper.newMockProducer(true));
 
         assertThrows(NullPointerException.class,
                 () -> new KafkaBasedTelemetrySender(null, kafkaProducerConfig, adapterConfig, tracer));
@@ -162,8 +164,8 @@ public class KafkaBasedTelemetrySenderTest {
     @Test
     public void testThatSendTelemetryThrowsOnMissingMandatoryParameter() {
         final QoS qos = QoS.AT_LEAST_ONCE;
-        final CachingKafkaProducerFactory<String, Buffer> factory = TestHelper
-                .newProducerFactory(TestHelper.newMockProducer(true));
+        final CachingKafkaProducerFactory<String, Buffer> factory = KafkaClientUnitTestHelper
+                .newProducerFactory(KafkaClientUnitTestHelper.newMockProducer(true));
         final KafkaBasedTelemetrySender sender = new KafkaBasedTelemetrySender(factory, kafkaProducerConfig,
                 adapterConfig, tracer);
 

--- a/test-utils/kafka-test-utils/pom.xml
+++ b/test-utils/kafka-test-utils/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>test-utils</artifactId>
+    <version>1.7.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>kafka-test-utils</artifactId>
+
+  <name>Hono Kafka Test Utils</name>
+  <description>Helper classes for implementing unit tests for components built using Kafka</description>
+  <url>https://www.eclipse.org/hono</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-kafka-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-kafka-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>core-test-utils</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/KafkaClientUnitTestHelper.java
+++ b/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/KafkaClientUnitTestHelper.java
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.hono.adapter.client.telemetry.kafka;
+package org.eclipse.hono.kafka.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,9 +42,9 @@ import io.vertx.kafka.client.serialization.BufferSerializer;
 /**
  * A helper class for writing tests with the Kafka client.
  */
-public class TestHelper {
+public class KafkaClientUnitTestHelper {
 
-    private TestHelper() {
+    private KafkaClientUnitTestHelper() {
     }
 
     /**

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -31,6 +31,7 @@
     <module>adapter-base-test-utils</module>
     <module>client-test-utils</module>
     <module>core-test-utils</module>
+    <module>kafka-test-utils</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
Pull up Kafka test helper class so that it can be used for the Kafka based north bound application tests