### PR TITLE
Enable reporting of jaeger client metrics

### DIFF
--- a/adapters/base-spring/pom.xml
+++ b/adapters/base-spring/pom.xml
@@ -151,6 +151,10 @@
           <groupId>io.jaegertracing</groupId>
           <artifactId>jaeger-client</artifactId>
         </dependency>
+        <dependency>
+          <groupId>io.jaegertracing</groupId>
+          <artifactId>jaeger-micrometer</artifactId>
+        </dependency>
       </dependencies>
     </profile>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -692,6 +692,12 @@
         <scope>runtime</scope>
       </dependency>
       <dependency>
+        <groupId>io.jaegertracing</groupId>
+        <artifactId>jaeger-micrometer</artifactId>
+        <version>${jaeger.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
         <version>4.9.0</version>

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -23,6 +23,7 @@ maven/mavencentral/io.dropwizard.metrics/metrics-core/4.1.14, Apache-2.0, approv
 maven/mavencentral/io.dropwizard.metrics/metrics-graphite/4.1.14, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jaegertracing/jaeger-client/1.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jaegertracing/jaeger-core/1.5.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.jaegertracing/jaeger-micrometer/1.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jaegertracing/jaeger-thrift/1.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jaegertracing/jaeger-tracerresolver/1.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jsonwebtoken/jjwt-api/0.11.2, Apache-2.0, approved, clearlydefined

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -23,6 +23,7 @@ io.dropwizard.metrics:metrics-core:jar:4.1.14
 io.dropwizard.metrics:metrics-graphite:jar:4.1.14
 io.jaegertracing:jaeger-client:jar:1.5.0
 io.jaegertracing:jaeger-core:jar:1.5.0
+io.jaegertracing:jaeger-micrometer:jar:1.5.0
 io.jaegertracing:jaeger-thrift:jar:1.5.0
 io.jaegertracing:jaeger-tracerresolver:jar:1.5.0
 io.jsonwebtoken:jjwt-api:jar:0.11.2

--- a/services/command-router/pom.xml
+++ b/services/command-router/pom.xml
@@ -73,6 +73,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <groupId>io.jaegertracing</groupId>
           <artifactId>jaeger-client</artifactId>
         </dependency>
+        <dependency>
+          <groupId>io.jaegertracing</groupId>
+          <artifactId>jaeger-micrometer</artifactId>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/services/device-connection/pom.xml
+++ b/services/device-connection/pom.xml
@@ -82,6 +82,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <groupId>io.jaegertracing</groupId>
           <artifactId>jaeger-client</artifactId>
         </dependency>
+        <dependency>
+          <groupId>io.jaegertracing</groupId>
+          <artifactId>jaeger-micrometer</artifactId>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/services/device-registry-file/pom.xml
+++ b/services/device-registry-file/pom.xml
@@ -96,6 +96,10 @@
           <groupId>io.jaegertracing</groupId>
           <artifactId>jaeger-client</artifactId>
         </dependency>
+        <dependency>
+          <groupId>io.jaegertracing</groupId>
+          <artifactId>jaeger-micrometer</artifactId>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/services/device-registry-jdbc/pom.xml
+++ b/services/device-registry-jdbc/pom.xml
@@ -164,6 +164,10 @@
           <groupId>io.jaegertracing</groupId>
           <artifactId>jaeger-client</artifactId>
         </dependency>
+        <dependency>
+          <groupId>io.jaegertracing</groupId>
+          <artifactId>jaeger-micrometer</artifactId>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -136,6 +136,10 @@
           <groupId>io.jaegertracing</groupId>
           <artifactId>jaeger-client</artifactId>
         </dependency>
+        <dependency>
+          <groupId>io.jaegertracing</groupId>
+          <artifactId>jaeger-micrometer</artifactId>
+        </dependency>
       </dependencies>
     </profile>
 


### PR DESCRIPTION
This is done via the added `jaeger-micrometer` dependency.

This includes for example `jaeger_tracer_reporter_spans_total` metrics. Analyzing such metrics with value `dropped` can help in determining whether the reporter max queue size (`JAEGER_REPORTER_MAX_QUEUE_SIZE` env variable, default 100) should potentially be increased.