### PR TITLE
AMQP adapter: Fix command not getting released in case device already disconnected

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/HonoProtonHelper.java
@@ -154,6 +154,8 @@ public final class HonoProtonHelper {
 
     /**
      * Checks if a link is established.
+     * <p>
+     * Note that this only applies to a link which has originally been created by the local peer.
      *
      * @param link The link to check.
      * @return {@code true} if the link has been established.
@@ -178,14 +180,26 @@ public final class HonoProtonHelper {
         if (link != null && link.isOpen()) {
             if (link.getSession() != null && link.getSession().getConnection() != null
                     && !link.getSession().getConnection().isDisconnected()) {
-                return true;                
+                return true;
             }
-            final String localLinkAddress = link instanceof ProtonSender ? link.getTarget().getAddress()
-                    : link.getSource().getAddress();
-            LOG.debug("{} link [address: {}] is locally open but underlying transport is disconnected",
-                    link instanceof ProtonSender ? "sender" : "receiver", localLinkAddress);
+            LOG.debug("{} link [source: {}, target: {}] is locally open but underlying transport is disconnected",
+                    link instanceof ProtonSender ? "sender" : "receiver", getRemoteOrLocalSourceAddress(link), getRemoteOrLocalTargetAddress(link));
         }
         return false;
+    }
+
+    private static String getRemoteOrLocalSourceAddress(final ProtonLink<?> link) {
+        if (link != null && link.getRemoteSource() != null) {
+            return link.getRemoteSource().getAddress();
+        }
+        return link != null && link.getSource() != null ? link.getSource().getAddress() : null;
+    }
+
+    private static String getRemoteOrLocalTargetAddress(final ProtonLink<?> link) {
+        if (link != null && link.getRemoteTarget() != null) {
+            return link.getRemoteTarget().getAddress();
+        }
+        return link != null && link.getTarget() != null ? link.getTarget().getAddress() : null;
     }
 
     /**


### PR DESCRIPTION
This fixes a potential NPE in `HonoProtonHelper.isLinkOpenAndConnected`.

It occurs for example when a command message got sent to an AMQP device and there is a timeout waiting for the disposition update, while the transport of the underlying AMQP connection already got closed (with the AMQP link still locally marked as open however). The NPE in that case leads to the command message not getting released.

````
java.lang.NullPointerException: null
  at org.eclipse.hono.util.HonoProtonHelper.isLinkOpenAndConnected(HonoProtonHelper.java:183)
  at org.eclipse.hono.adapter.amqp.VertxBasedAmqpProtocolAdapter.lambda$onCommandReceived$65(VertxBasedAmqpProtocolAdapter.java:998)
  at io.vertx.core.impl.VertxImpl$InternalTimerHandler.handle(VertxImpl.java:923)
````
