### PR TITLE
[#2064] Close MQTT connection on terminal errors

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/DeviceDisabledOrNotRegisteredException.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/DeviceDisabledOrNotRegisteredException.java
@@ -15,14 +15,13 @@ package org.eclipse.hono.adapter;
 import org.eclipse.hono.client.ClientErrorException;
 
 /**
- * An exception indicating that the adapter is not enabled.
+ * An exception indicating that the device is either not registered or disabled.
  */
-public class AdapterDisabledException extends ClientErrorException {
-
+public class DeviceDisabledOrNotRegisteredException extends ClientErrorException {
     /**
      * Resource key for the error message.
      */
-    public static final String MESSAGE_KEY = "CLIENT_ERROR_ADAPTER_DISABLED";
+    public static final String MESSAGE_KEY = "CLIENT_ERROR_DEVICE_DISABLED_OR_NOT_REGISTERED";
 
     private static final long serialVersionUID = 1L;
 
@@ -32,7 +31,7 @@ public class AdapterDisabledException extends ClientErrorException {
      * @param tenant The tenant that the device belongs to or {@code null} if unknown.
      * @param errorCode The code representing the erroneous outcome.
      */
-    public AdapterDisabledException(final String tenant, final int errorCode) {
+    public DeviceDisabledOrNotRegisteredException(final String tenant, final int errorCode) {
         super(tenant, errorCode, getLocalizedMessage(MESSAGE_KEY));
     }
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/GatewayDisabledOrNotRegisteredException.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/GatewayDisabledOrNotRegisteredException.java
@@ -15,14 +15,14 @@ package org.eclipse.hono.adapter;
 import org.eclipse.hono.client.ClientErrorException;
 
 /**
- * An exception indicating that the adapter is not enabled.
+ * An exception indicating that the gateway is either not registered or disabled.
  */
-public class AdapterDisabledException extends ClientErrorException {
+public class GatewayDisabledOrNotRegisteredException extends ClientErrorException {
 
     /**
      * Resource key for the error message.
      */
-    public static final String MESSAGE_KEY = "CLIENT_ERROR_ADAPTER_DISABLED";
+    public static final String MESSAGE_KEY = "CLIENT_ERROR_GATEWAY_DISABLED_OR_NOT_REGISTERED";
 
     private static final long serialVersionUID = 1L;
 
@@ -32,7 +32,7 @@ public class AdapterDisabledException extends ClientErrorException {
      * @param tenant The tenant that the device belongs to or {@code null} if unknown.
      * @param errorCode The code representing the erroneous outcome.
      */
-    public AdapterDisabledException(final String tenant, final int errorCode) {
+    public GatewayDisabledOrNotRegisteredException(final String tenant, final int errorCode) {
         super(tenant, errorCode, getLocalizedMessage(MESSAGE_KEY));
     }
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/TenantDisabledOrNotRegisteredException.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/TenantDisabledOrNotRegisteredException.java
@@ -15,14 +15,13 @@ package org.eclipse.hono.adapter;
 import org.eclipse.hono.client.ClientErrorException;
 
 /**
- * An exception indicating that the adapter is not enabled.
+ * An exception indicating that the tenant is not registered or disabled.
  */
-public class AdapterDisabledException extends ClientErrorException {
-
+public class TenantDisabledOrNotRegisteredException extends ClientErrorException {
     /**
      * Resource key for the error message.
      */
-    public static final String MESSAGE_KEY = "CLIENT_ERROR_ADAPTER_DISABLED";
+    public static final String MESSAGE_KEY = "CLIENT_ERROR_TENANT_DISABLED_OR_NOT_REGISTERED";
 
     private static final long serialVersionUID = 1L;
 
@@ -32,7 +31,7 @@ public class AdapterDisabledException extends ClientErrorException {
      * @param tenant The tenant that the device belongs to or {@code null} if unknown.
      * @param errorCode The code representing the erroneous outcome.
      */
-    public AdapterDisabledException(final String tenant, final int errorCode) {
+    public TenantDisabledOrNotRegisteredException(final String tenant, final int errorCode) {
         super(tenant, errorCode, getLocalizedMessage(MESSAGE_KEY));
     }
 }

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -464,11 +464,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                         checkDeviceRegistration(authenticatedDevice, span.context()),
                         getTenantConfiguration(authenticatedDevice.getTenantId(), span.context())
                                 .compose(tenantConfig -> CompositeFuture.all(
-                                        isAdapterEnabled(tenantConfig).recover(t -> Future.failedFuture(
-                                                new AdapterDisabledException(
-                                                        authenticatedDevice.getTenantId(),
-                                                        "adapter is disabled for tenant",
-                                                        t))),
+                                        isAdapterEnabled(tenantConfig),
                                         checkConnectionLimit(tenantConfig, span.context()))))
                     .map(ok -> {
                         log.debug("{} is registered and enabled", authenticatedDevice);
@@ -1347,7 +1343,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
      */
     protected static ErrorCondition getErrorCondition(final Throwable t) {
         final String errorMessage = getClientFacingErrorMessage(t);
-        if (t instanceof AuthorizationException) {
+        if (t instanceof AuthorizationException || t instanceof AdapterDisabledException) {
             return ProtonHelper.condition(AmqpError.UNAUTHORIZED_ACCESS, errorMessage);
         } else if (ServiceInvocationException.class.isInstance(t)) {
             final ServiceInvocationException error = (ServiceInvocationException) t;

--- a/client/src/main/resources/org/eclipse/hono/client/ServiceInvocationException_messages.properties
+++ b/client/src/main/resources/org/eclipse/hono/client/ServiceInvocationException_messages.properties
@@ -14,7 +14,11 @@
 # ServiceInvocationException messages
 
 # ClientErrorException
+CLIENT_ERROR_ADAPTER_DISABLED=adapter is disabled
+CLIENT_ERROR_DEVICE_DISABLED_OR_NOT_REGISTERED=device is disabled or not registered
+CLIENT_ERROR_GATEWAY_DISABLED_OR_NOT_REGISTERED=gateway is disabled or not registered
 CLIENT_ERROR_MESSAGE_UNDELIVERABLE=consumer declared message as undeliverable, it should not be redelivered
+CLIENT_ERROR_TENANT_DISABLED_OR_NOT_REGISTERED=tenant is disabled or not registered
 
 # ServerErrorException
 SERVER_ERROR_MESSAGE_NOT_PROCESSED=consumer didn't process the message

--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -621,7 +621,16 @@ Example payload:
 When a device publishes a telemetry, event or command response message and there is an error processing the message, the handling of the error depends on whether there is a [error topic subscription]({{< relref "#error-reporting-via-error-topic" >}}) for the device and whether a *on-error* property bag parameter was set on the topic used for sending the message.
 
 If no error subscription is in place and no *on-error* parameter was set, the default error handling behaviour is to close the MQTT connection to the device.
-If the device has a subscription on the error topic (on the same MQTT connection the device uses for sending messages), the default behaviour is to keep the MQTT connection open. 
+If the device has a subscription on the error topic (on the same MQTT connection the device uses for sending messages), the default behaviour is to keep the 
+MQTT connection open unless a terminal error happens. The errors that are classified as terminal are listed below.
+
+* The adapter is disabled for the tenant that the client belongs to.
+* The authenticated device or gateway is disabled or not registered.
+* The tenant is disabled or does not exist.
+
+{{% note %}}
+When a terminal error occurs, the connection will always be closed irrespective of any *on-error* parameter or error subscription.
+{{% /note %}}
 
 The following table lists the different behaviours based on the value of the *on-error* property bag parameter and the existence of an error subscription:
 

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -34,6 +34,7 @@ import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.amqp.AmqpMessageContext;
 import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
@@ -464,7 +465,9 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
                     ctx.verify(() -> {
                         assertThat(payload.getInteger("code")).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
                         // error message should be about the device being unknown or disabled
-                        assertThat(payload.getString("message")).contains("unknown");
+                        assertThat(payload.getString("message")).isEqualTo(
+                                ServiceInvocationException.getLocalizedMessage(
+                                        "CLIENT_ERROR_DEVICE_DISABLED_OR_NOT_REGISTERED"));
                         // validate topic segments; example: error//myDeviceId/telemetry/4/503
                         final String[] topicSegments = msg.topicName().split("/");
                         assertThat(topicSegments.length).isEqualTo(6);


### PR DESCRIPTION
This PR is to close the MQTT connection when one of the following terminal errors occur.

* The adapter is disabled for the tenant that the client belongs to.
* The device is disabled or not registered (provided that the device is not connected via a gateway).
* The gateway is disabled or not registered.
* The tenant is disabled or does not exist.