### PR TITLE
Expose tenant information service needed for tenant existence check in device registry

### DIFF
--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -31,6 +31,7 @@ import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
 import org.eclipse.hono.deviceregistry.service.deviceconnection.MapBasedDeviceConnectionsConfigProperties;
 import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantInformationService;
+import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.util.ServiceClientAdapter;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.http.HttpEndpoint;
@@ -40,10 +41,12 @@ import org.eclipse.hono.service.management.device.DelegatingDeviceManagementHttp
 import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.management.tenant.DelegatingTenantManagementHttpEndpoint;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
+import org.eclipse.hono.service.tenant.TenantService;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessagingType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -103,6 +106,17 @@ public class FileBasedServiceConfig {
     @Bean
     public FileBasedTenantService tenantService() {
         return new FileBasedTenantService(vertx);
+    }
+
+    /**
+     * Creates an instance of the tenant information service based on the file based tenant service as a Spring Bean.
+     *
+     * @return The service.
+     */
+    @Bean
+    @ConditionalOnBean(TenantService.class)
+    public TenantInformationService tenantInformationService() {
+        return new AutowiredTenantInformationService();
     }
 
     /**

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -44,6 +44,7 @@ import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
 import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantInformationService;
+import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.util.ServiceClientAdapter;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
@@ -473,6 +474,18 @@ public class ApplicationConfig {
     @Profile(Profiles.PROFILE_REGISTRY_ADAPTER + " & " + Profiles.PROFILE_TENANT_SERVICE)
     public TenantService tenantService() throws IOException {
         return new TenantServiceImpl(tenantAdapterStore(), tenantServiceProperties());
+    }
+
+    /**
+     * Provide a tenant information service, backed by the JDBC tenant service instance.
+     *
+     * @return The bean instance.
+     */
+    @Bean
+    @Scope("prototype")
+    @ConditionalOnBean(TenantService.class)
+    public TenantInformationService tenantInformationService() {
+        return new AutowiredTenantInformationService();
     }
 
     /**

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -43,6 +43,7 @@ import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
 import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantInformationService;
+import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.util.ServiceClientAdapter;
 import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.VertxBasedHealthCheckServer;
@@ -68,6 +69,7 @@ import org.eclipse.hono.util.MessagingType;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -435,6 +437,18 @@ public class ApplicationConfig {
         );
         healthCheckServer().registerHealthCheckResources(service);
         return service;
+    }
+
+    /**
+     * Exposes the tenant information service based on the MongoDB tenant service as a Spring Bean.
+     *
+     * @return The bean instance.
+     */
+    @Bean
+    @Scope("prototype")
+    @ConditionalOnBean(TenantService.class)
+    public TenantInformationService tenantInformationService() {
+        return new AutowiredTenantInformationService();
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -380,7 +380,6 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
         final VertxTestContext setup = new VertxTestContext();
 
         helper.registry.addDeviceForTenant(tenantId, tenant, deviceId, password).onComplete(setup.completing());
-        final String gatewayManagedDevice = helper.setupGatewayDeviceBlocking(tenantId, deviceId, 5);
 
         assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
         if (setup.failed()) {
@@ -388,6 +387,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
             return;
         }
 
+        final String gatewayManagedDevice = helper.setupGatewayDeviceBlocking(tenantId, deviceId, 5);
         testUploadMessageWithInvalidContentType(ctx, tenantId, deviceId, gatewayManagedDevice);
     }
 


### PR DESCRIPTION
Any device registration operation first checks if the given tenant exists or not
using tenant information service. Currently the device registry implementations
use a `NoopTenantInformationService` as there is no tenant information bean is
exposed in their `ApplicationConfig`. This has been fixed now.