### PR TITLE
[#2615] Fix sample.timeout() being invoked for each request

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
+++ b/client/src/main/java/org/eclipse/hono/client/impl/AbstractRequestResponseClient.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
@@ -481,26 +482,41 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
      *
      * @param correlationId The identifier of the request to cancel.
      * @param result The result to pass to the result handler registered for the correlation ID.
+     * @return {@code true} if a request with the given identifier was found and cancelled.
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @throws IllegalArgumentException if the result is succeeded.
      */
-    protected final void cancelRequest(final Object correlationId, final AsyncResult<R> result) {
-
+    protected final boolean cancelRequest(final Object correlationId, final AsyncResult<R> result) {
         Objects.requireNonNull(correlationId);
         Objects.requireNonNull(result);
 
         if (result.succeeded()) {
             throw new IllegalArgumentException("result must be failed");
-        } else {
-            final TriTuple<Handler<AsyncResult<R>>, Object, Span> handler = replyMap.remove(correlationId);
-            if (handler == null) {
-                // response has already been processed
-            } else {
-                LOG.debug("canceling request [target: {}, correlation ID: {}]: {}",
-                        linkTargetAddress, correlationId, result.cause().getMessage());
-                handler.one().handle(result);
-            }
         }
+        return cancelRequest(correlationId, result::cause);
+    }
+
+    /**
+     * Cancels an outstanding request with a given failure exception.
+     *
+     * @param correlationId The identifier of the request to cancel.
+     * @param exceptionSupplier The supplier of the failure exception.
+     * @return {@code true} if a request with the given identifier was found and cancelled.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    protected final boolean cancelRequest(final Object correlationId, final Supplier<Throwable> exceptionSupplier) {
+        Objects.requireNonNull(correlationId);
+        Objects.requireNonNull(exceptionSupplier);
+
+        return Optional.ofNullable(replyMap.remove(correlationId))
+                .map(handler -> {
+                    final Throwable throwable = exceptionSupplier.get();
+                    LOG.debug("canceling request [target: {}, correlation ID: {}]: {}",
+                            linkTargetAddress, correlationId, throwable.getMessage());
+                    handler.one().handle(Future.failedFuture(throwable));
+                    return true;
+                })
+                .orElse(false);
     }
 
     private R getRequestResponseResult(final Message message) {
@@ -928,9 +944,10 @@ public abstract class AbstractRequestResponseClient<R extends RequestResponseRes
                 });
                 if (requestTimeoutMillis > 0) {
                     connection.getVertx().setTimer(requestTimeoutMillis, tid -> {
-                        cancelRequest(correlationId, Future.failedFuture(new ServerErrorException(
-                                HttpURLConnection.HTTP_UNAVAILABLE, "request timed out after " + requestTimeoutMillis + "ms")));
-                        sample.timeout();
+                        if (cancelRequest(correlationId, () -> new ServerErrorException(
+                                HttpURLConnection.HTTP_UNAVAILABLE, "request timed out after " + requestTimeoutMillis + "ms"))) {
+                            sample.timeout();
+                        }
                     });
                 }
                 if (LOG.isDebugEnabled()) {

--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/RequestResponseClient.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/RequestResponseClient.java
@@ -379,24 +379,41 @@ public class RequestResponseClient<R extends RequestResponseResult<?>> extends A
      *
      * @param correlationId The identifier of the request to cancel.
      * @param result The result to pass to the result handler registered for the correlation ID.
+     * @return {@code true} if a request with the given identifier was found and cancelled.
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @throws IllegalArgumentException if the result is succeeded.
      */
-    private void cancelRequest(final Object correlationId, final AsyncResult<R> result) {
-
+    private boolean cancelRequest(final Object correlationId, final AsyncResult<R> result) {
         Objects.requireNonNull(correlationId);
         Objects.requireNonNull(result);
 
         if (result.succeeded()) {
             throw new IllegalArgumentException("result must be failed");
-        } else {
-            Optional.ofNullable(replyMap.remove(correlationId))
-                .ifPresent(handler -> {
-                    LOG.debug("canceling request [target: {}, correlation ID: {}]: {}",
-                            linkTargetAddress, correlationId, result.cause().getMessage());
-                    handler.one().handle(result);
-                });
         }
+        return cancelRequest(correlationId, result::cause);
+    }
+
+    /**
+     * Cancels an outstanding request with a given failure exception.
+     *
+     * @param correlationId The identifier of the request to cancel.
+     * @param exceptionSupplier The supplier of the failure exception.
+     * @return {@code true} if a request with the given identifier was found and cancelled.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    private boolean cancelRequest(final Object correlationId, final Supplier<Throwable> exceptionSupplier) {
+        Objects.requireNonNull(correlationId);
+        Objects.requireNonNull(exceptionSupplier);
+
+        return Optional.ofNullable(replyMap.remove(correlationId))
+                .map(handler -> {
+                    final Throwable throwable = exceptionSupplier.get();
+                    LOG.debug("canceling request [target: {}, correlation ID: {}]: {}",
+                            linkTargetAddress, correlationId, throwable.getMessage());
+                    handler.one().fail(throwable);
+                    return true;
+                })
+                .orElse(false);
     }
 
     /**
@@ -678,9 +695,10 @@ public class RequestResponseClient<R extends RequestResponseResult<?>> extends A
                 });
                 if (requestTimeoutMillis > 0) {
                     connection.getVertx().setTimer(requestTimeoutMillis, tid -> {
-                        cancelRequest(correlationId, Future.failedFuture(new ServerErrorException(
-                                HttpURLConnection.HTTP_UNAVAILABLE, "request timed out after " + requestTimeoutMillis + "ms")));
-                        sample.timeout();
+                        if (cancelRequest(correlationId, () -> new ServerErrorException(
+                                HttpURLConnection.HTTP_UNAVAILABLE, "request timed out after " + requestTimeoutMillis + "ms"))) {
+                            sample.timeout();
+                        }
                     });
                 }
                 if (LOG.isDebugEnabled()) {

--- a/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/RequestResponseClientTest.java
+++ b/clients/amqp-common/src/test/java/org/eclipse/hono/client/amqp/RequestResponseClientTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,9 +31,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.RequestResponseClientConfigProperties;
@@ -82,6 +85,7 @@ public class RequestResponseClientTest  {
     private ProtonReceiver receiver;
     private ProtonSender sender;
     private RequestResponseClientConfigProperties clientConfig;
+    private SendMessageSampler.Sample sample;
     private Span span;
 
     /**
@@ -99,6 +103,10 @@ public class RequestResponseClientTest  {
         receiver = AmqpClientUnitTestHelper.mockProtonReceiver();
         sender = AmqpClientUnitTestHelper.mockProtonSender();
 
+        final SendMessageSampler sampler = mock(SendMessageSampler.class);
+        sample = mock(SendMessageSampler.Sample.class);
+        when(sampler.start(anyString())).thenReturn(sample);
+
         clientConfig = new RequestResponseClientConfigProperties();
         connection = AmqpClientUnitTestHelper.mockHonoConnection(vertx, clientConfig, tracer);
         when(connection.isConnected(anyLong())).thenReturn(Future.succeededFuture());
@@ -111,7 +119,7 @@ public class RequestResponseClientTest  {
                 connection,
                 "ep",
                 "tenant",
-                SendMessageSampler.noop(),
+                sampler,
                 VertxMockSupport.mockHandler(),
                 VertxMockSupport.mockHandler());
     }
@@ -130,6 +138,17 @@ public class RequestResponseClientTest  {
     private Message verifySenderSend() {
         final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
         verify(sender).send(messageCaptor.capture(), VertxMockSupport.anyHandler());
+        return messageCaptor.getValue();
+    }
+
+    private Message verifySenderSendAndUpdateDelivery(final DeliveryState deliveryState) {
+        final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        final ArgumentCaptor<Handler<ProtonDelivery>> deliveryUpdatedHandlerCaptor = VertxMockSupport.argumentCaptorHandler();
+        verify(sender).send(messageCaptor.capture(), deliveryUpdatedHandlerCaptor.capture());
+
+        final ProtonDelivery requestDelivery = mock(ProtonDelivery.class);
+        when(requestDelivery.getRemoteState()).thenReturn(deliveryState);
+        deliveryUpdatedHandlerCaptor.getValue().handle(requestDelivery);
         return messageCaptor.getValue();
     }
 
@@ -209,6 +228,44 @@ public class RequestResponseClientTest  {
     }
 
     /**
+     * Verifies that the client configured with a zero request timeout sets no timer for
+     * canceling the request in case of no received response.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateAndSendRequestSetsNoTimerIfRequestTimeoutZero(final VertxTestContext ctx) {
+
+        // WHEN configuring the client with a zero request timeout and sending a request message
+        final JsonObject payload = new JsonObject().put("key", "value");
+        client
+            .map(c -> {
+                c.setRequestTimeout(0);
+                return c;
+            })
+            .onComplete(ctx.succeeding(c -> {
+                c.createAndSendRequest(
+                        "get",
+                        null,
+                        payload.toBuffer(),
+                        "application/json",
+                        SimpleRequestResponseResult::from,
+                        span);
+            }));
+
+        // THEN the message is sent
+        final Message request = verifySenderSend();
+        assertThat(request).isNotNull();
+        assertThat(request.getBody()).isNotNull();
+        assertThat(request.getBody()).isInstanceOf(Data.class);
+        final Buffer body = MessageHelper.getPayload(request);
+        assertThat(body.getBytes()).isEqualTo(payload.toBuffer().getBytes());
+        // and no timer has been set to time out the request
+        verify(vertx, never()).setTimer(anyLong(), VertxMockSupport.anyHandler());
+        ctx.completeNow();
+    }
+
+    /**
      * Verifies that the sender fails with an 503 error code if the peer rejects
      * a message with an "amqp:resource-limit-exceeded" error.
      *
@@ -257,8 +314,13 @@ public class RequestResponseClientTest  {
                 ctx.verify(() -> {
                     // THEN the result handler is failed with the expected error
                     failureAssertions.accept(t);
+                    verify(sample).completed(isA(Rejected.class));
                     // and a timer has been set to time out the request
-                    verify(vertx).setTimer(eq(clientConfig.getRequestTimeout()), VertxMockSupport.anyHandler());
+                    final ArgumentCaptor<Handler<Long>> timeoutHandlerCaptor = VertxMockSupport.argumentCaptorHandler();
+                    verify(vertx).setTimer(eq(clientConfig.getRequestTimeout()), timeoutHandlerCaptor.capture());
+                    // triggering the timer now that the request has been handled should not invoke the sampler timeout method
+                    timeoutHandlerCaptor.getValue().handle(1L);
+                    verify(sample, never()).timeout();
                 });
                 ctx.completeNow();
             }));
@@ -281,12 +343,8 @@ public class RequestResponseClientTest  {
     @Test
     public void testCreateAndSendRequestReturnsCorrespondingResponseMessage(final VertxTestContext ctx) {
 
-        // WHEN sending a request message to the peer without a timeout set
+        // WHEN sending a request message to the peer
         client
-            .map(c -> {
-                c.setRequestTimeout(0);
-                return c;
-            })
             .compose(c -> c.createAndSendRequest(
                 "request",
                 null,
@@ -299,14 +357,19 @@ public class RequestResponseClientTest  {
                     // THEN the response is passed to the handler registered with the request
                     assertEquals(200, s.getStatus());
                     assertEquals("payload", s.getPayload().toString());
-                    // and no response time-out handler has been set
-                    verify(vertx, never()).setTimer(anyLong(), VertxMockSupport.anyHandler());
+                    verify(sample).completed(isA(Accepted.class));
+                    // and a timer has been set to time out the request
+                    final ArgumentCaptor<Handler<Long>> timeoutHandlerCaptor = VertxMockSupport.argumentCaptorHandler();
+                    verify(vertx).setTimer(eq(clientConfig.getRequestTimeout()), timeoutHandlerCaptor.capture());
+                    // triggering the timer now that the request has been handled should not invoke the sampler timeout method
+                    timeoutHandlerCaptor.getValue().handle(1L);
+                    verify(sample, never()).timeout();
                 });
                 ctx.completeNow();
             }));
 
         // WHEN a response is received for the request
-        final Message request = verifySenderSend();
+        final Message request = verifySenderSendAndUpdateDelivery(new Accepted());
         final ProtonMessageHandler responseHandler = verifyResponseHandlerSet();
         final Message response = ProtonHelper.message("payload");
         response.setCorrelationId(request.getMessageId());
@@ -342,6 +405,8 @@ public class RequestResponseClientTest  {
                             HttpURLConnection.HTTP_UNAVAILABLE,
                             ((ServerErrorException) t).getErrorCode());
                     verify(span, never()).finish();
+                    verify(sample, never()).completed(any(DeliveryState.class));
+                    verify(sample).timeout();
                 });
                 ctx.completeNow();
             }));

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -9,6 +9,8 @@ description = "Information about changes in recent Hono releases. Includes new f
 ### Fixes & Enhancements
 
 * The CoAP adapter did not correctly track the time it took to forward a command message to a device. This has been fixed.
+* Sending requests using the Hono AMQP request-response client erroneously increased the `hono.downstream.timeout` metric.
+  This has been fixed.  
 
 ### Deprecations
 


### PR DESCRIPTION
This fixes #2615.