### PR TITLE
Update Sandbox URL in API docs, document "try it out" feature

### DIFF
--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -63,7 +63,8 @@ servers:
    - url: '{server}/v1'
      variables:
         server:
-           default: http://hono.eclipse.org:28080
+           default: http://hono.eclipseprojects.io:28080
+           description: Hono Sandbox
 
 security:
    - BearerAuth: []
@@ -138,7 +139,7 @@ paths:
             401:
                $ref: '#/components/responses/Unauthorized'
             404:
-               $ref: '#/components/responses/NotFound'                        
+               $ref: '#/components/responses/NotFound'
 
    /tenants/{tenantId}:
 
@@ -798,9 +799,9 @@ components:
                   determined from the certificate and this property is ignored.
                   Otherwise, if the `public-key` property is
                   used, this property is mandatory.
-                  NB: The value MUST be a string that complies with the format defined in 
-                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated 
-                  by the [date-time](http://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
+                  NB: The value MUST be a string that complies with the format defined in
+                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated
+                  by the [date-time](https://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
                   format in the OpenAPI specification.
             "not-after":
                type: string
@@ -813,9 +814,9 @@ components:
                   determined from the certificate and this property is ignored.
                   Otherwise, if the `public-key` property is
                   used, this property is mandatory.
-                  NB: The value MUST be a string that complies with the format defined in 
-                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated 
-                  by the [date-time](http://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
+                  NB: The value MUST be a string that complies with the format defined in
+                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated
+                  by the [date-time](https://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
                   format in the OpenAPI specification.
             "cert":
                type: string
@@ -966,9 +967,9 @@ components:
                format: date-time
                description: |
                   The point in time at which the data volume limit came into effect.
-                  NB: The value MUST be a string that complies with the format defined in 
-                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated 
-                  by the [date-time](http://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
+                  NB: The value MUST be a string that complies with the format defined in
+                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated
+                  by the [date-time](https://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
                   format in the OpenAPI specification.
             "max-bytes":
                type: integer
@@ -990,9 +991,9 @@ components:
                format: date-time
                description: |
                   The point in time at which the connection duration limit came into effect.
-                  NB: The value MUST be a string that complies with the format defined in 
-                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated 
-                  by the [date-time](http://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
+                  NB: The value MUST be a string that complies with the format defined in
+                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated
+                  by the [date-time](https://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
                   format in the OpenAPI specification.
             "max-minutes":
                type: integer
@@ -1323,18 +1324,18 @@ components:
                format: date-time
                description: |
                   The point in time from which on this secret will be accepted for authentication.
-                  NB: The value MUST be a string that complies with the format defined in 
-                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated 
-                  by the [date-time](http://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
+                  NB: The value MUST be a string that complies with the format defined in
+                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated
+                  by the [date-time](https://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
                   format in the OpenAPI specification.
             "not-after":
                type: string
                format: date-time
                description: |
                   The point in time after which this secret will no longer be accepted for authentication.
-                  NB: The value MUST be a string that complies with the format defined in 
-                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated 
-                  by the [date-time](http://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
+                  NB: The value MUST be a string that complies with the format defined in
+                  [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) as indicated
+                  by the [date-time](https://spec.openapis.org/oas/v3.0.1#dataTypeFormat)
                   format in the OpenAPI specification.
             "comment":
                type: string

--- a/site/documentation/layouts/shortcodes/swagger.html
+++ b/site/documentation/layouts/shortcodes/swagger.html
@@ -2,6 +2,21 @@
 
 <script>
 window.onload = function() {
+
+    const TryItOutButtonWithHonoSandboxInfo = function() {
+        return {
+            wrapComponents: {
+                TryItOutButton: (Original, { React }) => (props) => {
+                    return React.createElement("div", {style: {"font-size": '14px'}},
+                        React.createElement(Original, props),
+                        'using the ',
+                        React.createElement('a', {href: 'https://www.eclipse.org/hono/sandbox/'}, "Hono Sandbox")
+                    )
+                }
+            }
+        }
+    }
+
   // Begin Swagger UI call region
   const ui = SwaggerUIBundle({
     url: "{{ .Get 0 }}",
@@ -12,8 +27,12 @@ window.onload = function() {
       SwaggerUIStandalonePreset
     ],
     plugins: [
+      TryItOutButtonWithHonoSandboxInfo,
       SwaggerUIBundle.plugins.DownloadUrl
     ],
+//{{ if and (not (hasPrefix .Site.Params.honoVersion "stable")) (not (eq (string .Site.Params.honoVersion) "")) }}
+    supportedSubmitMethods: [], // hide "try it out" for non-stable version
+//{{ end }}
     layout: "StandaloneLayout",
     docExpansion: "none", // don't expand all the tags by default
     defaultModelRendering: "model", // display models instead of examples by default

--- a/site/documentation/static/css/hono.css
+++ b/site/documentation/static/css/hono.css
@@ -86,6 +86,12 @@
 	display: none;
 }
 
+/* let text after try-out button stay in same line */
+.swagger-ui .try-out {
+  padding-right: 7px;
+  display: inline-block;
+}
+
 .swagger-ui table, .swagger-ui thead, .swagger-ui td {
 	border: none;
 }

--- a/site/homepage/content/getting-started/index.md
+++ b/site/homepage/content/getting-started/index.md
@@ -94,6 +94,8 @@ and then proceed to the [Overview of Hono Components]({{< relref "#overview-of-h
 
 However, if the `curl` command yielded different output, you will need to set up Hono locally as described in the next section.
 
+For interacting with the Device Registry of the Hono Sandbox (e.g. for creating tenants, devices), you can also use the testing functionality integrated in the [Device Registry Management API documentation]({{% doclink "/api/management/" %}}).
+
 #### Setting up a local Hono Instance
 
 In case you cannot access the Hono Sandbox as described above, you will need to set up an instance of Hono running on your local computer.


### PR DESCRIPTION
Fix sandbox URL in [management API swagger UI](https://www.eclipse.org/hono/docs/api/management/) and make it obvious that the "Try it out" button refers to the sandbox. Also hide the "Try it out" button for non-stable Hono versions.