### PR TITLE
[#2661] Use Throwable param in CommandContext methods

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -35,7 +35,6 @@ import org.eclipse.hono.adapter.resourcelimits.NoopResourceLimitChecks;
 import org.eclipse.hono.adapter.resourcelimits.ResourceLimitChecks;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.telemetry.TelemetrySender;
@@ -1167,28 +1166,6 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                         return null;
                     }
                 });
-    }
-
-    /**
-     * Gets the error message suitable to be propagated to an external client.
-     *
-     * @param t The exception to extract the message from.
-     * @return The message.
-     */
-    public static String getClientFacingErrorMessage(final Throwable t) {
-        if (t instanceof ServerErrorException) {
-            final String clientFacingMessage = ((ServerErrorException) t).getClientFacingMessage();
-            if (clientFacingMessage != null) {
-                return clientFacingMessage;
-            }
-            switch (((ServerErrorException) t).getErrorCode()) {
-            case HttpURLConnection.HTTP_INTERNAL_ERROR:
-                return "Internal server error";
-            case HttpURLConnection.HTTP_UNAVAILABLE:
-                return "Temporarily unavailable";
-            }
-        }
-        return t.getMessage();
     }
 
     /**

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -1372,7 +1372,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
      * @return The error condition.
      */
     protected static ErrorCondition getErrorCondition(final Throwable t) {
-        final String errorMessage = getClientFacingErrorMessage(t);
+        final String errorMessage = ServiceInvocationException.getErrorMessageForExternalClient(t);
         if (t instanceof AuthorizationException || t instanceof AdapterDisabledException) {
             return ProtonHelper.condition(AmqpError.UNAUTHORIZED_ACCESS, errorMessage);
         } else if (ServiceInvocationException.class.isInstance(t)) {

--- a/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
@@ -766,7 +766,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         final ProtonDelivery unsuccessfulDelivery = mock(ProtonDelivery.class);
         when(unsuccessfulDelivery.remotelySettled()).thenReturn(true);
         when(unsuccessfulDelivery.getRemoteState()).thenReturn(remoteState);
-        testOneWayCommandOutcome(unsuccessfulDelivery, ctx -> verify(ctx).reject(any()), ProcessingOutcome.UNPROCESSABLE);
+        testOneWayCommandOutcome(unsuccessfulDelivery, ctx -> verify(ctx).reject((String) any()), ProcessingOutcome.UNPROCESSABLE);
     }
 
     /**
@@ -794,7 +794,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         final ProtonDelivery unsuccessfulDelivery = mock(ProtonDelivery.class);
         when(unsuccessfulDelivery.remotelySettled()).thenReturn(false);
         when(unsuccessfulDelivery.getRemoteState()).thenReturn(remoteState);
-        testOneWayCommandOutcome(unsuccessfulDelivery, ctx -> verify(ctx).release(), ProcessingOutcome.UNDELIVERABLE);
+        testOneWayCommandOutcome(unsuccessfulDelivery, ctx -> verify(ctx).release(any(Throwable.class)), ProcessingOutcome.UNDELIVERABLE);
     }
 
     private void testOneWayCommandOutcome(
@@ -1117,7 +1117,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
 
         adapter.onCommandReceived(tenantObject, deviceLink, context);
         // THEN the adapter releases the command
-        verify(context).release();
+        verify(context).release(any(Throwable.class));
     }
 
     /**

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapErrorResponse.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapErrorResponse.java
@@ -21,7 +21,6 @@ import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.MessageFormatException;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 
 /**
@@ -54,13 +53,7 @@ public final class CoapErrorResponse {
     public static Response newResponse(final Throwable cause, final ResponseCode fallbackCode) {
 
         final String message = Optional.ofNullable(cause)
-                .map(t -> {
-                    if (t instanceof ServerErrorException) {
-                        return ((ServerErrorException) t).getClientFacingMessage();
-                    } else {
-                        return t.getMessage();
-                    }
-                })
+                .map(ServiceInvocationException::getErrorMessageForExternalClient)
                 .orElse(null);
         final ResponseCode code = toCoapCode(cause, fallbackCode);
         final Response response = newResponse(code, message);

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TelemetryResourceTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/TelemetryResourceTest.java
@@ -505,7 +505,7 @@ public class TelemetryResourceTest extends ResourceTestBase {
                         eq(TtdStatus.COMMAND),
                         any());
                 // and the command delivery is released
-                verify(commandContext).release();
+                verify(commandContext).release(any(Throwable.class));
             });
             ctx.completeNow();
         }));

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -1403,10 +1403,6 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             final Span span = newChildSpan(spanContext, "publish error to device");
 
             final int errorCode = ServiceInvocationException.extractStatusCode(error);
-            final String clientFacingErrorMessage = error instanceof ServerErrorException
-                    ? ((ServerErrorException) error).getClientFacingMessage()
-                    : null;
-            final String errorMessage = Optional.ofNullable(clientFacingErrorMessage).orElse(error.getMessage());
             final String correlationId = Optional.ofNullable(context.correlationId()).orElse("-1");
             final String publishTopic = subscription.getErrorPublishTopic(context, errorCode);
             Tags.MESSAGE_BUS_DESTINATION.set(span, publishTopic);
@@ -1414,7 +1410,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
 
             final JsonObject errorJson = new JsonObject();
             errorJson.put("code", errorCode);
-            errorJson.put("message", errorMessage);
+            errorJson.put("message", ServiceInvocationException.getErrorMessageForExternalClient(error));
             errorJson.put("timestamp", ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS)
                     .format(DateTimeFormatter.ISO_INSTANT));
             errorJson.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, correlationId);

--- a/client/src/main/java/org/eclipse/hono/client/ServiceInvocationException.java
+++ b/client/src/main/java/org/eclipse/hono/client/ServiceInvocationException.java
@@ -192,4 +192,26 @@ public class ServiceInvocationException extends RuntimeException {
             return key;
         }
     }
+
+    /**
+     * Gets the error message suitable to be propagated to an external client.
+     *
+     * @param t The exception to extract the message from, may be {@code null}.
+     * @return The message or {@code null} if not set.
+     */
+    public static String getErrorMessageForExternalClient(final Throwable t) {
+        if (t instanceof ServerErrorException) {
+            final String clientFacingMessage = ((ServerErrorException) t).getClientFacingMessage();
+            if (clientFacingMessage != null) {
+                return clientFacingMessage;
+            }
+            switch (((ServerErrorException) t).getErrorCode()) {
+            case HttpURLConnection.HTTP_INTERNAL_ERROR:
+                return "Internal server error";
+            case HttpURLConnection.HTTP_UNAVAILABLE:
+                return "Temporarily unavailable";
+            }
+        }
+        return Optional.ofNullable(t).map(Throwable::getMessage).orElse(null);
+    }
 }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandContext.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedCommandContext.java
@@ -22,6 +22,7 @@ import org.apache.qpid.proton.amqp.messaging.Released;
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MapBasedExecutionContext;
@@ -78,6 +79,12 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
     }
 
     @Override
+    public void release(final Throwable error) {
+        Objects.requireNonNull(error);
+        updateDelivery(Released.getInstance());
+    }
+
+    @Override
     public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
         final Modified modified = new Modified();
         modified.setDeliveryFailed(deliveryFailed);
@@ -93,6 +100,10 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
         updateDelivery(rejected);
     }
 
+    @Override
+    public void reject(final Throwable error) {
+        reject(ServiceInvocationException.getErrorMessageForExternalClient(error));
+    }
 
     private void updateDelivery(final DeliveryState deliveryState) {
         final Span span = getTracingSpan();

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandSender.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedInternalCommandSender.java
@@ -97,7 +97,7 @@ public class ProtonBasedInternalCommandSender extends SenderCachingServiceClient
                     LOG.debug("failed to send command [{}] to downstream peer", commandContext.getCommand(), thr);
                     TracingHelper.logError(commandContext.getTracingSpan(),
                             "failed to send command message to downstream peer: " + thr);
-                    commandContext.release();
+                    commandContext.release(thr);
                     return Future.succeededFuture();
                 });
     }

--- a/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandContextWrapper.java
+++ b/clients/adapter-amqp/src/main/java/org/eclipse/hono/adapter/client/command/amqp/ProtonBasedLegacyCommandContextWrapper.java
@@ -15,9 +15,9 @@ package org.eclipse.hono.adapter.client.command.amqp;
 
 import java.util.Objects;
 
-import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.eclipse.hono.adapter.client.command.Command;
 import org.eclipse.hono.adapter.client.command.CommandContext;
+import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.Constants;
 
 import io.opentracing.Span;
@@ -64,14 +64,24 @@ public class ProtonBasedLegacyCommandContextWrapper implements CommandContext {
     }
 
     @Override
+    public void release(final Throwable error) {
+        Objects.requireNonNull(error);
+        ctx.release();
+    }
+
+    @Override
     public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
         ctx.modify(deliveryFailed, undeliverableHere);
     }
 
     @Override
     public void reject(final String cause) {
-        final ErrorCondition error = ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, cause);
-        ctx.reject(error);
+        ctx.reject(ProtonHelper.condition(Constants.AMQP_BAD_REQUEST, cause));
+    }
+
+    @Override
+    public void reject(final Throwable error) {
+        reject(ServiceInvocationException.getErrorMessageForExternalClient(error));
     }
 
     @Override

--- a/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandSender.java
+++ b/clients/adapter-kafka/src/main/java/org/eclipse/hono/adapter/client/command/kafka/KafkaBasedInternalCommandSender.java
@@ -72,7 +72,7 @@ public class KafkaBasedInternalCommandSender extends AbstractKafkaBasedMessageSe
                 getHeaders((KafkaBasedCommand) command),
                 commandContext.getTracingContext())
                         .onSuccess(v -> commandContext.accept())
-                        .onFailure(thr -> commandContext.release());
+                        .onFailure(thr -> commandContext.release(thr));
     }
 
     private static String getInternalCommandTopic(final String adapterInstanceId) {

--- a/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/InternalCommandSender.java
+++ b/clients/adapter/src/main/java/org/eclipse/hono/adapter/client/command/InternalCommandSender.java
@@ -28,7 +28,7 @@ public interface InternalCommandSender extends Lifecycle {
      * <p>
      * Note that the result of the send operation is getting applied to the command context here.
      * That means implementations are required to invoke one of the given command context's
-     * {@link CommandContext#accept()}, {@link CommandContext#release()}, {@link CommandContext#modify(boolean, boolean)}
+     * {@link CommandContext#accept()}, {@link CommandContext#release(Throwable)}, {@link CommandContext#modify(boolean, boolean)}
      * or {@link CommandContext#reject(String)} methods based on the outcome of sending the command to the
      * protocol adapter instance.
      *

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/AbstractMappingAndDelegatingCommandHandler.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/AbstractMappingAndDelegatingCommandHandler.java
@@ -115,7 +115,7 @@ public abstract class AbstractMappingAndDelegatingCommandHandler implements Life
                     }
                     log.debug(errorMsg, cause);
                     TracingHelper.logError(commandContext.getTracingSpan(), errorMsg, cause);
-                    commandContext.release();
+                    commandContext.release(cause);
                     return Future.failedFuture(cause);
                 })
                 .compose(result -> {


### PR DESCRIPTION
This is for #2661.

This is a preparation for letting the KafkaBasedCommandContext send Command Response messages in the release/modify/reject methods. The new Throwable param allows an error message and an error status code to be given.

In the first commit:
Move/rename the `AbstractProtocolAdapterBase#getClientFacingErrorMessage()` method to the `ServiceInvocationException` class.
Also fix setting of an error message in CoapErrorResponse.
