### PR TITLE
Catch exception publishing command to MQTT device

### DIFF
--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1414,9 +1414,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                     ? String.format("gateway [%s], device [%s]", authenticatedDevice.getDeviceId(), context.deviceId())
                     : String.format("device [%s]", context.deviceId());
 
-            final Promise<Integer> resultPromise = Promise.promise();
-            endpoint.publish(publishTopic, errorJson.toBuffer(), subscription.getQos(), false, false, resultPromise);
-            return resultPromise.future()
+            return publish(publishTopic, errorJson.toBuffer(), subscription.getQos())
                     .onSuccess(msgId -> {
                         log.debug("published error message [packet-id: {}] to {} [tenant-id: {}, MQTT client-id: {}, QoS: {}, topic: {}]",
                                 msgId, targetInfo, subscription.getTenant(), endpoint.clientIdentifier(),
@@ -1534,43 +1532,53 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
                 : String.format("device [%s]", command.getDeviceId());
 
             getCommandPayload(commandContext)
-                .onSuccess(mappedPayload -> {
-                    endpoint.publish(publishTopic, mappedPayload, subscription.getQos(), false, false, sentHandler -> {
-                        if (sentHandler.succeeded()) {
-
-                            final Integer msgId = sentHandler.result();
-                            log.debug("published command [packet-id: {}] to {} [tenant-id: {}, MQTT client-id: {}, QoS: {}, topic: {}]",
-                                msgId, targetInfo, subscription.getTenant(), endpoint.clientIdentifier(),
-                                subscription.getQos(), publishTopic);
-                            commandContext.getTracingSpan().log(subscription.getQos().value() > 0 ? "published command, packet-id: " + msgId
-                                : "published command");
-                            afterCommandPublished(msgId, commandContext, tenantObject, subscription);
-                        } else {
-                            log.debug("error publishing command to {} [tenant-id: {}, MQTT client-id: {}, QoS: {}, topic: {}]",
-                                targetInfo, subscription.getTenant(), endpoint.clientIdentifier(),
-                                subscription.getQos(), publishTopic, sentHandler.cause());
-                            TracingHelper.logError(commandContext.getTracingSpan(), "failed to publish command", sentHandler.cause());
-                            reportPublishedCommand(
+                    .onSuccess(mappedPayload -> {
+                        publish(publishTopic, mappedPayload, subscription.getQos())
+                                .onSuccess(msgId -> {
+                                    log.debug("published command [packet-id: {}] to {} [tenant-id: {}, MQTT client-id: {}, QoS: {}, topic: {}]",
+                                            msgId, targetInfo, subscription.getTenant(), endpoint.clientIdentifier(),
+                                            subscription.getQos(), publishTopic);
+                                    commandContext.getTracingSpan()
+                                            .log(subscription.getQos().value() > 0
+                                                    ? "published command, packet-id: " + msgId
+                                                    : "published command");
+                                    afterCommandPublished(msgId, commandContext, tenantObject, subscription);
+                                })
+                                .onFailure(thr -> {
+                                    log.debug("error publishing command to {} [tenant-id: {}, MQTT client-id: {}, QoS: {}, topic: {}]",
+                                            targetInfo, subscription.getTenant(), endpoint.clientIdentifier(),
+                                            subscription.getQos(), publishTopic, thr);
+                                    TracingHelper.logError(commandContext.getTracingSpan(), "failed to publish command", thr);
+                                    reportPublishedCommand(
+                                            tenantObject,
+                                            subscription,
+                                            commandContext,
+                                            ProcessingOutcome.from(thr));
+                                    commandContext.release();
+                                });
+                    }).onFailure(t -> {
+                        log.debug("error mapping command [tenant-id: {}, MQTT client-id: {}, QoS: {}]",
+                                subscription.getTenant(), endpoint.clientIdentifier(), subscription.getQos(), t);
+                        TracingHelper.logError(commandContext.getTracingSpan(), "failed to map command", t);
+                        reportPublishedCommand(
                                 tenantObject,
                                 subscription,
                                 commandContext,
-                                ProcessingOutcome.from(sentHandler.cause()));
-                            commandContext.release();
-                        }
+                                ProcessingOutcome.from(t));
+                        commandContext.release();
                     });
-                }
-            ).onFailure(t -> {
-                log.debug("error mapping command [tenant-id: {}, MQTT client-id: {}, QoS: {}]",
-                    subscription.getTenant(), endpoint.clientIdentifier(),
-                    subscription.getQos(), t);
-                TracingHelper.logError(commandContext.getTracingSpan(), "failed to map command", t);
-                reportPublishedCommand(
-                    tenantObject,
-                    subscription,
-                    commandContext,
-                    ProcessingOutcome.from(t));
-                commandContext.release();
-            });
+        }
+
+        private Future<Integer> publish(final String topic, final Buffer payload, final MqttQoS qosLevel) {
+            final Promise<Integer> publishSentPromise = Promise.promise();
+            try {
+                endpoint.publish(topic, payload, qosLevel, false, false, publishSentPromise);
+            } catch (final Exception e) {
+                publishSentPromise.fail(!endpoint.isConnected()
+                        ? new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "connection to device already closed")
+                        : new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, e));
+            }
+            return publishSentPromise.future();
         }
 
         private void afterCommandPublished(


### PR DESCRIPTION
Most notably catch an IllegalStateException thrown by MqttEndpointImpl.publish() if the connection is
already disconnected.

Up to now this was misleadingly written as an "Connection not accepted yet" error in the trace, with such an exception being logged:
````
WARN org.eclipse.hono.tracing.TracingHelper An unexpected error occurred!
java.lang.IllegalStateException: Connection not accepted yet
  at io.vertx.mqtt.impl.MqttEndpointImpl.checkConnected(MqttEndpointImpl.java:734)
  at io.vertx.mqtt.impl.MqttEndpointImpl.write(MqttEndpointImpl.java:712)
  at io.vertx.mqtt.impl.MqttEndpointImpl.publish(MqttEndpointImpl.java:458)
  at io.vertx.mqtt.impl.MqttEndpointImpl.publish(MqttEndpointImpl.java:440)
  at io.vertx.mqtt.impl.MqttEndpointImpl.publish(MqttEndpointImpl.java:50)
  at org.eclipse.hono.adapter.mqtt.AbstractVertxBasedMqttProtocolAdapter$MqttDeviceEndpoint.lambda$onCommandReceived$37(AbstractVertxBasedMqttProtocolAdapter.java:1532)
  at io.vertx.core.Future.lambda$onSuccess$0(Future.java:150)
  at io.vertx.core.impl.FutureImpl.dispatch(FutureImpl.java:105)
  at io.vertx.core.impl.FutureImpl.onComplete(FutureImpl.java:83)
  at io.vertx.core.Future.onSuccess(Future.java:148)
  at org.eclipse.hono.adapter.mqtt.AbstractVertxBasedMqttProtocolAdapter$MqttDeviceEndpoint.onCommandReceived(AbstractVertxBasedMqttProtocolAdapter.java:1531)
  at org.eclipse.hono.adapter.mqtt.AbstractVertxBasedMqttProtocolAdapter$MqttDeviceEndpoint.lambda$createCommandConsumer$30(AbstractVertxBasedMqttProtocolAdapter.java:1458)
````