### PR TITLE
[#2480] Refactor Command Router Kafka classes

### DIFF
--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
@@ -1,0 +1,472 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.client.kafka.consumer;
+
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.util.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.common.PartitionInfo;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.kafka.client.common.impl.Helper;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
+
+/**
+ * A consumer receiving records from a Kafka cluster.
+ * <p>
+ * Wraps a vert.x Kafka consumer while implementing the Hono {@link Lifecycle} interface,
+ * letting records be consumed by a given handler after the {@link #start()} method has been
+ * called.
+ */
+public class HonoKafkaConsumer implements Lifecycle {
+
+    private static final long WAIT_FOR_REBALANCE_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
+    /**
+     * Default value for 'max.poll.interval.ms', i.e. the maximum delay between invocations of poll(), also
+     * the time commit() will block when retrying the commit on an UNKNOWN_TOPIC_OR_PARTITION error.
+     * Kafka consumer default is 5min. Since the vert.x kafka consumer continuously polls, we can set this
+     * to a much lower value.
+     */
+    private static final String DEFAULT_MAX_POLL_INTERNAL_MS = Long.toString(TimeUnit.SECONDS.toMillis(20));
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+    protected final Vertx vertx;
+    protected final AtomicBoolean stopped = new AtomicBoolean();
+
+    private final Supplier<KafkaConsumer<String, Buffer>> consumerCreator;
+    private final AtomicReference<Promise<Void>> subscribeDonePromiseRef = new AtomicReference<>();
+    private final Handler<KafkaConsumerRecord<String, Buffer>> recordHandler;
+    private final Set<String> topics;
+    private final Pattern topicPattern;
+
+    private KafkaConsumer<String, Buffer> kafkaConsumer;
+    /**
+     * The ver.x context the KafkaConsumer runs in.
+     */
+    private Context context;
+    /**
+     * Currently subscribed topics matching the topic pattern (if set).
+     * Note that these are not (necessarily) the topics that this particular kafkaConsumer
+     * here will receive messages for.
+     */
+    private Set<String> subscribedTopicPatternTopics = new HashSet<>();
+    private Handler<Set<TopicPartition>> onPartitionsAssignedHandler;
+    private Handler<Set<TopicPartition>> onPartitionsRevokedHandler;
+    private Handler<Set<TopicPartition>> blockingOnPartitionsRevokedHandler;
+
+    /**
+     * Creates a consumer to receive records on the given topics.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param topics The Kafka topic to consume records from.
+     * @param recordHandler The handler to be invoked for each received record.
+     * @param consumerConfig The Kafka consumer configuration.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public HonoKafkaConsumer(
+            final Vertx vertx,
+            final Set<String> topics,
+            final Handler<KafkaConsumerRecord<String, Buffer>> recordHandler,
+            final Map<String, String> consumerConfig) {
+        this(vertx, Objects.requireNonNull(topics), null, recordHandler, consumerConfig);
+    }
+
+    /**
+     * Creates a consumer to receive records on topics that match the given pattern.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param topicPattern The pattern of Kafka topic names to consume records from.
+     * @param recordHandler The handler to be invoked for each received record.
+     * @param consumerConfig The Kafka consumer configuration.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public HonoKafkaConsumer(
+            final Vertx vertx,
+            final Pattern topicPattern,
+            final Handler<KafkaConsumerRecord<String, Buffer>> recordHandler,
+            final Map<String, String> consumerConfig) {
+        this(vertx, null, Objects.requireNonNull(topicPattern), recordHandler, consumerConfig);
+    }
+
+    private HonoKafkaConsumer(
+            final Vertx vertx,
+            final Set<String> topics,
+            final Pattern topicPattern,
+            final Handler<KafkaConsumerRecord<String, Buffer>> recordHandler,
+            final Map<String, String> consumerConfig) {
+
+        this.vertx = Objects.requireNonNull(vertx);
+        this.topics = topics;
+        this.topicPattern = topicPattern;
+        this.recordHandler = Objects.requireNonNull(recordHandler);
+        Objects.requireNonNull(consumerConfig);
+
+        if (!consumerConfig.containsKey(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) {
+            consumerConfig.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, DEFAULT_MAX_POLL_INTERNAL_MS);
+        }
+        if (!consumerConfig.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
+            log.trace("no group.id set, using a random UUID as default");
+            consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        }
+        consumerCreator = () -> KafkaConsumer.create(vertx, consumerConfig, String.class, Buffer.class);
+    }
+
+    /**
+     * Sets a handler to be invoked on the vert.x event loop thread
+     * when partitions are about to be assigned as part of a rebalance.
+     *
+     * @param onPartitionsAssignedHandler The handler to be invoked.
+     */
+    public final void setOnPartitionsAssignedHandler(final Handler<Set<TopicPartition>> onPartitionsAssignedHandler) {
+        this.onPartitionsAssignedHandler = Objects.requireNonNull(onPartitionsAssignedHandler);
+    }
+
+    /**
+     * Sets a handler to be invoked on the vert.x event loop thread
+     * when partitions are about to be revoked as part of a rebalance.
+     *
+     * @param onPartitionsRevokedHandler The handler to be invoked.
+     */
+    public final void setOnPartitionsRevokedHandler(final Handler<Set<TopicPartition>> onPartitionsRevokedHandler) {
+        this.onPartitionsRevokedHandler = Objects.requireNonNull(onPartitionsRevokedHandler);
+    }
+
+    /**
+     * Sets a handler to be invoked when partitions are about to be revoked as part of a rebalance.
+     * <p>
+     * This handler will be invoked on the Kafka thread of the consumer and can be used to commit partition offset
+     * synchronously.
+     *
+     * @param blockingOnPartitionsRevokedHandler The handler to be invoked.
+     * @throws IllegalStateException if invoked after {@link #start()} has been called.
+     */
+    protected final void setBlockingOnPartitionsRevokedHandler(final Handler<Set<TopicPartition>> blockingOnPartitionsRevokedHandler) {
+        if (kafkaConsumer != null) {
+            throw new IllegalStateException("must be called before the consumer is started");
+        }
+        this.blockingOnPartitionsRevokedHandler = Objects.requireNonNull(blockingOnPartitionsRevokedHandler);
+    }
+
+    /**
+     * Only to be used for unit tests.
+     * @param context The vert.x context to use.
+     */
+    void setContext(final Context context) {
+        this.context = context;
+    }
+
+    /**
+     * Gets the used vert.x KafkaConsumer.
+     *
+     * @return The Kafka consumer.
+     * @throws IllegalStateException if invoked before the KafkaConsumer is set via the {@link #start()} method.
+     */
+    protected final KafkaConsumer<String, Buffer> getKafkaConsumer() {
+        if (kafkaConsumer == null) {
+            throw new IllegalStateException("consumer not initialized/started");
+        }
+        return kafkaConsumer;
+    }
+
+    @Override
+    public Future<Void> start() {
+        if (context == null) {
+            context = Vertx.currentContext();
+            if (context == null) {
+                return Future.failedFuture(new IllegalStateException("consumer must be started in a Vert.x context"));
+            }
+        }
+        // create KafkaConsumer here so that it is created in the Vert.x context of the start() method (KafkaConsumer uses vertx.getOrCreateContext())
+        kafkaConsumer = consumerCreator.get();
+        kafkaConsumer.handler(recordHandler);
+        kafkaConsumer.exceptionHandler(error -> log.error("consumer error occurred", error));
+        installRebalanceListeners();
+        return subscribeAndWaitForRebalance()
+                .map(ok -> {
+                    if (topicPattern != null) {
+                        if (subscribedTopicPatternTopics.size() <= 5) {
+                            log.debug("subscribed to topic pattern [{}], matching topics: {}", topicPattern,
+                                    subscribedTopicPatternTopics);
+                        } else {
+                            log.debug("subscribed to topic pattern [{}], matching {} topics", topicPattern,
+                                    subscribedTopicPatternTopics.size());
+                        }
+                    } else {
+                        log.debug("subscribed to topics {}", topics);
+                    }
+                    return null;
+                });
+    }
+
+    private void installRebalanceListeners() {
+        if (blockingOnPartitionsRevokedHandler != null) {
+            // need to apply workaround to set the blockingOnPartitionsRevokedHandler
+            replaceRebalanceListener(kafkaConsumer, new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsAssigned(final Collection<org.apache.kafka.common.TopicPartition> partitions) {
+                    // invoked on the actual Kafka consumer thread, not the event loop thread!
+                    context.runOnContext(v -> HonoKafkaConsumer.this.onPartitionsAssigned(Helper.from(partitions)));
+                }
+                @Override
+                public void onPartitionsRevoked(final Collection<org.apache.kafka.common.TopicPartition> partitions) {
+                    // invoked on the actual Kafka consumer thread, not the event loop thread!
+                    final Set<TopicPartition> partitionsSet = Helper.from(partitions);
+                    blockingOnPartitionsRevokedHandler.handle(partitionsSet);
+                    context.runOnContext(v -> HonoKafkaConsumer.this.onPartitionsRevoked(partitionsSet));
+                }
+            });
+        } else {
+            kafkaConsumer.partitionsAssignedHandler(this::onPartitionsAssigned);
+            kafkaConsumer.partitionsRevokedHandler(this::onPartitionsRevoked);
+        }
+    }
+
+    private Future<Void> subscribeAndWaitForRebalance() {
+        if (stopped.get()) {
+            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "already stopped"));
+        }
+        final Promise<Void> subscribeDonePromise = subscribeDonePromiseRef
+                .updateAndGet(promise -> promise == null ? Promise.promise() : promise);
+        final Promise<Void> subscriptionPromise = Promise.promise();
+        if (topicPattern != null) {
+            kafkaConsumer.subscribe(topicPattern, subscriptionPromise);
+        } else {
+            kafkaConsumer.subscribe(topics, subscriptionPromise);
+        }
+        vertx.setTimer(WAIT_FOR_REBALANCE_TIMEOUT, ar -> {
+            if (!subscribeDonePromise.future().isComplete()) {
+                final String errorMsg = "timed out waiting for rebalance and update of subscribed topics";
+                log.warn(errorMsg);
+                subscribeDonePromise.tryFail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, errorMsg));
+            }
+        });
+        return CompositeFuture.all(subscriptionPromise.future(), subscribeDonePromise.future()).mapEmpty();
+    }
+
+    private void onPartitionsAssigned(final Set<TopicPartition> partitionsSet) {
+        if (log.isDebugEnabled()) {
+            log.debug("partitions assigned: [{}]", HonoKafkaConsumerHelper.getPartitionsDebugString(partitionsSet));
+        }
+        // if a topic pattern is used, kafkaConsumer.subscription() will be used to fetch the actual subscribed topics;
+        // if a fixed topic list is used instead, calling kafkaConsumer.subscription() would be of no use since it
+        // always returns the topics used in the kafkaConsumer.subscribe(Collection) call, regardless of whether they exist
+        // (kafkaConsumer.subscribe(Collection) would have auto-created the topics anyway, if "auto.create.topics.enable" is true)
+        if (topicPattern != null) {
+            updateSubscribedTopicPatternTopics();
+        } else {
+            Optional.ofNullable(subscribeDonePromiseRef.getAndSet(null))
+                    .ifPresent(Promise::tryComplete);
+        }
+        if (onPartitionsAssignedHandler != null) {
+            onPartitionsAssignedHandler.handle(partitionsSet);
+        }
+    }
+
+    private void updateSubscribedTopicPatternTopics() {
+        // update subscribedTopicPatternTopics (subscription() will return the actual topics, i.e. not the topic pattern if one is used
+        kafkaConsumer.subscription(ar -> {
+            if (ar.succeeded()) {
+                subscribedTopicPatternTopics = new HashSet<>(ar.result());
+            } else {
+                log.warn("failed to get subscription", ar.cause());
+            }
+            Optional.ofNullable(subscribeDonePromiseRef.getAndSet(null))
+                    .ifPresent(promise -> {
+                        if (ar.succeeded()) {
+                            promise.tryComplete();
+                        } else {
+                            promise.tryFail(ar.cause());
+                        }
+                    });
+        });
+    }
+
+    private void onPartitionsRevoked(final Set<TopicPartition> partitionsSet) {
+        if (log.isDebugEnabled()) {
+            log.debug("partitions revoked: [{}]", HonoKafkaConsumerHelper.getPartitionsDebugString(partitionsSet));
+        }
+        if (onPartitionsRevokedHandler != null) {
+            onPartitionsRevokedHandler.handle(partitionsSet);
+        }
+    }
+
+    @Override
+    public Future<Void> stop() {
+        if (kafkaConsumer == null) {
+            return Future.failedFuture("not started");
+        } else if (!stopped.compareAndSet(false, true)) {
+            return Future.failedFuture("already stopped");
+        }
+        final Promise<Void> consumerClosePromise = Promise.promise();
+        kafkaConsumer.close(consumerClosePromise);
+        return consumerClosePromise.future();
+    }
+
+    /**
+     * Gets the list of actual topics that match the topic pattern of this consumer.
+     * Returns an empty list if this consumer doesn't use a topic pattern.
+     *
+     * @return The list of topics.
+     */
+    public final Set<String> getSubscribedTopicPatternTopics() {
+        if (topicPattern == null) {
+            return Set.of();
+        }
+        return new HashSet<>(subscribedTopicPatternTopics);
+    }
+
+    /**
+     * Checks whether the given topic is one this consumer is subscribed to.
+     * <p>
+     * If this consumer uses a topic pattern subscription, this method checks whether the given
+     * topic is part of the list of actual topics the pattern has been evaluated to.
+     * <p>
+     * Note that this does not necessarily mean that this consumer will actually receive messages
+     * for the topic - the topic partitions could currently be assigned to another consumer in the
+     * same consumer group.
+     *
+     * @param topic The topic to check.
+     * @return {@code true} if the topic is among the subscribed topics.
+     * @throws NullPointerException if topic is {@code null}.
+     */
+    public final boolean isAmongKnownSubscribedTopics(final String topic) {
+        Objects.requireNonNull(topic);
+        if (topics != null) {
+            return topics.contains(topic);
+        }
+        return subscribedTopicPatternTopics.contains(topic);
+    }
+
+    /**
+     * Tries to ensure that the given topic is part of the list of topics this consumer is subscribed to.
+     * <p>
+     * Note that this method is only applicable if a topic pattern subscription is used, otherwise an
+     * {@link IllegalStateException} is thrown.
+     * <p>
+     * This is relevant if the topic either has just been created and this consumer doesn't know about it yet or
+     * the topic doesn't exist yet. In the latter case, this method will try to trigger creation of the topic,
+     * which may succeed if "auto.create.topics.enable" is true, and wait for the following rebalance to check
+     * if the topic is part of the subscribed topics then.
+     *
+     * @param topic The topic to use.
+     * @return A future indicating the outcome of the operation. The Future is succeeded if the topic exists and
+     *         is among the subscribed topics. The Future is failed with a {@link ServerErrorException} if the topic
+     *         doesn't exist or there was an error determining whether the topic is part of the subscription.
+     * @throws IllegalArgumentException If this consumer doesn't use a topic pattern or the topic doesn't match the pattern.
+     * @throws NullPointerException if topic is {@code null}.
+     */
+    public final Future<Void> ensureTopicIsAmongSubscribedTopicPatternTopics(final String topic) {
+        Objects.requireNonNull(topic);
+        if (topics != null) {
+            throw new IllegalStateException("consumer doesn't use topic pattern");
+        } else if (!topicPattern.matcher(topic).find()) {
+            throw new IllegalArgumentException("topic doesn't match pattern");
+        }
+        if (kafkaConsumer == null) {
+            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, "not started"));
+        } else if (stopped.get()) {
+            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "already stopped"));
+        }
+        // check whether topic exists and its existence has been applied to the wildcard subscription yet;
+        // use previously updated topics list (less costly than invoking kafkaConsumer.subscription() here)
+        if (subscribedTopicPatternTopics.contains(topic)) {
+            log.debug("ensureTopicIsAmongSubscribedTopics: topic is already subscribed [{}]", topic);
+            return Future.succeededFuture();
+        }
+        final Promise<List<PartitionInfo>> topicCheckFuture = Promise.promise();
+        // check whether topic has been created since the last rebalance
+        // and if not, potentially create it here implicitly
+        // (partitionsFor() will create the topic if it doesn't exist, provided "auto.create.topics.enable" is true)
+        HonoKafkaConsumerHelper.partitionsFor(kafkaConsumer, topic, topicCheckFuture);
+        return topicCheckFuture.future()
+                .recover(thr -> {
+                    log.warn("ensureTopicIsAmongSubscribedTopics: error getting partitions for topic [{}]", topic, thr);
+                    return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE,
+                            "error getting topic partitions", thr));
+                }).compose(partitions -> {
+                    if (partitions.isEmpty()) {
+                        log.warn("ensureTopicIsAmongSubscribedTopics: topic doesn't exist and didn't get auto-created: {}", topic);
+                        return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE,
+                                "topic doesn't exist and didn't get auto-created"));
+                    }
+                    // again check topics in case rebalance happened in between
+                    if (subscribedTopicPatternTopics.contains(topic)) {
+                        return Future.succeededFuture();
+                    }
+                    // the topic list of a wildcard subscription only gets refreshed periodically by default (interval is defined by "metadata.max.age.ms");
+                    // therefore enforce a refresh here by again subscribing to the topic pattern
+                    log.debug("ensureTopicIsAmongSubscribedTopics: verified topic existence, wait for subscription update and rebalance [{}]", topic);
+                    return subscribeAndWaitForRebalance()
+                            .compose(v -> {
+                                if (!subscribedTopicPatternTopics.contains(topic)) {
+                                    log.warn("ensureTopicIsAmongSubscribedTopics: subscription not updated with topic after rebalance [topic: {}]", topic);
+                                    return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE,
+                                                    "subscription not updated with topic after rebalance"));
+                                }
+                                log.debug("ensureTopicIsAmongSubscribedTopics: done updating topic subscription");
+                                return Future.succeededFuture(v);
+                            });
+                });
+    }
+
+    /**
+     * Replaces the internal rebalance listener of the given vert.x KafkaConsumer with the given one via reflection.
+     * <p>
+     * This is a workaround for enabling an <em>onPartitionsRevokedHandler</em> to be invoked in a blocking
+     * fashion on the vert.x worker thread that the KafkaConsumer is using, e.g. to do a manual offset commit
+     * via <em>commitSync</em> before the new partition assignment is in place. Without this modification, a handler
+     * set via {@link KafkaConsumer#partitionsRevokedHandler(Handler)} will always be invoked asynchronously on the
+     * vert.x event loop thread, which could mean that the new partition assignment is already done by then.
+     *
+     * @param consumer The consumer to replace the rebalance listener in.
+     * @param listener The rebalance listener to set.
+     */
+    private static void replaceRebalanceListener(final KafkaConsumer<String, Buffer> consumer,
+            final ConsumerRebalanceListener listener) {
+        try {
+            final Field field = KafkaReadStreamImpl.class.getDeclaredField("rebalanceListener");
+            field.setAccessible(true);
+            field.set(consumer.asStream(), listener);
+        } catch (final Exception e) {
+            throw new IllegalArgumentException("Failed to adapt rebalance listener", e);
+        }
+    }
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerHelper.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.client.kafka.consumer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.kafka.client.common.PartitionInfo;
+import io.vertx.kafka.client.common.impl.Helper;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+
+/**
+ * Provides helper methods for working with a vert.x {@link KafkaConsumer}.
+ */
+public abstract class HonoKafkaConsumerHelper {
+
+    private HonoKafkaConsumerHelper() {
+    }
+
+    /**
+     * Get metadata about the partitions for a given topic.
+     * <p>
+     * This method is adapted from {@code io.vertx.kafka.client.consumer.impl.KafkaConsumerImpl#partitionsFor(String, Handler)}
+     * and fixes an NPE in case {@code KafkaConsumer#partitionsFor(String)} returns {@code null}
+     * (happens if "auto.create.topics.enable" is false).
+     * <p>
+     * This method will become obsolete when updating to a Kafka client in which https://issues.apache.org/jira/browse/KAFKA-12260
+     * ("PartitionsFor should not return null value") is solved.
+     * TODO remove this method once updated Kafka client is used
+     *
+     * @param kafkaConsumer The KafkaConsumer to use.
+     * @param topic The topic to get partitions info for.
+     * @param handler The handler to invoke with the result.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static void partitionsFor(final KafkaConsumer<?, ?> kafkaConsumer,
+            final String topic, final Handler<AsyncResult<List<PartitionInfo>>> handler) {
+        Objects.requireNonNull(kafkaConsumer);
+        Objects.requireNonNull(topic);
+        Objects.requireNonNull(handler);
+        kafkaConsumer.asStream().partitionsFor(topic, done -> {
+
+            if (done.succeeded()) {
+                if (done.result() == null) {
+                    handler.handle(Future.succeededFuture(List.of()));
+                } else {
+                    final List<PartitionInfo> partitions = new ArrayList<>();
+                    for (final org.apache.kafka.common.PartitionInfo kafkaPartitionInfo: done.result()) {
+
+                        final PartitionInfo partitionInfo = new PartitionInfo();
+                        partitionInfo
+                                .setInSyncReplicas(
+                                        Stream.of(kafkaPartitionInfo.inSyncReplicas()).map(Helper::from).collect(Collectors.toList()))
+                                .setLeader(Helper.from(kafkaPartitionInfo.leader()))
+                                .setPartition(kafkaPartitionInfo.partition())
+                                .setReplicas(
+                                        Stream.of(kafkaPartitionInfo.replicas()).map(Helper::from).collect(Collectors.toList()))
+                                .setTopic(kafkaPartitionInfo.topic());
+
+                        partitions.add(partitionInfo);
+                    }
+                    handler.handle(Future.succeededFuture(partitions));
+                }
+            } else {
+                handler.handle(Future.failedFuture(done.cause()));
+            }
+        });
+    }
+
+    /**
+     * Returns a string representation of the given partitions, to be used for debug log messages.
+     *
+     * @param partitionsSet The partitions to use.
+     * @return The string representation.
+     * @throws NullPointerException if partitionsSet is {@code null}.
+     */
+    public static String getPartitionsDebugString(final Collection<io.vertx.kafka.client.common.TopicPartition> partitionsSet) {
+        Objects.requireNonNull(partitionsSet);
+        return partitionsSet.size() <= 20 // skip details for larger set
+                ? partitionsSet.stream()
+                .collect(Collectors.groupingBy(io.vertx.kafka.client.common.TopicPartition::getTopic,
+                        Collectors.mapping(io.vertx.kafka.client.common.TopicPartition::getPartition, Collectors.toCollection(TreeSet::new))))
+                .toString()
+                : partitionsSet.size() + " topic partitions";
+    }
+}

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -12,29 +12,17 @@
  *******************************************************************************/
 package org.eclipse.hono.commandrouter.impl.kafka;
 
-import java.net.HttpURLConnection;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedInternalCommandSender;
 import org.eclipse.hono.adapter.client.registry.TenantClient;
-import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 import org.eclipse.hono.commandrouter.CommandConsumerFactory;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
@@ -46,17 +34,10 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.kafka.client.common.PartitionInfo;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.kafka.client.common.impl.Helper;
-import io.vertx.kafka.client.consumer.KafkaConsumer;
 
 /**
  * A factory for creating clients for the <em>Kafka messaging infrastructure</em> to receive commands.
@@ -73,20 +54,10 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
 
     private static final Pattern COMMANDS_TOPIC_PATTERN = Pattern
             .compile(Pattern.quote(HonoTopic.Type.COMMAND.prefix) + ".*");
-    private static final long WAIT_FOR_REBALANCE_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
 
-    private final Supplier<KafkaConsumer<String, Buffer>> consumerCreator;
     private final KafkaBasedMappingAndDelegatingCommandHandler commandHandler;
-    private final AtomicReference<Promise<Void>> onSubscribedTopicsNextUpdated = new AtomicReference<>();
     private final Tracer tracer;
-    private final Vertx vertx;
-    /**
-     * Currently subscribed topics, i.e. the topics matching COMMANDS_TOPIC_PATTERN.
-     * Note that these are not (necessarily) the topics that this particular kafkaConsumer
-     * here will receive messages for.
-     */
-    private Set<String> subscribedTopics = new HashSet<>();
-    private KafkaConsumer<String, Buffer> kafkaConsumer;
+    private final HonoKafkaConsumer kafkaConsumer;
 
     /**
      * Creates a new factory to process commands via the Kafka cluster.
@@ -111,7 +82,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
             final KafkaConsumerConfigProperties kafkaConsumerConfig,
             final Tracer tracer) {
 
-        this.vertx = Objects.requireNonNull(vertx);
+        Objects.requireNonNull(vertx);
         Objects.requireNonNull(tenantClient);
         Objects.requireNonNull(commandTargetMapper);
         Objects.requireNonNull(kafkaProducerFactory);
@@ -123,102 +94,27 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
                 kafkaProducerFactory, kafkaProducerConfig, tracer);
         commandHandler = new KafkaBasedMappingAndDelegatingCommandHandler(tenantClient, commandTargetMapper,
                 internalCommandSender, tracer);
-        final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig("cmd-router");
+        final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig("consumer");
         consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "cmd-router-group");
-        consumerCreator = () -> KafkaConsumer.create(vertx, consumerConfig, String.class, Buffer.class);
+        kafkaConsumer = new HonoKafkaConsumer(vertx, COMMANDS_TOPIC_PATTERN,
+                commandHandler::mapAndDelegateIncomingCommandMessage, consumerConfig);
     }
 
     @Override
     public Future<Void> start() {
-        // create KafkaConsumer here so that it is created in the Vert.x context of the start() method (KafkaConsumer uses vertx.getOrCreateContext())
-        kafkaConsumer = consumerCreator.get();
-        //TODO in the next iteration: handling of offsets and commits.
-        // And if required, to use a consumer(at most once) class similar to the AbstractAtLeastOnceKafkaConsumer
-        kafkaConsumer
-                .handler(commandHandler::mapAndDelegateIncomingCommandMessage)
-                .partitionsAssignedHandler(this::onPartitionsAssigned)
-                .partitionsRevokedHandler(this::onPartitionsRevoked)
-                .exceptionHandler(error -> LOG.error("consumer error occurred", error));
-
-        return CompositeFuture.all(commandHandler.start(), subscribeAndWaitForRebalanceAndTopicsUpdate())
-                .map(ok -> {
-                    LOG.debug("subscribed to topic pattern [{}], matching {} topics", COMMANDS_TOPIC_PATTERN, subscribedTopics.size());
-                    return null;
-                });
-    }
-
-    private Future<Void> subscribeAndWaitForRebalanceAndTopicsUpdate() {
-        final Promise<Void> subscribedTopicsPromise = onSubscribedTopicsNextUpdated
-                .updateAndGet(promise -> promise == null ? Promise.promise() : promise);
-        final Promise<Void> subscriptionPromise = Promise.promise();
-        kafkaConsumer.subscribe(COMMANDS_TOPIC_PATTERN, subscriptionPromise);
-        vertx.setTimer(WAIT_FOR_REBALANCE_TIMEOUT, ar -> {
-            if (!subscribedTopicsPromise.future().isComplete()) {
-                final String errorMsg = "timed out waiting for rebalance and update of subscribed topics";
-                LOG.warn(errorMsg);
-                subscribedTopicsPromise.tryFail(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, errorMsg));
-            }
-        });
-        return CompositeFuture.all(subscriptionPromise.future(), subscribedTopicsPromise.future()).mapEmpty();
-    }
-
-    private void onPartitionsAssigned(final Set<TopicPartition> partitionsSet) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("partitions assigned: [{}]", getPartitionsDebugString(partitionsSet));
-        }
-        // update subscribedTopics (subscription() will return the actual topics, not the topic pattern)
-        kafkaConsumer.subscription(ar -> {
-            if (ar.succeeded()) {
-                subscribedTopics = new HashSet<>(ar.result());
-            } else {
-                LOG.warn("failed to get subscription", ar.cause());
-            }
-            Optional.ofNullable(onSubscribedTopicsNextUpdated.getAndSet(null))
-                    .ifPresent(promise -> {
-                        if (ar.succeeded()) {
-                            promise.tryComplete();
-                        } else {
-                            promise.tryFail(ar.cause());
-                        }
-                    });
-        });
-    }
-
-    private void onPartitionsRevoked(final Set<TopicPartition> partitionsSet) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("partitions revoked: [{}]", getPartitionsDebugString(partitionsSet));
-        }
-    }
-
-    private String getPartitionsDebugString(final Set<TopicPartition> partitionsSet) {
-        return partitionsSet.size() <= 20 // skip details for larger set
-                ? partitionsSet.stream()
-                .collect(Collectors.groupingBy(TopicPartition::getTopic,
-                        Collectors.mapping(TopicPartition::getPartition, Collectors.toCollection(TreeSet::new))))
-                .toString()
-                : partitionsSet.size() + " topic partitions";
+        return kafkaConsumer.start();
     }
 
     @Override
     public Future<Void> stop() {
-        if (kafkaConsumer == null) {
-            return Future.failedFuture("not started");
-        }
-        final Promise<Void> consumerClosePromise = Promise.promise();
-        kafkaConsumer.close(consumerClosePromise);
-        return CompositeFuture.all(commandHandler.stop(), consumerClosePromise.future())
+        return CompositeFuture.all(commandHandler.stop(), kafkaConsumer.stop())
                 .mapEmpty();
     }
 
     @Override
     public Future<Void> createCommandConsumer(final String tenantId, final SpanContext context) {
-        if (kafkaConsumer == null) {
-            return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, "not started"));
-        }
         final String topic = new HonoTopic(HonoTopic.Type.COMMAND, tenantId).toString();
-        // check whether tenant topic exists and its existence has been applied to the wildcard subscription yet;
-        // use previously updated topics list (less costly than invoking kafkaConsumer.subscription() here)
-        if (subscribedTopics.contains(topic)) {
+        if (kafkaConsumer.isAmongKnownSubscribedTopics(topic)) {
             LOG.debug("createCommandConsumer: topic is already subscribed [{}]", topic);
             return Future.succeededFuture();
         }
@@ -228,86 +124,12 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
                 .start();
         TracingHelper.TAG_TENANT_ID.set(span, tenantId);
         Tags.MESSAGE_BUS_DESTINATION.set(span, topic);
-
-        final Promise<List<PartitionInfo>> topicCheckFuture = Promise.promise();
-        // check whether tenant topic has been created since the last rebalance
-        // and if not, potentially create it here implicitly
-        // (partitionsFor() will create the topic if it doesn't exist, provided "auto.create.topics.enable" is true)
-        partitionsFor(topic, topicCheckFuture);
-        return topicCheckFuture.future()
-                .recover(thr -> {
-                    LOG.warn("createCommandConsumer: error getting partitions for topic [{}]", topic, thr);
-                    return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE,
-                            "error getting topic partitions", thr));
-                }).compose(partitions -> {
-                    if (partitions.isEmpty()) {
-                        LOG.warn("createCommandConsumer: topic doesn't exist and didn't get auto-created: {}", topic);
-                        return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE,
-                                "topic doesn't exist and didn't get auto-created"));
-                    }
-                    // again check topics in case rebalance happened in between
-                    if (subscribedTopics.contains(topic)) {
-                        return Future.succeededFuture();
-                    }
-                    // the topic list of a wildcard subscription only gets refreshed periodically by default (interval is defined by "metadata.max.age.ms");
-                    // therefore enforce a refresh here by again subscribing to the topic pattern
-                    LOG.debug("createCommandConsumer: verified topic existence, wait for subscription update and rebalance [{}]", topic);
-                    span.log("verified topic existence, wait for subscription update and rebalance");
-                    return subscribeAndWaitForRebalanceAndTopicsUpdate()
-                            .compose(v -> {
-                                if (!subscribedTopics.contains(topic)) {
-                                    LOG.warn("createCommandConsumer: subscription not updated with topic after rebalance [topic: {}]", topic);
-                                    return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE,
-                                                    "subscription not updated with topic after rebalance"));
-                                }
-                                LOG.debug("createCommandConsumer: done updating topic subscription");
-                                return Future.succeededFuture(v);
-                            });
-                }).onComplete(ar -> {
+        return kafkaConsumer.ensureTopicIsAmongSubscribedTopicPatternTopics(topic)
+                .onComplete(ar -> {
                     if (ar.failed()) {
                         TracingHelper.logError(span, ar.cause());
                     }
                     span.finish();
                 });
-    }
-
-    /**
-     * This method is adapted from {@code io.vertx.kafka.client.consumer.impl.KafkaConsumerImpl#partitionsFor(String, Handler)}
-     * and fixes an NPE in case {@code KafkaConsumer#partitionsFor(String)} returns {@code null}
-     * (happens if "auto.create.topics.enable" is false).
-     * <p>
-     * This method will become obsolete when updating to a Kafka client in which https://issues.apache.org/jira/browse/KAFKA-12260
-     * ("PartitionsFor should not return null value") is solved.
-     * TODO remove this method once updated Kafka client is used
-     */
-    private KafkaConsumer<String, Buffer> partitionsFor(final String topic, final Handler<AsyncResult<List<PartitionInfo>>> handler) {
-        kafkaConsumer.asStream().partitionsFor(topic, done -> {
-
-            if (done.succeeded()) {
-                if (done.result() == null) {
-                    handler.handle(Future.succeededFuture(List.of()));
-                } else {
-                    final List<PartitionInfo> partitions = new ArrayList<>();
-                    for (final org.apache.kafka.common.PartitionInfo kafkaPartitionInfo: done.result()) {
-
-                        final PartitionInfo partitionInfo = new PartitionInfo();
-                        partitionInfo
-                                .setInSyncReplicas(
-                                        Stream.of(kafkaPartitionInfo.inSyncReplicas()).map(Helper::from).collect(Collectors.toList()))
-                                .setLeader(Helper.from(kafkaPartitionInfo.leader()))
-                                .setPartition(kafkaPartitionInfo.partition())
-                                .setReplicas(
-                                        Stream.of(kafkaPartitionInfo.replicas()).map(Helper::from).collect(Collectors.toList()))
-                                .setTopic(kafkaPartitionInfo.topic());
-
-                        partitions.add(partitionInfo);
-                    }
-                    handler.handle(Future.succeededFuture(partitions));
-                }
-            } else {
-                handler.handle(Future.failedFuture(done.cause()));
-            }
-        });
-        return kafkaConsumer;
     }
 }

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
@@ -12,15 +12,8 @@
  *******************************************************************************/
 package org.eclipse.hono.commandrouter.impl.kafka;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.function.Supplier;
 
-import org.apache.kafka.common.TopicPartition;
 import org.eclipse.hono.adapter.client.command.CommandContext;
 import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedCommand;
 import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedCommandContext;
@@ -30,14 +23,11 @@ import org.eclipse.hono.client.impl.CommandConsumer;
 import org.eclipse.hono.client.kafka.tracing.KafkaTracingHelper;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.commandrouter.impl.AbstractMappingAndDelegatingCommandHandler;
-import org.eclipse.hono.tracing.TracingHelper;
-import org.eclipse.hono.util.Pair;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 
@@ -46,13 +36,8 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
  */
 public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappingAndDelegatingCommandHandler {
 
-    private static final String KEY_COMMAND_SEND_ACTION_SUPPLIER_AND_RESULT_PROMISE = "commandSendActionSupplierAndResultPromise";
-    /**
-     * Queue in which the received commands per TopicPartition are kept so that they can
-     * be delegated in the same order they were received.
-     */
-    private final Map<TopicPartition, CommandQueue> commandQueues = new HashMap<>();
     private final Tracer tracer;
+    private final KafkaCommandProcessingQueue commandQueue;
 
     /**
      * Creates a new KafkaBasedMappingAndDelegatingCommandHandler instance.
@@ -69,6 +54,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
             final KafkaBasedInternalCommandSender internalCommandSender,
             final Tracer tracer) {
         super(tenantClient, commandTargetMapper, internalCommandSender);
+        this.commandQueue = new KafkaCommandProcessingQueue();
         this.tracer = Objects.requireNonNull(tracer);
     }
 
@@ -107,9 +93,6 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
             return Future.failedFuture("command is invalid");
         }
         log.trace("received valid command record [{}]", command);
-        final TopicPartition topicPartition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
-        final CommandQueue commandQueue = commandQueues
-                .computeIfAbsent(topicPartition, k -> new CommandQueue());
         commandQueue.add(commandContext);
 
         return mapAndDelegateIncomingCommand(commandContext)
@@ -130,117 +113,8 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
     @Override
     protected Future<Void> sendCommand(final CommandContext commandContext, final String targetAdapterInstanceId) {
         final KafkaBasedCommandContext cmdContext = (KafkaBasedCommandContext) commandContext;
-        final TopicPartition topicPartition = new TopicPartition(
-                cmdContext.getCommand().getRecord().topic(), cmdContext.getCommand().getRecord().partition());
-        final CommandQueue commandQueue = commandQueues.get(topicPartition);
-
         return commandQueue.applySendCommandAction(cmdContext,
                 () -> super.sendCommand(commandContext, targetAdapterInstanceId));
     }
 
-    /**
-     * Keeps track of commands that are currently being processed and ensures that
-     * the "SendCommandAction" provided via {@link #applySendCommandAction(KafkaBasedCommandContext, Supplier)}
-     * is invoked on command objects in the same order that the commands got added
-     * to the queue.
-     */
-    class CommandQueue {
-        private final Queue<KafkaBasedCommandContext> queue = new LinkedList<>();
-
-        /**
-         * Adds the given command to the queue.
-         *
-         * @param commandContext The context containing the command to add.
-         * @throws NullPointerException if commandContext is {@code null}.
-         */
-        public void add(final KafkaBasedCommandContext commandContext) {
-            Objects.requireNonNull(commandContext);
-            queue.add(commandContext);
-        }
-
-        /**
-         * Removes the given command from the queue.
-         * <p>
-         * To be used for commands for which processing resulted in an error
-         * and {@link #applySendCommandAction(KafkaBasedCommandContext, Supplier)}
-         * will not be invoked.
-         *
-         * @param commandContext The context containing the command to add.
-         * @throws NullPointerException if commandContext is {@code null}.
-         */
-        public void remove(final KafkaBasedCommandContext commandContext) {
-            Objects.requireNonNull(commandContext);
-            if (queue.remove(commandContext)) {
-                sendNextCommandInQueueIfPossible();
-            }
-        }
-
-        /**
-         * Either invokes the given sendAction directly if it is next-in-line or makes sure the action is
-         * invoked at a later point in time according to the order in which commands were originally received.
-         *
-         * @param commandContext The context of the command to apply the given sendAction for.
-         * @param sendActionSupplier The Supplier for the action to send the given command to the internal Command and
-         *                           Control API endpoint provided by protocol adapters.
-         * @return A future indicating the outcome of sending the command message. If the given command is
-         *         not in the queue, a failed future will be returned and the command context is released.
-         * @throws NullPointerException if any of the parameters is {@code null}.
-         */
-        public Future<Void> applySendCommandAction(final KafkaBasedCommandContext commandContext,
-                final Supplier<Future<Void>> sendActionSupplier) {
-            Objects.requireNonNull(commandContext);
-            Objects.requireNonNull(sendActionSupplier);
-
-            final Promise<Void> resultPromise = Promise.promise();
-            final Pair<Supplier<Future<Void>>, Promise<Void>> sendActionSupplierAndResultPromise = Pair
-                    .of(sendActionSupplier, resultPromise);
-            if (commandContext.equals(queue.peek())) {
-                sendGivenCommandAndNextInQueueIfPossible(sendActionSupplierAndResultPromise);
-            } else if (!queue.contains(commandContext)) {
-                log.warn("command can't be sent - not in queue [{}]", commandContext.getCommand());
-                TracingHelper.logError(commandContext.getTracingSpan(), "command can't be sent - not in queue");
-                commandContext.release();
-                resultPromise.fail(new IllegalStateException("command can't be sent - not in queue"));
-            } else {
-                // given command is not next-in-line;
-                // that means determining its target adapter instance has finished sooner (maybe because of fewer data-grid requests)
-                // compared to a command that was received earlier
-                log.debug("sending of command with offset {} delayed waiting for processing of offset {} [delayed {}]",
-                        getRecordOffset(commandContext), getRecordOffset(queue.peek()), commandContext.getCommand());
-                commandContext.getTracingSpan().log(String.format("waiting for an earlier command with offset %d to be processed first",
-                        getRecordOffset(queue.peek())));
-                commandContext.put(KEY_COMMAND_SEND_ACTION_SUPPLIER_AND_RESULT_PROMISE, sendActionSupplierAndResultPromise);
-            }
-            return resultPromise.future();
-        }
-
-        private void sendGivenCommandAndNextInQueueIfPossible(
-                final Pair<Supplier<Future<Void>>, Promise<Void>> sendActionSupplierAndResultPromise) {
-            final KafkaBasedCommandContext commandContext = queue.remove();
-            log.trace("sending [{}]", commandContext.getCommand());
-            // TODO use the supplier result future to keep track of the latest fully processed command record with regard to its partition offset
-            sendActionSupplierAndResultPromise.one().get()
-                    .onComplete(sendActionSupplierAndResultPromise.two());
-            sendNextCommandInQueueIfPossible();
-        }
-
-        private void sendNextCommandInQueueIfPossible() {
-            Optional.ofNullable(queue.peek())
-                    .map(this::getSendActionSupplierAndResultPromise)
-                    .ifPresent(this::sendGivenCommandAndNextInQueueIfPossible);
-        }
-
-        private Pair<Supplier<Future<Void>>, Promise<Void>> getSendActionSupplierAndResultPromise(
-                final KafkaBasedCommandContext context) {
-            return context.get(KEY_COMMAND_SEND_ACTION_SUPPLIER_AND_RESULT_PROMISE);
-        }
-
-        private long getRecordOffset(final KafkaBasedCommandContext context) {
-            if (context == null) {
-                return -1;
-            }
-            return context.getCommand().getRecord().offset();
-        }
-
-    }
 }

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueue.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueue.java
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.commandrouter.impl.kafka;
+
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.hono.adapter.client.command.kafka.KafkaBasedCommandContext;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * Queue with the commands currently being processed, maintaining FIFO semantics and keeping track of partition offsets
+ * of the last fully processed commands per partition.
+ */
+public class KafkaCommandProcessingQueue {
+
+    /**
+     * The queues that contain the commands currently being processed, with the commands stored according to the
+     * TopicPartition they were received from and in the order they were received.
+     */
+    private final Map<TopicPartition, TopicPartitionCommandQueue> commandQueues = new HashMap<>();
+
+    /**
+     * Adds the command represented by the given command context.
+     *
+     * @param commandContext The context containing the command to add.
+     * @throws NullPointerException if commandContext is {@code null}.
+     */
+    public void add(final KafkaBasedCommandContext commandContext) {
+        Objects.requireNonNull(commandContext);
+        final KafkaConsumerRecord<String, Buffer> record = commandContext.getCommand().getRecord();
+        final TopicPartition topicPartition = new TopicPartition(record.topic(), record.partition());
+        final TopicPartitionCommandQueue commandQueue = commandQueues
+                .computeIfAbsent(topicPartition, k -> new TopicPartitionCommandQueue());
+        commandQueue.add(commandContext);
+    }
+
+    /**
+     * Removes the command represented by the given command context.
+     * <p>
+     * To be used for commands for which processing resulted in an error
+     * and {@link #applySendCommandAction(KafkaBasedCommandContext, Supplier)}
+     * will not be invoked.
+     *
+     * @param commandContext The context containing the command to remove.
+     */
+    public void remove(final KafkaBasedCommandContext commandContext) {
+        Objects.requireNonNull(commandContext);
+        final KafkaConsumerRecord<String, Buffer> record = commandContext.getCommand().getRecord();
+        final TopicPartition topicPartition = new TopicPartition(record.topic(), record.partition());
+        Optional.ofNullable(commandQueues.get(topicPartition))
+                .ifPresent(commandQueue -> commandQueue.remove(commandContext));
+    }
+
+    /**
+     * Either invokes the given sendAction directly if it is next-in-line or makes sure the action is
+     * invoked at a later point in time according to the order in which commands were originally received.
+     *
+     * @param commandContext The context of the command to apply the given sendAction for.
+     * @param sendActionSupplier The Supplier for the action to send the given command to the internal Command and
+     *                           Control API endpoint provided by protocol adapters.
+     * @return A future indicating the outcome of sending the command message. If the given command is
+     *         not in the corresponding queue, a failed future will be returned and the command context is released.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public Future<Void> applySendCommandAction(final KafkaBasedCommandContext commandContext,
+            final Supplier<Future<Void>> sendActionSupplier) {
+        final TopicPartition topicPartition = new TopicPartition(
+                commandContext.getCommand().getRecord().topic(), commandContext.getCommand().getRecord().partition());
+        final TopicPartitionCommandQueue commandQueue = commandQueues.get(topicPartition);
+        if (commandQueue == null) {
+            return Future.failedFuture(new IllegalStateException("command can't be sent - corresponding queue does not exist"));
+        }
+        return commandQueue.applySendCommandAction(commandContext, sendActionSupplier);
+    }
+
+    /**
+     * Keeps track of commands that are currently being processed and ensures that
+     * the "SendCommandAction" provided via {@link #applySendCommandAction(KafkaBasedCommandContext, Supplier)}
+     * is invoked on command objects in the same order that the commands got added
+     * to the queue.
+     */
+    static class TopicPartitionCommandQueue {
+
+        private static final Logger LOG = LoggerFactory.getLogger(TopicPartitionCommandQueue.class);
+
+        private static final String KEY_COMMAND_SEND_ACTION_SUPPLIER_AND_RESULT_PROMISE = "commandSendActionSupplierAndResultPromise";
+
+        private final Deque<KafkaBasedCommandContext> queue = new LinkedList<>();
+
+        /**
+         * Adds the given command to the queue.
+         *
+         * @param commandContext The context containing the command to add.
+         * @throws NullPointerException if commandContext is {@code null}.
+         */
+        public void add(final KafkaBasedCommandContext commandContext) {
+            Objects.requireNonNull(commandContext);
+            queue.add(commandContext);
+        }
+
+        /**
+         * Removes the given command from the queue.
+         * <p>
+         * To be used for commands for which processing resulted in an error
+         * and {@link #applySendCommandAction(KafkaBasedCommandContext, Supplier)}
+         * will not be invoked.
+         *
+         * @param commandContext The context containing the command to add.
+         * @throws NullPointerException if commandContext is {@code null}.
+         */
+        public void remove(final KafkaBasedCommandContext commandContext) {
+            Objects.requireNonNull(commandContext);
+            if (queue.remove(commandContext)) {
+                sendNextCommandInQueueIfPossible();
+            }
+        }
+
+        /**
+         * Either invokes the given sendAction directly if it is next-in-line or makes sure the action is
+         * invoked at a later point in time according to the order in which commands were originally received.
+         *
+         * @param commandContext The context of the command to apply the given sendAction for.
+         * @param sendActionSupplier The Supplier for the action to send the given command to the internal Command and
+         *                           Control API endpoint provided by protocol adapters.
+         * @return A future indicating the outcome of sending the command message. If the given command is
+         *         not in the queue, a failed future will be returned and the command context is released.
+         * @throws NullPointerException if any of the parameters is {@code null}.
+         */
+        public Future<Void> applySendCommandAction(final KafkaBasedCommandContext commandContext,
+                final Supplier<Future<Void>> sendActionSupplier) {
+            Objects.requireNonNull(commandContext);
+            Objects.requireNonNull(sendActionSupplier);
+
+            final Promise<Void> resultPromise = Promise.promise();
+            if (commandContext.equals(queue.peek())) {
+                // the usual case - first command added to the queue is the first command to send to the protocol adapter
+                sendGivenCommandAndNextInQueueIfPossible(queue.remove(), sendActionSupplier, resultPromise);
+            } else if (!queue.contains(commandContext)) {
+                LOG.warn("command can't be sent - not in queue [{}]", commandContext.getCommand());
+                TracingHelper.logError(commandContext.getTracingSpan(), "command can't be sent - not in queue");
+                commandContext.release();
+                resultPromise.fail(new IllegalStateException("command can't be sent - not in queue"));
+            } else {
+                // given command is not next-in-line;
+                // that means determining its target adapter instance has finished sooner (maybe because of fewer data-grid requests)
+                // compared to a command that was received earlier
+                LOG.debug("sending of command with offset {} delayed waiting for processing of offset {} [delayed {}]",
+                        getRecordOffset(commandContext), getRecordOffset(queue.peek()), commandContext.getCommand());
+                commandContext.getTracingSpan()
+                        .log(String.format("waiting for an earlier command with offset %d to be processed first",
+                                getRecordOffset(queue.peek())));
+                commandContext.put(KEY_COMMAND_SEND_ACTION_SUPPLIER_AND_RESULT_PROMISE, Pair
+                        .of(sendActionSupplier, resultPromise));
+            }
+            return resultPromise.future();
+        }
+
+        private void sendGivenCommandAndNextInQueueIfPossible(final KafkaBasedCommandContext commandContext,
+                final Supplier<Future<Void>> sendActionSupplier, final Promise<Void> sendActionCompletedPromise) {
+            LOG.trace("sending [{}]", commandContext.getCommand());
+            // TODO use the supplier result future to keep track of the latest fully processed command record with regard to its partition offset
+            sendActionSupplier.get()
+                    .onComplete(sendActionCompletedPromise);
+            sendNextCommandInQueueIfPossible();
+        }
+
+        private void sendNextCommandInQueueIfPossible() {
+            Optional.ofNullable(queue.peek())
+                    // sendActionSupplierAndResultPromise not null means command is ready to be sent
+                    .map(this::getSendActionSupplierAndResultPromise)
+                    .ifPresent(pair -> sendGivenCommandAndNextInQueueIfPossible(queue.remove(), pair.one(), pair.two()));
+        }
+
+        private Pair<Supplier<Future<Void>>, Promise<Void>> getSendActionSupplierAndResultPromise(
+                final KafkaBasedCommandContext context) {
+            return context.get(KEY_COMMAND_SEND_ACTION_SUPPLIER_AND_RESULT_PROMISE);
+        }
+
+        private long getRecordOffset(final KafkaBasedCommandContext context) {
+            if (context == null) {
+                return -1;
+            }
+            return context.getCommand().getRecord().offset();
+        }
+    }
+}


### PR DESCRIPTION
This is for [#2480].

This serves as a preparation for adding manual offset commits for the Kafka consumer used in the Command Router.
A `HonoKafkaConsumer` class has been introduced here, extracted from the existing code in the `KafkaBasedCommandConsumerFactoryImpl`.
In a subsequent PR, a `ManualOffsetCommitKafkaConsumer` subclass shall be introduced. Preparations for that, including usage of a workaround (using reflection) to allow doing synchronous offset commits when partitions are revoked, are included here.