### PR TITLE
[#2543] Prevent connectionResultHandler getting invoked twice

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -96,6 +96,11 @@
     <!--  testing -->
     <dependency>
       <groupId>org.eclipse.hono</groupId>
+      <artifactId>core-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-demo-certs</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
This fixes #2543:
A failed open handler result now closes the connection, preventing the connectionResultHandler from getting invoked twice.
