### PR TITLE
#2469 Making test execution messaging system specific by annotation

### DIFF
--- a/tests/src/test/java/org/eclipse/hono/tests/AssumeMessagingSystem.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/AssumeMessagingSystem.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.tests;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.eclipse.hono.application.client.ApplicationClient;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * An annotation which configures a test to run with a specific messaging system only.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(AssumeMessagingSystemCondition.class)
+public @interface AssumeMessagingSystem {
+
+    /**
+     * The type of the messaging system for which the test shall be run exclusively.
+     *
+     * @return The type of the messaging system, represented by a sublass of {@link ApplicationClient}
+     */
+    Class<? extends ApplicationClient<?>> type();
+
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/AssumeMessagingSystemCondition.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/AssumeMessagingSystemCondition.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.tests;
+
+import java.util.Optional;
+
+import org.eclipse.hono.application.client.ApplicationClient;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+/**
+ * An {@link ExecutionCondition} for the {@link AssumeMessagingSystem} annotation which derives the condition for
+ * executing the annotated test from the system properties by leveraging the {@link IntegrationTestSupport} class.
+ */
+public class AssumeMessagingSystemCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+        final Optional<AssumeMessagingSystem> annotation = AnnotationUtils.findAnnotation(context.getElement(), AssumeMessagingSystem.class);
+        if (annotation.isPresent()) {
+            final Class<? extends ApplicationClient<?>> assumedApplicationClientType = annotation.get().type();
+
+            final Class<? extends ApplicationClient<?>> applicationClientClass = IntegrationTestSupport.getConfiguredApplicationClientType();
+            if (!applicationClientClass.equals(assumedApplicationClientType)) {
+                return ConditionEvaluationResult.disabled(String.format("Test assumes to run on %s, but current test profile is %s. Skipping test!",
+                                assumedApplicationClientType.getSimpleName(),
+                                applicationClientClass.getSimpleName()));
+            } else {
+                return ConditionEvaluationResult.enabled(String.format("Test assumes to run on %s, which matches current test profile is %s. Running test!",
+                        assumedApplicationClientType.getSimpleName(),
+                        applicationClientClass.getSimpleName()));
+            }
+        }
+        return ConditionEvaluationResult.enabled("Test makes no assumptions of messaging systems. Running test.");
+    }
+
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -42,10 +42,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.eclipse.hono.application.client.ApplicationClient;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.application.client.amqp.AmqpApplicationClient;
 import org.eclipse.hono.application.client.amqp.ProtonBasedApplicationClient;
+import org.eclipse.hono.application.client.kafka.KafkaApplicationClient;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.config.ClientConfigProperties;
@@ -58,6 +60,7 @@ import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -522,6 +525,19 @@ public final class IntegrationTestSupport {
         props.setRequestTimeout(timeout);
         props.setFlowLatency(timeout);
         return props;
+    }
+
+    /**
+     * Get the application client type which is configured for the running integration test.
+     *
+     * @return The application client type.
+     */
+    public static Class<? extends ApplicationClient<?>> getConfiguredApplicationClientType() {
+        if (Strings.isNullOrEmpty(IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS)) {
+            return AmqpApplicationClient.class;
+        } else {
+            return KafkaApplicationClient.class;
+        }
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryJmsQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/TelemetryJmsQoS1IT.java
@@ -28,7 +28,9 @@ import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.naming.NamingException;
 
+import org.eclipse.hono.application.client.amqp.AmqpApplicationClient;
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.jms.JmsBasedHonoConnection;
 import org.eclipse.hono.util.TelemetryConstants;
@@ -121,6 +123,7 @@ public class TelemetryJmsQoS1IT {
      * @throws Exception if the test fails.
      */
     @Test
+    @AssumeMessagingSystem(type = AmqpApplicationClient.class)
     public void testTelemetryUpload() throws Exception {
 
         final String tenantId = helper.getRandomTenantId();

--- a/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
@@ -22,11 +22,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.amqp.AmqpApplicationClient;
 import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
 import org.eclipse.hono.client.NoConsumerException;
 import org.eclipse.hono.client.SendMessageTimeoutException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.QoS;
@@ -149,6 +151,7 @@ public class TelemetryHttpIT extends HttpTestBase {
      * @param ctx The test context
      */
     @Test
+    @AssumeMessagingSystem(type = AmqpApplicationClient.class)
     public void testUploadMessageFailsForNoConsumer(final VertxTestContext ctx) {
 
         // GIVEN a device
@@ -190,6 +193,7 @@ public class TelemetryHttpIT extends HttpTestBase {
      * @throws InterruptedException if test is interrupted while running.
      */
     @Test
+    @AssumeMessagingSystem(type = AmqpApplicationClient.class)
     public void testUploadQos1MessageFailsIfDeliveryStateNotUpdated(
             final Vertx vertx,
             final VertxTestContext ctx)


### PR DESCRIPTION
This is a further preparation for migrating the ITs to Kafka.

Some tests do not make sense to be executed when ITs are run with Kafka as the Kafka "protocol" does not offer the same functionality as AMQP 1.0. 

For instance, it is not possible to determine if a consumer has actually processed the message (testUploadMessageFailsForNoConsumer) or there is no delivery state to be updated (testUploadQos1MessageFailsIfDeliveryStateNotUpdated).

The tests for the JMS client of Apache Qpid do also not make sense in a Kafka context as far as I can judge.

The implemented annotation can be used to skip those tests automatically when the Kafka profile is set.
