### PR TITLE
[#2478] Extend northbound application client to send one way commands

### DIFF
--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/AmqpApplicationClient.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/AmqpApplicationClient.java
@@ -25,10 +25,11 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 /**
- * A client that supports Hono's north bound operations to send commands and receive telemetry,
+ * An AMQP 1.0 based client that supports Hono's north bound operations to send commands and receive telemetry,
  * event and command response messages.
  */
-public interface AmqpApplicationClient extends ApplicationClient<AmqpMessageContext>, ConnectionLifecycle<HonoConnection> {
+public interface AmqpApplicationClient
+        extends ApplicationClient<AmqpMessageContext>, ConnectionLifecycle<HonoConnection> {
 
     /**
      * Creates a client for consuming messages from Hono's north bound <em>Telemetry API</em>.

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
@@ -14,6 +14,7 @@ package org.eclipse.hono.application.client.amqp;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.application.client.CommandSender;
@@ -25,6 +26,7 @@ import org.eclipse.hono.util.AddressHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
 
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -66,6 +68,34 @@ public class ProtonBasedCommandSender extends SenderCachingServiceClient impleme
         Objects.requireNonNull(correlationId);
         Objects.requireNonNull(replyId);
 
+        return sendCommand(tenantId, deviceId, command, contentType, data, correlationId, replyId, properties,
+                newChildSpan(context, "send command"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> sendOneWayCommand(
+            final String tenantId,
+            final String deviceId, 
+            final String command,
+            final String contentType,
+            final Buffer data,
+            final Map<String, Object> properties,
+            final SpanContext context) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(command);
+
+        return sendCommand(tenantId, deviceId, command, contentType, data, null, null, properties,
+                newChildSpan(context, "send one-way command"));
+    }
+
+    private Future<Void> sendCommand(final String tenantId, final String deviceId, final String command,
+            final String contentType, final Buffer data, final String correlationId, final String replyId,
+            final Map<String, Object> properties, final Span span) {
+
         return getOrCreateSenderLink(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId)
                 .recover(thr -> Future.failedFuture(StatusCodeMapper.toServerError(thr)))
                 .compose(sender -> {
@@ -74,7 +104,7 @@ public class ProtonBasedCommandSender extends SenderCachingServiceClient impleme
                                     connection.getConfig());
                     final Message msg = createMessage(tenantId, deviceId, command, contentType, data, correlationId,
                             replyId, targetAddress, properties);
-                    return sender.sendAndWaitForOutcome(msg, newChildSpan(context, "send command"));
+                    return sender.sendAndWaitForOutcome(msg, span);
                 })
                 .mapEmpty();
     }
@@ -86,10 +116,11 @@ public class ProtonBasedCommandSender extends SenderCachingServiceClient impleme
 
         MessageHelper.setCreationTime(msg);
         msg.setAddress(targetAddress);
-        msg.setReplyTo(
-                String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, replyId));
+        Optional.ofNullable(replyId)
+                .ifPresent(id -> msg.setReplyTo(String.format("%s/%s/%s",
+                        CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, id)));
+        Optional.ofNullable(correlationId).ifPresent(msg::setCorrelationId);
         MessageHelper.setApplicationProperties(msg, properties);
-        msg.setCorrelationId(correlationId);
         msg.setSubject(command);
         MessageHelper.setPayload(msg, contentType, data);
         MessageHelper.addTenantId(msg, tenantId);

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSenderTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSenderTest.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.application.client.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.MessageHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonMessageHandler;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * Tests verifying behavior of {@link ProtonBasedCommandSender}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class ProtonBasedCommandSenderTest {
+
+    private ProtonBasedCommandSender commandSender;
+    private ProtonSender sender;
+    private ProtonDelivery protonDelivery;
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    void setUp() {
+        final var vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
+        final HonoConnection connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx);
+
+        final ProtonReceiver receiver = AmqpClientUnitTestHelper.mockProtonReceiver();
+        when(connection.createReceiver(
+                anyString(),
+                any(ProtonQoS.class),
+                any(ProtonMessageHandler.class),
+                anyInt(),
+                anyBoolean(),
+                VertxMockSupport.anyHandler())).thenReturn(Future.succeededFuture(receiver));
+
+        protonDelivery = mock(ProtonDelivery.class);
+        when(protonDelivery.remotelySettled()).thenReturn(true);
+        when(protonDelivery.getRemoteState()).thenReturn(new Accepted());
+
+        sender = AmqpClientUnitTestHelper.mockProtonSender();
+        when(sender.send(any(Message.class), VertxMockSupport.anyHandler())).thenReturn(protonDelivery);
+        when(connection.createSender(anyString(), any(), any())).thenReturn(Future.succeededFuture(sender));
+
+        commandSender = new ProtonBasedCommandSender(connection, SendMessageSampler.Factory.noop());
+    }
+
+    /**
+     * Verifies that a one-way command sent to a device succeeds.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendOneWayCommandSucceeds(final VertxTestContext ctx) {
+        final String tenantId = UUID.randomUUID().toString();
+        final String deviceId = UUID.randomUUID().toString();
+        final String subject = "setVolume";
+        final Map<String, Object> applicationProperties = Map.of("appKey", "appValue");
+        final ArgumentCaptor<Handler<ProtonDelivery>> dispositionHandlerCaptor = VertxMockSupport.argumentCaptorHandler();
+        final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+
+        // WHEN sending a one-way command with some application properties and payload
+        final Future<Void> sendCommandFuture = commandSender
+                .sendOneWayCommand(tenantId, deviceId, subject, null, Buffer.buffer("{\"value\": 20}"),
+                        applicationProperties, NoopSpan.INSTANCE.context())
+                .onComplete(ctx.completing());
+
+        // VERIFY that the command is being sent
+        verify(sender).send(messageCaptor.capture(), dispositionHandlerCaptor.capture());
+
+        // VERIFY that the future waits for the disposition to be updated by the peer
+        assertThat(sendCommandFuture.isComplete()).isFalse();
+
+        // THEN the disposition is updated and the peer accepts the message
+        dispositionHandlerCaptor.getValue().handle(protonDelivery);
+
+        //VERIFY if the message properties are properly set
+        final Message message = messageCaptor.getValue();
+        assertThat(MessageHelper.getDeviceId(message)).isEqualTo(deviceId);
+        assertThat(message.getSubject()).isEqualTo(subject);
+        assertThat(MessageHelper.getApplicationProperty(message.getApplicationProperties(), "appKey", String.class))
+                .isEqualTo("appValue");
+        assertThat(sendCommandFuture.isComplete()).isTrue();
+    }
+
+    /**
+     * Verifies that a command asynchronously sent to a device succeeds.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendAsyncCommandSucceeds(final VertxTestContext ctx) {
+        final String tenantId = UUID.randomUUID().toString();
+        final String deviceId = UUID.randomUUID().toString();
+        final String subject = "setVolume";
+        final String correlationId = UUID.randomUUID().toString();
+        final String replyId = "reply-id";
+        final Map<String, Object> applicationProperties = Map.of("appKey", "appValue");
+        final ArgumentCaptor<Handler<ProtonDelivery>> dispositionHandlerCaptor = VertxMockSupport.argumentCaptorHandler();
+        final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+
+        // WHEN sending a one-way command with some application properties and payload
+        final Future<Void> sendCommandFuture = commandSender
+                .sendAsyncCommand(tenantId, deviceId, subject, null, Buffer.buffer("{\"value\": 20}"),
+                        correlationId, replyId, applicationProperties, NoopSpan.INSTANCE.context())
+                .onComplete(ctx.completing());
+
+        // VERIFY that the command is being sent
+        verify(sender).send(messageCaptor.capture(), dispositionHandlerCaptor.capture());
+
+        // VERIFY that the future waits for the disposition to be updated by the peer
+        assertThat(sendCommandFuture.isComplete()).isFalse();
+
+        // THEN the disposition is updated and the peer accepts the message
+        dispositionHandlerCaptor.getValue().handle(protonDelivery);
+
+        //VERIFY if the message properties are properly set
+        final Message message = messageCaptor.getValue();
+        assertThat(MessageHelper.getDeviceId(message)).isEqualTo(deviceId);
+        assertThat(message.getSubject()).isEqualTo(subject);
+        assertThat(MessageHelper.getCorrelationId(message)).isEqualTo(correlationId);
+        assertThat(MessageHelper.getApplicationProperty(message.getApplicationProperties(), "appKey", String.class))
+                .isEqualTo("appValue");
+        assertThat(sendCommandFuture.isComplete()).isTrue();
+    }
+
+}

--- a/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
+++ b/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.application.client.kafka.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
+import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
+import org.eclipse.hono.util.MessageHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.opentracing.noop.NoopSpan;
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests verifying behavior of {@link KafkaBasedCommandSender}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class KafkaBasedCommandSenderTest {
+    private KafkaBasedCommandSender commandSender;
+    private MockProducer<String, Buffer> mockProducer;
+    private String tenantId;
+    private String deviceId;
+
+    /**
+     *
+     * Sets up fixture.
+     *
+     */
+    @BeforeEach
+    void setUp() {
+        final KafkaProducerConfigProperties producerConfig;
+        final CachingKafkaProducerFactory<String, Buffer> producerFactory;
+
+        producerConfig = new KafkaProducerConfigProperties();
+        producerConfig.setProducerConfig(Map.of("client.id", "application-test-sender"));
+        mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
+        producerFactory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
+
+        commandSender = new KafkaBasedCommandSender(producerFactory, producerConfig, NoopTracerFactory.create());
+
+        tenantId = UUID.randomUUID().toString();
+        deviceId = UUID.randomUUID().toString();
+    }
+
+    /**
+     * Verifies that a command sent asynchronously to a device succeeds.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendAsyncCommandSucceeds(final VertxTestContext ctx) {
+        final Map<String, Object> headerProperties = new HashMap<>();
+        final String correlationId = UUID.randomUUID().toString();
+        final String subject = "setVolume";
+        headerProperties.put("appKey", "appValue");
+
+        commandSender
+                .sendAsyncCommand(tenantId, deviceId, subject, null, Buffer.buffer("{\"value\": 20}"), correlationId,
+                null, headerProperties, NoopSpan.INSTANCE.context())
+                .onComplete(ctx.succeeding(ok -> {
+                    ctx.verify(() -> {
+                        final ProducerRecord<String, Buffer> commandRecord = mockProducer.history().get(0);
+                        assertThat(commandRecord.key()).isEqualTo(deviceId);
+                        assertThat(commandRecord.headers()).containsOnlyOnce(
+                                new RecordHeader(MessageHelper.SYS_PROPERTY_SUBJECT, subject.getBytes()));
+                        assertThat(commandRecord.headers()).containsOnlyOnce(
+                                new RecordHeader(MessageHelper.SYS_PROPERTY_CORRELATION_ID, correlationId.getBytes()));
+                        assertThat(commandRecord.headers()).containsOnlyOnce(
+                                new RecordHeader("appKey", "appValue".getBytes()));
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that a one-way command sent to a device succeeds.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendOneWayCommandSucceeds(final VertxTestContext ctx) {
+        final Map<String, Object> headerProperties = new HashMap<>();
+        final String subject = "setVolume";
+        headerProperties.put("appKey", "appValue");
+
+        commandSender
+                .sendOneWayCommand(tenantId, deviceId, subject, null, Buffer.buffer("{\"value\": 20}"), headerProperties,
+                NoopSpan.INSTANCE.context())
+                .onComplete(ctx.succeeding(ok -> {
+                    ctx.verify(() -> {
+                        final ProducerRecord<String, Buffer> commandRecord = mockProducer.history().get(0);
+                        assertThat(commandRecord.key()).isEqualTo(deviceId);
+                        assertThat(commandRecord.headers()).containsOnlyOnce(
+                                new RecordHeader(MessageHelper.SYS_PROPERTY_SUBJECT, subject.getBytes()));
+                        assertThat(commandRecord.headers()).containsOnlyOnce(
+                                new RecordHeader("appKey", "appValue".getBytes()));
+                    });
+                    ctx.completeNow();
+                }));
+    }
+}

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
@@ -86,7 +86,7 @@ public interface CommandSender extends Lifecycle {
      * @param replyId An arbitrary string which will be used to create the reply-to address to be included in commands
      *            sent to devices of the tenant. If the messaging network specific Command &amp; Control implementation does
      *            not require a replyId, the specified value will be ignored.
-     * @param properties The headers to include in the command message as AMQP application properties.
+     * @param properties The headers to include in the command message.
      * @return A future indicating the result of the operation.
      *         <p>
      *         If the command was accepted, the future will succeed.
@@ -129,7 +129,7 @@ public interface CommandSender extends Lifecycle {
      * @param replyId An arbitrary string which will be used to create the reply-to address to be included in commands
      *            sent to devices of the tenant. If the messaging network specific Command &amp; Control implementation does
      *            not require a replyId, the specified value will be ignored.
-     * @param properties The headers to include in the command message as AMQP application properties.
+     * @param properties The headers to include in the command message.
      * @param context The currently active OpenTracing span context that is used to trace the execution of this
      *            operation or {@code null} if no span is currently active.
      * @return A future indicating the result of the operation.
@@ -153,4 +153,62 @@ public interface CommandSender extends Lifecycle {
             Map<String, Object> properties,
             SpanContext context);
 
+    /**
+     * Sends a <em>one-way command</em> to a device, i.e. there is no response expected from the device.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected to a protocol adapter
+     * and needs to have indicated its intent to receive commands.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The name of the command.
+     * @param data The input data to the command or {@code null} if the command has no input data.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         If the one-way command was accepted, the future will succeed.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the one-way command could 
+     *         not be forwarded to the device.
+     * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
+     */
+    default Future<Void> sendOneWayCommand(
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final Buffer data) {
+        return sendOneWayCommand(tenantId, deviceId, command, null, data, null, null);
+    }
+
+    /**
+     * Sends a <em>one-way command</em> to a device, i.e. there is no response from the device expected.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected to a protocol adapter
+     * and needs to have indicated its intent to receive commands.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The name of the command.
+     * @param contentType The type of the data submitted as part of the one-way command or {@code null} if unknown.
+     * @param data The input data to the command or {@code null} if the command has no input data.
+     * @param properties The headers to include in the one-way command message.
+     * @param context The currently active OpenTracing span context that is used to trace the execution of this
+     *            operation or {@code null} if no span is currently active.
+     * @return A future indicating the result of the operation:
+     *         <p>
+     *         If the one-way command was accepted, the future will succeed.
+     *         <p>
+     *         The future will fail with a {@link ServiceInvocationException} if the one-way command could 
+     *         not be forwarded to the device.
+     * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
+     */
+    Future<Void> sendOneWayCommand(
+            String tenantId,
+            String deviceId,
+            String command,
+            String contentType,
+            Buffer data,
+            Map<String, Object> properties,
+            SpanContext context);
 }

--- a/test-utils/client-test-utils/src/main/java/org/eclipse/hono/client/amqp/test/AmqpClientUnitTestHelper.java
+++ b/test-utils/client-test-utils/src/main/java/org/eclipse/hono/client/amqp/test/AmqpClientUnitTestHelper.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.client.amqp.test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -171,6 +172,8 @@ public final class AmqpClientUnitTestHelper {
             handler.handle(result.future());
             return result.future();
         });
+        when(connection.isConnected()).thenReturn(Future.succeededFuture());
+        when(connection.isConnected(anyLong())).thenReturn(Future.succeededFuture());
         return connection;
     }
 }


### PR DESCRIPTION
This PR extends northbound application client to send one way commands.