### PR TITLE
Prevent endless loop when re-activating command routing

### DIFF
--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
@@ -248,6 +248,7 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
                         TracingHelper.logError(span, "failed to create command consumer", t);
                         if (t instanceof ServerErrorException) {
                             // add to end of queue in order to retry at a later time
+                            LOG.info("failed to create command consumer", t);
                             span.log("marking tenant for later re-try to create command consumer");
                             tenantsToEnable.addLast(tenantId);
                         }

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
@@ -243,8 +243,12 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
 
         final var attempt = tenantsToEnable.pollFirst();
         if (attempt == null) {
-            reenabledTenants.clear();
-            LOG.debug("finished re-enabling of command routing");
+            // at this point there might still be pending (re-try) tasks on the event loop,
+            // thus we need to wait for those to have finished before declaring victory
+            if (tenantsInProcess.isEmpty()) {
+                reenabledTenants.clear();
+                LOG.debug("finished re-enabling of command routing");
+            }
         } else {
             tenantsInProcess.add(attempt.one());
             final long delay = calculateDelayMillis(attempt.two());

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
@@ -44,7 +44,6 @@ import io.opentracing.References;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.log.Fields;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImplTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImplTest.java
@@ -16,6 +16,7 @@ package org.eclipse.hono.commandrouter.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -24,10 +25,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.HttpURLConnection;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.client.util.MessagingClient;
@@ -57,6 +60,8 @@ class CommandRouterServiceImplTest {
     private CommandRouterServiceImpl service;
     private CommandConsumerFactory commandConsumerFactory;
     private Context context;
+    private Vertx vertx;
+    private TenantClient tenantClient;
 
     /**
      * Sets up the fixture.
@@ -64,7 +69,7 @@ class CommandRouterServiceImplTest {
     @BeforeEach
     void setUp() {
         final var registrationClient = mock(DeviceRegistrationClient.class);
-        final var tenantClient = mock(TenantClient.class);
+        tenantClient = mock(TenantClient.class);
         when(tenantClient.get(anyString(), any())).thenAnswer(invocation -> {
             return Future.succeededFuture(TenantObject.from(invocation.getArgument(0)));
         });
@@ -72,8 +77,9 @@ class CommandRouterServiceImplTest {
         commandConsumerFactory = mock(CommandConsumerFactory.class);
         final MessagingClient<CommandConsumerFactory> factories = new MessagingClient<>();
         factories.setClient(MessagingType.amqp, commandConsumerFactory);
-        final Vertx vertx = mock(Vertx.class);
+        vertx = mock(Vertx.class);
         context = VertxMockSupport.mockContext(vertx);
+        when(context.owner()).thenReturn(vertx);
         service = new CommandRouterServiceImpl(
                 new CommandRouterServiceConfigProperties(),
                 registrationClient,
@@ -134,5 +140,103 @@ class CommandRouterServiceImplTest {
         verify(commandConsumerFactory).createCommandConsumer(eq("tenant4"), any());
         // AND no new task has been added to the event loop
         assertThat(eventLoop).isEmpty();
+    }
+
+    /**
+     * Verifies that exponential back-off is used for rescheduling attempts
+     * to enable command routing if an attempt fails.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    void testEnableCommandRoutingUsesExponentialBackoff() {
+
+        final Deque<Handler<?>> eventLoop = new LinkedList<>();
+        doAnswer(invocation -> {
+            eventLoop.addLast(invocation.getArgument(0));
+            return null;
+        }).when(context).runOnContext(VertxMockSupport.anyHandler());
+
+        when(vertx.setTimer(anyLong(), VertxMockSupport.anyHandler())).thenAnswer(invocation -> {
+            eventLoop.addLast(invocation.getArgument(1));
+            return 1L;
+        });
+
+        when(tenantClient.get(eq("tenant1"), any())).thenReturn(
+                Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)),
+                Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)),
+                Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)),
+                Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)),
+                Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)),
+                Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE)),
+                Future.succeededFuture(TenantObject.from("tenant1")));
+
+        final List<String> firstTenants = List.of("tenant1");
+        service.enableCommandRouting(firstTenants, NoopSpan.INSTANCE);
+        // THEN no command consumer has been created yet
+        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), any());
+        // BUT a first task to process the first tenant ID has been scheduled
+        verify(context).runOnContext(VertxMockSupport.anyHandler());
+        assertThat(eventLoop).hasSize(1);
+
+        // WHEN running the next task on the event loop
+        eventLoop.pollFirst().handle(null);
+        // THEN no command consumer has been created yet
+        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), any());
+        // AND a new task for retrying the attempt has been scheduled with the
+        // delay corresponding to the number of unsuccessful attempts tha have been made
+        verify(vertx).setTimer(eq(400L), VertxMockSupport.anyHandler());
+        assertThat(eventLoop).hasSize(1);
+
+        // WHEN running the next task on the event loop
+        eventLoop.pollFirst().handle(null);
+        // THEN no command consumer has been created yet
+        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), any());
+        // AND a new task for retrying the attempt has been scheduled with the
+        // delay corresponding to the number of unsuccessful attempts tha have been made
+        verify(vertx).setTimer(eq(800L), VertxMockSupport.anyHandler());
+        assertThat(eventLoop).hasSize(1);
+
+        // WHEN running the next task on the event loop
+        eventLoop.pollFirst().handle(null);
+        // THEN no command consumer has been created yet
+        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), any());
+        // AND a new task for retrying the attempt has been scheduled with the
+        // delay corresponding to the number of unsuccessful attempts tha have been made
+        verify(vertx).setTimer(eq(1600L), VertxMockSupport.anyHandler());
+        assertThat(eventLoop).hasSize(1);
+
+        // WHEN running the next task on the event loop
+        eventLoop.pollFirst().handle(null);
+        // THEN no command consumer has been created yet
+        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), any());
+        // AND a new task for retrying the attempt has been scheduled with the
+        // delay corresponding to the number of unsuccessful attempts tha have been made
+        verify(vertx).setTimer(eq(3200L), VertxMockSupport.anyHandler());
+        assertThat(eventLoop).hasSize(1);
+
+        // WHEN running the next task on the event loop
+        eventLoop.pollFirst().handle(null);
+        // THEN no command consumer has been created yet
+        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), any());
+        // AND a new task for retrying the attempt has been scheduled with the
+        // delay corresponding to the number of unsuccessful attempts tha have been made
+        verify(vertx).setTimer(eq(6400L), VertxMockSupport.anyHandler());
+        assertThat(eventLoop).hasSize(1);
+
+        // WHEN running the next task on the event loop
+        eventLoop.pollFirst().handle(null);
+        // THEN no command consumer has been created yet
+        verify(commandConsumerFactory, never()).createCommandConsumer(anyString(), any());
+        // AND a new task for retrying the attempt has been scheduled with the
+        // delay corresponding to the number of unsuccessful attempts tha have been made
+        verify(vertx).setTimer(eq(10000L), VertxMockSupport.anyHandler());
+        assertThat(eventLoop).hasSize(1);
+
+        // WHEN running the next task on the event loop
+        eventLoop.pollFirst().handle(null);
+        // THEN a command consumer has been created
+        verify(commandConsumerFactory).createCommandConsumer(eq("tenant1"), any());
+        // AND no new task for retrying the attempt has been added to the event loop
+        assertThat(eventLoop).hasSize(0);
     }
 }

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImplTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImplTest.java
@@ -27,8 +27,6 @@ import static org.mockito.Mockito.when;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.TenantClient;


### PR DESCRIPTION
This addresses #2705

Actually, there has not been an endless loop as far as I can tell but the list of tenant IDs to re-activate routing for had grown larger and larger over time ...