### PR TITLE
[#2535] Remove "tech preview" status of Command Router

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
       matrix:
         device-registry: [file,jdbc,mongodb]
         include:
-          # let the jdbc test-run use the command-router component
+          # let the jdbc test-run use the device connection service component (instead of the command router)
           - device-registry: jdbc
-            commandrouting-mode: commandrouter
+            commandrouting-mode: dev-con-service
           # let the mongodb test-run use the quarkus adapters
           - device-registry: mongodb
             component-type: quarkus-jvm
 
-    name: Use ${{ matrix.device-registry }}-registry [${{ matrix.adapters-type }}${{ matrix.commandrouting-mode }}]
+    name: Use ${{ matrix.device-registry }}-registry [${{ matrix.component-type }}${{ matrix.commandrouting-mode }}]
     steps:
     - uses: actions/checkout@v2
     - name: Cache local Maven repository

--- a/site/documentation/content/admin-guide/command-router-config.md
+++ b/site/documentation/content/admin-guide/command-router-config.md
@@ -10,11 +10,6 @@ The Command Router service provides an implementation of Eclipse Hono&trade;'s [
 
 <!--more-->
 
-{{% note title="Tech preview" %}}
-This component is not considered production ready yet. It is meant as a replacement for the component implementing the [Device Connection API]({{< relref "/api/device-connection" >}}).
-It can be used by configuring the [Command Router service connection properties]({{< relref "common-config.md/#command-router-service-connection-configuration" >}}), instead of the Device Connection service connection properties, in the protocol adapter.
-{{% /note %}}
-
 The Command Router component provides an implementation of the Command Router API which uses a remote *data grid* for storing information about device connections. The data grid can be scaled out independently from the Command Router service components to meet the storage demands at hand.
 
 The Command Router component is implemented as a Spring Boot application. It can be run either directly from the command line or by means of starting the corresponding [Docker image](https://hub.docker.com/r/eclipse/hono-service-command-router/) created from it.

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -21,6 +21,7 @@ description = "Information about changes in recent Hono releases. Includes new f
   [MQTT Adapter User Guide] ({{% doclink "/user-guide/mqtt-adapter/#error-reporting-via-error-topic" %}}) for details.
 * The LoraWAN protocol adapter now supports command and control for providers *Chirpstack*, *Firefly* and *Loriot*.
 * The MQTT adapter now supports mapping the command payload through an external http service.
+* The Command Router component has been promoted from *tech preview* to *fully supported*.
 
 ### Fixes & Enhancements
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -76,13 +76,13 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
 
     <!--
      Properties defining whether the Device Connection service (now deprecated) or the Command Router service
-     shall be used for Command & Control. The default here lets the Device Connection service be used.
-     See the 'command-router' maven profile below for the Command Router values.
+     shall be used for Command & Control. The default here lets the Command Router service be used.
+     See the 'device-connection-service' maven profile below for the Device Connection service values.
      -->
-    <hono.command-related-service.configname>deviceConnection</hono.command-related-service.configname>
-    <hono.command-related-service.host>${hono.device-connection.host}</hono.command-related-service.host>
-    <hono.commandrouter.disabled>true</hono.commandrouter.disabled>
-    <hono.device-connection.disabled>false</hono.device-connection.disabled>
+    <hono.command-related-service.configname>commandRouter</hono.command-related-service.configname>
+    <hono.command-related-service.host>${hono.commandrouter.host}</hono.command-related-service.host>
+    <hono.commandrouter.disabled>false</hono.commandrouter.disabled>
+    <hono.device-connection.disabled>true</hono.device-connection.disabled>
 
     <!--
       Messaging related properties - AMQP is used as the default one.
@@ -316,18 +316,18 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       </properties>
     </profile>
     <profile>
-      <id>command-router</id>
+      <id>device-connection-service</id>
       <activation>
         <property>
           <name>hono.commandrouting.mode</name>
-          <value>commandrouter</value>
+          <value>dev-con-service</value>
         </property>
       </activation>
       <properties>
-        <hono.command-related-service.configname>commandRouter</hono.command-related-service.configname>
-        <hono.command-related-service.host>${hono.commandrouter.host}</hono.command-related-service.host>
-        <hono.commandrouter.disabled>false</hono.commandrouter.disabled>
-        <hono.device-connection.disabled>true</hono.device-connection.disabled>
+        <hono.command-related-service.configname>deviceConnection</hono.command-related-service.configname>
+        <hono.command-related-service.host>${hono.device-connection.host}</hono.command-related-service.host>
+        <hono.commandrouter.disabled>true</hono.commandrouter.disabled>
+        <hono.device-connection.disabled>false</hono.device-connection.disabled>
       </properties>
     </profile>
     <profile>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -140,11 +140,11 @@ Note: the profile can also be activated by setting the Maven property *hono.comp
 mvn verify -Prun-tests -Dhono.components.type=quarkus-jvm
 ```
 
-### Running the Tests with the Command Router component
+### Running the Tests with the Device Connection service component
 
-By default, the integration tests are run using the Device Connection service component. In order to use the Command
-Router service component instead, the `command-router` maven profile can be set:
+By default, the integration tests are run using the Command Router service component. In order to use the Device
+Connection service component instead, the `device-connection-service` maven profile can be set:
 
 ```sh
-mvn verify -Prun-tests,command-router
+mvn verify -Prun-tests,device-connection-service
 ```


### PR DESCRIPTION
Also use Command Router per default in the integration tests.

This fixes #2535.