### PR TITLE
Make the AMQP network config non-mandatory in the adapters

### DIFF
--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractAdapterConfig.java
@@ -139,9 +139,10 @@ public abstract class AbstractAdapterConfig extends AbstractMessagingClientConfi
             final CommandRouterClient commandRouterClient = context.getBean(CommandRouterClient.class);
             adapter.setCommandRouterClient(commandRouterClient);
             final CommandRouterCommandConsumerFactory commandConsumerFactory = commandConsumerFactory(commandRouterClient);
-            commandConsumerFactory.registerInternalCommandConsumer(
-                    (id, handlers) -> new ProtonBasedInternalCommandConsumer(commandConsumerConnection(vertx()), id, handlers));
-
+            if (commandConsumerFactoryConfig().isHostConfigured()) {
+                commandConsumerFactory.registerInternalCommandConsumer(
+                        (id, handlers) -> new ProtonBasedInternalCommandConsumer(commandConsumerConnection(vertx()), id, handlers));
+            }
             if (kafkaAdminClientConfig.isConfigured() && kafkaConsumerConfig.isConfigured()) {
                 commandConsumerFactory.registerInternalCommandConsumer(
                         (id, handlers) -> new KafkaBasedInternalCommandConsumer(vertx(), kafkaAdminClientConfig,

--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
@@ -64,7 +64,6 @@ public abstract class AbstractMessagingClientConfig extends AdapterConfiguration
      * @param tracer The tracer instance.
      * @param vertx The Vert.x instance to use.
      * @param adapterProperties The adapter's configuration properties.
-     *
      * @return The created messaging clients.
      */
     protected MessagingClients messagingClients(
@@ -189,7 +188,6 @@ public abstract class AbstractMessagingClientConfig extends AdapterConfiguration
      * and is already trying to establish the connection to the configured peer.
      *
      * @param vertx The Vert.x instance to use.
-     *
      * @return The connection.
      */
     @Qualifier(Constants.QUALIFIER_MESSAGING)
@@ -213,7 +211,8 @@ public abstract class AbstractMessagingClientConfig extends AdapterConfiguration
     }
 
     /**
-     * Exposes configuration properties for Command and Control.
+     * Exposes configuration properties for accessing the AMQP Messaging Network for receiving upstream commands as a
+     * Spring bean.
      *
      * @return The Properties.
      */
@@ -229,10 +228,9 @@ public abstract class AbstractMessagingClientConfig extends AdapterConfiguration
     }
 
     /**
-     * Exposes the connection used for receiving upstream commands as a Spring bean.
+     * Exposes the connection to the AMQP Messaging Network used for receiving upstream commands as a Spring bean.
      *
      * @param vertx The Vert.x instance to use.
-     *
      * @return The connection.
      */
     @Bean


### PR DESCRIPTION
The protocol adapter AMQP consumers on the internal command address will now only be used if the AMQP consumer is actually configured.
Needed for a setup that only uses a Kafka messaging network.