### PR TITLE
Adapt connection limit strategy to VM being used

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -207,7 +207,7 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
      */
     private void logJvmDetails() {
         if (LOG.isInfoEnabled()) {
-            LOG.info("running on Java VM [version: {}, name: {}, vendor: {}, max memory: {}MB, processors: {}]",
+            LOG.info("running on Java VM [version: {}, name: {}, vendor: {}, max memory: {}MiB, processors: {}]",
                     System.getProperty("java.version"),
                     System.getProperty("java.vm.name"),
                     System.getProperty("java.vm.vendor"),

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/limiting/MemoryBasedConnectionLimitStrategy.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/limiting/MemoryBasedConnectionLimitStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -75,7 +75,8 @@ public class MemoryBasedConnectionLimitStrategy implements ConnectionLimitStrate
 
     @Override
     public String getResourcesDescription() {
-        return "max. available memory: " + maxMemory / 1_000_000 + "MB";
+        return String.format("max. available memory: %dMB, memory required to start: %dMB",
+                maxMemory / 1_000_000, memoryRequiredToStart / 1_000_000);
     }
 
 }

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/limiting/MemoryBasedConnectionLimitStrategyTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/limiting/MemoryBasedConnectionLimitStrategyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -24,17 +24,6 @@ public class MemoryBasedConnectionLimitStrategyTest {
 
     private static final int MINIMAL_MEMORY = 100_000_000;
     private static final int MEMORY_PER_CONNECTION = 20_000;
-
-    /**
-     * Verifies the description of the resources that the strategy takes into account.
-     */
-    @Test
-    public void getResourcesDescription() {
-        assertEquals("max. available memory: 1MB", new MemoryBasedConnectionLimitStrategy(MINIMAL_MEMORY,
-                MEMORY_PER_CONNECTION, 1_000_000).getResourcesDescription());
-        assertEquals("max. available memory: 10MB", new MemoryBasedConnectionLimitStrategy(MINIMAL_MEMORY,
-                MEMORY_PER_CONNECTION, 10_000_000).getResourcesDescription());
-    }
 
     /**
      * Verifies that the recommended connection limit is not negative.

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -105,14 +105,19 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
 
     // These values should be made configurable.
     /**
-     * The minimum amount of memory that the adapter requires to run.
+     * The minimum amount of memory (bytes) that the adapter requires to run on a standard Java VM.
      */
-    private static final int MINIMAL_MEMORY = 100_000_000; // 100MB: minimal memory necessary for startup
+    private static final int MINIMAL_MEMORY_JVM = 100_000_000;
+    /**
+     * The minimum amount of memory (bytes) that the adapter requires to run on a Substrate VM (i.e. when running
+     * as a GraalVM native image).
+     */
+    private static final int MINIMAL_MEMORY_SUBSTRATE = 35_000_000;
 
     /**
-     * The amount of memory required for each connection.
+     * The amount of memory (bytes) required for each connection.
      */
-    private static final int MEMORY_PER_CONNECTION = 20_000; // 20KB: expected avg. memory consumption per connection
+    private static final int MEMORY_PER_CONNECTION = 20_000;
 
     /**
      * The AMQP server instance that maps to a secure port.
@@ -229,7 +234,8 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
     private ConnectionLimitManager createConnectionLimitManager() {
         return new DefaultConnectionLimitManager(
                 new MemoryBasedConnectionLimitStrategy(
-                        MINIMAL_MEMORY, MEMORY_PER_CONNECTION + getConfig().getMaxSessionWindowSize()),
+                        getConfig().isSubstrateVm() ? MINIMAL_MEMORY_SUBSTRATE : MINIMAL_MEMORY_JVM,
+                        MEMORY_PER_CONNECTION + getConfig().getMaxSessionWindowSize()),
                 () -> metrics.getNumberOfConnections(), getConfig());
     }
 

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -105,13 +105,18 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
         extends AbstractProtocolAdapterBase<T> {
 
     /**
-     * The minimum amount of memory that the adapter requires to run.
+     * The minimum amount of memory (bytes) that the adapter requires to run on a standard Java VM.
      */
-    protected static final int MINIMAL_MEMORY = 100_000_000; // 100MB: minimal memory necessary for startup
+    protected static final int MINIMAL_MEMORY_JVM = 100_000_000;
     /**
-     * The amount of memory required for each connection.
+     * The minimum amount of memory (bytes) that the adapter requires to run on a Substrate VM (i.e. when running
+     * as a GraalVM native image).
      */
-    protected static final int MEMORY_PER_CONNECTION = 20_000; // 20KB: expected avg. memory consumption per connection
+    protected static final int MINIMAL_MEMORY_SUBSTRATE = 35_000_000;
+    /**
+     * The amount of memory (bytes) required for each connection.
+     */
+    protected static final int MEMORY_PER_CONNECTION = 20_000;
 
     private static final int IANA_MQTT_PORT = 1883;
     private static final int IANA_SECURE_MQTT_PORT = 8883;
@@ -349,7 +354,9 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
 
     private ConnectionLimitManager createConnectionLimitManager() {
         return new DefaultConnectionLimitManager(
-                new MemoryBasedConnectionLimitStrategy(MINIMAL_MEMORY, MEMORY_PER_CONNECTION),
+                new MemoryBasedConnectionLimitStrategy(
+                        getConfig().isSubstrateVm() ? MINIMAL_MEMORY_SUBSTRATE : MINIMAL_MEMORY_JVM,
+                        MEMORY_PER_CONNECTION),
                 () -> metrics.getNumberOfConnections(), getConfig());
     }
 

--- a/core/src/main/java/org/eclipse/hono/config/ServerConfig.java
+++ b/core/src/main/java/org/eclipse/hono/config/ServerConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,6 +29,15 @@ public class ServerConfig extends AbstractConfig {
     private String insecurePortBindAddress = Constants.LOOPBACK_DEVICE_ADDRESS;
     private int insecurePort = Constants.PORT_UNCONFIGURED;
     private boolean sni = false;
+
+    /**
+     * Checks if the current thread is running on the Graal Substrate VM.
+     *
+     * @return {@code true} if the <em>java.vm.name</em> system property value start with {@code Substrate}.
+     */
+    public final boolean isSubstrateVm() {
+        return System.getProperty("java.vm.name", "unknown").startsWith("Substrate");
+    }
 
     /**
      * Gets the host name or literal IP address of the network interface that this server's secure port is configured to

--- a/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractServiceApplication.java
+++ b/service-base-quarkus/src/main/java/org/eclipse/hono/service/quarkus/AbstractServiceApplication.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.service.quarkus;
+
+import javax.inject.Inject;
+
+import org.eclipse.hono.service.HealthCheckServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.cpu.CpuCoreSensor;
+
+/**
+ * A base class for implementing Quarkus based services.
+ *
+ */
+public abstract class AbstractServiceApplication {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractServiceApplication.class);
+
+    @Inject
+    protected Vertx vertx;
+
+    @Inject
+    protected MeterRegistry meterRegistry;
+
+    @Inject
+    protected HealthCheckServer healthCheckServer;
+
+    /**
+     * Logs information about the JVM.
+     */
+    protected void logJvmDetails() {
+        if (LOG.isInfoEnabled()) {
+            LOG.info("running on Java VM [version: {}, name: {}, vendor: {}, max memory: {}MiB, processors: {}]",
+                    System.getProperty("java.version"),
+                    System.getProperty("java.vm.name"),
+                    System.getProperty("java.vm.vendor"),
+                    Runtime.getRuntime().maxMemory() >> 20,
+                    CpuCoreSensor.availableProcessors());
+        }
+    }
+}

--- a/services/auth-quarkus/src/main/java/org/eclipse/hono/authentication/quarkus/Application.java
+++ b/services/auth-quarkus/src/main/java/org/eclipse/hono/authentication/quarkus/Application.java
@@ -23,38 +23,32 @@ import org.eclipse.hono.authentication.SimpleAuthenticationServer;
 import org.eclipse.hono.authentication.file.FileBasedAuthenticationService;
 import org.eclipse.hono.config.quarkus.ApplicationConfigProperties;
 import org.eclipse.hono.config.quarkus.ServiceConfigProperties;
-import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.auth.AuthTokenHelper;
 import org.eclipse.hono.service.auth.AuthTokenHelperImpl;
 import org.eclipse.hono.service.auth.AuthenticationService;
 import org.eclipse.hono.service.auth.HonoSaslAuthenticatorFactory;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.quarkus.AbstractServiceApplication;
 import org.eclipse.hono.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.arc.config.ConfigPrefix;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.impl.cpu.CpuCoreSensor;
 import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
 
 /**
  * The Quarkus based Authentication server main application class.
  */
 @ApplicationScoped
-public class Application {
+public class Application extends AbstractServiceApplication {
 
     private static final String COMPONENT_NAME = "Hono Authentication Server";
     private static final Logger LOG = LoggerFactory.getLogger(Application.class);
-
-    @Inject
-    Vertx vertx;
 
     @Inject
     ApplicationConfigProperties appConfig;
@@ -65,17 +59,13 @@ public class Application {
     @Inject
     FileBasedAuthenticationServiceConfigProperties serviceConfig;
 
-    @Inject
-    HealthCheckServer healthCheckServer;
-
-    @Inject
-    MeterRegistry meterRegistry;
-
     String getComponentName() {
         return COMPONENT_NAME;
     }
 
     void onStart(final @Observes StartupEvent ev) {
+
+        logJvmDetails();
 
         LOG.info("adding common tags to meter registry");
         meterRegistry.config().commonTags(MetricsTags.forService(Constants.SERVICE_NAME_AUTH));
@@ -116,23 +106,6 @@ public class Application {
                 });
             });
         shutdown.join();
-    }
-
-    /**
-     * Logs information about the JVM.
-     *
-     * @param start The event indicating that the application has been started.
-     */
-    protected void logJvmDetails(@Observes final StartupEvent start) {
-        if (LOG.isInfoEnabled()) {
-            LOG.info("running on Java VM [version: {}, name: {}, vendor: {}, max memory: {}MB, processors: {}]",
-                    System.getProperty("java.version"),
-                    System.getProperty("java.vm.name"),
-                    System.getProperty("java.vm.vendor"),
-                    Runtime.getRuntime().maxMemory() >> 20,
-                    CpuCoreSensor.availableProcessors());
-        }
-
     }
 
     AuthTokenHelper authTokenFactory() {

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/Application.java
@@ -40,13 +40,13 @@ import org.eclipse.hono.config.quarkus.ApplicationConfigProperties;
 import org.eclipse.hono.config.quarkus.ServiceConfigProperties;
 import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
 import org.eclipse.hono.service.HealthCheckProvider;
-import org.eclipse.hono.service.HealthCheckServer;
 import org.eclipse.hono.service.amqp.AmqpEndpoint;
 import org.eclipse.hono.service.auth.AuthenticationService;
 import org.eclipse.hono.service.cache.Caches;
 import org.eclipse.hono.service.commandrouter.CommandRouterService;
 import org.eclipse.hono.service.commandrouter.DelegatingCommandRouterAmqpEndpoint;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.quarkus.AbstractServiceApplication;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.RegistrationResult;
@@ -57,7 +57,6 @@ import org.slf4j.LoggerFactory;
 
 import com.github.benmanes.caffeine.cache.Cache;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.opentracing.Tracer;
 import io.quarkus.arc.config.ConfigPrefix;
 import io.quarkus.runtime.ShutdownEvent;
@@ -66,8 +65,6 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
-import io.vertx.core.Vertx;
-import io.vertx.core.impl.cpu.CpuCoreSensor;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
 
@@ -75,13 +72,10 @@ import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
  * The Quarkus based Command Router main application class.
  */
 @ApplicationScoped
-public class Application {
+public class Application extends AbstractServiceApplication {
 
     private static final String COMPONENT_NAME = "Hono Command Router";
     private static final Logger LOG = LoggerFactory.getLogger(Application.class);
-
-    @Inject
-    Vertx vertx;
 
     @Inject
     Tracer tracer;
@@ -112,12 +106,6 @@ public class Application {
 
     @Inject
     DeviceConnectionInfo deviceConnectionInfo;
-
-    @Inject
-    HealthCheckServer healthCheckServer;
-
-    @Inject
-    MeterRegistry meterRegistry;
 
     @Inject
     ProtonSaslAuthenticatorFactory saslAuthenticatorFactory;
@@ -180,21 +168,6 @@ public class Application {
                 });
             });
         shutdown.join();
-    }
-
-    /**
-     * Logs information about the JVM.
-     */
-    private void logJvmDetails() {
-        if (LOG.isInfoEnabled()) {
-            LOG.info("running on Java VM [version: {}, name: {}, vendor: {}, max memory: {}MB, processors: {}]",
-                    System.getProperty("java.version"),
-                    System.getProperty("java.vm.name"),
-                    System.getProperty("java.vm.vendor"),
-                    Runtime.getRuntime().maxMemory() >> 20,
-                    CpuCoreSensor.availableProcessors());
-        }
-
     }
 
     private CommandRouterAmqpServer amqpServer() {

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -14,8 +14,8 @@ hono:
     insecurePortEnabled: true
     keyPath: /etc/hono/certs/amqp-adapter-key.pem
     certPath: /etc/hono/certs/amqp-adapter-cert.pem
-    maxConnections: 10
     sendMessageToDeviceTimeout: ${adapter.sendMessageToDeviceTimeout}
+    maxFrameSize: 4096
     supportedCipherSuites:
     # one TLS 1.3 cipher suite
     - "TLS_AES_128_GCM_SHA256"

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -14,7 +14,6 @@ hono:
     insecurePortEnabled: true
     keyPath: /etc/hono/certs/mqtt-adapter-key.pem
     certPath: /etc/hono/certs/mqtt-adapter-cert.pem
-    maxConnections: 10
     sendMessageToDeviceTimeout: ${adapter.sendMessageToDeviceTimeout}
   messaging:
     name: 'Hono MQTT Adapter'


### PR DESCRIPTION
The protocol adapters use the MemoryBasedConnectionLimitStrategy to
determine the number of connections that can be established with devices
based on the memory available to the adapter process.

The adapters currently assume to be running on a standard Java VM and
therefore assess the minimum amount of memory required for running to be
100MB (excluding memory allocated for device connections).

When using the Quarkus based native images, the memory footprint of the
adapters is significantly lower. This is now reflected in the MQTT and
AMQP adapters which first check the type of VM they are running on and
then adapt the minimum required memory accordingly.

Fixes #2675
