### PR TITLE
Respect status when sending synchronous command via Kafka

### DIFF
--- a/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClient.java
+++ b/clients/application-amqp/src/main/java/org/eclipse/hono/application/client/amqp/ProtonBasedRequestResponseCommandClient.java
@@ -158,7 +158,7 @@ final class ProtonBasedRequestResponseCommandClient extends
                 .map(status -> new RequestResponseResult<>(status, downStreamMessage,
                         CacheDirective.from(MessageHelper.getCacheDirective(message)), null))
                 .orElseGet(() -> {
-                    LOGGER.trace(
+                    LOGGER.warn(
                             "response message has no status code application property [reply-to: {}, correlation ID: {}]",
                             message.getReplyTo(), message.getCorrelationId());
                     return null;

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -300,7 +300,7 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
             return HttpURLConnection.HTTP_INTERNAL_ERROR;
         });
 
-        if (status >= 200 && status < 300) {
+        if (StatusCodeMapper.isSuccessful(status)) {
             return Future.succeededFuture(message);
         } else {
             return Future.failedFuture(StatusCodeMapper.from(status, null));


### PR DESCRIPTION
The JavaDoc of the `sendCommand()` methods in the class `CommandSender` defines that the returned future fails if the response does not contain a status code with 2xx. This commit adds that the status code is taken into account in `KafkaBasedCommandSender`.