### PR TITLE
[#2478] Prepare for Kafka based north-bound API implementation to send commands and receive responses

### DIFF
--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedCommandSender.java
@@ -18,12 +18,12 @@ import java.util.Optional;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.application.client.CommandSender;
+import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.StatusCodeMapper;
 import org.eclipse.hono.client.amqp.SenderCachingServiceClient;
 import org.eclipse.hono.util.AddressHelper;
-import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
 
@@ -39,7 +39,8 @@ import io.vertx.proton.ProtonHelper;
  * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control/">
  *      Command &amp; Control API for AMQP 1.0 Specification</a>
  */
-public class ProtonBasedCommandSender extends SenderCachingServiceClient implements CommandSender {
+public class ProtonBasedCommandSender extends SenderCachingServiceClient
+        implements CommandSender<AmqpMessageContext> {
 
     private final ProtonBasedRequestResponseCommandClient requestResponseClient;
 
@@ -100,12 +101,18 @@ public class ProtonBasedCommandSender extends SenderCachingServiceClient impleme
      * {@inheritDoc}
      */
     @Override
-    public Future<BufferResult> sendCommand(final String tenantId, final String deviceId, final String command,
-            final String contentType, final Buffer data, final String replyId, final Map<String, Object> properties,
+    public Future<DownstreamMessage<AmqpMessageContext>> sendCommand(
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final String contentType,
+            final Buffer data,
+            final String replyId,
+            final Map<String, Object> properties,
             final SpanContext context) {
 
-        return requestResponseClient.sendCommand(tenantId, deviceId, command, contentType, data, replyId, properties,
-                context);
+        return requestResponseClient
+                .sendCommand(tenantId, deviceId, command, contentType, data, replyId, properties, context);
     }
 
     private Future<Void> sendCommand(final String tenantId, final String deviceId, final String command,

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClient.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClient.java
@@ -165,12 +165,19 @@ final class ProtonBasedRequestResponseCommandClient extends
                 });
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method has been overridden as it is defined as abstract in the parent class and not to be used.
+     *
+     * @throws UnsupportedOperationException if this method is invoked.
+     */
     @Override
     protected RequestResponseResult<DownstreamMessage<AmqpMessageContext>> getResult(final int status,
             final String contentType, final Buffer payload, final CacheDirective cacheDirective,
             final ApplicationProperties applicationProperties) {
         // This method is not used but need to be overridden as it is defined as abstract in the parent class
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     private Future<RequestResponseClient<RequestResponseResult<DownstreamMessage<AmqpMessageContext>>>> getOrCreateClient(

--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClient.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClient.java
@@ -12,12 +12,16 @@
  */
 package org.eclipse.hono.application.client.amqp;
 
+import java.net.HttpURLConnection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.client.ServiceInvocationException;
@@ -27,15 +31,19 @@ import org.eclipse.hono.client.amqp.RequestResponseClient;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.AddressHelper;
-import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RequestResponseResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.proton.ProtonDelivery;
 
 /**
  * A vertx-proton based client for sending and receiving commands synchronously.
@@ -43,9 +51,9 @@ import io.vertx.core.buffer.Buffer;
  * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control/">
  *      Command &amp; Control API for AMQP 1.0 Specification</a>
  */
-final class ProtonBasedRequestResponseCommandClient
-        extends AbstractRequestResponseServiceClient<Buffer, BufferResult> {
-
+final class ProtonBasedRequestResponseCommandClient extends
+        AbstractRequestResponseServiceClient<DownstreamMessage<AmqpMessageContext>, RequestResponseResult<DownstreamMessage<AmqpMessageContext>>> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProtonBasedRequestResponseCommandClient.class);
     private int messageCounter;
 
     /**
@@ -68,15 +76,6 @@ final class ProtonBasedRequestResponseCommandClient
     @Override
     protected String getKey(final String tenantId) {
         return String.format("%s-%s", CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected BufferResult getResult(final int status, final String contentType, final Buffer payload,
-            final CacheDirective cacheDirective, final ApplicationProperties applicationProperties) {
-        return BufferResult.from(status, contentType, payload, applicationProperties);
     }
 
     /**
@@ -107,8 +106,14 @@ final class ProtonBasedRequestResponseCommandClient
      *         <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.
      * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
      */
-    public Future<BufferResult> sendCommand(final String tenantId, final String deviceId, final String command,
-            final String contentType, final Buffer data, final String replyId, final Map<String, Object> properties,
+    public Future<DownstreamMessage<AmqpMessageContext>> sendCommand(
+            final String tenantId,
+            final String deviceId,
+            final String command,
+            final String contentType,
+            final Buffer data,
+            final String replyId,
+            final Map<String, Object> properties,
             final SpanContext context) {
 
         Objects.requireNonNull(tenantId);
@@ -119,28 +124,57 @@ final class ProtonBasedRequestResponseCommandClient
 
         return getOrCreateClient(tenantId, replyId)
                 .compose(client -> {
-                    final String messageTargetAddress = AddressHelper
-                            .getTargetAddress(CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, deviceId,
-                                    connection.getConfig());
+                    final String messageTargetAddress = AddressHelper.getTargetAddress(
+                            CommandConstants.NORTHBOUND_COMMAND_REQUEST_ENDPOINT, tenantId, deviceId,
+                            connection.getConfig());
                     return client.createAndSendRequest(command, messageTargetAddress, properties, data, contentType,
-                            this::getRequestResponseResult, currentSpan);
+                            this::mapCommandResponse, currentSpan);
                 })
                 .recover(error -> {
                     Tags.HTTP_STATUS.set(currentSpan, ServiceInvocationException.extractStatusCode(error));
                     TracingHelper.logError(currentSpan, error);
                     return Future.failedFuture(error);
                 })
-                .map(bufferResult -> {
-                    setTagsForResult(currentSpan, bufferResult);
-                    if (bufferResult != null && bufferResult.isError()) {
-                        throw StatusCodeMapper.from(bufferResult);
+                .map(result -> {
+                    if (result == null) {
+                        throw new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST);
+                    } else {
+                        setTagsForResult(currentSpan, result);
+                        if (result.isError()) {
+                            throw StatusCodeMapper.from(result);
+                        }
+                        return result.getPayload();
                     }
-                    return bufferResult;
                 })
                 .onComplete(r -> currentSpan.finish());
     }
 
-    private Future<RequestResponseClient<BufferResult>> getOrCreateClient(final String tenantId, final String replyId) {
+    private RequestResponseResult<DownstreamMessage<AmqpMessageContext>> mapCommandResponse(final Message message,
+            final ProtonDelivery delivery) {
+        final DownstreamMessage<AmqpMessageContext> downStreamMessage = ProtonBasedDownstreamMessage.from(message, delivery);
+
+        return Optional
+                .ofNullable(MessageHelper.getStatus(message))
+                .map(status -> new RequestResponseResult<>(status, downStreamMessage,
+                        CacheDirective.from(MessageHelper.getCacheDirective(message)), null))
+                .orElseGet(() -> {
+                    LOGGER.trace(
+                            "response message has no status code application property [reply-to: {}, correlation ID: {}]",
+                            message.getReplyTo(), message.getCorrelationId());
+                    return null;
+                });
+    }
+
+    @Override
+    protected RequestResponseResult<DownstreamMessage<AmqpMessageContext>> getResult(final int status,
+            final String contentType, final Buffer payload, final CacheDirective cacheDirective,
+            final ApplicationProperties applicationProperties) {
+        // This method is not used but need to be overridden as it is defined as abstract in the parent class
+        return null;
+    }
+
+    private Future<RequestResponseClient<RequestResponseResult<DownstreamMessage<AmqpMessageContext>>>> getOrCreateClient(
+            final String tenantId, final String replyId) {
 
         return connection.isConnected(getDefaultConnectionCheckTimeout())
                 .compose(v -> connection.executeOnContext(result -> clientFactory.getOrCreateClient(

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -18,12 +18,13 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.hono.application.client.CommandSender;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
-import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.MessageHelper;
 
 import io.opentracing.SpanContext;
@@ -37,7 +38,8 @@ import io.vertx.core.buffer.Buffer;
  * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">
  *      Command &amp; Control API for Kafka Specification</a>
  */
-public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender implements CommandSender {
+public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
+        implements CommandSender<KafkaMessageContext> {
 
     /**
      * Creates a new Kafka-based command sender.
@@ -111,7 +113,7 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender imp
      * @throws NullPointerException if tenantId, deviceId, or command is {@code null}.
      */
     @Override
-    public Future<BufferResult> sendCommand(
+    public Future<DownstreamMessage<KafkaMessageContext>> sendCommand(
             final String tenantId,
             final String deviceId,
             final String command,

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/ApplicationClient.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/ApplicationClient.java
@@ -22,7 +22,7 @@ import io.vertx.core.Handler;
  *
  * @param <T> The type of context that messages are being received in.
  */
-public interface ApplicationClient<T extends MessageContext> extends CommandSender {
+public interface ApplicationClient<T extends MessageContext> extends CommandSender<T> {
 
     /**
      * Creates a client for consuming data from Hono's north bound <em>Telemetry API</em>.

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
@@ -15,7 +15,6 @@ package org.eclipse.hono.application.client;
 import java.util.Map;
 
 import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.util.BufferResult;
 import org.eclipse.hono.util.Lifecycle;
 
 import io.opentracing.SpanContext;
@@ -25,12 +24,13 @@ import io.vertx.core.buffer.Buffer;
 /**
  * A client for sending commands.
  *
- * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control/">
- *      Command &amp; Control API for AMQP 1.0 Specification</a>
- * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">
- *      Command &amp; Control API for Kafka Specification</a>
+ * @param <T> The type of context that messages are being received in.
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control/"> Command &amp; Control API for AMQP 1.0
+ *      Specification</a>
+ * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/"> Command &amp; Control API for Kafka
+ *      Specification</a>
  */
-public interface CommandSender extends Lifecycle {
+public interface CommandSender<T extends MessageContext> extends Lifecycle {
 
     /**
      * Sends an async command to a device, i.e. there is no immediate response expected from the device, but
@@ -234,7 +234,7 @@ public interface CommandSender extends Lifecycle {
      *         <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.
      * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
      */
-    default Future<BufferResult> sendCommand(
+    default Future<DownstreamMessage<T>> sendCommand(
             final String tenantId,
             final String deviceId,
             final String command,
@@ -265,7 +265,7 @@ public interface CommandSender extends Lifecycle {
      *         <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.
      * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
      */
-    default Future<BufferResult> sendCommand(
+    default Future<DownstreamMessage<T>> sendCommand(
             final String tenantId,
             final String deviceId,
             final String command,
@@ -303,7 +303,7 @@ public interface CommandSender extends Lifecycle {
      *         <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.
      * @throws NullPointerException if any of tenantId, deviceId or command are {@code null}.
      */
-    Future<BufferResult> sendCommand(
+    Future<DownstreamMessage<T>> sendCommand(
             String tenantId,
             String deviceId,
             String command,

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -416,8 +416,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                             IntegrationTestSupport.getSendCommandTimeout())
                         .map(response -> {
                             ctx.verify(() -> {
-                                assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_DEVICE_ID, String.class)).isEqualTo(commandTargetDeviceId);
-                                assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_TENANT_ID, String.class)).isEqualTo(tenantId);
+                                assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
+                                assertThat(response.getTenantId()).isEqualTo(tenantId);
                             });
                             return response;
                         });

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -63,7 +63,6 @@ import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistryManagementConstants;
@@ -795,8 +794,8 @@ public abstract class CoapTestBase {
                                     .map(response -> {
                                         ctx.verify(() -> {
                                             assertThat(response.getContentType()).isEqualTo("text/plain");
-                                            assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_DEVICE_ID, String.class)).isEqualTo(commandTargetDeviceId);
-                                            assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_TENANT_ID, String.class)).isEqualTo(tenantId);
+                                            assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
+                                            assertThat(response.getTenantId()).isEqualTo(tenantId);
                                         });
                                         return response;
                                     });

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -46,7 +46,6 @@ import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.tests.Tenants;
 import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistryManagementConstants;
@@ -1176,8 +1175,8 @@ import io.vertx.junit5.VertxTestContext;
                                         .map(response -> {
                                             ctx.verify(() -> {
                                                 assertThat(response.getContentType()).isEqualTo("text/plain");
-                                                assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_DEVICE_ID, String.class)).isEqualTo(commandTargetDeviceId);
-                                                assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_TENANT_ID, String.class)).isEqualTo(tenantId);
+                                                assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
+                                                assertThat(response.getTenantId()).isEqualTo(tenantId);
                                             });
                                             return response;
                                         });

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -39,7 +39,6 @@ import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.CommandEndpointConfiguration.SubscriberRole;
 import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.EventConstants;
-import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
@@ -257,8 +256,8 @@ public class CommandAndControlMqttIT extends MqttTestBase {
                     IntegrationTestSupport.getSendCommandTimeout())
                     .map(response -> {
                         ctx.verify(() -> {
-                            assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_DEVICE_ID, String.class)).isEqualTo(commandTargetDeviceId);
-                            assertThat(response.getApplicationProperty(MessageHelper.APP_PROPERTY_TENANT_ID, String.class)).isEqualTo(tenantId);
+                            assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
+                            assertThat(response.getTenantId()).isEqualTo(tenantId);
                         });
                         return response;
                     });


### PR DESCRIPTION
Currently the method defined in `ApplicationClient` to send a command and receive a response returns an object of type `Future<BufferResult>`. `org.eclipse.hono.util.BufferResult` is not _protocol agnostic_ as it's constructor takes `ApplicationProperties` as one of the parameters and so it's parent class `RequestResponseResult`. 

One approach is to make it protocol agnostic by replacing with `Map<String, Object>` or `org.eclipse.hono.application.client.MessageProperties` and updating all the classes that use it.

On the other hand, could also use `DownstreamMessage<MessageContext>` instead of `BufferResult` as we already do in case of command response consumer in the north-bound side. IMHO it suits better than the `BufferResult` as command response is also a downstream message and also the end users need not deal with one more new type. Also the methods to retrieve each property are well encapsulated there. 

This PR has the method changed to ` Future<DownstreamMessage<T>> sendCommand(...)` and also the Proton based implementation has been updated with it.