### PR TITLE
[#2480] Ensure command records get routed in the original order

### DIFF
--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandContext.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedCommandContext.java
@@ -15,7 +15,6 @@ package org.eclipse.hono.adapter.client.command.kafka;
 
 import java.util.Objects;
 
-import org.eclipse.hono.adapter.client.command.Command;
 import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.MapBasedExecutionContext;
@@ -32,7 +31,7 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBasedCommandContext.class);
 
-    private final Command command;
+    private final KafkaBasedCommand command;
 
     /**
      * Creates a new command context.
@@ -52,7 +51,7 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
     }
 
     @Override
-    public Command getCommand() {
+    public KafkaBasedCommand getCommand() {
         return command;
     }
 

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
@@ -12,8 +12,16 @@
  *******************************************************************************/
 package org.eclipse.hono.commandrouter.impl.kafka;
 
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.function.Supplier;
 
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedCommand;
 import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedCommandContext;
 import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedInternalCommandSender;
@@ -22,10 +30,14 @@ import org.eclipse.hono.client.impl.CommandConsumer;
 import org.eclipse.hono.client.kafka.tracing.KafkaTracingHelper;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.commandrouter.impl.AbstractMappingAndDelegatingCommandHandler;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Pair;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 
@@ -33,6 +45,13 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
  * Handler for commands received at the tenant-specific topic.
  */
 public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappingAndDelegatingCommandHandler {
+
+    private static final String KEY_COMMAND_SEND_ACTION_SUPPLIER_AND_RESULT_PROMISE = "commandSendActionSupplierAndResultPromise";
+    /**
+     * Queue in which the received commands per TopicPartition are kept so that they can
+     * be delegated in the same order they were received.
+     */
+    private final Map<TopicPartition, CommandQueue> commandQueues = new HashMap<>();
     private final Tracer tracer;
 
     /**
@@ -50,9 +69,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
             final KafkaBasedInternalCommandSender internalCommandSender,
             final Tracer tracer) {
         super(tenantClient, commandTargetMapper, internalCommandSender);
-        Objects.requireNonNull(tracer);
-
-        this.tracer = tracer;
+        this.tracer = Objects.requireNonNull(tracer);
     }
 
     /**
@@ -63,9 +80,10 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
      * and delegates the command to the resulting protocol adapter instance.
      *
      * @param consumerRecord The consumer record corresponding to the command.
+     * @return A future indicating the output of the operation.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    public void mapAndDelegateIncomingCommandMessage(final KafkaConsumerRecord<String, Buffer> consumerRecord) {
+    public Future<Void> mapAndDelegateIncomingCommandMessage(final KafkaConsumerRecord<String, Buffer> consumerRecord) {
         Objects.requireNonNull(consumerRecord);
 
         final KafkaBasedCommand command;
@@ -73,7 +91,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
             command = KafkaBasedCommand.from(consumerRecord);
         } catch (final IllegalArgumentException exception) {
             log.debug("command record is invalid", exception);
-            return;
+            return Future.failedFuture("command record is invalid");
         }
 
         final SpanContext spanContext = KafkaTracingHelper.extractSpanContext(tracer, consumerRecord);
@@ -83,12 +101,146 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
         final KafkaBasedCommandContext commandContext = new KafkaBasedCommandContext(command, currentSpan);
 
         command.logToSpan(currentSpan);
-        if (command.isValid()) {
-            log.trace("received valid command record [{}]", command);
-            mapAndDelegateIncomingCommand(commandContext);
-        } else {
+        if (!command.isValid()) {
             log.debug("received invalid command record [{}]", command);
             commandContext.reject("malformed command message");
+            return Future.failedFuture("command is invalid");
         }
+        log.trace("received valid command record [{}]", command);
+        final TopicPartition topicPartition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
+        final CommandQueue commandQueue = commandQueues
+                .computeIfAbsent(topicPartition, k -> new CommandQueue());
+        commandQueue.add(commandContext);
+
+        return mapAndDelegateIncomingCommand(commandContext)
+                .onFailure(thr -> commandQueue.remove(commandContext));
+    }
+
+    /**
+     * Sends the given command to the internal Command and Control API endpoint provided by protocol adapters.
+     * <p>
+     * Overridden to make sure that the order in which commands are sent via this method is the same in which
+     * commands have been received (with respect to the topic partition of the command record).
+     * This means that the actual sending of the command may get delayed here.
+     *
+     * @param commandContext Context of the command to send.
+     * @param targetAdapterInstanceId The target protocol adapter instance id.
+     * @return A future indicating the output of the operation.
+     */
+    @Override
+    protected Future<Void> sendCommand(final CommandContext commandContext, final String targetAdapterInstanceId) {
+        final KafkaBasedCommandContext cmdContext = (KafkaBasedCommandContext) commandContext;
+        final TopicPartition topicPartition = new TopicPartition(
+                cmdContext.getCommand().getRecord().topic(), cmdContext.getCommand().getRecord().partition());
+        final CommandQueue commandQueue = commandQueues.get(topicPartition);
+
+        return commandQueue.applySendCommandAction(cmdContext,
+                () -> super.sendCommand(commandContext, targetAdapterInstanceId));
+    }
+
+    /**
+     * Keeps track of commands that are currently being processed and ensures that
+     * the "SendCommandAction" provided via {@link #applySendCommandAction(KafkaBasedCommandContext, Supplier)}
+     * is invoked on command objects in the same order that the commands got added
+     * to the queue.
+     */
+    class CommandQueue {
+        private final Queue<KafkaBasedCommandContext> queue = new LinkedList<>();
+
+        /**
+         * Adds the given command to the queue.
+         *
+         * @param commandContext The context containing the command to add.
+         * @throws NullPointerException if commandContext is {@code null}.
+         */
+        public void add(final KafkaBasedCommandContext commandContext) {
+            Objects.requireNonNull(commandContext);
+            queue.add(commandContext);
+        }
+
+        /**
+         * Removes the given command from the queue.
+         * <p>
+         * To be used for commands for which processing resulted in an error
+         * and {@link #applySendCommandAction(KafkaBasedCommandContext, Supplier)}
+         * will not be invoked.
+         *
+         * @param commandContext The context containing the command to add.
+         * @throws NullPointerException if commandContext is {@code null}.
+         */
+        public void remove(final KafkaBasedCommandContext commandContext) {
+            Objects.requireNonNull(commandContext);
+            if (queue.remove(commandContext)) {
+                sendNextCommandInQueueIfPossible();
+            }
+        }
+
+        /**
+         * Either invokes the given sendAction directly if it is next-in-line or makes sure the action is
+         * invoked at a later point in time according to the order in which commands were originally received.
+         *
+         * @param commandContext The context of the command to apply the given sendAction for.
+         * @param sendActionSupplier The Supplier for the action to send the given command to the internal Command and
+         *                           Control API endpoint provided by protocol adapters.
+         * @return A future indicating the outcome of sending the command message. If the given command is
+         *         not in the queue, a failed future will be returned and the command context is released.
+         * @throws NullPointerException if any of the parameters is {@code null}.
+         */
+        public Future<Void> applySendCommandAction(final KafkaBasedCommandContext commandContext,
+                final Supplier<Future<Void>> sendActionSupplier) {
+            Objects.requireNonNull(commandContext);
+            Objects.requireNonNull(sendActionSupplier);
+
+            final Promise<Void> resultPromise = Promise.promise();
+            final Pair<Supplier<Future<Void>>, Promise<Void>> sendActionSupplierAndResultPromise = Pair
+                    .of(sendActionSupplier, resultPromise);
+            if (commandContext.equals(queue.peek())) {
+                sendGivenCommandAndNextInQueueIfPossible(sendActionSupplierAndResultPromise);
+            } else if (!queue.contains(commandContext)) {
+                log.warn("command can't be sent - not in queue [{}]", commandContext.getCommand());
+                TracingHelper.logError(commandContext.getTracingSpan(), "command can't be sent - not in queue");
+                commandContext.release();
+                resultPromise.fail(new IllegalStateException("command can't be sent - not in queue"));
+            } else {
+                // given command is not next-in-line;
+                // that means determining its target adapter instance has finished sooner (maybe because of fewer data-grid requests)
+                // compared to a command that was received earlier
+                log.debug("sending of command with offset {} delayed waiting for processing of offset {} [delayed {}]",
+                        getRecordOffset(commandContext), getRecordOffset(queue.peek()), commandContext.getCommand());
+                commandContext.getTracingSpan().log(String.format("waiting for an earlier command with offset %d to be processed first",
+                        getRecordOffset(queue.peek())));
+                commandContext.put(KEY_COMMAND_SEND_ACTION_SUPPLIER_AND_RESULT_PROMISE, sendActionSupplierAndResultPromise);
+            }
+            return resultPromise.future();
+        }
+
+        private void sendGivenCommandAndNextInQueueIfPossible(
+                final Pair<Supplier<Future<Void>>, Promise<Void>> sendActionSupplierAndResultPromise) {
+            final KafkaBasedCommandContext commandContext = queue.remove();
+            log.trace("sending [{}]", commandContext.getCommand());
+            // TODO use the supplier result future to keep track of the latest fully processed command record with regard to its partition offset
+            sendActionSupplierAndResultPromise.one().get()
+                    .onComplete(sendActionSupplierAndResultPromise.two());
+            sendNextCommandInQueueIfPossible();
+        }
+
+        private void sendNextCommandInQueueIfPossible() {
+            Optional.ofNullable(queue.peek())
+                    .map(this::getSendActionSupplierAndResultPromise)
+                    .ifPresent(this::sendGivenCommandAndNextInQueueIfPossible);
+        }
+
+        private Pair<Supplier<Future<Void>>, Promise<Void>> getSendActionSupplierAndResultPromise(
+                final KafkaBasedCommandContext context) {
+            return context.get(KEY_COMMAND_SEND_ACTION_SUPPLIER_AND_RESULT_PROMISE);
+        }
+
+        private long getRecordOffset(final KafkaBasedCommandContext context) {
+            if (context == null) {
+                return -1;
+            }
+            return context.getCommand().getRecord().offset();
+        }
+
     }
 }

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
@@ -12,11 +12,13 @@
  *******************************************************************************/
 package org.eclipse.hono.commandrouter.impl.kafka;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedCommandContext;
 import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedInternalCommandSender;
 import org.eclipse.hono.adapter.client.registry.TenantClient;
@@ -41,20 +44,25 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.TenantObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
 
 /**
  * Verifies behavior of {@link KafkaBasedMappingAndDelegatingCommandHandler}.
  */
+@ExtendWith(VertxExtension.class)
 public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
 
-    private TenantClient tenantClient;
     private CommandTargetMapper commandTargetMapper;
     private KafkaBasedMappingAndDelegatingCommandHandler cmdHandler;
     private KafkaBasedInternalCommandSender internalCommandSender;
@@ -71,7 +79,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
         deviceId = UUID.randomUUID().toString();
         adapterInstanceId = UUID.randomUUID().toString();
 
-        tenantClient = mock(TenantClient.class);
+        final TenantClient tenantClient = mock(TenantClient.class);
         when(tenantClient.get(eq(tenantId), any())).thenReturn(Future.succeededFuture(TenantObject.from(tenantId)));
 
         commandTargetMapper = mock(CommandTargetMapper.class);
@@ -79,6 +87,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
                 .thenReturn(Future.succeededFuture(createTargetAdapterInstanceJson(deviceId, adapterInstanceId)));
 
         internalCommandSender = mock(KafkaBasedInternalCommandSender.class);
+        when(internalCommandSender.sendCommand(any(), any())).thenReturn(Future.succeededFuture());
 
         cmdHandler = new KafkaBasedMappingAndDelegatingCommandHandler(tenantClient, commandTargetMapper,
                 internalCommandSender, TracingMockSupport.mockTracer(TracingMockSupport.mockSpan()));
@@ -92,7 +101,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
     @Test
     public void testCommandDelegationForValidCommand() {
         // GIVEN a valid command record
-        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(tenantId, deviceId, "cmd-subject");
+        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(tenantId, deviceId, "cmd-subject", 0, 0);
 
         // WHEN mapping and delegating the command
         cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord);
@@ -119,7 +128,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
     @Test
     public void testCommandDelegationForInValidCommand() {
         // GIVEN a command record that does not contain a device ID
-        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(tenantId, deviceId, null);
+        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(tenantId, deviceId, null, 0, 0);
 
         // WHEN mapping and delegating the command
         cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord);
@@ -136,9 +145,9 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
     @Test
     public void testCommandDelegationWhenNoAdapterInstanceIsFound() {
         // GIVEN a valid command record
-        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(tenantId, deviceId, "cmd-subject");
+        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(tenantId, deviceId, "cmd-subject", 0, 0);
 
-        //WHEN no target adapter instance is found
+        // WHEN no target adapter instance is found
         when(commandTargetMapper.getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId), any()))
                 .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
         // WHEN mapping and delegating the command
@@ -149,6 +158,131 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
     }
 
     /**
+     * Verifies the behaviour of the
+     * {@link KafkaBasedMappingAndDelegatingCommandHandler#mapAndDelegateIncomingCommandMessage(KafkaConsumerRecord)}
+     * method in a scenario where the mapping operation for one command completes earlier than for a previously received
+     * command. The order in which commands are then delegated to the target adapter instance has to be the same
+     * as the order in which commands were received.
+     *
+     * @param ctx The vert.x test context
+     */
+    @Test
+    public void testIncomingCommandOrderIsPreservedWhenDelegating(final VertxTestContext ctx) {
+        final String deviceId1 = "device1";
+        final String deviceId2 = "device2";
+        final String deviceId3 = "device3";
+        final String deviceId4 = "device4";
+
+        // GIVEN valid command records
+        final KafkaConsumerRecord<String, Buffer> commandRecord1 = getCommandRecord(tenantId, deviceId1, "subject1", 0, 1);
+        final KafkaConsumerRecord<String, Buffer> commandRecord2 = getCommandRecord(tenantId, deviceId2, "subject2", 0, 2);
+        final KafkaConsumerRecord<String, Buffer> commandRecord3 = getCommandRecord(tenantId, deviceId3, "subject3", 0, 3);
+        final KafkaConsumerRecord<String, Buffer> commandRecord4 = getCommandRecord(tenantId, deviceId4, "subject4", 0, 4);
+
+        // WHEN getting the target adapter instances for the commands results in different delays for each command
+        // so that the invocations are completed with the order: commandRecord3, commandRecord2, commandRecord1, commandRecord4
+        final Promise<JsonObject> resultForCommand1 = Promise.promise();
+        when(commandTargetMapper.getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId1), any()))
+                .thenReturn(resultForCommand1.future());
+        final Promise<JsonObject> resultForCommand2 = Promise.promise();
+        when(commandTargetMapper.getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId2), any()))
+                .thenReturn(resultForCommand2.future());
+        final Promise<JsonObject> resultForCommand3 = Promise.promise();
+        when(commandTargetMapper.getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId3), any()))
+                .thenReturn(resultForCommand3.future());
+        doAnswer(invocation -> {
+            resultForCommand3.complete(createTargetAdapterInstanceJson(deviceId3, adapterInstanceId));
+            resultForCommand2.complete(createTargetAdapterInstanceJson(deviceId2, adapterInstanceId));
+            resultForCommand1.complete(createTargetAdapterInstanceJson(deviceId1, adapterInstanceId));
+            return Future.succeededFuture(createTargetAdapterInstanceJson(deviceId4, adapterInstanceId));
+        }).when(commandTargetMapper).getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId4), any());
+
+        // WHEN mapping and delegating the commands
+        final Future<Void> cmd1Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord1);
+        final Future<Void> cmd2Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord2);
+        final Future<Void> cmd3Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord3);
+        final Future<Void> cmd4Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord4);
+
+        // THEN the messages are delegated in the original order
+        CompositeFuture.all(cmd1Future, cmd2Future, cmd3Future, cmd4Future)
+                .onComplete(ctx.succeeding(r -> {
+                    ctx.verify(() -> {
+                        final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
+                        verify(internalCommandSender, times(4)).sendCommand(commandContextCaptor.capture(), any());
+                        final List<CommandContext> capturedCommandContexts = commandContextCaptor.getAllValues();
+                        assertThat(capturedCommandContexts.get(0).getCommand().getDeviceId()).isEqualTo(deviceId1);
+                        assertThat(capturedCommandContexts.get(1).getCommand().getDeviceId()).isEqualTo(deviceId2);
+                        assertThat(capturedCommandContexts.get(2).getCommand().getDeviceId()).isEqualTo(deviceId3);
+                        assertThat(capturedCommandContexts.get(3).getCommand().getDeviceId()).isEqualTo(deviceId4);
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies the behaviour of the
+     * {@link KafkaBasedMappingAndDelegatingCommandHandler#mapAndDelegateIncomingCommandMessage(KafkaConsumerRecord)}
+     * method in a scenario where the rather long-running processing of a command delays subsequent, already mapped
+     * commands from getting delegated to the target adapter instance. After the processing of the first command finally
+     * resulted in an error, the subsequent commands shall get delegated in the correct order.
+     *
+     * @param ctx The vert.x test context
+     */
+    @Test
+    public void testCommandDelegationOrderWithMappingFailedForFirstEntry(final VertxTestContext ctx) {
+        final String deviceId1 = "device1";
+        final String deviceId2 = "device2";
+        final String deviceId3 = "device3";
+        final String deviceId4 = "device4";
+
+        // GIVEN valid command records
+        final KafkaConsumerRecord<String, Buffer> commandRecord1 = getCommandRecord(tenantId, deviceId1, "subject1", 0, 1);
+        final KafkaConsumerRecord<String, Buffer> commandRecord2 = getCommandRecord(tenantId, deviceId2, "subject2", 0, 2);
+        final KafkaConsumerRecord<String, Buffer> commandRecord3 = getCommandRecord(tenantId, deviceId3, "subject3", 0, 3);
+        final KafkaConsumerRecord<String, Buffer> commandRecord4 = getCommandRecord(tenantId, deviceId4, "subject4", 0, 4);
+
+        // WHEN getting the target adapter instances for the commands results in different delays for each command
+        // so that the invocations are completed with the order: commandRecord3, commandRecord2, commandRecord1 (failed), commandRecord4
+        // with command 1 getting failed
+        final Promise<JsonObject> resultForCommand1 = Promise.promise();
+        when(commandTargetMapper.getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId1), any()))
+                .thenReturn(resultForCommand1.future());
+        final Promise<JsonObject> resultForCommand2 = Promise.promise();
+        when(commandTargetMapper.getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId2), any()))
+                .thenReturn(resultForCommand2.future());
+        final Promise<JsonObject> resultForCommand3 = Promise.promise();
+        when(commandTargetMapper.getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId3), any()))
+                .thenReturn(resultForCommand3.future());
+        doAnswer(invocation -> {
+            resultForCommand3.complete(createTargetAdapterInstanceJson(deviceId3, adapterInstanceId));
+            resultForCommand2.complete(createTargetAdapterInstanceJson(deviceId2, adapterInstanceId));
+            resultForCommand1.fail("mapping of command 1 failed for some reason");
+            return Future.succeededFuture(createTargetAdapterInstanceJson(deviceId4, adapterInstanceId));
+        }).when(commandTargetMapper).getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId4), any());
+
+        // WHEN mapping and delegating the commands
+        final Future<Void> cmd1Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord1);
+        final Future<Void> cmd2Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord2);
+        final Future<Void> cmd3Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord3);
+        final Future<Void> cmd4Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord4);
+
+        // THEN the messages are delegated in the original order, with command 1 left out because it timed out
+        CompositeFuture.all(cmd2Future, cmd3Future, cmd4Future)
+                .onComplete(ctx.succeeding(r -> {
+                    ctx.verify(() -> {
+                        assertThat(cmd1Future.failed()).isTrue();
+                        final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
+                        verify(internalCommandSender, times(3)).sendCommand(commandContextCaptor.capture(), any());
+                        final List<CommandContext> capturedCommandContexts = commandContextCaptor.getAllValues();
+                        assertThat(capturedCommandContexts.get(0).getCommand().getDeviceId()).isEqualTo(deviceId2);
+                        assertThat(capturedCommandContexts.get(1).getCommand().getDeviceId()).isEqualTo(deviceId3);
+                        assertThat(capturedCommandContexts.get(2).getCommand().getDeviceId()).isEqualTo(deviceId4);
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
      * Verifies the behaviour of the 
      * {@link KafkaBasedMappingAndDelegatingCommandHandler#mapAndDelegateIncomingCommandMessage(KafkaConsumerRecord)}
      * method in a scenario where there is no device id in the incoming command record.
@@ -156,7 +290,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
     @Test
     public void testCommandRecordWithoutDeviceId() {
         // GIVEN a command record that does not contain a device ID
-        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(tenantId, null, "cmd-subject");
+        final KafkaConsumerRecord<String, Buffer> commandRecord = getCommandRecord(tenantId, null, "cmd-subject", 0, 0);
 
         // WHEN mapping and delegating the command
         cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord);
@@ -176,7 +310,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
 
     @SuppressWarnings("unchecked")
     private KafkaConsumerRecord<String, Buffer> getCommandRecord(final String tenantId, final String deviceId,
-            final String subject) {
+            final String subject, final int partition, final long offset) {
         final List<KafkaHeader> headers = new ArrayList<>();
         final String topic = new HonoTopic(HonoTopic.Type.COMMAND, tenantId).toString();
         final KafkaConsumerRecord<String, Buffer> consumerRecord = mock(KafkaConsumerRecord.class);
@@ -188,6 +322,8 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
         when(consumerRecord.headers()).thenReturn(headers);
         when(consumerRecord.topic()).thenReturn(topic);
         when(consumerRecord.key()).thenReturn(deviceId);
+        when(consumerRecord.partition()).thenReturn(partition);
+        when(consumerRecord.offset()).thenReturn(offset);
 
         return consumerRecord;
     }


### PR DESCRIPTION
This is for #2480:
This is needed because records with an offset smaller than one already received get skipped in the target protocol adapter (see #2596).

Records handled in the Command Router `mapAndDelegateIncomingCommandMessage` method may overtake each other because determining the target protocol adapter instance may involve a different number of data grid requests and therefore may vary in duration.