### PR TITLE
Use payload of error command response as exception message

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/CommandClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -44,7 +44,7 @@ public interface CommandClient extends RequestResponseClient {
      * @return A future indicating the result of the operation.
      *         <p>
      *         The future will succeed if a response with status 2xx has been received from the device.
-     *         If the response has no payload, the future will complete with {@code null}.
+     *         If the response has no payload, the future will complete with a BufferResult that has a {@code null} payload.
      *         <p>
      *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
      *         the (error) status code. Status codes are defined at
@@ -68,7 +68,8 @@ public interface CommandClient extends RequestResponseClient {
      * @param properties The headers to include in the command message as AMQP application properties.
      * @return A future indicating the result of the operation.
      *         <p>
-     *         The future will succeed if a response with status 2xx has been received from the device. If the response has no payload, the future will complete with {@code null}.
+     *         The future will succeed if a response with status 2xx has been received from the device.
+     *         If the response has no payload, the future will complete with a BufferResult that has a {@code null} payload.
      *         <p>
      *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
      *         the (error) status code. Status codes are defined at <a href="https://www.eclipse.org/hono/docs/api/command-and-control">Command and Control API</a>.

--- a/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/CommandClientImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,6 +14,7 @@
 package org.eclipse.hono.client.impl;
 
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
 
@@ -171,11 +172,13 @@ public class CommandClientImpl extends AbstractRequestResponseClient<BufferResul
         return mapResultAndFinishSpan(
                 resultTracker.future(),
                 result -> {
-                    if (result.isOk()) {
-                        return result;
-                    } else {
-                        throw StatusCodeMapper.from(result);
+                    if (result.isError()) {
+                        final String detailMessage = result.getPayload() != null && result.getPayload().length() > 0
+                                ? result.getPayload().toString(StandardCharsets.UTF_8)
+                                : null;
+                        throw StatusCodeMapper.from(result.getStatus(), detailMessage);
                     }
+                    return result;
                 },
                 currentSpan);
     }

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -13,6 +13,7 @@
 package org.eclipse.hono.application.client.kafka.impl;
 
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -151,9 +152,6 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
         return sendCommand(tenantId, deviceId, command, contentType, data, correlationId, properties, true, context);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<Void> sendOneWayCommand(
             final String tenantId,
@@ -316,7 +314,10 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
         if (StatusCodeMapper.isSuccessful(status)) {
             return Future.succeededFuture(message);
         } else {
-            return Future.failedFuture(StatusCodeMapper.from(status, null));
+            final String detailMessage = message.getPayload() != null && message.getPayload().length() > 0
+                    ? message.getPayload().toString(StandardCharsets.UTF_8)
+                    : null;
+            return Future.failedFuture(StatusCodeMapper.from(status, detailMessage));
         }
     }
 

--- a/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
+++ b/clients/application-kafka/src/test/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSenderTest.java
@@ -268,6 +268,7 @@ public class KafkaBasedCommandSenderTest {
                                 assertThat(ar.cause()).isInstanceOf(ServiceInvocationException.class);
                                 assertThat(((ServiceInvocationException) ar.cause()).getErrorCode())
                                         .isEqualTo(expectedStatusCode);
+                                assertThat(ar.cause().getMessage()).isEqualTo(responsePayload);
                             }
                         });
                         ctx.completeNow();

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/CommandSender.java
@@ -227,7 +227,7 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
      * @return A future indicating the result of the operation.
      *         <p>
      *         The future will succeed if a response with status 2xx has been received from the device.
-     *         If the response has no payload, the future will complete with {@code null}.
+     *         If the response has no payload, the future will complete with a DownstreamMessage that has a {@code null} payload.
      *         <p>
      *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
      *         the (error) status code. Status codes are defined at
@@ -258,7 +258,7 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
      * @return A future indicating the result of the operation.
      *         <p>
      *         The future will succeed if a response with status 2xx has been received from the device.
-     *         If the response has no payload, the future will complete with {@code null}.
+     *         If the response has no payload, the future will complete with a DownstreamMessage that has a {@code null} payload.
      *         <p>
      *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
      *         the (error) status code. Status codes are defined at 
@@ -296,7 +296,7 @@ public interface CommandSender<T extends MessageContext> extends Lifecycle {
      * @return A future indicating the result of the operation.
      *         <p>
      *         The future will succeed if a response with status 2xx has been received from the device.
-     *         If the response has no payload, the future will complete with {@code null}.
+     *         If the response has no payload, the future will complete with a DownstreamMessage that has a {@code null} payload.
      *         <p>
      *         Otherwise, the future will fail with a {@link ServiceInvocationException} containing
      *         the (error) status code. Status codes are defined at 


### PR DESCRIPTION
This conforms to the C&C API definition that the message body of a command response with an error status MAY contain a detailed description of the error that occurred.