### PR TITLE
Replace legacy northbound client with new interface in example application

### DIFF
--- a/examples/hono-client-examples/pom.xml
+++ b/examples/hono-client-examples/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.

--- a/examples/hono-client-examples/pom.xml
+++ b/examples/hono-client-examples/pom.xml
@@ -35,7 +35,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
-      <artifactId>hono-client</artifactId>
+      <artifactId>hono-client-application-amqp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-application-kafka</artifactId>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
@@ -13,25 +13,31 @@
 
 package org.eclipse.hono.vertx.example.base;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.function.Consumer;
 
-import org.apache.qpid.proton.message.Message;
-import org.eclipse.hono.client.ApplicationClientFactory;
-import org.eclipse.hono.client.CommandClient;
+import org.eclipse.hono.application.client.ApplicationClient;
+import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
+import org.eclipse.hono.application.client.MessageContext;
+import org.eclipse.hono.application.client.amqp.AmqpApplicationClient;
+import org.eclipse.hono.application.client.amqp.ProtonBasedApplicationClient;
+import org.eclipse.hono.application.client.kafka.impl.KafkaApplicationClientImpl;
 import org.eclipse.hono.client.HonoConnection;
-import org.eclipse.hono.client.MessageConsumer;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.util.MessageHelper;
-import org.eclipse.hono.util.MessageTap;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -52,13 +58,15 @@ public class HonoExampleApplicationBase {
     public static final String HONO_CLIENT_PASSWORD = System.getProperty("password", "verysecret");
     public static final Boolean USE_PLAIN_CONNECTION = Boolean.valueOf(System.getProperty("plain.connection", "false"));
     public static final Boolean SEND_ONE_WAY_COMMANDS = Boolean.valueOf(System.getProperty("sendOneWayCommands", "false"));
+    public static final Boolean USE_KAFKA = Boolean.valueOf(System.getProperty("kafka", "false"));
 
     private static final Logger LOG = LoggerFactory.getLogger(HonoExampleApplicationBase.class);
 
     protected final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 1000;
 
     private final Vertx vertx = Vertx.vertx();
-    private final ApplicationClientFactory clientFactory;
+    private final ApplicationClient<? extends MessageContext> client;
+    private final int port;
 
     /**
      * A map holding a handler to cancel a timer that was started to send commands periodically to a device.
@@ -71,6 +79,23 @@ public class HonoExampleApplicationBase {
      * Only affects devices that use a connection oriented protocol like MQTT.
      */
     private final Map<String, TimeUntilDisconnectNotification> pendingTtdNotification = new HashMap<>();
+    private MessageConsumer eventConsumer;
+    private MessageConsumer telemetryConsumer;
+
+    /**
+     * The client for sending and receiving data is instantiated here.
+     * <p>
+     * Depending of the value of {@link #USE_KAFKA} either a Kafka based or an AMQP based messaging client is created.
+     */
+    public HonoExampleApplicationBase() {
+        if (USE_KAFKA) {
+            port = HonoExampleConstants.HONO_KAFKA_CONSUMER_PORT;
+            client = createKafkaApplicationClient();
+        } else {
+            port = HonoExampleConstants.HONO_AMQP_CONSUMER_PORT;
+            client = createAmqpApplicationClient();
+        }
+    }
 
     /**
      * The consumer needs one connection to the AMQP 1.0 messaging network from which it can consume data.
@@ -80,11 +105,11 @@ public class HonoExampleApplicationBase {
      * NB: if you want to integrate this code with your own software, it might be necessary to copy the trust
      * store to your project as well and adopt the file path.
      */
-    public HonoExampleApplicationBase() {
+    private ApplicationClient<? extends MessageContext> createAmqpApplicationClient() {
 
         final ClientConfigProperties props = new ClientConfigProperties();
-        props.setHost(HonoExampleConstants.HONO_AMQP_CONSUMER_HOST);
-        props.setPort(HonoExampleConstants.HONO_AMQP_CONSUMER_PORT);
+        props.setHost(HonoExampleConstants.HONO_MESSAGING_HOST);
+        props.setPort(port);
         if (!USE_PLAIN_CONNECTION) {
             props.setUsername(HONO_CLIENT_USER);
             props.setPassword(HONO_CLIENT_PASSWORD);
@@ -92,72 +117,120 @@ public class HonoExampleApplicationBase {
             props.setHostnameVerificationRequired(false);
         }
 
-        clientFactory = ApplicationClientFactory.create(HonoConnection.newConnection(vertx, props));
+        return new ProtonBasedApplicationClient(HonoConnection.newConnection(vertx, props));
     }
 
     /**
-     * Initiate the connection and set the message handling method to treat data that is received.
+     * Creates an application client for Kafka based messaging. Unlike with AMQP, the Kafka clients manage their
+     * connections to the cluster internally.
+     * <p>
+     * NB: if you want to integrate this code with your own software, it might be necessary to copy the trust store to
+     * your project as well and adopt the file path.
+     */
+    private ApplicationClient<? extends MessageContext> createKafkaApplicationClient() {
+        final String clientIdPrefix = "example.application"; // used by Kafka for request logging
+        final String consumerGroupId = "hono-example-application";
+
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("bootstrap.servers", HonoExampleConstants.HONO_MESSAGING_HOST + ":" + port);
+        // add the following lines with appropriate values to enable TLS
+        // properties.put("ssl.truststore.location", "/path/to/file");
+        // properties.put("ssl.truststore.password", "secret");
+
+        final KafkaConsumerConfigProperties consumerConfig = new KafkaConsumerConfigProperties();
+        consumerConfig.setCommonClientConfig(properties);
+        consumerConfig.setDefaultClientIdPrefix(clientIdPrefix);
+        consumerConfig.setConsumerConfig(Map.of("group.id", consumerGroupId));
+
+        final KafkaProducerConfigProperties producerConfig = new KafkaProducerConfigProperties();
+        producerConfig.setCommonClientConfig(properties);
+        producerConfig.setDefaultClientIdPrefix(clientIdPrefix);
+
+        final KafkaProducerFactory<String, Buffer> producerFactory = KafkaProducerFactory.sharedProducerFactory(vertx);
+        return new KafkaApplicationClientImpl(vertx, consumerConfig, producerFactory, producerConfig);
+    }
+
+    /**
+     * Start the application client and set the message handling method to treat data that is received.
      *
-     * @throws Exception Thrown if the latch is interrupted during waiting or if the read from System.in throws an IOException.
+     * @throws Exception Thrown if the latch is interrupted during waiting or if the read from System.in throws an
+     *             IOException.
      */
     protected void consumeData() throws Exception {
 
         final CountDownLatch latch = new CountDownLatch(1);
 
-        final Future<MessageConsumer> startFuture = clientFactory.connect()
-                .onSuccess(connectedClient -> {
-                    clientFactory.addDisconnectListener(c -> LOG.info("lost connection to Hono, trying to reconnect ..."));
-                    clientFactory.addReconnectListener(c -> LOG.info("reconnected to Hono"));
+        final Future<MessageConsumer> startFuture = client.start()
+                .onSuccess(v -> {
+                    if (client instanceof AmqpApplicationClient) {
+                        final AmqpApplicationClient ac = (AmqpApplicationClient) client;
+                        ac.addDisconnectListener(c -> LOG.info("lost connection to Hono, trying to reconnect ..."));
+                        ac.addReconnectListener(c -> LOG.info("reconnected to Hono"));
+                    }
                 })
-                .compose(con -> createConsumer())
-                .onFailure(cause -> LOG.error("clientFactory could not create downstream consumer for [{}:{}]",
-                        HonoExampleConstants.HONO_AMQP_CONSUMER_HOST,
-                        HonoExampleConstants.HONO_AMQP_CONSUMER_PORT, cause))
+                .compose(con -> createEventConsumer())
+                .onSuccess(eventConsumer -> this.eventConsumer = eventConsumer)
+                .compose(con -> createTelemetryConsumer())
+                .onSuccess(telemetryConsumer -> this.telemetryConsumer = telemetryConsumer)
+                .onSuccess(v -> LOG.info("Consumer ready for telemetry and event messages."))
+                .onFailure(cause -> LOG.error("{} consumer failed to start [{}:{}]",
+                        USE_KAFKA ? "Kafka" : "AMQP", HonoExampleConstants.HONO_MESSAGING_HOST, port, cause))
                 .onComplete(ar -> latch.countDown());
 
         latch.await();
 
+        @SuppressWarnings("rawtypes")
+        final List<Future> closeFutures = new ArrayList<>();
         if (startFuture.succeeded()) {
             System.in.read();
+            closeFutures.add(eventConsumer.close());
+            closeFutures.add(telemetryConsumer.close());
+            closeFutures.add(client.stop());
         }
-        vertx.close();
+        CompositeFuture.join(closeFutures).onComplete(ar -> vertx.close()); // wait for clients to be closed
     }
 
     /**
-     * Create the message consumer that handles the downstream messages and invokes the notification callback
+     * Create the message consumer that handles event messages and invokes the notification callback
      * {@link #handleCommandReadinessNotification(TimeUntilDisconnectNotification)} if the message indicates that it
-     * stays connected for a specified time. Supported are telemetry and event MessageConsumer.
+     * stays connected for a specified time.
      *
-     * @return A succeeded future that contains the MessageConsumer if the creation was successful, a failed
-     *         Future otherwise.
+     * @return A succeeded future if the creation was successful, a failed Future otherwise.
      */
-    private Future<MessageConsumer> createConsumer() {
-        // create the eventHandler by using the helper functionality for demultiplexing messages to callbacks
-        final Consumer<Message> eventHandler = MessageTap.getConsumer(
-                this::handleEventMessage, this::handleCommandReadinessNotification);
-
-        // create the telemetryHandler by using the helper functionality for demultiplexing messages to
-        // callbacks
-        final Consumer<Message> telemetryHandler = MessageTap.getConsumer(
-                this::handleTelemetryMessage, this::handleCommandReadinessNotification);
-
-        return clientFactory.createEventConsumer(HonoExampleConstants.TENANT_ID,
-                eventHandler,
-                closeHook -> LOG.error("remotely detached consumer link")
-        ).compose(messageConsumer -> clientFactory.createTelemetryConsumer(HonoExampleConstants.TENANT_ID,
-                telemetryHandler, closeHook -> LOG.error("remotely detached consumer link")
-        ).compose(telemetryMessageConsumer -> {
-            LOG.info("Consumer ready for telemetry and event messages.");
-            return Future.succeededFuture(telemetryMessageConsumer);
-        }).recover(t ->
-                Future.failedFuture(t)
-        ));
+    private Future<MessageConsumer> createEventConsumer() {
+        return client.createEventConsumer(
+                HonoExampleConstants.TENANT_ID,
+                msg -> {
+                    // handle command readiness notification
+                    msg.getTimeUntilDisconnectNotification().ifPresent(this::handleCommandReadinessNotification);
+                    handleEventMessage(msg);
+                },
+                cause -> LOG.error("event consumer closed by remote", cause));
     }
 
-    private void printMessage(final String tenantId, final Message msg, final String messageType) {
+    /**
+     * Create the message consumer that handles telemetry messages and invokes the notification callback
+     * {@link #handleCommandReadinessNotification(TimeUntilDisconnectNotification)} if the message indicates that it
+     * stays connected for a specified time.
+     *
+     * @return A succeeded future if the creation was successful, a failed Future otherwise.
+     */
+    private Future<MessageConsumer> createTelemetryConsumer() {
+        return client.createTelemetryConsumer(
+                HonoExampleConstants.TENANT_ID,
+                msg -> {
+                    // handle command readiness notification
+                    msg.getTimeUntilDisconnectNotification().ifPresent(this::handleCommandReadinessNotification);
+                    handleTelemetryMessage(msg);
+                },
+                cause -> LOG.error("telemetry consumer closed by remote", cause));
+    }
+
+    private void printMessage(final String tenantId, final DownstreamMessage<? extends MessageContext> msg,
+            final String messageType) {
         if (LOG.isDebugEnabled()) {
-            final String content = MessageHelper.getPayloadAsString(msg);
-            final String deviceId = MessageHelper.getDeviceId(msg);
+            final String content = Optional.ofNullable(msg.getPayload()).map(Buffer::toString).orElse(null);
+            final String deviceId = msg.getDeviceId();
 
             final StringBuilder sb = new StringBuilder("received ").
                     append(messageType).
@@ -188,17 +261,17 @@ public class HonoExampleApplicationBase {
             handlePermanentlyConnectedCommandReadinessNotification(notification);
         } else {
             LOG.info("Device is ready to receive a command : [{}].", notification.toString());
-            createCommandClientAndSendCommand(notification);
+            sendCommand(notification);
         }
     }
 
     /**
      * Handle a ttd notification for permanently connected devices.
      * <p>
-     * Instead of immediately handling the notification, it is first put to a map and a timer is started to handle it later.
-     * Notifications for the same device that are received before the timer expired, will overwrite the original notification.
-     * By this an <em>event flickering</em> (like it could occur when starting the app while several notifications were persisted
-     * in the AMQP network) is handled correctly.
+     * Instead of immediately handling the notification, it is first put to a map and a timer is started to handle it
+     * later. Notifications for the same device that are received before the timer expired, will overwrite the original
+     * notification. By this an <em>event flickering</em> (like it could occur when starting the app while several
+     * notifications were persisted in the messaging network) is handled correctly.
      * <p>
      * If the contained <em>ttd</em> is set to -1, a command will be sent periodically every
      * {@link HonoExampleConstants#COMMAND_INTERVAL_FOR_DEVICES_CONNECTED_WITH_UNLIMITED_EXPIRY} seconds to the device
@@ -230,7 +303,7 @@ public class HonoExampleApplicationBase {
                         // cancel a still existing timer for this device (if found)
                         cancelPeriodicCommandSender(notification);
                         // immediately send the first command
-                        createCommandClientAndSendCommand(notificationToHandle);
+                        sendCommand(notificationToHandle);
 
                         // for devices that stay connected, start a periodic timer now that repeatedly sends a command
                         // to the device
@@ -238,11 +311,9 @@ public class HonoExampleApplicationBase {
                                 (long) HonoExampleConstants.COMMAND_INTERVAL_FOR_DEVICES_CONNECTED_WITH_UNLIMITED_EXPIRY
                                         * 1000,
                                 id -> {
-                                    createCommandClientAndSendCommand(notificationToHandle).map(commandClient -> {
-                                        // register a canceler for this timer directly after it was created
-                                        setPeriodicCommandSenderTimerCanceler(id, notification, commandClient);
-                                        return null;
-                                    });
+                                    sendCommand(notificationToHandle);
+                                    // register a canceler for this timer directly after it was created
+                                    setPeriodicCommandSenderTimerCanceler(id, notification);
                                 });
                     } else {
                         LOG.info("Device notified as not being ready to receive a command (anymore) : [{}].", notification.toString());
@@ -258,26 +329,20 @@ public class HonoExampleApplicationBase {
     }
 
     /**
-     * Create a command client for the device for that a {@link TimeUntilDisconnectNotification} was received, if no such
-     * command client is already active.
+     * Sends a command to the device for which a {@link TimeUntilDisconnectNotification} was received.
+     *
      * @param notification The notification that was received for the device.
      */
-    private Future<CommandClient> createCommandClientAndSendCommand(final TimeUntilDisconnectNotification notification) {
-        return clientFactory.getOrCreateCommandClient(notification.getTenantId())
-                .map(commandClient -> {
-                    commandClient.setRequestTimeout(calculateCommandTimeout(notification));
+    private void sendCommand(final TimeUntilDisconnectNotification notification) {
 
-                    // send the command upstream to the device
-                    if (SEND_ONE_WAY_COMMANDS) {
-                        sendOneWayCommandToAdapter(notification.getDeviceId(), commandClient, notification);
-                    } else {
-                        sendCommandToAdapter(notification.getDeviceId(), commandClient, notification);
-                    }
-                    return commandClient;
-                }).otherwise(t -> {
-                    LOG.error("Could not create command client", t);
-                    return null;
-                });
+        final long commandTimeout = calculateCommandTimeout(notification);
+        // TODO set request timeout
+
+        if (SEND_ONE_WAY_COMMANDS) {
+            sendOneWayCommandToAdapter(notification.getTenantId(), notification.getDeviceId(), notification);
+        } else {
+            sendCommandToAdapter(notification.getTenantId(), notification.getDeviceId(), notification);
+        }
     }
 
     /**
@@ -297,9 +362,9 @@ public class HonoExampleApplicationBase {
         }
     }
 
-    private void setPeriodicCommandSenderTimerCanceler(final Long timerId, final TimeUntilDisconnectNotification ttdNotification, final CommandClient commandClient) {
+    private void setPeriodicCommandSenderTimerCanceler(final Long timerId,
+            final TimeUntilDisconnectNotification ttdNotification) {
         this.periodicCommandSenderTimerCancelerMap.put(ttdNotification.getTenantAndDeviceId(), v -> {
-            closeCommandClient(commandClient, ttdNotification);
             vertx.cancelTimer(timerId);
             periodicCommandSenderTimerCancelerMap.remove(ttdNotification.getTenantAndDeviceId());
         });
@@ -325,25 +390,20 @@ public class HonoExampleApplicationBase {
      * <p>
      * If the contained <em>ttd</em> is set to a value @gt; 0, the commandClient will be closed after a response was received.
      * If the contained <em>ttd</em> is set to -1, the commandClient will remain open for further commands to be sent.
-     * @param commandClient The command client to be used for sending the command to the device.
      * @param ttdNotification The ttd notification that was received for the device.
      */
-    private void sendCommandToAdapter(final String deviceId, final CommandClient commandClient, final TimeUntilDisconnectNotification ttdNotification) {
+    private void sendCommandToAdapter(final String tenantId, final String deviceId,
+            final TimeUntilDisconnectNotification ttdNotification) {
         final Buffer commandBuffer = buildCommandPayload();
         final String command = "setBrightness";
         if (LOG.isDebugEnabled()) {
             LOG.debug("Sending command [{}] to [{}].", command, ttdNotification.getTenantAndDeviceId());
         }
 
-        commandClient.sendCommand(deviceId, command, "application/json", commandBuffer, buildCommandProperties()).map(result -> {
+        client.sendCommand(tenantId, deviceId, command, "application/json", commandBuffer, buildCommandProperties()).map(result -> {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Successfully sent command payload: [{}].", commandBuffer.toString());
                 LOG.debug("And received response: [{}].", Optional.ofNullable(result.getPayload()).orElseGet(Buffer::buffer).toString());
-            }
-
-            if (ttdNotification.getTtd() != -1) {
-                // do not close the command client if device stays connected
-                closeCommandClient(commandClient, ttdNotification);
             }
             return result;
         }).otherwise(t -> {
@@ -352,11 +412,6 @@ public class HonoExampleApplicationBase {
                 LOG.debug("Command was replied with error code [{}].", errorCode);
             } else {
                 LOG.debug("Could not send command : {}.", t.getMessage());
-            }
-
-            if (ttdNotification.getTtd() != -1) {
-                // do not close the command client if device stays connected
-                closeCommandClient(commandClient, ttdNotification);
             }
             return null;
         });
@@ -367,10 +422,10 @@ public class HonoExampleApplicationBase {
      * <p>
      * If the contained <em>ttd</em> is set to a value @gt; 0, the commandClient will be closed after a response was received.
      * If the contained <em>ttd</em> is set to -1, the commandClient will remain open for further commands to be sent.
-     * @param commandClient The command client to be used for sending the notification command to the device.
      * @param ttdNotification The ttd notification that was received for the device.
      */
-    private void sendOneWayCommandToAdapter(final String deviceId, final CommandClient commandClient, final TimeUntilDisconnectNotification ttdNotification) {
+    private void sendOneWayCommandToAdapter(final String tenantId, final String deviceId,
+            final TimeUntilDisconnectNotification ttdNotification) {
         final Buffer commandBuffer = buildOneWayCommandPayload();
         final String command = "sendLifecycleInfo";
 
@@ -378,14 +433,9 @@ public class HonoExampleApplicationBase {
             LOG.debug("Sending one-way command [{}] to [{}].", command, ttdNotification.getTenantAndDeviceId());
         }
 
-        commandClient.sendOneWayCommand(deviceId, command, commandBuffer).map(statusResult -> {
+        client.sendOneWayCommand(tenantId, deviceId, command, commandBuffer).map(statusResult -> {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Successfully sent one-way command payload: [{}] and received status [{}].", commandBuffer.toString(), statusResult);
-            }
-
-            if (ttdNotification.getTtd() != -1) {
-                // do not close the command client if device stays connected
-                closeCommandClient(commandClient, ttdNotification);
             }
             return statusResult;
         }).otherwise(t -> {
@@ -395,21 +445,7 @@ public class HonoExampleApplicationBase {
             } else {
                 LOG.debug("Could not send one-way command : {}.", t.getMessage());
             }
-
-            if (ttdNotification.getTtd() != -1) {
-                // do not close the command client if device stays connected
-                closeCommandClient(commandClient, ttdNotification);
-            }
             return null;
-        });
-    }
-
-    private void closeCommandClient(final CommandClient commandClient, final TimeUntilDisconnectNotification ttdNotification) {
-        // do not close the command client if device stays connected
-        commandClient.close(v -> {
-            if (LOG.isDebugEnabled()) {
-                LOG.trace("Closed commandClient for [{}].", ttdNotification.getTenantAndDeviceId());
-            }
         });
     }
 
@@ -440,7 +476,7 @@ public class HonoExampleApplicationBase {
      *
      * @param msg The message that was received.
      */
-    private void handleTelemetryMessage(final Message msg) {
+    private void handleTelemetryMessage(final DownstreamMessage<? extends MessageContext> msg) {
         printMessage(HonoExampleConstants.TENANT_ID, msg, "telemetry");
     }
 
@@ -451,7 +487,7 @@ public class HonoExampleApplicationBase {
      *
      * @param msg The message that was received.
      */
-    private void handleEventMessage(final Message msg) {
+    private void handleEventMessage(final DownstreamMessage<? extends MessageContext> msg) {
         printMessage(HonoExampleConstants.TENANT_ID, msg, "event");
     }
 }

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleApplicationBase.java
@@ -167,6 +167,7 @@ public class HonoExampleApplicationBase {
                     }
                 })
                 .compose(v -> CompositeFuture.all(createEventConsumer(), createTelemetryConsumer()))
+                .onSuccess(v -> LOG.info("Consumer ready for telemetry and event messages."))
                 .onFailure(cause -> LOG.error("{} consumer failed to start [{}:{}]",
                         USE_KAFKA ? "Kafka" : "AMQP", HonoExampleConstants.HONO_MESSAGING_HOST, port, cause))
                 .onComplete(ar -> latch.countDown());

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleConstants.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/vertx/example/base/HonoExampleConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -28,11 +28,15 @@ public class HonoExampleConstants {
     /**
      * The name or IP address of the host to connect to for consuming messages.
      */
-    public static final String HONO_AMQP_CONSUMER_HOST = System.getProperty("consumer.host", HONO_CONTAINER_HOST);
+    public static final String HONO_MESSAGING_HOST = System.getProperty("consumer.host", HONO_CONTAINER_HOST);
     /**
      * Port of the AMQP network where consumers can receive data (in the standard setup this is the port of the qdrouter).
      */
     public static final int HONO_AMQP_CONSUMER_PORT = Integer.parseInt(System.getProperty("consumer.port", "15671"));
+    /**
+     * Port of the Kafka bootstrap server where consumers can receive data.
+     */
+    public static final int HONO_KAFKA_CONSUMER_PORT = Integer.parseInt(System.getProperty("consumer.port", "9092"));
 
     public static final String TENANT_ID = "DEFAULT_TENANT";
 

--- a/examples/hono-client-examples/src/main/resources/logback.xml
+++ b/examples/hono-client-examples/src/main/resources/logback.xml
@@ -28,8 +28,9 @@
     <appender-ref ref="STDOUT" />
   </root>
 
+  <logger name="org.apache.kafka" level="WARN"/>
   <logger name="org.eclipse.hono.vertx.example" level="DEBUG"/>
-  <logger name="org.eclipse.hono.client" level="INFO"/>
+  <logger name="org.eclipse.hono.application.client" level="INFO"/>
   <logger name="org.eclipse.hono.connection" level="DEBUG"/>
 
 </configuration>

--- a/examples/hono-client-examples/src/main/resources/logback.xml
+++ b/examples/hono-client-examples/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+    Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.

--- a/examples/hono-client-examples/src/main/resources/logback.xml
+++ b/examples/hono-client-examples/src/main/resources/logback.xml
@@ -30,6 +30,7 @@
 
   <logger name="org.apache.kafka" level="WARN"/>
   <logger name="org.eclipse.hono.vertx.example" level="DEBUG"/>
+  <logger name="org.eclipse.hono.client" level="INFO"/>
   <logger name="org.eclipse.hono.application.client" level="INFO"/>
   <logger name="org.eclipse.hono.connection" level="DEBUG"/>
 

--- a/site/documentation/content/dev-guide/java_client_consumer.md
+++ b/site/documentation/content/dev-guide/java_client_consumer.md
@@ -47,7 +47,8 @@ The application waits for messages until you press any key or kill it.
 It is started by
 
 ~~~sh
-# in directory: hono/examples/
+# in directory: hono/examples/hono-client-examples/
+mvn clean package
 mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoExampleApplication
 ~~~
 
@@ -79,3 +80,13 @@ If you want to integrate the code with your own software, please copy the provid
 from the Hono project to the `resources` directory of your project
 and adopt the code pointing to the file location.
 
+### Kafka based Messaging
+
+To use Kafka based messaging instead of an AMQP network, set the property `kafka` to `true` provide the host and port of a bootstrap server:
+
+~~~sh
+mvn exec:java -Dexec.mainClass=org.eclipse.hono.vertx.example.HonoExampleApplication -Dconsumer.host=192.168.99.100 -Dconsumer.port=9092 -Dkafka=true
+~~~
+
+Additional properties for the Kafka producers and consumers can be added in the code, for example to enable encrypted communication. 
+For the available configuration options refer to the [Kafka documentation]()https://kafka.apache.org/documentation/#configuration. 


### PR DESCRIPTION
This replaces the legacy northbound client (`ApplicationClientFactory`) in the module `hono-example-client` with the new client (`ApplicationClient`).