### PR TITLE
Add basic LwM2M registration support to CoAP adapter

### DIFF
--- a/adapters/coap-vertx-base/pom.xml
+++ b/adapters/coap-vertx-base/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -35,6 +35,10 @@
     <dependency>
       <groupId>org.eclipse.californium</groupId>
       <artifactId>scandium</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-server-cf</artifactId>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterProperties.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterProperties.java
@@ -71,6 +71,7 @@ public class CoapAdapterProperties extends ProtocolAdapterProperties {
     private int exchangeLifetime = DEFAULT_EXCHANGE_LIFETIME;
     private boolean messageOffloadingEnabled = DEFAULT_MESSAGE_OFFLOADING;
     private int timeoutToAck = DEFAULT_TIMEOUT_TO_ACK;
+    private boolean lwm2mEnabled = false;
 
     /**
      * Gets the regular expression used for splitting up
@@ -387,5 +388,29 @@ public class CoapAdapterProperties extends ProtocolAdapterProperties {
             throw new IllegalArgumentException("timeout to ack must be at least -1");
         }
         this.timeoutToAck = timeoutToAck;
+    }
+
+    /**
+     * Enables or disables the adapter's support for LwM2M.
+     * <p>
+     * Support for LwM2M is an experimental feature. The exact extent to which LwM2M is supported
+     * may change without prior notice.
+     *
+     * @param enabled {@code true} if the adapter should support LwM2M.
+     */
+    public void setLwm2mEnabled(final boolean enabled) {
+        this.lwm2mEnabled = enabled;
+    }
+
+    /**
+     * Checks if the adapter supports LwM2M.
+     * <p>
+     * Support for LwM2M is an experimental feature. The exact extent to which LwM2M is supported
+     * may change without prior notice.
+     *
+     * @return {@code true} if the adapter supports LwM2M.
+     */
+    public final boolean isLwm2mEnabled() {
+        return lwm2mEnabled;
     }
 }

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResource.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResource.java
@@ -47,7 +47,7 @@ import io.vertx.core.Promise;
 /**
  * A CoAP resource that supports the tracking of request processing using <em>OpenTracing</em>.
  * <p>
- * This resource supports processing of {@code POST} and {@code PUT} requests only.
+ * This resource supports processing of {@code POST}, {@code PUT} and {@code DELETE} requests only.
  */
 public abstract class TracingSupportingHonoResource extends CoapResource {
 
@@ -168,7 +168,7 @@ public abstract class TracingSupportingHonoResource extends CoapResource {
     /**
      * {@inheritDoc}
      * <p>
-     * This implementation handles POST and PUT requests only.
+     * This implementation handles POST, PUT and DELETE requests only.
      * All other request codes result in a 4.05 response code.
      * <p>
      * For each request, a new OpenTracing {@code Span} is created. The {@code Span} context is
@@ -208,6 +208,11 @@ public abstract class TracingSupportingHonoResource extends CoapResource {
             result = createCoapContextForPut(coapExchange, currentSpan)
                 .compose(coapContext -> applyTraceSamplingPriority(coapContext, currentSpan))
                 .compose(this::handlePut);
+            break;
+        case DELETE:
+            result = createCoapContextForDelete(coapExchange, currentSpan)
+                .compose(coapContext -> applyTraceSamplingPriority(coapContext, currentSpan))
+                .compose(this::handleDelete);
             break;
         default:
             result = Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_BAD_METHOD));
@@ -271,6 +276,22 @@ public abstract class TracingSupportingHonoResource extends CoapResource {
     }
 
     /**
+     * Creates a CoAP context for an incoming DELETE request.
+     * <p>
+     * This default implementation always returns a future that is failed with a
+     * {@link ServerErrorException} with status code {@value HttpURLConnection#HTTP_NOT_IMPLEMENTED}.
+     *
+     * @param coapExchange The CoAP exchange to process.
+     * @param span The <em>OpenTracing</em> root span that is used to track the processing of the created context.
+     * @return A future indicating the outcome of processing the request.
+     *         The future will be succeeded with the created CoAP context,
+     *         otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     */
+    protected Future<CoapContext> createCoapContextForDelete(final CoapExchange coapExchange, final Span span) {
+        return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
+    }
+
+    /**
      * Applies the trace sampling priority configured for the tenant associated with the
      * given CoAP context to the given span.
      *
@@ -320,6 +341,22 @@ public abstract class TracingSupportingHonoResource extends CoapResource {
      *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
      */
     protected Future<?> handlePut(final CoapContext coapContext) {
+        return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
+    }
+
+    /**
+     * Invoked for an incoming DELETE request.
+     * <p>
+     * This default implementation sends a response back to the client
+     * with response code {@link ResponseCode#NOT_IMPLEMENTED}.
+     *
+     * @param coapContext The CoAP context of the current request.
+     * @return A future indicating the outcome of processing the request.
+     *         The future will be succeeded if the request has been processed successfully
+     *         and a CoAP response has been sent back to the client.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     */
+    protected Future<?> handleDelete(final CoapContext coapContext) {
         return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
     }
 

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/LeshanBasedLwM2MRegistrationStore.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/LeshanBasedLwM2MRegistrationStore.java
@@ -1,0 +1,469 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.coap.lwm2m;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.hono.adapter.client.command.CommandConsumer;
+import org.eclipse.hono.adapter.coap.CoapProtocolAdapter;
+import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.service.metric.MetricsTags.EndpointType;
+import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
+import org.eclipse.hono.service.metric.MetricsTags.QoS;
+import org.eclipse.hono.service.metric.MetricsTags.TtdStatus;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
+import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeEncoder;
+import org.eclipse.leshan.core.observation.Observation;
+import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.core.request.ObserveRequest;
+import org.eclipse.leshan.core.response.ObserveResponse;
+import org.eclipse.leshan.server.californium.observation.ObservationServiceImpl;
+import org.eclipse.leshan.server.californium.registration.CaliforniumRegistrationStore;
+import org.eclipse.leshan.server.californium.request.CaliforniumLwM2mRequestSender;
+import org.eclipse.leshan.server.model.StandardModelProvider;
+import org.eclipse.leshan.server.observation.ObservationListener;
+import org.eclipse.leshan.server.observation.ObservationService;
+import org.eclipse.leshan.server.registration.ExpirationListener;
+import org.eclipse.leshan.server.registration.Registration;
+import org.eclipse.leshan.server.registration.RegistrationUpdate;
+import org.eclipse.leshan.server.request.LwM2mRequestSender2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.log.Fields;
+import io.opentracing.tag.Tags;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+
+
+/**
+ * An Eclipse Leshan based registration store.
+ *
+ */
+public class LeshanBasedLwM2MRegistrationStore implements LwM2MRegistrationStore, Lifecycle, ExpirationListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LeshanBasedLwM2MRegistrationStore.class);
+    private static final String KEY_ENDPOINT_TYPE = "ep_type";
+
+    private final Map<String, CommandConsumer> commandConsumers = new ConcurrentHashMap<>();
+    private final CoapProtocolAdapter adapter;
+    private final Tracer tracer;
+    private final CaliforniumRegistrationStore registrationStore;
+
+    private LwM2mRequestSender2 lwm2mRequestSender;
+    private ObservationService observationService;
+    private Map<String, EndpointType> resourcesToObserve = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a new store.
+     *
+     * @param registrationStore The component to use for storing LwM2M registration information.
+     * @param adapter The protocol adapter to use for interacting with Hono's service components
+     *                and the messaging infrastructure.
+     * @param tracer Open Tracing tracer to use for tracking the processing of requests.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public LeshanBasedLwM2MRegistrationStore(
+            final CaliforniumRegistrationStore registrationStore,
+            final CoapProtocolAdapter adapter,
+            final Tracer tracer) {
+        this.registrationStore = Objects.requireNonNull(registrationStore);
+        this.adapter = Objects.requireNonNull(adapter);
+        this.tracer = Objects.requireNonNull(tracer);
+        // observe Device and Firmware objects by default
+        resourcesToObserve.put("/3/0", EndpointType.TELEMETRY);
+        resourcesToObserve.put("/5/0", EndpointType.EVENT);
+    }
+
+    @Override
+    public Future<Void> start() {
+        registrationStore.setExpirationListener(this);
+        final var modelProvider = new StandardModelProvider();
+        final var nodeDecoder = new DefaultLwM2mNodeDecoder();
+
+        final var observationServiceImpl = new ObservationServiceImpl(
+                registrationStore,
+                modelProvider,
+                nodeDecoder);
+        Optional.ofNullable(adapter.getSecureEndpoint()).ifPresent(ep -> {
+            ep.addNotificationListener(observationServiceImpl);
+            observationServiceImpl.setNonSecureEndpoint(ep);
+        });
+        Optional.ofNullable(adapter.getInsecureEndpoint()).ifPresent(ep -> {
+            ep.addNotificationListener(observationServiceImpl);
+            observationServiceImpl.setNonSecureEndpoint(ep);
+        });
+
+        observationServiceImpl.addListener(new ObservationListener() {
+
+            @Override
+            public void onResponse(
+                    final Observation observation,
+                    final Registration registration,
+                    final ObserveResponse response) {
+
+                adapter.runOnContext(go -> {
+                    handleNotification(registration, response);
+                });
+            }
+
+            @Override
+            public void onError(
+                    final Observation observation,
+                    final Registration registration,
+                    final Exception error) {
+            }
+
+            @Override
+            public void newObservation(final Observation observation, final Registration registration) {
+                LOG.debug("established new {} for {}", observation, registration);
+            }
+
+            @Override
+            public void cancelled(final Observation observation) {
+            }
+        });
+
+        lwm2mRequestSender = new CaliforniumLwM2mRequestSender(
+                adapter.getSecureEndpoint(),
+                adapter.getInsecureEndpoint(),
+                observationServiceImpl,
+                modelProvider,
+                new DefaultLwM2mNodeEncoder(),
+                nodeDecoder);
+
+        observationService = observationServiceImpl;
+        registrationStore.start();
+
+        return Future.succeededFuture();
+    }
+
+    @Override
+    public Future<Void> stop() {
+        if (registrationStore != null) {
+            registrationStore.stop();
+        }
+        return Future.succeededFuture();
+    }
+
+    private Future<?> sendLifetimeAsTtdEvent(
+            final Device originDevice,
+            final Registration registration,
+            final SpanContext tracingContext) {
+
+        final int lifetime = registration.getBindingMode() == BindingMode.U
+                ? registration.getLifeTimeInSec().intValue()
+                : 20;
+        return adapter.sendTtdEvent(
+                originDevice.getTenantId(),
+                originDevice.getDeviceId(),
+                null,
+                lifetime,
+                tracingContext);
+    }
+
+    void setResourcesToObserve(final Map<String, EndpointType> mappings) {
+        resourcesToObserve.clear();
+        if (mappings != null) {
+            resourcesToObserve.putAll(mappings);
+        }
+    }
+
+    private Future<Map<String, EndpointType>> getResourcesToObserve(
+            final String tenantId,
+            final String deviceId,
+            final SpanContext tracingContext) {
+
+        // TODO determine resources to observe from device registration info
+        return Future.succeededFuture(resourcesToObserve);
+    }
+
+
+    private void observeConfiguredResources(
+            final Registration registration,
+            final SpanContext tracingContext) {
+
+        final String tenantId = LwM2MUtils.getTenantId(registration);
+        final String deviceId = LwM2MUtils.getDeviceId(registration);
+
+        final var span = tracer.buildSpan("observe configured resources")
+                .addReference(References.FOLLOWS_FROM, tracingContext)
+                .withTag(TracingHelper.TAG_TENANT_ID, tenantId)
+                .withTag(TracingHelper.TAG_DEVICE_ID, deviceId)
+                .withTag(Tags.SPAN_KIND, Tags.SPAN_KIND_CLIENT)
+                .withTag(LwM2MUtils.TAG_LWM2M_REGISTRATION_ID, registration.getId())
+                .start();
+
+        getResourcesToObserve(tenantId, deviceId, span.context())
+            .onSuccess(resourcesToObserve -> {
+                resourcesToObserve.entrySet()
+                    .forEach(entry -> observeResource(
+                            registration,
+                            tenantId,
+                            deviceId,
+                            entry.getKey(),
+                            entry.getValue(),
+                            tracingContext));
+            })
+            .onComplete(r -> span.finish());
+    }
+
+    private boolean isResourceSupported(final Registration registration, final String resource) {
+        return Stream.of(registration.getObjectLinks())
+                .anyMatch(link -> resource.startsWith(link.getUrl()));
+    }
+
+    private void observeResource(
+            final Registration registration,
+            final String tenantId,
+            final String deviceId,
+            final String resource,
+            final EndpointType endpoint,
+            final SpanContext tracingContext) {
+
+        final var span = tracer.buildSpan("observe resource")
+                .addReference(References.CHILD_OF, tracingContext)
+                .withTag(TracingHelper.TAG_TENANT_ID, tenantId)
+                .withTag(TracingHelper.TAG_DEVICE_ID, deviceId)
+                .withTag(Tags.SPAN_KIND, Tags.SPAN_KIND_CLIENT)
+                .withTag(LwM2MUtils.TAG_LWM2M_REGISTRATION_ID, registration.getId())
+                .withTag(LwM2MUtils.TAG_LWM2M_RESOURCE, resource)
+                .start();
+
+        if (!isResourceSupported(registration, resource)) {
+            TracingHelper.logError(span, "device does not support resource");
+            span.finish();
+            return;
+        }
+
+        lwm2mRequestSender.send(
+                registration,
+                new ObserveRequest(null, resource, Map.of(KEY_ENDPOINT_TYPE, endpoint.getCanonicalName())),
+                req -> {
+                    ((Request) req).setConfirmable(true);
+                },
+                30_000L, // we require the device to answer quickly
+                response -> {
+                    if (response.isFailure()) {
+                        TracingHelper.logError(span, "failed to establish observation");
+                    } else {
+                        adapter.runOnContext(go -> {
+                            handleNotification(registration, response);
+                        });
+                    }
+                    span.setTag(Tags.HTTP_STATUS, response.getCode().getCode());
+                    span.finish();
+                },
+                t -> {
+                    TracingHelper.logError(span, Map.of(
+                            Fields.MESSAGE, "failed to send observe request",
+                            Fields.ERROR_KIND, "Exception",
+                            Fields.ERROR_OBJECT, t));
+                    span.finish();
+                });
+    }
+
+    /**
+     * Forwards a notification received from a device to downstream consumers.
+     *
+     * @param registration The device's LwM2M registration information.
+     * @param response The response message that contains the notification.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    void handleNotification(
+            final Registration registration,
+            final ObserveResponse response) {
+
+        Objects.requireNonNull(registration);
+        Objects.requireNonNull(response);
+
+        final var observation = response.getObservation();
+        LOG.debug("handling notification for {}", observation);
+        final Device authenticatedDevice = LwM2MUtils.getDevice(registration);
+        final EndpointType endpoint = Optional.ofNullable(observation.getContext().get(KEY_ENDPOINT_TYPE))
+                .map(EndpointType::fromString)
+                .orElse(EndpointType.TELEMETRY);
+
+        final Span currentSpan = tracer.buildSpan("process notification")
+                .withTag(Tags.SPAN_KIND, Tags.SPAN_KIND_CONSUMER)
+                .withTag(Tags.COMPONENT, adapter.getTypeName())
+                .withTag(TracingHelper.TAG_TENANT_ID, authenticatedDevice.getTenantId())
+                .withTag(TracingHelper.TAG_DEVICE_ID, authenticatedDevice.getDeviceId())
+                .withTag(LwM2MUtils.TAG_LWM2M_REGISTRATION_ID, registration.getId())
+                .withTag(LwM2MUtils.TAG_LWM2M_RESOURCE, observation.getPath().toString())
+                .start();
+
+        final var ctx = NotificationContext.fromResponse(
+                response,
+                authenticatedDevice,
+                adapter.getMetrics().startTimer(),
+                currentSpan);
+
+        final Map<String, Object> props = ctx.getDownstreamMessageProperties();
+        props.put(MessageHelper.APP_PROPERTY_ORIG_ADAPTER, adapter.getTypeName());
+
+        final Future<TenantObject> tenantTracker = adapter.getTenantClient().get(ctx.getTenantId(), currentSpan.context())
+                .compose(tenantObject -> CompositeFuture.all(
+                        adapter.isAdapterEnabled(tenantObject),
+                        adapter.checkMessageLimit(tenantObject, ctx.getPayload().length(), currentSpan.context()))
+                    .map(tenantObject));
+        final Future<RegistrationAssertion> tokenTracker = adapter.getRegistrationAssertion(
+                ctx.getTenantId(),
+                ctx.getAuthenticatedDevice().getDeviceId(),
+                null,
+                currentSpan.context());
+
+        CompositeFuture.join(tenantTracker, tokenTracker)
+            .compose(ok -> {
+                if (EndpointType.EVENT == endpoint) {
+                    LOG.debug("forwarding observe response as event");
+                    return adapter.getEventSender(tenantTracker.result()).sendEvent(
+                            tenantTracker.result(),
+                            tokenTracker.result(),
+                            ctx.getContentType(),
+                            ctx.getPayload(),
+                            props,
+                            currentSpan.context());
+                } else {
+                    LOG.debug("forwarding observe response as telemetry message");
+                    return adapter.getTelemetrySender(tenantTracker.result()).sendTelemetry(
+                            tenantTracker.result(),
+                            tokenTracker.result(),
+                            ctx.getRequestedQos(),
+                            ctx.getContentType(),
+                            ctx.getPayload(),
+                            props,
+                            currentSpan.context());
+                }
+            })
+            .onComplete(r -> {
+                final ProcessingOutcome outcome;
+                if (r.succeeded()) {
+                    outcome = ProcessingOutcome.FORWARDED;
+                } else {
+                    outcome = ClientErrorException.class.isInstance(r.cause()) ?
+                            ProcessingOutcome.UNPROCESSABLE : ProcessingOutcome.UNDELIVERABLE;
+                    TracingHelper.logError(currentSpan, r.cause());
+                }
+                adapter.getMetrics().reportTelemetry(
+                        endpoint,
+                        authenticatedDevice.getTenantId(),
+                        tenantTracker.result(),
+                        outcome,
+                        EndpointType.EVENT == endpoint ? QoS.AT_LEAST_ONCE : QoS.AT_MOST_ONCE,
+                        ctx.getPayload().length(),
+                        TtdStatus.NONE,
+                        ctx.getTimer());
+                currentSpan.finish();
+            });
+    }
+
+    @Override
+    public void registrationExpired(final Registration registration, final Collection<Observation> observations) {
+        Optional.ofNullable(commandConsumers.remove(registration.getId()))
+            .ifPresent(consumer -> {
+                adapter.runOnContext(go -> {
+                    final Device device = LwM2MUtils.getDevice(registration);
+                    consumer.close(null)
+                        .onComplete(r -> observations.forEach(obs -> {
+                            LOG.debug("canceling {} of {}", obs, device);
+                            observationService.cancelObservation(obs);
+                        }));
+                });
+            });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> addRegistration(final Registration registration, final SpanContext tracingContext) {
+
+        final var device = LwM2MUtils.getDevice(registration);
+        final var existingRegistration = registrationStore.addRegistration(registration);
+
+        if (existingRegistration == null) {
+            LOG.debug("added {} for {}", registration, device);
+        } else {
+            LOG.debug("replaced existing {} for {} with new {}", existingRegistration, device, registration);
+        }
+
+        return adapter.getCommandConsumerFactory()
+            .createCommandConsumer(
+                device.getTenantId(),
+                device.getDeviceId(),
+                commandContext -> {
+                    Tags.COMPONENT.set(commandContext.getTracingSpan(), adapter.getTypeName());
+                 // TODO add logic for sending commands to device
+                },
+                null,
+                tracingContext)
+            .compose(commandConsumer -> {
+                commandConsumers.put(registration.getId(), commandConsumer);
+                return sendLifetimeAsTtdEvent(device, registration, tracingContext);
+            })
+            .onSuccess(ok -> observeConfiguredResources(registration, tracingContext))
+            .mapEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> updateRegistration(final RegistrationUpdate registrationUpdate, final SpanContext tracingContext) {
+
+        final var updatedRegistration = registrationStore.updateRegistration(registrationUpdate);
+        final var device = LwM2MUtils.getDevice(updatedRegistration.getPreviousRegistration());
+
+        return sendLifetimeAsTtdEvent(device, updatedRegistration.getUpdatedRegistration(), tracingContext)
+                .mapEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> removeRegistration(final String registrationId, final SpanContext tracingContext) {
+
+        // this also removes all observations associated with the registration
+        final var deregistration = registrationStore.removeRegistration(registrationId);
+        final var device = LwM2MUtils.getDevice(deregistration.getRegistration());
+
+        registrationExpired(deregistration.getRegistration(), deregistration.getObservations());
+        return adapter.sendTtdEvent(
+                device.getTenantId(),
+                device.getDeviceId(),
+                null,
+                0,
+                tracingContext)
+                .mapEmpty();
+    }
+}

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/LwM2MRegistrationStore.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/LwM2MRegistrationStore.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.coap.lwm2m;
+
+import org.eclipse.leshan.server.registration.Registration;
+import org.eclipse.leshan.server.registration.RegistrationUpdate;
+
+import io.opentracing.SpanContext;
+import io.vertx.core.Future;
+
+/**
+ * A service for keeping track of registration info of LwM2M devices.
+ *
+ */
+public interface LwM2MRegistrationStore {
+
+    /**
+     * Adds registration information for a device.
+     *
+     * @param registration The LwM2M registration data for the device.
+     * @param tracingContext The Open Tracing context to use for tracking the processing of the request
+     *                       or {@code null} if no tracing should be done.
+     * @return A future indicating the outcome of the operation.
+     *         The future will be succeeded if the registration information has been added newly or has replaced
+     *         an existing registration for the device.
+     *         The future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} if the
+     *         registration information could not be stored.
+     * @throws NullPointerException if registration is {@code null}.
+     */
+    Future<Void> addRegistration(Registration registration, SpanContext tracingContext);
+
+    /**
+     * Updates registration information for a device.
+     *
+     * @param registrationUpdate The LwM2M registration data to update for the device.
+     * @param tracingContext The Open Tracing context to use for tracking the processing of the request
+     *                       or {@code null} if no tracing should be done.
+     * @return A future indicating the outcome of the operation.
+     *         The future will be succeeded if the registration information has been updated successfully.
+     *         The future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} if the
+     *         registration information could not be updated.
+     * @throws NullPointerException if registration is {@code null}.
+     */
+    Future<Void> updateRegistration(RegistrationUpdate registrationUpdate, SpanContext tracingContext);
+
+    /**
+     * Removes registration information for a device.
+     *
+     * @param registrationId The identifier of the registration to remove.
+     * @param tracingContext The Open Tracing context to use for tracking the processing of the request
+     *                       or {@code null} if no tracing should be done.
+     * @return A future indicating the outcome of the operation.
+     *         The future will be succeeded if the registration information has been removed successfully.
+     *         The future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} if the
+     *         registration information could not be updated.
+     * @throws NullPointerException if registration is {@code null}.
+     */
+    Future<Void> removeRegistration(String registrationId, SpanContext tracingContext);
+}

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/LwM2MResourceDirectory.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/LwM2MResourceDirectory.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.coap.lwm2m;
+
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.hono.adapter.coap.CoapContext;
+import org.eclipse.hono.adapter.coap.CoapProtocolAdapter;
+import org.eclipse.hono.adapter.coap.TracingSupportingHonoResource;
+import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.Strings;
+import org.eclipse.leshan.core.Link;
+import org.eclipse.leshan.core.californium.EndpointContextUtil;
+import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.server.registration.Registration;
+import org.eclipse.leshan.server.registration.RegistrationUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+
+/**
+ * A CoAP resource implementing basic parts of the
+ * <a href="https://tools.ietf.org/html/draft-ietf-core-resource-directory-23">
+ * CoRE Resource Directory</a>.
+ * <p>
+ * The registration, update and removal requests of devices are mapped to <em>empty
+ * notification</em> events containing the <em>lifetime</em> provided by the device
+ * as TTD value.
+ *
+ */
+public final class LwM2MResourceDirectory extends TracingSupportingHonoResource implements Lifecycle {
+
+    private static final String QUERY_PARAM_BINDING_MODE = "b";
+    private static final String QUERY_PARAM_ENDPOINT = "ep";
+    private static final String QUERY_PARAM_LIFETIME = "lt";
+    private static final String QUERY_PARAM_LWM2M_VERSION = "lwm2m";
+    private static final Logger LOG = LoggerFactory.getLogger(LwM2MResourceDirectory.class);
+
+    private final Set<BindingMode> supportedBindingModes = Set.of(BindingMode.U, BindingMode.UQ);
+    private final LwM2MRegistrationStore registrationStore;
+
+    /**
+     * Creates a new resource directory resource.
+     *
+     * @param adapter The protocol adapter that this resource is part of.
+     * @param registrationStore The component to use for managing registration information.
+     * @param tracer Open Tracing tracer to use for tracking the processing of requests.
+     */
+    public LwM2MResourceDirectory(
+            final CoapProtocolAdapter adapter,
+            final LwM2MRegistrationStore registrationStore,
+            final Tracer tracer) {
+        super(adapter, tracer, "rd");
+        getAttributes().addResourceType("core.rd");
+        this.registrationStore = Objects.requireNonNull(registrationStore);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> start() {
+        if (registrationStore instanceof Lifecycle) {
+            ((Lifecycle) registrationStore).start();
+        }
+        return Future.succeededFuture();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<Void> stop() {
+        if (registrationStore instanceof Lifecycle) {
+            ((Lifecycle) registrationStore).stop();
+        }
+        return Future.succeededFuture();
+    }
+
+    private String getRegistrationId(final Device device) {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Future<CoapContext> createCoapContextForPost(final CoapExchange coapExchange, final Span span) {
+        return getAuthenticatedDevice(coapExchange)
+                .map(device -> CoapContext.fromRequest(coapExchange, device, device, null, span));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Future<CoapContext> createCoapContextForDelete(final CoapExchange coapExchange, final Span span) {
+        return getAuthenticatedDevice(coapExchange)
+                .map(device -> CoapContext.fromRequest(coapExchange, device, device, null, span));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Handles a request to create or update a device's registration.
+     */
+    @Override
+    protected Future<?> handlePost(final CoapContext ctx) {
+
+        final Request request = ctx.getExchange().advanced().getRequest();
+        LOG.debug("processing POST request: {}", request);
+
+        // we only support confirmable messages
+        if (!ctx.isConfirmable()) {
+            return Future.failedFuture(new ClientErrorException(
+                    HttpURLConnection.HTTP_BAD_REQUEST,
+                    "LwM2M does not support CoAP NON requests"));
+        }
+
+        if (!ctx.isDeviceAuthenticated()) {
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN,
+                    "server does not support noSec security mode"));
+        }
+
+        final List<String> uri = ctx.getExchange().getRequestOptions().getUriPath();
+        if (uri.size() > 2) {
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+        }
+
+        final String lwm2mVersion = ctx.getQueryParameter(QUERY_PARAM_LWM2M_VERSION);
+        final String endpoint = ctx.getQueryParameter(QUERY_PARAM_ENDPOINT);
+        final Long lifetime = Optional.ofNullable(ctx.getQueryParameter(QUERY_PARAM_LIFETIME))
+                .map(lt -> {
+                    try {
+                        return Long.valueOf(lt);
+                    } catch (final NumberFormatException e) {
+                        return -1L;
+                    }
+                })
+                .orElse(null);
+        final BindingMode bindingMode = Optional.ofNullable(ctx.getQueryParameter(QUERY_PARAM_BINDING_MODE))
+                .map(BindingMode::valueOf)
+                .orElse(BindingMode.U);
+        final Link[] objectLinks = Link.parse(request.getPayload());
+
+        final Promise<ResponseCode> result = Promise.promise();
+        if (uri.size() == 1) {
+            handleRegister(ctx, lwm2mVersion, endpoint, bindingMode, lifetime, objectLinks).onComplete(result);
+        } else {
+            // URI path can have at most 2 segments as already verified above
+            handleUpdate(ctx, bindingMode, lifetime, objectLinks, uri.get(1)).onComplete(result);
+        }
+        return result.future().onSuccess(ctx::respondWithCode);
+    }
+
+    private Future<ResponseCode> handleRegister(
+            final CoapContext ctx,
+            final String lwm2mVersion,
+            final String endpoint,
+            final BindingMode bindingMode,
+            final long lifetime,
+            final Link[] objectLinks) {
+
+        final Promise<ResponseCode> result = Promise.promise();
+
+        final Span currentSpan = TracingHelper
+                .buildChildSpan(getTracer(), ctx.getTracingContext(), "register LwM2M device", getAdapter().getTypeName())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                .withTag(TracingHelper.TAG_TENANT_ID, ctx.getTenantId())
+                .withTag(TracingHelper.TAG_DEVICE_ID, ctx.getOriginDevice().getDeviceId())
+                .start();
+
+        LOG.debug("processing LwM2M registration request for {}", ctx.getOriginDevice());
+        currentSpan.log(Map.of(
+                "lwm2m", lwm2mVersion,
+                "endpoint", endpoint,
+                "binding mode", bindingMode.name(),
+                "lifetime (secs)", lifetime));
+
+        if (Strings.isNullOrEmpty(lwm2mVersion)) {
+            result.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
+                    QUERY_PARAM_LWM2M_VERSION + " query parameter must be non-empty"));
+        } else if (!lwm2mVersion.startsWith("1.0")) {
+            result.fail(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
+                    "server supports LwM2M version 1.0.x only"));
+        } else if (Strings.isNullOrEmpty(endpoint)) {
+            result.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
+                    QUERY_PARAM_ENDPOINT + " query parameter must be non-empty"));
+        } else if (lifetime <= 0) {
+            result.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
+                    QUERY_PARAM_LIFETIME + " query parameter must be positive integer"));
+        } else if (!supportedBindingModes.contains(bindingMode)) {
+            result.fail(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
+                    "server supports binding modes U and UQ only"));
+        } else {
+            final var identity = EndpointContextUtil.extractIdentity(ctx.getExchange().advanced().getRequest().getSourceContext());
+            final var registration = new Registration.Builder(getRegistrationId(ctx.getOriginDevice()), endpoint, identity)
+                    .lwM2mVersion(lwm2mVersion)
+                    .lifeTimeInSec(lifetime)
+                    .bindingMode(bindingMode)
+                    .objectLinks(objectLinks)
+                    .additionalRegistrationAttributes(Map.of(
+                            TracingHelper.TAG_TENANT_ID.getKey(), ctx.getTenantId(),
+                            TracingHelper.TAG_DEVICE_ID.getKey(), ctx.getAuthenticatedDevice().getDeviceId()))
+                    .build();
+
+            registrationStore.addRegistration(registration, currentSpan.context())
+                .onSuccess(ok -> {
+                    currentSpan.setTag(LwM2MUtils.TAG_LWM2M_REGISTRATION_ID, registration.getId());
+                    ctx.getExchange().setLocationPath(String.format("%s/%s", getName(), registration.getId()));
+                    result.complete(ResponseCode.CREATED);
+                })
+                .onFailure(t -> result.fail(t));
+        }
+        return result.future()
+                .onFailure(t -> TracingHelper.logError(currentSpan, t))
+                .onComplete(r -> currentSpan.finish());
+    }
+
+    private Future<ResponseCode> handleUpdate(
+            final CoapContext ctx,
+            final BindingMode bindingMode,
+            final Long lifetime,
+            final Link[] objectlinks,
+            final String registrationId) {
+
+        final Promise<ResponseCode> result = Promise.promise();
+
+        final Span currentSpan = TracingHelper
+                .buildChildSpan(getTracer(), ctx.getTracingContext(), "update LwM2M device registration", getAdapter().getTypeName())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                .withTag(TracingHelper.TAG_TENANT_ID, ctx.getTenantId())
+                .withTag(TracingHelper.TAG_DEVICE_ID, ctx.getOriginDevice().getDeviceId())
+                .withTag(LwM2MUtils.TAG_LWM2M_REGISTRATION_ID, registrationId)
+                .start();
+
+        LOG.debug("processing LwM2M registration update request [tenant-id: {}, device-id: {}, registration ID: {}]",
+                ctx.getTenantId(), ctx.getOriginDevice().getDeviceId(), registrationId);
+        final Map<String, Object> items = new HashMap<>(2);
+        Optional.ofNullable(bindingMode).ifPresent(bm -> items.put("binding mode", bm.name()));
+        Optional.ofNullable(lifetime).ifPresent(lt -> items.put("lifetime (secs)", lt));
+        currentSpan.log(items);
+
+        if (lifetime != null && lifetime <= 0) {
+            result.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST,
+                    "lifetime query parameter must be positive integer"));
+        } else if (bindingMode != null && !supportedBindingModes.contains(bindingMode)) {
+            result.fail(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
+                    "server supports binding modes U and UQ only"));
+        } else {
+            final var registrationUpdate = new RegistrationUpdate(
+                    registrationId,
+                    EndpointContextUtil.extractIdentity(ctx.getExchange().advanced().getRequest().getSourceContext()),
+                    lifetime,
+                    null,
+                    bindingMode,
+                    objectlinks,
+                    null);
+
+            registrationStore.updateRegistration(registrationUpdate, currentSpan.context())
+                .onSuccess(ok -> result.complete(ResponseCode.CHANGED))
+                .onFailure(t -> result.fail(t));
+        }
+        return result.future()
+                .onFailure(t -> TracingHelper.logError(currentSpan, t))
+                .onComplete(r -> currentSpan.finish());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Handles a request to delete a device's registration.
+     */
+    @Override
+    protected Future<?> handleDelete(final CoapContext ctx) {
+
+        final List<String> uri = ctx.getExchange().getRequestOptions().getUriPath();
+
+        if (uri.size() == 2) {
+            return handleDeregister(ctx, uri.get(1)).onSuccess(ctx::respondWithCode);
+        } else {
+            return Future.failedFuture(new ClientErrorException(
+                    HttpURLConnection.HTTP_NOT_FOUND,
+                    "request URI for deregistering is defined as /rd/${registrationId}"));
+        }
+    }
+
+    private Future<ResponseCode> handleDeregister(final CoapContext ctx, final String registrationId) {
+
+        final Device device = ctx.getAuthenticatedDevice();
+        final Span currentSpan = TracingHelper
+                .buildChildSpan(getTracer(), ctx.getTracingContext(), "deregister LwM2M device", getAdapter().getTypeName())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                .withTag(TracingHelper.TAG_TENANT_ID, device.getTenantId())
+                .withTag(TracingHelper.TAG_DEVICE_ID, device.getDeviceId())
+                .withTag(LwM2MUtils.TAG_LWM2M_REGISTRATION_ID, registrationId)
+                .start();
+
+        LOG.debug("processing request for deregistration of {} using registration ID {}", device, registrationId);
+
+        return registrationStore.removeRegistration(registrationId, currentSpan.context())
+            .map(ResponseCode.DELETED)
+            .onFailure(t -> TracingHelper.logError(currentSpan, t))
+            .onComplete(r -> currentSpan.finish());
+    }
+}

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/LwM2MUtils.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/LwM2MUtils.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.coap.lwm2m;
+
+import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.leshan.server.registration.Registration;
+
+/**
+ * Helper methods for LwM2M.
+ *
+ */
+final class LwM2MUtils {
+
+    static final String TAG_LWM2M_REGISTRATION_ID = "lwm2m_registration_id";
+    static final String TAG_LWM2M_RESOURCE = "path";
+
+    private LwM2MUtils() {
+        // prevent instantiation
+    }
+
+    static Device getDevice(final Registration registration) {
+        return new Device(getTenantId(registration), getDeviceId(registration));
+    }
+
+    static String getTenantId(final Registration registration) {
+        return registration.getAdditionalRegistrationAttributes().get(TracingHelper.TAG_TENANT_ID.getKey());
+    }
+
+    static String getDeviceId(final Registration registration) {
+        return registration.getAdditionalRegistrationAttributes().get(TracingHelper.TAG_DEVICE_ID.getKey());
+    }
+
+
+}

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/NotificationContext.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/lwm2m/NotificationContext.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.adapter.coap.lwm2m;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.hono.auth.Device;
+import org.eclipse.hono.util.MapBasedTelemetryExecutionContext;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.leshan.core.observation.Observation;
+import org.eclipse.leshan.core.response.ObserveResponse;
+
+import io.micrometer.core.instrument.Timer.Sample;
+import io.opentracing.Span;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A dictionary of relevant information required during the processing of an observe notification contained in
+ * a CoAP response message published by a LwM2M client (device).
+ *
+ */
+public final class NotificationContext extends MapBasedTelemetryExecutionContext {
+
+    private final Response response;
+    private final Observation observation;
+    private final Sample timer;
+
+    private NotificationContext(
+            final ObserveResponse response,
+            final Device authenticatedDevice,
+            final Sample timer,
+            final Span span) {
+        super(span, authenticatedDevice);
+        this.response = (Response) response.getCoapResponse();
+        this.observation = response.getObservation();
+        this.timer = timer;
+    }
+
+    /**
+     * Creates a new context for an observe notification.
+     *
+     * @param response The CoAP response containing the notification.
+     * @param authenticatedDevice The authenticated device that the notification has been received from.
+     * @param timer The object to use for measuring the time it takes to process the request.
+     * @param span The <em>OpenTracing</em> root span that is used to track the processing of this context.
+     * @return The context.
+     * @throws NullPointerException if response, originDevice, span or timer are {@code null}.
+     */
+    public static NotificationContext fromResponse(
+            final ObserveResponse response,
+            final Device authenticatedDevice,
+            final Sample timer,
+            final Span span) {
+
+        Objects.requireNonNull(response);
+        Objects.requireNonNull(authenticatedDevice);
+        Objects.requireNonNull(span);
+        Objects.requireNonNull(timer);
+
+        return new NotificationContext(response, authenticatedDevice, timer, span);
+    }
+
+    /**
+     * Gets the tenant identifier.
+     *
+     * @return The tenant.
+     */
+    public String getTenantId() {
+        return getAuthenticatedDevice().getTenantId();
+    }
+
+    /**
+     * Gets the CoAP response.
+     *
+     * @return The response.
+     */
+    public Response getResponse() {
+        return response;
+    }
+
+    /**
+     * Gets the payload of the response.
+     *
+     * @return payload of response
+     */
+    public Buffer getPayload() {
+        final byte[] payload = response.getPayload();
+        if (payload == null || payload.length == 0) {
+            return Buffer.buffer();
+        } else {
+            return Buffer.buffer(payload);
+        }
+    }
+
+    /**
+     * Gets the media type that corresponds to the <em>content-format</em> option of the CoAP response.
+     * <p>
+     * The media type is determined as follows:
+     * <ol>
+     * <li>If the response doesn't contain a <em>content-format</em> option, the media type
+     * is {@code null}</li>
+     * <li>Otherwise, if the content-format code is registered with IANA, the media type is the one
+     * that has been registered for the code</li>
+     * <li>Otherwise, the media type is <em>unknown/code</em> where code is the value of the content-format
+     * option</li>
+     * </ol>
+     *
+     * @return The media type or {@code null} if the response does not contain a content-format option.
+     */
+    public String getContentType() {
+        if (response.getOptions().hasContentFormat()) {
+            return MediaTypeRegistry.toString(response.getOptions().getContentFormat());
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Gets the object used for measuring the time it takes to process this response.
+     *
+     * @return The timer or {@code null} if not set.
+     */
+    public Sample getTimer() {
+        return timer;
+    }
+
+    /**
+     * Checks if the response has been sent using a CONfirmable message.
+     *
+     * @return {@code true} if the response message is CONfirmable.
+     */
+    public boolean isConfirmable() {
+        return response.isConfirmable();
+    }
+
+    @Override
+    public QoS getRequestedQos() {
+        return isConfirmable() ? QoS.AT_LEAST_ONCE : QoS.AT_MOST_ONCE;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return An empty optional.
+     */
+    @Override
+    public Optional<Duration> getTimeToLive() {
+        return Optional.empty();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The observed resource path.
+     */
+    @Override
+    public String getOrigAddress() {
+        return observation.getPath().toString();
+    }
+}

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/EventResourceTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/EventResourceTest.java
@@ -30,6 +30,7 @@ import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
@@ -84,12 +85,12 @@ public class EventResourceTest extends ResourceTestBase {
         // THEN the message is being forwarded downstream
         assertEventHasBeenSentDownstream("tenant", "device", "text/plain");
         // but the device does not get a response
-        verify(coapExchange, never()).respond(any(Response.class));
+        verify(secureEndpoint, never()).sendResponse(any(Exchange.class), any(Response.class));
 
         // until the event has been accepted
         outcome.complete();
 
-        verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED.equals(res.getCode())));
+        verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED == res.getCode()));
         verify(metrics).reportTelemetry(
                 eq(MetricsTags.EndpointType.EVENT),
                 eq("tenant"),

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TelemetryResourceTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TelemetryResourceTest.java
@@ -33,6 +33,7 @@ import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.auth.Device;
@@ -229,7 +230,7 @@ public class TelemetryResourceTest extends ResourceTestBase {
         resource.handlePost(context);
 
         // THEN the device gets a response indicating success
-        verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED.equals(res.getCode())));
+        verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED == res.getCode()));
         // and the message has been forwarded downstream
         assertTelemetryMessageHasBeenSentDownstream(
                 QoS.AT_MOST_ONCE,
@@ -268,7 +269,7 @@ public class TelemetryResourceTest extends ResourceTestBase {
         resource.handlePost(context);
 
         // THEN the device gets a response indicating success
-        verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED.equals(res.getCode())));
+        verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED == res.getCode()));
         // and the message has been forwarded downstream
         assertTelemetryMessageHasBeenSentDownstream(
                 QoS.AT_MOST_ONCE,
@@ -315,11 +316,11 @@ public class TelemetryResourceTest extends ResourceTestBase {
                 "device",
                 "text/plain");
         // and the device does not get a response
-        verify(coapExchange, never()).respond(any(Response.class));
+        verify(secureEndpoint, never()).sendResponse(any(Exchange.class), any(Response.class));
         // until the telemetry message has been accepted
         outcome.complete();
 
-        verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED.equals(res.getCode())));
+        verify(coapExchange).respond(argThat((Response res) -> ResponseCode.CHANGED == res.getCode()));
         verify(metrics).reportTelemetry(
                 eq(MetricsTags.EndpointType.TELEMETRY),
                 eq("tenant"),
@@ -485,7 +486,7 @@ public class TelemetryResourceTest extends ResourceTestBase {
                 "device",
                 "text/plain");
         // with no response being sent to the device yet
-        verify(coapExchange, never()).respond(any(Response.class));
+        verify(secureEndpoint, never()).sendResponse(any(Exchange.class), any(Response.class));
 
         // WHEN the telemetry message delivery gets failed with an exception representing a "released" delivery outcome
         sendTelemetryOutcome.fail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE));

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResourceTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TracingSupportingHonoResourceTest.java
@@ -79,11 +79,11 @@ public class TracingSupportingHonoResourceTest {
     private CoapProtocolAdapter adapter;
 
     private static Stream<Code> supportedRequestCodes() {
-        return Stream.of(Code.POST, Code.PUT);
+        return Stream.of(Code.POST, Code.PUT, Code.DELETE);
     }
 
     private static Stream<Code> unsupportedRequestCodes() {
-        return Stream.of(Code.CUSTOM_30, Code.DELETE, Code.FETCH, Code.GET, Code.IPATCH, Code.PATCH);
+        return Stream.of(Code.CUSTOM_30, Code.FETCH, Code.GET, Code.IPATCH, Code.PATCH);
     }
 
     /**

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/lwm2m/LeshanBasedLwM2MRegistrationStoreTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/lwm2m/LeshanBasedLwM2MRegistrationStoreTest.java
@@ -1,0 +1,320 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.coap.lwm2m;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
+import org.eclipse.californium.core.network.RandomTokenGenerator;
+import org.eclipse.californium.core.network.TokenGenerator;
+import org.eclipse.californium.core.network.TokenGenerator.Scope;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.observe.Observation;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.hono.adapter.coap.ResourceTestBase;
+import org.eclipse.hono.service.metric.MetricsTags.EndpointType;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.leshan.core.Link;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.server.californium.registration.CaliforniumRegistrationStore;
+import org.eclipse.leshan.server.californium.registration.InMemoryRegistrationStore;
+import org.eclipse.leshan.server.registration.Registration;
+import org.eclipse.leshan.server.registration.RegistrationUpdate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopSpan;
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+
+/**
+ * Tests verifying behavior of {@link LeshanBasedLwM2MRegistrationStore}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class LeshanBasedLwM2MRegistrationStoreTest extends ResourceTestBase {
+
+    private final InetSocketAddress clientAddress = InetSocketAddress.createUnresolved("localhost", 15000);
+    private final TokenGenerator tokenGenerator = new RandomTokenGenerator(NetworkConfig.createStandardWithoutFile());
+
+    private LeshanBasedLwM2MRegistrationStore store;
+    private Tracer tracer = NoopTracerFactory.create();
+    private Identity identity;
+    private CaliforniumRegistrationStore observationStore;
+
+    /**
+     * Sets up the fixture.
+     */
+    @BeforeEach
+    void setUp(final VertxTestContext ctx) {
+        givenAnAdapter(properties);
+        observationStore = new InMemoryRegistrationStore();
+        store = new LeshanBasedLwM2MRegistrationStore(observationStore, adapter, tracer);
+        store.setResourcesToObserve(Map.of("/3/0", EndpointType.TELEMETRY));
+        store.start().onComplete(ctx.completing());
+        identity = Identity.psk(clientAddress, "device");
+    }
+
+    private Registration newRegistration(
+            final String registrationId,
+            final String endpoint,
+            final String lwm2mVersion,
+            final Integer lifetime,
+            final BindingMode bindingMode) {
+
+        final Link[] objectLinks = Link.parse("</3/0>".getBytes(StandardCharsets.UTF_8));
+
+        return new Registration.Builder("reg-id", endpoint, identity)
+                .lwM2mVersion(lwm2mVersion)
+                .lifeTimeInSec(lifetime.longValue())
+                .bindingMode(bindingMode)
+                .objectLinks(objectLinks)
+                .additionalRegistrationAttributes(Map.of(
+                        TracingHelper.TAG_TENANT_ID.getKey(), "tenant",
+                        TracingHelper.TAG_DEVICE_ID.getKey(), "device"))
+                .build();
+    }
+
+    private Token assertObserveRelationEstablished(final String registrationId, final String resourcePath) {
+
+        final LwM2mPath path = new LwM2mPath(resourcePath);
+        // capture outbound observe request for the given resource
+        final var observeRequest = ArgumentCaptor.forClass(Request.class);
+        verify(secureEndpoint).sendRequest(observeRequest.capture());
+        assertThat(observeRequest.getValue().getCode()).isEqualTo(Code.GET);
+        assertThat(observeRequest.getValue().getOptions().hasObserve()).isTrue();
+        assertThat(observeRequest.getValue().getOptions().getUriPathString()).isEqualTo(resourcePath);
+        // and set token on request which is required by Leshan's message observer handling the response
+        final var token = tokenGenerator.createToken(Scope.SHORT_TERM);
+        observeRequest.getValue().setToken(token);
+
+        // and let device accept the observe request
+        final var observeResponse = new Response(ResponseCode.CONTENT);
+        observeResponse.getOptions().setObserve(1);
+        observeResponse.getOptions().setContentFormat(MediaTypeRegistry.APPLICATION_VND_OMA_LWM2M_TLV);
+        observeRequest.getValue().getMessageObservers()
+            .forEach(obs -> {
+                // required to prevent NPE when processing response
+                obs.onReadyToSend();
+                obs.onResponse(observeResponse);
+            });
+        // add observation to Californium CoapEndpoint's ObservationStore
+        // so that it can be found (and canceled) when removing the LwM2M registration
+        // in a "non-mocked" environment this would be done automatically under the hood
+        // by the CoapEndpoint implementation
+        observationStore.putIfAbsent(token, new Observation(
+                observeRequest.getValue(),
+                new AddressEndpointContext(clientAddress)));
+        assertThat(observationStore.getObservations(registrationId)).anyMatch(obs -> obs.getPath().getObjectId() == path.getObjectId());
+        return token;
+    }
+
+    /**
+     * Verifies that the store sends an empty notification downstream that corresponds to the
+     * binding mode used by the device. Also verifies that the resources configured for the
+     * device are getting observed.
+     *
+     * @param endpoint The endpoint name that the device uses when registering.
+     * @param bindingMode The binding mode that the device uses when registering.
+     * @param lifetime The lifetime that the device uses when registering.
+     * @param lwm2mVersion The version of the LwM2M enabler that the device uses when registering.
+     * @param notificationEndpoint The type of endpoint to use for forwarding notifications.
+     * @param ctx The vert.x test context.
+     */
+    @ParameterizedTest
+    @CsvSource(value = { "test-ep,U,84600,v1.0,TELEMETRY", "test-ep,UQ,300,v1.0.2,EVENT"})
+    public void testAddRegistrationSucceeds(
+            final String endpoint,
+            final BindingMode bindingMode,
+            final Integer lifetime,
+            final String lwm2mVersion,
+            final EndpointType notificationEndpoint,
+            final VertxTestContext ctx) {
+
+        // GIVEN an adapter with a downstream consumer
+        givenATelemetrySenderForAnyTenant();
+        givenAnEventSenderForAnyTenant();
+        store.setResourcesToObserve(Map.of("/3/0", notificationEndpoint));
+
+        // WHEN a device registers the standard Device object
+        final var registrationId = "reg-id";
+        final var registration = newRegistration(registrationId, endpoint, lwm2mVersion, lifetime, bindingMode);
+
+        store.addRegistration(registration, NoopSpan.INSTANCE.context())
+            .onComplete(ctx.succeeding(ok -> {
+                ctx.verify(() -> {
+                    // THEN the store sends an empty notification downstream corresponding
+                    // to the binding mode,
+                    verify(adapter).sendTtdEvent(
+                            eq("tenant"),
+                            eq("device"),
+                            isNull(),
+                            eq(BindingMode.U == bindingMode ? lifetime : 20),
+                            any());
+                });
+                // opens a command consumer for the device
+                ctx.verify(() -> {
+                    verify(commandConsumerFactory).createCommandConsumer(
+                            eq("tenant"),
+                            eq("device"),
+                            VertxMockSupport.anyHandler(),
+                            isNull(),
+                            any());
+                });
+                ctx.verify(() -> {
+                    // and establishes an observe relation for the Device object
+                    assertObserveRelationEstablished(registrationId, "3/0");
+                    // THEN the store forwards the observe response downstream
+                    if (notificationEndpoint == EndpointType.TELEMETRY) {
+                        assertTelemetryMessageHasBeenSentDownstream(
+                                QoS.AT_MOST_ONCE,
+                                "tenant",
+                                "device",
+                                MediaTypeRegistry.toString(MediaTypeRegistry.APPLICATION_VND_OMA_LWM2M_TLV));
+                    }
+                    if (notificationEndpoint == EndpointType.EVENT) {
+                        assertEventHasBeenSentDownstream(
+                                "tenant",
+                                "device",
+                                MediaTypeRegistry.toString(MediaTypeRegistry.APPLICATION_VND_OMA_LWM2M_TLV));
+                    }
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that the store sends an empty notification downstream that corresponds to the
+     * binding mode used by the device.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testUpdateRegistrationSucceeds(final VertxTestContext ctx) {
+
+        // GIVEN a registered device
+        givenATelemetrySenderForAnyTenant();
+        final var registrationId = "reg-id";
+        final var originalRegistration = newRegistration(registrationId, "device-ep", "v1.0.2", 84600, BindingMode.U);
+
+        store.addRegistration(originalRegistration, null)
+            .compose(ok -> {
+                ctx.verify(() -> {
+                    assertObserveRelationEstablished(registrationId, "3/0");
+                });
+                // WHEN the device updates its registration with a new lifetime
+                final var registrationUpdate = new RegistrationUpdate(
+                        registrationId,
+                        identity,
+                        300L,
+                        null,
+                        null,
+                        null,
+                        null);
+                return store.updateRegistration(registrationUpdate, null);
+            })
+            .onComplete(ctx.succeeding(ok -> {
+                ctx.verify(() -> {
+                    // THEN the device's command consumer is being kept open
+                    verify(commandConsumer, never()).close(any());
+                    // and an empty notification is being sent downstream
+                    // with a TTD reflecting the updated lifetime
+                    verify(adapter).sendTtdEvent(
+                            eq("tenant"),
+                            eq("device"),
+                            isNull(),
+                            eq(300),
+                            any());
+                    // and the observation of the Device object is kept alive
+                    verify(secureEndpoint, never()).cancelObservation(any(Token.class));
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that the store sends an empty notification downstream with a TTD of 0.
+     * Also verifies that the command consumer for the device is being closed and that observations for
+     * the device are being canceled.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testRemoveRegistrationSucceeds(final VertxTestContext ctx) {
+
+        // GIVEN a registered device
+        givenATelemetrySenderForAnyTenant();
+        final var registrationId = "reg-id";
+        final var originalRegistration = newRegistration(registrationId, "device-ep", "v1.0.2", 84600, BindingMode.U);
+
+        store.addRegistration(originalRegistration, null)
+            .map(ok -> {
+                final AtomicReference<Token> observationToken = new AtomicReference<>();
+                ctx.verify(() -> {
+                    observationToken.set(assertObserveRelationEstablished(registrationId, "3/0"));
+                });
+                // WHEN the device deregisters
+                store.removeRegistration(registrationId, null);
+                return observationToken.get();
+            })
+            .onComplete(ctx.succeeding(observationToken -> {
+                ctx.verify(() -> {
+                    // THEN the device's command consumer is being closed
+                    verify(commandConsumer).close(any());
+                    // and an empty notification is being sent downstream
+                    verify(adapter).sendTtdEvent(
+                            eq("tenant"),
+                            eq("device"),
+                            isNull(),
+                            eq(0),
+                            any());
+                    // and the observation of the Device object is being canceled
+                    verify(secureEndpoint).cancelObservation(observationToken);
+                    // and no more observations are registered
+                    assertThat(observationStore.getObservations(registrationId)).isEmpty();
+                });
+                ctx.completeNow();
+            }));
+    }
+}

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/lwm2m/LwM2MResourceDirectoryTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/lwm2m/LwM2MResourceDirectoryTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.adapter.coap.lwm2m;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.hono.adapter.coap.CoapContext;
+import org.eclipse.hono.adapter.coap.ResourceTestBase;
+import org.eclipse.hono.auth.Device;
+import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.server.registration.Registration;
+import org.eclipse.leshan.server.registration.RegistrationUpdate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+
+/**
+ * Tests verifying behavior of {@link LwM2MResourceDirectory}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+class LwM2MResourceDirectoryTest extends ResourceTestBase {
+
+    private LwM2MResourceDirectory resource;
+    private Device device = new Device("tenant", "device");
+    private LwM2MRegistrationStore store;
+
+    /**
+     * Sets up the resource under test.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @BeforeEach
+    void createResource(final VertxTestContext ctx) {
+        store = mock(LwM2MRegistrationStore.class);
+        when(store.addRegistration(any(Registration.class), any())).thenReturn(Future.succeededFuture());
+        when(store.updateRegistration(any(RegistrationUpdate.class), any())).thenReturn(Future.succeededFuture());
+        when(store.removeRegistration(anyString(), any())).thenReturn(Future.succeededFuture());
+
+        givenAnAdapter(properties);
+        resource = new LwM2MResourceDirectory(adapter, store, NoopTracerFactory.create());
+        resource.start().onComplete(ctx.completing());
+    }
+
+    private String givenARegisteredDevice(final Device device, final BindingMode bindingMode, final long lifetime) {
+        final OptionSet options = new OptionSet();
+        options.setUriPath("rd");
+        options.setUriQuery(String.format("ep=test-device&lwm2m=1.0&b=%s&lt=%d", bindingMode.name(), lifetime));
+        options.setContentFormat(MediaTypeRegistry.APPLICATION_LINK_FORMAT);
+        final CoapExchange exchange = newCoapExchange(Buffer.buffer(), CoAP.Type.CON, options);
+        final var context = CoapContext.fromRequest(exchange, device, device, "auth-id", span);
+
+        resource.handlePost(context);
+
+        // THEN the device has been registered
+        final var registration = ArgumentCaptor.forClass(Registration.class);
+        verify(store).addRegistration(registration.capture(), any());
+        assertThat(registration.getValue().getBindingMode()).isEqualTo(bindingMode);
+        assertThat(registration.getValue().getLifeTimeInSec()).isEqualTo(lifetime);
+        // and a CoAP response with code 2.01 is sent back to the device
+        final var response = ArgumentCaptor.forClass(Response.class);
+        verify(exchange).respond(response.capture());
+        assertThat(response.getValue().getCode()).isEqualTo(ResponseCode.CREATED);
+        // that contains the registration ID in the location-path option
+        final var locationPath = ArgumentCaptor.forClass(String.class);
+        verify(exchange).setLocationPath(locationPath.capture());
+        assertThat(locationPath.getValue()).isNotNull();
+        // return registration ID
+        return locationPath.getValue().substring(locationPath.getValue().lastIndexOf("/") + 1);
+    }
+
+    /**
+     * Verifies that a device can successfully register using any of the supported binding modes.
+     *
+     * @param bindingMode The binding mode that the device uses when registering.
+     * @param lifetime The lifetime that the device uses when registering.
+     */
+    @ParameterizedTest
+    @CsvSource(value = { "U,84600", "UQ,20"})
+    void testDeviceRegistersSuccessfully(final BindingMode bindingMode, final Integer lifetime) {
+
+        givenARegisteredDevice(device, bindingMode, lifetime);
+    }
+
+    /**
+     * Verifies that a device can successfully update its registration.
+     */
+    @Test
+    void testDeviceUpdatesRegistrationSuccessfully() {
+
+        // GIVEN a device that has registered with non-queue mode
+        final var registrationId = givenARegisteredDevice(device, BindingMode.U, 84600);
+
+        // WHEN the device sends a request to update its registration
+        final OptionSet options = new OptionSet();
+        options.setUriPath("rd/" + registrationId);
+        options.setUriQuery("b=U&lt=10000");
+        final CoapExchange exchange = newCoapExchange(Buffer.buffer(), CoAP.Type.CON, options);
+        final var context = CoapContext.fromRequest(exchange, device, device, "auth-id", span);
+        resource.handlePost(context);
+
+        // THEN the registration in the store has been updated accordingly
+        verify(store).updateRegistration(argThat(update -> update.getBindingMode() == BindingMode.U
+                && update.getLifeTimeInSec() == 10000L), any());
+        // and a CoAP response with code 2.04 is sent back to the device
+        final var response = ArgumentCaptor.forClass(Response.class);
+        verify(exchange).respond(response.capture());
+        assertThat(response.getValue().getCode()).isEqualTo(ResponseCode.CHANGED);
+    }
+
+    /**
+     * Verifies that a device can successfully de-register.
+     */
+    @Test
+    void testDeviceDeregistersSuccessfully() {
+
+        // GIVEN a registered device
+        final var registrationId = givenARegisteredDevice(device, BindingMode.U, 84600);
+        // WHEN the device deregisters
+        final OptionSet options = new OptionSet();
+        options.setUriPath("rd/" + registrationId);
+        final CoapExchange exchange = newCoapExchange(Buffer.buffer(), CoAP.Type.CON, options);
+        final var context = CoapContext.fromRequest(exchange, device, device, "auth-id", span);
+        resource.handleDelete(context);
+
+        // THEN the registration in the store has been removed
+        verify(store).removeRegistration(eq(registrationId), any());
+        // and a CoAP response with code 2.04 is sent back to the device
+        final var response = ArgumentCaptor.forClass(Response.class);
+        verify(exchange).respond(response.capture());
+        assertThat(response.getValue().getCode()).isEqualTo(ResponseCode.DELETED);
+    }
+}

--- a/adapters/coap-vertx-base/src/test/resources/logback-test.xml
+++ b/adapters/coap-vertx-base/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -29,6 +29,8 @@
   </root>
 
   <logger name="org.eclipse.hono.adapter" level="INFO"/>
+  <logger name="org.eclipse.hono.adapter.coap" level="INFO"/>
+  <logger name="org.eclipse.hono.adapter.coap.lwm2m" level="INFO"/>
   <logger name="org.eclipse.hono.auth" level="INFO"/>
   <logger name="org.eclipse.hono.client" level="INFO"/>
   <logger name="org.eclipse.hono.config" level="INFO"/>

--- a/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/quarkus/Application.java
+++ b/adapters/coap-vertx-quarkus/src/main/java/org/eclipse/hono/adapter/coap/quarkus/Application.java
@@ -23,7 +23,10 @@ import org.eclipse.hono.adapter.coap.CommandResponseResource;
 import org.eclipse.hono.adapter.coap.EventResource;
 import org.eclipse.hono.adapter.coap.TelemetryResource;
 import org.eclipse.hono.adapter.coap.impl.VertxBasedCoapAdapter;
+import org.eclipse.hono.adapter.coap.lwm2m.LeshanBasedLwM2MRegistrationStore;
+import org.eclipse.hono.adapter.coap.lwm2m.LwM2MResourceDirectory;
 import org.eclipse.hono.adapter.quarkus.AbstractProtocolAdapterApplication;
+import org.eclipse.leshan.server.californium.registration.InMemoryRegistrationStore;
 
 /**
  * The Hono CoAP adapter main application class.
@@ -58,6 +61,15 @@ public class Application extends AbstractProtocolAdapterApplication<CoapAdapterP
                 new TelemetryResource(adapter, tracer, vertx),
                 new EventResource(adapter, tracer, vertx),
                 new CommandResponseResource(adapter, tracer, vertx)));
+        if (protocolAdapterProperties.isLwm2mEnabled()) {
+            final var observationStore = new InMemoryRegistrationStore();
+            adapter.setObservationStore(observationStore);
+            final var store = new LeshanBasedLwM2MRegistrationStore(
+                    observationStore,
+                    adapter,
+                    tracer);
+            adapter.addResources(Set.of(new LwM2MResourceDirectory(adapter, store, tracer)));
+        }
         return adapter;
     }
 }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -53,6 +53,7 @@
     <junit.jupiter.version>5.7.1</junit.jupiter.version>
     <kafka-clients.version>2.6.0</kafka-clients.version>
     <kafka.image.name>confluentinc/cp-kafka:6.1.0</kafka.image.name>
+    <leshan.version>1.3.1</leshan.version>
     <log4j.version>2.12.1</log4j.version>
     <logback.version>1.2.3</logback.version>
     <mchange-commons.version>0.2.15</mchange-commons.version>
@@ -250,6 +251,18 @@
         <groupId>org.eclipse.californium</groupId>
         <artifactId>scandium</artifactId>
         <version>${californium.version}</version>
+      </dependency>
+
+      <!-- Leshan -->
+      <dependency>
+        <groupId>org.eclipse.leshan</groupId>
+        <artifactId>leshan-server-cf</artifactId>
+        <version>${leshan.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.leshan</groupId>
+        <artifactId>leshan-client-cf</artifactId>
+        <version>${leshan.version}</version>
       </dependency>
 
       <!-- Micrometer -->

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -267,6 +267,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-client-cf</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapPublishTestBase.java
@@ -1,0 +1,1015 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.tests.coap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.qpid.proton.message.Message;
+import org.assertj.core.data.Index;
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.CoapHandler;
+import org.eclipse.californium.core.CoapResponse;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.MessageContext;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tests.AssumeMessagingSystem;
+import org.eclipse.hono.tests.IntegrationTestSupport;
+import org.eclipse.hono.util.Adapter;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.MessagingType;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistryManagementConstants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Base class for CoAP adapter integration tests.
+ *
+ */
+public abstract class CoapPublishTestBase extends CoapTestBase {
+
+    /**
+     * The period of time in milliseconds after which test cases should time out.
+     */
+    protected static final long TEST_TIMEOUT_MILLIS = 20000; // 20 seconds
+    /**
+     * The number of messages to send in a test.
+     */
+    protected static final int MESSAGES_TO_SEND = 60;
+
+    private static final String COMMAND_TO_SEND = "setDarkness";
+    private static final String COMMAND_JSON_KEY = "darkness";
+
+    /**
+     * Creates a test specific message consumer.
+     *
+     * @param tenantId        The tenant to create the consumer for.
+     * @param messageConsumer The handler to invoke for every message received.
+     * @return A future succeeding with the created consumer.
+     */
+    protected abstract Future<MessageConsumer> createConsumer(
+            String tenantId, Handler<DownstreamMessage<? extends MessageContext>> messageConsumer);
+
+    /**
+     * Gets the name of the resource that unauthenticated devices
+     * or gateways should use for uploading data.
+     *
+     * @param tenant The tenant.
+     * @param deviceId The device ID.
+     * @return The resource name.
+     */
+    protected abstract String getPutResource(String tenant, String deviceId);
+
+    /**
+     * Gets the name of the resource that authenticated devices
+     * should use for uploading data.
+     *
+     * @return The resource name.
+     */
+    protected abstract String getPostResource();
+
+    /**
+     * Gets the CoAP message type to use for requests to the adapter.
+     *
+     * @return The type.
+     */
+    protected abstract Type getMessageType();
+
+    /**
+     * Triggers the establishment of a downstream sender
+     * for a tenant so that subsequent messages will be
+     * more likely to be forwarded.
+     *
+     * @param client The CoAP client to use for sending the request.
+     * @param request The request to send.
+     * @return A succeeded future.
+     */
+    protected final Future<Void> warmUp(final CoapClient client, final Request request) {
+
+        logger.debug("sending request to trigger CoAP adapter's downstream message sender");
+        final Promise<Void> result = Promise.promise();
+        client.advanced(new CoapHandler() {
+
+            @Override
+            public void onLoad(final CoapResponse response) {
+                waitForWarmUp();
+            }
+
+            @Override
+            public void onError() {
+                waitForWarmUp();
+            }
+
+            private void waitForWarmUp() {
+                vertx.setTimer(1000, tid -> result.complete());
+            }
+        }, request);
+        return result.future();
+    }
+
+    /**
+     * Asserts the status code of a failed CoAP request.
+     *
+     * @param ctx The test context to verify the status for.
+     * @param expectedStatus The expected status.
+     * @param t The exception to verify.
+     */
+    protected static void assertStatus(final VertxTestContext ctx, final int expectedStatus, final Throwable t) {
+        ctx.verify(() -> {
+            assertThat(t).isInstanceOf(CoapResultException.class);
+            assertThat(((CoapResultException) t).getErrorCode()).isEqualTo(expectedStatus);
+        });
+    }
+
+    /**
+     * Verifies that a number of messages uploaded to Hono's CoAP adapter
+     * can be successfully consumed via the AMQP Messaging Network.
+     *
+     * @param ctx The test context.
+     * @throws InterruptedException if the test fails.
+     */
+    @Test
+    public void testUploadMessagesAnonymously(final VertxTestContext ctx) throws InterruptedException {
+
+        final Tenant tenant = new Tenant();
+
+        final VertxTestContext setup = new VertxTestContext();
+        helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, SECRET)
+        .onComplete(setup.completing());
+        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
+
+        final CoapClient client = getCoapClient();
+        testUploadMessages(ctx, tenantId,
+                () -> warmUp(client, createCoapRequest(Code.PUT, getPutResource(tenantId, deviceId), 0)),
+                count -> {
+                    final Promise<OptionSet> result = Promise.promise();
+                    final Request request = createCoapRequest(Code.PUT, getPutResource(tenantId, deviceId), count);
+                    client.advanced(getHandler(result), request);
+                    return result.future();
+                });
+    }
+
+    /**
+     * Verifies that a number of messages uploaded to Hono's CoAP adapter using TLS_PSK based authentication can be
+     * successfully consumed via the AMQP Messaging Network.
+     *
+     * @param ctx The test context.
+     * @throws InterruptedException if the test fails.
+     */
+    @Test
+    public void testUploadMessagesUsingPsk(final VertxTestContext ctx) throws InterruptedException {
+
+        final Tenant tenant = new Tenant();
+
+        final VertxTestContext setup = new VertxTestContext();
+        helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, SECRET)
+        .onComplete(setup.completing());
+        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
+
+        final CoapClient client = getCoapsClient(deviceId, tenantId, SECRET);
+
+        testUploadMessages(ctx, tenantId,
+                () -> warmUp(client, createCoapsRequest(Code.POST, getPostResource(), 0)),
+                count -> {
+                    final Promise<OptionSet> result = Promise.promise();
+                    final Request request = createCoapsRequest(Code.POST, getPostResource(), count);
+                    client.advanced(getHandler(result), request);
+                    return result.future();
+                });
+    }
+
+    /**
+     * Verifies that a number of messages uploaded to the CoAP adapter via a gateway
+     * using TLS_PSK can be successfully consumed via the AMQP Messaging Network.
+     *
+     * @param ctx The test context.
+     * @throws InterruptedException if the test fails.
+     */
+    @Test
+    public void testUploadMessagesViaGateway(final VertxTestContext ctx) throws InterruptedException {
+
+        // GIVEN a device that is connected via two gateways
+        final Tenant tenant = new Tenant();
+        final String gatewayOneId = helper.getRandomDeviceId(tenantId);
+        final String gatewayTwoId = helper.getRandomDeviceId(tenantId);
+        final Device deviceData = new Device();
+        deviceData.setVia(Arrays.asList(gatewayOneId, gatewayTwoId));
+
+        final VertxTestContext setup = new VertxTestContext();
+        helper.registry.addPskDeviceForTenant(tenantId, tenant, gatewayOneId, SECRET)
+        .compose(ok -> helper.registry.addPskDeviceToTenant(tenantId, gatewayTwoId, SECRET))
+        .compose(ok -> helper.registry.registerDevice(tenantId, deviceId, deviceData))
+        .onComplete(setup.completing());
+        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
+
+        final CoapClient gatewayOne = getCoapsClient(gatewayOneId, tenantId, SECRET);
+        final CoapClient gatewayTwo = getCoapsClient(gatewayTwoId, tenantId, SECRET);
+
+        testUploadMessages(ctx, tenantId,
+                () -> warmUp(gatewayOne, createCoapsRequest(Code.PUT, getPutResource(tenantId, deviceId), 0)),
+                count -> {
+                    final CoapClient client = (count.intValue() & 1) == 0 ? gatewayOne : gatewayTwo;
+                    final Promise<OptionSet> result = Promise.promise();
+                    final Request request = createCoapsRequest(Code.PUT, getPutResource(tenantId, deviceId), count);
+                    client.advanced(getHandler(result), request);
+                    return result.future();
+                });
+    }
+
+    /**
+     * Verifies that an edge device is auto-provisioned if it connects via a gateway equipped with the corresponding
+     * authority.
+     *
+     * @param ctx The test context.
+     * @throws InterruptedException if the test fails.
+     */
+    @Test
+    public void testAutoProvisioningViaGateway(final VertxTestContext ctx) throws InterruptedException {
+
+        final Tenant tenant = new Tenant();
+        final String gatewayId = helper.getRandomDeviceId(tenantId);
+        final Device gateway = new Device()
+                .setAuthorities(Collections.singleton(RegistryManagementConstants.AUTHORITY_AUTO_PROVISIONING_ENABLED));
+
+        final String edgeDeviceId = helper.getRandomDeviceId(tenantId);
+        helper.createAutoProvisioningMessageConsumers(ctx, tenantId, edgeDeviceId)
+                .compose(ok -> helper.registry.addPskDeviceForTenant(tenantId, tenant, gatewayId, gateway, SECRET))
+                .compose(ok -> {
+                    final Promise<OptionSet> result = Promise.promise();
+                    final Request request = createCoapsRequest(Code.PUT, getPutResource(tenantId, edgeDeviceId), 0);
+
+                    final CoapClient client = getCoapsClient(gatewayId, tenantId, SECRET);
+                    client.advanced(getHandler(result), request);
+
+                    return result.future();
+                })
+                .onComplete(ctx.succeeding());
+    }
+
+    /**
+     * Uploads messages to the CoAP endpoint.
+     *
+     * @param ctx The test context to run on.
+     * @param tenantId The tenant that the device belongs to.
+     * @param warmUp A sender of messages used to warm up the adapter before
+     *               running the test itself or {@code null} if no warm up should
+     *               be performed. 
+     * @param requestSender The test device that will publish the data.
+     * @throws InterruptedException if the test is interrupted before it
+     *              has finished.
+     */
+    protected void testUploadMessages(
+            final VertxTestContext ctx,
+            final String tenantId,
+            final Supplier<Future<?>> warmUp,
+            final Function<Integer, Future<OptionSet>> requestSender) throws InterruptedException {
+        testUploadMessages(ctx, tenantId, warmUp, null, requestSender);
+    }
+
+    /**
+     * Uploads messages to the CoAP endpoint.
+     *
+     * @param ctx The test context to run on.
+     * @param tenantId The tenant that the device belongs to.
+     * @param messageConsumer Consumer that is invoked when a message was received.
+     * @param warmUp A sender of messages used to warm up the adapter before
+     *               running the test itself or {@code null} if no warm up should
+     *               be performed. 
+     * @param requestSender The test device that will publish the data.
+     * @throws InterruptedException if the test is interrupted before it
+     *              has finished.
+     */
+    protected void testUploadMessages(
+            final VertxTestContext ctx,
+            final String tenantId,
+            final Supplier<Future<?>> warmUp,
+            final Consumer<DownstreamMessage<? extends MessageContext>> messageConsumer,
+            final Function<Integer, Future<OptionSet>> requestSender) throws InterruptedException {
+        testUploadMessages(ctx, tenantId, warmUp, messageConsumer, requestSender, MESSAGES_TO_SEND, null);
+    }
+
+    /**
+     * Uploads messages to the CoAP endpoint.
+     *
+     * @param ctx The test context to run on.
+     * @param tenantId The tenant that the device belongs to.
+     * @param warmUp A sender of messages used to warm up the adapter before running the test itself or {@code null} if
+     *            no warm up should be performed.
+     * @param messageConsumer Consumer that is invoked when a message was received.
+     * @param requestSender The test device that will publish the data.
+     * @param numberOfMessages The number of messages that are uploaded.
+     * @param expectedQos The expected QoS level, may be {@code null} leading to expecting the default for event or telemetry.
+     * @throws InterruptedException if the test is interrupted before it has finished.
+     */
+    protected void testUploadMessages(
+            final VertxTestContext ctx,
+            final String tenantId,
+            final Supplier<Future<?>> warmUp,
+            final Consumer<DownstreamMessage<? extends MessageContext>> messageConsumer,
+            final Function<Integer, Future<OptionSet>> requestSender,
+            final int numberOfMessages,
+            final QoS expectedQos) throws InterruptedException {
+
+        final CountDownLatch received = new CountDownLatch(numberOfMessages);
+
+        final VertxTestContext setup = new VertxTestContext();
+        createConsumer(tenantId, msg -> {
+            ctx.verify(() -> {
+                logger.trace("received {}", msg);
+                IntegrationTestSupport.assertTelemetryMessageProperties(msg, tenantId);
+                assertThat(msg.getQos()).isEqualTo(getExpectedQoS(expectedQos));
+                assertAdditionalMessageProperties(msg);
+                if (messageConsumer != null) {
+                    messageConsumer.accept(msg);
+                }
+            });
+            received.countDown();
+            if (received.getCount() % 20 == 0) {
+                logger.info("messages received: {}", numberOfMessages - received.getCount());
+            }
+        })
+        .compose(ok -> Optional.ofNullable(warmUp).map(w -> w.get()).orElseGet(() -> Future.succeededFuture()))
+        .onComplete(setup.completing());
+        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
+
+        final long start = System.currentTimeMillis();
+        final AtomicInteger messageCount = new AtomicInteger(0);
+
+        while (messageCount.get() < numberOfMessages && !ctx.failed()) {
+
+            final CountDownLatch sending = new CountDownLatch(1);
+            requestSender.apply(messageCount.getAndIncrement()).compose(this::assertCoapResponse)
+                    .onComplete(attempt -> {
+                        if (attempt.succeeded()) {
+                            logger.debug("sent message {}", messageCount.get());
+                        } else {
+                            logger.info("failed to send message {}: {}", messageCount.get(),
+                                    attempt.cause().getMessage());
+                            ctx.failNow(attempt.cause());
+                        }
+                        sending.countDown();
+                    });
+
+            if (messageCount.get() % 20 == 0) {
+                logger.info("messages sent: {}", messageCount.get());
+            }
+            sending.await();
+        }
+        if (ctx.failed()) {
+            return;
+        }
+
+        final long timeToWait = Math.max(TEST_TIMEOUT_MILLIS - 1000, Math.round(numberOfMessages * 20));
+        if (received.await(timeToWait, TimeUnit.MILLISECONDS)) {
+            logger.info("sent {} and received {} messages after {} milliseconds",
+                    messageCount, numberOfMessages - received.getCount(), System.currentTimeMillis() - start);
+            ctx.completeNow();
+        } else {
+            logger.info("sent {} and received {} messages after {} milliseconds",
+                    messageCount, numberOfMessages - received.getCount(), System.currentTimeMillis() - start);
+            ctx.failNow(new AssertionError("did not receive all messages sent"));
+        }
+    }
+
+    /**
+     * Verifies that the adapter fails to authenticate a device if the shared key registered
+     * for the device does not match the key used by the device in the DTLS handshake.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    public void testUploadFailsForNonMatchingSharedKey(final VertxTestContext ctx) {
+
+        final Tenant tenant = new Tenant();
+
+        // GIVEN a device for which PSK credentials have been registered
+        helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, "NOT" + SECRET)
+        .compose(ok -> {
+            // WHEN a device tries to upload data and authenticate using the PSK
+            // identity for which the server has a different shared secret on record
+            final CoapClient client = getCoapsClient(deviceId, tenantId, SECRET);
+            final Promise<OptionSet> result = Promise.promise();
+            client.advanced(getHandler(result), createCoapsRequest(Code.POST, getPostResource(), 0));
+            return result.future();
+        })
+        .onComplete(ctx.failing(t -> {
+            // THEN the request fails because the DTLS handshake cannot be completed
+            assertStatus(ctx, HttpURLConnection.HTTP_UNAVAILABLE, t);
+            ctx.completeNow();
+        }));
+    }
+
+    /**
+     * Verifies that the CoAP adapter rejects messages from a device that belongs to a tenant for which the CoAP adapter
+     * has been disabled.
+     *
+     * @param ctx The test context
+     */
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    public void testUploadMessageFailsForDisabledTenant(final VertxTestContext ctx) {
+
+        // GIVEN a tenant for which the CoAP adapter is disabled
+        final Tenant tenant = new Tenant();
+        tenant.addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_COAP).setEnabled(false));
+
+        helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, SECRET)
+        .compose(ok -> {
+
+            // WHEN a device that belongs to the tenant uploads a message
+            final CoapClient client = getCoapsClient(deviceId, tenantId, SECRET);
+            final Promise<OptionSet> result = Promise.promise();
+            // THEN a FORBIDDEN response code is returned
+            client.advanced(getHandler(result, ResponseCode.FORBIDDEN), createCoapsRequest(Code.POST, getPostResource(), 0));
+            return result.future();
+        })
+        .onComplete(ctx.completing());
+    }
+
+    /**
+     * Verifies that the CoAP adapter rejects messages from a disabled device.
+     *
+     * @param ctx The test context
+     */
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    public void testUploadMessageFailsForDisabledDevice(final VertxTestContext ctx) {
+
+        // GIVEN a disabled device
+        final Tenant tenant = new Tenant();
+        final Device deviceData = new Device();
+        deviceData.setEnabled(false);
+
+        helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, deviceData, SECRET)
+        .compose(ok -> {
+
+            // WHEN the device tries to upload a message
+            final CoapClient client = getCoapsClient(deviceId, tenantId, SECRET);
+            final Promise<OptionSet> result = Promise.promise();
+            // THEN a NOT_FOUND response code is returned
+            client.advanced(getHandler(result, ResponseCode.NOT_FOUND), createCoapsRequest(Code.POST, getPostResource(), 0));
+            return result.future();
+        })
+        .onComplete(ctx.completing());
+    }
+
+    /**
+     * Verifies that the CoAP adapter rejects messages from a disabled gateway
+     * for an enabled device with a 403.
+     *
+     * @param ctx The test context
+     */
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    public void testUploadMessageFailsForDisabledGateway(final VertxTestContext ctx) {
+
+        // GIVEN a device that is connected via a disabled gateway
+        final Tenant tenant = new Tenant();
+        final String gatewayId = helper.getRandomDeviceId(tenantId);
+        final Device gatewayData = new Device();
+        gatewayData.setEnabled(false);
+        final Device deviceData = new Device();
+        deviceData.setVia(Collections.singletonList(gatewayId));
+
+        helper.registry.addPskDeviceForTenant(tenantId, tenant, gatewayId, gatewayData, SECRET)
+        .compose(ok -> helper.registry.registerDevice(tenantId, deviceId, deviceData))
+        .compose(ok -> {
+
+            // WHEN the gateway tries to upload a message for the device
+            final Promise<OptionSet> result = Promise.promise();
+            final CoapClient client = getCoapsClient(gatewayId, tenantId, SECRET);
+            // THEN a FORBIDDEN response code is returned
+            client.advanced(getHandler(result, ResponseCode.FORBIDDEN), createCoapsRequest(Code.PUT, getPutResource(tenantId, deviceId), 0));
+            return result.future();
+        })
+        .onComplete(ctx.completing());
+    }
+
+    /**
+     * Verifies that the CoAP adapter rejects messages from a gateway for a device that it is not authorized for with a
+     * 403.
+     *
+     * @param ctx The test context
+     */
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    public void testUploadMessageFailsForUnauthorizedGateway(final VertxTestContext ctx) {
+
+        // GIVEN a device that is connected via gateway "not-the-created-gateway"
+        final Tenant tenant = new Tenant();
+        final String gatewayId = helper.getRandomDeviceId(tenantId);
+        final Device deviceData = new Device();
+        deviceData.setVia(Collections.singletonList("not-the-created-gateway"));
+
+        helper.registry.addPskDeviceForTenant(tenantId, tenant, gatewayId, SECRET)
+        .compose(ok -> helper.registry.registerDevice(tenantId, deviceId, deviceData))
+        .compose(ok -> {
+
+            // WHEN another gateway tries to upload a message for the device
+            final Promise<OptionSet> result = Promise.promise();
+            final CoapClient client = getCoapsClient(gatewayId, tenantId, SECRET);
+            // THEN a FORBIDDEN response code is returned
+            client.advanced(getHandler(result, ResponseCode.FORBIDDEN),
+                    createCoapsRequest(Code.PUT, getPutResource(tenantId, deviceId), 0));
+            return result.future();
+        })
+        .onComplete(ctx.completing());
+    }
+
+    /**
+     * Verifies that the CoAP adapter delivers a command to a device and accepts
+     * the corresponding response from the device.
+     *
+     * @param endpointConfig The endpoints to use for sending/receiving commands.
+     * @param ctx The test context.
+     * @throws InterruptedException if the test fails.
+     */
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("commandAndControlVariants")
+    @AssumeMessagingSystem(type = MessagingType.amqp) // TODO remove when Kafka C&C is implemented!
+    public void testUploadMessagesWithTtdThatReplyWithCommand(
+            final CoapCommandEndpointConfiguration endpointConfig,
+            final VertxTestContext ctx) throws InterruptedException {
+
+        final Tenant tenant = new Tenant();
+        testUploadMessagesWithTtdThatReplyWithCommand(endpointConfig, tenant, ctx);
+    }
+
+    private void testUploadMessagesWithTtdThatReplyWithCommand(
+            final CoapCommandEndpointConfiguration endpointConfig,
+            final Tenant tenant, final VertxTestContext ctx) throws InterruptedException {
+
+        final String expectedCommand = String.format("%s=%s", Constants.HEADER_COMMAND, COMMAND_TO_SEND);
+
+        final VertxTestContext setup = new VertxTestContext();
+
+        if (endpointConfig.isSubscribeAsUnauthenticatedDevice()) {
+            helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, SECRET).onComplete(setup.completing());
+        } else {
+            helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, SECRET).onComplete(setup.completing());
+        }
+        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
+
+        final String commandTargetDeviceId = endpointConfig.isSubscribeAsGateway()
+                ? helper.setupGatewayDeviceBlocking(tenantId, deviceId, 5)
+                : deviceId;
+        final String subscribingDeviceId = endpointConfig.isSubscribeAsGatewayForSingleDevice() ? commandTargetDeviceId
+                : deviceId;
+
+        final CoapClient client = endpointConfig.isSubscribeAsUnauthenticatedDevice() ? getCoapClient()
+                : getCoapsClient(deviceId, tenantId, SECRET);
+        final AtomicInteger counter = new AtomicInteger();
+
+        testUploadMessages(ctx, tenantId,
+                () -> warmUp(client, createCoapsOrCoapRequest(endpointConfig, deviceId, 0)),
+                msg -> {
+
+                    msg.getTimeUntilDisconnectNotification()
+                        .map(notification -> {
+                            logger.trace("received piggy backed message [ttd: {}]: {}", notification.getTtd(), msg);
+                            ctx.verify(() -> {
+                                assertThat(notification.getTenantId()).isEqualTo(tenantId);
+                                assertThat(notification.getDeviceId()).isEqualTo(subscribingDeviceId);
+                            });
+                            // now ready to send a command
+                            final JsonObject inputData = new JsonObject().put(COMMAND_JSON_KEY, (int) (Math.random() * 100));
+                            return helper.sendCommand(
+                                    tenantId,
+                                    commandTargetDeviceId,
+                                    COMMAND_TO_SEND,
+                                    "application/json",
+                                    inputData.toBuffer(),
+                                    // set "forceCommandRerouting" message property so that half the command are rerouted via the AMQP network
+                                    IntegrationTestSupport.newCommandMessageProperties(() -> counter.getAndIncrement() >= MESSAGES_TO_SEND / 2),
+                                    notification.getMillisecondsUntilExpiry())
+                                    .map(response -> {
+                                        ctx.verify(() -> {
+                                            assertThat(response.getContentType()).isEqualTo("text/plain");
+                                            assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
+                                            assertThat(response.getTenantId()).isEqualTo(tenantId);
+                                        });
+                                        return response;
+                                    });
+                        });
+                },
+                count -> {
+                    final Promise<OptionSet> result = Promise.promise();
+                    final Request request = createCoapsOrCoapRequest(endpointConfig, commandTargetDeviceId, count);
+                    request.getOptions().addUriQuery(String.format("%s=%d", Constants.HEADER_TIME_TILL_DISCONNECT, 5));
+                    client.advanced(getHandler(result, ResponseCode.CHANGED), request);
+                    return result.future()
+                            .map(responseOptions -> {
+                                ctx.verify(() -> {
+                                    assertResponseContainsCommand(
+                                            endpointConfig,
+                                            responseOptions,
+                                            expectedCommand,
+                                            tenantId,
+                                            commandTargetDeviceId);
+                                });
+                                final List<String> locationPath = responseOptions.getLocationPath();
+                                return locationPath.get(locationPath.size() - 1);
+                            })
+                            .compose(receivedCommandRequestId -> {
+                                // send a response to the command now
+                                final String responseUri = endpointConfig.getCommandResponseUri(tenantId, commandTargetDeviceId, receivedCommandRequestId);
+                                logger.debug("sending response to command [uri: {}]", responseUri);
+
+                                final Buffer body = Buffer.buffer("ok");
+                                final Promise<OptionSet> commandResponseResult = Promise.promise();
+                                final Request commandResponseRequest = createCoapsOrCoapRequest(endpointConfig,
+                                        responseUri, body.getBytes());
+                                commandResponseRequest.getOptions()
+                                    .setContentFormat(MediaTypeRegistry.TEXT_PLAIN)
+                                    .addUriQuery(String.format("%s=%d", Constants.HEADER_COMMAND_RESPONSE_STATUS, 200));
+                                client.advanced(getHandler(commandResponseResult, ResponseCode.CHANGED), commandResponseRequest);
+                                return commandResponseResult.future()
+                                        .recover(thr -> {
+                                            // wrap exception, making clear it occurred when sending the command response,
+                                            // not the preceding telemetry/event message
+                                            final String msg = "Error sending command response: " + thr.getMessage();
+                                            return Future.failedFuture(thr instanceof ServiceInvocationException
+                                                    ? new ServiceInvocationException(tenantId, ((ServiceInvocationException) thr).getErrorCode(), msg, thr)
+                                                    : new RuntimeException(msg, thr));
+                                        });
+                            });
+                });
+    }
+
+    private void assertResponseContainsCommand(
+            final CoapCommandEndpointConfiguration endpointConfiguration,
+            final OptionSet responseOptions,
+            final String expectedCommand,
+            final String tenantId,
+            final String commandTargetDeviceId) {
+
+        assertThat(responseOptions.getLocationQuery())
+            .as("location query must contain parameter [%s]", expectedCommand)
+            .contains(expectedCommand);
+        assertThat(responseOptions.getContentFormat()).isEqualTo(MediaTypeRegistry.APPLICATION_JSON);
+        int idx = 0;
+        assertThat(responseOptions.getLocationPath()).contains(CommandConstants.COMMAND_RESPONSE_ENDPOINT, Index.atIndex(idx++));
+        if (endpointConfiguration.isSubscribeAsGateway()) {
+            assertThat(responseOptions.getLocationPath()).contains(tenantId, Index.atIndex(idx++));
+            assertThat(responseOptions.getLocationPath()).contains(commandTargetDeviceId, Index.atIndex(idx++));
+        }
+        // request ID
+        assertThat(responseOptions.getLocationPath().get(idx))
+            .as("location path must contain command request ID")
+            .isNotNull();
+    }
+
+    /**
+     * Verifies that the CoAP adapter delivers a one-way command to a device.
+     *
+     * @param endpointConfig The endpoints to use for sending/receiving commands.
+     * @param ctx The test context
+     * @throws InterruptedException if the test fails.
+     */
+    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
+    @MethodSource("commandAndControlVariants")
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    public void testUploadMessagesWithTtdThatReplyWithOneWayCommand(
+            final CoapCommandEndpointConfiguration endpointConfig,
+            final VertxTestContext ctx) throws InterruptedException {
+
+        final Tenant tenant = new Tenant();
+        final String expectedCommand = String.format("%s=%s", Constants.HEADER_COMMAND, COMMAND_TO_SEND);
+
+        final VertxTestContext setup = new VertxTestContext();
+        if (endpointConfig.isSubscribeAsUnauthenticatedDevice()) {
+            helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, SECRET).onComplete(setup.completing());
+        } else {
+            helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, SECRET).onComplete(setup.completing());
+        }
+        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
+
+        final CoapClient client = endpointConfig.isSubscribeAsUnauthenticatedDevice() ? getCoapClient()
+                : getCoapsClient(deviceId, tenantId, SECRET);
+        final AtomicInteger counter = new AtomicInteger();
+
+        final String commandTargetDeviceId = endpointConfig.isSubscribeAsGateway()
+                ? helper.setupGatewayDeviceBlocking(tenantId, deviceId, 5)
+                : deviceId;
+        final String subscribingDeviceId = endpointConfig.isSubscribeAsGatewayForSingleDevice() ? commandTargetDeviceId
+                : deviceId;
+
+        testUploadMessages(ctx, tenantId,
+                () -> warmUp(client, createCoapsRequest(Code.POST, getPostResource(), 0)),
+                msg -> {
+                    final Integer ttd = msg.getTimeTillDisconnect();
+                    logger.debug("north-bound message received {}, ttd: {}", msg, ttd);
+                    msg.getTimeUntilDisconnectNotification().ifPresent(notification -> {
+                        ctx.verify(() -> {
+                            assertThat(notification.getTenantId()).isEqualTo(tenantId);
+                            assertThat(notification.getDeviceId()).isEqualTo(subscribingDeviceId);
+                        });
+                        logger.debug("send one-way-command");
+                        final JsonObject inputData = new JsonObject().put(COMMAND_JSON_KEY, (int) (Math.random() * 100));
+                        helper.sendOneWayCommand(
+                                tenantId,
+                                commandTargetDeviceId,
+                                COMMAND_TO_SEND,
+                                "application/json",
+                                inputData.toBuffer(),
+                                // set "forceCommandRerouting" message property so that half the command are rerouted via the AMQP network
+                                IntegrationTestSupport.newCommandMessageProperties(() -> counter.getAndIncrement() >= MESSAGES_TO_SEND / 2),
+                                notification.getMillisecondsUntilExpiry() / 2);
+                    });
+                },
+                count -> {
+                    final Promise<OptionSet> result = Promise.promise();
+                    final Request request = createCoapsOrCoapRequest(endpointConfig, commandTargetDeviceId, count);
+                    request.getOptions().addUriQuery(String.format("%s=%d", Constants.HEADER_TIME_TILL_DISCONNECT, 4));
+                    logger.debug("south-bound send {}", request);
+                    client.advanced(getHandler(result, ResponseCode.CHANGED), request);
+                    return result.future()
+                            .map(responseOptions -> {
+                                ctx.verify(() -> {
+                                    assertResponseContainsOneWayCommand(
+                                            endpointConfig,
+                                            responseOptions,
+                                            expectedCommand,
+                                            tenantId,
+                                            commandTargetDeviceId);
+                                });
+                                return responseOptions;
+                            });
+                });
+    }
+
+    private void assertResponseContainsOneWayCommand(
+            final CoapCommandEndpointConfiguration endpointConfiguration,
+            final OptionSet responseOptions,
+            final String expectedCommand,
+            final String tenantId,
+            final String commandTargetDeviceId) {
+
+        assertThat(responseOptions.getLocationQuery())
+            .as("response doesn't contain command")
+            .contains(expectedCommand);
+        assertThat(responseOptions.getContentFormat()).isEqualTo(MediaTypeRegistry.APPLICATION_JSON);
+        assertThat(responseOptions.getLocationPath()).contains(CommandConstants.COMMAND_ENDPOINT, Index.atIndex(0));
+        if (endpointConfiguration.isSubscribeAsGateway()) {
+            assertThat(responseOptions.getLocationPath()).contains(tenantId, Index.atIndex(1));
+            assertThat(responseOptions.getLocationPath()).contains(commandTargetDeviceId, Index.atIndex(2));
+        }
+    }
+
+    private QoS getExpectedQoS(final QoS qos) {
+        if (qos != null) {
+            return qos;
+        }
+
+        switch (getMessageType()) {
+            case CON:
+                return QoS.AT_LEAST_ONCE;
+            case NON:
+                return QoS.AT_MOST_ONCE;
+            default:
+                throw new IllegalArgumentException("Either QoS must be non-null or message type must be CON or NON!");
+        }
+    }
+
+    /**
+     * Performs additional checks on messages received by a downstream consumer.
+     * <p>
+     * This default implementation does nothing. Subclasses should override this method to implement
+     * reasonable checks.
+     *
+     * @param ctx The test context.
+     * @param msg The message to perform checks on.
+     */
+    protected void assertAdditionalMessageProperties(final VertxTestContext ctx, final Message msg) {
+        // empty
+    }
+
+    /**
+     * Performs additional checks on the response received in reply to a CoAP request.
+     * <p>
+     * This default implementation always returns a succeeded future.
+     * Subclasses should override this method to implement reasonable checks.
+     *
+     * @param responseOptions The CoAP options from the response.
+     * @return A future indicating the outcome of the checks.
+     */
+    protected Future<?> assertCoapResponse(final OptionSet responseOptions) {
+        return Future.succeededFuture();
+    }
+
+    /**
+     * Sends some (optional) messages before uploading the batch of
+     * real test messages.
+     *
+     * @param client The CoAP client to use for sending the messages.
+     * @return A succeeded future upon completion.
+     */
+    protected Future<Void> sendWarmUpMessages(final CoapClient client) {
+        return Future.succeededFuture();
+    }
+
+    /**
+     * Creates a CoAP request using either the <em>coaps</em> or <em>coap</em> scheme,
+     * depending on the given endpoint configuration.
+     *
+     * @param endpointConfig The endpoint configuration.
+     * @param requestDeviceId The identifier of the device to publish data for.
+     * @param msgNo The message number.
+     * @return The request to send.
+     */
+    protected Request createCoapsOrCoapRequest(
+            final CoapCommandEndpointConfiguration endpointConfig,
+            final String requestDeviceId,
+            final int msgNo) {
+
+        if (endpointConfig.isSubscribeAsGatewayForSingleDevice()) {
+            return createCoapsRequest(Code.PUT, getMessageType(), getPutResource(tenantId, requestDeviceId), msgNo);
+        } else if (endpointConfig.isSubscribeAsUnauthenticatedDevice()) {
+            return createCoapRequest(Code.PUT, getMessageType(), getPutResource(tenantId, requestDeviceId), msgNo);
+        } else {
+            return createCoapsRequest(Code.POST, getMessageType(), getPostResource(), msgNo);
+        }
+    }
+
+    /**
+     * Creates a CoAP request using either the <em>coaps</em> or <em>coap</em> scheme,
+     * depending on the given endpoint configuration.
+     *
+     * @param endpointConfig The endpoint configuration.
+     * @param resource the resource path.
+     * @param payload The payload to send in the request body.
+     * @return The request to send.
+     */
+    protected Request createCoapsOrCoapRequest(
+            final CoapCommandEndpointConfiguration endpointConfig,
+            final String resource,
+            final byte[] payload) {
+
+        if (endpointConfig.isSubscribeAsGateway()) {
+            // Gateway uses PUT when acting on behalf of a device
+            return createCoapsRequest(Code.PUT, Type.CON, resource, payload);
+        } else if (endpointConfig.isSubscribeAsUnauthenticatedDevice()) {
+            return createCoapRequest(Code.PUT, Type.CON, resource, payload);
+        } else {
+            return createCoapsRequest(Code.POST, Type.CON, resource, payload);
+        }
+    }
+
+    /**
+     * Creates a CoAP request using the <em>coap</em> scheme.
+     *
+     * @param code The CoAP request code.
+     * @param resource the resource path.
+     * @param msgNo The message number.
+     * @return The request to send.
+     */
+    protected Request createCoapRequest(
+            final Code code,
+            final String resource,
+            final int msgNo) {
+
+        return createCoapRequest(code, getMessageType(), resource, msgNo);
+    }
+
+    /**
+     * Creates a CoAP request using the <em>coap</em> scheme.
+     *
+     * @param code The CoAP request code.
+     * @param type The message type.
+     * @param resource the resource path.
+     * @param payload The payload to send in the request body.
+     * @return The request to send.
+     */
+    protected Request createCoapRequest(
+            final Code code,
+            final Type type,
+            final String resource,
+            final byte[] payload) {
+        final Request request = new Request(code, type);
+        request.setURI(getCoapRequestUri(resource));
+        request.setPayload(payload);
+        request.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+        return request;
+    }
+
+    /**
+     * Creates a CoAP request using the <em>coap</em> scheme.
+     *
+     * @param code The CoAP request code.
+     * @param type The message type.
+     * @param resource the resource path.
+     * @param msgNo The message number.
+     * @return The request to send.
+     */
+    protected Request createCoapRequest(
+            final Code code,
+            final Type type,
+            final String resource,
+            final int msgNo) {
+        final Request request = new Request(code, type);
+        request.setURI(getCoapRequestUri(resource));
+        request.setPayload("hello " + msgNo);
+        request.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+        return request;
+    }
+
+    /**
+     * Creates a CoAP request using the <em>coaps</em> scheme.
+     *
+     * @param code The CoAP request code.
+     * @param resource the resource path.
+     * @param msgNo The message number.
+     * @return The request to send.
+     */
+    protected Request createCoapsRequest(
+            final Code code,
+            final String resource,
+            final int msgNo) {
+
+        return createCoapsRequest(code, getMessageType(), resource, msgNo);
+    }
+
+    /**
+     * Creates a CoAP request using the <em>coaps</em> scheme.
+     *
+     * @param code The CoAP request code.
+     * @param type The message type.
+     * @param resource the resource path.
+     * @param msgNo The message number.
+     * @return The request to send.
+     */
+    protected Request createCoapsRequest(
+            final Code code,
+            final Type type,
+            final String resource,
+            final int msgNo) {
+
+        final String payload = "hello " + msgNo;
+        return createCoapsRequest(code, type, resource, payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Creates a CoAP request using the <em>coaps</em> scheme.
+     *
+     * @param code The CoAP request code.
+     * @param type The message type.
+     * @param resource the resource path.
+     * @param payload The payload to send in the request body.
+     * @return The request to send.
+     */
+    protected Request createCoapsRequest(
+            final Code code,
+            final Type type,
+            final String resource,
+            final byte[] payload) {
+        final Request request = new Request(code, type);
+        request.setURI(getCoapsRequestUri(resource));
+        request.setPayload(payload);
+        request.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+        return request;
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.hono.tests.coap;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.net.HttpURLConnection;
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
@@ -22,29 +20,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import org.assertj.core.data.Index;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapHandler;
 import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.Utils;
-import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
-import org.eclipse.californium.core.coap.CoAP.Type;
-import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.OptionSet;
-import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.scandium.DTLSConnector;
@@ -52,37 +35,19 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedSinglePskStore;
 import org.eclipse.hono.application.client.DownstreamMessage;
-import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.MessageContext;
-import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.service.management.device.Device;
-import org.eclipse.hono.service.management.tenant.Tenant;
-import org.eclipse.hono.tests.AssumeMessagingSystem;
 import org.eclipse.hono.tests.CommandEndpointConfiguration.SubscriberRole;
 import org.eclipse.hono.tests.IntegrationTestSupport;
-import org.eclipse.hono.util.Adapter;
-import org.eclipse.hono.util.CommandConstants;
-import org.eclipse.hono.util.Constants;
-import org.eclipse.hono.util.MessagingType;
-import org.eclipse.hono.util.QoS;
-import org.eclipse.hono.util.RegistryManagementConstants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
-import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 /**
@@ -101,20 +66,15 @@ public abstract class CoapTestBase {
      * for managing tenants/devices/credentials.
      */
     protected static IntegrationTestSupport helper;
-    /**
-     * The period of time in milliseconds after which test cases should time out.
-     */
-    protected static final long TEST_TIMEOUT_MILLIS = 20000; // 20 seconds
-
-    protected static final int MESSAGES_TO_SEND = 60;
-
-    private static final String COMMAND_TO_SEND = "setDarkness";
-    private static final String COMMAND_JSON_KEY = "darkness";
 
     /**
      * A logger to be shared with subclasses.
      */
     protected final Logger logger = LoggerFactory.getLogger(getClass());
+    /**
+     * The vert.x instance.
+     */
+    protected final Vertx vertx = Vertx.vertx();
 
     /**
      * The IP address and port of the CoAP adapter's secure endpoint.
@@ -129,7 +89,18 @@ public abstract class CoapTestBase {
      */
     protected String deviceId;
 
-    private final Vertx vertx = Vertx.vertx();
+    /**
+     * Maps a CoAP response code to the corresponding HTTP status code.
+     *
+     * @param responseCode The CoAP response code.
+     * @return The status code.
+     */
+    protected static int toHttpStatusCode(final ResponseCode responseCode) {
+        int result = 0;
+        result += responseCode.codeClass * 100;
+        result += responseCode.codeDetail;
+        return result;
+    }
 
     /**
      * Creates the endpoint configuration variants for Command &amp; Control scenarios.
@@ -171,7 +142,6 @@ public abstract class CoapTestBase {
     /**
      * Deletes all temporary objects from the Device Registry which
      * have been created during the last test execution.
-     *
      *
      * @param ctx The vert.x context.
      */
@@ -236,87 +206,6 @@ public abstract class CoapTestBase {
     }
 
     /**
-     * Creates a test specific message consumer.
-     *
-     * @param tenantId        The tenant to create the consumer for.
-     * @param messageConsumer The handler to invoke for every message received.
-     * @return A future succeeding with the created consumer.
-     */
-    protected abstract Future<MessageConsumer> createConsumer(
-            String tenantId, Handler<DownstreamMessage<? extends MessageContext>> messageConsumer);
-
-    /**
-     * Gets the name of the resource that unauthenticated devices
-     * or gateways should use for uploading data.
-     *
-     * @param tenant The tenant.
-     * @param deviceId The device ID.
-     * @return The resource name.
-     */
-    protected abstract String getPutResource(String tenant, String deviceId);
-
-    /**
-     * Gets the name of the resource that authenticated devices
-     * should use for uploading data.
-     *
-     * @return The resource name.
-     */
-    protected abstract String getPostResource();
-
-    /**
-     * Gets the CoAP message type to use for requests to the adapter.
-     *
-     * @return The type.
-     */
-    protected abstract Type getMessageType();
-
-    /**
-     * Triggers the establishment of a downstream sender
-     * for a tenant so that subsequent messages will be
-     * more likely to be forwarded.
-     *
-     * @param client The CoAP client to use for sending the request.
-     * @param request The request to send.
-     * @return A succeeded future.
-     */
-    protected final Future<Void> warmUp(final CoapClient client, final Request request) {
-
-        logger.debug("sending request to trigger CoAP adapter's downstream message sender");
-        final Promise<Void> result = Promise.promise();
-        client.advanced(new CoapHandler() {
-
-            @Override
-            public void onLoad(final CoapResponse response) {
-                waitForWarmUp();
-            }
-
-            @Override
-            public void onError() {
-                waitForWarmUp();
-            }
-
-            private void waitForWarmUp() {
-                vertx.setTimer(1000, tid -> result.complete());
-            }
-        }, request);
-        return result.future();
-    }
-
-    /**
-     * Asserts the status code of a failed CoAP request.
-     *
-     * @param ctx The test context to verify the status for.
-     * @param expectedStatus The expected status.
-     * @param t The exception to verify.
-     */
-    protected static void assertStatus(final VertxTestContext ctx, final int expectedStatus, final Throwable t) {
-        ctx.verify(() -> {
-            assertThat(t).isInstanceOf(CoapResultException.class);
-            assertThat(((CoapResultException) t).getErrorCode()).isEqualTo(expectedStatus);
-        });
-    }
-
-    /**
      * Perform additional checks on a received message.
      * <p>
      * This default implementation does nothing. Subclasses should override this method to implement
@@ -327,670 +216,6 @@ public abstract class CoapTestBase {
      */
     protected void assertAdditionalMessageProperties(final DownstreamMessage<? extends MessageContext> msg) {
         // empty
-    }
-
-    /**
-     * Verifies that a number of messages uploaded to Hono's CoAP adapter
-     * can be successfully consumed via the AMQP Messaging Network.
-     *
-     * @param ctx The test context.
-     * @throws InterruptedException if the test fails.
-     */
-    @Test
-    public void testUploadMessagesAnonymously(final VertxTestContext ctx) throws InterruptedException {
-
-        final Tenant tenant = new Tenant();
-
-        final VertxTestContext setup = new VertxTestContext();
-        helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, SECRET)
-        .onComplete(setup.completing());
-        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
-
-        final CoapClient client = getCoapClient();
-        testUploadMessages(ctx, tenantId,
-                () -> warmUp(client, createCoapRequest(Code.PUT, getPutResource(tenantId, deviceId), 0)),
-                count -> {
-                    final Promise<OptionSet> result = Promise.promise();
-                    final Request request = createCoapRequest(Code.PUT, getPutResource(tenantId, deviceId), count);
-                    client.advanced(getHandler(result), request);
-                    return result.future();
-                });
-    }
-
-    /**
-     * Verifies that a number of messages uploaded to Hono's CoAP adapter using TLS_PSK based authentication can be
-     * successfully consumed via the AMQP Messaging Network.
-     *
-     * @param ctx The test context.
-     * @throws InterruptedException if the test fails.
-     */
-    @Test
-    public void testUploadMessagesUsingPsk(final VertxTestContext ctx) throws InterruptedException {
-
-        final Tenant tenant = new Tenant();
-
-        final VertxTestContext setup = new VertxTestContext();
-        helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, SECRET)
-        .onComplete(setup.completing());
-        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
-
-        final CoapClient client = getCoapsClient(deviceId, tenantId, SECRET);
-
-        testUploadMessages(ctx, tenantId,
-                () -> warmUp(client, createCoapsRequest(Code.POST, getPostResource(), 0)),
-                count -> {
-                    final Promise<OptionSet> result = Promise.promise();
-                    final Request request = createCoapsRequest(Code.POST, getPostResource(), count);
-                    client.advanced(getHandler(result), request);
-                    return result.future();
-                });
-    }
-
-    /**
-     * Verifies that a number of messages uploaded to the CoAP adapter via a gateway
-     * using TLS_PSK can be successfully consumed via the AMQP Messaging Network.
-     *
-     * @param ctx The test context.
-     * @throws InterruptedException if the test fails.
-     */
-    @Test
-    public void testUploadMessagesViaGateway(final VertxTestContext ctx) throws InterruptedException {
-
-        // GIVEN a device that is connected via two gateways
-        final Tenant tenant = new Tenant();
-        final String gatewayOneId = helper.getRandomDeviceId(tenantId);
-        final String gatewayTwoId = helper.getRandomDeviceId(tenantId);
-        final Device deviceData = new Device();
-        deviceData.setVia(Arrays.asList(gatewayOneId, gatewayTwoId));
-
-        final VertxTestContext setup = new VertxTestContext();
-        helper.registry.addPskDeviceForTenant(tenantId, tenant, gatewayOneId, SECRET)
-        .compose(ok -> helper.registry.addPskDeviceToTenant(tenantId, gatewayTwoId, SECRET))
-        .compose(ok -> helper.registry.registerDevice(tenantId, deviceId, deviceData))
-        .onComplete(setup.completing());
-        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
-
-        final CoapClient gatewayOne = getCoapsClient(gatewayOneId, tenantId, SECRET);
-        final CoapClient gatewayTwo = getCoapsClient(gatewayTwoId, tenantId, SECRET);
-
-        testUploadMessages(ctx, tenantId,
-                () -> warmUp(gatewayOne, createCoapsRequest(Code.PUT, getPutResource(tenantId, deviceId), 0)),
-                count -> {
-                    final CoapClient client = (count.intValue() & 1) == 0 ? gatewayOne : gatewayTwo;
-                    final Promise<OptionSet> result = Promise.promise();
-                    final Request request = createCoapsRequest(Code.PUT, getPutResource(tenantId, deviceId), count);
-                    client.advanced(getHandler(result), request);
-                    return result.future();
-                });
-    }
-
-    /**
-     * Verifies that an edge device is auto-provisioned if it connects via a gateway equipped with the corresponding
-     * authority.
-     *
-     * @param ctx The test context.
-     * @throws InterruptedException if the test fails.
-     */
-    @Test
-    public void testAutoProvisioningViaGateway(final VertxTestContext ctx) throws InterruptedException {
-
-        final Tenant tenant = new Tenant();
-        final String gatewayId = helper.getRandomDeviceId(tenantId);
-        final Device gateway = new Device()
-                .setAuthorities(Collections.singleton(RegistryManagementConstants.AUTHORITY_AUTO_PROVISIONING_ENABLED));
-
-        final String edgeDeviceId = helper.getRandomDeviceId(tenantId);
-        helper.createAutoProvisioningMessageConsumers(ctx, tenantId, edgeDeviceId)
-                .compose(ok -> helper.registry.addPskDeviceForTenant(tenantId, tenant, gatewayId, gateway, SECRET))
-                .compose(ok -> {
-                    final Promise<OptionSet> result = Promise.promise();
-                    final Request request = createCoapsRequest(Code.PUT, getPutResource(tenantId, edgeDeviceId), 0);
-
-                    final CoapClient client = getCoapsClient(gatewayId, tenantId, SECRET);
-                    client.advanced(getHandler(result), request);
-
-                    return result.future();
-                })
-                .onComplete(ctx.succeeding());
-    }
-
-    /**
-     * Uploads messages to the CoAP endpoint.
-     *
-     * @param ctx The test context to run on.
-     * @param tenantId The tenant that the device belongs to.
-     * @param warmUp A sender of messages used to warm up the adapter before
-     *               running the test itself or {@code null} if no warm up should
-     *               be performed. 
-     * @param requestSender The test device that will publish the data.
-     * @throws InterruptedException if the test is interrupted before it
-     *              has finished.
-     */
-    protected void testUploadMessages(
-            final VertxTestContext ctx,
-            final String tenantId,
-            final Supplier<Future<?>> warmUp,
-            final Function<Integer, Future<OptionSet>> requestSender) throws InterruptedException {
-        testUploadMessages(ctx, tenantId, warmUp, null, requestSender);
-    }
-
-    /**
-     * Uploads messages to the CoAP endpoint.
-     *
-     * @param ctx The test context to run on.
-     * @param tenantId The tenant that the device belongs to.
-     * @param messageConsumer Consumer that is invoked when a message was received.
-     * @param warmUp A sender of messages used to warm up the adapter before
-     *               running the test itself or {@code null} if no warm up should
-     *               be performed. 
-     * @param requestSender The test device that will publish the data.
-     * @throws InterruptedException if the test is interrupted before it
-     *              has finished.
-     */
-    protected void testUploadMessages(
-            final VertxTestContext ctx,
-            final String tenantId,
-            final Supplier<Future<?>> warmUp,
-            final Consumer<DownstreamMessage<? extends MessageContext>> messageConsumer,
-            final Function<Integer, Future<OptionSet>> requestSender) throws InterruptedException {
-        testUploadMessages(ctx, tenantId, warmUp, messageConsumer, requestSender, MESSAGES_TO_SEND, null);
-    }
-
-    /**
-     * Uploads messages to the CoAP endpoint.
-     *
-     * @param ctx The test context to run on.
-     * @param tenantId The tenant that the device belongs to.
-     * @param warmUp A sender of messages used to warm up the adapter before running the test itself or {@code null} if
-     *            no warm up should be performed.
-     * @param messageConsumer Consumer that is invoked when a message was received.
-     * @param requestSender The test device that will publish the data.
-     * @param numberOfMessages The number of messages that are uploaded.
-     * @param expectedQos The expected QoS level, may be {@code null} leading to expecting the default for event or telemetry.
-     * @throws InterruptedException if the test is interrupted before it has finished.
-     */
-    protected void testUploadMessages(
-            final VertxTestContext ctx,
-            final String tenantId,
-            final Supplier<Future<?>> warmUp,
-            final Consumer<DownstreamMessage<? extends MessageContext>> messageConsumer,
-            final Function<Integer, Future<OptionSet>> requestSender,
-            final int numberOfMessages,
-            final QoS expectedQos) throws InterruptedException {
-
-        final CountDownLatch received = new CountDownLatch(numberOfMessages);
-
-        final VertxTestContext setup = new VertxTestContext();
-        createConsumer(tenantId, msg -> {
-            ctx.verify(() -> {
-                logger.trace("received {}", msg);
-                IntegrationTestSupport.assertTelemetryMessageProperties(msg, tenantId);
-                assertThat(msg.getQos()).isEqualTo(getExpectedQoS(expectedQos));
-                assertAdditionalMessageProperties(msg);
-                if (messageConsumer != null) {
-                    messageConsumer.accept(msg);
-                }
-            });
-            received.countDown();
-            if (received.getCount() % 20 == 0) {
-                logger.info("messages received: {}", numberOfMessages - received.getCount());
-            }
-        })
-        .compose(ok -> Optional.ofNullable(warmUp).map(w -> w.get()).orElseGet(() -> Future.succeededFuture()))
-        .onComplete(setup.completing());
-        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
-
-        final long start = System.currentTimeMillis();
-        final AtomicInteger messageCount = new AtomicInteger(0);
-
-        while (messageCount.get() < numberOfMessages && !ctx.failed()) {
-
-            final CountDownLatch sending = new CountDownLatch(1);
-            requestSender.apply(messageCount.getAndIncrement()).compose(this::assertCoapResponse)
-                    .onComplete(attempt -> {
-                        if (attempt.succeeded()) {
-                            logger.debug("sent message {}", messageCount.get());
-                        } else {
-                            logger.info("failed to send message {}: {}", messageCount.get(),
-                                    attempt.cause().getMessage());
-                            ctx.failNow(attempt.cause());
-                        }
-                        sending.countDown();
-                    });
-
-            if (messageCount.get() % 20 == 0) {
-                logger.info("messages sent: {}", messageCount.get());
-            }
-            sending.await();
-        }
-        if (ctx.failed()) {
-            return;
-        }
-
-        final long timeToWait = Math.max(TEST_TIMEOUT_MILLIS - 1000, Math.round(numberOfMessages * 20));
-        if (received.await(timeToWait, TimeUnit.MILLISECONDS)) {
-            logger.info("sent {} and received {} messages after {} milliseconds",
-                    messageCount, numberOfMessages - received.getCount(), System.currentTimeMillis() - start);
-            ctx.completeNow();
-        } else {
-            logger.info("sent {} and received {} messages after {} milliseconds",
-                    messageCount, numberOfMessages - received.getCount(), System.currentTimeMillis() - start);
-            ctx.failNow(new AssertionError("did not receive all messages sent"));
-        }
-    }
-
-    /**
-     * Verifies that the adapter fails to authenticate a device if the shared key registered
-     * for the device does not match the key used by the device in the DTLS handshake.
-     *
-     * @param ctx The vert.x test context.
-     */
-    @Test
-    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    public void testUploadFailsForNonMatchingSharedKey(final VertxTestContext ctx) {
-
-        final Tenant tenant = new Tenant();
-
-        // GIVEN a device for which PSK credentials have been registered
-        helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, "NOT" + SECRET)
-        .compose(ok -> {
-            // WHEN a device tries to upload data and authenticate using the PSK
-            // identity for which the server has a different shared secret on record
-            final CoapClient client = getCoapsClient(deviceId, tenantId, SECRET);
-            final Promise<OptionSet> result = Promise.promise();
-            client.advanced(getHandler(result), createCoapsRequest(Code.POST, getPostResource(), 0));
-            return result.future();
-        })
-        .onComplete(ctx.failing(t -> {
-            // THEN the request fails because the DTLS handshake cannot be completed
-            assertStatus(ctx, HttpURLConnection.HTTP_UNAVAILABLE, t);
-            ctx.completeNow();
-        }));
-    }
-
-    /**
-     * Verifies that the CoAP adapter rejects messages from a device that belongs to a tenant for which the CoAP adapter
-     * has been disabled.
-     *
-     * @param ctx The test context
-     */
-    @Test
-    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    public void testUploadMessageFailsForDisabledTenant(final VertxTestContext ctx) {
-
-        // GIVEN a tenant for which the CoAP adapter is disabled
-        final Tenant tenant = new Tenant();
-        tenant.addAdapterConfig(new Adapter(Constants.PROTOCOL_ADAPTER_TYPE_COAP).setEnabled(false));
-
-        helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, SECRET)
-        .compose(ok -> {
-
-            // WHEN a device that belongs to the tenant uploads a message
-            final CoapClient client = getCoapsClient(deviceId, tenantId, SECRET);
-            final Promise<OptionSet> result = Promise.promise();
-            // THEN a FORBIDDEN response code is returned
-            client.advanced(getHandler(result, ResponseCode.FORBIDDEN), createCoapsRequest(Code.POST, getPostResource(), 0));
-            return result.future();
-        })
-        .onComplete(ctx.completing());
-    }
-
-    /**
-     * Verifies that the CoAP adapter rejects messages from a disabled device.
-     *
-     * @param ctx The test context
-     */
-    @Test
-    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    public void testUploadMessageFailsForDisabledDevice(final VertxTestContext ctx) {
-
-        // GIVEN a disabled device
-        final Tenant tenant = new Tenant();
-        final Device deviceData = new Device();
-        deviceData.setEnabled(false);
-
-        helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, deviceData, SECRET)
-        .compose(ok -> {
-
-            // WHEN the device tries to upload a message
-            final CoapClient client = getCoapsClient(deviceId, tenantId, SECRET);
-            final Promise<OptionSet> result = Promise.promise();
-            // THEN a NOT_FOUND response code is returned
-            client.advanced(getHandler(result, ResponseCode.NOT_FOUND), createCoapsRequest(Code.POST, getPostResource(), 0));
-            return result.future();
-        })
-        .onComplete(ctx.completing());
-    }
-
-    /**
-     * Verifies that the CoAP adapter rejects messages from a disabled gateway
-     * for an enabled device with a 403.
-     *
-     * @param ctx The test context
-     */
-    @Test
-    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    public void testUploadMessageFailsForDisabledGateway(final VertxTestContext ctx) {
-
-        // GIVEN a device that is connected via a disabled gateway
-        final Tenant tenant = new Tenant();
-        final String gatewayId = helper.getRandomDeviceId(tenantId);
-        final Device gatewayData = new Device();
-        gatewayData.setEnabled(false);
-        final Device deviceData = new Device();
-        deviceData.setVia(Collections.singletonList(gatewayId));
-
-        helper.registry.addPskDeviceForTenant(tenantId, tenant, gatewayId, gatewayData, SECRET)
-        .compose(ok -> helper.registry.registerDevice(tenantId, deviceId, deviceData))
-        .compose(ok -> {
-
-            // WHEN the gateway tries to upload a message for the device
-            final Promise<OptionSet> result = Promise.promise();
-            final CoapClient client = getCoapsClient(gatewayId, tenantId, SECRET);
-            // THEN a FORBIDDEN response code is returned
-            client.advanced(getHandler(result, ResponseCode.FORBIDDEN), createCoapsRequest(Code.PUT, getPutResource(tenantId, deviceId), 0));
-            return result.future();
-        })
-        .onComplete(ctx.completing());
-    }
-
-    /**
-     * Verifies that the CoAP adapter rejects messages from a gateway for a device that it is not authorized for with a
-     * 403.
-     *
-     * @param ctx The test context
-     */
-    @Test
-    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    public void testUploadMessageFailsForUnauthorizedGateway(final VertxTestContext ctx) {
-
-        // GIVEN a device that is connected via gateway "not-the-created-gateway"
-        final Tenant tenant = new Tenant();
-        final String gatewayId = helper.getRandomDeviceId(tenantId);
-        final Device deviceData = new Device();
-        deviceData.setVia(Collections.singletonList("not-the-created-gateway"));
-
-        helper.registry.addPskDeviceForTenant(tenantId, tenant, gatewayId, SECRET)
-        .compose(ok -> helper.registry.registerDevice(tenantId, deviceId, deviceData))
-        .compose(ok -> {
-
-            // WHEN another gateway tries to upload a message for the device
-            final Promise<OptionSet> result = Promise.promise();
-            final CoapClient client = getCoapsClient(gatewayId, tenantId, SECRET);
-            // THEN a FORBIDDEN response code is returned
-            client.advanced(getHandler(result, ResponseCode.FORBIDDEN),
-                    createCoapsRequest(Code.PUT, getPutResource(tenantId, deviceId), 0));
-            return result.future();
-        })
-        .onComplete(ctx.completing());
-    }
-
-    /**
-     * Verifies that the CoAP adapter delivers a command to a device and accepts
-     * the corresponding response from the device.
-     *
-     * @param endpointConfig The endpoints to use for sending/receiving commands.
-     * @param ctx The test context.
-     * @throws InterruptedException if the test fails.
-     */
-    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
-    @MethodSource("commandAndControlVariants")
-    @AssumeMessagingSystem(type = MessagingType.amqp) // TODO remove when Kafka C&C is implemented!
-    public void testUploadMessagesWithTtdThatReplyWithCommand(
-            final CoapCommandEndpointConfiguration endpointConfig,
-            final VertxTestContext ctx) throws InterruptedException {
-
-        final Tenant tenant = new Tenant();
-        testUploadMessagesWithTtdThatReplyWithCommand(endpointConfig, tenant, ctx);
-    }
-
-    private void testUploadMessagesWithTtdThatReplyWithCommand(
-            final CoapCommandEndpointConfiguration endpointConfig,
-            final Tenant tenant, final VertxTestContext ctx) throws InterruptedException {
-
-        final String expectedCommand = String.format("%s=%s", Constants.HEADER_COMMAND, COMMAND_TO_SEND);
-
-        final VertxTestContext setup = new VertxTestContext();
-
-        if (endpointConfig.isSubscribeAsUnauthenticatedDevice()) {
-            helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, SECRET).onComplete(setup.completing());
-        } else {
-            helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, SECRET).onComplete(setup.completing());
-        }
-        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
-
-        final String commandTargetDeviceId = endpointConfig.isSubscribeAsGateway()
-                ? helper.setupGatewayDeviceBlocking(tenantId, deviceId, 5)
-                : deviceId;
-        final String subscribingDeviceId = endpointConfig.isSubscribeAsGatewayForSingleDevice() ? commandTargetDeviceId
-                : deviceId;
-
-        final CoapClient client = endpointConfig.isSubscribeAsUnauthenticatedDevice() ? getCoapClient()
-                : getCoapsClient(deviceId, tenantId, SECRET);
-        final AtomicInteger counter = new AtomicInteger();
-
-        testUploadMessages(ctx, tenantId,
-                () -> warmUp(client, createCoapsOrCoapRequest(endpointConfig, deviceId, 0)),
-                msg -> {
-
-                    msg.getTimeUntilDisconnectNotification()
-                        .map(notification -> {
-                            logger.trace("received piggy backed message [ttd: {}]: {}", notification.getTtd(), msg);
-                            ctx.verify(() -> {
-                                assertThat(notification.getTenantId()).isEqualTo(tenantId);
-                                assertThat(notification.getDeviceId()).isEqualTo(subscribingDeviceId);
-                            });
-                            // now ready to send a command
-                            final JsonObject inputData = new JsonObject().put(COMMAND_JSON_KEY, (int) (Math.random() * 100));
-                            return helper.sendCommand(
-                                    tenantId,
-                                    commandTargetDeviceId,
-                                    COMMAND_TO_SEND,
-                                    "application/json",
-                                    inputData.toBuffer(),
-                                    // set "forceCommandRerouting" message property so that half the command are rerouted via the AMQP network
-                                    IntegrationTestSupport.newCommandMessageProperties(() -> counter.getAndIncrement() >= MESSAGES_TO_SEND / 2),
-                                    notification.getMillisecondsUntilExpiry())
-                                    .map(response -> {
-                                        ctx.verify(() -> {
-                                            assertThat(response.getContentType()).isEqualTo("text/plain");
-                                            assertThat(response.getDeviceId()).isEqualTo(commandTargetDeviceId);
-                                            assertThat(response.getTenantId()).isEqualTo(tenantId);
-                                        });
-                                        return response;
-                                    });
-                        });
-                },
-                count -> {
-                    final Promise<OptionSet> result = Promise.promise();
-                    final Request request = createCoapsOrCoapRequest(endpointConfig, commandTargetDeviceId, count);
-                    request.getOptions().addUriQuery(String.format("%s=%d", Constants.HEADER_TIME_TILL_DISCONNECT, 5));
-                    client.advanced(getHandler(result, ResponseCode.CHANGED), request);
-                    return result.future()
-                            .map(responseOptions -> {
-                                ctx.verify(() -> {
-                                    assertResponseContainsCommand(
-                                            endpointConfig,
-                                            responseOptions,
-                                            expectedCommand,
-                                            tenantId,
-                                            commandTargetDeviceId);
-                                });
-                                final List<String> locationPath = responseOptions.getLocationPath();
-                                return locationPath.get(locationPath.size() - 1);
-                            })
-                            .compose(receivedCommandRequestId -> {
-                                // send a response to the command now
-                                final String responseUri = endpointConfig.getCommandResponseUri(tenantId, commandTargetDeviceId, receivedCommandRequestId);
-                                logger.debug("sending response to command [uri: {}]", responseUri);
-
-                                final Buffer body = Buffer.buffer("ok");
-                                final Promise<OptionSet> commandResponseResult = Promise.promise();
-                                final Request commandResponseRequest = createCoapsOrCoapRequest(endpointConfig,
-                                        responseUri, body.getBytes());
-                                commandResponseRequest.getOptions()
-                                    .setContentFormat(MediaTypeRegistry.TEXT_PLAIN)
-                                    .addUriQuery(String.format("%s=%d", Constants.HEADER_COMMAND_RESPONSE_STATUS, 200));
-                                client.advanced(getHandler(commandResponseResult, ResponseCode.CHANGED), commandResponseRequest);
-                                return commandResponseResult.future()
-                                        .recover(thr -> {
-                                            // wrap exception, making clear it occurred when sending the command response,
-                                            // not the preceding telemetry/event message
-                                            final String msg = "Error sending command response: " + thr.getMessage();
-                                            return Future.failedFuture(thr instanceof ServiceInvocationException
-                                                    ? new ServiceInvocationException(tenantId, ((ServiceInvocationException) thr).getErrorCode(), msg, thr)
-                                                    : new RuntimeException(msg, thr));
-                                        });
-                            });
-                });
-    }
-
-    private void assertResponseContainsCommand(
-            final CoapCommandEndpointConfiguration endpointConfiguration,
-            final OptionSet responseOptions,
-            final String expectedCommand,
-            final String tenantId,
-            final String commandTargetDeviceId) {
-
-        assertThat(responseOptions.getLocationQuery())
-            .as("location query must contain parameter [%s]", expectedCommand)
-            .contains(expectedCommand);
-        assertThat(responseOptions.getContentFormat()).isEqualTo(MediaTypeRegistry.APPLICATION_JSON);
-        int idx = 0;
-        assertThat(responseOptions.getLocationPath()).contains(CommandConstants.COMMAND_RESPONSE_ENDPOINT, Index.atIndex(idx++));
-        if (endpointConfiguration.isSubscribeAsGateway()) {
-            assertThat(responseOptions.getLocationPath()).contains(tenantId, Index.atIndex(idx++));
-            assertThat(responseOptions.getLocationPath()).contains(commandTargetDeviceId, Index.atIndex(idx++));
-        }
-        // request ID
-        assertThat(responseOptions.getLocationPath().get(idx))
-            .as("location path must contain command request ID")
-            .isNotNull();
-    }
-
-    /**
-     * Verifies that the CoAP adapter delivers a one-way command to a device.
-     *
-     * @param endpointConfig The endpoints to use for sending/receiving commands.
-     * @param ctx The test context
-     * @throws InterruptedException if the test fails.
-     */
-    @ParameterizedTest(name = IntegrationTestSupport.PARAMETERIZED_TEST_NAME_PATTERN)
-    @MethodSource("commandAndControlVariants")
-    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    public void testUploadMessagesWithTtdThatReplyWithOneWayCommand(
-            final CoapCommandEndpointConfiguration endpointConfig,
-            final VertxTestContext ctx) throws InterruptedException {
-
-        final Tenant tenant = new Tenant();
-        final String expectedCommand = String.format("%s=%s", Constants.HEADER_COMMAND, COMMAND_TO_SEND);
-
-        final VertxTestContext setup = new VertxTestContext();
-        if (endpointConfig.isSubscribeAsUnauthenticatedDevice()) {
-            helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, SECRET).onComplete(setup.completing());
-        } else {
-            helper.registry.addPskDeviceForTenant(tenantId, tenant, deviceId, SECRET).onComplete(setup.completing());
-        }
-        ctx.verify(() -> assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue());
-
-        final CoapClient client = endpointConfig.isSubscribeAsUnauthenticatedDevice() ? getCoapClient()
-                : getCoapsClient(deviceId, tenantId, SECRET);
-        final AtomicInteger counter = new AtomicInteger();
-
-        final String commandTargetDeviceId = endpointConfig.isSubscribeAsGateway()
-                ? helper.setupGatewayDeviceBlocking(tenantId, deviceId, 5)
-                : deviceId;
-        final String subscribingDeviceId = endpointConfig.isSubscribeAsGatewayForSingleDevice() ? commandTargetDeviceId
-                : deviceId;
-
-        testUploadMessages(ctx, tenantId,
-                () -> warmUp(client, createCoapsRequest(Code.POST, getPostResource(), 0)),
-                msg -> {
-                    final Integer ttd = msg.getTimeTillDisconnect();
-                    logger.debug("north-bound message received {}, ttd: {}", msg, ttd);
-                    msg.getTimeUntilDisconnectNotification().ifPresent(notification -> {
-                        ctx.verify(() -> {
-                            assertThat(notification.getTenantId()).isEqualTo(tenantId);
-                            assertThat(notification.getDeviceId()).isEqualTo(subscribingDeviceId);
-                        });
-                        logger.debug("send one-way-command");
-                        final JsonObject inputData = new JsonObject().put(COMMAND_JSON_KEY, (int) (Math.random() * 100));
-                        helper.sendOneWayCommand(
-                                tenantId,
-                                commandTargetDeviceId,
-                                COMMAND_TO_SEND,
-                                "application/json",
-                                inputData.toBuffer(),
-                                // set "forceCommandRerouting" message property so that half the command are rerouted via the AMQP network
-                                IntegrationTestSupport.newCommandMessageProperties(() -> counter.getAndIncrement() >= MESSAGES_TO_SEND / 2),
-                                notification.getMillisecondsUntilExpiry() / 2);
-                    });
-                },
-                count -> {
-                    final Promise<OptionSet> result = Promise.promise();
-                    final Request request = createCoapsOrCoapRequest(endpointConfig, commandTargetDeviceId, count);
-                    request.getOptions().addUriQuery(String.format("%s=%d", Constants.HEADER_TIME_TILL_DISCONNECT, 4));
-                    logger.debug("south-bound send {}", request);
-                    client.advanced(getHandler(result, ResponseCode.CHANGED), request);
-                    return result.future()
-                            .map(responseOptions -> {
-                                ctx.verify(() -> {
-                                    assertResponseContainsOneWayCommand(
-                                            endpointConfig,
-                                            responseOptions,
-                                            expectedCommand,
-                                            tenantId,
-                                            commandTargetDeviceId);
-                                });
-                                return responseOptions;
-                            });
-                });
-    }
-
-    private void assertResponseContainsOneWayCommand(
-            final CoapCommandEndpointConfiguration endpointConfiguration,
-            final OptionSet responseOptions,
-            final String expectedCommand,
-            final String tenantId,
-            final String commandTargetDeviceId) {
-
-        assertThat(responseOptions.getLocationQuery())
-            .as("response doesn't contain command")
-            .contains(expectedCommand);
-        assertThat(responseOptions.getContentFormat()).isEqualTo(MediaTypeRegistry.APPLICATION_JSON);
-        assertThat(responseOptions.getLocationPath()).contains(CommandConstants.COMMAND_ENDPOINT, Index.atIndex(0));
-        if (endpointConfiguration.isSubscribeAsGateway()) {
-            assertThat(responseOptions.getLocationPath()).contains(tenantId, Index.atIndex(1));
-            assertThat(responseOptions.getLocationPath()).contains(commandTargetDeviceId, Index.atIndex(2));
-        }
-    }
-
-    private QoS getExpectedQoS(final QoS qos) {
-        if (qos != null) {
-            return qos;
-        }
-
-        switch (getMessageType()) {
-            case CON:
-                return QoS.AT_LEAST_ONCE;
-            case NON:
-                return QoS.AT_MOST_ONCE;
-            default:
-                throw new IllegalArgumentException("Either QoS must be non-null or message type must be CON or NON!");
-        }
-    }
-
-    /**
-     * Performs additional checks on the response received in reply to a CoAP request.
-     * <p>
-     * This default implementation always returns a succeeded future.
-     * Subclasses should override this method to implement reasonable checks.
-     *
-     * @param responseOptions The CoAP options from the response.
-     * @return A future indicating the outcome of the checks.
-     */
-    protected Future<?> assertCoapResponse(final OptionSet responseOptions) {
-        return Future.succeededFuture();
     }
 
     /**
@@ -1037,13 +262,6 @@ public abstract class CoapTestBase {
         };
     }
 
-    private static int toHttpStatusCode(final ResponseCode responseCode) {
-        int result = 0;
-        result += responseCode.codeClass * 100;
-        result += responseCode.codeDetail;
-        return result;
-    }
-
     /**
      * Creates a URI for a resource that uses the <em>coap</em> scheme.
      *
@@ -1052,7 +270,7 @@ public abstract class CoapTestBase {
      */
     protected final URI getCoapRequestUri(final String resource) {
 
-        return getRequestUri("coap", resource);
+        return getRequestUri("coap", resource, null);
     }
 
     /**
@@ -1063,10 +281,20 @@ public abstract class CoapTestBase {
      */
     protected final URI getCoapsRequestUri(final String resource) {
 
-        return getRequestUri("coaps", resource);
+        return getRequestUri("coaps", resource, null);
     }
 
-    private URI getRequestUri(final String scheme, final String resource) {
+    /**
+     * Creates a URI for a resource and query parameters.
+     *
+     * @param scheme The URI scheme to use.
+     * @param resource The resource path.
+     * @param query The query parameters or {@code null}.
+     * @return The URI.
+     * @throws NullPointerException if scheme or resource are {@code null}.
+     * @throws IllegalArgumentException if scheme is neither <em>coap</em> nor <em>coaps</em>.
+     */
+    protected URI getRequestUri(final String scheme, final String resource, final String query) {
 
         final int port;
         switch (scheme) {
@@ -1080,171 +308,10 @@ public abstract class CoapTestBase {
             throw new IllegalArgumentException();
         }
         try {
-            return new URI(scheme, null, IntegrationTestSupport.COAP_HOST, port, resource, null, null);
+            return new URI(scheme, null, IntegrationTestSupport.COAP_HOST, port, resource, query, null);
         } catch (final URISyntaxException e) {
             // cannot happen
             return null;
         }
-    }
-
-    /**
-     * Creates a CoAP request using either the <em>coaps</em> or <em>coap</em> scheme,
-     * depending on the given endpoint configuration.
-     *
-     * @param endpointConfig The endpoint configuration.
-     * @param requestDeviceId The identifier of the device to publish data for.
-     * @param msgNo The message number.
-     * @return The request to send.
-     */
-    protected Request createCoapsOrCoapRequest(
-            final CoapCommandEndpointConfiguration endpointConfig,
-            final String requestDeviceId,
-            final int msgNo) {
-
-        if (endpointConfig.isSubscribeAsGatewayForSingleDevice()) {
-            return createCoapsRequest(Code.PUT, getMessageType(), getPutResource(tenantId, requestDeviceId), msgNo);
-        } else if (endpointConfig.isSubscribeAsUnauthenticatedDevice()) {
-            return createCoapRequest(Code.PUT, getMessageType(), getPutResource(tenantId, requestDeviceId), msgNo);
-        } else {
-            return createCoapsRequest(Code.POST, getMessageType(), getPostResource(), msgNo);
-        }
-    }
-
-    /**
-     * Creates a CoAP request using either the <em>coaps</em> or <em>coap</em> scheme,
-     * depending on the given endpoint configuration.
-     *
-     * @param endpointConfig The endpoint configuration.
-     * @param resource the resource path.
-     * @param payload The payload to send in the request body.
-     * @return The request to send.
-     */
-    protected Request createCoapsOrCoapRequest(
-            final CoapCommandEndpointConfiguration endpointConfig,
-            final String resource,
-            final byte[] payload) {
-
-        if (endpointConfig.isSubscribeAsGateway()) {
-            // Gateway uses PUT when acting on behalf of a device
-            return createCoapsRequest(Code.PUT, Type.CON, resource, payload);
-        } else if (endpointConfig.isSubscribeAsUnauthenticatedDevice()) {
-            return createCoapRequest(Code.PUT, Type.CON, resource, payload);
-        } else {
-            return createCoapsRequest(Code.POST, Type.CON, resource, payload);
-        }
-    }
-
-    /**
-     * Creates a CoAP request using the <em>coap</em> scheme.
-     *
-     * @param code The CoAP request code.
-     * @param resource the resource path.
-     * @param msgNo The message number.
-     * @return The request to send.
-     */
-    protected Request createCoapRequest(
-            final Code code,
-            final String resource,
-            final int msgNo) {
-
-        return createCoapRequest(code, getMessageType(), resource, msgNo);
-    }
-
-    /**
-     * Creates a CoAP request using the <em>coap</em> scheme.
-     *
-     * @param code The CoAP request code.
-     * @param type The message type.
-     * @param resource the resource path.
-     * @param payload The payload to send in the request body.
-     * @return The request to send.
-     */
-    protected Request createCoapRequest(
-            final Code code,
-            final Type type,
-            final String resource,
-            final byte[] payload) {
-        final Request request = new Request(code, type);
-        request.setURI(getCoapRequestUri(resource));
-        request.setPayload(payload);
-        request.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
-        return request;
-    }
-
-    /**
-     * Creates a CoAP request using the <em>coap</em> scheme.
-     *
-     * @param code The CoAP request code.
-     * @param type The message type.
-     * @param resource the resource path.
-     * @param msgNo The message number.
-     * @return The request to send.
-     */
-    protected Request createCoapRequest(
-            final Code code,
-            final Type type,
-            final String resource,
-            final int msgNo) {
-        final Request request = new Request(code, type);
-        request.setURI(getCoapRequestUri(resource));
-        request.setPayload("hello " + msgNo);
-        request.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
-        return request;
-    }
-
-    /**
-     * Creates a CoAP request using the <em>coaps</em> scheme.
-     *
-     * @param code The CoAP request code.
-     * @param resource the resource path.
-     * @param msgNo The message number.
-     * @return The request to send.
-     */
-    protected Request createCoapsRequest(
-            final Code code,
-            final String resource,
-            final int msgNo) {
-
-        return createCoapsRequest(code, getMessageType(), resource, msgNo);
-    }
-
-    /**
-     * Creates a CoAP request using the <em>coaps</em> scheme.
-     *
-     * @param code The CoAP request code.
-     * @param type The message type.
-     * @param resource the resource path.
-     * @param msgNo The message number.
-     * @return The request to send.
-     */
-    protected Request createCoapsRequest(
-            final Code code,
-            final Type type,
-            final String resource,
-            final int msgNo) {
-
-        final String payload = "hello " + msgNo;
-        return createCoapsRequest(code, type, resource, payload.getBytes(StandardCharsets.UTF_8));
-    }
-
-    /**
-     * Creates a CoAP request using the <em>coaps</em> scheme.
-     *
-     * @param code The CoAP request code.
-     * @param type The message type.
-     * @param resource the resource path.
-     * @param payload The payload to send in the request body.
-     * @return The request to send.
-     */
-    protected Request createCoapsRequest(
-            final Code code,
-            final Type type,
-            final String resource,
-            final byte[] payload) {
-        final Request request = new Request(code, type);
-        request.setURI(getCoapsRequestUri(resource));
-        request.setPayload(payload);
-        request.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
-        return request;
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
@@ -45,7 +45,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
-public class EventCoapIT extends CoapTestBase {
+public class EventCoapIT extends CoapPublishTestBase {
 
     private static final String POST_URI = "/" + EventConstants.EVENT_ENDPOINT;
     private static final String PUT_URI_TEMPLATE = POST_URI + "/%s/%s";

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -48,7 +48,7 @@ import io.vertx.junit5.VertxTestContext;
  *
  */
 @ExtendWith(VertxExtension.class)
-public class TelemetryCoapIT extends CoapTestBase {
+public class TelemetryCoapIT extends CoapPublishTestBase {
 
     private static final String POST_URI = "/" + TelemetryConstants.TELEMETRY_ENDPOINT;
     private static final String PUT_URI_TEMPLATE = POST_URI + "/%s/%s";

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/lwm2m/ExampleDevice.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/lwm2m/ExampleDevice.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.tests.coap.lwm2m;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.TimeZone;
+
+import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
+import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
+import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.response.ExecuteResponse;
+import org.eclipse.leshan.core.response.ObserveResponse;
+import org.eclipse.leshan.core.response.ReadResponse;
+import org.eclipse.leshan.core.response.WriteResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Handler;
+
+/**
+ * An example implementation of the standard LwM2M Firmware object.
+ */
+public class ExampleDevice extends BaseInstanceEnabler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExampleDevice.class);
+
+    private static final Random RANDOM = new Random();
+    private static final List<Integer> SUPPORTED_RESOURCES = List.of(0, 1, 2, 3, 4, 5, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21);
+
+    private Handler<Void> rebootHandler;
+    private Handler<Void> resetHandler;
+    private String utcOffset = new SimpleDateFormat("X").format(Calendar.getInstance().getTime());
+    private String timeZone = TimeZone.getDefault().getID();
+
+    /**
+     * Creates a new device.
+     */
+    public ExampleDevice() {
+    }
+
+    /**
+     * Sets the handler to invoke when the device's <em>reboot</em> resource is being executed.
+     *
+     * @param handler The handler.
+     */
+    public void setRebootHandler(final Handler<Void> handler) {
+        this.rebootHandler = handler;
+    }
+
+    /**
+     * Sets the handler to invoke when the device's <em>reset</em> resource is being executed.
+     *
+     * @param handler The handler.
+     */
+    public void setResetHandler(final Handler<Void> handler) {
+        this.resetHandler = handler;
+    }
+
+    @Override
+    public ObserveResponse observe(final ServerIdentity identity) {
+        LOG.debug("Observe on Device");
+        return super.observe(identity);
+    }
+
+    @Override
+    public ReadResponse read(final ServerIdentity identity, final int resourceid) {
+        LOG.debug("Read on Device resource /{}/{}/{}", getModel().id, getId(), resourceid);
+        switch (resourceid) {
+        case 0:
+            return ReadResponse.success(resourceid, getManufacturer());
+        case 1:
+            return ReadResponse.success(resourceid, getModelNumber());
+        case 2:
+            return ReadResponse.success(resourceid, getSerialNumber());
+        case 3:
+            return ReadResponse.success(resourceid, getFirmwareVersion());
+        case 9:
+            return ReadResponse.success(resourceid, getBatteryLevel());
+        case 10:
+            return ReadResponse.success(resourceid, getMemoryFree());
+        case 11:
+            final Map<Integer, Long> errorCodes = new HashMap<>();
+            errorCodes.put(0, getErrorCode());
+            return ReadResponse.success(resourceid, errorCodes, Type.INTEGER);
+        case 13:
+            return ReadResponse.success(resourceid, getCurrentTime());
+        case 14:
+            return ReadResponse.success(resourceid, getUtcOffset());
+        case 15:
+            return ReadResponse.success(resourceid, getTimezone());
+        case 16:
+            return ReadResponse.success(resourceid, getSupportedBinding());
+        case 17:
+            return ReadResponse.success(resourceid, getDeviceType());
+        case 18:
+            return ReadResponse.success(resourceid, getHardwareVersion());
+        case 19:
+            return ReadResponse.success(resourceid, getSoftwareVersion());
+        case 20:
+            return ReadResponse.success(resourceid, getBatteryStatus());
+        case 21:
+            return ReadResponse.success(resourceid, getMemoryTotal());
+        default:
+            return super.read(identity, resourceid);
+        }
+    }
+
+    @Override
+    public ExecuteResponse execute(final ServerIdentity identity, final int resourceid, final String params) {
+        String withParams = null;
+        if (params != null && params.length() != 0) {
+            withParams = " with params " + params;
+        }
+        LOG.debug("Execute on Device resource /{}/{}/{} {}", getModel().id, getId(), resourceid,
+                withParams != null ? withParams : "");
+
+        switch (resourceid) {
+        case 4:
+            Optional.ofNullable(rebootHandler).ifPresent(h -> h.handle(null));
+            LOG.info("rebooting device");
+//            new Timer("Reboot Lwm2mClient").schedule(new TimerTask() {
+//                @Override
+//                public void run() {
+//                    getLwM2mClient().stop(true);
+//                    try {
+//                        Thread.sleep(500);
+//                    } catch (InterruptedException e) {
+//                    }
+//                    getLwM2mClient().start();
+//                }
+//            }, 500);
+            break;
+        case 5:
+            LOG.info("resetting device");
+            Optional.ofNullable(resetHandler).ifPresent(h -> h.handle(null));
+            break;
+        default:
+            // do nothing
+        }
+        return ExecuteResponse.success();
+    }
+
+    @Override
+    public WriteResponse write(final ServerIdentity identity, final int resourceid, final LwM2mResource value) {
+        LOG.debug("Write on Device resource /{}/{}/{}", getModel().id, getId(), resourceid);
+
+        switch (resourceid) {
+        case 13:
+            return WriteResponse.notFound();
+        case 14:
+            setUtcOffset((String) value.getValue());
+            fireResourcesChange(resourceid);
+            return WriteResponse.success();
+        case 15:
+            setTimezone((String) value.getValue());
+            fireResourcesChange(resourceid);
+            return WriteResponse.success();
+        default:
+            return super.write(identity, resourceid, value);
+        }
+    }
+
+    private String getManufacturer() {
+        return "Leshan Demo Device";
+    }
+
+    private String getModelNumber() {
+        return "Model 500";
+    }
+
+    private String getSerialNumber() {
+        return "LT-500-000-0001";
+    }
+
+    private String getFirmwareVersion() {
+        return "1.0.0";
+    }
+
+    private long getErrorCode() {
+        return 0;
+    }
+
+    private int getBatteryLevel() {
+        return RANDOM.nextInt(101);
+    }
+
+    private long getMemoryFree() {
+        return Runtime.getRuntime().freeMemory() / 1024;
+    }
+
+    private Date getCurrentTime() {
+        return new Date();
+    }
+
+    private String getUtcOffset() {
+        return utcOffset;
+    }
+
+    private void setUtcOffset(final String t) {
+        utcOffset = t;
+    }
+
+    private String getTimezone() {
+        return timeZone;
+    }
+
+    private void setTimezone(final String t) {
+        timeZone = t;
+    }
+
+    private String getSupportedBinding() {
+        return "U";
+    }
+
+    private String getDeviceType() {
+        return "Demo";
+    }
+
+    private String getHardwareVersion() {
+        return "1.0.1";
+    }
+
+    private String getSoftwareVersion() {
+        return "1.0.2";
+    }
+
+    private int getBatteryStatus() {
+        return RANDOM.nextInt(7);
+    }
+
+    private long getMemoryTotal() {
+        return Runtime.getRuntime().totalMemory() / 1024;
+    }
+
+    @Override
+    public List<Integer> getAvailableResourceIds(final ObjectModel model) {
+        return SUPPORTED_RESOURCES;
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/lwm2m/ExampleFirmware.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/lwm2m/ExampleFirmware.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.tests.coap.lwm2m;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
+import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
+import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.response.ExecuteResponse;
+import org.eclipse.leshan.core.response.ObserveResponse;
+import org.eclipse.leshan.core.response.ReadResponse;
+import org.eclipse.leshan.core.response.WriteResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An example implementation of the standard LwM2M Firmware object.
+ */
+public class ExampleFirmware extends BaseInstanceEnabler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExampleFirmware.class);
+
+    private static final List<Integer> SUPPORTED_RESOURCES = List.of(1, 2, 3, 5, 8, 9);
+
+    private Map<Integer, Long> supportedDownloadProtocols = Map.of(0, 3L); // only support https
+    private int supportedDeliveryMethod = 0; // only support pull
+    private String packageUri = "";
+    private int state = 0;
+    private int updateResult = 0;
+
+    /**
+     * Creates a new Firmware object.
+     */
+    public ExampleFirmware() {
+    }
+
+    @Override
+    public ObserveResponse observe(final ServerIdentity identity) {
+        LOG.debug("Observe on Firmware");
+        return super.observe(identity);
+    }
+
+    @Override
+    public ReadResponse read(final ServerIdentity identity, final int resourceid) {
+        LOG.debug("Read on Firmware resource /{}/{}/{}", getModel().id, getId(), resourceid);
+        switch (resourceid) {
+        case 1:
+            return ReadResponse.success(resourceid, getPackageUri());
+        case 3:
+            return ReadResponse.success(resourceid, getState());
+        case 5:
+            return ReadResponse.success(resourceid, getUpdateResult());
+        case 8:
+            return ReadResponse.success(resourceid, supportedDownloadProtocols, Type.INTEGER);
+        case 9:
+            return ReadResponse.success(resourceid, supportedDeliveryMethod);
+        default:
+            return super.read(identity, resourceid);
+        }
+    }
+
+    @Override
+    public ExecuteResponse execute(final ServerIdentity identity, final int resourceid, final String params) {
+        String withParams = null;
+        if (params != null && params.length() != 0) {
+            withParams = " with params " + params;
+        }
+        LOG.debug("Execute on Firmware resource /{}/{}/{} {}", getModel().id, getId(), resourceid,
+                withParams != null ? withParams : "");
+
+        switch (resourceid) {
+        case 2: // update
+            LOG.info("starting firmware update");
+            break;
+        default:
+            return super.execute(identity, resourceid, params);
+        }
+        return ExecuteResponse.success();
+    }
+
+    @Override
+    public WriteResponse write(final ServerIdentity identity, final int resourceid, final LwM2mResource value) {
+        LOG.debug("Write on Firmware resource /{}/{}/{}", getModel().id, getId(), resourceid);
+
+        switch (resourceid) {
+        case 1:
+            setPackageUri((String) value.getValue());
+            return WriteResponse.success();
+        default:
+            return super.write(identity, resourceid, value);
+        }
+    }
+
+    private void setPackageUri(final String packageUri) {
+        this.packageUri = packageUri;
+    }
+
+    private String getPackageUri() {
+        return packageUri;
+    }
+
+    void setState(final int newState) {
+        this.state = newState;
+    }
+
+    private int getState() {
+        return state;
+    }
+
+    void setUpdateResult(final int result) {
+        this.updateResult = result;
+    }
+
+    private int getUpdateResult() {
+        return updateResult;
+    }
+
+    @Override
+    public List<Integer> getAvailableResourceIds(final ObjectModel model) {
+        return SUPPORTED_RESOURCES;
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/lwm2m/LeshanClientObserver.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/lwm2m/LeshanClientObserver.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.tests.coap.lwm2m;
+
+import org.eclipse.leshan.client.observer.LwM2mClientObserver2;
+import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.ResponseCode;
+import org.eclipse.leshan.core.request.BootstrapRequest;
+import org.eclipse.leshan.core.request.DeregisterRequest;
+import org.eclipse.leshan.core.request.RegisterRequest;
+import org.eclipse.leshan.core.request.UpdateRequest;
+
+/**
+ * A LeshanClientObserver.
+ *
+ */
+public class LeshanClientObserver implements LwM2mClientObserver2 {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onBootstrapStarted(final ServerIdentity bsserver, final BootstrapRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onBootstrapSuccess(final ServerIdentity bsserver, final BootstrapRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onBootstrapFailure(
+            final ServerIdentity bsserver,
+            final BootstrapRequest request,
+            final ResponseCode responseCode,
+            final String errorMessage,
+            final Exception cause) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onBootstrapTimeout(final ServerIdentity bsserver, final BootstrapRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onRegistrationStarted(final ServerIdentity server, final RegisterRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onRegistrationSuccess(final ServerIdentity server, final RegisterRequest request,
+            final String registrationID) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onRegistrationFailure(final ServerIdentity server, final RegisterRequest request,
+            final ResponseCode responseCode,
+            final String errorMessage, final Exception cause) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onRegistrationTimeout(final ServerIdentity server, final RegisterRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onUpdateStarted(final ServerIdentity server, final UpdateRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onUpdateSuccess(final ServerIdentity server, final UpdateRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onUpdateFailure(final ServerIdentity server, final UpdateRequest request,
+            final ResponseCode responseCode,
+            final String errorMessage, final Exception cause) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onUpdateTimeout(final ServerIdentity server, final UpdateRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onDeregistrationStarted(final ServerIdentity server, final DeregisterRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onDeregistrationSuccess(final ServerIdentity server, final DeregisterRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onDeregistrationFailure(final ServerIdentity server, final DeregisterRequest request,
+            final ResponseCode responseCode,
+            final String errorMessage, final Exception cause) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onDeregistrationTimeout(final ServerIdentity server, final DeregisterRequest request) {
+        // TODO Auto-generated method stub
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onUnexpectedError(final Throwable unexpectedError) {
+        // TODO Auto-generated method stub
+
+    }
+
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/lwm2m/LwM2mIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/lwm2m/LwM2mIT.java
@@ -1,0 +1,454 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.tests.coap.lwm2m;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.exception.ConnectorException;
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.ClientHandshaker;
+import org.eclipse.californium.scandium.dtls.DTLSSession;
+import org.eclipse.californium.scandium.dtls.HandshakeException;
+import org.eclipse.californium.scandium.dtls.Handshaker;
+import org.eclipse.californium.scandium.dtls.ResumingClientHandshaker;
+import org.eclipse.californium.scandium.dtls.ResumingServerHandshaker;
+import org.eclipse.californium.scandium.dtls.ServerHandshaker;
+import org.eclipse.californium.scandium.dtls.SessionAdapter;
+import org.eclipse.californium.scandium.dtls.SessionId;
+import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tests.IntegrationTestSupport;
+import org.eclipse.hono.tests.coap.CoapTestBase;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.leshan.client.californium.LeshanClient;
+import org.eclipse.leshan.client.californium.LeshanClientBuilder;
+import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
+import org.eclipse.leshan.client.object.Security;
+import org.eclipse.leshan.client.object.Server;
+import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
+import org.eclipse.leshan.client.resource.ObjectsInitializer;
+import org.eclipse.leshan.client.resource.listener.ObjectsListenerAdapter;
+import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.LwM2mId;
+import org.eclipse.leshan.core.californium.DefaultEndpointFactory;
+import org.eclipse.leshan.core.model.LwM2mModel;
+import org.eclipse.leshan.core.model.ObjectLoader;
+import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.model.StaticModel;
+import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
+import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeEncoder;
+import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.core.request.RegisterRequest;
+import org.eclipse.leshan.core.request.UpdateRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Promise;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Integration tests for sending commands to a device connected to the CoAP adapter.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+public class LwM2mIT extends CoapTestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LwM2mIT.class);
+
+    private LeshanClient client;
+    private ExampleDevice deviceObject;
+    private ExampleFirmware firmwareObject;
+
+    @BeforeEach
+    void createClientObjects() {
+        deviceObject = new ExampleDevice();
+        firmwareObject = new ExampleFirmware();
+    }
+
+    @AfterEach
+    void stopClient() {
+        if (client != null) {
+            client.destroy(true);
+        }
+    }
+
+    /**
+     * Verifies that a LwM2M device using binding mode <em>U</em> can successfully register, update its
+     * registration and unregister using the CoAP adapter's resource directory resource.
+     * <p>
+     * Also verifies that registration, updating the registration and de-registration trigger empty downstream
+     * notifications with a TTD reflecting the device's lifetime and that the adapter establishes observations
+     * for resources configured for the device.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    public void testNonQueueModeRegistration(final VertxTestContext ctx) {
+
+        final Checkpoint deviceAcceptsCommands = ctx.checkpoint(2);
+        final Checkpoint deviceNoLongerAcceptsCommands = ctx.checkpoint();
+        final Promise<Void> firmwareNotificationReceived = Promise.promise();
+        final Promise<Void> deviceNotificationReceived = Promise.promise();
+
+        final int lifetime = 24 * 60 * 60; // 24h
+        final int communicationPeriod = 300_000; // update registration every 5m
+        final String endpoint = "test-device";
+
+        helper.registry.addPskDeviceForTenant(tenantId, new Tenant(), deviceId, SECRET)
+            .compose(ok -> helper.applicationClient.createEventConsumer(
+                    tenantId,
+                    msg -> {
+                        final String origAddress = msg.getProperties().getProperty(MessageHelper.APP_PROPERTY_ORIG_ADDRESS, String.class);
+                        logger.info("received event [content-type: {}, orig_address: {}]", msg.getContentType(), origAddress);
+                        Optional.ofNullable(msg.getTimeTillDisconnect())
+                            .ifPresent(ttd -> {
+                                switch (ttd) {
+                                case lifetime:
+                                    deviceAcceptsCommands.flag();
+                                    break;
+                                case 0:
+                                    deviceNoLongerAcceptsCommands.flag();
+                                    // fall through
+                                default:
+                                    break;
+                                }
+                            });
+                        if (msg.getContentType().startsWith("application/vnd.oma.lwm2m")) {
+                            Optional.ofNullable(origAddress)
+                                .filter(s -> s.equals("/5/0"))
+                                .ifPresent(s -> firmwareNotificationReceived.complete());
+                        }
+                    },
+                    remoteClose -> {}))
+            .compose(eventConsumer -> helper.applicationClient.createTelemetryConsumer(
+                    tenantId,
+                    msg -> {
+                        final String origAddress = msg.getProperties().getProperty(MessageHelper.APP_PROPERTY_ORIG_ADDRESS, String.class);
+                        logger.info("received telemetry message [content-type: {}, orig_address: {}]", msg.getContentType(), origAddress);
+                        if (msg.getContentType().startsWith("application/vnd.oma.lwm2m")) {
+                            Optional.ofNullable(origAddress)
+                                .filter(s -> s.equals("/3/0"))
+                                .ifPresent(s -> deviceNotificationReceived.complete());
+                        }
+                    },
+                    remoteClose -> {}))
+            .compose(eventConsumer -> {
+                final Promise<LeshanClient> result = Promise.promise();
+                try {
+                    final var leshanClient = createLeshanClient(endpoint, BindingMode.U, lifetime, communicationPeriod);
+                    result.complete(leshanClient);
+                } catch (final CertificateEncodingException e) {
+                    result.fail(e);
+                }
+                return result.future();
+            })
+            .compose(leshanClient -> {
+                client = leshanClient;
+                final Promise<Void> registered = Promise.promise();
+                client.addObserver(new LeshanClientObserver() {
+                    @Override
+                    public void onRegistrationSuccess(
+                            final ServerIdentity server,
+                            final RegisterRequest request,
+                            final String registrationID) {
+                        registered.complete();
+                    }
+                });
+                client.start();
+                return CompositeFuture.all(
+                        registered.future(),
+                        deviceNotificationReceived.future(),
+                        firmwareNotificationReceived.future());
+            })
+            .compose(ok -> {
+                final Promise<Void> updated = Promise.promise();
+                client.addObserver(new LeshanClientObserver() {
+                    @Override
+                    public void onUpdateSuccess(
+                            final ServerIdentity server,
+                            final UpdateRequest request) {
+                        updated.complete();
+                    }
+                });
+                client.triggerRegistrationUpdate();
+                return updated.future();
+            })
+            .onSuccess(ok -> client.stop(true));
+    }
+
+    /**
+     * Verifies that a de-registration request to the CoAP adapter's resource directory
+     * resource triggers an event with a TTD.
+     *
+     * @param ctx The vert.x test context.
+     * @throws InterruptedException if the fixture cannot be created.
+     * @throws ConnectorException if the CoAP adapter is not available.
+     * @throws IOException if the CoAP adapter is not available.
+     */
+    @Test
+    @Disabled
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    public void testDeregistrationTriggersEvent(final VertxTestContext ctx) throws InterruptedException, ConnectorException, IOException {
+
+        final Checkpoint notificationReceived = ctx.checkpoint();
+
+        helper.registry.addPskDeviceForTenant(tenantId, new Tenant(), deviceId, SECRET)
+        .compose(ok -> helper.applicationClient.createEventConsumer(
+                tenantId,
+                msg -> {
+                    logger.trace("received event: {}", msg);
+                    msg.getTimeUntilDisconnectNotification()
+                        .ifPresent(notification -> {
+                            ctx.verify(() -> assertThat(notification.getTtd()).isEqualTo(0));
+                            notificationReceived.flag();
+                        });
+                },
+                remoteClose -> {}))
+        .compose(c -> {
+            final CoapClient client = getCoapsClient(deviceId, tenantId, SECRET);
+            final Request request = new Request(Code.DELETE);
+            request.setURI(getCoapsRequestUri(String.format("/rd/%s:%s", tenantId, deviceId)));
+            final Promise<OptionSet> result = Promise.promise();
+            client.advanced(getHandler(result, ResponseCode.DELETED), request);
+            return result.future();
+        })
+        .onComplete(ctx.completing());
+    }
+
+    private LeshanClient createLeshanClient(
+            final String endpoint,
+            final BindingMode bindingMode,
+            final int lifetime,
+            final Integer communicationPeriod) throws CertificateEncodingException {
+
+        final var serverURI = getCoapsRequestUri(null);
+
+        return createLeshanClient(
+                endpoint,
+                bindingMode,
+                null,
+                lifetime,
+                communicationPeriod,
+                serverURI.toString(),
+                IntegrationTestSupport.getUsername(deviceId, tenantId).getBytes(StandardCharsets.UTF_8),
+                SECRET.getBytes(StandardCharsets.UTF_8),
+                null,
+                null,
+                null,
+                null,
+                null,
+                false, // do not support deprecated content encoding
+                false, // do not support deprecated ciphers
+                false, // do not perform new DTLS handshake before updating registration
+                false, // try to resume DTLS session
+                null); // use all supported ciphers
+    }
+
+    private LeshanClient createLeshanClient(
+            final String endpoint,
+            final BindingMode bindingMode,
+            final Map<String, String> additionalAttributes,
+            final int lifetime,
+            final Integer communicationPeriod,
+            final String serverURI,
+            final byte[] pskIdentity,
+            final byte[] pskKey,
+            final PrivateKey clientPrivateKey,
+            final PublicKey clientPublicKey,
+            final PublicKey serverPublicKey,
+            final X509Certificate clientCertificate,
+            final X509Certificate serverCertificate,
+            final boolean supportOldFormat,
+            final boolean supportDeprecatedCiphers,
+            final boolean reconnectOnUpdate,
+            final boolean forceFullhandshake,
+            final List<CipherSuite> ciphers) throws CertificateEncodingException {
+
+        // Initialize model
+        final List<ObjectModel> models = ObjectLoader.loadDefault();
+
+        // Initialize object list
+        final LwM2mModel model = new StaticModel(models);
+        final ObjectsInitializer initializer = new ObjectsInitializer(model);
+        if (pskIdentity != null) {
+            initializer.setInstancesForObject(LwM2mId.SECURITY, Security.psk(serverURI, 123, pskIdentity, pskKey));
+            initializer.setInstancesForObject(LwM2mId.SERVER, new Server(123, lifetime, bindingMode, false));
+        } else if (clientPublicKey != null) {
+            initializer.setInstancesForObject(LwM2mId.SECURITY, Security.rpk(serverURI, 123, clientPublicKey.getEncoded(),
+                    clientPrivateKey.getEncoded(), serverPublicKey.getEncoded()));
+            initializer.setInstancesForObject(LwM2mId.SERVER, new Server(123, lifetime, bindingMode, false));
+        } else if (clientCertificate != null) {
+            initializer.setInstancesForObject(LwM2mId.SECURITY, Security.x509(serverURI, 123, clientCertificate.getEncoded(),
+                    clientPrivateKey.getEncoded(), serverCertificate.getEncoded()));
+            initializer.setInstancesForObject(LwM2mId.SERVER, new Server(123, lifetime, bindingMode, false));
+        } else {
+            initializer.setInstancesForObject(LwM2mId.SECURITY, Security.noSec(serverURI, 123));
+            initializer.setInstancesForObject(LwM2mId.SERVER, new Server(123, lifetime, bindingMode, false));
+        }
+        initializer.setInstancesForObject(LwM2mId.DEVICE, deviceObject);
+        initializer.setInstancesForObject(LwM2mId.FIRMWARE, firmwareObject);
+
+        final List<LwM2mObjectEnabler> enablers = initializer.createAll();
+
+        // Create CoAP Config
+        final NetworkConfig coapConfig = LeshanClientBuilder.createDefaultNetworkConfig();
+
+        // Create DTLS Config
+        final DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder();
+        dtlsConfig.setRecommendedCipherSuitesOnly(!supportDeprecatedCiphers);
+        if (ciphers != null) {
+            dtlsConfig.setSupportedCipherSuites(ciphers);
+        }
+
+        // Configure Registration Engine
+        final DefaultRegistrationEngineFactory engineFactory = new DefaultRegistrationEngineFactory();
+        engineFactory.setCommunicationPeriod(communicationPeriod);
+        engineFactory.setReconnectOnUpdate(reconnectOnUpdate);
+        engineFactory.setResumeOnConnect(!forceFullhandshake);
+
+        // configure EndpointFactory
+        final DefaultEndpointFactory endpointFactory = new DefaultEndpointFactory("LWM2M CLIENT") {
+            @Override
+            protected Connector createSecuredConnector(final DtlsConnectorConfig dtlsConfig) {
+
+                return new DTLSConnector(dtlsConfig) {
+                    @Override
+                    protected void onInitializeHandshaker(final Handshaker handshaker) {
+                        handshaker.addSessionListener(new SessionAdapter() {
+
+                            private SessionId sessionIdentifier = null;
+
+                            @Override
+                            public void handshakeStarted(final Handshaker handshaker) throws HandshakeException {
+                                if (handshaker instanceof ResumingServerHandshaker) {
+                                    LOG.info("DTLS abbreviated Handshake initiated by server : STARTED ...");
+                                } else if (handshaker instanceof ServerHandshaker) {
+                                    LOG.info("DTLS Full Handshake initiated by server : STARTED ...");
+                                } else if (handshaker instanceof ResumingClientHandshaker) {
+                                    sessionIdentifier = handshaker.getSession().getSessionIdentifier();
+                                    LOG.info("DTLS abbreviated Handshake initiated by client : STARTED ...");
+                                } else if (handshaker instanceof ClientHandshaker) {
+                                    LOG.info("DTLS Full Handshake initiated by client : STARTED ...");
+                                }
+                            }
+
+                            @Override
+                            public void sessionEstablished(final Handshaker handshaker, final DTLSSession establishedSession)
+                                    throws HandshakeException {
+                                if (handshaker instanceof ResumingServerHandshaker) {
+                                    LOG.info("DTLS abbreviated Handshake initiated by server : SUCCEED");
+                                } else if (handshaker instanceof ServerHandshaker) {
+                                    LOG.info("DTLS Full Handshake initiated by server : SUCCEED");
+                                } else if (handshaker instanceof ResumingClientHandshaker) {
+                                    if (sessionIdentifier != null && sessionIdentifier
+                                            .equals(handshaker.getSession().getSessionIdentifier())) {
+                                        LOG.info("DTLS abbreviated Handshake initiated by client : SUCCEED");
+                                    } else {
+                                        LOG.info(
+                                                "DTLS abbreviated turns into Full Handshake initiated by client : SUCCEED");
+                                    }
+                                } else if (handshaker instanceof ClientHandshaker) {
+                                    LOG.info("DTLS Full Handshake initiated by client : SUCCEED");
+                                }
+                            }
+
+                            @Override
+                            public void handshakeFailed(final Handshaker handshaker, final Throwable error) {
+                                // get cause
+                                final String cause;
+                                if (error != null) {
+                                    if (error.getMessage() != null) {
+                                        cause = error.getMessage();
+                                    } else {
+                                        cause = error.getClass().getName();
+                                    }
+                                } else {
+                                    cause = "unknown cause";
+                                }
+
+                                if (handshaker instanceof ResumingServerHandshaker) {
+                                    LOG.info("DTLS abbreviated Handshake initiated by server : FAILED ({})", cause);
+                                } else if (handshaker instanceof ServerHandshaker) {
+                                    LOG.info("DTLS Full Handshake initiated by server : FAILED ({})", cause);
+                                } else if (handshaker instanceof ResumingClientHandshaker) {
+                                    LOG.info("DTLS abbreviated Handshake initiated by client : FAILED ({})", cause);
+                                } else if (handshaker instanceof ClientHandshaker) {
+                                    LOG.info("DTLS Full Handshake initiated by client : FAILED ({})", cause);
+                                }
+                            }
+                        });
+                    }
+                };
+            }
+        };
+
+        // Create client
+        final LeshanClientBuilder builder = new LeshanClientBuilder(endpoint);
+        builder.setObjects(enablers);
+        builder.setCoapConfig(coapConfig);
+        builder.setDtlsConfig(dtlsConfig);
+        builder.setRegistrationEngineFactory(engineFactory);
+        builder.setEndpointFactory(endpointFactory);
+        if (supportOldFormat) {
+            builder.setDecoder(new DefaultLwM2mNodeDecoder(true));
+            builder.setEncoder(new DefaultLwM2mNodeEncoder(true));
+        }
+        builder.setAdditionalAttributes(additionalAttributes);
+        final LeshanClient client = builder.build();
+        client.getObjectTree().addListener(new ObjectsListenerAdapter() {
+            @Override
+            public void objectRemoved(final LwM2mObjectEnabler object) {
+                LOG.info("Object {} disabled.", object.getId());
+            }
+
+            @Override
+            public void objectAdded(final LwM2mObjectEnabler object) {
+                LOG.info("Object {} enabled.", object.getId());
+            }
+        });
+
+        return client;
+    }
+
+}

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -15,6 +15,7 @@ hono:
     insecurePort: 5683
     maxConnections: 100
     maxPayloadSize: 2048
+    lwm2mEnabled: true
   messaging:
     name: 'Hono CoAP Adapter'
     host: ${hono.amqp-network.host}
@@ -90,6 +91,10 @@ quarkus:
         level: INFO
       "org.eclipse.hono.adapter":
         level: INFO
+      "org.eclipse.hono.adapter.coap":
+        level: INFO
+      "org.eclipse.hono.adapter.coap.lwm2m":
+        level: DEBUG
   vertx:
     max-event-loop-execute-time: ${max.event-loop.execute-time}
     prefer-native-transport: true

--- a/tests/src/test/resources/coap/logback-spring.xml
+++ b/tests/src/test/resources/coap/logback-spring.xml
@@ -31,6 +31,7 @@
   <springProfile name="trace">
     <logger name="org.eclipse.hono.adapter.coap" level="TRACE"/>
     <logger name="org.eclipse.hono.adapter.coap.impl" level="TRACE"/>
+    <logger name="org.eclipse.hono.adapter.coap.lwm2m" level="TRACE"/>
     <logger name="org.eclipse.hono.adapter.client" level="TRACE"/>
     <logger name="org.eclipse.hono.client" level="TRACE"/>
     <logger name="org.eclipse.hono.client.amqp" level="TRACE"/>
@@ -40,11 +41,13 @@
     <logger name="org.eclipse.hono.service.auth" level="TRACE"/>
     <logger name="org.eclipse.hono.service.auth.device" level="TRACE"/>
     <logger name="org.eclipse.hono.util" level="TRACE"/>
+    <logger name="org.eclipse.leshan" level="DEBUG"/>
   </springProfile>
 
   <springProfile name="dev">
     <logger name="org.eclipse.hono.adapter.coap" level="DEBUG"/>
     <logger name="org.eclipse.hono.adapter.coap.impl" level="DEBUG"/>
+    <logger name="org.eclipse.hono.adapter.coap.lwm2m" level="DEBUG"/>
     <logger name="org.eclipse.hono.adapter.client" level="DEBUG"/>
     <logger name="org.eclipse.hono.client" level="DEBUG"/>
     <logger name="org.eclipse.hono.client.amqp" level="DEBUG"/>
@@ -54,6 +57,7 @@
     <logger name="org.eclipse.hono.service.auth" level="DEBUG"/>
     <logger name="org.eclipse.hono.service.auth.device" level="DEBUG"/>
     <logger name="org.eclipse.hono.util" level="DEBUG"/>
+    <logger name="org.eclipse.leshan" level="DEBUG"/>
   </springProfile>
 
   <springProfile name="prod">

--- a/tests/src/test/resources/logback-test-include-dev.xml
+++ b/tests/src/test/resources/logback-test-include-dev.xml
@@ -27,8 +27,10 @@
   <logger name="org.eclipse.hono.tests.CrudHttpClient" level="DEBUG"/>
   <logger name="org.eclipse.hono.tests.amqp" level="DEBUG"/>
   <logger name="org.eclipse.hono.tests.coap" level="DEBUG"/>
+  <logger name="org.eclipse.hono.tests.coap.lwm2m" level="DEBUG"/>
   <logger name="org.eclipse.hono.tests.http" level="DEBUG"/>
   <logger name="org.eclipse.hono.tests.jms" level="DEBUG"/>
   <logger name="org.eclipse.hono.tests.mqtt" level="DEBUG"/>
   <logger name="org.eclipse.hono.tests.registry" level="DEBUG"/>
+  <logger name="org.eclipse.leshan" level="DEBUG"/>
 </included>

--- a/tests/src/test/resources/logback-test-include-prod.xml
+++ b/tests/src/test/resources/logback-test-include-prod.xml
@@ -25,8 +25,9 @@
   <logger name="org.eclipse.hono.tests.CrudHttpClient" level="INFO"/>
   <logger name="org.eclipse.hono.tests.amqp" level="INFO"/>
   <logger name="org.eclipse.hono.tests.coap" level="INFO"/>
-  <logger name="org.eclipse.hono.tests.http" level="INFO"/>
+  <logger name="org.eclipse.hono.tests.coap.lwm2m" level="INFO"/>
   <logger name="org.eclipse.hono.tests.jms" level="INFO"/>
   <logger name="org.eclipse.hono.tests.mqtt" level="INFO"/>
   <logger name="org.eclipse.hono.tests.registry" level="INFO"/>
+  <logger name="org.eclipse.leshan" level="INFO"/>
 </included>

--- a/tests/src/test/resources/logback-test-include-trace.xml
+++ b/tests/src/test/resources/logback-test-include-trace.xml
@@ -27,8 +27,10 @@
   <logger name="org.eclipse.hono.tests.CrudHttpClient" level="TRACE"/>
   <logger name="org.eclipse.hono.tests.amqp" level="TRACE"/>
   <logger name="org.eclipse.hono.tests.coap" level="TRACE"/>
+  <logger name="org.eclipse.hono.tests.coap.lwm2m" level="TRACE"/>
   <logger name="org.eclipse.hono.tests.http" level="TRACE"/>
   <logger name="org.eclipse.hono.tests.jms" level="TRACE"/>
   <logger name="org.eclipse.hono.tests.mqtt" level="TRACE"/>
   <logger name="org.eclipse.hono.tests.registry" level="TRACE"/>
+  <logger name="org.eclipse.leshan" level="TRACE"/>
 </included>


### PR DESCRIPTION
The CoAP adapter has been extended with a "Resource Directory" resource
as used by LwM2M 1.0.2. It currently supports registration, updating of
a registration and de-registration of devices using binding modes U and
UQ only.

Upon registration the adapter creates a command consumer for the device
and sends an empty notification downstream which contains a TTD
reflecting the binding mode, i.e. the TTD will be the registered
lifetime for binding mode U and a fixed 20 seconds for mode UQ.

However, the adapter does not support forwarding commands to devices
yet.

The adapter also creates observations of LwM2M objects Device and
Firmware upon registration. In a future version the particular resources
to observe should be configurable at the device level.

Notifications received for the observations are being forwarded
downstream as telemetry or event messages, depending on the type of
object being observed.

The CoAP adapter's configuration properties have been extended with an
undocumented feature flag ("lwm2mEnabled") for enabling support for
LwM2M. The feature is disabled by default.
