### PR TITLE
Fix jaeger RemoteControlledSampler not working in quarkus native images

### DIFF
--- a/service-base-quarkus/pom.xml
+++ b/service-base-quarkus/pom.xml
@@ -25,6 +25,10 @@
   <description>Base classes for implementing Hono services using Quarkus.</description>
   <url>https://www.eclipse.org/hono</url>
 
+  <properties>
+    <jaeger-reflection-config/>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -192,6 +196,78 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jaeger</id>
+      <properties>
+        <jaeger-reflection-config>
+  {
+    "name" : "io.jaegertracing.internal.samplers.http.OperationSamplingParameters",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "fields" : [
+      { "name" : "defaultSamplingProbability", "allowWrite" : true },
+      { "name" : "defaultLowerBoundTracesPerSecond", "allowWrite" : true },
+      { "name" : "perOperationStrategies", "allowWrite" : true }
+    ]
+  },
+  {
+    "name" : "io.jaegertracing.internal.samplers.http.PerOperationSamplingParameters",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "fields" : [
+      { "name" : "operation", "allowWrite" : true },
+      { "name" : "probabilisticSampling", "allowWrite" : true }
+    ]
+  },
+  {
+    "name" : "io.jaegertracing.internal.samplers.http.ProbabilisticSamplingStrategy",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "fields" : [
+      { "name" : "samplingRate", "allowWrite" : true }
+    ]
+  },
+  {
+    "name" : "io.jaegertracing.internal.samplers.http.RateLimitingSamplingStrategy",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "fields" : [
+      { "name" : "maxTracesPerSecond", "allowWrite" : true }
+    ]
+  },
+  {
+    "name" : "io.jaegertracing.internal.samplers.http.SamplingStrategyResponse",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "fields" : [
+      { "name" : "probabilisticSampling", "allowWrite" : true },
+      { "name" : "rateLimitingSampling", "allowWrite" : true },
+      { "name" : "operationSampling", "allowWrite" : true }
+    ]
+  },
+        </jaeger-reflection-config>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/service-base-quarkus/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-base-quarkus/reflection-config.json
+++ b/service-base-quarkus/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-base-quarkus/reflection-config.json
@@ -1,4 +1,5 @@
 [
+  ${jaeger-reflection-config}
   {
     "name": "org.apache.logging.log4j.message.ReusableMessageFactory",
     "methods": [


### PR DESCRIPTION
Jaeger tracing currently doesn't work when using quarkus-native images and a jaeger sampling configuration that uses the sampling strategies defined in the Jaeger Collector component (i.e. using the RemoteControlledSampler).


This seems caused by the reflection used in conjunction with the `io.jaegertracing.internal.samplers.HttpSamplingManager` class.
There, a `SamplingStrategyResponse` object is deserialized from the JSON response using gson, which makes use of reflection to do so. That means that, at least with the current `quarkus-jaeger` code, a reflection config has to be defined in places where the JaegerTracer is used (see also https://github.com/quarkusio/quarkus/issues/10402#issuecomment-845717069).

This PR adds that. 

Hope would be that https://github.com/quarkusio/quarkus/issues/10402 gets solved in a way that doesn't make such a configuration necessary, so that this reflection config can be removed again with a quarkus update.


Relates to:
https://github.com/eclipse/packages/pull/245

---
I've triggered a test build here also without the `jaeger` maven profile. That causes some warnings (e.g. `WARNING: Could not resolve io.jaegertracing.internal.samplers.http.OperationSamplingParameters for reflection configuration.`), but the build succeeds.
