### PR TITLE
Handle received message delivery getting updated from remote

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandler.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AdapterInstanceCommandHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.hono.client.Command;
 import org.eclipse.hono.client.CommandContext;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.HonoProtonHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.Strings;
@@ -109,6 +110,10 @@ public final class AdapterInstanceCommandHandler {
         CommandConsumer.logReceivedCommandToSpan(command, currentSpan);
 
         if (commandHandler != null) {
+            HonoProtonHelper.onReceivedMessageDeliveryUpdatedFromRemote(delivery, d -> {
+                LOG.debug("got unexpected disposition update for received command message [remote state: {}, {}]", delivery.getRemoteState(), command);
+                currentSpan.log("got unexpected disposition update for received command message [remote state: " + delivery.getRemoteState() + "]");
+            });
             LOG.trace("using [{}] for received command [{}]", commandHandler, command);
             // command.isValid() check not done here - it is to be done in the command handler
             commandHandler.handleCommand(CommandContext.from(command, delivery, currentSpan));

--- a/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/HonoConnectionImpl.java
@@ -912,6 +912,8 @@ public class HonoConnectionImpl implements HonoConnection {
                 receiver.setQoS(qos);
                 receiver.setPrefetch(preFetchSize);
                 receiver.handler((delivery, message) -> {
+                    HonoProtonHelper.onReceivedMessageDeliveryUpdatedFromRemote(delivery,
+                            d -> log.debug("got unexpected disposition update for received message [remote state: {}]", delivery.getRemoteState()));
                     try {
                         messageHandler.handle(delivery, message);
                         if (log.isTraceEnabled()) {

--- a/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,10 +23,12 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonDelivery;
 import io.vertx.proton.ProtonLink;
 import io.vertx.proton.ProtonReceiver;
 import io.vertx.proton.ProtonSender;
 import io.vertx.proton.ProtonSession;
+import io.vertx.proton.impl.ProtonDeliveryImpl;
 
 /**
  * Utility methods for working with Proton objects.
@@ -307,5 +309,24 @@ public final class HonoProtonHelper {
             closeHandler.handle(null);
             link.free();
         });
+    }
+
+    /**
+     * Sets a handler that will be invoked when the given message delivery of a received message gets updated from the
+     * remote peer before the local receiver updates the delivery.
+     * <p>
+     * A scenario where such a handler could be useful would be that the remote sender of the message only waits a
+     * limited time for the disposition update and afterwards aborts (i.e. releases) the delivery from the sender side.
+     * With the handler here, the receiver can get notified of such a delivery update.
+     *
+     * @param delivery The delivery to set the handler on. Must be a delivery provided by a <em>ProtonReceiver</em>
+     *            handler. Note that the delivery actually needs to be a {@link ProtonDeliveryImpl}, otherwise the
+     *            given handler won't get registered.
+     * @param handler The handler to invoke.
+     */
+    public static void onReceivedMessageDeliveryUpdatedFromRemote(final ProtonDelivery delivery, final Handler<ProtonDelivery> handler) {
+        if (delivery instanceof ProtonDeliveryImpl) {
+            ((ProtonDeliveryImpl) delivery).handler(handler);
+        }
     }
 }

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/AbstractRequestResponseEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/AbstractRequestResponseEndpoint.java
@@ -161,6 +161,8 @@ public abstract class AbstractRequestResponseEndpoint<T extends ServiceConfigPro
             // set up handlers
 
             receiver.handler((delivery, message) -> {
+                HonoProtonHelper.onReceivedMessageDeliveryUpdatedFromRemote(delivery,
+                        d -> logger.debug("got unexpected disposition update for received message [remote state: {}]", delivery.getRemoteState()));
                 try {
                     handleRequestMessage(con, receiver, targetAddress, delivery, message);
                 } catch (final Exception ex) {


### PR DESCRIPTION
Use a handler that will be invoked when a AMQP message delivery of a received message gets updated from the remote peer before the local receiver updates the delivery.

A corresponding scenario would be that the remote sender of the message only waits a limited time for the disposition update and afterwards aborts (i.e. releases) the delivery from the sender side. With the handler here, the receiver can get notified of such a delivery update.
