### PR TITLE
[#2478] Part 1: Extend ApplicationClient to send commands and wait for command responses

### DIFF
--- a/clients/adapter-amqp/pom.xml
+++ b/clients/adapter-amqp/pom.xml
@@ -44,10 +44,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
-    </dependency>
 
     <!-- test -->
     <dependency>

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandRouterClient.java
@@ -19,13 +19,13 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
-import org.eclipse.hono.adapter.client.amqp.AbstractRequestResponseServiceClient;
-import org.eclipse.hono.adapter.client.amqp.RequestResponseClient;
 import org.eclipse.hono.adapter.client.command.CommandRouterClient;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.AbstractRequestResponseServiceClient;
+import org.eclipse.hono.client.amqp.RequestResponseClient;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedDeviceConnectionClient.java
@@ -21,13 +21,13 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
-import org.eclipse.hono.adapter.client.amqp.AbstractRequestResponseServiceClient;
-import org.eclipse.hono.adapter.client.amqp.RequestResponseClient;
 import org.eclipse.hono.adapter.client.command.DeviceConnectionClient;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler.Factory;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.AbstractRequestResponseServiceClient;
+import org.eclipse.hono.client.amqp.RequestResponseClient;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedCredentialsClient.java
@@ -18,13 +18,13 @@ import java.net.HttpURLConnection;
 import java.util.Objects;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
-import org.eclipse.hono.adapter.client.amqp.AbstractRequestResponseServiceClient;
-import org.eclipse.hono.adapter.client.amqp.RequestResponseClient;
 import org.eclipse.hono.adapter.client.registry.CredentialsClient;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.AbstractRequestResponseServiceClient;
+import org.eclipse.hono.client.amqp.RequestResponseClient;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.Constants;

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedDeviceRegistrationClient.java
@@ -19,8 +19,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
-import org.eclipse.hono.adapter.client.amqp.AbstractRequestResponseServiceClient;
-import org.eclipse.hono.adapter.client.amqp.RequestResponseClient;
 import org.eclipse.hono.adapter.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
@@ -28,6 +26,8 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.AbstractRequestResponseServiceClient;
+import org.eclipse.hono.client.amqp.RequestResponseClient;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/registry/amqp/ProtonBasedTenantClient.java
@@ -24,13 +24,13 @@ import java.util.function.Supplier;
 import javax.security.auth.x500.X500Principal;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
-import org.eclipse.hono.adapter.client.amqp.AbstractRequestResponseServiceClient;
-import org.eclipse.hono.adapter.client.amqp.RequestResponseClient;
 import org.eclipse.hono.adapter.client.registry.TenantClient;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.AbstractRequestResponseServiceClient;
+import org.eclipse.hono.client.amqp.RequestResponseClient;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.MessageHelper;

--- a/clients/amqp-common/pom.xml
+++ b/clients/amqp-common/pom.xml
@@ -34,6 +34,10 @@
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>org.eclipse.hono</groupId>

--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/AbstractRequestResponseServiceClient.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/AbstractRequestResponseServiceClient.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.eclipse.hono.adapter.client.amqp;
+package org.eclipse.hono.client.amqp;
 
 import java.net.HttpURLConnection;
 import java.util.Arrays;
@@ -27,7 +27,6 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
-import org.eclipse.hono.client.amqp.AbstractServiceClient;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CacheDirective;

--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/RequestResponseClient.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/RequestResponseClient.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.eclipse.hono.adapter.client.amqp;
+package org.eclipse.hono.client.amqp;
 
 import java.net.HttpURLConnection;
 import java.util.Arrays;
@@ -34,7 +34,6 @@ import org.eclipse.hono.client.RequestResponseClientConfigProperties;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.StatusCodeMapper;
-import org.eclipse.hono.client.amqp.AbstractHonoClient;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.HonoProtonHelper;
 import org.eclipse.hono.util.MessageHelper;

--- a/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/AbstractRequestResponseServiceClientTest.java
+++ b/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/AbstractRequestResponseServiceClientTest.java
@@ -12,7 +12,7 @@
  */
 
 
-package org.eclipse.hono.adapter.client.amqp;
+package org.eclipse.hono.client.amqp;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/RequestResponseClientTest.java
+++ b/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/RequestResponseClientTest.java
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.adapter.client.amqp;
+package org.eclipse.hono.client.amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/SimpleRequestResponseResult.java
+++ b/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/SimpleRequestResponseResult.java
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.adapter.client.amqp;
+package org.eclipse.hono.client.amqp;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.message.Message;

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
@@ -23,6 +23,7 @@ import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.amqp.SenderCachingServiceClient;
 import org.eclipse.hono.util.AddressHelper;
+import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
 
@@ -40,6 +41,8 @@ import io.vertx.proton.ProtonHelper;
  */
 public class ProtonBasedCommandSender extends SenderCachingServiceClient implements CommandSender {
 
+    private final ProtonBasedRequestResponseCommandClient requestResponseClient;
+
     /**
      * Creates a new vertx-proton based command sender.
      *
@@ -51,6 +54,7 @@ public class ProtonBasedCommandSender extends SenderCachingServiceClient impleme
             final HonoConnection connection,
             final SendMessageSampler.Factory samplerFactory) {
         super(connection, samplerFactory);
+        requestResponseClient = new ProtonBasedRequestResponseCommandClient(connection, samplerFactory);
     }
 
     /**
@@ -90,6 +94,18 @@ public class ProtonBasedCommandSender extends SenderCachingServiceClient impleme
 
         return sendCommand(tenantId, deviceId, command, contentType, data, null, null, properties,
                 newChildSpan(context, "send one-way command"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<BufferResult> sendCommand(final String tenantId, final String deviceId, final String command,
+            final String contentType, final Buffer data, final String replyId, final Map<String, Object> properties,
+            final SpanContext context) {
+
+        return requestResponseClient.sendCommand(tenantId, deviceId, command, contentType, data, replyId, properties,
+                context);
     }
 
     private Future<Void> sendCommand(final String tenantId, final String deviceId, final String command,

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClient.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClient.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.application.client.amqp;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.amqp.AbstractRequestResponseServiceClient;
+import org.eclipse.hono.client.amqp.RequestResponseClient;
+import org.eclipse.hono.client.impl.CachingClientFactory;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.AddressHelper;
+import org.eclipse.hono.util.BufferResult;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.CommandConstants;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A vertx-proton based client for sending and receiving commands synchronously.
+ *
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control/">
+ *      Command &amp; Control API for AMQP 1.0 Specification</a>
+ */
+final class ProtonBasedRequestResponseCommandClient
+        extends AbstractRequestResponseServiceClient<Buffer, BufferResult> {
+
+    private int messageCounter;
+
+    /**
+     * Creates a vertx-proton based client for sending and receiving commands synchronously.
+     *
+     * @param connection The connection to the service.
+     * @param samplerFactory The factory for creating samplers for tracing AMQP messages being sent.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    protected ProtonBasedRequestResponseCommandClient(
+            final HonoConnection connection,
+            final SendMessageSampler.Factory samplerFactory) {
+        super(connection, samplerFactory,
+                new CachingClientFactory<>(connection.getVertx(), RequestResponseClient::isOpen), null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getKey(final String tenantId) {
+        return String.format("%s-%s", CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected BufferResult getResult(final int status, final String contentType, final Buffer payload,
+            final CacheDirective cacheDirective, final ApplicationProperties applicationProperties) {
+        return BufferResult.from(status, contentType, payload, applicationProperties);
+    }
+
+    /**
+     * Sends a command to a device and expects a response.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected to a protocol adapter
+     * and needs to have indicated its intent to receive commands.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The name of the command.
+     * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
+     * @param data The input data to the command or {@code null} if the command has no input data.
+     * @param replyId An arbitrary string which gets used for the response link address in the form of
+     *            <em>command_response/${tenantId}/${replyId}</em>. If it is {@code null} then an unique 
+     *                identifier generated using {@link UUID#randomUUID()} is used.
+     * @param properties The headers to include in the command message as AMQP application properties.
+     * @param context The currently active OpenTracing span context that is used to trace the execution of this
+     *            operation or {@code null} if no span is currently active.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed if a response with status 2xx has been received from the device.
+     *         If the response has no payload, the future will complete with {@code null}.
+     *         <p>
+     *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code. Status codes are defined at 
+     *         <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.
+     * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
+     */
+    public Future<BufferResult> sendCommand(final String tenantId, final String deviceId, final String command,
+            final String contentType, final Buffer data, final String replyId, final Map<String, Object> properties,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(command);
+
+        final Span currentSpan = newChildSpan(context, "send command and receive response");
+
+        return getOrCreateClient(tenantId, replyId)
+                .compose(client -> {
+                    final String messageTargetAddress = AddressHelper
+                            .getTargetAddress(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, deviceId,
+                                    connection.getConfig());
+                    return client.createAndSendRequest(command, messageTargetAddress, properties, data, contentType,
+                            this::getRequestResponseResult, currentSpan);
+                })
+                .recover(error -> {
+                    Tags.HTTP_STATUS.set(currentSpan, ServiceInvocationException.extractStatusCode(error));
+                    TracingHelper.logError(currentSpan, error);
+                    return Future.failedFuture(error);
+                })
+                .map(bufferResult -> {
+                    setTagsForResult(currentSpan, bufferResult);
+                    if (bufferResult != null && bufferResult.isError()) {
+                        throw StatusCodeMapper.from(bufferResult);
+                    }
+                    return bufferResult;
+                })
+                .onComplete(r -> currentSpan.finish());
+    }
+
+    private Future<RequestResponseClient<BufferResult>> getOrCreateClient(final String tenantId, final String replyId) {
+
+        return connection.isConnected(getDefaultConnectionCheckTimeout())
+                .compose(v -> connection.executeOnContext(result -> clientFactory.getOrCreateClient(
+                        getKey(tenantId),
+                        () -> RequestResponseClient.forEndpoint(
+                                connection,
+                                CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT,
+                                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT,
+                                tenantId,
+                                Optional.ofNullable(replyId).orElse(UUID.randomUUID().toString()),
+                                this::createMessageId,
+                                samplerFactory.create(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT),
+                                this::removeClient, this::removeClient),
+                        result)));
+    }
+
+    /**
+     * The command's message ID is transferred to the device in order to be able to correlate the response received from
+     * the device with the request message. It is therefore desirable to keep the message ID as short as possible in
+     * order to reduce the number of bytes exchanged with the device.
+     * <p>
+     * This methods creates message IDs based on a counter that is increased on each invocation.
+     *
+     * @return The message ID.
+     */
+    private String createMessageId() {
+        return Long.toString(++messageCounter, Character.MAX_RADIX);
+    }
+
+}

--- a/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClientTest.java
+++ b/clients/application-amqp/src/test/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClientTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.application.client.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.SendMessageSampler;
+import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonMessageHandler;
+import io.vertx.proton.ProtonQoS;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+/**
+ * Tests verifying behavior of {@link ProtonBasedRequestResponseCommandClient}.
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class ProtonBasedRequestResponseCommandClientTest {
+    private HonoConnection connection;
+    private ProtonBasedRequestResponseCommandClient requestResponseCommandClient;
+    private ProtonSender sender;
+    private ProtonDelivery protonDelivery;
+    private String tenantId;
+    private String deviceId;
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    void setUp() {
+        final var vertx = mock(Vertx.class);
+        connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx);
+
+        final ProtonReceiver receiver = AmqpClientUnitTestHelper.mockProtonReceiver();
+        when(connection.createReceiver(anyString(), any(ProtonQoS.class), any(ProtonMessageHandler.class),
+                VertxMockSupport.anyHandler()))
+                        .thenReturn(Future.succeededFuture(receiver));
+
+        protonDelivery = mock(ProtonDelivery.class);
+        sender = AmqpClientUnitTestHelper.mockProtonSender();
+        when(sender.send(any(Message.class), VertxMockSupport.anyHandler())).thenReturn(protonDelivery);
+        when(connection.createSender(anyString(), any(), any())).thenReturn(Future.succeededFuture(sender));
+        requestResponseCommandClient = new ProtonBasedRequestResponseCommandClient(connection, SendMessageSampler.Factory.noop());
+
+        tenantId = UUID.randomUUID().toString();
+        deviceId = UUID.randomUUID().toString();
+    }
+
+    /**
+     * Verifies that a command has been sent to a device and also a response for that command from that device has been
+     * received successfully.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendCommandSucceeds(final VertxTestContext ctx) {
+        final String subject = "setVolume";
+        final String replyId = UUID.randomUUID().toString();
+        final Map<String, Object> properties = Map.of("appKey", "appValue");
+        final int commandStatus = HttpURLConnection.HTTP_OK;
+        final String responseContentType = MessageHelper.CONTENT_TYPE_APPLICATION_JSON;
+        final String responsePayload = "{\"status\": 1}";
+
+        // WHEN sending a command with some application properties and payload
+        requestResponseCommandClient
+                .sendCommand(tenantId, deviceId, subject, null, Buffer.buffer("{\"value\": 20}"), replyId,
+                        properties, NoopSpan.INSTANCE.context())
+                .onComplete(ctx.succeeding(response -> {
+                    ctx.verify(() -> {
+                        // VERIFY the properties of the received response.
+                        assertThat(response.getStatus()).isEqualTo(commandStatus);
+                        assertThat(response.getContentType()).isEqualTo(responseContentType);
+                        assertThat(response.getPayload().toString()).isEqualTo(responsePayload);
+                    });
+                    ctx.completeNow();
+                }));
+
+        // VERIFY that the command has been sent and it's properties
+        final Message sentMessage = AmqpClientUnitTestHelper.assertMessageHasBeenSent(sender);
+        assertThat(sentMessage.getSubject()).isEqualTo(subject);
+        assertThat(sentMessage.getReplyTo()).endsWith(replyId);
+        assertThat(MessageHelper.getApplicationProperty(sentMessage.getApplicationProperties(), "appKey", String.class))
+                .isEqualTo("appValue");
+
+        final Message response = ProtonHelper.message();
+        response.setCorrelationId(sentMessage.getMessageId());
+        MessageHelper.addTenantId(response, tenantId);
+        MessageHelper.addDeviceId(response, deviceId);
+        MessageHelper.addStatus(response, commandStatus);
+        MessageHelper.setPayload(response, MessageHelper.CONTENT_TYPE_APPLICATION_JSON, Buffer.buffer(responsePayload));
+        AmqpClientUnitTestHelper.assertReceiverLinkCreated(connection).handle(protonDelivery, response);
+    }
+
+    /**
+     * Verifies that a command sent has its properties set correctly.
+     *
+     * <ul>
+     * <li>subject set to given command</li>
+     * <li>message-id not null</li>
+     * <li>content-type set to given type</li>
+     * <li>target address set to command/${tenant_id}/${device_id}</li>
+     * <li>reply-to address set to command_response/${tenant_id}/${reply_id}</li>
+     * </ul>
+     */
+    @Test
+    public void testSendCommandSetsProperties() {
+        final String replyId = UUID.randomUUID().toString();
+        final Map<String, Object> applicationProperties = new HashMap<>();
+        applicationProperties.put("appKey", "appValue");
+
+        requestResponseCommandClient
+                .sendCommand(tenantId, deviceId, "doSomething", "text/plain", Buffer.buffer("payload"), replyId,
+                        applicationProperties, NoopSpan.INSTANCE
+                                .context());
+
+        final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(sender).send(messageCaptor.capture(), VertxMockSupport.anyHandler());
+        assertThat(messageCaptor.getValue().getAddress()).isEqualTo(
+                String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, deviceId));
+        assertThat(messageCaptor.getValue().getReplyTo()).isEqualTo(
+                String.format("%s/%s/%s", CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT, tenantId, replyId));
+        assertThat(messageCaptor.getValue().getSubject()).isEqualTo("doSomething");
+        assertNotNull(messageCaptor.getValue().getMessageId());
+        assertThat(messageCaptor.getValue().getContentType()).isEqualTo("text/plain");
+        assertNotNull(messageCaptor.getValue().getApplicationProperties());
+        assertThat(messageCaptor.getValue().getApplicationProperties().getValue().get("appKey")).isEqualTo("appValue");
+    }
+}

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -23,6 +23,7 @@ import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
+import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.MessageHelper;
 
 import io.opentracing.SpanContext;
@@ -98,6 +99,33 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender imp
         Objects.requireNonNull(command);
 
         return sendCommand(tenantId, deviceId, command, contentType, data, null, properties, false, context);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * The replyId is not used in the Kafka based implementation. It can be set to {@code null}.
+     * If set it will be ignored.
+     *
+     * @throws NullPointerException if tenantId, deviceId, or command is {@code null}.
+     */
+    @Override
+    public Future<BufferResult> sendCommand(
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final String contentType,
+            final Buffer data,
+            final String replyId,
+            final Map<String, Object> properties,
+            final SpanContext context) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(command);
+
+        // TODO to implement.
+        return null;
     }
 
     private Future<Void> sendCommand(final String tenantId, final String deviceId, final String command,

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.application.client;
 import java.util.Map;
 
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.Lifecycle;
 
 import io.opentracing.SpanContext;
@@ -209,6 +210,106 @@ public interface CommandSender extends Lifecycle {
             String command,
             String contentType,
             Buffer data,
+            Map<String, Object> properties,
+            SpanContext context);
+
+    /**
+     * Sends a command to a device and expects a response.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected to a protocol adapter
+     * and needs to have indicated its intent to receive commands.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The name of the command.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed if a response with status 2xx has been received from the device.
+     *         If the response has no payload, the future will complete with {@code null}.
+     *         <p>
+     *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code. Status codes are defined at
+     *         <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.
+     * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
+     */
+    default Future<BufferResult> sendCommand(
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final Buffer data) {
+        return sendCommand(tenantId, deviceId, command, null, data, null);
+    }
+
+    /**
+     * Sends a command to a device and expects a response.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected to a protocol adapter
+     * and needs to have indicated its intent to receive commands.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The name of the command.
+     * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @param properties The headers to include in the command message.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed if a response with status 2xx has been received from the device.
+     *         If the response has no payload, the future will complete with {@code null}.
+     *         <p>
+     *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code. Status codes are defined at 
+     *         <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.
+     * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
+     */
+    default Future<BufferResult> sendCommand(
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final String contentType,
+            final Buffer data,
+            final Map<String, Object> properties) {
+        return sendCommand(tenantId, deviceId, command, contentType, data, null, properties, null);
+    }
+
+    /**
+     * Sends a command to a device and expects a response.
+     * <p>
+     * A device needs to be (successfully) registered before a client can upload
+     * any data for it. The device also needs to be connected to a protocol adapter
+     * and needs to have indicated its intent to receive commands.
+     *
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device to send the command to.
+     * @param command The name of the command.
+     * @param contentType The type of the data submitted as part of the command or {@code null} if unknown.
+     * @param data The command data to send to the device or {@code null} if the command has no input data.
+     * @param replyId An arbitrary string which will be used to create the reply-to address to be included in commands
+     *                sent to devices of the tenant. If the messaging network specific Command &amp; Control 
+     *                implementation does not require a replyId, the specified value will be ignored.
+     * @param properties The headers to include in the command message.
+     * @param context The currently active OpenTracing span context that is used to trace the execution of this
+     *            operation or {@code null} if no span is currently active.
+     * @return A future indicating the result of the operation.
+     *         <p>
+     *         The future will succeed if a response with status 2xx has been received from the device.
+     *         If the response has no payload, the future will complete with {@code null}.
+     *         <p>
+     *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
+     *         the (error) status code. Status codes are defined at 
+     *         <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.
+     * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
+     */
+    Future<BufferResult> sendCommand(
+            String tenantId,
+            String deviceId,
+            String command,
+            String contentType,
+            Buffer data,
+            String replyId,
             Map<String, Object> properties,
             SpanContext context);
 }


### PR DESCRIPTION
This PR contains new methods added to the `ApplicationClient` which enables the client to send a command, wait and receive a response for that command. In order to keep this PR short and easier for review, it contains only AMQP 1.0 based implementation of these API methods. Kafka based implementation will be provided in the consecutive PR.