### PR TITLE
Add support for limiting registration entries at tenant level

### DIFF
--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -278,6 +278,14 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_MAX_CONNECTIONS = "max-connections";
     /**
+     * The name of the property that contains the maximum number of credentials allowed per device of a tenant.
+     */
+    public static final String FIELD_MAX_CREDENTIALS_PER_DEVICE = "max-credentials-per-device";
+    /**
+     * The name of the property that contains the maximum number of devices to be allowed for a tenant.
+     */
+    public static final String FIELD_MAX_DEVICES = "max-devices";
+    /**
      * The name of the property that contains the maximum connection duration in minutes to be allowed for a tenant.
      */
     public static final String FIELD_MAX_MINUTES = "max-minutes";
@@ -316,11 +324,15 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      * The name of the property that contains the mode of the period for which the data usage
      * is calculated.
      */
-    public static final String FIELD_PERIOD_MODE = "mode";    
+    public static final String FIELD_PERIOD_MODE = "mode";
     /**
      * The name of the property that contains the number of days for which the data usage is calculated.
      */
-    public static final String FIELD_PERIOD_NO_OF_DAYS = "no-of-days";    
+    public static final String FIELD_PERIOD_NO_OF_DAYS = "no-of-days";
+    /**
+     * The name of the property that contains the configuration options for the registration limits.
+     */
+    public static final String FIELD_REGISTRATION_LIMITS = "registration-limits";
     /**
      * The name of the property that contains the configuration options for the resource limits.
      */

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/RegistrationLimits.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/RegistrationLimits.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.service.management.tenant;
+
+import org.eclipse.hono.util.RegistryManagementConstants;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A definition of limits for registry entries.
+ */
+public class RegistrationLimits {
+
+    static final int UNLIMITED = -1;
+
+    @JsonProperty(RegistryManagementConstants.FIELD_MAX_DEVICES)
+    private int maxNumberOfDevices = UNLIMITED;
+    @JsonProperty(RegistryManagementConstants.FIELD_MAX_CREDENTIALS_PER_DEVICE)
+    private int maxCredentialsPerDevice = UNLIMITED;
+
+    /**
+     * Checks if the number of devices per tenant is limited.
+     *
+     * @return {@code true} if maxNumberOfDevices is &gt; {@value #UNLIMITED}.
+     */
+    @JsonIgnore
+    public final boolean isNumberOfDevicesLimited() {
+        return maxNumberOfDevices > UNLIMITED;
+    }
+
+    /**
+     * @return The maxNumberOfDevices.
+     */
+    public final int getMaxNumberOfDevices() {
+        return maxNumberOfDevices;
+    }
+
+    /**
+     * @param maxNumberOfDevices The maxNumberOfDevices to set.
+     * @throws IllegalArgumentException if the value is &lt; {@value #UNLIMITED}.
+     * @return A reference to this object for command chaining.
+     */
+    public final RegistrationLimits setMaxNumberOfDevices(final int maxNumberOfDevices) {
+        if (maxNumberOfDevices < UNLIMITED) {
+            throw new IllegalArgumentException("max number of devices must be >= " + UNLIMITED);
+        }
+        this.maxNumberOfDevices = maxNumberOfDevices;
+        return this;
+    }
+
+    /**
+     * Checks if the number of credentials per device is limited.
+     *
+     * @return {@code true} if maxCredentialsPerDevice is &gt; {@value #UNLIMITED}.
+     */
+    @JsonIgnore
+    public final boolean isNumberOfCredentialsPerDeviceLimited() {
+        return maxCredentialsPerDevice > UNLIMITED;
+    }
+
+    /**
+     * @return The maxCredentialsPerDevice.
+     */
+    public final int getMaxCredentialsPerDevice() {
+        return maxCredentialsPerDevice;
+    }
+
+    /**
+     * @param maxCredentialsPerDevice The maxCredentialsPerDevice to set.
+     * @throws IllegalArgumentException if the value is &lt; {@value #UNLIMITED}.
+     * @return A reference to this object for command chaining.
+     */
+    public final RegistrationLimits setMaxCredentialsPerDevice(final int maxCredentialsPerDevice) {
+        if (maxCredentialsPerDevice < UNLIMITED) {
+            throw new IllegalArgumentException("max credentials per device must be >= " + UNLIMITED);
+        }
+        this.maxCredentialsPerDevice = maxCredentialsPerDevice;
+        return this;
+    }
+}

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/TenantTest.java
@@ -335,6 +335,39 @@ public class TenantTest {
     }
 
     /**
+     * Encode "registration-limits" section.
+     */
+    @Test
+    public void testEncodeRegistrationLimits() {
+        final var tenant = new Tenant()
+                .setRegistrationLimits(new RegistrationLimits()
+                        .setMaxNumberOfDevices(100)
+                        .setMaxCredentialsPerDevice(5));
+        final var json = JsonObject.mapFrom(tenant);
+        final var limits = json.getJsonObject(RegistryManagementConstants.FIELD_REGISTRATION_LIMITS);
+        assertNotNull(limits);
+        assertEquals(100, limits.getInteger(RegistryManagementConstants.FIELD_MAX_DEVICES));
+        assertEquals(5,  limits.getInteger(RegistryManagementConstants.FIELD_MAX_CREDENTIALS_PER_DEVICE));
+    }
+
+    /**
+     * Decode "registration-limits" section.
+     */
+    @Test
+    public void testDecodeRegistrationLimits() {
+        final JsonObject tenantSpec = new JsonObject()
+                .put(RegistryManagementConstants.FIELD_REGISTRATION_LIMITS, new JsonObject()
+                        .put(RegistryManagementConstants.FIELD_MAX_DEVICES, 100)
+                        .put(RegistryManagementConstants.FIELD_MAX_CREDENTIALS_PER_DEVICE, 5));
+
+        final Tenant tenant = tenantSpec.mapTo(Tenant.class);
+        assertNotNull(tenant);
+        assertTrue(tenant.isEnabled());
+        assertEquals(100, tenant.getRegistrationLimits().getMaxNumberOfDevices());
+        assertEquals(5, tenant.getRegistrationLimits().getMaxCredentialsPerDevice());
+    }
+
+    /**
      * Verify that the trust anchor IDs are unique.
      */
     @Test

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedRegistrationConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedRegistrationConfigProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -28,6 +28,16 @@ public final class MongoDbBasedRegistrationConfigProperties extends AbstractMong
     private static final String DEFAULT_DEVICE_COLLECTION_NAME = "devices";
 
     private int maxDevicesPerTenant = UNLIMITED_DEVICES_PER_TENANT;
+
+    /**
+     * Checks if the number of devices per tenant is limited.
+     *
+     * @return {@code true} if the configured number of devices per tenant is &gt;
+     *         {@value #UNLIMITED_DEVICES_PER_TENANT}.
+     */
+    public boolean isNumberOfDevicesPerTenantLimited() {
+        return maxDevicesPerTenant > UNLIMITED_DEVICES_PER_TENANT;
+    }
 
     /**
      * Gets the maximum number of devices that can be registered for each tenant.

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
@@ -12,26 +12,47 @@
  *******************************************************************************/
 package org.eclipse.hono.deviceregistry.mongodb.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
-import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
+import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
+import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
 import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
 import org.eclipse.hono.service.credentials.CredentialsService;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.credentials.Credentials;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.service.management.tenant.RegistrationLimits;
+import org.eclipse.hono.service.management.tenant.Tenant;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.opentracing.Span;
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.MongoClient;
@@ -57,45 +78,59 @@ public class MongoDbBasedCredentialServiceTest implements AbstractCredentialsSer
     private MongoDbBasedCredentialsService credentialsService;
     private MongoDbBasedRegistrationService registrationService;
     private MongoDbBasedDeviceBackend deviceBackendService;
+    private TenantInformationService tenantInformationService;
     private Vertx vertx;
+
+    /**
+     * Creates the MongoDB client.
+     */
+    @BeforeAll
+    public void createMongoDbClient() {
+
+        vertx = Vertx.vertx();
+        mongoClient = MongoDbTestUtils.getMongoClient(vertx, "hono-credentials-test");
+    }
 
     /**
      * Starts up the service.
      *
+     * @param testInfo Test case meta information.
      * @param testContext The test context to use for running asynchronous tests.
      */
-    @BeforeAll
-    public void startService(final VertxTestContext testContext) {
+    @BeforeEach
+    public void setup(final TestInfo testInfo, final VertxTestContext testContext) {
+        LOG.info("running {}", testInfo.getDisplayName());
 
-        vertx = Vertx.vertx();
-        mongoClient = MongoDbTestUtils.getMongoClient(vertx, "hono-credentials-test");
+        tenantInformationService = mock(TenantInformationService.class);
+        when(tenantInformationService.getTenant(anyString(), any())).thenReturn(Future.succeededFuture(new Tenant()));
+        when(tenantInformationService.tenantExists(anyString(), any())).thenAnswer(invocation -> {
+            return Future.succeededFuture(OperationResult.ok(
+                    HttpURLConnection.HTTP_OK,
+                    TenantKey.from(invocation.getArgument(0)),
+                    Optional.empty(),
+                    Optional.empty()));
+        });
 
         credentialsService = new MongoDbBasedCredentialsService(
                 vertx,
                 mongoClient,
                 credentialsServiceConfig,
                 new SpringBasedHonoPasswordEncoder());
+        credentialsService.setTenantInformationService(tenantInformationService);
         registrationService = new MongoDbBasedRegistrationService(
                 vertx,
                 mongoClient,
                 registrationServiceConfig);
-        deviceBackendService = new MongoDbBasedDeviceBackend(this.registrationService, this.credentialsService,
-                new NoopTenantInformationService());
+        registrationService.setTenantInformationService(tenantInformationService);
+        deviceBackendService = new MongoDbBasedDeviceBackend(
+                this.registrationService,
+                this.credentialsService,
+                tenantInformationService);
         // start services sequentially as concurrent startup seems to cause
         // concurrency issues sometimes
         credentialsService.createIndices()
             .compose(ok -> registrationService.createIndices())
             .onComplete(testContext.completing());
-    }
-
-    /**
-     * Prints the test name.
-     *
-     * @param testInfo Test case meta information.
-     */
-    @BeforeEach
-    public void setup(final TestInfo testInfo) {
-        LOG.info("running {}", testInfo.getDisplayName());
     }
 
     /**
@@ -143,5 +178,69 @@ public class MongoDbBasedCredentialServiceTest implements AbstractCredentialsSer
     @Override
     public DeviceManagementService getDeviceManagementService() {
         return this.deviceBackendService;
+    }
+
+    /**
+     * Verifies that a request to add credentials for a device fails with a 403 status code
+     * if the number of credentials exceeds the tenant's configured limit.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testAddCredentialsFailsForExceededCredentialsPerDeviceLimit(final VertxTestContext ctx) {
+        final var tenantId = UUID.randomUUID().toString();
+        final var deviceId = UUID.randomUUID().toString();
+
+        when(tenantInformationService.getTenant(anyString(), any()))
+            .thenReturn(Future.succeededFuture(new Tenant().setRegistrationLimits(
+                    new RegistrationLimits().setMaxCredentialsPerDevice(1))));
+
+        credentialsService.addCredentials(
+                    tenantId,
+                    deviceId,
+                    List.of(
+                            Credentials.createPasswordCredential("device1", "secret"),
+                            Credentials.createPasswordCredential("device2", "secret")),
+                    Optional.empty(),
+                    NoopSpan.INSTANCE)
+            .onComplete(ctx.succeeding(r -> {
+                ctx.verify(() -> {
+                    verify(tenantInformationService).getTenant(eq(tenantId), any(Span.class));
+                    assertThat(r.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that a request to update credentials of a device fails with a 403 status code
+     * if the number of credentials exceeds the tenant's configured limit.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testUpdateCredentialsFailsForExceededCredentialsPerDeviceLimit(final VertxTestContext ctx) {
+        final var tenantId = UUID.randomUUID().toString();
+        final var deviceId = UUID.randomUUID().toString();
+
+        when(tenantInformationService.getTenant(anyString(), any()))
+            .thenReturn(Future.succeededFuture(new Tenant().setRegistrationLimits(
+                    new RegistrationLimits().setMaxCredentialsPerDevice(1))));
+
+        credentialsService.updateCredentials(
+                tenantId,
+                deviceId,
+                List.of(
+                        Credentials.createPasswordCredential("device1", "secret"),
+                        Credentials.createPasswordCredential("device2", "secret")),
+                Optional.empty(),
+                NoopSpan.INSTANCE)
+            .onComplete(ctx.succeeding(r -> {
+                ctx.verify(() -> {
+                    verify(tenantInformationService).getTenant(eq(tenantId), any(Span.class));
+                    assertThat(r.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
+                });
+                ctx.completeNow();
+            }));
     }
 }

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -36,7 +36,7 @@ info:
    license:
       name: EPL-2.0
       url: https://www.eclipse.org/legal/epl-2.0/
-   version: 1.8.0
+   version: 1.9.0
 
 externalDocs:
    description: Eclipse Hono™ web page
@@ -716,6 +716,8 @@ components:
                   telemetry, event and command messages is calculated as the minimum multiple
                   of the configured value that is greater than or equal to the messages
                   payload size.
+            "registration-limits":
+               $ref: '#/components/schemas/RegistrationLimits'
             "resource-limits":
                $ref: '#/components/schemas/ResourceLimit'
             "tracing":
@@ -884,6 +886,23 @@ components:
                default: true
             "ext":
                $ref: '#/components/schemas/Extensions'
+
+      RegistrationLimits:
+         type: object
+         additionalProperties: false
+         properties:
+            "max-devices":
+               type: integer
+               default: -1
+               description: |
+                  The maximum number of devices that can be registered for a tenant.
+                  A value of `-1` (the default) indicates that no limit is set.
+            "max-credentials-per-device":
+               type: integer
+               default: -1
+               description: |
+                  The maximum number of credentials that can be registered for a device.
+                  A value of `-1` (the default) indicates that no limit is set.
 
       ResourceLimit:
          type: object

--- a/site/documentation/content/user-guide/mongodb-based-device-registry.md
+++ b/site/documentation/content/user-guide/mongodb-based-device-registry.md
@@ -3,17 +3,59 @@ title = "MongoDB Based Device Registry"
 weight = 205
 +++
 
-The MongoDB based Device Registry component provides implementations of Hono's [Tenant API]({{< relref "/api/tenant" >}}), [Device Registration API]({{< relref "/api/device-registration" >}}) and [Credentials API]({{< relref "/api/credentials" >}}). As such it exposes AMQP 1.0 based endpoints for retrieving the relevant information. Protocol adapters use these APIs to determine a device's registration status, e.g. if it is enabled and if it is registered with a particular tenant, and to authenticate a device before accepting any data for processing from it.
+The MongoDB based Device Registry component provides implementations of Hono's [Tenant API]({{< relref "/api/tenant" >}}),
+[Device Registration API]({{< relref "/api/device-registration" >}}) and [Credentials API]({{< relref "/api/credentials" >}}).
+As such, it exposes AMQP 1.0 based endpoints for retrieving the relevant information. Protocol adapters use these APIs
+to determine a device's registration status, e.g. if it is enabled and if it is registered with a particular tenant,
+and to authenticate a device before accepting any data for processing from it.
 
-In addition to the above APIs, this Device Registry also exposes HTTP endpoints for managing the contents of the Device Registry according to the [Device Registry Management API]({{< relref "/api/management" >}}). It uses a MongoDB database to persist the data. The credentials, device and tenant information are stored in separate collections in a MongoDB database. For more information on how to configure the MongoDB based device registry, see [MongoDB based Device Registry configuration]({{< relref "/admin-guide/mongodb-device-registry-config.md" >}}).
+In addition to the above APIs, this Device Registry also exposes HTTP endpoints for managing the contents of the Device
+Registry according to the [Device Registry Management API]({{< relref "/api/management" >}}). It uses a MongoDB database
+to persist tenant, device and credentials data into separate collections.
+
+For more information on how to configure the MongoDB based device registry, see
+[MongoDB based Device Registry configuration]({{< relref "mongodb-device-registry-config" >}}).
 
 ## Authentication
 
-This Device Registry secures its HTTP Endpoints using basic authentication mechanism. Thereby the clients connecting to the MongoDB based Device Registry are required to authenticate. For more information on how to enable the authentication and configure it, please refer to the `hono.registry.http.authenticationRequired` property in the [MongoDB based Device Registry configuration]({{< relref "/admin-guide/mongodb-device-registry-config#service-configuration" >}}).
+This Device Registry secures its HTTP Endpoints using basic authentication mechanism. Thereby the clients connecting
+to the MongoDB based Device Registry are required to authenticate. For more information on how to enable the
+authentication and configure it, please refer to the `hono.registry.http.authenticationRequired` property in the
+[MongoDB based Device Registry configuration]({{< relref "mongodb-device-registry-config#service-configuration" >}}).
 
 ## Managing Tenants
 
 Please refer to the [Device Registry Management API]({{< relref "/api/management#tenants" >}}) for information about managing tenants.
+
+### Registration Limits
+
+The registry supports the enforcement of *registration limits* defined at the tenant level. The registry enforces
+
+* the maximum number of devices that can be registered for a tenant and
+* the maximum number of credentials that can be registered for each device of a tenant.
+
+In order to enable enforcement of any of these limits for a tenant, the corresponding *registration-limits* property needs to
+be set explicitly on the tenant like in the example below:
+
+```json
+{
+  "registration-limits": {
+    "max-devices": 100,
+    "max-credentials-per-device": 5
+  }
+}
+```
+
+{{% note title="Global Maximum Device per Tenant Limit" %}}
+The registry can be configured with a global limit for the number of devices that can be registered per tenant.
+The value can be set via the registry's *HONO_REGISTRY_SVC_MAX_DEVICES_PER_TENANT* configuration variable.
+The maximum number of devices allowed for a particular tenant is determined as follows:
+
+1. If the tenants's *registration-limits*/*max-devices* property has a value > -1 then that value is used as the limit.
+1. Otherwise, if the *HONO_REGISTRY_SVC_MAX_DEVICES_PER_TENANT* configuration variable has a value > -1 then that value
+   is used as the limit.
+1. Otherwise, the number of devices is unlimited.
+{{% /note %}}
 
 ## Managing Devices
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -6,10 +6,16 @@ description = "Information about changes in recent Hono releases. Includes new f
 
 ## 1.9.0 (not yet released)
 
+### New Features
+
+* The Mongo DB based registry now supports enforcement of registration limits configured at the tenant level.
+  In particular, the maximum number of devices and the maximum number of credentials per device can be set in
+  a tenant's registration-limits property. Please refer to the Mongo DB User Guide for details.
+
 ### Fixes & Enhancements
 
-* The value of the properties `auto-provisioned` and `auto-provisioning-notification-sent` are always *false* while 
-  retrieving device registration information using the MongoDB based registry implementation. This has been fixed now.
+* The value of the properties `auto-provisioned` and `auto-provisioning-notification-sent` had always been *false* when
+  retrieving device registration information using the MongoDB based registry implementation. This has been fixed.
 
 ### Deprecations
 


### PR DESCRIPTION
The Mongo DB based registry now supports enforcement of registration
limits configured at the tenant level. In particular, the maximum number
of devices and the maximum number of credentials per device can be set
in a tenant's registration-limits property.

Fixes #2626