### PR TITLE
[#2480] Skip duplicate command records

### DIFF
--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandSender.java
@@ -94,6 +94,10 @@ public class KafkaBasedInternalCommandSender extends AbstractKafkaBasedMessageSe
                 .ifPresent(id -> headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.APP_PROPERTY_CMD_VIA,
                         command.getGatewayId())));
 
+        headers.add(KafkaRecordHelper.createKafkaHeader(KafkaRecordHelper.HEADER_ORIGINAL_PARTITION,
+                command.getRecord().partition()));
+        headers.add(KafkaRecordHelper.createKafkaHeader(KafkaRecordHelper.HEADER_ORIGINAL_OFFSET,
+                command.getRecord().offset()));
         return headers;
     }
 }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaRecordHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaRecordHelper.java
@@ -37,6 +37,16 @@ public final class KafkaRecordHelper {
      * The name of the boolean Kafka record header that defines whether a response is required for the command.
      */
     public static final String HEADER_RESPONSE_REQUIRED = "response-required";
+    /**
+     * The name of the Integer Kafka record header that contains the index of the tenant topic partition
+     * that a command record was originally stored in.
+     */
+    public static final String HEADER_ORIGINAL_PARTITION = "orig-partition";
+    /**
+     * The name of the Long Kafka record header that contains the offset in the tenant topic partition
+     * that a command record was originally stored in.
+     */
+    public static final String HEADER_ORIGINAL_OFFSET = "orig-offset";
 
     private KafkaRecordHelper() {
     }


### PR DESCRIPTION
This is for #2480:
After a command router has crashed (via a hard kill, not properly closing the Kafka consumer, so that last partition offsets aren't committed), some command records may get sent again on the internal topic.
This change here skips these records in the consumer that reads from this topic by keeping track of the already handled offsets concerning the original tenant-based command topic.
