### PR TITLE
[#2480] Implement and use Kafka consumer with own auto-commit

### DIFF
--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumer.java
@@ -1,0 +1,454 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.kafka.consumer;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.hono.util.Pair;
+import org.eclipse.hono.util.Strings;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * A Kafka consumer that automatically commits partition offsets corresponding to the latest record per
+ * partition whose (asynchronous) handling has been marked as completed.
+ * <p>
+ * A scenario that this consumer addresses is one of a received record taking quite long to be handled asynchronously
+ * while the consumer is closed and the application exits. With the standard <em>enable.auto.commit</em> behaviour,
+ * an offset commit for that record will already be done on closing the consumer so that another consumer of the
+ * consumer group won't read that record again, meaning the record potentially only gets partially handled.
+ * Using the auto-commit implementation in this class, only the offset of a record whose handling was marked as
+ * completed gets committed. This prevents incompletely handled records and thereby enables at-least-once semantics.
+ * <p>
+ * In terms of when offsets are committed, the behaviour is similar to the one used for a consumer with
+ * <em>enable.auto.commit</em>. Commits are done periodically (using <em>commitAsync</em>) and when a rebalance
+ * happens or the consumer is stopped (using <em>commitSync</em>). The periodic commit interval is defined via
+ * the standard <em>auto.commit.interval.ms</em> configuration property.
+ * <p>
+ * In order to not fall behind with the position of the committed offset vs. the last received offset, users of this
+ * class have to make sure that the record handling function, which provides the completion Future, is completed in time.
+ * <p>
+ * In contrast to the <em>enable.auto.commit</em> behaviour, identical offsets are skipped during successive commits.
+ * It is only after a period defined by <em>hono.offsets.skip.recommit.period.seconds</em> has elapsed, that such offsets
+ * are committed again. This is to make sure that such offsets don't reach their retention time, provided the recommit
+ * period is lower than the <em>offsets.retention.minutes</em> broker config value.
+ */
+public class AsyncHandlingAutoCommitKafkaConsumer extends HonoKafkaConsumer {
+
+    /**
+     * The name of the configuration property to define the period for which committing an already committed offset is
+     * skipped, until it may be recommitted if it is still the latest offset.
+     */
+    public static final String CONFIG_HONO_OFFSETS_SKIP_RECOMMIT_PERIOD_SECONDS = "hono.offsets.skip.recommit.period.seconds";
+    /**
+     * The default periodic commit interval.
+     */
+    public static final Duration DEFAULT_COMMIT_INTERVAL = Duration.ofSeconds(5);
+    /**
+     * The default period for which committing an already committed offset is skipped,
+     * until it may be recommitted if it is still the latest offset.
+     */
+    public static final Duration DEFAULT_OFFSETS_SKIP_RECOMMIT_PERIOD = Duration.ofMinutes(30);
+
+    private final long commitIntervalMillis;
+    private final long skipOffsetRecommitPeriodSeconds;
+    private final Map<TopicPartition, TopicPartitionOffsets> offsetsMap = new HashMap<>();
+    private final AtomicBoolean periodicCommitInvocationInProgress = new AtomicBoolean();
+
+    private Long periodicCommitTimerId;
+
+    /**
+     * Creates a consumer to receive records on the given topics.
+     * <p>
+     * Partition offsets returned by invoking the given supplier are committed periodically and
+     * when a rebalance happens. The periodic commit interval is taken from the
+     * <em>auto.commit.interval.ms</em> config value.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param topics The Kafka topic to consume records from.
+     * @param recordHandler The function to be invoked for each received record. The completion of its Future return
+     *                      value marks the record handling as finished so that the corresponding offset may be committed.
+     * @param consumerConfig The Kafka consumer configuration.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws IllegalArgumentException if the consumerConfig is missing a "group.id" entry.
+     */
+    public AsyncHandlingAutoCommitKafkaConsumer(
+            final Vertx vertx,
+            final Set<String> topics,
+            final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> recordHandler,
+            final Map<String, String> consumerConfig) {
+        this(new AtomicReference<>(), vertx, topics, null, recordHandler, consumerConfig);
+    }
+
+    /**
+     * Creates a consumer to receive records on topics that match the given pattern.
+     * <p>
+     * Partition offsets returned by invoking the given supplier are committed periodically and
+     * when a rebalance happens. The periodic commit interval is taken from the
+     * <em>auto.commit.interval.ms</em> config value.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param topicPattern The pattern of Kafka topic names to consume records from.
+     * @param recordHandler The function to be invoked for each received record. The completion of its Future return
+     *                      value marks the record handling as finished so that the corresponding offset may be committed.
+     * @param consumerConfig The Kafka consumer configuration.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @throws IllegalArgumentException if the consumerConfig is missing a "group.id" entry.
+     */
+    public AsyncHandlingAutoCommitKafkaConsumer(
+            final Vertx vertx,
+            final Pattern topicPattern,
+            final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> recordHandler,
+            final Map<String, String> consumerConfig) {
+        this(new AtomicReference<>(), vertx, null, topicPattern, recordHandler, consumerConfig);
+    }
+
+    private AsyncHandlingAutoCommitKafkaConsumer(
+            final AtomicReference<AsyncHandlingAutoCommitKafkaConsumer> selfRef,
+            final Vertx vertx,
+            final Set<String> topics,
+            final Pattern topicPattern,
+            final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> recordHandler,
+            final Map<String, String> consumerConfig) {
+        super(vertx, topics, topicPattern, mapRecordHandler(selfRef, recordHandler), validateAndAdaptConsumerConfig(consumerConfig));
+        selfRef.setPlain(this);
+
+        this.commitIntervalMillis = getCommitInterval(consumerConfig);
+        this.skipOffsetRecommitPeriodSeconds = getSkipOffsetRecommitPeriodSeconds(consumerConfig);
+    }
+
+    private static Handler<KafkaConsumerRecord<String, Buffer>> mapRecordHandler(
+            final AtomicReference<AsyncHandlingAutoCommitKafkaConsumer> selfRef,
+            final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> recordHandler) {
+        return record -> {
+            final OffsetsQueueEntry offsetsQueueEntry = selfRef.getPlain().setRecordReceived(record);
+            recordHandler.apply(record)
+                    .onComplete(ar -> offsetsQueueEntry.setHandlingComplete());
+        };
+    }
+
+    private static Map<String, String> validateAndAdaptConsumerConfig(final Map<String, String> consumerConfig) {
+        if (Strings.isNullOrEmpty(consumerConfig.get(ConsumerConfig.GROUP_ID_CONFIG))) {
+            throw new IllegalArgumentException(ConsumerConfig.GROUP_ID_CONFIG + " config entry has to be set");
+        }
+        consumerConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        return consumerConfig;
+    }
+
+    private static long getCommitInterval(final Map<String, String> consumerConfig) {
+        return Optional.ofNullable(consumerConfig.get(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG))
+                .map(Long::parseLong)
+                .orElse(DEFAULT_COMMIT_INTERVAL.toMillis());
+    }
+
+    private static long getSkipOffsetRecommitPeriodSeconds(final Map<String, String> consumerConfig) {
+        return Optional.ofNullable(consumerConfig.get(CONFIG_HONO_OFFSETS_SKIP_RECOMMIT_PERIOD_SECONDS))
+                .map(Long::parseLong)
+                .orElse(DEFAULT_OFFSETS_SKIP_RECOMMIT_PERIOD.toSeconds());
+    }
+
+    @Override
+    public Future<Void> start() {
+        return super.start().onComplete(v -> startPeriodicCommitTimer());
+    }
+
+    @Override
+    public Future<Void> stop() {
+        if (periodicCommitTimerId != null) {
+            vertx.cancelTimer(periodicCommitTimerId);
+        }
+        return super.stop();
+    }
+
+    @Override
+    protected void onPartitionsAssignedBlocking(final Set<io.vertx.kafka.client.common.TopicPartition> partitionsSet) {
+        final Consumer<String, Buffer> wrappedConsumer = getKafkaConsumer().asStream().unwrap();
+        clearObsoleteTopicPartitionOffsets(wrappedConsumer.assignment());
+    }
+
+    @Override
+    protected void onPartitionsRevokedBlocking(final Set<io.vertx.kafka.client.common.TopicPartition> partitionsSet) {
+        commitOffsetsSync();
+    }
+
+    /**
+     * To be run on the Kafka polling thread.
+     */
+    private void commitOffsetsSync() {
+        if (Vertx.currentContext() != null) {
+            throw new IllegalStateException("must be run on the polling thread");
+        }
+        final Map<TopicPartition, OffsetAndMetadata> offsets = getOffsetsToCommit();
+        if (!offsets.isEmpty()) {
+            try {
+                if (log.isTraceEnabled()) {
+                    log.trace("commitSync; offsets: [{}]", HonoKafkaConsumerHelper.getOffsetsDebugString(offsets));
+                }
+                // commit invoked on the wrappedConsumer, so that it is run synchronously on the current thread
+                final Consumer<String, Buffer> wrappedConsumer = getKafkaConsumer().asStream().unwrap();
+                wrappedConsumer.commitSync(offsets);
+                setCommittedOffsets(offsets);
+                log.trace("commitSync succeeded");
+            } catch (final Exception e) {
+                log.warn("commit failed: {}", e.toString());
+            }
+        } else {
+            log.trace("skip commitSync - no offsets to commit");
+        }
+    }
+
+    private void startPeriodicCommitTimer() {
+        periodicCommitTimerId = vertx.setPeriodic(commitIntervalMillis, tid -> {
+            if (!periodicCommitInvocationInProgress.compareAndSet(false, true)) {
+                log.trace("periodic commit already triggered, skipping invocation");
+                return;
+            }
+            // run periodic commit on the kafka polling thread, to be able to call commitAsync (not provided by the vert.x KafkaConsumer)
+            runOnKafkaWorkerThread(v -> {
+                final var offsets = getOffsetsToCommit();
+                if (!offsets.isEmpty()) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("do periodic commit; offsets: [{}]", HonoKafkaConsumerHelper.getOffsetsDebugString(offsets));
+                    }
+                    final Consumer<String, Buffer> wrappedConsumer = getKafkaConsumer().asStream().unwrap();
+                    wrappedConsumer.commitAsync(offsets, (committedOffsets, error) -> {
+                        if (error != null) {
+                            log.info("periodic commit failed: {}", error.toString());
+                        } else {
+                            log.trace("periodic commit succeeded");
+                            setCommittedOffsets(committedOffsets);
+                        }
+                    });
+                } else {
+                    log.trace("skip periodic commit - no offsets to commit");
+                }
+                periodicCommitInvocationInProgress.set(false);
+            });
+        });
+    }
+
+    // synchronized because offsetsMap is accessed from vert.x event loop and kafka polling thread
+    private synchronized OffsetsQueueEntry setRecordReceived(final KafkaConsumerRecord<String, Buffer> record) {
+        final TopicPartition topicPartition = new TopicPartition(record.topic(), record.partition());
+        return offsetsMap
+                .computeIfAbsent(topicPartition, k -> new TopicPartitionOffsets(topicPartition))
+                .addOffset(record.offset());
+    }
+
+    // synchronized because offsetsMap is accessed from vert.x event loop and kafka polling thread
+    private synchronized void clearObsoleteTopicPartitionOffsets(final Collection<TopicPartition> currentlyAssignedPartitions) {
+        Objects.requireNonNull(currentlyAssignedPartitions);
+        final var partitionOffsetsIterator = offsetsMap.entrySet().iterator();
+        while (partitionOffsetsIterator.hasNext()) {
+            final var topicPartitionOffsetsEntry = partitionOffsetsIterator.next();
+            if (!currentlyAssignedPartitions.contains(topicPartitionOffsetsEntry.getKey())) {
+                if (!topicPartitionOffsetsEntry.getValue().allCompleted()) {
+                    log.debug("partition [{}] not assigned to consumer anymore but not all entries completed yet!",
+                            topicPartitionOffsetsEntry.getKey());
+                } else if (topicPartitionOffsetsEntry.getValue().needsCommit()) {
+                    log.warn("partition [{}] not assigned to consumer anymore but offset corresponding to the latest handled record hasn't been committed yet!",
+                            topicPartitionOffsetsEntry.getKey());
+                } else {
+                    log.trace("partition [{}] not assigned to consumer anymore; no still outstanding offset commits there",
+                            topicPartitionOffsetsEntry.getKey());
+                }
+                partitionOffsetsIterator.remove();
+            }
+        }
+    }
+
+    // synchronized because offsetsMap is accessed from vert.x event loop and kafka polling thread
+    private synchronized Map<TopicPartition, OffsetAndMetadata> getOffsetsToCommit() {
+        return offsetsMap.entrySet().stream()
+                // map each to key/value Pair only if offsets needs to be committed
+                .flatMap(entry -> entry.getValue().getLastSequentiallyCompletedOffsetForCommit().stream()
+                        .map(uncommittedOffset -> Pair.of(entry.getKey(),
+                                new OffsetAndMetadata(uncommittedOffset + 1, ""))))
+                .collect(Collectors.toMap(Pair::one, Pair::two));
+    }
+
+    // synchronized because offsetsMap is accessed from vert.x event loop and kafka polling thread
+    private synchronized void setCommittedOffsets(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        offsets.forEach((partition, offsetAndMetadata) -> {
+            Optional.ofNullable(offsetsMap.get(partition))
+                    .ifPresent(queue -> queue.setLastCommittedOffset(offsetAndMetadata.offset() - 1));
+        });
+    }
+
+    /**
+     * Keeps offset data for a TopicPartition.
+     */
+    class TopicPartitionOffsets {
+
+        private final TopicPartition topicPartition;
+        private final Deque<OffsetsQueueEntry> queue = new LinkedList<>();
+
+        private long lastSequentiallyCompletedOffset = -1;
+        private long lastCommittedOffset = -1;
+        private Instant lastCommitTime;
+
+        /**
+         * Creates a new TopicPartitionOffsets object.
+         *
+         * @param topicPartition The topic partition to store the offsets for.
+         * @throws NullPointerException if topicPartition is {@code null}.
+         */
+        TopicPartitionOffsets(final TopicPartition topicPartition) {
+            this.topicPartition = Objects.requireNonNull(topicPartition);
+        }
+
+        /**
+         * Registers the given offset. To be invoked when the record has just been received.
+         * @param offset The offset to register.
+         * @return The added queue entry.
+         */
+        public OffsetsQueueEntry addOffset(final long offset) {
+            cleanupAndUpdateLastCompletedOffset();
+            final OffsetsQueueEntry queueEntry = new OffsetsQueueEntry(offset);
+            queue.add(queueEntry);
+            return queueEntry;
+        }
+
+        /**
+         * Gets the partition offset to use for an offset commit. That is the offset of the last record in the row of
+         * fully handled records if it either hasn't been committed yet or the time of the last commit is older than
+         * the 'skipOffsetRecommitPeriodSeconds'. Note that for the actual commit, {@code 1} has to be added to the
+         * returned value.
+         * <p>
+         * Otherwise an empty Optional is returned.
+         *
+         * @return The offset wrapped in an Optional or an empty Optional if no offset commit is needed.
+         */
+        public Optional<Long> getLastSequentiallyCompletedOffsetForCommit() {
+            cleanupAndUpdateLastCompletedOffset();
+            if (lastSequentiallyCompletedOffset == -1) {
+                return Optional.empty();
+            }
+            if (!queue.isEmpty()) {
+                log.trace("getOffsetsToCommit: record with offset {} to use for commit is {} entries behind last received offset {}; partition [{}]",
+                        lastSequentiallyCompletedOffset, queue.size(), queue.getLast().getOffset(), topicPartition);
+            }
+            if (lastSequentiallyCompletedOffset != lastCommittedOffset) {
+                return Optional.of(lastSequentiallyCompletedOffset);
+            } else if (lastCommitTime != null
+                    && lastCommitTime.isBefore(Instant.now().minusSeconds(skipOffsetRecommitPeriodSeconds))) {
+                log.trace("getOffsetsToCommit: record with offset {} will be recommitted (last commit {} too long ago); partition [{}]",
+                        lastSequentiallyCompletedOffset, lastCommitTime, topicPartition);
+                return Optional.of(lastSequentiallyCompletedOffset);
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        private void cleanupAndUpdateLastCompletedOffset() {
+            while (Optional.ofNullable(queue.peek()).map(OffsetsQueueEntry::isHandlingComplete).orElse(false)) {
+                lastSequentiallyCompletedOffset = queue.remove().getOffset();
+            }
+        }
+
+        /**
+         * Marks the given offset (as returned by {@link #getLastSequentiallyCompletedOffsetForCommit()}) as
+         * committed. Note that the offset here is the offset of the last completed record, the value in the actual
+         * commit is this value plus {@code 1}.
+         *
+         * @param offset The offset to set.
+         */
+        public void setLastCommittedOffset(final long offset) {
+            if (offset >= lastCommittedOffset) {
+                this.lastCommitTime = Instant.now();
+                this.lastCommittedOffset = offset;
+            }
+        }
+
+        /**
+         * Checks whether all received records have been marked as completed.
+         *
+         * @return {@code true} if all received records are completed.
+         */
+        public boolean allCompleted() {
+            cleanupAndUpdateLastCompletedOffset();
+            return queue.isEmpty();
+        }
+
+        /**
+         * Checks whether there is an already completed record whose offset hasn't been committed yet.
+         * @return {@code true} if an offset commit is needed for this TopicPartition.
+         */
+        public boolean needsCommit() {
+            cleanupAndUpdateLastCompletedOffset();
+            return lastSequentiallyCompletedOffset != -1 && lastSequentiallyCompletedOffset != lastCommittedOffset;
+        }
+    }
+
+    /**
+     * An entry used in the TopicPartitionOffsets.
+     */
+    static class OffsetsQueueEntry {
+        private final long offset;
+        private final AtomicBoolean handlingComplete = new AtomicBoolean();
+
+        /**
+         * Creates a new OffsetsQueueEntry.
+         * @param offset The offset of the entry.
+         */
+        OffsetsQueueEntry(final long offset) {
+            this.offset = offset;
+        }
+
+        /**
+         * Gets the offset.
+         * @return The offset.
+         */
+        public long getOffset() {
+            return offset;
+        }
+
+        /**
+         * Marks the handling of the record corresponding to this entry as completed.
+         */
+        public void setHandlingComplete() {
+            handlingComplete.set(true);
+        }
+
+        /**
+         * Checks whether the handling of the record corresponding to this entry has been marked as completed.
+         * @return {@code true} if record handling is complete.
+         */
+        public boolean isHandlingComplete() {
+            return handlingComplete.get();
+        }
+    }
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerHelper.java
@@ -15,10 +15,14 @@ package org.eclipse.hono.client.kafka.consumer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -92,13 +96,28 @@ public abstract class HonoKafkaConsumerHelper {
      * @return The string representation.
      * @throws NullPointerException if partitionsSet is {@code null}.
      */
-    public static String getPartitionsDebugString(final Collection<io.vertx.kafka.client.common.TopicPartition> partitionsSet) {
+    public static String getPartitionsDebugString(final Collection<TopicPartition> partitionsSet) {
         Objects.requireNonNull(partitionsSet);
         return partitionsSet.size() <= 20 // skip details for larger set
                 ? partitionsSet.stream()
-                .collect(Collectors.groupingBy(io.vertx.kafka.client.common.TopicPartition::getTopic,
-                        Collectors.mapping(io.vertx.kafka.client.common.TopicPartition::getPartition, Collectors.toCollection(TreeSet::new))))
+                .collect(Collectors.groupingBy(TopicPartition::topic,
+                        Collectors.mapping(TopicPartition::partition, Collectors.toCollection(TreeSet::new))))
                 .toString()
                 : partitionsSet.size() + " topic partitions";
+    }
+
+    /**
+     * Returns a string representation of the given offsets, to be used for debug/trace log messages.
+     *
+     * @param offsets The offsets to use.
+     * @return The string representation.
+     * @throws NullPointerException if offsets is {@code null}.
+     */
+    public static String getOffsetsDebugString(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        Objects.requireNonNull(offsets);
+        return offsets.size() <= 20 // skip details for larger map
+                ? offsets.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().offset())).toString()
+                : offsets.size() + " offsets";
     }
 }

--- a/clients/kafka-common/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-client-kafka-common/reflection-config.json
+++ b/clients/kafka-common/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-client-kafka-common/reflection-config.json
@@ -16,5 +16,12 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl",
+    "fields" : [
+      { "name" : "rebalanceListener", "allowWrite" : true },
+      { "name" : "worker", "allowWrite" : true }
+    ]
   }
 ]

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumerTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumerTest.java
@@ -1,0 +1,492 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.client.kafka.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * Verifies the behavior of {@link AsyncHandlingAutoCommitKafkaConsumer}.
+ */
+@Timeout(value = 20, timeUnit = TimeUnit.SECONDS)
+@ExtendWith(VertxExtension.class)
+public class AsyncHandlingAutoCommitKafkaConsumerTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncHandlingAutoCommitKafkaConsumerTest.class);
+
+    private static final String TOPIC = "test.topic";
+    private static final String TOPIC2 = "test.topic2";
+    private static final Pattern TOPIC_PATTERN = Pattern.compile(Pattern.quote("test.") + ".*");
+    private static final int PARTITION = 0;
+    private static final TopicPartition topicPartition = new TopicPartition(TOPIC, PARTITION);
+    private static final TopicPartition topic2Partition = new TopicPartition(TOPIC2, PARTITION);
+    private static final Node LEADER = new Node(1, "broker1", 9092);
+
+    private KafkaConsumerConfigProperties consumerConfigProperties;
+    private Vertx vertx;
+    private Context context;
+    private HonoKafkaConsumer consumer;
+    private KafkaMockConsumer mockConsumer;
+
+    /**
+     * Sets up fixture.
+     *
+     * @param vertx The vert.x instance.
+     */
+    @BeforeEach
+    public void setUp(final Vertx vertx) {
+        this.vertx = vertx;
+        context = vertx.getOrCreateContext();
+
+        mockConsumer = new KafkaMockConsumer(OffsetResetStrategy.LATEST);
+
+        final Map<String, String> commonProperties = Map.of(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "servers");
+        consumerConfigProperties = new KafkaConsumerConfigProperties();
+        consumerConfigProperties.setCommonClientConfig(commonProperties);
+    }
+
+    /**
+     * Verifies that trying to create a consumer without a group.id in the config fails.
+     */
+    @Test
+    public void testConsumerCreationFailsForMissingGroupId() {
+        final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> handler = record -> {
+            LOG.debug("{}", record);
+            return Future.succeededFuture();
+        };
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+
+        assertThatThrownBy(() -> {
+            new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of("test"), handler, consumerConfig);
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /**
+     * Verifies that trying to create a consumer with a topic list succeeds.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testConsumerCreationWithTopicListSucceeds(final VertxTestContext ctx) {
+        final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> handler = record -> Future.succeededFuture();
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+
+        consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.updatePartitions(TOPIC, List.of(getPartitionInfo(TOPIC, PARTITION)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition));
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.completing());
+        });
+    }
+
+    /**
+     * Verifies that trying to create a consumer with a topic pattern succeeds.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testConsumerCreationWithTopicPatternSucceeds(final VertxTestContext ctx) {
+        final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> handler = record -> Future.succeededFuture();
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+
+        consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, TOPIC_PATTERN, handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.updatePartitions(TOPIC, List.of(getPartitionInfo(TOPIC, PARTITION)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition));
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.completing());
+        });
+    }
+
+    /**
+     * Verifies that the consumer commits the last fully handled records on rebalance.
+     *
+     * @param ctx The vert.x test context.
+     * @throws InterruptedException if the test execution gets interrupted.
+     */
+    @Test
+    public void testConsumerCommitsOffsetsOnRebalance(final VertxTestContext ctx) throws InterruptedException {
+        final int numTestRecords = 5;
+        final VertxTestContext receivedRecordsCtx = new VertxTestContext();
+        final Checkpoint receivedRecordsCheckpoint = receivedRecordsCtx.checkpoint(numTestRecords);
+        final Map<Long, Promise<Void>> recordsHandlingPromiseMap = new HashMap<>();
+        final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> handler = record -> {
+            final Promise<Void> promise = Promise.promise();
+            if (recordsHandlingPromiseMap.put(record.offset(), promise) != null) {
+                receivedRecordsCtx.failNow(new IllegalStateException("received record with duplicate offset"));
+            }
+            receivedRecordsCheckpoint.flag();
+            return promise.future();
+        };
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        consumerConfig.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "300000"); // periodic commit shall not play a role here
+
+        consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.updatePartitions(TOPIC, List.of(getPartitionInfo(TOPIC, PARTITION)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition));
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.succeeding(v2 -> {
+                mockConsumer.schedulePollTask(() -> {
+                    IntStream.range(0, numTestRecords).forEach(offset -> {
+                        mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, PARTITION, offset, "key_" + offset, Buffer.buffer()));
+                    });
+                });
+            }));
+        });
+        assertThat(receivedRecordsCtx.awaitCompletion(5, TimeUnit.SECONDS))
+                .as("records received in 5s").isTrue();
+        if (receivedRecordsCtx.failed()) {
+            ctx.failNow(receivedRecordsCtx.causeOfFailure());
+            return;
+        }
+
+        // records received, complete the handling of some of them
+        recordsHandlingPromiseMap.get(0L).complete();
+        recordsHandlingPromiseMap.get(1L).complete();
+        // offset 3 not completed yet, hence offset 1 is the latest in the row of fully handled records
+        final AtomicInteger latestFullyHandledOffset = new AtomicInteger(1);
+        recordsHandlingPromiseMap.get(4L).complete();
+
+        // define VertxTestContexts for 3 checks (3x rebalance/commit)
+        final AtomicInteger checkIndex = new AtomicInteger(0);
+        final List<VertxTestContext> commitCheckContexts = IntStream.range(0, 3)
+                .mapToObj(i -> new VertxTestContext()).collect(Collectors.toList());
+        final List<Checkpoint> commitCheckpoints = commitCheckContexts.stream()
+                .map(c -> c.checkpoint(1)).collect(Collectors.toList());
+        final InterruptableSupplier<Boolean> waitForCurrentCommitCheckResult = () -> {
+            assertThat(commitCheckContexts.get(checkIndex.get()).awaitCompletion(5, TimeUnit.SECONDS))
+                    .as("partition assigned in 5s for checking of commits").isTrue();
+            if (commitCheckContexts.get(checkIndex.get()).failed()) {
+                ctx.failNow(commitCheckContexts.get(checkIndex.get()).causeOfFailure());
+                return false;
+            }
+            return true;
+        };
+
+        consumer.setOnPartitionsAssignedHandler(partitions -> {
+            final Map<TopicPartition, OffsetAndMetadata> committed = mockConsumer.committed(Set.of(topicPartition));
+            ctx.verify(() -> {
+                final OffsetAndMetadata offsetAndMetadata = committed.get(topicPartition);
+                assertThat(offsetAndMetadata).isNotNull();
+                assertThat(offsetAndMetadata.offset()).isEqualTo(latestFullyHandledOffset.get() + 1L);
+            });
+            commitCheckpoints.get(checkIndex.get()).flag();
+        });
+        // now force a rebalance which should trigger the above onPartitionsAssignedHandler
+        mockConsumer.rebalance(List.of(topicPartition));
+        if (!waitForCurrentCommitCheckResult.get()) {
+            return;
+        }
+        checkIndex.incrementAndGet();
+
+        // now another rebalance (ie. commit trigger) - no change in offsets
+        mockConsumer.rebalance(List.of(topicPartition));
+        if (!waitForCurrentCommitCheckResult.get()) {
+            return;
+        }
+        checkIndex.incrementAndGet();
+
+        // now complete some more promises
+        recordsHandlingPromiseMap.get(2L).complete();
+        recordsHandlingPromiseMap.get(3L).complete();
+        // offset 4 already complete
+        latestFullyHandledOffset.set(4);
+        // again rebalance/commit
+        mockConsumer.rebalance(List.of(topicPartition));
+        if (waitForCurrentCommitCheckResult.get()) {
+            ctx.completeNow();
+        }
+    }
+
+    /**
+     * Verifies that the consumer commits the last fully handled records when it is stopped.
+     *
+     * @param ctx The vert.x test context.
+     * @throws InterruptedException if the test execution gets interrupted.
+     */
+    @Test
+    public void testConsumerCommitsOffsetsOnStop(final VertxTestContext ctx) throws InterruptedException {
+        final int numTestRecords = 5;
+        final VertxTestContext receivedRecordsCtx = new VertxTestContext();
+        final Checkpoint receivedRecordsCheckpoint = receivedRecordsCtx.checkpoint(numTestRecords);
+        final Map<Long, Promise<Void>> recordsHandlingPromiseMap = new HashMap<>();
+        final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> handler = record -> {
+            final Promise<Void> promise = Promise.promise();
+            if (recordsHandlingPromiseMap.put(record.offset(), promise) != null) {
+                receivedRecordsCtx.failNow(new IllegalStateException("received record with duplicate offset"));
+            }
+            receivedRecordsCheckpoint.flag();
+            return promise.future();
+        };
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        consumerConfig.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "300000"); // periodic commit shall not play a role here
+
+        consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.updatePartitions(TOPIC, List.of(getPartitionInfo(TOPIC, PARTITION)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition));
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.succeeding(v2 -> {
+                mockConsumer.schedulePollTask(() -> {
+                    IntStream.range(0, numTestRecords).forEach(offset -> {
+                        mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, PARTITION, offset, "key_" + offset, Buffer.buffer()));
+                    });
+                });
+            }));
+        });
+        assertThat(receivedRecordsCtx.awaitCompletion(5, TimeUnit.SECONDS))
+                .as("records received in 5s").isTrue();
+        if (receivedRecordsCtx.failed()) {
+            ctx.failNow(receivedRecordsCtx.causeOfFailure());
+            return;
+        }
+
+        // records received, complete the handling of some of them
+        recordsHandlingPromiseMap.get(0L).complete();
+        recordsHandlingPromiseMap.get(1L).complete();
+        // offset 3 not completed yet, hence offset 1 is the latest in the row of fully handled records
+        final int latestFullyHandledOffset = 1;
+        recordsHandlingPromiseMap.get(4L).complete();
+
+        mockConsumer.setSkipSettingClosedFlagOnNextClose(); // otherwise mockConsumer committed() can't be called
+        // now close the consumer
+        consumer.stop().onComplete(v -> {
+            final Map<TopicPartition, OffsetAndMetadata> committed = mockConsumer.committed(Set.of(topicPartition));
+            ctx.verify(() -> {
+                final OffsetAndMetadata offsetAndMetadata = committed.get(topicPartition);
+                assertThat(offsetAndMetadata).isNotNull();
+                assertThat(offsetAndMetadata.offset()).isEqualTo(latestFullyHandledOffset + 1L);
+            });
+            ctx.completeNow();
+        });
+    }
+
+    /**
+     * Verifies that the consumer commits the last fully handled records periodically.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testConsumerCommitsOffsetsPeriodically(final VertxTestContext ctx) {
+        final Promise<Void> testRecordsReceived = Promise.promise();
+        final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> handler = record -> {
+            testRecordsReceived.complete();
+            return Future.succeededFuture();
+        };
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        // 100ms commit interval - keep the value not too low,
+        // otherwise the frequent commit task on the event loop thread will prevent the test main thread from getting things done
+        consumerConfig.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "100");
+
+        consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.updatePartitions(TOPIC, List.of(getPartitionInfo(TOPIC, PARTITION)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition));
+
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.succeeding(v2 -> {
+                mockConsumer.schedulePollTask(() -> {
+                    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, PARTITION, 0, "key_0", Buffer.buffer()));
+                });
+            }));
+        });
+        testRecordsReceived.future().onComplete(v -> {
+            // we have no hook to integrate into for the commit check
+            // therefore do the check multiple times with some delay in between
+            final AtomicInteger checkCount = new AtomicInteger(0);
+            vertx.setPeriodic(30, tid -> {
+                checkCount.incrementAndGet();
+                // check offsets
+                final Map<TopicPartition, OffsetAndMetadata> committed = mockConsumer.committed(Set.of(topicPartition));
+                if (!committed.isEmpty()) {
+                    ctx.verify(() -> {
+                        final OffsetAndMetadata offsetAndMetadata = committed.get(topicPartition);
+                        assertThat(offsetAndMetadata).isNotNull();
+                        assertThat(offsetAndMetadata.offset()).isEqualTo(1L);
+                    });
+                    ctx.completeNow();
+                    vertx.cancelTimer(tid);
+                } else {
+                    if (checkCount.get() >= 10) {
+                        vertx.cancelTimer(tid);
+                        ctx.failNow(new AssertionError("offset should have been committed"));
+                    }
+                }
+            });
+        });
+    }
+
+    /**
+     * Verifies that a scenario of a partition being revoked and not assigned again, while there are
+     * still not fully handled records, is identified by the consumer.
+     *
+     * @param ctx The vert.x test context.
+     * @throws InterruptedException if the test execution gets interrupted.
+     */
+    @Test
+    public void testScenarioWithPartitionRevokedWhileHandlingIncomplete(final VertxTestContext ctx) throws InterruptedException {
+        final int numTestRecords = 5;
+        final VertxTestContext receivedRecordsCtx = new VertxTestContext();
+        final Checkpoint receivedRecordsCheckpoint = receivedRecordsCtx.checkpoint(numTestRecords);
+        final Map<Long, Promise<Void>> recordsHandlingPromiseMap = new HashMap<>();
+        final Function<KafkaConsumerRecord<String, Buffer>, Future<Void>> handler = record -> {
+            final Promise<Void> promise = Promise.promise();
+            if (recordsHandlingPromiseMap.put(record.offset(), promise) != null) {
+                receivedRecordsCtx.failNow(new IllegalStateException("received record with duplicate offset"));
+            }
+            receivedRecordsCheckpoint.flag();
+            return promise.future();
+        };
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        consumerConfig.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG,
+                "300000"); // periodic commit shall not play a role here
+
+        consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.updatePartitions(TOPIC, List.of(getPartitionInfo(TOPIC, PARTITION)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition));
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.succeeding(v2 -> {
+                mockConsumer.schedulePollTask(() -> {
+                    IntStream.range(0, numTestRecords).forEach(offset -> {
+                        mockConsumer.addRecord(
+                                new ConsumerRecord<>(TOPIC, PARTITION, offset, "key_" + offset, Buffer.buffer()));
+                    });
+                });
+            }));
+        });
+        assertThat(receivedRecordsCtx.awaitCompletion(5, TimeUnit.SECONDS))
+                .as("records received in 5s").isTrue();
+        if (receivedRecordsCtx.failed()) {
+            ctx.failNow(receivedRecordsCtx.causeOfFailure());
+            return;
+        }
+        // records received, but their handling isn't completed yet
+        // do a rebalance with the currently assigned partition not being assigned anymore after it
+        mockConsumer.updateEndOffsets(Map.of(topic2Partition, ((long) 0)));
+        mockConsumer.rebalance(List.of(topic2Partition));
+        // mark the handling of some records as completed
+        recordsHandlingPromiseMap.get(0L).complete();
+        recordsHandlingPromiseMap.get(1L).complete();
+        recordsHandlingPromiseMap.get(2L).complete();
+
+        final Checkpoint commitCheckDone = ctx.checkpoint(1);
+        consumer.setOnPartitionsAssignedHandler(partitions -> {
+            final Map<TopicPartition, OffsetAndMetadata> committed = mockConsumer.committed(Set.of(topicPartition));
+            ctx.verify(() -> {
+                // the rebalance after having completed the records of the now unassigned partition
+                // should have triggered no offset commits
+                assertThat(committed).isEmpty();
+            });
+            commitCheckDone.flag();
+        });
+        // now force a rebalance which should trigger the above onPartitionsAssignedHandler
+        mockConsumer.rebalance(List.of(topicPartition));
+    }
+
+    @NotNull
+    private PartitionInfo getPartitionInfo(final String topic, final int partition) {
+        final Node[] replicas = new Node[]{LEADER};
+        return new PartitionInfo(topic, partition, LEADER, replicas, replicas);
+    }
+
+    /**
+     * Supplier whose get() method might throw an {@link InterruptedException}.
+     * @param <T> The type of results supplied by this supplier.
+     */
+    @FunctionalInterface
+    interface InterruptableSupplier<T> {
+        /**
+         * Gets a result.
+         * @return The result.
+         * @throws InterruptedException If getting the result was interrupted.
+         */
+        T get() throws InterruptedException;
+    }
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerTest.java
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.client.kafka.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+/**
+ * Verifies the behavior of {@link HonoKafkaConsumerTest}.
+ */
+@Timeout(value = 20, timeUnit = TimeUnit.SECONDS)
+@ExtendWith(VertxExtension.class)
+public class HonoKafkaConsumerTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HonoKafkaConsumerTest.class);
+
+    private static final String TOPIC = "test.topic";
+    private static final String TOPIC2 = "test.topic2";
+    private static final String TOPIC3 = "test.topic3";
+    private static final Pattern TOPIC_PATTERN = Pattern.compile(Pattern.quote("test.") + ".*");
+    private static final int PARTITION = 0;
+    private static final TopicPartition topicPartition = new TopicPartition(TOPIC, PARTITION);
+    private static final TopicPartition topic2Partition = new TopicPartition(TOPIC2, PARTITION);
+    private static final TopicPartition topic3Partition = new TopicPartition(TOPIC3, PARTITION);
+    private static final Node LEADER = new Node(1, "broker1", 9092);
+
+    private KafkaConsumerConfigProperties consumerConfigProperties;
+    private Vertx vertx;
+    private Context context;
+    private HonoKafkaConsumer consumer;
+    private KafkaMockConsumer mockConsumer;
+
+    /**
+     * Sets up fixture.
+     *
+     * @param vertx The vert.x instance.
+     */
+    @BeforeEach
+    public void setUp(final Vertx vertx) {
+        this.vertx = vertx;
+        context = vertx.getOrCreateContext();
+
+        mockConsumer = new KafkaMockConsumer(OffsetResetStrategy.LATEST);
+
+        final Map<String, String> commonProperties = Map.of(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "servers");
+        consumerConfigProperties = new KafkaConsumerConfigProperties();
+        consumerConfigProperties.setCommonClientConfig(commonProperties);
+    }
+
+    /**
+     * Verifies that trying to create a HonoKafkaConsumer with a topic list succeeds.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testConsumerCreationWithTopicListSucceeds(final VertxTestContext ctx) {
+        final Handler<KafkaConsumerRecord<String, Buffer>> handler = record -> LOG.debug("{}", record);
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+
+        consumer = new HonoKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition));
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.completing());
+        });
+    }
+
+    /**
+     * Verifies that trying to create a HonoKafkaConsumer with a topic pattern succeeds.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testConsumerCreationWithTopicPatternSucceeds(final VertxTestContext ctx) {
+        final Handler<KafkaConsumerRecord<String, Buffer>> handler = record -> LOG.debug("{}", record);
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+
+        consumer = new HonoKafkaConsumer(vertx, TOPIC_PATTERN, handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, (long) 0, topic2Partition, (long) 0));
+        mockConsumer.updatePartitions(TOPIC, List.of(getPartitionInfo(TOPIC, PARTITION)));
+        mockConsumer.updatePartitions(TOPIC2, List.of(getPartitionInfo(TOPIC2, PARTITION)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition, topic2Partition));
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.succeeding(v2 -> {
+                ctx.verify(() -> {
+                    assertThat(consumer.getSubscribedTopicPatternTopics()).isEqualTo(Set.of(TOPIC, TOPIC2));
+                    assertThat(consumer.isAmongKnownSubscribedTopics(TOPIC)).isTrue();
+                    assertThat(consumer.isAmongKnownSubscribedTopics(TOPIC2)).isTrue();
+                    assertThat(consumer.ensureTopicIsAmongSubscribedTopicPatternTopics(TOPIC).succeeded()).isTrue();
+                    assertThat(consumer.ensureTopicIsAmongSubscribedTopicPatternTopics(TOPIC2).succeeded()).isTrue();
+                });
+                ctx.completeNow();
+            }));
+        });
+    }
+
+    /**
+     * Verifies that invoking <em>ensureTopicIsAmongSubscribedTopicPatternTopics</em> succeeds for
+     * a topic that matches the topic pattern but has been created after the consumer started.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testEnsureTopicIsAmongSubscribedTopicsSucceedsForAddedTopic(final VertxTestContext ctx) {
+        final Handler<KafkaConsumerRecord<String, Buffer>> handler = record -> LOG.debug("{}", record);
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+
+        consumer = new HonoKafkaConsumer(vertx, TOPIC_PATTERN, handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, (long) 0, topic2Partition, (long) 0));
+        mockConsumer.updatePartitions(TOPIC, List.of(getPartitionInfo(TOPIC, PARTITION)));
+        mockConsumer.updatePartitions(TOPIC2, List.of(getPartitionInfo(TOPIC2, PARTITION)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition, topic2Partition));
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.succeeding(v2 -> {
+                ctx.verify(() -> {
+                    assertThat(consumer.getSubscribedTopicPatternTopics()).isEqualTo(Set.of(TOPIC, TOPIC2));
+                });
+                // now update partitions with the one for topic3
+                mockConsumer.updatePartitions(TOPIC3, List.of(getPartitionInfo(TOPIC3, PARTITION)));
+                mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition, topic2Partition, topic3Partition));
+                mockConsumer.updateEndOffsets(Map.of(topic3Partition, (long) 0));
+
+                consumer.ensureTopicIsAmongSubscribedTopicPatternTopics(TOPIC3).onComplete(ctx.succeeding(v3 -> {
+                    ctx.verify(() -> {
+                        assertThat(consumer.getSubscribedTopicPatternTopics()).isEqualTo(Set.of(TOPIC, TOPIC2, TOPIC3));
+                    });
+                    ctx.completeNow();
+                }));
+            }));
+        });
+    }
+
+    /**
+     * Verifies that the HonoKafkaConsumer invokes the provided handler on received records.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testConsumerInvokesHandlerOnReceivedRecords(final VertxTestContext ctx) {
+        final int numTestRecords = 5;
+        final Checkpoint receivedRecordsCheckpoint = ctx.checkpoint(numTestRecords);
+        final Handler<KafkaConsumerRecord<String, Buffer>> handler = record -> {
+            receivedRecordsCheckpoint.flag();
+        };
+        final Map<String, String> consumerConfig = consumerConfigProperties.getConsumerConfig("test");
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+
+        consumer = new HonoKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig) {
+            @Override
+            KafkaConsumer<String, Buffer> createKafkaConsumer() {
+                return KafkaConsumer.create(vertx, mockConsumer);
+            }
+        };
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.setRebalancePartitionAssignmentOnSubscribe(List.of(topicPartition));
+        context.runOnContext(v -> {
+            consumer.start().onComplete(ctx.succeeding(v2 -> {
+                mockConsumer.schedulePollTask(() -> {
+                    IntStream.range(0, numTestRecords).forEach(offset -> {
+                        mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, PARTITION, offset, "key_" + offset, Buffer.buffer()));
+                    });
+                });
+            }));
+        });
+    }
+
+    @NotNull
+    private PartitionInfo getPartitionInfo(final String topic, final int partition) {
+        final Node[] replicas = new Node[]{LEADER};
+        return new PartitionInfo(topic, partition, LEADER, replicas, replicas);
+    }
+
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/KafkaMockConsumer.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/KafkaMockConsumer.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.kafka.consumer;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A {@link MockConsumer} with additional support, e.g. invoking {@code ConsumerRebalanceListener} handlers.
+ */
+class KafkaMockConsumer extends MockConsumer<String, Buffer> {
+
+    private Collection<TopicPartition> onSubscribeRebalancePartitionAssignment;
+    private ConsumerRebalanceListener rebalanceListener;
+    private final AtomicBoolean skipSettingClosedFlagOnNextClose = new AtomicBoolean();
+
+    KafkaMockConsumer(final OffsetResetStrategy offsetResetStrategy) {
+        super(offsetResetStrategy);
+    }
+
+    /**
+     * Marks the following subscribe() invocations to be followed by a rebalance with the given partition
+     * assignment, if the given assignment collection isn't {@code null}.
+     *
+     * @param assignment The partition assignment to set. Use {@code null} to reset the assignment and skip
+     *                   the rebalance on following subscribe() invocations.
+     */
+    public void setRebalancePartitionAssignmentOnSubscribe(final Collection<TopicPartition> assignment) {
+        onSubscribeRebalancePartitionAssignment = assignment;
+    }
+
+    @Override
+    public synchronized void subscribe(final Pattern pattern, final ConsumerRebalanceListener listener) {
+        this.rebalanceListener = listener;
+        subscription().clear(); // clear() is needed for successive invocations of subscribe(pattern) to work;
+                                // otherwise the 2nd invocation will cause the subscription list to only contain
+                                // partitions added in between
+        super.subscribe(pattern, listener);
+        Optional.ofNullable(onSubscribeRebalancePartitionAssignment)
+                .ifPresent(this::rebalance);
+    }
+
+    @Override
+    public synchronized void subscribe(final Collection<String> topics,
+            final ConsumerRebalanceListener listener) {
+        this.rebalanceListener = listener;
+        super.subscribe(topics, listener);
+        Optional.ofNullable(onSubscribeRebalancePartitionAssignment)
+                .ifPresent(this::rebalance);
+    }
+
+    @Override
+    public synchronized void rebalance(final Collection<TopicPartition> newAssignment) {
+        Optional.ofNullable(rebalanceListener)
+                .ifPresent(listener -> listener.onPartitionsRevoked(assignment()));
+        super.rebalance(newAssignment);
+        Optional.ofNullable(rebalanceListener)
+                .ifPresent(listener -> listener.onPartitionsAssigned(newAssignment));
+    }
+
+    /**
+     * Skips setting the "closed" flag on the next close() invocation.
+     * <p>
+     * Can be used to still be able to invoke some methods (e.g. committed()) on the MockConsumer
+     * after close() was called.
+     */
+    public void setSkipSettingClosedFlagOnNextClose() {
+        skipSettingClosedFlagOnNextClose.setPlain(true);
+    }
+
+    @Override
+    public synchronized void close() {
+        Optional.ofNullable(rebalanceListener)
+                .ifPresent(listener -> listener.onPartitionsRevoked(assignment()));
+        if (!skipSettingClosedFlagOnNextClose.compareAndSet(true, false)) {
+            super.close();
+        }
+    }
+}

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
@@ -43,6 +43,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
      * Creates a new KafkaBasedMappingAndDelegatingCommandHandler instance.
      *
      * @param tenantClient The Tenant service client.
+     * @param commandQueue The command queue to use for keeping track of the command processing.
      * @param commandTargetMapper The mapper component to determine the command target.
      * @param internalCommandSender The command sender to publish commands to the internal command topic.
      * @param tracer The tracer instance.
@@ -50,11 +51,12 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
      */
     public KafkaBasedMappingAndDelegatingCommandHandler(
             final TenantClient tenantClient,
+            final KafkaCommandProcessingQueue commandQueue,
             final CommandTargetMapper commandTargetMapper,
             final KafkaBasedInternalCommandSender internalCommandSender,
             final Tracer tracer) {
         super(tenantClient, commandTargetMapper, internalCommandSender);
-        this.commandQueue = new KafkaCommandProcessingQueue();
+        this.commandQueue = Objects.requireNonNull(commandQueue);
         this.tracer = Objects.requireNonNull(tracer);
     }
 

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
@@ -65,6 +65,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
 
     private CommandTargetMapper commandTargetMapper;
     private KafkaBasedMappingAndDelegatingCommandHandler cmdHandler;
+    private KafkaCommandProcessingQueue commandQueue;
     private KafkaBasedInternalCommandSender internalCommandSender;
     private String tenantId;
     private String deviceId;
@@ -89,7 +90,8 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
         internalCommandSender = mock(KafkaBasedInternalCommandSender.class);
         when(internalCommandSender.sendCommand(any(), any())).thenReturn(Future.succeededFuture());
 
-        cmdHandler = new KafkaBasedMappingAndDelegatingCommandHandler(tenantClient, commandTargetMapper,
+        commandQueue = new KafkaCommandProcessingQueue();
+        cmdHandler = new KafkaBasedMappingAndDelegatingCommandHandler(tenantClient, commandQueue, commandTargetMapper,
                 internalCommandSender, TracingMockSupport.mockTracer(TracingMockSupport.mockSpan()));
     }
 


### PR DESCRIPTION
This is for #2480.
This adds an extended HonoKafkaConsumer that automatically commits partition offsets corresponding to the latest record per partition whose (asynchronous) processing has been marked as completed (provided all its preceding records are also completed).

This consumer is used for receiving commands in the Command Router.

In contrast to the default `enable.auto.commit` behaviour, identical offsets are skipped during successive commits. (They are recommitted after a certain time to prevent them from reaching their retention time.) This helps in case a corresponding partition just got deleted. Not trying to commit the offset then means the consumer won't block/retry for a long time in this case - see https://github.com/eclipse/hono/issues/2623#issuecomment-824906383.