### PR TITLE
Prevent ERROR logs for requests with invalid URI

### DIFF
--- a/service-base/src/main/java/org/eclipse/hono/service/http/DefaultFailureHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/DefaultFailureHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -58,7 +58,7 @@ public class DefaultFailureHandler implements Handler<RoutingContext> {
                 LOG.debug("skipping processing of failed route, response already ended");
             } else {
                 LOG.debug("handling failed route for request [method: {}, URI: {}, status: {}] - {}",
-                        ctx.request().method(), ctx.request().absoluteURI(), ctx.statusCode(), ctx.getBody(),
+                        ctx.request().method(), HttpUtils.getAbsoluteURI(ctx.request()), ctx.statusCode(), ctx.getBody(),
                         ctx.failure());
                 if (ctx.failure() != null) {
                     if (ctx.failure() instanceof ServiceInvocationException) {

--- a/service-base/src/main/java/org/eclipse/hono/service/http/TracingHandler.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/TracingHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,14 +18,14 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Handler;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -36,12 +36,13 @@ import io.vertx.ext.web.RoutingContext;
  * This class has been copied from the <a href="https://github.com/opentracing-contrib/java-vertx-web">
  * OpenTracing Vert.x Web Instrumentation</a> project.
  * It has been adapted to support Opentracing 0.33 and slightly adapted to Hono's code style guide.
+ * Also the used logging framework has been changed to slf4j.
  *
  * @author Pavol Loffay
  */
 public class TracingHandler implements Handler<RoutingContext> {
 
-    public static final String CURRENT_SPAN = TracingHandler.class.getName() + ".severSpan";
+    public static final String CURRENT_SPAN = TracingHandler.class.getName() + ".serverSpan";
 
     private static final Logger log = LoggerFactory.getLogger(TracingHandler.class);
 
@@ -153,7 +154,7 @@ public class TracingHandler implements Handler<RoutingContext> {
             final Span span = (Span) object;
             serverContext = span.context();
         } else {
-            log.error("Sever SpanContext is null or not an instance of SpanContext");
+            log.warn("Server SpanContext is null or not an instance of SpanContext");
         }
 
         return serverContext;

--- a/service-base/src/main/java/org/eclipse/hono/service/http/WebSpanDecorator.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/WebSpanDecorator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -28,6 +28,7 @@ import io.vertx.core.http.HttpServerResponse;
  * This class has been copied from the <a href="https://github.com/opentracing-contrib/java-vertx-web">
  * OpenTracing Vert.x Web Instrumentation</a> project.
  * It has been adapted to support Opentracing 0.33 and slightly adapted to Hono's code style guide.
+ * There have also been minor improvements to the StandardTags inner class.
  *
  * @author Pavol Loffay
  */
@@ -74,14 +75,14 @@ public interface WebSpanDecorator {
         public void onRequest(final HttpServerRequest request, final Span span) {
             Tags.COMPONENT.set(span, "vertx");
             Tags.HTTP_METHOD.set(span, request.method().toString());
-            Tags.HTTP_URL.set(span, request.absoluteURI());
+            Tags.HTTP_URL.set(span, HttpUtils.getAbsoluteURI(request));
         }
 
         @Override
         public void onReroute(final HttpServerRequest request, final Span span) {
             final Map<String, String> logs = new HashMap<>(2);
             logs.put("event", "reroute");
-            logs.put(Tags.HTTP_URL.getKey(), request.absoluteURI());
+            logs.put(Tags.HTTP_URL.getKey(), HttpUtils.getAbsoluteURI(request));
             logs.put(Tags.HTTP_METHOD.getKey(), request.method().toString());
             span.log(logs);
         }

--- a/service-base/src/test/java/org/eclipse/hono/service/http/HttpUtilsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/http/HttpUtilsTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.service.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.http.HttpServerRequest;
+
+/**
+ * Test verifying functionality of the {@link HttpUtils} class.
+ */
+public class HttpUtilsTest {
+
+    /**
+     * Verifies that trying to get the absolute URI for a request with
+     * an invalid URI doesn't return {@code null}.
+     */
+    @Test
+    public void testGetAbsoluteURIReturnsNotNullForInvalidURI() {
+        final String scheme = "http";
+        final String host = "localhost";
+        final String relativeUri = "/index.php?s=/Index/\\think";
+        assertThrows(URISyntaxException.class, () -> new URI(relativeUri));
+
+        final HttpServerRequest req = mock(HttpServerRequest.class);
+        when(req.uri()).thenReturn(relativeUri);
+        when(req.scheme()).thenReturn(scheme);
+        when(req.host()).thenReturn(host);
+        final String absoluteURI = HttpUtils.getAbsoluteURI(req);
+
+        assertThat(absoluteURI).isEqualTo(scheme + "://" + host + relativeUri);
+    }
+
+}

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpointTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpointTest.java
@@ -61,8 +61,6 @@ import io.vertx.ext.web.Router;
 public class DelegatingDeviceManagementHttpEndpointTest {
 
     private DeviceManagementService service;
-    private DelegatingDeviceManagementHttpEndpoint<DeviceManagementService> endpoint;
-    private Vertx vertx;
     private Router router;
     private MultiMap requestParams;
     private MultiMap requestHeaders;
@@ -75,7 +73,7 @@ public class DelegatingDeviceManagementHttpEndpointTest {
     @BeforeEach
     public void setUp() {
 
-        vertx = mock(Vertx.class);
+        final Vertx vertx = mock(Vertx.class);
         router = Router.router(vertx);
         // make sure that ServiceInvocationExceptions are properly handled
         // and result in the exception's error code being set on the response
@@ -96,7 +94,7 @@ public class DelegatingDeviceManagementHttpEndpointTest {
                 any(List.class),
                 any(Span.class)))
             .thenReturn(Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_OK)));
-        endpoint = new DelegatingDeviceManagementHttpEndpoint<DeviceManagementService>(vertx, service);
+        final var endpoint = new DelegatingDeviceManagementHttpEndpoint<>(vertx, service);
         endpoint.setConfiguration(new ServiceConfigProperties());
         endpoint.addRoutes(router);
         requestParams = MultiMap.caseInsensitiveMultiMap();
@@ -430,14 +428,17 @@ public class DelegatingDeviceManagementHttpEndpointTest {
 
     private static HttpServerRequest newRequest(
             final HttpMethod method,
-            final String path,
+            final String relativeURI,
             final MultiMap requestHeaders,
             final MultiMap requestParams,
             final HttpServerResponse response) {
 
         final HttpServerRequest request = mock(HttpServerRequest.class);
         when(request.method()).thenReturn(method);
-        when(request.path()).thenReturn(path);
+        when(request.scheme()).thenReturn("http");
+        when(request.host()).thenReturn("localhost");
+        when(request.uri()).thenReturn(relativeURI);
+        when(request.path()).thenReturn(relativeURI);
         when(request.headers()).thenReturn(requestHeaders);
         when(request.params()).thenReturn(requestParams);
         when(request.response()).thenReturn(response);


### PR DESCRIPTION
When the HTTP adapter receives a request with a URI that contains illegal characters, there are 4 ERROR log entries created each time, all from places in the code where either a log entry or tracing span output gets written (in `ComponentMetaDataDecorator` and `DefaultFailureHandler`).
Example:
````
ERROR io.vertx.core.http.impl.HttpServerRequestImpl Failed to create abs uri
java.net.URISyntaxException: Illegal character in query at index 20: /index.php?s=/Index/\think\app/invokefunction&function=call_user_func_array&vars[0]=md5&vars[1][]=HelloThinkPHP21
	at java.base/java.net.URI$Parser.fail(Unknown Source)
	at java.base/java.net.URI$Parser.checkChars(Unknown Source)
	at java.base/java.net.URI$Parser.parseHierarchical(Unknown Source)
	at java.base/java.net.URI$Parser.parse(Unknown Source)
	at java.base/java.net.URI.<init>(Unknown Source)
	at io.vertx.core.http.impl.HttpUtils.absoluteURI(HttpUtils.java:366)
	at io.vertx.core.http.impl.HttpServerRequestImpl.absoluteURI(HttpServerRequestImpl.java:372)
	at io.vertx.ext.web.impl.HttpServerRequestWrapper.absoluteURI(HttpServerRequestWrapper.java:234)
->	at org.eclipse.hono.service.http.ComponentMetaDataDecorator.onRequest(ComponentMetaDataDecorator.java:65)
	at org.eclipse.hono.service.http.TracingHandler.lambda$handlerNormal$1(TracingHandler.java:109)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at org.eclipse.hono.service.http.TracingHandler.handlerNormal(TracingHandler.java:108)
````
The ERROR log comes from the vert.x `HttpServerRequestImpl#absoluteURI` method catching that exception and logging it.