### PR TITLE
[#2623] Close created Kafka consumers when client is stopped

### DIFF
--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaBasedCommandSender.java
@@ -109,6 +109,7 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
     @SuppressWarnings("rawtypes")
     @Override
     public Future<Void> stop() {
+        // assemble futures for closing the command response consumers
         final List<Future> closeKafkaClientsTracker = commandResponseSubscriptions
                 .keySet()
                 .stream()
@@ -117,9 +118,10 @@ public class KafkaBasedCommandSender extends AbstractKafkaBasedMessageSender
                 .map(MessageConsumer::close)
                 .collect(Collectors.toList());
 
+        // add future for closing command producer
         closeKafkaClientsTracker.add(super.stop());
 
-        return CompositeFuture.all(closeKafkaClientsTracker)
+        return CompositeFuture.join(closeKafkaClientsTracker)
                 .mapEmpty();
     }
 

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AbstractAtLeastOnceKafkaConsumer.java
@@ -251,7 +251,8 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
     }
 
     /**
-     * Closes the underlying Kafka consumer and tries to commit the current offsets before.
+     * Closes the underlying Kafka consumer and tries to commit the current offsets before (if the consumer hasn't
+     * already been stopped).
      * <p>
      * This does not invoke the close handler.
      *
@@ -260,6 +261,9 @@ public abstract class AbstractAtLeastOnceKafkaConsumer<T> implements Lifecycle {
      */
     @Override
     public Future<Void> stop() {
+        if (stopped) {
+            return Future.succeededFuture();
+        }
         return tryCommitAndClose();
     }
 


### PR DESCRIPTION
This is for #2623.

Makes sure the created Kafka consumers get stopped when the `KafkaApplicationClient` is stopped.

This behaviour is analogeous to closing a `ProtonBasedApplicationClient`, where by closing the underlying AMQP connection all receivers are also stopped.