### PR TITLE
Use "hono.kafka" config prefix in Command Router

### DIFF
--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/KafkaRuntimeConfigProducer.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/KafkaRuntimeConfigProducer.java
@@ -36,17 +36,17 @@ public class KafkaRuntimeConfigProducer {
     /**
      * The prefix of the common Kafka configuration.
      */
-    public static final String COMMON_CONFIG_PREFIX = "hono.command.kafka.commonClientConfig";
+    public static final String COMMON_CONFIG_PREFIX = "hono.kafka.commonClientConfig";
 
     /**
      * The prefix of the Kafka producer configuration.
      */
-    public static final String PRODUCER_CONFIG_PREFIX = "hono.command.kafka.producerConfig";
+    public static final String PRODUCER_CONFIG_PREFIX = "hono.kafka.producerConfig";
 
     /**
      * The prefix of the Kafka consumer configuration.
      */
-    public static final String CONSUMER_CONFIG_PREFIX = "hono.command.kafka.consumerConfig";
+    public static final String CONSUMER_CONFIG_PREFIX = "hono.kafka.consumerConfig";
 
     private static final String DEFAULT_CLIENT_ID_PREFIX = "cmd-router";
 

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/spring/ApplicationConfig.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/spring/ApplicationConfig.java
@@ -402,7 +402,7 @@ public class ApplicationConfig {
      *
      * @return The properties.
      */
-    @ConfigurationProperties(prefix = "hono.command.kafka")
+    @ConfigurationProperties(prefix = "hono.kafka")
     @Bean
     public KafkaConsumerConfigProperties kafkaConsumerConfig() {
         final KafkaConsumerConfigProperties kafkaConsumerConfigProperties = new KafkaConsumerConfigProperties();
@@ -415,7 +415,7 @@ public class ApplicationConfig {
      *
      * @return The properties.
      */
-    @ConfigurationProperties(prefix = "hono.command.kafka")
+    @ConfigurationProperties(prefix = "hono.kafka")
     @Bean
     public KafkaProducerConfigProperties kafkaProducerConfig() {
         final KafkaProducerConfigProperties configProperties = new KafkaProducerConfigProperties();

--- a/tests/src/test/resources/commandrouter/application.yml
+++ b/tests/src/test/resources/commandrouter/application.yml
@@ -48,9 +48,9 @@ hono:
     linkEstablishmentTimeout: ${link.establishment.timeout}
     flowLatency: ${flow.latency}
     requestTimeout: ${request.timeout}
-    kafka:
-      commonClientConfig:
-        bootstrap.servers: ${hono.kafka.bootstrap.servers}
+  kafka:
+    commonClientConfig:
+      bootstrap.servers: ${hono.kafka.bootstrap.servers}
   vertx:
     maxEventLoopExecuteTime: ${max.event-loop.execute-time}
     preferNative: true


### PR DESCRIPTION
Using "hono.kafka" instead of "hono.command.kafka" follows the convention used in the protocol adapters.