### PR TITLE
Reduce load on Prometheus server when checking limits

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/resourcelimits/quarkus/ResourceLimitChecksProducer.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/resourcelimits/quarkus/ResourceLimitChecksProducer.java
@@ -13,6 +13,7 @@
 package org.eclipse.hono.adapter.resourcelimits.quarkus;
 
 import java.time.Duration;
+import java.util.concurrent.Executors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
@@ -62,6 +63,8 @@ public class ResourceLimitChecksProducer {
             webClientOptions.setSsl(config.isTlsEnabled());
 
             final Caffeine<Object, Object> builder = Caffeine.newBuilder()
+                    // make sure we run one Prometheus query at a time
+                    .executor(Executors.newSingleThreadExecutor())
                     .initialCapacity(config.getCacheMinSize())
                     .maximumSize(config.getCacheMaxSize())
                     .expireAfterWrite(Duration.ofSeconds(config.getCacheTimeout()));

--- a/adapter-base/src/test/resources/logback-test.xml
+++ b/adapter-base/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<!DOCTYPE configuration>
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.eclipse.hono.adapter" level="INFO"/>
+  <logger name="org.eclipse.hono.adapter.resourcelimits" level="INFO"/>
+
+</configuration>

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -18,6 +18,9 @@ description = "Information about changes in recent Hono releases. Includes new f
 * Support for uplink messages from the Embedded LNS on MultiTech gateways.
 * The *hono.connections.attempts* metric has been extended with a `cipher-suite` tag which contains the name of the
   cipher suite that is used in a device's attempt to establish a TLS based connection to an adapter.
+* The Prometheus based resource limit checks have been improved to reduce the load generated on the Prometheus server
+  in cases where a protocol adapter to which many devices of many different tenants were connected would crash
+  (or be shut down) and the devices would immediately re-connect to another instance of the protocol adapter.
 
 ### Deprecations
 


### PR DESCRIPTION
This addresses #2084

The Prometheus based resource limit checks were prone to generating a
lot of load on a Prometheus server under certain conditions.
In particular, the load would spike, if a protocol adapter to which many
devices of many different tenants were connected would crash (or be shut
down) and the devices would immediately re-connect to another instance
of the protocol adapter. In this case, for the first device per tenant
up to three queries would be issued to Prometheus' query API, depending
on whether the tenant's current limited resource values were already
available in the cache or not. For multiple devices from different
tenants connecting in parallel, this could lead to a high load of
queries on the Prometheus server.

The limit checks have been changed to reduce (if not prevent) these
spikes:
1. The Java Executor used for running the queries has been changed from
the default (multi-threaded) implementation to a single-threaded
implementation. This results in one query being issued to Prometheus at
a time (per adapter instance).
2. When invoking any of the methods to check if a limit is reached, the
methods now immediately return FALSE (passing the check) if the required
limited resource value for the tenant is not yet in the cache.
Regardless of this behavior, a task to load the value into the cache is
scheduled using the Executor in the background.

In addition to these changes, the query to determine the used data
volume for the current accounting period has been slightly optimized to
reduce the amount of data that needs to be processed on the Prometheus
server.