### PR TITLE
[#2265] Refactor auto-provisioning of edge devices

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractAutoProvisioningEventSender.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractAutoProvisioningEventSender.java
@@ -163,20 +163,23 @@ public abstract class AbstractAutoProvisioningEventSender implements Lifecycle {
      * @param tenantId The tenant identifier.
      * @param deviceId The edge device identifier.
      * @param device The edge device registration information.
+     * @param deviceVersion The version of the device registration information to check before update,
+     *                      may be {@link Optional#empty()}.
      * @param span The span to be used for tracing this operation.
      * @return A future indicating the outcome of the operation.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     protected Future<Void> updateAutoProvisioningNotificationSent(final String tenantId,
-            final String deviceId, final Device device, final Span span) {
+            final String deviceId, final Device device, final Optional<String> deviceVersion, final Span span) {
 
         Objects.requireNonNull(tenantId);
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(device);
+        Objects.requireNonNull(deviceVersion);
         Objects.requireNonNull(span);
 
         device.setStatus(new DeviceStatus().setAutoProvisioningNotificationSent(true));
-        return deviceManagementService.updateDevice(tenantId, deviceId, device, Optional.empty(), span)
+        return deviceManagementService.updateDevice(tenantId, deviceId, device, deviceVersion, span)
                 .compose(result -> {
                     if (HttpURLConnection.HTTP_NO_CONTENT == result.getStatus()) {
                         return Future.succeededFuture();

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractAutoProvisioningEventSender.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractAutoProvisioningEventSender.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.deviceregistry.service.device;
+
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.hono.adapter.client.telemetry.EventSender;
+import org.eclipse.hono.client.util.MessagingClient;
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.service.management.device.DeviceStatus;
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
+import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * Abstract helper class for sending auto-provisioning event.
+ */
+public abstract class AbstractAutoProvisioningEventSender implements Lifecycle {
+    /**
+     * A logger to be shared with subclasses.
+     */
+    protected final Logger LOG = LoggerFactory.getLogger(getClass());
+    protected final DeviceManagementService deviceManagementService;
+    protected final MessagingClient<EventSender> eventClients;
+    protected final Vertx vertx;
+
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    /**
+     * Creates an instance of {@link AbstractAutoProvisioningEventSender}.
+     *
+     * @param vertx The vert.x instance to use.
+     * @param deviceManagementService The device management service.
+     * @param eventClients The messaging clients to send auto-provisioned events.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public AbstractAutoProvisioningEventSender(final Vertx vertx,
+            final DeviceManagementService deviceManagementService,
+            final MessagingClient<EventSender> eventClients) {
+        Objects.requireNonNull(vertx);
+        Objects.requireNonNull(deviceManagementService);
+        Objects.requireNonNull(eventClients);
+
+        this.vertx = vertx;
+        this.deviceManagementService = deviceManagementService;
+        this.eventClients = eventClients;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The future returned by the configured {@linkplain EventSender#start() event sender's start() method}.
+     */
+    @Override
+    public final Future<Void> start() {
+        if (started.compareAndSet(false, true)) {
+            LOG.debug("starting up");
+            // decouple establishment of the sender's downstream connection from this component's
+            // start-up process and instead rely on the event sender's readiness check to succeed
+            // once the connection has been established
+            eventClients.start();
+        }
+        return Future.succeededFuture();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The future returned by the configured {@linkplain EventSender#stop() event sender's stop() method}.
+     */
+    @Override
+    public final Future<Void> stop() {
+        if (started.compareAndSet(true, false)) {
+            LOG.debug("shutting down");
+            return eventClients.stop();
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+
+    /**
+     * Send an auto-provisioning event with content type
+     * {@value EventConstants#CONTENT_TYPE_DEVICE_PROVISIONING_NOTIFICATION}.
+     *
+     * @param tenantId The tenant identifier.
+     * @param tenant The tenant information.
+     * @param deviceId The device identifier.
+     * @param gatewayId The gateway identifier if an edge device is being auto-provisioned.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
+     *            implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation. The future will be succeeded if the auto-provisioning
+     *         event is sent successfully.
+     * @throws NullPointerException if any of the parameters except gateway id is {@code null}.
+     * @see "https://www.eclipse.org/hono/docs/api/event/#device-provisioning-notification"
+     */
+    protected Future<Void> sendAutoProvisioningEvent(
+            final String tenantId,
+            final Tenant tenant,
+            final String deviceId,
+            final String gatewayId,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(span);
+
+        LOG.debug("sending auto-provisioning event [tenant-id: {}, device-id: {}, gateway-id: {}]", tenant, deviceId,
+                gatewayId);
+
+        // TODO to remove once able to send events without providing an argument of type TenantObject
+        final TenantObject tenantConfig = DeviceRegistryUtils.convertTenant(tenantId, tenant)
+                .mapTo(TenantObject.class);
+        final EventSender eventSender = eventClients.getClient(tenantConfig);
+
+        return eventSender
+                .sendEvent(tenantConfig, new RegistrationAssertion(deviceId),
+                        EventConstants.CONTENT_TYPE_DEVICE_PROVISIONING_NOTIFICATION, null,
+                        assembleAutoProvisioningEventProperties(tenantId, gatewayId), span.context())
+                .onSuccess(ok -> {
+                    span.log("sent auto-provisioning event successfully");
+                    LOG.debug(
+                            "sent auto-provisioning event successfully [tenant-id: {}, device-id: {}, gateway-id: {}]",
+                            tenantId, deviceId, gatewayId);
+                })
+                .onFailure(t -> LOG.warn(
+                        "error sending auto-provisioning event [tenant-id: {}, device-id: {}, gateway-id: {}]",
+                        tenantId, deviceId, gatewayId));
+    }
+
+    /**
+     * Update the device registration information that the auto-provisioning notification has been successfully sent.
+     *
+     * @param tenantId The tenant identifier.
+     * @param deviceId The edge device identifier.
+     * @param device The edge device registration information.
+     * @param span The span to be used for tracing this operation.
+     * @return A future indicating the outcome of the operation.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    protected Future<Void> updateAutoProvisioningNotificationSent(final String tenantId,
+            final String deviceId, final Device device, final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(span);
+
+        device.setStatus(new DeviceStatus().setAutoProvisioningNotificationSent(true));
+        return deviceManagementService.updateDevice(tenantId, deviceId, device, Optional.empty(), span)
+                .compose(result -> {
+                    if (HttpURLConnection.HTTP_NO_CONTENT == result.getStatus()) {
+                        return Future.succeededFuture();
+                    } else {
+                        final String errorMessage = String.format(
+                                "error updating device with 'AutoProvisioningNotificationSent=true' [status: %s, tenant-id: %s, device-id: %s]",
+                                result.getStatus(), tenantId, deviceId);
+                        LOG.warn(errorMessage);
+                        Tags.HTTP_STATUS.set(span, result.getStatus());
+                        TracingHelper.logError(span,
+                                "error updating device with 'AutoProvisioningNotificationSent=true'");
+                        return Future.failedFuture(errorMessage);
+                    }
+                });
+    }
+
+    private static Map<String, Object> assembleAutoProvisioningEventProperties(final String tenantId,
+            final String gatewayId) {
+        final HashMap<String, Object> props = new HashMap<>();
+
+        props.put(MessageHelper.APP_PROPERTY_ORIG_ADDRESS, EventConstants.EVENT_ENDPOINT);
+        props.put(MessageHelper.APP_PROPERTY_REGISTRATION_STATUS, EventConstants.RegistrationStatus.NEW.name());
+        props.put(MessageHelper.APP_PROPERTY_ORIG_ADAPTER, Constants.PROTOCOL_ADAPTER_TYPE_DEVICE_REGISTRY);
+        props.put(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
+        Optional.ofNullable(gatewayId)
+                .ifPresent(id -> props.put(MessageHelper.APP_PROPERTY_GATEWAY_ID, id));
+
+        return props;
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/DeviceKey.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/DeviceKey.java
@@ -36,7 +36,7 @@ public final class DeviceKey {
      * @param tenantId The id of the tenant.
      * @param deviceId The id of the device.
      */
-    public DeviceKey(final String tenantId, final String deviceId) {
+    private DeviceKey(final String tenantId, final String deviceId) {
         this.tenantId = tenantId;
         this.deviceId = deviceId;
     }
@@ -72,6 +72,21 @@ public final class DeviceKey {
         Objects.requireNonNull(deviceId);
 
         return new DeviceKey(tenantKey.getTenantId(), deviceId);
+    }
+
+    /**
+     * Creates a device key from tenant and device identifiers.
+     *
+     * @param tenantId The tenant identifier.
+     * @param deviceId The device identifier.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @return The device key.
+     */
+    public static DeviceKey from(final String tenantId, final String deviceId) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return new DeviceKey(tenantId, deviceId);
     }
 
     @Override

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/EdgeDeviceAutoProvisioner.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/EdgeDeviceAutoProvisioner.java
@@ -154,7 +154,8 @@ public class EdgeDeviceAutoProvisioner extends AbstractAutoProvisioningEventSend
                                         }
 
                                         final Device deviceData = readDeviceResult.getPayload();
-                                        return updateAutoProvisioningNotificationSent(tenantId, deviceId, deviceData, span)
+                                        return updateAutoProvisioningNotificationSent(tenantId, deviceId, deviceData,
+                                                readDeviceResult.getResourceVersion(), span)
                                                 //auto-provisioning still succeeds even if the device registration cannot be updated with the notification flag
                                                 .recover(error -> Future.succeededFuture())
                                                 .map(deviceData);
@@ -218,7 +219,8 @@ public class EdgeDeviceAutoProvisioner extends AbstractAutoProvisioningEventSend
                                     tenantId, deviceId);
                             span.log("sending event - notificationSent flag wasn't updated in between");
                             return sendAutoProvisioningEvent(tenantId, tenant, deviceId, gatewayId, span)
-                                    .compose(ok -> updateAutoProvisioningNotificationSent(tenantId, deviceId, readDevice, span)
+                                    .compose(ok -> updateAutoProvisioningNotificationSent(tenantId, deviceId,
+                                            readDevice, readDeviceResult.getResourceVersion(), span)
                                                     // auto-provisioning still succeeds even if the device registration
                                                     // cannot be updated with the notification flag
                                                     .recover(error -> Future.succeededFuture()));

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedServiceConfig.java
@@ -27,8 +27,8 @@ import org.eclipse.hono.client.util.MessagingClient;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
-import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
+import org.eclipse.hono.deviceregistry.service.device.EdgeDeviceAutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.deviceconnection.MapBasedDeviceConnectionsConfigProperties;
 import org.eclipse.hono.deviceregistry.service.tenant.DefaultTenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
@@ -249,15 +249,14 @@ public class FileBasedServiceConfig {
 
         final var tenantInformationService = tenantInformationService();
 
-        final AutoProvisioner autoProvisioner = new AutoProvisioner();
-        autoProvisioner.setDeviceManagementService(registrationService);
-        autoProvisioner.setVertx(vertx);
-        autoProvisioner.setTracer(tracer);
-        autoProvisioner.setTenantInformationService(tenantInformationService);
-        autoProvisioner.setEventSenders(eventSenders());
-        autoProvisioner.setConfig(autoProvisionerConfigProperties());
+        final EdgeDeviceAutoProvisioner edgeDeviceAutoProvisioner = new EdgeDeviceAutoProvisioner(
+                vertx,
+                registrationService,
+                eventSenders(),
+                autoProvisionerConfigProperties(),
+                tracer);
 
-        registrationService.setAutoProvisioner(autoProvisioner);
+        registrationService.setEdgeDeviceAutoProvisioner(edgeDeviceAutoProvisioner);
 
         final FileBasedCredentialsService credentialsService = new FileBasedCredentialsService(
                 vertx,

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
@@ -37,9 +37,8 @@ import java.util.UUID;
 import org.eclipse.hono.adapter.client.telemetry.EventSender;
 import org.eclipse.hono.client.util.MessagingClient;
 import org.eclipse.hono.deviceregistry.DeviceRegistryTestUtils;
-import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
-import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
+import org.eclipse.hono.deviceregistry.service.device.EdgeDeviceAutoProvisioner;
 import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
@@ -56,6 +55,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import io.opentracing.noop.NoopSpan;
+import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -94,17 +94,16 @@ public class FileBasedRegistrationServiceTest implements AbstractRegistrationSer
         registrationService = new FileBasedRegistrationService(vertx);
         registrationService.setConfig(registrationConfig);
 
-        final AutoProvisioner autoProvisioner = new AutoProvisioner();
-        autoProvisioner.setVertx(vertx);
-        autoProvisioner.setTenantInformationService(mock(TenantInformationService.class));
-        autoProvisioner.setDeviceManagementService(registrationService);
-        autoProvisioner.setConfig(new AutoProvisionerConfigProperties());
-
         final MessagingClient<EventSender> messagingClients = mockEventSenders();
 
-        autoProvisioner.setEventSenders(messagingClients);
+        final EdgeDeviceAutoProvisioner edgeDeviceAutoProvisioner = new EdgeDeviceAutoProvisioner(
+                vertx,
+                registrationService,
+                messagingClients,
+                new AutoProvisionerConfigProperties(),
+                NoopTracerFactory.create());
 
-        registrationService.setAutoProvisioner(autoProvisioner);
+        registrationService.setEdgeDeviceAutoProvisioner(edgeDeviceAutoProvisioner);
     }
 
     private MessagingClient<EventSender> mockEventSenders() {

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/ApplicationConfig.java
@@ -43,8 +43,8 @@ import org.eclipse.hono.deviceregistry.jdbc.impl.TenantManagementServiceImpl;
 import org.eclipse.hono.deviceregistry.jdbc.impl.TenantServiceImpl;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryAmqpServer;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
-import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
+import org.eclipse.hono.deviceregistry.service.device.EdgeDeviceAutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.tenant.DefaultTenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.util.ServiceClientAdapter;
@@ -437,15 +437,14 @@ public class ApplicationConfig {
     public RegistrationService registrationService(final SchemaCreator schemaCreator) throws IOException {
 
         final RegistrationServiceImpl registrationService = new RegistrationServiceImpl(devicesAdapterStore(), schemaCreator);
-        final AutoProvisioner autoProvisioner = new AutoProvisioner();
+        final EdgeDeviceAutoProvisioner edgeDeviceAutoProvisioner = new EdgeDeviceAutoProvisioner(
+                vertx(),
+                registrationManagementService(),
+                eventSenders(),
+                autoProvisionerConfigProperties(),
+                tracer());
 
-        autoProvisioner.setDeviceManagementService(registrationManagementService());
-        autoProvisioner.setVertx(vertx());
-        autoProvisioner.setTracer(tracer());
-        autoProvisioner.setEventSenders(eventSenders());
-        autoProvisioner.setConfig(autoProvisionerConfigProperties());
-        autoProvisioner.setTenantInformationService(tenantInformationService());
-        registrationService.setAutoProvisioner(autoProvisioner);
+        registrationService.setEdgeDeviceAutoProvisioner(edgeDeviceAutoProvisioner);
 
         return registrationService;
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/ApplicationConfig.java
@@ -40,8 +40,8 @@ import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedRegistrationS
 import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedTenantService;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryAmqpServer;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
-import org.eclipse.hono.deviceregistry.service.device.AutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
+import org.eclipse.hono.deviceregistry.service.device.EdgeDeviceAutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.tenant.DefaultTenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.util.ServiceClientAdapter;
@@ -387,15 +387,14 @@ public class ApplicationConfig {
                 mongoClient(),
                 registrationServiceProperties());
 
-        final AutoProvisioner autoProvisioner = new AutoProvisioner();
-        autoProvisioner.setVertx(vertx());
-        autoProvisioner.setTracer(tracer());
-        autoProvisioner.setDeviceManagementService(service);
-        autoProvisioner.setTenantInformationService(tenantInformationService());
-        autoProvisioner.setEventSenders(eventSenders());
-        autoProvisioner.setConfig(autoProvisionerConfigProperties());
+        final EdgeDeviceAutoProvisioner edgeDeviceAutoProvisioner = new EdgeDeviceAutoProvisioner(
+                vertx(),
+                service,
+                eventSenders(),
+                autoProvisionerConfigProperties(),
+                tracer());
 
-        service.setAutoProvisioner(autoProvisioner);
+        service.setEdgeDeviceAutoProvisioner(edgeDeviceAutoProvisioner);
         healthCheckServer().registerHealthCheckResources(service);
         return service;
     }


### PR DESCRIPTION
* Helper methods to send auto-provisioned events have been pulled
  up to a new `AbstractAutoProvisioningEventSender` for reuse thereby
  preparing for the issue #2665.
* Edge device auto-provisioning doesn't require tenant information
  service anymore but rather takes a tenant instance as an argument
  which is provided by the `AbstractRegistrationService`. The code has
  also been optimised so that the `AbstractRegistrationService`
  now uses `getTenant()` instead of `tenantExists()` to check if a tenant
  exists and also passes this tenant instance as an argument to the
  auto-provisioning helper method.
* `AutoProvisioner` has been renamed to `EdgeDeviceAutoProvisioner` to suit
  the actual purpose of that class and also the constructor has been
  adapted to replace the various _setter_ methods in that class.
* The version is checked now while updating device registration for property 
  `AutoProvisioningNotificationSent`.