### PR TITLE
Run command handler in correct vert.x context

### DIFF
--- a/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandConsumerTest.java
+++ b/clients/adapter-amqp/src/test/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandConsumerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.proton.ProtonDelivery;
@@ -52,6 +53,7 @@ public class ProtonBasedInternalCommandConsumerTest {
 
     private ProtonBasedInternalCommandConsumer internalCommandConsumer;
     private CommandHandlers commandHandlers;
+    private Context context;
 
     /**
      * Sets up fixture.
@@ -64,6 +66,7 @@ public class ProtonBasedInternalCommandConsumerTest {
         commandHandlers = new CommandHandlers();
         internalCommandConsumer = new ProtonBasedInternalCommandConsumer(honoConnection, adapterInstanceId,
                 commandHandlers);
+        context = VertxMockSupport.mockContext(mock(Vertx.class));
     }
 
     /**
@@ -115,7 +118,7 @@ public class ProtonBasedInternalCommandConsumerTest {
         message.setCorrelationId(correlationId);
 
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
-        commandHandlers.putCommandHandler(Constants.DEFAULT_TENANT, deviceId, null, commandHandler);
+        commandHandlers.putCommandHandler(Constants.DEFAULT_TENANT, deviceId, null, commandHandler, context);
 
         internalCommandConsumer.handleCommandMessage(mock(ProtonDelivery.class), message);
 
@@ -143,7 +146,7 @@ public class ProtonBasedInternalCommandConsumerTest {
                 new ApplicationProperties(Collections.singletonMap(MessageHelper.APP_PROPERTY_CMD_VIA, gatewayId)));
 
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
-        commandHandlers.putCommandHandler(Constants.DEFAULT_TENANT, gatewayId, null, commandHandler);
+        commandHandlers.putCommandHandler(Constants.DEFAULT_TENANT, gatewayId, null, commandHandler, context);
 
         internalCommandConsumer.handleCommandMessage(mock(ProtonDelivery.class), message);
 
@@ -171,7 +174,7 @@ public class ProtonBasedInternalCommandConsumerTest {
         message.setCorrelationId(correlationId);
 
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
-        commandHandlers.putCommandHandler(Constants.DEFAULT_TENANT, deviceId, gatewayId, commandHandler);
+        commandHandlers.putCommandHandler(Constants.DEFAULT_TENANT, deviceId, gatewayId, commandHandler, context);
 
         internalCommandConsumer.handleCommandMessage(mock(ProtonDelivery.class), message);
 

--- a/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandConsumerTest.java
+++ b/clients/adapter-kafka/src/test/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandConsumerTest.java
@@ -33,7 +33,9 @@ import org.mockito.ArgumentCaptor;
 
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.kafka.admin.KafkaAdminClient;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
@@ -48,6 +50,7 @@ public class KafkaBasedInternalCommandConsumerTest {
 
     private KafkaBasedInternalCommandConsumer internalCommandConsumer;
     private CommandHandlers commandHandlers;
+    private Context context;
 
     /**
      * Sets up fixture.
@@ -67,6 +70,7 @@ public class KafkaBasedInternalCommandConsumerTest {
                 adapterInstanceId,
                 commandHandlers,
                 tracer);
+        context = VertxMockSupport.mockContext(mock(Vertx.class));
     }
 
     /**
@@ -83,7 +87,7 @@ public class KafkaBasedInternalCommandConsumerTest {
         final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(deviceId, headers);
 
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
-        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler);
+        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler, context);
 
         internalCommandConsumer.handleCommandMessage(commandRecord);
 
@@ -109,7 +113,7 @@ public class KafkaBasedInternalCommandConsumerTest {
                 getHeaders(tenantId, deviceId, subject));
 
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
-        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler);
+        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler, context);
 
         internalCommandConsumer.handleCommandMessage(commandRecord);
 
@@ -136,7 +140,7 @@ public class KafkaBasedInternalCommandConsumerTest {
         final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(deviceId, headers);
 
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
-        commandHandlers.putCommandHandler(tenantId, gatewayId, null, commandHandler);
+        commandHandlers.putCommandHandler(tenantId, gatewayId, null, commandHandler, context);
 
         internalCommandConsumer.handleCommandMessage(commandRecord);
 
@@ -164,7 +168,7 @@ public class KafkaBasedInternalCommandConsumerTest {
                 getHeaders(tenantId, deviceId, subject));
 
         final Handler<CommandContext> commandHandler = VertxMockSupport.mockHandler();
-        commandHandlers.putCommandHandler(tenantId, deviceId, gatewayId, commandHandler);
+        commandHandlers.putCommandHandler(tenantId, deviceId, gatewayId, commandHandler, context);
 
         internalCommandConsumer.handleCommandMessage(commandRecord);
 

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandHandlerWrapper.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandHandlerWrapper.java
@@ -15,7 +15,9 @@ package org.eclipse.hono.adapter.client.command;
 
 import java.util.Objects;
 
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 
 /**
  * Wraps a command handler to be used in a command consumer.
@@ -26,6 +28,7 @@ public final class CommandHandlerWrapper {
     private final String deviceId;
     private final String gatewayId;
     private final Handler<CommandContext> commandHandler;
+    private final Context context;
 
     /**
      * Creates a new CommandHandlerWrapper.
@@ -38,14 +41,16 @@ public final class CommandHandlerWrapper {
      *                  using a {@code null} value here and providing the gateway id in the <em>deviceId</em>
      *                  parameter.)
      * @param commandHandler The command handler.
+     * @param context The vert.x context to run the handler on or {@code null} to invoke the handler directly.
      * @throws NullPointerException If tenantId, deviceId or commandHandler is {@code null}.
      */
     public CommandHandlerWrapper(final String tenantId, final String deviceId, final String gatewayId,
-                                 final Handler<CommandContext> commandHandler) {
+            final Handler<CommandContext> commandHandler, final Context context) {
         this.tenantId = Objects.requireNonNull(tenantId);
         this.deviceId = Objects.requireNonNull(deviceId);
         this.gatewayId = gatewayId;
         this.commandHandler = Objects.requireNonNull(commandHandler);
+        this.context = context;
     }
 
     /**
@@ -82,7 +87,11 @@ public final class CommandHandlerWrapper {
      * @param commandContext The command context to pass on to the command handler.
      */
     public void handleCommand(final CommandContext commandContext) {
-        commandHandler.handle(commandContext);
+        if (context == null || Vertx.currentContext() == context) {
+            commandHandler.handle(commandContext);
+        } else {
+            context.runOnContext(go -> commandHandler.handle(commandContext));
+        }
     }
 
     @Override

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandHandlers.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandHandlers.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
 
 /**
@@ -45,16 +46,17 @@ public class CommandHandlers {
      * @param commandHandler The command handler. The handler must invoke one of the terminal methods of the passed
      *                       in {@link CommandContext} in order to settle the command message transfer and finish
      *                       the trace span associated with the {@link CommandContext}.
+     * @param context The vert.x context to run the handler on or {@code null} to invoke the handler directly.
      * @return The replaced handler entry or {@code null} if there was none.
      * @throws NullPointerException If any of tenantId, deviceId or commandHandler is {@code null}.
      */
     public CommandHandlerWrapper putCommandHandler(final String tenantId, final String deviceId,
-            final String gatewayId, final Handler<CommandContext> commandHandler) {
+            final String gatewayId, final Handler<CommandContext> commandHandler, final Context context) {
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(commandHandler);
 
-        return putCommandHandler(new CommandHandlerWrapper(tenantId, deviceId, gatewayId, commandHandler));
+        return putCommandHandler(new CommandHandlerWrapper(tenantId, deviceId, gatewayId, commandHandler, context));
     }
 
     /**

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandRouterCommandConsumerFactory.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/CommandRouterCommandConsumerFactory.java
@@ -34,6 +34,7 @@ import io.opentracing.SpanContext;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 
 /**
  * A factory for creating consumers of command messages.
@@ -120,9 +121,6 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
         return CompositeFuture.all(futures).mapEmpty();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final Future<CommandConsumer> createCommandConsumer(
             final String tenantId,
@@ -138,9 +136,6 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
         return doCreateCommandConsumer(tenantId, deviceId, null, commandHandler, lifespan, context);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final Future<CommandConsumer> createCommandConsumer(
             final String tenantId,
@@ -172,7 +167,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
 
         // register the command handler
         final CommandHandlerWrapper commandHandlerWrapper = new CommandHandlerWrapper(tenantId, deviceId, gatewayId,
-                commandHandler);
+                commandHandler, Vertx.currentContext());
         commandHandlers.putCommandHandler(commandHandlerWrapper);
         final Instant lifespanStart = Instant.now();
 


### PR DESCRIPTION
Command processing in the adapters needs to be done in the correct vert.x context. Otherwise there will for example be concurrency issues in the AMQP adapter concerning the AMQP connection to the device used for sending the command. 

Since there is only *one* KafkaBasedInternalCommandConsumer instance where commands are received, command handlers explicitly need to be run on the correct context. (That isn't a problem with the  ProtonBasedInternalCommandConsumer since its (multiple) instances use the same context as the corresponding adapter verticles.)
