### PR TITLE
Add support for an In-Memory database to the JDBC registry

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -35,7 +35,7 @@
     <californium.version>2.6.2</californium.version>
     <commons-cli.version>1.4</commons-cli.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.14.0</dispatch-router.image.name>
-    <flyway-core.version>7.7.2</flyway-core.version>
+    <flyway-core.version>7.3.2</flyway-core.version>
     <guava.version>29.0-jre</guava.version>
     <gson.version>2.8.5</gson.version>
     <h2.version>1.4.200</h2.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -35,6 +35,7 @@
     <californium.version>2.6.2</californium.version>
     <commons-cli.version>1.4</commons-cli.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.14.0</dispatch-router.image.name>
+    <flyway-core.version>7.7.2</flyway-core.version>
     <guava.version>29.0-jre</guava.version>
     <gson.version>2.8.5</gson.version>
     <h2.version>1.4.200</h2.version>
@@ -858,6 +859,11 @@
             <artifactId>animal-sniffer-annotations</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-core</artifactId>
+        <version>${flyway-core.version}</version>
       </dependency>
 
       <!-- Testing -->

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -132,6 +132,7 @@ maven/mavencentral/org.apache.thrift/libthrift/0.13.0, Apache-2.0, approved, CQ2
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.19.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/2.5.2, MIT, approved, clearlydefined
+maven/mavencentral/org.flywaydb/flyway-core/7.3.2, Apache-2.0, approved, CQ22947
 maven/mavencentral/org.graalvm.sdk/graal-sdk/20.3.1, UPL-1.0, approved, clearlydefined
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, BSD-2-Clause, approved, CQ13192
 maven/mavencentral/org.infinispan/infinispan-client-hotrod/11.0.9.Final, Apache-2.0, approved, clearlydefined

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -132,6 +132,7 @@ org.apache.thrift:libthrift:jar:0.13.0
 org.apiguardian:apiguardian-api:jar:1.1.0
 org.assertj:assertj-core:jar:3.19.0
 org.checkerframework:checker-qual:jar:2.5.2
+org.flywaydb:flyway-core:jar:7.3.2
 org.graalvm.sdk:graal-sdk:jar:20.3.1
 org.hdrhistogram:HdrHistogram:jar:2.1.12
 org.infinispan:infinispan-client-hotrod:jar:11.0.9.Final

--- a/services/device-registry-jdbc/pom.xml
+++ b/services/device-registry-jdbc/pom.xml
@@ -52,6 +52,10 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-auth-jdbc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
 
     <!-- JDBC drivers -->
     <dependency>

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -103,7 +103,7 @@ import io.vertx.ext.web.handler.BasicAuthHandler;
  * Spring Boot configuration for the JDBC based device registry application.
  */
 @Configuration
-@Import(PrometheusSupport.class)
+@Import({ PrometheusSupport.class, InMemoryDbConfig.class, PersistentDbConfig.class })
 public class ApplicationConfig {
 
     private static final String BEAN_NAME_AMQP_SERVER = "amqpServer";
@@ -207,28 +207,6 @@ public class ApplicationConfig {
     // JDBC store properties
     //
     //
-
-    /**
-     * Expose JDBC device registry service properties.
-     *
-     * @return The properties.
-     */
-    @Bean
-    @ConfigurationProperties("hono.registry.jdbc")
-    public JdbcDeviceStoreProperties devicesProperties() {
-        return new JdbcDeviceStoreProperties();
-    }
-
-    /**
-     * Expose JDBC tenant service properties.
-     *
-     * @return The properties.
-     */
-    @Bean
-    @ConfigurationProperties("hono.tenant.jdbc")
-    public JdbcTenantStoreProperties tenantsProperties() {
-        return new JdbcTenantStoreProperties();
-    }
 
     /**
      * Provider a new device backing store for the adapter facing service.

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/InMemoryDbConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/InMemoryDbConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceregistry.jdbc;
+
+import org.eclipse.hono.service.base.jdbc.config.JdbcDeviceStoreProperties;
+import org.eclipse.hono.service.base.jdbc.config.JdbcProperties;
+import org.eclipse.hono.service.base.jdbc.config.JdbcTenantStoreProperties;
+import org.flywaydb.core.Flyway;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Spring Boot configuration for the in-memory H2 database.
+ * <p>
+ * When using this profile, any provided JDBC configuration properties are ignored.
+ */
+@Configuration
+@Profile("in-memory")
+public class InMemoryDbConfig {
+
+    /**
+     * Expose JDBC device registry service properties.
+     *
+     * @param properties The configuration properties.
+     * @return The properties.
+     */
+    @Bean
+    public JdbcDeviceStoreProperties devicesProperties(final JdbcProperties properties) {
+        final JdbcDeviceStoreProperties deviceStoreProperties = new JdbcDeviceStoreProperties();
+        deviceStoreProperties.setManagement(properties);
+        deviceStoreProperties.setAdapter(properties);
+        return deviceStoreProperties;
+    }
+
+    /**
+     * Expose JDBC tenant service properties.
+     *
+     * @param properties The configuration properties.
+     * @return The properties.
+     */
+    @Bean
+    public JdbcTenantStoreProperties tenantsProperties(final JdbcProperties properties) {
+        final JdbcTenantStoreProperties tenantStoreProperties = new JdbcTenantStoreProperties();
+        tenantStoreProperties.setManagement(properties);
+        tenantStoreProperties.setAdapter(properties);
+        return tenantStoreProperties;
+    }
+
+    /**
+     * Expose the properties for the in-memory database.
+     * <p>
+     * Creates the static configuration of the in-memory database and invokes the database migration to prepare the
+     * database.
+     *
+     * @return The properties.
+     */
+    @Bean
+    public JdbcProperties dbProperties() {
+        final JdbcProperties properties = new JdbcProperties();
+        properties.setDriverClass("org.h2.Driver");
+        properties.setUrl("jdbc:h2:mem:dr;DB_CLOSE_DELAY=-1");
+        properties.setUsername("sa");
+
+        prepareDatabase(properties); // apply DB migrations to prepare the database
+
+        return properties;
+    }
+
+    private void prepareDatabase(final JdbcProperties props) {
+        final Flyway flyway = Flyway.configure().dataSource(props.getUrl(), props.getUsername(), props.getPassword())
+                .load();
+        flyway.migrate();
+    }
+}

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/PersistentDbConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/PersistentDbConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceregistry.jdbc;
+
+import org.eclipse.hono.service.base.jdbc.config.JdbcDeviceStoreProperties;
+import org.eclipse.hono.service.base.jdbc.config.JdbcTenantStoreProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Spring Boot configuration that exposes the provided JDBC registry service properties as beans.
+ */
+@Configuration
+@Profile("!in-memory")
+public class PersistentDbConfig {
+
+    /**
+     * Expose JDBC device registry service properties.
+     *
+     * @return The properties.
+     */
+    @Bean
+    @ConfigurationProperties("hono.registry.jdbc")
+    public JdbcDeviceStoreProperties devicesProperties() {
+        return new JdbcDeviceStoreProperties();
+    }
+
+    /**
+     * Expose JDBC tenant service properties.
+     *
+     * @return The properties.
+     */
+    @Bean
+    @ConfigurationProperties("hono.tenant.jdbc")
+    public JdbcTenantStoreProperties tenantsProperties() {
+        return new JdbcTenantStoreProperties();
+    }
+
+}

--- a/services/device-registry-jdbc/src/main/resources/db/migration/V01__Create_tables.sql
+++ b/services/device-registry-jdbc/src/main/resources/db/migration/V01__Create_tables.sql
@@ -1,0 +1,92 @@
+-- create tenants
+
+CREATE TABLE IF NOT EXISTS tenants
+(
+    TENANT_ID CHAR(36) NOT NULL,
+    VERSION   CHAR(36) NOT NULL,
+    DATA      TEXT,
+
+    PRIMARY KEY (TENANT_ID)
+);
+
+CREATE TABLE IF NOT EXISTS tenant_trust_anchors
+(
+    SUBJECT_DN VARCHAR(256) NOT NULL,
+    TENANT_ID  CHAR(36)     NOT NULL,
+    DATA       TEXT,
+
+    PRIMARY KEY (SUBJECT_DN),
+    FOREIGN KEY (TENANT_ID) REFERENCES tenants (TENANT_ID) ON DELETE CASCADE
+);
+
+-- create indexes for non-primary key access paths
+
+CREATE INDEX idx_tenant_trust_anchors_tenant ON tenant_trust_anchors (TENANT_ID);
+
+
+-- create devices
+
+CREATE TABLE IF NOT EXISTS device_registrations
+(
+    TENANT_ID VARCHAR(256) NOT NULL,
+    DEVICE_ID VARCHAR(256) NOT NULL,
+    VERSION   CHAR(36)     NOT NULL,
+
+    CREATED TIMESTAMP NOT NULL,
+    UPDATED_ON TIMESTAMP,
+
+    AUTO_PROVISIONED BOOLEAN,
+    AUTO_PROVISIONING_NOTIFICATION_SENT BOOLEAN,
+
+    DATA      TEXT,
+
+    PRIMARY KEY (TENANT_ID, DEVICE_ID)
+);
+
+CREATE TABLE IF NOT EXISTS device_credentials
+(
+    TENANT_ID VARCHAR(256) NOT NULL,
+    DEVICE_ID VARCHAR(256) NOT NULL,
+
+    TYPE      VARCHAR(64)  NOT NULL,
+    AUTH_ID   VARCHAR(256) NOT NULL,
+
+    DATA      TEXT,
+
+    PRIMARY KEY (TENANT_ID, TYPE, AUTH_ID),
+    FOREIGN KEY (TENANT_ID, DEVICE_ID) REFERENCES device_registrations (TENANT_ID, DEVICE_ID) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS device_groups
+(
+    TENANT_ID VARCHAR(256) NOT NULL,
+    DEVICE_ID VARCHAR(256) NOT NULL,
+    GROUP_ID  VARCHAR(256) NOT NULL,
+
+    PRIMARY KEY (TENANT_ID, DEVICE_ID, GROUP_ID),
+    FOREIGN KEY (TENANT_ID, DEVICE_ID) REFERENCES device_registrations (TENANT_ID, DEVICE_ID) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS device_states
+(
+    TENANT_ID           VARCHAR(256) NOT NULL,
+    DEVICE_ID           VARCHAR(256) NOT NULL,
+
+    LAST_KNOWN_GATEWAY  VARCHAR(256),
+    ADAPTER_INSTANCE_ID VARCHAR(256),
+
+    PRIMARY KEY (TENANT_ID, DEVICE_ID)
+);
+
+-- create indexes for non-primary key access paths
+
+CREATE INDEX idx_device_registrations_tenant ON device_registrations (TENANT_ID);
+
+CREATE INDEX idx_device_credentials_tenant ON device_credentials (TENANT_ID);
+CREATE INDEX idx_device_credentials_tenant_and_device ON device_credentials (TENANT_ID, DEVICE_ID);
+
+CREATE INDEX idx_device_states_tenant ON device_states (TENANT_ID);
+
+CREATE INDEX idx_device_member_of_tenant ON device_groups (TENANT_ID);
+CREATE INDEX idx_device_member_of_tenant_and_device ON device_groups (TENANT_ID, DEVICE_ID);
+

--- a/services/device-registry-jdbc/src/main/resources/db/migration/V02__Add_example_data.sql
+++ b/services/device-registry-jdbc/src/main/resources/db/migration/V02__Add_example_data.sql
@@ -1,0 +1,18 @@
+INSERT INTO tenants (tenant_id, version, data)
+VALUES ('DEFAULT_TENANT', 'initial-version', '{"enabled":true}'),
+       ('HTTP_TENANT', 'initial-version', '{"enabled":true,"adapters":[{"type":"hono-http","enabled":true,"device-authentication-required":true},{"type":"hono-mqtt","enabled":false,"device-authentication-required":true},{"type":"hono-kura","enabled":false,"device-authentication-required":true},{"type":"hono-coap","enabled":false,"device-authentication-required":true}]}');
+
+INSERT INTO tenant_trust_anchors (subject_dn, tenant_id, data)
+VALUES ('CN=DEFAULT_TENANT_CA,OU=Hono,O=Eclipse IoT,L=Ottawa,C=CA', 'DEFAULT_TENANT', '{"id":"a5efdaf5-e13b-4f00-97f4-6e516148bffa","public-key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElkwCSPlO563eQb6ONdULAISm2XngGGSoAAz+I1s8zkS9guPUpNKoxeczLtKlObelHqBgIZtRXdrPRgXidGOnmQ==","algorithm":"EC","not-before":"2019-09-18T08:35:40Z","not-after":"2020-09-17T08:35:40Z","auto-provisioning-enabled":false}');
+
+INSERT INTO device_registrations (tenant_id, device_id, version, created, auto_provisioned, data)
+VALUES ('DEFAULT_TENANT', '4711', 'initial-version', CURRENT_TIMESTAMP(), FALSE, '{"enabled":true,"defaults":{"content-type":"application/vnd.bumlux","importance":"high"}}'),
+       ('DEFAULT_TENANT', '4712', 'initial-version', CURRENT_TIMESTAMP(), FALSE, '{"enabled":true,"via":["gw-1"]}'),
+       ('DEFAULT_TENANT', 'gw-1', 'initial-version', CURRENT_TIMESTAMP(), FALSE, '{"enabled":true}');
+
+INSERT INTO device_credentials (tenant_id, device_id, type, auth_id, data)
+VALUES ('DEFAULT_TENANT', '4711', 'hashed-password', 'sensor1', '{"type":"hashed-password","auth-id":"sensor1","secrets":[{"id":"38784caf-83de-4008-a9fe-98687103ad29","not-before":"2017-05-01T13:00:00Z","not-after":"2037-06-01T13:00:00Z","comment":"pwd: hono-secret","hash-function":"bcrypt","pwd-hash":"$2a$10$N7UMjhZ2hYx.yuvW9WVXZ.4y33mr6MvnpAsZ8wgLHnkamH2tZ1jD."}],"enabled":true}'),
+       ('DEFAULT_TENANT', '4711', 'psk', 'sensor1', '{"type":"psk","auth-id":"sensor1","secrets":[{"id":"ab3db625-ca16-4469-9300-75eee7a322f1","not-before":"2017-12-31T23:00:00Z","not-after":"2037-06-01T13:00:00Z","comment":"key: hono-secret","key":"aG9uby1zZWNyZXQ="}],"enabled":true}'),
+       ('DEFAULT_TENANT', '4711', 'x509-cert', 'CN=Device 4711,OU=Hono,O=Eclipse IoT,L=Ottawa,C=CA', '{"type":"x509-cert","auth-id":"CN=Device 4711,OU=Hono,O=Eclipse IoT,L=Ottawa,C=CA","secrets":[{"id":"a38a313c-5dda-49eb-a009-b0f1f343f93a","comment":"The secrets array must contain an object, which can be empty."}],"enabled":true}'),
+       ('DEFAULT_TENANT', 'gw-1', 'hashed-password', 'gw', '{"type":"hashed-password","auth-id":"gw","secrets":[{"id":"7d1fbda2-0f48-4c25-a0c3-1591df939aab","not-before":"2017-12-31T23:00:00Z","not-after":"2037-06-01T13:00:00Z","comment":"pwd: gw-secret","hash-function":"bcrypt","pwd-hash":"$2a$10$GMcN0iV9gJV7L1sH6J82Xebc1C7CGJ..Rbs./vcTuTuxPEgS9DOa6"}],"enabled":true}'),
+       ('DEFAULT_TENANT', 'gw-1', 'psk', 'gw', '{"type":"psk","auth-id":"gw","secrets":[{"id":"b1004571-7d69-4f1f-92aa-ffdcb0d2e992","not-before":"2017-12-31T23:00:00Z","not-after":"2037-06-01T13:00:00Z","comment":"key: gw-secret","key":"Z3ctc2VjcmV0"}],"enabled":true}');


### PR DESCRIPTION
This resolves #2587.
Since an in-memory database does not store data beyond the runtime of the application, a DB with the expected schema must be created each time the Registry Application is started. For the example registry, the example data needs to be created afterward as well. Both tasks can be elegantly solved with a DB migration tool like Flyway.
As far as I can see, there is no logic for the former in Hono yet. For creating the example data, the IoT Packages project contains a job that creates the data via the HTTP API. However, this cannot be used with the in-memory DB, because the data must be created after each start of the registry and not only during the initial deployment. Flyway supports this purpose as well.