### PR TITLE
[#2272] Refactor tenant information service

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -164,6 +164,11 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_EXT                         = "ext";
     /**
+     * The name of the property that defines the messaging type to be used for a tenant.
+     */
+    public static final String FIELD_EXT_MESSAGING_TYPE = "messaging-type";
+
+    /**
      * The name of the field that contains the id of the entity (e.g. secret id).
      */
     public static final String FIELD_ID = "id";

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/NoopTenantInformationService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/NoopTenantInformationService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,8 +19,7 @@ import java.util.Optional;
 
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
-import org.eclipse.hono.util.TenantObject;
-import org.eclipse.hono.util.TenantResult;
+import org.eclipse.hono.service.management.tenant.Tenant;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
@@ -39,12 +38,13 @@ public final class NoopTenantInformationService implements TenantInformationServ
      */
     @Override
     public Future<Result<TenantKey>> tenantExists(final String tenantId, final Span span) {
-        return Future.succeededFuture(OperationResult.ok(HttpURLConnection.HTTP_OK, TenantKey.from(tenantId), Optional.empty(), Optional.empty()));
+        return Future.succeededFuture(OperationResult.ok(HttpURLConnection.HTTP_OK, TenantKey.from(tenantId),
+                Optional.empty(), Optional.empty()));
     }
 
     @Override
-    public Future<TenantResult<TenantObject>> getTenant(final String tenantId, final Span span) {
-        return Future.succeededFuture(TenantResult.from(HttpURLConnection.HTTP_OK, TenantObject.from(tenantId, true)));
+    public Future<Tenant> getTenant(final String tenantId, final Span span) {
+        return Future.succeededFuture(new Tenant());
     }
 
 }

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/TenantInformationService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/tenant/TenantInformationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,7 @@
 package org.eclipse.hono.deviceregistry.service.tenant;
 
 import org.eclipse.hono.service.management.Result;
-import org.eclipse.hono.util.TenantObject;
-import org.eclipse.hono.util.TenantResult;
+import org.eclipse.hono.service.management.tenant.Tenant;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
@@ -53,15 +52,10 @@ public interface TenantInformationService {
      *            it may set tags and use this span as the parent for any spans created in this method.
      *
      * @return A future indicating the outcome of the operation.
-     *             The <em>status</em> will be
-     *             <ul>
-     *             <li><em>200 OK</em> if a tenant with the given ID is registered.
-     *             The <em>payload</em> will contain the tenant's configuration information.</li>
-     *             <li><em>404 Not Found</em> if no tenant with the given identifier exists.</li>
-     *             </ul>
-     *
+     *         If succeeds the future contains the tenant information. Otherwise, the future will fail with
+     *         a {@link org.eclipse.hono.client.ServiceInvocationException} containing a corresponding status code.
      * @throws NullPointerException if any argument is {@code null}.
      */
-     Future<TenantResult<TenantObject>> getTenant(String tenantId, Span span);
+     Future<Tenant> getTenant(String tenantId, Span span);
 
 }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisionerTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AutoProvisionerTest.java
@@ -39,6 +39,7 @@ import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.management.device.DeviceStatus;
+import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.Constants;
@@ -48,7 +49,6 @@ import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.RegistryManagementConstants;
 import org.eclipse.hono.util.TenantObject;
-import org.eclipse.hono.util.TenantResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,8 +85,7 @@ class AutoProvisionerTest {
     public void setUp() {
         tenantInformationService = mock(TenantInformationService.class);
         when(tenantInformationService.getTenant(anyString(), any(Span.class)))
-                .thenAnswer(invocation -> Future.succeededFuture(TenantResult.from(HttpURLConnection.HTTP_OK,
-                        TenantObject.from(invocation.getArgument(0), true))));
+                .thenAnswer(invocation -> Future.succeededFuture(new Tenant()));
 
         span = TracingMockSupport.mockSpan();
         vertx = mock(Vertx.class);

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -30,7 +30,7 @@ import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
 import org.eclipse.hono.deviceregistry.service.deviceconnection.MapBasedDeviceConnectionsConfigProperties;
-import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantInformationService;
+import org.eclipse.hono.deviceregistry.service.tenant.DefaultTenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.util.ServiceClientAdapter;
 import org.eclipse.hono.service.HealthCheckServer;
@@ -41,12 +41,10 @@ import org.eclipse.hono.service.management.device.DelegatingDeviceManagementHttp
 import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.management.tenant.DelegatingTenantManagementHttpEndpoint;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
-import org.eclipse.hono.service.tenant.TenantService;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessagingType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -109,14 +107,14 @@ public class FileBasedServiceConfig {
     }
 
     /**
-     * Creates an instance of the tenant information service based on the file based tenant service as a Spring Bean.
+     * Creates an instance of the tenant information service based on the file based tenant management service
+     * as a Spring Bean.
      *
      * @return The service.
      */
     @Bean
-    @ConditionalOnBean(TenantService.class)
     public TenantInformationService tenantInformationService() {
-        return new AutowiredTenantInformationService();
+        return new DefaultTenantInformationService(tenantService());
     }
 
     /**
@@ -249,8 +247,7 @@ public class FileBasedServiceConfig {
         final FileBasedRegistrationService registrationService = new FileBasedRegistrationService(vertx);
         registrationService.setConfig(registrationProperties());
 
-        final var tenantInformationService = new AutowiredTenantInformationService();
-        tenantInformationService.setService(tenantService());
+        final var tenantInformationService = tenantInformationService();
 
         final AutoProvisioner autoProvisioner = new AutoProvisioner();
         autoProvisioner.setDeviceManagementService(registrationService);

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -42,7 +42,7 @@ import org.eclipse.hono.deviceregistry.server.DeviceRegistryAmqpServer;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
-import org.eclipse.hono.deviceregistry.service.tenant.AutowiredTenantInformationService;
+import org.eclipse.hono.deviceregistry.service.tenant.DefaultTenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.util.ServiceClientAdapter;
 import org.eclipse.hono.service.HealthCheckServer;
@@ -69,7 +69,6 @@ import org.eclipse.hono.util.MessagingType;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -388,14 +387,11 @@ public class ApplicationConfig {
                 mongoClient(),
                 registrationServiceProperties());
 
-        final var tenantInformationService = new AutowiredTenantInformationService();
-        tenantInformationService.setService(tenantService());
-
         final AutoProvisioner autoProvisioner = new AutoProvisioner();
         autoProvisioner.setVertx(vertx());
         autoProvisioner.setTracer(tracer());
         autoProvisioner.setDeviceManagementService(service);
-        autoProvisioner.setTenantInformationService(tenantInformationService);
+        autoProvisioner.setTenantInformationService(tenantInformationService());
         autoProvisioner.setEventSenders(eventSenders());
         autoProvisioner.setConfig(autoProvisionerConfigProperties());
 
@@ -440,15 +436,14 @@ public class ApplicationConfig {
     }
 
     /**
-     * Exposes the tenant information service based on the MongoDB tenant service as a Spring Bean.
+     * Exposes the tenant information service based on the MongoDB tenant management service as a Spring Bean.
      *
      * @return The bean instance.
      */
     @Bean
     @Scope("prototype")
-    @ConditionalOnBean(TenantService.class)
     public TenantInformationService tenantInformationService() {
-        return new AutowiredTenantInformationService();
+        return new DefaultTenantInformationService(tenantService());
     }
 
     /**


### PR DESCRIPTION
For more details refer to the [discussion thread](https://github.com/eclipse/hono/pull/2647#discussion_r628183627).

* `TenantInformation.getTenant(...)` returns a result that contains `Tenant` instead of `TenantObject`.
* `AutowiredTenantInformationService` internally makes use of `TenantManagementService` instead of `TenantService`.
