### PR TITLE
[#2549] Load Kafka client configuration from property file(s)

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/client/kafka/quarkus/KafkaAdminClientConfigProperties.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/client/kafka/quarkus/KafkaAdminClientConfigProperties.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client.kafka.quarkus;
+
+import io.quarkus.arc.config.ConfigProperties;
+
+/**
+ * Standard {@link org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties} which can be bound to environment
+ * variables by Quarkus.
+ */
+@ConfigProperties(namingStrategy = ConfigProperties.NamingStrategy.VERBATIM, failOnMismatchingMember = false)
+public class KafkaAdminClientConfigProperties extends org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties {
+
+}

--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/client/kafka/quarkus/KafkaConsumerConfigProperties.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/client/kafka/quarkus/KafkaConsumerConfigProperties.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client.kafka.quarkus;
+
+import io.quarkus.arc.config.ConfigProperties;
+
+/**
+ * Standard {@link org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties} which can be bound to environment
+ * variables by Quarkus.
+ */
+@ConfigProperties(namingStrategy = ConfigProperties.NamingStrategy.VERBATIM, failOnMismatchingMember = false)
+public class KafkaConsumerConfigProperties
+        extends org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties {
+
+}

--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/client/kafka/quarkus/KafkaProducerConfigProperties.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/client/kafka/quarkus/KafkaProducerConfigProperties.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client.kafka.quarkus;
+
+import io.quarkus.arc.config.ConfigProperties;
+
+/**
+ * Standard {@link org.eclipse.hono.client.kafka.KafkaProducerConfigProperties} which can be bound to environment
+ * variables by Quarkus.
+ */
+@ConfigProperties(namingStrategy = ConfigProperties.NamingStrategy.VERBATIM, failOnMismatchingMember = false)
+public class KafkaProducerConfigProperties extends org.eclipse.hono.client.kafka.KafkaProducerConfigProperties {
+}

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
@@ -14,7 +14,6 @@ package org.eclipse.hono.adapter.client.command.kafka;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.HashMap;
 import java.util.UUID;
 
 import org.apache.kafka.clients.producer.MockProducer;
@@ -54,7 +53,6 @@ public class KafkaBasedCommandResponseSenderTest {
     @BeforeEach
     public void setUp() {
         kafkaProducerConfig = new KafkaProducerConfigProperties();
-        kafkaProducerConfig.setProducerConfig(new HashMap<>());
     }
 
     @Test

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -35,11 +35,9 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.TenantObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.buffer.Buffer;
@@ -68,15 +66,6 @@ public class AbstractKafkaBasedDownstreamSenderTest {
     private final TenantObject tenant = new TenantObject(TENANT_ID, true);
     private final RegistrationAssertion device = new RegistrationAssertion(DEVICE_ID);
     private final ProtocolAdapterProperties adapterConfig = new ProtocolAdapterProperties();
-
-
-    /**
-     * Sets up the fixture.
-     */
-    @BeforeEach
-    public void setUp() {
-        config.setProducerConfig(Map.of("hono.kafka.producerConfig.bootstrap.servers", "localhost:9092"));
-    }
 
     /**
      * Verifies that {@link AbstractKafkaBasedDownstreamSender#start()} creates a producer and

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedEventSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,9 +16,6 @@ package org.eclipse.hono.adapter.client.telemetry.kafka;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
@@ -33,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.buffer.Buffer;
@@ -60,8 +56,6 @@ public class KafkaBasedEventSenderTest {
     public void setUp() {
 
         kafkaProducerConfig = new KafkaProducerConfigProperties();
-        kafkaProducerConfig.setProducerConfig(new HashMap<>());
-
     }
 
     /**

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/telemetry/kafka/KafkaBasedTelemetrySenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,9 +16,6 @@ package org.eclipse.hono.adapter.client.telemetry.kafka;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
@@ -33,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.buffer.Buffer;
@@ -60,7 +56,6 @@ public class KafkaBasedTelemetrySenderTest {
     public void setUp() {
 
         kafkaProducerConfig = new KafkaProducerConfigProperties();
-        kafkaProducerConfig.setProducerConfig(new HashMap<>());
 
     }
 

--- a/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImplTest.java
+++ b/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImplTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -14,7 +14,7 @@ package org.eclipse.hono.application.client.kafka.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -51,7 +51,10 @@ import io.vertx.kafka.client.consumer.KafkaConsumer;
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
 public class KafkaApplicationClientImplTest {
+
+    private static final String PROPERTY_FILE_COMMON = "target/test-classes/common.properties";
     private static final String PARAMETERIZED_TEST_NAME_PATTERN = "{displayName} [{index}]; parameters: {argumentsWithNames}";
+
     private KafkaApplicationClientImpl client;
     private MockConsumer<String, Buffer> mockConsumer;
     private String tenantId;
@@ -72,6 +75,7 @@ public class KafkaApplicationClientImplTest {
     @BeforeEach
     void setUp(final Vertx vertx) {
         final KafkaProducerConfigProperties producerConfig = new KafkaProducerConfigProperties();
+        producerConfig.setPropertyFiles(List.of(PROPERTY_FILE_COMMON));
         final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
         final CachingKafkaProducerFactory<String, Buffer> producerFactory = KafkaClientUnitTestHelper
                 .newProducerFactory(mockProducer);
@@ -81,8 +85,7 @@ public class KafkaApplicationClientImplTest {
         mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
 
         final KafkaConsumerConfigProperties consumerConfig = new KafkaConsumerConfigProperties();
-        consumerConfig.setConsumerConfig(Map.of("client.id", "application-test-consumer"));
-        producerConfig.setProducerConfig(Map.of("client.id", "application-test-sender"));
+        consumerConfig.setPropertyFiles(List.of(PROPERTY_FILE_COMMON));
 
         client = new KafkaApplicationClientImpl(vertx, consumerConfig, producerFactory, producerConfig);
         client.setKafkaConsumerFactory(() -> KafkaConsumer.create(vertx, mockConsumer));

--- a/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
+++ b/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
@@ -60,7 +60,6 @@ public class KafkaBasedCommandSenderTest {
         final CachingKafkaProducerFactory<String, Buffer> producerFactory;
 
         producerConfig = new KafkaProducerConfigProperties();
-        producerConfig.setProducerConfig(Map.of("client.id", "application-test-sender"));
         mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
         producerFactory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
 

--- a/clients/application-kafka/src/test/resources/common.properties
+++ b/clients/application-kafka/src/test/resources/common.properties
@@ -1,0 +1,1 @@
+bootstrap.servers=kafka.eclipseprojects.io

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigProperties.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -9,12 +9,10 @@
  * http://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
- */
+ *******************************************************************************/
 
 package org.eclipse.hono.client.kafka;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -31,28 +29,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
  * @see <a href="https://www.eclipse.org/hono/docs/api/event-kafka">Event API for Kafka Specification</a>
  * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">Command &amp; Control API for Kafka Specification</a>
  */
-public class KafkaAdminClientConfigProperties extends AbstractKafkaConfigProperties {
-
-    private Map<String, String> adminClientConfig;
-
-    /**
-     * Sets the Kafka admin client config properties to be used.
-     *
-     * @param adminConfig The config properties.
-     * @throws NullPointerException if the config is {@code null}.
-     */
-    public final void setAdminClientConfig(final Map<String, String> adminConfig) {
-        this.adminClientConfig = Objects.requireNonNull(adminConfig);
-    }
-
-    /**
-     * Checks if a configuration has been set.
-     *
-     * @return true if configuration is present.
-     */
-    public final boolean isConfigured() {
-        return commonClientConfig != null || adminClientConfig != null;
-    }
+public class KafkaAdminClientConfigProperties extends KafkaConfigProperties {
 
     /**
      * Gets the Kafka admin client configuration to which additional properties were applied. The following properties are
@@ -65,28 +42,15 @@ public class KafkaAdminClientConfigProperties extends AbstractKafkaConfigPropert
      * Note: This method should be called for each new admin client, ensuring that a unique client id is used.
      *
      * @param adminClientName A name for the admin client to include in the added {@code client.id} property.
-     * @return a copy of the admin client configuration with the applied properties or an empty map if neither an admin
-     *         client configuration was set with {@link #setAdminClientConfig(Map)} nor common configuration properties were
-     *         set with {@link #setCommonClientConfig(Map)}.
+     * @return The admin client configuration properties.
      * @throws NullPointerException if adminClientName is {@code null}.
      */
     public final Map<String, String> getAdminClientConfig(final String adminClientName) {
         Objects.requireNonNull(adminClientName);
 
-        if (commonClientConfig == null && adminClientConfig == null) {
-            return Collections.emptyMap();
-        }
-
-        final Map<String, String> newConfig = new HashMap<>();
-        if (commonClientConfig != null) {
-            newConfig.putAll(commonClientConfig);
-        }
-        if (adminClientConfig != null) {
-            newConfig.putAll(adminClientConfig);
-        }
+        final Map<String, String> newConfig = getConfig();
 
         setUniqueClientId(newConfig, adminClientName, AdminClientConfig.CLIENT_ID_CONFIG);
         return newConfig;
     }
-
 }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaConfigProperties.java
@@ -13,39 +13,113 @@
 
 package org.eclipse.hono.client.kafka;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.UUID;
 
+import org.eclipse.hono.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Common configuration properties for Kafka clients.
  */
-public abstract class AbstractKafkaConfigProperties {
+public class KafkaConfigProperties {
+
+    /**
+     * The default prefix to use for creating Kafka client IDs.
+     */
+    public static final String DEFAULT_CLIENT_ID_PREFIX = "hono";
+
+    protected static final String PROPERTY_BOOTSTRAP_SERVERS = "bootstrap.servers";
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
     /**
-     * Common client config properties.
-     */
-    protected Map<String, String> commonClientConfig;
-    /**
      * Client id prefix to be applied if no {@code client.id} property is set in the common
      * or specific client config properties.
      */
-    protected String defaultClientIdPrefix;
+    protected String defaultClientIdPrefix = DEFAULT_CLIENT_ID_PREFIX;
+
+    private final Properties propsFromFile = new Properties();
 
     /**
-     * Sets the common Kafka client config properties to be used.
+     * Post-processes the configuration properties.
+     * <p>
+     * Invoked by {@link #getConfig()} with the properties that have been loaded from the configured files.
+     * <p>
+     * This default implementation does nothing.
      *
-     * @param commonClientConfig The config properties.
-     * @throws NullPointerException if the config is {@code null}.
+     * @param configuration The configuration properties.
      */
-    public final void setCommonClientConfig(final Map<String, String> commonClientConfig) {
-        this.commonClientConfig = Objects.requireNonNull(commonClientConfig);
+    protected void postProcessConfiguration(final Map<String, String> configuration) {
+    }
+
+    /**
+     * Sets the paths to files from which to load Kafka client configuration properties.
+     * <p>
+     * The files will be read in the given order.
+     *
+     * @param files The paths to the files.
+     * @throws NullPointerException if files is {@code null}.
+     * @throws IllegalArgumentException if any of the files cannot be read.
+     */
+    public final void setPropertyFiles(final List<String> files) {
+        Objects.requireNonNull(files);
+        synchronized (propsFromFile) {
+            files.forEach(path -> loadPropertiesFromFile(path, propsFromFile));
+        }
+    }
+
+    private void loadPropertiesFromFile(final String path, final Properties props) {
+        try (InputStream in = new FileInputStream(path)) {
+            props.load(in);
+            log.info("successfully loaded Kafka client configuration from file [{}]", path);
+        } catch (final FileNotFoundException e) {
+            log.info("could not find property file [{}], ignoring ...", path);
+            throw new IllegalArgumentException("could not find property file", e);
+        } catch (IOException e) {
+            log.info("failed to load Kafka client configuration from file [{}], ignoring ...", path, e);
+            throw new IllegalArgumentException("failed to load properties from file", e);
+        }
+    }
+
+    /**
+     * Checks if this client configuration specifies Kafka bootstrap servers.
+     *
+     * @return {@code true} if this configuration contains a property with name {@value #PROPERTY_BOOTSTRAP_SERVERS}.
+     */
+    public final boolean isConfigured() {
+        return propsFromFile.containsKey(PROPERTY_BOOTSTRAP_SERVERS);
+    }
+
+    /**
+     * Gets the Kafka client configuration properties.
+     * <p>
+     * The returned map contains the properties loaded from the configured {@linkplain #setPropertyFiles(List)
+     * property files}.
+     *
+     * @return The configuration properties.
+     */
+    public final Map<String, String> getConfig() {
+        final Map<String, String> config = new HashMap<>();
+        synchronized (propsFromFile) {
+            propsFromFile.forEach((k, v) -> {
+                if (k instanceof String && v instanceof String) {
+                    config.put((String) k, (String) v);
+                }
+            });
+        }
+        postProcessConfiguration(config);
+        return config;
     }
 
     /**
@@ -54,6 +128,8 @@ public abstract class AbstractKafkaConfigProperties {
      * <p>
      * If the common or specific client config already contains a value for key {@code client.id}, that one
      * will be used and the parameter here will be ignored.
+     * <p>
+     * The default value of this property is {@value #DEFAULT_CLIENT_ID_PREFIX}.
      *
      * @param clientId The client ID prefix to set.
      * @throws NullPointerException if the client ID is {@code null}.
@@ -104,11 +180,10 @@ public abstract class AbstractKafkaConfigProperties {
         final UUID uuid = UUID.randomUUID();
         final String clientIdPrefix = Optional.ofNullable(config.get(clientIdPropertyName))
                 .orElse(defaultClientIdPrefix);
-        if (clientIdPrefix == null) {
+        if (Strings.isNullOrEmpty(clientIdPrefix)) {
             config.put(clientIdPropertyName, String.format("%s-%s", clientName, uuid));
         } else {
             config.put(clientIdPropertyName, String.format("%s-%s-%s", clientIdPrefix, clientName, uuid));
         }
     }
-
 }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaProducerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaProducerConfigProperties.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.hono.client.kafka;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -32,39 +30,35 @@ import org.apache.kafka.clients.producer.ProducerConfig;
  * @see <a href="https://www.eclipse.org/hono/docs/api/event-kafka">Event API for Kafka Specification</a>
  * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">Command &amp; Control API for Kafka Specification</a>
  */
-public class KafkaProducerConfigProperties extends AbstractKafkaConfigProperties {
-
-    private Map<String, String> producerConfig;
+public class KafkaProducerConfigProperties extends KafkaConfigProperties {
 
     /**
-     * Sets the Kafka producer config properties to be used.
-     *
-     * @param producerConfig The config properties.
-     * @throws NullPointerException if the config is {@code null}.
-     */
-    public final void setProducerConfig(final Map<String, String> producerConfig) {
-        this.producerConfig = Objects.requireNonNull(producerConfig);
-    }
-
-    /**
-     * Checks if a configuration has been set.
-     *
-     * @return true if configuration is present.
-     */
-    public final boolean isConfigured() {
-        return commonClientConfig != null || producerConfig != null;
-    }
-
-    /**
-     * Gets the Kafka producer configuration to which additional properties were applied. The following properties are
-     * set here to the given configuration:
+     * {@inheritDoc}
+     * <p>
+     * Adds the following properties:
      * <ul>
      * <li>{@code enable.idempotence=true}: enables idempotent producer behavior</li>
      * <li>{@code key.serializer=org.apache.kafka.common.serialization.StringSerializer}: defines how message keys are
      * serialized</li>
      * <li>{@code value.serializer=io.vertx.kafka.client.serialization.BufferSerializer}: defines how message values are
      * serialized</li>
-     *
+     * </ul>
+     */
+    @Override
+    protected void postProcessConfiguration(final Map<String, String> configuration) {
+        overrideConfigProperty(configuration, ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringSerializer");
+
+        overrideConfigProperty(configuration, ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "io.vertx.kafka.client.serialization.BufferSerializer");
+
+        overrideConfigProperty(configuration, ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+    }
+
+    /**
+     * Gets the Kafka producer configuration to which additional properties were applied. The following properties are
+     * set here to the given configuration:
+     * <ul>
      * <li>{@code client.id}=${unique client id}: the client id will be set to a unique value containing the already set
      * client id or alternatively the value set via {@link #setDefaultClientIdPrefix(String)}, the given producerName
      * and a newly created UUID.</li>
@@ -72,9 +66,7 @@ public class KafkaProducerConfigProperties extends AbstractKafkaConfigProperties
      * Note: This method should be called for each new producer, ensuring that a unique client id is used.
      *
      * @param producerName A name for the producer to include in the added {@code client.id} property.
-     * @return a copy of the producer configuration with the applied properties or an empty map if neither a producer
-     *         client configuration was set with {@link #setProducerConfig(Map)} nor common configuration properties were
-     *         set with {@link #setCommonClientConfig(Map)}.
+     * @return The producer configuration properties.
      * @throws NullPointerException if producerName is {@code null}.
      * @see <a href="https://kafka.apache.org/documentation/#enable.idempotence">The Kafka documentation -
      *      "Producer Configs" - enable.idempotence</a>
@@ -82,28 +74,8 @@ public class KafkaProducerConfigProperties extends AbstractKafkaConfigProperties
     public final Map<String, String> getProducerConfig(final String producerName) {
         Objects.requireNonNull(producerName);
 
-        if (commonClientConfig == null && producerConfig == null) {
-            return Collections.emptyMap();
-        }
-
-        final Map<String, String> newConfig = new HashMap<>();
-        if (commonClientConfig != null) {
-            newConfig.putAll(commonClientConfig);
-        }
-        if (producerConfig != null) {
-            newConfig.putAll(producerConfig);
-        }
-
-        overrideConfigProperty(newConfig, ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.StringSerializer");
-
-        overrideConfigProperty(newConfig, ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                "io.vertx.kafka.client.serialization.BufferSerializer");
-
-        overrideConfigProperty(newConfig, ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
-
+        final Map<String, String> newConfig = getConfig();
         setUniqueClientId(newConfig, producerName, ProducerConfig.CLIENT_ID_CONFIG);
         return newConfig;
     }
-
 }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -1,4 +1,4 @@
-/*
+/*******************************************************************************
  * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -9,7 +9,7 @@
  * http://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
- */
+ *******************************************************************************/
 
 package org.eclipse.hono.client.kafka.consumer;
 
@@ -53,7 +53,6 @@ import io.vertx.kafka.client.consumer.OffsetAndMetadata;
  * The consumer starts consuming when {@link #start()} is invoked. It needs to be closed by invoking {@link #stop()} to
  * release the resources. A stopped instance cannot be started again.
  * <p>
- * </p>
  * ERROR CASES:
  * <p>
  * Errors can happen when polling, in message processing, and when committing the offset to Kafka.

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
@@ -13,13 +13,11 @@
 
 package org.eclipse.hono.client.kafka.consumer;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
+import org.eclipse.hono.client.kafka.KafkaConfigProperties;
 
 /**
  * Configuration properties for Kafka consumers.
@@ -32,43 +30,39 @@ import org.eclipse.hono.client.kafka.AbstractKafkaConfigProperties;
  * @see <a href="https://www.eclipse.org/hono/docs/api/event-kafka">Event API for Kafka Specification</a>
  * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">Command &amp; Control API for Kafka Specification</a>
  */
-public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties {
+public class KafkaConsumerConfigProperties extends KafkaConfigProperties {
 
     /**
      * The default amount of time (milliseconds) to wait for records when polling records.
      */
     public static final long DEFAULT_POLL_TIMEOUT = 100L; // ms
 
-    private Map<String, String> consumerConfig;
     private long pollTimeout = DEFAULT_POLL_TIMEOUT;
 
     /**
-     * Sets the Kafka consumer config properties to be used.
-     *
-     * @param consumerConfig The config properties.
-     * @throws NullPointerException if the config is {@code null}.
+     * {@inheritDoc}
+     * <p>
+     * Adds the following properties:
+     * <ul>
+     * <li>{@code key.serializer=org.apache.kafka.common.serialization.StringSerializer}: defines how message keys are
+     * serialized</li>
+     * <li>{@code value.serializer=io.vertx.kafka.client.serialization.BufferSerializer}: defines how message values are
+     * serialized</li>
+     * </ul>
      */
-    public final void setConsumerConfig(final Map<String, String> consumerConfig) {
-        this.consumerConfig = Objects.requireNonNull(consumerConfig);
-    }
+    @Override
+    protected void postProcessConfiguration(final Map<String, String> configuration) {
+        overrideConfigProperty(configuration, ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringDeserializer");
 
-    /**
-     * Checks if a configuration has been set.
-     *
-     * @return true if configuration is present.
-     */
-    public final boolean isConfigured() {
-        return commonClientConfig != null || consumerConfig != null;
+        overrideConfigProperty(configuration, ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                "io.vertx.kafka.client.serialization.BufferDeserializer");
     }
 
     /**
      * Gets the Kafka consumer configuration to which additional properties were applied. The following properties are
      * set here to the given configuration:
      * <ul>
-     * <li>{@code key.deserializer=org.apache.kafka.common.serialization.StringDeserializer}: defines how message keys
-     * are deserialized</li>
-     * <li>{@code value.deserializer=io.vertx.kafka.client.serialization.BufferDeserializer}: defines how message values
-     * are deserialized</li>
      * <li>{@code client.id}=${unique client id}: the client id will be set to a unique value containing the already set
      * client id or alternatively the value set via {@link #setDefaultClientIdPrefix(String)}, the given consumerName
      * and a newly created UUID.</li>
@@ -76,32 +70,13 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
      * Note: This method should be called for each new consumer, ensuring that a unique client id is used.
      *
      * @param consumerName A name for the consumer to include in the added {@code client.id} property.
-     * @return a copy of the consumer configuration with the applied properties or an empty map if neither a consumer
-     *         client configuration was set with {@link #setConsumerConfig(Map)} nor common configuration properties were
-     *         set with {@link #setCommonClientConfig(Map)}.
+     * @return The consumer configuration properties.
      * @throws NullPointerException if consumerName is {@code null}.
      */
     public final Map<String, String> getConsumerConfig(final String consumerName) {
         Objects.requireNonNull(consumerName);
 
-        if (commonClientConfig == null && consumerConfig == null) {
-            return Collections.emptyMap();
-        }
-
-        final Map<String, String> newConfig = new HashMap<>();
-        if (commonClientConfig != null) {
-            newConfig.putAll(commonClientConfig);
-        }
-        if (consumerConfig != null) {
-            newConfig.putAll(consumerConfig);
-        }
-
-        overrideConfigProperty(newConfig, ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.StringDeserializer");
-
-        overrideConfigProperty(newConfig, ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-                "io.vertx.kafka.client.serialization.BufferDeserializer");
-
+        final Map<String, String> newConfig = getConfig();
         setUniqueClientId(newConfig, consumerName, ConsumerConfig.CLIENT_ID_CONFIG);
         return newConfig;
     }
@@ -132,5 +107,4 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
     public final long getPollTimeout() {
         return pollTimeout;
     }
-
 }

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/CachingKafkaProducerFactoryTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/CachingKafkaProducerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -50,9 +51,10 @@ import io.vertx.kafka.client.serialization.BufferSerializer;
  */
 public class CachingKafkaProducerFactoryTest {
 
+    private static final String PROPERTY_FILE_PRODUCER = "target/test-classes/producer.properties";
     private static final String PRODUCER_NAME = "test-producer";
 
-    private final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+    private KafkaProducerConfigProperties configProperties;
 
     private CachingKafkaProducerFactory<String, Buffer> factory;
 
@@ -78,7 +80,8 @@ public class CachingKafkaProducerFactoryTest {
 
         factory = new CachingKafkaProducerFactory<>(instanceSupplier);
 
-        configProperties.setProducerConfig(Map.of("bootstrap.servers", "localhost:9092"));
+        configProperties = new KafkaProducerConfigProperties();
+        configProperties.setPropertyFiles(List.of(PROPERTY_FILE_PRODUCER));
     }
 
     /**

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaAdminClientConfigPropertiesTest.java
@@ -14,9 +14,8 @@
 package org.eclipse.hono.client.kafka;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -26,65 +25,7 @@ import org.junit.jupiter.api.Test;
  */
 public class KafkaAdminClientConfigPropertiesTest {
 
-    /**
-     * Verifies that trying to set a {@code null} config throws a {@link NullPointerException}.
-     */
-    @Test
-    public void testThatConfigCanNotBeSetToNull() {
-        assertThrows(NullPointerException.class, () -> new KafkaAdminClientConfigProperties().setAdminClientConfig(null));
-    }
-
-    /**
-     * Verifies that trying to set a {@code null} client ID throws a {@link NullPointerException}.
-     */
-    @Test
-    public void testThatClientIdCanNotBeSetToNull() {
-        assertThrows(NullPointerException.class, () -> new KafkaAdminClientConfigProperties().setDefaultClientIdPrefix(null));
-    }
-
-    /**
-     * Verifies that properties provided with {@link KafkaAdminClientConfigProperties#setAdminClientConfig(Map)} are returned
-     * in {@link KafkaAdminClientConfigProperties#getAdminClientConfig(String)}.
-     */
-    @Test
-    public void testThatGetAdminClientConfigReturnsGivenProperties() {
-        final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
-        config.setAdminClientConfig(Collections.singletonMap("foo", "bar"));
-
-        final Map<String, String> adminClientConfig = config.getAdminClientConfig("adminClientName");
-        assertThat(adminClientConfig.get("foo")).isEqualTo("bar");
-    }
-
-    /**
-     * Verifies that properties provided with {@link KafkaAdminClientConfigProperties#setAdminClientConfig(Map)} and
-     * {@link AbstractKafkaConfigProperties#setCommonClientConfig(Map)} are returned
-     * in {@link KafkaAdminClientConfigProperties#getAdminClientConfig(String)}, with the admin client config properties having
-     * precedence.
-     */
-    @Test
-    public void testThatGetAdminClientConfigReturnsGivenPropertiesWithCommonProperties() {
-        final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
-        config.setCommonClientConfig(Map.of("foo", "toBeOverridden", "common", "commonValue"));
-        config.setAdminClientConfig(Collections.singletonMap("foo", "bar"));
-
-        final Map<String, String> adminClientConfig = config.getAdminClientConfig("adminClientName");
-        assertThat(adminClientConfig.get("foo")).isEqualTo("bar");
-        assertThat(adminClientConfig.get("common")).isEqualTo("commonValue");
-    }
-
-    /**
-     * Verifies that {@link KafkaAdminClientConfigProperties#isConfigured()} returns false if no configuration has been
-     * set, and true otherwise.
-     */
-    @Test
-    public void testIsConfiguredMethod() {
-
-        assertThat(new KafkaAdminClientConfigProperties().isConfigured()).isFalse();
-
-        final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
-        config.setAdminClientConfig(Collections.singletonMap("foo", "bar"));
-        assertThat(config.isConfigured()).isTrue();
-    }
+    private static final String PROPERTY_FILE_CLIENT_ID = "target/test-classes/clientid.properties";
 
     /**
      * Verifies that the client ID set with {@link KafkaAdminClientConfigProperties#setDefaultClientIdPrefix(String)} is applied when it
@@ -95,7 +36,6 @@ public class KafkaAdminClientConfigPropertiesTest {
         final String clientId = "the-client";
 
         final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
-        config.setAdminClientConfig(Collections.emptyMap());
         config.setDefaultClientIdPrefix(clientId);
 
         final Map<String, String> adminClientConfig = config.getAdminClientConfig("adminClientName");
@@ -108,14 +48,12 @@ public class KafkaAdminClientConfigPropertiesTest {
      */
     @Test
     public void testThatClientIdIsNotAppliedIfAlreadyPresent() {
-        final String userProvidedClientId = "custom-client";
 
         final KafkaAdminClientConfigProperties config = new KafkaAdminClientConfigProperties();
-        config.setAdminClientConfig(Collections.singletonMap("client.id", userProvidedClientId));
+        config.setPropertyFiles(List.of(PROPERTY_FILE_CLIENT_ID));
         config.setDefaultClientIdPrefix("other-client");
 
         final Map<String, String> adminClientConfig = config.getAdminClientConfig("adminClientName");
-        assertThat(adminClientConfig.get("client.id")).startsWith(userProvidedClientId + "-adminClientName-");
+        assertThat(adminClientConfig.get("client.id")).startsWith("configured-id-adminClientName-");
     }
-
 }

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaConfigPropertiesTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaConfigPropertiesTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Tests verifying behavior of {@link KafkaConfigProperties}.
+ */
+class KafkaConfigPropertiesTest {
+
+    static final String PROPERTY_FILE_CLIENT_ID = "target/test-classes/clientid.properties";
+    static final String PROPERTY_FILE_COMMON = "target/test-classes/common.properties";
+    static final String PROPERTY_FILE_ADMIN = "target/test-classes/admin.properties";
+
+    /**
+     * Verifies that the property file list cannot be {@code null}.
+     */
+    @Test
+    public void testThatConfigFilesCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaConfigProperties().setPropertyFiles(null));
+    }
+
+    /**
+     * Verifies that the client ID can not be set to {@code null}.
+     */
+    @Test
+    public void testThatClientIdCanNotBeSetToNull() {
+        assertThrows(NullPointerException.class, () -> new KafkaConfigProperties().setDefaultClientIdPrefix(null));
+    }
+
+    /**
+     * Verifies that properties are successfully read from configured files.
+     */
+    @Test
+    public void testGetConfigReturnsPropertiesFromFiles() {
+        final var config = new KafkaConfigProperties();
+        config.setPropertyFiles(List.of(PROPERTY_FILE_COMMON, PROPERTY_FILE_ADMIN));
+
+        final Map<String, String> adminClientConfig = config.getConfig();
+        assertThat(adminClientConfig.get("foo")).isEqualTo("bar");
+        assertThat(adminClientConfig.get("common")).isEqualTo("commonValue");
+    }
+
+    /**
+     * Verifies that non-existing property file is detected.
+     */
+    @Test
+    public void testSetPropertyFilesDetectsMissingFile() {
+        final var config = new KafkaConfigProperties();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> config.setPropertyFiles(List.of("non-existing.properties")));
+    }
+
+    /**
+     * Verifies that properties are considered <em>configured</em> only if <em>bootstrap.servers</em>
+     * have been set.
+     */
+    @Test
+    public void testIsConfiguredMethod() {
+
+        assertThat(new KafkaConfigProperties().isConfigured()).isFalse();
+
+        final var config = new KafkaConfigProperties();
+        config.setPropertyFiles(List.of(PROPERTY_FILE_COMMON));
+        assertThat(config.isConfigured()).isTrue();
+    }
+}

--- a/clients/kafka-common/src/test/resources/admin.properties
+++ b/clients/kafka-common/src/test/resources/admin.properties
@@ -1,0 +1,2 @@
+ssl.truststore.location=/etc/trusted-ca.pem
+foo=bar

--- a/clients/kafka-common/src/test/resources/clientid.properties
+++ b/clients/kafka-common/src/test/resources/clientid.properties
@@ -1,0 +1,1 @@
+client.id=configured-id

--- a/clients/kafka-common/src/test/resources/common.properties
+++ b/clients/kafka-common/src/test/resources/common.properties
@@ -1,0 +1,3 @@
+bootstrap.servers=kafka.eclipseprojects.io
+common=commonValue
+foo=toBeOverridden

--- a/clients/kafka-common/src/test/resources/consumer.properties
+++ b/clients/kafka-common/src/test/resources/consumer.properties
@@ -1,0 +1,4 @@
+key.serializer=foo
+value.serializer=bar
+enable.idempotence=baz
+fetch.min.bytes=2048

--- a/clients/kafka-common/src/test/resources/producer.properties
+++ b/clients/kafka-common/src/test/resources/producer.properties
@@ -1,0 +1,4 @@
+key.serializer=foo
+value.serializer=bar
+enable.idempotence=baz
+retries=5

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/client/kafka/quarkus/ClientConfigurationProducer.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/client/kafka/quarkus/ClientConfigurationProducer.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.client.kafka.quarkus;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * A producer of application scoped Kafka client configuration.
+ *
+ */
+@ApplicationScoped
+public class ClientConfigurationProducer {
+
+    @ConfigProperty(name = "hono.command.kafka.commonClientConfigPath", defaultValue = "/opt/hono/config/kafka-common.properties")
+    String commonClientConfigPath;
+
+    @ConfigProperty(name = "hono.command.kafka.consumerConfigPath", defaultValue = "/opt/hono/config/kafka-consumer.properties")
+    String consumerConfigPath;
+
+    @ConfigProperty(name = "hono.command.kafka.producerConfigPath", defaultValue = "/opt/hono/config/kafka-producer.properties")
+    String producerConfigPath;
+
+    @Produces
+    KafkaConsumerConfigProperties consumerProperties() {
+        final var props = new KafkaConsumerConfigProperties();
+        props.setCommonClientConfigPath(commonClientConfigPath);
+        props.setConsumerConfigPath(consumerConfigPath);
+        return props;
+    }
+
+    @Produces
+    KafkaProducerConfigProperties producerProperties() {
+        final var props = new KafkaProducerConfigProperties();
+        props.setCommonClientConfigPath(commonClientConfigPath);
+        props.setProducerConfigPath(consumerConfigPath);
+        return props;
+    }
+}

--- a/site/documentation/content/admin-guide/common-config.md
+++ b/site/documentation/content/admin-guide/common-config.md
@@ -50,8 +50,9 @@ with `HONO_MESSAGING` being used as `${PREFIX}`. Since there are no responses be
 
 ### Kafka based Messaging Configuration
 
-Protocol adapters can be configured to allow publishing messages to an *Apache Kafka&reg; cluster* instead of an AMQP Messaging Network. 
-Which messaging to be used, can be configured at the tenant _or_ for all tenants if a protocol adapter is only configured with one messaging system.
+Protocol adapters can be configured to allow publishing messages to an *Apache Kafka&reg; cluster* instead of an AMQP Messaging Network.
+Which messaging to be used, can be configured for each tenant individually _or_ for all tenants if a protocol adapter
+is configured with one type messaging infrastructure only.
 For details refer to [Hono Kafka Client Configuration]({{< relref "hono-kafka-client-configuration.md/#configuration-for-kafka-based-messaging" >}})
 
 The Kafka client is configured according to [Hono Kafka Client Configuration]({{< relref "hono-kafka-client-configuration.md" >}}).

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -3,21 +3,22 @@ title = "Hono Kafka Client Configuration"
 weight = 342
 +++
 
-Protocol adapters can be configured to use Kafka for the messaging. The Kafka client used there can be configured with 
-environment variables and/or command line options.
+Protocol adapters and other Hono components can be configured to use Kafka as the messaging infrastructure.
+The Kafka client used for that purpose can be configured with environment variables and/or command line options.
 
 {{% note title="Tech preview" %}}
-The support of Kafka as a messaging system is currently a preview and not yet ready for production. 
-The implementation as well as it's APIs may change with the next version. 
+Support for Kafka as the messaging infrastructure is currently considered a *Technology Preview* and should therefore
+not (yet) be used in production scenarios.
+In particular, the APIs and client implementation may change without prior notice.
 {{% /note %}}
 
-## Configure for Kafka based Messaging
+## Configuring Kafka based Messaging
 
-The selection of whether to use AMQP or Kafka for the messaging can be configured on the tenant. This requires that
-protocol adapters must have the configurations for both messaging networks. 
+The selection of whether to use AMQP or Kafka for the messaging can be configured at the tenant level.
+This requires that protocol adapters must have the configurations for both messaging networks.
 To configure a tenant to use Kafka, the [tenant configuration]({{< relref "/api/tenant#tenant-information-format" >}}) 
-must contain a field `ext`, which contains a field with the key `messaging-type` and the value `kafka` 
-(to use AMQP, the value must be `amqp`).
+must contain a property `ext/messaging-type` with value `kafka`. If no such property is configured or the property has
+value `amqp`, the AMQP 1.0 Messaging Network is used instead.
 The following example shows a tenant that is configured to use Kafka for messaging:
 
 ~~~json
@@ -31,31 +32,34 @@ The following example shows a tenant that is configured to use Kafka for messagi
 ~~~
 
 If the configuration of a protocol adapter contains only the connection to one messaging system, this will be used.
-**NB**: If only one messaging network is configured at protocol adapters, make sure that tenants are not configured to use another. 
+**NB**: If only one messaging network is configured at protocol adapters, make sure that tenants are not configured to use another.
 
-## Producer Configuration Properties
+## Configuring Kafka Producers
 
-The `org.eclipse.hono.client.kafka.CachingKafkaProducerFactory` factory can be used to create Kafka producers for Hono's Kafka based APIs. 
-The producers created by the factory are configured with instances of the class `org.eclipse.hono.client.kafka.KafkaProducerConfigProperties`
-which can be used to programmatically configure a producer. 
+The `org.eclipse.hono.client.kafka.CachingKafkaProducerFactory` factory can be used to create Kafka *producers* for publishing
+messages to Hono's Kafka based APIs.
 
-The configuration needs to be provided in the form `HONO_KAFKA_PRODUCERCONFIG_${PROPERTY}` as an environment variable or
-as a command line option in the form `hono.kafka.producerConfig.${property}`, where `${PROPERTY}` respectively 
-`${property}` is any of the Kafka client's [producer properties](https://kafka.apache.org/documentation/#producerconfigs). 
-The provided configuration is passed directly to the Kafka producer without Hono parsing or validating it.
+The following table provides an overview of the configuration variables and corresponding command line options for configuring
+the factory. Note that the variables map to the properties of class `org.eclipse.hono.client.kafka.KafkaProducerConfigProperties`
+which can be used to programmatically configure the producers being created by the factory.
 
-The following properties can _not_ be set using this mechanism because the protocol adapters use fixed values instead 
-in order to implement the message delivery semantics defined by Hono's Telemetry and Event APIs.
+| Environment Variable<br>Command Line Option | Mandatory | Default Value | Description  |
+| :------------------------------------------ | :-------: | :------------ | :------------|
+| `HONO_KAFKA_DEFAULTCLIENTIDPREFIX`<br>`--hono.kafka.defaultClientIdPrefix` | no | - | The prefix for the client ID that is passed to the Kafka server to allow application specific server-side request logging.<br>If the configuration properties read from the configured files already contain a value for key `client.id`, that value will be used and this property's value will be ignored. |
+| `HONO_KAFKA_PROPERTYFILES`<br>`--hono.kafka.propertyFiles` | yes | - | A comma separated list of paths to files containing [Kafka properties](https://kafka.apache.org/documentation/#configuration) that should be used for configuring the connection to the broker and the producers created. The files will be loaded in the specified order. The provided configuration is passed directly to the Kafka client without Hono parsing or validating it. |
 
-| Kafka Producer Config Property | Fixed Value |
-| :----------------------------- | :---------- |
-| `key.serializer` | `org.apache.kafka.common.serialization.StringSerializer` |
-| `value.serializer` | `io.vertx.kafka.client.serialization.BufferSerializer` |
+The following properties will be ignored if set in any of the configured property files.
+Instead, Hono uses the specified fixed values in order to implement the message delivery semantics defined by Hono's
+Telemetry and Event APIs.
+
+| Property Name      | Fixed Value |
+| :----------------- | :---------- |
+| `key.serializer`     | `org.apache.kafka.common.serialization.StringSerializer` |
+| `value.serializer`   | `io.vertx.kafka.client.serialization.BufferSerializer` |
 | `enable.idempotence` | `true` |
 
-{{% note title="Enable Kafka based Messaging" %}}
-The Kafka client requires the property `bootstrap.servers` to be provided. This variable is the minimal configuration 
-required to enable Kafka based messaging.
+{{% note title="Minimum required Configuration" %}}
+The Kafka client requires at least the `bootstrap.servers` property to be set in one of the configured property files.
 {{% /note %}}
 
 ### Using TLS
@@ -65,33 +69,32 @@ The factory can be configured to use TLS for
 * authenticating the brokers in the Kafka cluster during connection establishment and
 * (optionally) authenticating to the broker using a client certificate
 
-To use this, a Kafka Producer configuration as described in 
-[Kafka documentation - section "Security"](https://kafka.apache.org/documentation/#security_configclients) needs to be provided. 
-The properties must be prefixed with `HONO_KAFKA_PRODUCERCONFIG_` and `hono.kafka.producerConfig.` respectively as shown in 
-[Producer Configuration Properties]({{< relref "#producer-configuration-properties" >}}).
-The complete reference of available properties and the possible values is available in 
-[Kafka documentation - section "Producer Configs"](https://kafka.apache.org/documentation/#producerconfigs).
+Please refer to the [Producer Configs](https://kafka.apache.org/documentation/#producerconfigs) section of the Kafka
+documentation for a reference of corresponding properties and their possible values.
 
-## Consumer Configuration Properties
+## Configuring Kafka Consumers
 
-Consumers for Hono's Kafka based APIs are configured with instances of the class `org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties`
-which can be used to programmatically configure a consumer.
+The following table provides an overview of the configuration variables and corresponding command line options for configuring
+consumers. Note that the variables map to the properties of class `org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties`
+which can be used to programmatically configure the consumers being created.
 
-The configuration needs to be provided in the form `HONO_KAFKA_CONSUMERCONFIG_${PROPERTY}` as an environment variable or
-as a command line option in the form `hono.kafka.consumerConfig.${property}`, where `${PROPERTY}` respectively
-`${property}` is any of the Kafka client's [consumer properties](https://kafka.apache.org/documentation/#consumerconfigs).
-The provided configuration is passed directly to the Kafka consumer without Hono parsing or validating it.
+| Environment Variable<br>Command Line Option | Mandatory | Default Value | Description  |
+| :------------------------------------------ | :-------: | :------------ | :------------|
+| `HONO_KAFKA_DEFAULTCLIENTIDPREFIX`<br>`--hono.kafka.defaultClientIdPrefix` | no | - | The prefix for the client ID that is passed to the Kafka server to allow application specific server-side request logging.<br>If the configuration properties read from the configured files already contain a value for key `client.id`, that value will be used and this property's value will be ignored. |
+| `HONO_KAFKA_PROPERTYFILES`<br>`--hono.kafka.propertyFiles` | yes | - | A comma separated list of paths to files containing [Kafka properties](https://kafka.apache.org/documentation/#configuration) that should be used for configuring the connection to the broker and the consumers created. The files will be loaded in the specified order. The provided configuration is passed directly to the Kafka client without Hono parsing or validating it. |
+| `HONO_KAFKA_POLLTIMEOUT`<br>`--hono.kafka.pollTimeout` | no | `100` | The time to wait for records when polling the Kafka broker in milliseconds. |
 
-The following properties can _not_ be set using this mechanism because the protocol adapters use fixed values instead.
+The following properties will be ignored if set in any of the configured property files.
+Instead, Hono uses the specified fixed values in order to implement the message delivery semantics defined by Hono's
+Telemetry and Event APIs.
 
-| Kafka Consumer Config Property | Fixed Value |
-| :----------------------------- | :---------- |
-| `key.deserializer` | `org.apache.kafka.common.serialization.StringDeserializer` |
+| Property Name      | Fixed Value |
+| :----------------- | :---------- |
+| `key.deserializer`   | `org.apache.kafka.common.serialization.StringDeserializer` |
 | `value.deserializer` | `io.vertx.kafka.client.serialization.BufferDeserializer` |
 
-{{% note title="Enable Kafka based Messaging" %}}
-The Kafka client requires the property `bootstrap.servers` to be provided. This variable is the minimal configuration
-required to enable Kafka based messaging.
+{{% note title="Minimum required Configuration" %}}
+The Kafka client requires at least the `bootstrap.servers` property to be set in one of the configured property files.
 {{% /note %}}
 
 ### Using TLS
@@ -101,27 +104,22 @@ The factory can be configured to use TLS for
 * authenticating the brokers in the Kafka cluster during connection establishment and
 * (optionally) authenticating to the broker using a client certificate
 
-To use this, a Kafka Consumer configuration as described in
-[Kafka documentation - section "Security"](https://kafka.apache.org/documentation/#security_configclients) needs to be provided.
-The properties must be prefixed with `HONO_KAFKA_CONSUMERCONFIG_` and `hono.kafka.consumerConfig.` respectively as shown in
-[Consumer Configuration Properties]({{< relref "#consumer-configuration-properties" >}}).
-The complete reference of available properties and the possible values is available in
-[Kafka documentation - section "Consumer Configs"](https://kafka.apache.org/documentation/#consumerconfigs).
+Please refer to the [Consumer Configs](https://kafka.apache.org/documentation/#consumerconfigs) section of the Kafka
+documentation for a reference of corresponding properties and their possible values.
 
+## Configuring Admin Clients
 
-## Admin Client Configuration Properties
+The following table provides an overview of the configuration variables and corresponding command line options for configuring
+an Admin Client. Note that the variables map to the properties of class `org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties`
+which can be used to programmatically configure the admin clients being created.
 
-Admin clients for Hono's Kafka based APIs are configured with instances of the class `org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties`
-which can be used to programmatically configure an admin client.
+| Environment Variable<br>Command Line Option | Mandatory | Default Value | Description  |
+| :------------------------------------------ | :-------: | :------------ | :------------|
+| `HONO_KAFKA_DEFAULTCLIENTIDPREFIX`<br>`--hono.kafka.defaultClientIdPrefix` | no | - | The prefix for the client ID that is passed to the Kafka server to allow application specific server-side request logging.<br>If the configuration properties read from the configured files already contain a value for key `client.id`, that value will be used and this property's value will be ignored. |
+| `HONO_KAFKA_PROPERTYFILES`<br>`--hono.kafka.propertyFiles` | yes | - | A comma separated list of paths to files containing [Kafka properties](https://kafka.apache.org/documentation/#configuration) that should be used for configuring the connection to the broker and the clients created. The files will be loaded in the specified order. The provided configuration is passed directly to the Kafka client without Hono parsing or validating it. |
 
-The configuration needs to be provided in the form `HONO_KAFKA_ADMINCLIENTCONFIG_${PROPERTY}` as an environment variable or
-as a command line option in the form `hono.kafka.adminClientConfig.${property}`, where `${PROPERTY}` respectively
-`${property}` is any of the Kafka client's [admin client properties](https://kafka.apache.org/documentation/#adminclientconfigs).
-The provided configuration is passed directly to the Kafka admin client without Hono parsing or validating it.
-
-{{% note title="Enable Kafka based Messaging" %}}
-The Kafka client requires the property `bootstrap.servers` to be provided. This variable is the minimal configuration
-required to enable Kafka based messaging.
+{{% note title="Minimum required Configuration" %}}
+The Kafka client requires at least the `bootstrap.servers` property to be set in one of the configured property files.
 {{% /note %}}
 
 ### Using TLS
@@ -131,21 +129,5 @@ The factory can be configured to use TLS for
 * authenticating the brokers in the Kafka cluster during connection establishment and
 * (optionally) authenticating to the broker using a client certificate
 
-To use this, a Kafka admin client configuration as described in
-[Kafka documentation - section "Security"](https://kafka.apache.org/documentation/#security_configclients) needs to be provided.
-The properties must be prefixed with `HONO_KAFKA_ADMINCLIENTCONFIG_` and `hono.kafka.adminClientConfig.` respectively as shown in
-[Admin Client Configuration Properties]({{< relref "#admin-client-configuration-properties" >}}).
-The complete reference of available properties and the possible values is available in
-[Kafka documentation - section "Admin Configs"](https://kafka.apache.org/documentation/#adminclientconfigs).
-
-## Common Configuration Properties
-
-Configuration properties that are common to all the client types described above can be put in a common configuration section.
-This will avoid having to define duplicate configuration properties for the different client types.
-
-Relevant properties are `bootstrap.servers` and the properties related to the TLS configuration (see chapters above).
-
-The properties must be prefixed with `HONO_KAFKA_COMMONCLIENTCONFIG_` and `hono.kafka.commonClientConfig.` respectively.
-
-A property with the same name defined in the configuration of one of the specific client types above will have precedence
-over the common property.
+Please refer to the [AdminClient Configs](https://kafka.apache.org/documentation/#adminclientconfigs) section of the Kafka
+documentation for a reference of corresponding properties and their possible values.

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -110,6 +110,5 @@ spring:
   profiles: kafka
 hono:
   kafka:
-    producerConfig:
-      bootstrap:
-        servers: ${hono.kafka.bootstrap.servers}
+    propertyFiles:
+    - "/${hono.amqp-adapter.config-dir}/kafka.properties"

--- a/tests/src/test/resources/amqp/kafka.properties
+++ b/tests/src/test/resources/amqp/kafka.properties
@@ -1,0 +1,1 @@
+bootstrap.servers=${hono.kafka.bootstrap.servers}

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -109,6 +109,5 @@ spring:
   profiles: kafka
 hono:
   kafka:
-    producerConfig:
-      bootstrap:
-        servers: ${hono.kafka.bootstrap.servers}
+    propertyFiles:
+    - "/${hono.coap-adapter.config-dir}/kafka.properties"

--- a/tests/src/test/resources/coap/kafka.properties
+++ b/tests/src/test/resources/coap/kafka.properties
@@ -1,0 +1,1 @@
+bootstrap.servers=${hono.kafka.bootstrap.servers}

--- a/tests/src/test/resources/deviceregistry-jdbc/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc/application.yml
@@ -84,6 +84,5 @@ spring:
   profiles: kafka
 hono:
   kafka:
-    producerConfig:
-      bootstrap:
-        servers: ${hono.kafka.bootstrap.servers}
+    propertyFiles:
+    - "/etc/hono/kafka.properties"

--- a/tests/src/test/resources/deviceregistry-jdbc/kafka.properties
+++ b/tests/src/test/resources/deviceregistry-jdbc/kafka.properties
@@ -1,0 +1,1 @@
+bootstrap.servers=${hono.kafka.bootstrap.servers}

--- a/tests/src/test/resources/deviceregistry-mongodb/application.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/application.yml
@@ -63,6 +63,5 @@ spring:
   profiles: kafka
 hono:
   kafka:
-    producerConfig:
-      bootstrap:
-        servers: ${hono.kafka.bootstrap.servers}
+    propertyFiles:
+    - "/etc/hono/kafka.properties"

--- a/tests/src/test/resources/deviceregistry-mongodb/kafka.properties
+++ b/tests/src/test/resources/deviceregistry-mongodb/kafka.properties
@@ -1,0 +1,1 @@
+bootstrap.servers=${hono.kafka.bootstrap.servers}

--- a/tests/src/test/resources/deviceregistry/application.yml
+++ b/tests/src/test/resources/deviceregistry/application.yml
@@ -62,6 +62,5 @@ spring:
   profiles: kafka
 hono:
   kafka:
-    producerConfig:
-      bootstrap:
-        servers: ${hono.kafka.bootstrap.servers}
+    propertyFiles:
+    - "/etc/hono/kafka.properties"

--- a/tests/src/test/resources/deviceregistry/kafka.properties
+++ b/tests/src/test/resources/deviceregistry/kafka.properties
@@ -1,0 +1,1 @@
+bootstrap.servers=${hono.kafka.bootstrap.servers}

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -109,7 +109,6 @@ spring:
   profiles: kafka
 hono:
   kafka:
-    producerConfig:
-      bootstrap:
-        servers: ${hono.kafka.bootstrap.servers}
+    propertyFiles:
+    - "/${hono.http-adapter.config-dir}/kafka.properties"
 

--- a/tests/src/test/resources/http/kafka.properties
+++ b/tests/src/test/resources/http/kafka.properties
@@ -1,0 +1,1 @@
+bootstrap.servers=${hono.kafka.bootstrap.servers}

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -110,6 +110,5 @@ spring:
   profiles: kafka
 hono:
   kafka:
-    producerConfig:
-      bootstrap:
-        servers: ${hono.kafka.bootstrap.servers}
+    propertyFiles:
+    - "/${hono.mqtt-adapter.config-dir}/kafka.properties"

--- a/tests/src/test/resources/mqtt/kafka.properties
+++ b/tests/src/test/resources/mqtt/kafka.properties
@@ -1,0 +1,1 @@
+bootstrap.servers=${hono.kafka.bootstrap.servers}


### PR DESCRIPTION
This addresses #2549 

The classes used for configuring Kafka producers and consumers have been
refactored to read (Kafka) configuration properties from file(s) that
have been configured via a setter accepting a list of file names instead
of a Map of configuration properties.

This way, the configuration can also be set when using Quarkus based
images. The existing setters accepting Map<String, String> have been
removed in order to reduce mimgration efforts when migrating to Quarkus
completely.

Don't worry, most files changed are property files that are needed for running the integration tests.
Code changes affect only about ten files.