### PR TITLE
[#2478] Add kafka based implementation to send commands and receive responses by the north bound side

### DIFF
--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImpl.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImpl.java
@@ -81,7 +81,7 @@ public class KafkaApplicationClientImpl extends KafkaBasedCommandSender implemen
             final KafkaProducerFactory<String, Buffer> producerFactory,
             final KafkaProducerConfigProperties producerConfig,
             final Tracer tracer) {
-        super(producerFactory, producerConfig, tracer);
+        super(vertx, consumerConfig, producerFactory, producerConfig, tracer);
 
         Objects.requireNonNull(vertx);
         Objects.requireNonNull(consumerConfig);

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -12,48 +12,110 @@
  */
 package org.eclipse.hono.application.client.kafka.impl;
 
+import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.eclipse.hono.application.client.CommandSender;
 import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.kafka.KafkaMessageContext;
+import org.eclipse.hono.client.SendMessageTimeoutException;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
+import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
+import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.MessageHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
 
 /**
- * A Kafka based client for sending commands.
+ * A Kafka based client for sending commands and receiving command responses.
  *
  * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/">
  *      Command &amp; Control API for Kafka Specification</a>
  */
 public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
         implements CommandSender<KafkaMessageContext> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaBasedCommandSender.class);
+    //TODO to make this timeout configurable
+    private static final Duration COMMAND_TIMEOUT = Duration.ofSeconds(30);
+
+    private final KafkaConsumerConfigProperties consumerConfig;
+    private Function<Handler<DownstreamMessage<KafkaMessageContext>>, Future<MessageConsumer>> commandResponseConsumerFactory;
+    // The tenant identifiers are stored as keys in the map. The message consumers which are used to receive command
+    // responses for the tenant mentioned in the key are stored as values.
+    private final ConcurrentHashMap<String, MessageConsumer> commandResponseSubscriptions = new ConcurrentHashMap<>();
+    // The tenant identifiers are stored as keys in the map. The value is an another map with correlation ids as keys
+    // and expiring command promises as values. This correlation ids are used to correlate the response messages with 
+    // that of the command.
+    private final ConcurrentHashMap<String, ConcurrentHashMap<String, ExpiringCommandPromise>> pendingCommandResponses = new ConcurrentHashMap<>();
+    private Supplier<String> correlationIdSupplier = () -> UUID.randomUUID().toString();
+    private final Vertx vertx;
 
     /**
      * Creates a new Kafka-based command sender.
      *
+     * @param vertx The vert.x instance to use.
+     * @param consumerConfig The Kafka consumer configuration properties to use.
+     *                       The value of the config parameter 'auto.offset.reset' should be 'latest'. 
+     *                       If any other value is set then it is overridden with 'latest'.
      * @param producerFactory The factory to use for creating Kafka producers.
-     * @param config          The Kafka producer configuration properties to use.
-     * @param tracer          The OpenTracing tracer.
+     * @param producerConfig The Kafka producer configuration properties to use.
+     * @param tracer The OpenTracing tracer.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public KafkaBasedCommandSender(
+            final Vertx vertx,
+            final KafkaConsumerConfigProperties consumerConfig,
             final KafkaProducerFactory<String, Buffer> producerFactory,
-            final KafkaProducerConfigProperties config,
+            final KafkaProducerConfigProperties producerConfig,
             final Tracer tracer) {
-        super(producerFactory, "command-sender", config, tracer);
+        super(producerFactory, "command-sender", producerConfig, tracer);
+        this.vertx = Objects.requireNonNull(vertx);
+        this.consumerConfig = Objects.requireNonNull(consumerConfig);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Future<Void> stop() {
+        final List<Future> closeKafkaClientsTracker = commandResponseSubscriptions
+                .keySet()
+                .stream()
+                .map(commandResponseSubscriptions::remove)
+                .filter(Objects::nonNull)
+                .map(MessageConsumer::close)
+                .collect(Collectors.toList());
+
+        closeKafkaClientsTracker.add(super.stop());
+
+        return CompositeFuture.all(closeKafkaClientsTracker)
+                .mapEmpty();
     }
 
     /**
@@ -126,8 +188,52 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(command);
 
-        // TODO to implement.
-        return null;
+        final String correlationId = correlationIdSupplier.get();
+        final Span span = TracingHelper
+                .buildChildSpan(tracer, context, "send command and wait for response", getClass().getSimpleName())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+                .withTag(TracingHelper.TAG_TENANT_ID, tenantId)
+                .withTag(TracingHelper.TAG_DEVICE_ID, deviceId)
+                .withTag(TracingHelper.TAG_CORRELATION_ID, correlationId)
+                .start();
+        final ExpiringCommandPromise expiringCommandPromise = new ExpiringCommandPromise(
+                correlationId,
+                COMMAND_TIMEOUT,
+                // Remove the correlation id if times out
+                x -> Optional.ofNullable(pendingCommandResponses.get(tenantId))
+                        .ifPresent(ids -> ids.remove(correlationId)),
+                span);
+
+        subscribeForCommandResponse(tenantId, span)
+                .compose(ok -> sendCommand(tenantId, deviceId, command, contentType, data, correlationId, properties,
+                        true, span.context())
+                                .onSuccess(sent -> {
+                                    //Store the correlation id and the expiring command promise
+                                    pendingCommandResponses.computeIfAbsent(tenantId, k -> new ConcurrentHashMap<>())
+                                            .put(correlationId, expiringCommandPromise);
+                                    LOGGER.debug("sent command [correlation-id: {}] and waiting for response", correlationId);
+                                    span.log("sent command and waiting for response");
+                                })
+                                .onFailure(error -> {
+                                    LOGGER.debug("error sending command", error);
+                                    TracingHelper.logError(span, "error sending command", error);
+                                    expiringCommandPromise.tryCompleteAndCancelTimer(Future.failedFuture(error));
+                                }));
+
+        return expiringCommandPromise.future()
+                .onComplete(o -> span.finish());
+    }
+
+    // visible for testing
+    void setCommandResponseConsumerFactory(
+            final Function<Handler<DownstreamMessage<KafkaMessageContext>>, Future<MessageConsumer>> commandResponseConsumerFactory) {
+        this.commandResponseConsumerFactory = commandResponseConsumerFactory;
+    }
+
+    // visible for testing
+    void setCorrelationIdSupplier(final Supplier<String> correlationIdSupplier) {
+        Objects.requireNonNull(correlationIdSupplier);
+        this.correlationIdSupplier = correlationIdSupplier;
     }
 
     private Future<Void> sendCommand(final String tenantId, final String deviceId, final String command,
@@ -158,5 +264,139 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
         props.put(KafkaRecordHelper.HEADER_RESPONSE_REQUIRED, responseRequired);
 
         return props;
+    }
+
+    private Handler<DownstreamMessage<KafkaMessageContext>> getCommandResponseHandler(final String tenantId) {
+        return message -> {
+            if (message.getCorrelationId() != null) {
+                // if the correlation id of the received response matches with that of the command
+                Optional.ofNullable(pendingCommandResponses.get(tenantId))
+                        .map(ids -> ids.remove(message.getCorrelationId()))
+                        .ifPresentOrElse(
+                                expiringCommandPromise -> expiringCommandPromise
+                                        .tryCompleteAndCancelTimer(Future.succeededFuture(message)),
+                                () -> LOGGER.trace(
+                                        "ignoring received command response [correlation-id: {}] as there is no matching correlation id found",
+                                        message.getCorrelationId()));
+            }
+        };
+    }
+
+    private Future<Void> subscribeForCommandResponse(final String tenantId, final Span span) {
+        final Handler<DownstreamMessage<KafkaMessageContext>> messageHandler = getCommandResponseHandler(tenantId);
+
+        if (commandResponseSubscriptions.get(tenantId) != null) {
+            LOGGER.debug("command response consumer already exists for tenant [{}]", tenantId);
+            span.log("command response consumer already exists");
+            return Future.succeededFuture();
+        } else {
+            final Map<String, String> consumerConfig = this.consumerConfig
+                    .getConsumerConfig(HonoTopic.Type.COMMAND_RESPONSE.toString());
+            final String autoOffsetResetConfigValue = consumerConfig.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
+            //Ensure that 'auto.offset.reset' is always set to 'latest'.
+            if (autoOffsetResetConfigValue != null && !autoOffsetResetConfigValue.equals("latest")) {
+                LOGGER.warn("[auto.offset.reset] value is set to other than [latest]. It will be ignored and internally set to [latest]");
+            }
+            consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+            // Use a unique group-id so that all command responses for this tenant are received by this consumer.
+            // Thereby the responses can be correlated with the command that has been sent.
+            consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, tenantId + "-" + UUID.randomUUID());
+
+            return Optional.ofNullable(commandResponseConsumerFactory)
+                    .map(t -> t.apply(messageHandler))
+                    .orElseGet(
+                            () -> KafkaBasedDownstreamMessageConsumer.create(
+                                    tenantId,
+                                    HonoTopic.Type.COMMAND_RESPONSE,
+                                    KafkaConsumer.create(vertx, consumerConfig),
+                                    this.consumerConfig,
+                                    messageHandler,
+                                    t -> LOGGER.debug("closed consumer for tenant [{}]", tenantId)))
+                    .recover(error -> {
+                        LOGGER.debug("error creating command response consumer for tenant [{}]", tenantId, error);
+                        TracingHelper.logError(span, "error creating command response consumer", error);
+                        return Future.failedFuture(error);
+                    })
+                    .map(consumer -> {
+                        LOGGER.debug("created command response consumer for tenant [{}]", tenantId);
+                        span.log("created command response consumer");
+                        commandResponseSubscriptions.put(tenantId, consumer);
+                        return null;
+                    });
+        }
+    }
+
+    /**
+     * Wrapped promise with an expiration mechanism, failing the promise after a given time if it has not been completed
+     * yet.
+     */
+    private class ExpiringCommandPromise {
+        private final Promise<DownstreamMessage<KafkaMessageContext>> promise = Promise.promise();
+        private final Span span;
+        private Long timerId;
+
+        /**
+         * Starts a timer so that after the given timeout value, this promise shall get failed if not completed already.
+         *
+         * @param correlationId The identifier to use for correlating a command with it's response.
+         * @param timeout The timeout duration to use for the timer.
+         * @param timeOutHandler The operation to run after this promise got failed as part of a timeout.
+         * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+         *             An implementation should log (error) events on this span and it may set tags and use this span as
+         *             the parent for any spans created in this method.
+         * @throws NullPointerException if the timeout or span is {@code null}.
+         */
+        ExpiringCommandPromise(final String correlationId, final Duration timeout, final Handler<Void> timeOutHandler,
+                final Span span) {
+            Objects.requireNonNull(timeout);
+            Objects.requireNonNull(span);
+
+            this.span = span;
+            timerId = vertx.setTimer(timeout.toMillis(), id -> {
+                final SendMessageTimeoutException error = new SendMessageTimeoutException(
+                        "send command/wait for response timed out after " + timeout + "ms");
+                timerId = null;
+                LOGGER.debug("cancelling sending command [correlation-id: {}] and waiting for response after {} ms",
+                        correlationId, timeout);
+                TracingHelper.logError(span, error);
+                promise.tryFail(error);
+                Optional.ofNullable(timeOutHandler)
+                        .ifPresent(handler -> handler.handle(null));
+            });
+        }
+
+        /**
+         * Completes this promise with the given result and stops the expiration timer.
+         *
+         * @param commandResponseResult The result that contains the command response to complete this promise with.
+         * @throws NullPointerException if the commandResponseResult is {@code null}.
+         */
+        final void tryCompleteAndCancelTimer(
+                final AsyncResult<DownstreamMessage<KafkaMessageContext>> commandResponseResult) {
+            Objects.requireNonNull(commandResponseResult);
+
+            Optional.ofNullable(timerId)
+                    .ifPresent(vertx::cancelTimer);
+
+            if (commandResponseResult.succeeded()) {
+                final String correlationId = Optional.ofNullable(commandResponseResult.result())
+                        .map(DownstreamMessage::getCorrelationId)
+                        .orElse("");
+                LOGGER.trace("received command response [correlation-id: {}]", correlationId);
+                span.log("received command response");
+                promise.tryComplete(commandResponseResult.result());
+            } else {
+                promise.tryFail(commandResponseResult.cause());
+            }
+        }
+
+        /**
+         * Returns the future corresponding to this promise.
+         *
+         * @return the future corresponding to this promise.
+         */
+        final Future<DownstreamMessage<KafkaMessageContext>> future() {
+            return promise.future();
+        }
     }
 }

--- a/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
+++ b/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
@@ -14,16 +14,29 @@ package org.eclipse.hono.application.client.kafka.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
 import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
+import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,10 +45,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.opentracing.noop.NoopSpan;
 import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
 
 /**
  * Tests verifying behavior of {@link KafkaBasedCommandSender}.
@@ -45,27 +60,34 @@ import io.vertx.junit5.VertxTestContext;
 @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
 public class KafkaBasedCommandSenderTest {
     private KafkaBasedCommandSender commandSender;
+    private KafkaConsumerConfigProperties consumerConfig;
     private MockProducer<String, Buffer> mockProducer;
+    private MockConsumer<String, Buffer> mockConsumer;
     private String tenantId;
     private String deviceId;
+    private Vertx vertx;
 
     /**
      *
      * Sets up fixture.
      *
+     * @param vertx The vert.x instance to use.
      */
     @BeforeEach
-    void setUp() {
+    void setUp(final Vertx vertx) {
         final KafkaProducerConfigProperties producerConfig;
         final CachingKafkaProducerFactory<String, Buffer> producerFactory;
 
+        this.vertx = vertx;
+        consumerConfig = new KafkaConsumerConfigProperties();
+        mockConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
         producerConfig = new KafkaProducerConfigProperties();
         producerConfig.setProducerConfig(Map.of("client.id", "application-test-sender"));
         mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
         producerFactory = KafkaClientUnitTestHelper.newProducerFactory(mockProducer);
 
-        commandSender = new KafkaBasedCommandSender(producerFactory, producerConfig, NoopTracerFactory.create());
-
+        commandSender = new KafkaBasedCommandSender(vertx, consumerConfig, producerFactory, producerConfig,
+                NoopTracerFactory.create());
         tenantId = UUID.randomUUID().toString();
         deviceId = UUID.randomUUID().toString();
     }
@@ -126,4 +148,65 @@ public class KafkaBasedCommandSenderTest {
                     ctx.completeNow();
                 }));
     }
+
+    /**
+     * Verifies that a command sent to a device succeeds and also a response is received from the device.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testSendCommandAndReceiveResponse(final VertxTestContext ctx) {
+        final Map<String, Object> headerProperties = new HashMap<>();
+        final String command = "setVolume";
+        final String correlationId = UUID.randomUUID().toString();
+        headerProperties.put("appKey", "appValue");
+        final String responsePayload = "success";
+        final int responseStatus = HttpURLConnection.HTTP_OK;
+
+        // This correlation id is used for both command and it's response.
+        commandSender.setCorrelationIdSupplier(() -> correlationId);
+
+        //start a command response consumer
+        commandSender.setCommandResponseConsumerFactory((msgHandler) -> KafkaBasedDownstreamMessageConsumer
+                        .create(tenantId, HonoTopic.Type.COMMAND_RESPONSE, KafkaConsumer.create(vertx, mockConsumer),
+                                consumerConfig, msgHandler, t -> {})
+                        .onSuccess(ok -> {
+                            // Send a command response with the same correlation id as that of the command
+                            final ConsumerRecord<String, Buffer> commandResponseRecord = commandResponseRecord(tenantId,
+                                    deviceId, correlationId, responseStatus, Buffer.buffer(responsePayload));
+                            final String responseTopic = new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId).toString();
+                            final TopicPartition responseTopicPartition = new TopicPartition(responseTopic, 0);
+                            mockConsumer.updateBeginningOffsets(Map.of(responseTopicPartition, 0L));
+                            mockConsumer.updateEndOffsets(Map.of(responseTopicPartition, 0L));
+                            mockConsumer.rebalance(Collections.singletonList(responseTopicPartition));
+                            mockConsumer.addRecord(commandResponseRecord);
+                        }));
+        // Send a command to the device
+        commandSender.sendCommand(tenantId, deviceId, command, null, Buffer.buffer("test"), headerProperties)
+                .onComplete(ctx.succeeding(response -> {
+                    ctx.verify(() -> {
+                        // Verify the command response that has been received
+                        assertThat(response.getDeviceId()).isEqualTo(deviceId);
+                        assertThat(response.getStatus()).isEqualTo(responseStatus);
+                        assertThat(response.getPayload().toString()).isEqualTo(responsePayload);
+                    });
+                    ctx.completeNow();
+                    mockConsumer.close();
+                    commandSender.stop();
+                }));
+    }
+
+    private ConsumerRecord<String, Buffer> commandResponseRecord(final String tenantId, final String deviceId,
+            final String correlationId, final int status, final Buffer payload) {
+        final List<Header> headers = new ArrayList<>();
+
+        headers.add(new RecordHeader(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId.getBytes()));
+        headers.add(new RecordHeader(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId.getBytes()));
+        headers.add(new RecordHeader(MessageHelper.SYS_PROPERTY_CORRELATION_ID, correlationId.getBytes()));
+        headers.add(new RecordHeader(MessageHelper.APP_PROPERTY_STATUS, String.valueOf(status).getBytes()));
+        return new ConsumerRecord<>(new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, tenantId).toString(), 0, 0, -1L,
+                TimestampType.NO_TIMESTAMP_TYPE, -1L, -1, -1, deviceId,
+                payload, new RecordHeaders(headers.toArray(Header[]::new)));
+    }
+
 }

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
@@ -22,9 +22,9 @@ import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 
 /**
- * A client for sending commands.
+ * A client for sending commands and receiving command responses.
  *
- * @param <T> The type of context that messages are being received in.
+ * @param <T> The type of context that command response messages are being received in.
  * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control/"> Command &amp; Control API for AMQP 1.0
  *      Specification</a>
  * @see <a href="https://www.eclipse.org/hono/docs/api/command-and-control-kafka/"> Command &amp; Control API for Kafka

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -371,7 +371,7 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
         kafkaConsumer.commit(offsetsToBeCommitted, completionHandler);
         return completionHandler.future()
                 .map(committedOffsets -> {
-                    LOG.debug("successfully committed offsets");
+                    LOG.trace("successfully committed offsets");
                     offsetsToBeCommitted.clear();
                     return null;
                 });

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/KafkaConsumerConfigProperties.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.hono.client.kafka.consumer;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -85,7 +84,7 @@ public class KafkaConsumerConfigProperties extends AbstractKafkaConfigProperties
         Objects.requireNonNull(consumerName);
 
         if (commonClientConfig == null && consumerConfig == null) {
-            return Collections.emptyMap();
+            return new HashMap<>();
         }
 
         final Map<String, String> newConfig = new HashMap<>();


### PR DESCRIPTION
This PR adds a Kafka based implementation to send commands and receive responses by the north bound side.

In order keep the PR small, the other PR #2571 needs to be merged first.