### PR TITLE
 [#2545] Close AMQP device connection on terminal errors

### DIFF
--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -110,6 +110,11 @@ The AMQP adapter distinguishes between two types of errors when a message is pub
 
 For a client side error, the adapter settles the message transfer with the *rejected* outcome and provides an error description in the corresponding disposition frame. In the case of a server-side error, the adapter settles the message with the *released* outcome, indicating to the client that the message itself was OK but it cannot be delivered due to a failure beyond the control of the client. In the latter case, a client may attempt to re-send the message unaltered.
 
+In case of terminal errors the AMQP connection to the device is closed. The errors that are classified as terminal are listed below.
+
+* The adapter is disabled for the tenant that the client belongs to.
+* The authenticated device or gateway is disabled or not registered.
+* The tenant is disabled or does not exist.
 
 ## AMQP Command-line Client
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -23,6 +23,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   [MQTT Adapter User Guide] ({{% doclink "/user-guide/mqtt-adapter/#error-reporting-via-error-topic" %}}) for details.
 * The MQTT adapter now supports mapping the command payload through an external http service.
 * The Command Router component has been promoted from *tech preview* to *fully supported*.
+* The AMQP adapter now closes the network connection to the device if any terminal errors happen. Please refer to the
+  [AMQP Adapter User Guide]({{% doclink "/user-guide/amqp-adapter/#error-handling" %}}) for details.
 
 ### Fixes & Enhancements
 


### PR DESCRIPTION
This PR closes the issue #2545.

Now the _AMQP_ adapter closes the connection to the device if one of the following terminal errors occur.

* The adapter is disabled for the tenant that the client belongs to.
* The authenticated device or gateway is disabled or not registered.
* The tenant is disabled or does not exist.