### PR TITLE
Update Jaeger to 1.6.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -42,7 +42,7 @@
     <infinispan.version>11.0.9.Final</infinispan.version>
     <jackson.version>2.11.3</jackson.version>
     <jaeger.image.name>jaegertracing/all-in-one:1.22</jaeger.image.name>
-    <jaeger.version>1.5.0</jaeger.version>
+    <jaeger.version>1.6.0</jaeger.version>
     <java-base-image.name>docker.io/openjdk:11-jre-slim</java-base-image.name>
     <javassist.version>3.26.0-GA</javassist.version>
     <jaxb.api.version>2.2.12</jaxb.api.version>
@@ -690,6 +690,14 @@
         <artifactId>jaeger-thrift</artifactId>
         <version>${jaeger.version}</version>
         <scope>runtime</scope>
+        <exclusions>
+          <!-- libthrift 0.14.1 used by jaeger-thrift 1.6.0 unnecessarily includes tomcat-embed-core dependency - see THRIFT-5375;
+               TODO remove exclusion after updating jaeger to version with newer libthrift  -->
+          <exclusion>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.jaegertracing</groupId>

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -21,11 +21,11 @@ maven/mavencentral/com.squareup.okio/okio/2.8.0, Apache-2.0, approved, clearlyde
 maven/mavencentral/com.squareup/protoparser/4.0.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.dropwizard.metrics/metrics-core/4.1.14, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.dropwizard.metrics/metrics-graphite/4.1.14, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.jaegertracing/jaeger-client/1.5.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.jaegertracing/jaeger-core/1.5.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.jaegertracing/jaeger-micrometer/1.5.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.jaegertracing/jaeger-thrift/1.5.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.jaegertracing/jaeger-tracerresolver/1.5.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.jaegertracing/jaeger-client/1.6.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.jaegertracing/jaeger-core/1.6.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.jaegertracing/jaeger-micrometer/1.6.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.jaegertracing/jaeger-thrift/1.6.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.jaegertracing/jaeger-tracerresolver/1.6.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jsonwebtoken/jjwt-api/0.11.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jsonwebtoken/jjwt-impl/0.11.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jsonwebtoken/jjwt-jackson/0.11.2, Apache-2.0, approved, clearlydefined
@@ -129,7 +129,7 @@ maven/mavencentral/org.apache.logging.log4j/log4j-api/2.13.3, Apache-2.0, approv
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.13.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.qpid/proton-j/0.33.8, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.sshd/sshd-common/2.3.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apache.thrift/libthrift/0.13.0, Apache-2.0, approved, CQ22260
+maven/mavencentral/org.apache.thrift/libthrift/0.14.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.19.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/2.5.2, MIT, approved, clearlydefined

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -21,11 +21,11 @@ com.squareup.okio:okio:jar:2.8.0
 com.squareup:protoparser:jar:4.0.3
 io.dropwizard.metrics:metrics-core:jar:4.1.14
 io.dropwizard.metrics:metrics-graphite:jar:4.1.14
-io.jaegertracing:jaeger-client:jar:1.5.0
-io.jaegertracing:jaeger-core:jar:1.5.0
-io.jaegertracing:jaeger-micrometer:jar:1.5.0
-io.jaegertracing:jaeger-thrift:jar:1.5.0
-io.jaegertracing:jaeger-tracerresolver:jar:1.5.0
+io.jaegertracing:jaeger-client:jar:1.6.0
+io.jaegertracing:jaeger-core:jar:1.6.0
+io.jaegertracing:jaeger-micrometer:jar:1.6.0
+io.jaegertracing:jaeger-thrift:jar:1.6.0
+io.jaegertracing:jaeger-tracerresolver:jar:1.6.0
 io.jsonwebtoken:jjwt-api:jar:0.11.2
 io.jsonwebtoken:jjwt-impl:jar:0.11.2
 io.jsonwebtoken:jjwt-jackson:jar:0.11.2
@@ -129,7 +129,7 @@ org.apache.logging.log4j:log4j-api:jar:2.13.3
 org.apache.logging.log4j:log4j-to-slf4j:jar:2.13.3
 org.apache.qpid:proton-j:jar:0.33.8
 org.apache.sshd:sshd-common:jar:2.3.0
-org.apache.thrift:libthrift:jar:0.13.0
+org.apache.thrift:libthrift:jar:0.14.1
 org.apiguardian:apiguardian-api:jar:1.1.0
 org.assertj:assertj-core:jar:3.19.0
 org.checkerframework:checker-qual:jar:2.5.2


### PR DESCRIPTION
Includes update of `org.apache.thrift:libthrift` from `0.13.0` to `0.14.1` (includes fix for CVE-2020-13949).