### PR TITLE
[#2490] Support Kafka messaging in Quarkus based Adapters.

### DIFF
--- a/adapter-base-quarkus/pom.xml
+++ b/adapter-base-quarkus/pom.xml
@@ -58,6 +58,11 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-tracerresolver</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-kafka-client</artifactId>
+      <version>${quarkus.platform.version}</version>
+    </dependency>
 
     <!-- testing -->
     <dependency>
@@ -111,6 +116,32 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-config-yaml</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-ide-launcher</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>
@@ -122,6 +153,15 @@
       <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+            <maven.home>${maven.home}</maven.home>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/KafkaRuntimeConfigProducer.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/KafkaRuntimeConfigProducer.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.quarkus;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties;
+import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parses Hono's Kafka configuration properties and provides them as beans.
+ * <p>
+ * This replaces the behavior of {@link io.quarkus.kafka.client.runtime.KafkaRuntimeConfigProducer} from Quarkus' Kafka
+ * extension. The dependency also provides some patches that are required to use the Kafka clients in native images with
+ * GraalVM.
+ */
+@ApplicationScoped
+public class KafkaRuntimeConfigProducer {
+
+    /**
+     * The prefix for Hono's common Kafka configuration.
+     */
+    public static final String COMMON_CONFIG_PREFIX = "hono.kafka.commonClientConfig";
+
+    /**
+     * The prefix for Hono's Kafka producer configuration.
+     */
+    public static final String PRODUCER_CONFIG_PREFIX = "hono.kafka.producerConfig";
+
+    /**
+     * The prefix for Hono's Kafka consumer configuration.
+     */
+    public static final String CONSUMER_CONFIG_PREFIX = "hono.kafka.consumerConfig";
+
+    /**
+     * The prefix for Hono's Kafka admin client configuration.
+     */
+    public static final String ADMIN_CLIENT_CONFIG_PREFIX = "hono.kafka.adminClientConfig";
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaRuntimeConfigProducer.class);
+
+    /**
+     * Exposes Hono's Kafka producer configuration properties as a bean.
+     * <p>
+     * The configuration properties are derived from the provided configuration with the prefixes
+     * {@link #COMMON_CONFIG_PREFIX} and {@link #PRODUCER_CONFIG_PREFIX}.
+     *
+     * @return The configuration properties.
+     */
+    @Produces
+    @Singleton
+    public KafkaProducerConfigProperties createKafkaProducerRuntimeConfig() {
+        final Config config = ConfigProvider.getConfig();
+
+        final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();
+        configProperties.setCommonClientConfig(createPropertiesFromConfig(config, COMMON_CONFIG_PREFIX));
+        configProperties.setProducerConfig(createPropertiesFromConfig(config, PRODUCER_CONFIG_PREFIX));
+        return configProperties;
+    }
+
+    /**
+     * Exposes Hono's Kafka consumer configuration properties as a bean.
+     * <p>
+     * The configuration properties are derived from the provided configuration with the prefixes
+     * {@link #COMMON_CONFIG_PREFIX} and {@link #CONSUMER_CONFIG_PREFIX}.
+     *
+     * @return The configuration properties.
+     */
+    @Produces
+    @Singleton
+    public KafkaConsumerConfigProperties createKafkaConsumerRuntimeConfig() {
+        final Config config = ConfigProvider.getConfig();
+
+        final KafkaConsumerConfigProperties configProperties = new KafkaConsumerConfigProperties();
+        configProperties.setCommonClientConfig(createPropertiesFromConfig(config, COMMON_CONFIG_PREFIX));
+        configProperties.setConsumerConfig(createPropertiesFromConfig(config, CONSUMER_CONFIG_PREFIX));
+        return configProperties;
+    }
+
+    /**
+     * Exposes Hono's Kafka admin client configuration properties as a bean.
+     * <p>
+     * The configuration properties are derived from the provided configuration with the prefixes
+     * {@link #COMMON_CONFIG_PREFIX} and {@link #ADMIN_CLIENT_CONFIG_PREFIX}.
+     *
+     * @return The configuration properties.
+     */
+    @Produces
+    @Singleton
+    public KafkaAdminClientConfigProperties createKafkaAdminClientRuntimeConfig() {
+        final Config config = ConfigProvider.getConfig();
+
+        final KafkaAdminClientConfigProperties configProperties = new KafkaAdminClientConfigProperties();
+        configProperties.setCommonClientConfig(createPropertiesFromConfig(config, COMMON_CONFIG_PREFIX));
+        configProperties.setAdminClientConfig(createPropertiesFromConfig(config, ADMIN_CLIENT_CONFIG_PREFIX));
+        return configProperties;
+    }
+
+    private Map<String, String> createPropertiesFromConfig(final Config config, final String configPrefix) {
+        final Map<String, String> properties = new HashMap<>();
+
+        LOG.trace("config properties picked up with names: {}", config.getPropertyNames());
+
+        StreamSupport.stream(config.getPropertyNames().spliterator(), false)
+                .filter(name -> name.startsWith(configPrefix))
+                .distinct()
+                .sorted()
+                .forEach(name -> {
+                    final String key = name.substring(configPrefix.length() + 1)
+                            .toLowerCase()
+                            .replaceAll("\"", "")
+                            .replaceAll("[^a-z0-9.]", ".");
+                    final String value = config.getOptionalValue(name, String.class).orElse("");
+                    properties.put(key, value);
+                });
+
+        LOG.debug("Kafka config properties: {}", properties);
+        return properties;
+    }
+
+}

--- a/adapter-base-quarkus/src/test/java/org/eclipse/hono/adapter/quarkus/KafkaRuntimeConfigProducerTest.java
+++ b/adapter-base-quarkus/src/test/java/org/eclipse/hono/adapter/quarkus/KafkaRuntimeConfigProducerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.quarkus;
+
+import javax.inject.Inject;
+
+import org.eclipse.hono.client.kafka.KafkaAdminClientConfigProperties;
+import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Verifies that {@link KafkaRuntimeConfigProducer} parses yaml files correctly and exposes the configuration as a
+ * beans.
+ */
+@QuarkusTest
+public class KafkaRuntimeConfigProducerTest {
+
+    @Inject
+    KafkaProducerConfigProperties kafkaProducerConfig;
+
+    @Inject
+    KafkaConsumerConfigProperties kafkaConsumerConfig;
+
+    @Inject
+    KafkaAdminClientConfigProperties kafkaAdminClientConfig;
+
+    /**
+     * Asserts that the Kafka configuration is exposed as a bean.
+     */
+    @Test
+    public void testThatBeanIsProvided() {
+        Assertions.assertNotNull(kafkaProducerConfig);
+        Assertions.assertNotNull(kafkaProducerConfig);
+
+        Assertions.assertNotNull(kafkaConsumerConfig);
+        Assertions.assertNotNull(kafkaConsumerConfig);
+
+        Assertions.assertNotNull(kafkaAdminClientConfig);
+        Assertions.assertNotNull(kafkaAdminClientConfig);
+    }
+
+    /**
+     * Asserts that properties with prefix {@link KafkaRuntimeConfigProducer#COMMON_CONFIG_PREFIX} are present.
+     */
+    @Test
+    public void testThatCommonConfigIsPresent() {
+        Assertions.assertEquals("present", kafkaProducerConfig.getProducerConfig("test").get("common.property"));
+    }
+
+    /**
+     * Asserts that properties with prefix {@link KafkaRuntimeConfigProducer#CONSUMER_CONFIG_PREFIX} are present.
+     */
+    @Test
+    public void testThatConsumerConfigIsPresent() {
+        Assertions.assertEquals("consumer", kafkaConsumerConfig.getConsumerConfig("test").get("consumer.property"));
+    }
+
+    /**
+     * Asserts that properties with prefix {@link KafkaRuntimeConfigProducer#ADMIN_CLIENT_CONFIG_PREFIX} are present.
+     */
+    @Test
+    public void testThatAdminClientConfigIsPresent() {
+        Assertions.assertEquals("admin",
+                kafkaAdminClientConfig.getAdminClientConfig("test").get("admin.property"));
+    }
+
+    /**
+     * Asserts that properties with prefix {@link KafkaRuntimeConfigProducer#PRODUCER_CONFIG_PREFIX} are present.
+     */
+    @Test
+    public void testThatProducerConfigIsPresent() {
+        Assertions.assertEquals("producer", kafkaProducerConfig.getProducerConfig("test").get("producer.property"));
+    }
+
+    /**
+     * Asserts that the properties' keys are converted to lowercase.
+     */
+    @Test
+    public void testThatKeysAreLowercase() {
+        Assertions.assertEquals("bar", kafkaProducerConfig.getProducerConfig("test").get("foo"));
+    }
+
+    /**
+     * Asserts that compound keys that contain dots are added and not changed.
+     */
+    @Test
+    public void testThatKeysWithDotsAreAllowed() {
+        Assertions.assertEquals("example.com:9999",
+                kafkaProducerConfig.getProducerConfig("test").get("bootstrap.servers"));
+    }
+
+    /**
+     * Asserts that properties with a numeric value added as strings.
+     */
+    @Test
+    public void testThatNumberArePresentAsStrings() {
+        Assertions.assertEquals("123", kafkaProducerConfig.getProducerConfig("test").get("number"));
+    }
+
+}

--- a/adapter-base-quarkus/src/test/resources/application.yaml
+++ b/adapter-base-quarkus/src/test/resources/application.yaml
@@ -1,0 +1,17 @@
+hono:
+  kafka:
+    commonClientConfig:
+      common:
+        property: "present"
+      number: 123
+      bootstrap.servers: example.com:9999
+      FOO: bar
+      admin.property: "common"
+      consumer.property: "common"
+      producer.property: "common"
+    adminClientConfig:
+      admin.property: "admin"
+    consumerConfig:
+      consumer.property: "consumer"
+    producerConfig:
+      producer.property: "producer"

--- a/adapters/amqp-vertx-quarkus/src/main/resources/reflection-config.json
+++ b/adapters/amqp-vertx-quarkus/src/main/resources/reflection-config.json
@@ -37,5 +37,23 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferSerializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferDeserializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]

--- a/adapters/coap-vertx-quarkus/src/main/resources/reflection-config.json
+++ b/adapters/coap-vertx-quarkus/src/main/resources/reflection-config.json
@@ -37,5 +37,23 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferSerializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferDeserializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]

--- a/adapters/http-vertx-quarkus/src/main/resources/reflection-config.json
+++ b/adapters/http-vertx-quarkus/src/main/resources/reflection-config.json
@@ -37,5 +37,23 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferSerializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferDeserializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]

--- a/adapters/lora-vertx-quarkus/src/main/resources/reflection-config.json
+++ b/adapters/lora-vertx-quarkus/src/main/resources/reflection-config.json
@@ -37,5 +37,23 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferSerializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferDeserializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]

--- a/adapters/mqtt-vertx-quarkus/src/main/resources/reflection-config.json
+++ b/adapters/mqtt-vertx-quarkus/src/main/resources/reflection-config.json
@@ -37,5 +37,23 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferSerializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.serialization.BufferDeserializer",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]


### PR DESCRIPTION
This fixes #2490. It adds support for messaging with Kafka to the Quarkus-based protocol adapters. It uses the Quarkus Kafka Extension which provides two features:
a) it parses the Kafka configuration and b) it provides fixes to the original Kafka client that are necessary to run it in GraalVM. The class `KafkaRuntimeConfigProducer` overwrites the config parsing so that it supports the Hono-specific prefixes for the Kafka configuration.

Initially, I implemented a custom Quarkus extension that parses Hono's Kafka configuration properties and provides them as beans. When testing it in native images, I found that the Kafka client needs a couple of fixes to run in GraalVM. Instead of implementing them on our own, we can simply include `quarkus-kafka-client` which already contains the fixes. So, I simply overwrite the parsing log for the Kafka config. The price is that produces and consumer properties are added to the same map so that one cannot use different values for the same common properties. But FMPOV this should be no real issue in practice. 

An alternative approach is provided by #2550.

Open: 
The Vert.x `BufferSerializer` needs to be added to the reflections file  (and maybe other classes as well) for the native image to work.