### PR TITLE
Rework cli profiles

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/app/AbstractApplicationClient.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/AbstractApplicationClient.java
@@ -30,8 +30,6 @@ abstract class AbstractApplicationClient extends AbstractCliClient {
 
     @Value(value = "${tenant.id}")
     protected String tenantId;
-    @Value(value = "${device.id}")
-    protected String deviceId;
     @Value(value = "${connection.retryInterval}")
     protected int connectionRetryInterval;
     protected ApplicationClient<? extends MessageContext> client;

--- a/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/Commander.java
@@ -47,6 +47,8 @@ public class Commander extends AbstractApplicationClient {
     private final Scanner scanner = new Scanner(System.in);
     @Value(value = "${command.timeoutInSeconds}")
     private int commandTimeOutInSeconds;
+    @Value(value = "${device.id}")
+    private String deviceId;
     private WorkerExecutor workerExecutor;
 
     /**

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -1,32 +1,38 @@
+# The file contains some default configurations for Hono's CLI tool.
+#
+# The Hono CLI serves two different use cases:
+# For the first one, it can be used as a southbound client to Hono's AMQP protocol adapter
+# and simulates an AMQP enabled device. This southbound client is activated by setting
+# one of the profiles "amqp-send" or "amqp-command".
+#
+# For the second use case, it serves as a northbound client that simulates a business application
+# that receives telemetry data and events or sends commands upstream to devices.
+# The northbound client supports a couple of profiles that provide some defaults:
+# 1. select the mode: "receiver" or "command"
+# 2. select the target: "sandbox" or "local"
+# 3. optionally add "kafka" to enable Kafka based messaging (otherwise AMQP is used for messaging).
+
 spring:
   jmx:
     enabled: false
   profiles:
-    active: receiver,ssl
+    active: receiver,sandbox
 
 hono:
   client:
-    host: localhost
     reconnectAttempts: 5
 
 connection:
   retryInterval: 1000
 
-tenant:
-  id: DEFAULT_TENANT
-device:
-  id: 4711
-
 ---
+# Enables the "receiver" mode of the northbound client used to receive telemetry data and/or event messages.
+# Use this profile together with either "sandbox" or "local".
 
 spring:
   config:
     activate:
       on-profile: receiver
-
-hono:
-  client:
-    port: 15671
 
 address:
   resolver:
@@ -39,6 +45,79 @@ message:
   type: all
 
 ---
+# Enables the "command" mode of the northbound client used to send commands to devices.
+# Use this profile together with either "sandbox" or "local".
+
+spring:
+  config:
+    activate:
+      on-profile: command
+
+command:
+  timeoutInSeconds: 60
+
+---
+# Configuration for the Hono sandbox - see:
+# https://www.eclipse.org/hono/getting-started/
+# Use this profile together with either "receiver" or "command".
+
+spring:
+  config:
+    activate:
+      on-profile: sandbox
+
+hono:
+  client:
+    host: hono.eclipseprojects.io
+    port: 15672
+    tlsEnabled: false
+    username: consumer@HONO
+    password: verysecret
+  kafka:
+    commonClientConfig:
+      bootstrap.servers: hono.eclipseprojects.io:9092
+      security.protocol: SASL_PLAINTEXT
+      sasl.mechanism: SCRAM-SHA-256
+      sasl.jaas.config: "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"hono\" password=\"hono-secret\";"
+
+---
+# Configuration for example deployment in local Kubernetes cluster - see:
+# https://www.eclipse.org/hono/getting-started/
+# Use this profile together with either "receiver" or "command".
+# If used with Kafka based messaging, bootstrap servers and the truststore path need to be provided additionally.
+
+spring:
+  config:
+    activate:
+      on-profile: local
+
+hono:
+  client:
+    port: 15672
+    tlsEnabled: false
+    username: consumer@HONO
+    password: verysecret
+  kafka:
+    commonClientConfig:
+      bootstrap.servers: UNCONFIGURED
+      security.protocol: SASL_SSL
+      sasl.jaas.config: "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"hono\" password=\"hono-secret\";"
+      sasl.mechanism: SCRAM-SHA-512
+      ssl.truststore.location: UNCONFIGURED
+      ssl.truststore.password: honotrust
+      ssl.endpoint.identification.algorithm: ""
+
+tenant:
+  id: DEFAULT_TENANT
+device:
+  id: 4711
+
+---
+# This profile enables Kafka based messaging - see:
+# https://www.eclipse.org/hono/getting-started-kafka/
+# Use this profile together with either "receiver" or "command".
+# Additionally activate either "sandbox" or "local".
+# If not using the sandbox, bootstrap servers and the truststore path need to be provided additionally.
 
 spring:
   config:
@@ -48,11 +127,14 @@ spring:
 hono:
   kafka:
     commonClientConfig:
-      bootstrap.servers: localhost:9092
+      client.id: hono-cli
     consumerConfig:
-      group.id: hono-cli
+      group.id: cli
 
 ---
+# This profile enables the collection of statistics of received messages from
+# Hono's northbound Telemetry and Event APIs.
+# Use this profile together with "receiver".
 
 spring:
   config:
@@ -64,21 +146,9 @@ statistic:
   autoreset: false
 
 ---
-
-# For use with the demo certificates.
-# Do not use this profile for certificates that the JVM trusts, e.g. for the Hono sandbox. Simply set hono.client.tlsEnabled 
-# to true. 
-spring:
-  config:
-    activate:
-      on-profile: ssl
-hono:
-  client:
-    hostnameVerificationRequired: false
-    trustStorePath: target/config/hono-demo-certs-jar/trusted-certs.pem
-    tlsEnabled: true
-
----
+# Enables the southbound client for Hono's AMQP protocol adapter- see:
+# https://www.eclipse.org/hono/docs/user-guide/amqp-adapter/
+# It is not to be combined with the other profiles.
 
 spring:
   config:
@@ -87,29 +157,9 @@ spring:
 
 hono:
   client:
+    host: hono.eclipseprojects.io
     port: 5672
 
 message:
   address: telemetry
   payload: '{"temp": 5}'
-
----
-
-spring:
-  config:
-    activate:
-      on-profile: command
-
-hono:
-  client:
-    port: 15671
-
-command:
-  timeoutInSeconds: 60
-
-tenant:
-  id: DEFAULT_TENANT
-
-device:
-  id: 4711
-

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -126,7 +126,7 @@ The command-line client supports the following parameters (with default values):
 * `--spring.profiles.active=amqp-command`: Profile for receiving and responding to command request messages.
 * `--message.address`: The AMQP 1.0 message address (default: `telemetry`)
 * `--message.payload`: The message payload body (default: `'{"temp": 5}'`)
-* `--hono.client.host`: The host name that the AMQP adapter is running on (default: `localhost`)
+* `--hono.client.host`: The host name that the AMQP adapter is running on (default: the address of [Hono Sandbox]({{% homelink "sandbox/" %}}))
 * `--hono.client.port`: The port that the adapter is listening for incoming connections (default: `5672`)
 
 To run the client to send a telemetry message to Hono, open a terminal and execute the following:
@@ -197,7 +197,7 @@ Publish some JSON data for device `4711` using a client certificate for authenti
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.port=5671 --hono.client.certPath=config/hono-demo-certs-jar/device-4711-cert.pem --hono.client.keyPath=config/hono-demo-certs-jar/device-4711-key.pem --hono.client.trustStorePath=config/hono-demo-certs-jar/trusted-certs.pem --hono.client.hostnameVerificationRequired=false
+java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.port=5671 --hono.client.certPath=config/hono-demo-certs-jar/device-4711-cert.pem --hono.client.keyPath=config/hono-demo-certs-jar/device-4711-key.pem --hono.client.tlsEnabled=true --hono.client.hostnameVerificationRequired=false
 ~~~
 
 ## Publish Telemetry Data (unauthenticated Device)
@@ -243,14 +243,14 @@ A device that publishes data on behalf of another device is called a gateway dev
 
 **Examples**
 
-A gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing some JSON data for device `4711`:
+A gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing some JSON data for device `4712`:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=t/DEFAULT_TENANT/4711
+java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=t/DEFAULT_TENANT/4712
 ~~~
 
-In this example, we are using message address `t/DEFAULT_TENANT/4711` which contains the device that the gateway is publishing the message for.
+In this example, we are using message address `t/DEFAULT_TENANT/4712` which contains the device that the gateway is publishing the message for.
 
 ## Publishing Events
 
@@ -336,14 +336,14 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --message.addre
 
 **Example**
 
-A gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing some JSON data for device `4711`:
+A gateway connecting to the adapter using `gw@DEFAULT_TENANT` as username and `gw-secret` as password and then publishing some JSON data for device `4712`:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=e/DEFAULT_TENANT/4711
+java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-send --hono.client.username=gw@DEFAULT_TENANT --hono.client.password=gw-secret --message.address=e/DEFAULT_TENANT/4712
 ~~~
 
-In this example, we are using message address `e/DEFAULT_TENANT/4711` which contains the device that the gateway is publishing the message for.
+In this example, we are using message address `e/DEFAULT_TENANT/4712` which contains the device that the gateway is publishing the message for.
 
 ## Command & Control
 
@@ -432,9 +432,9 @@ for uploading command responses. All other combinations are not supported by the
 
 ### Examples
 
-The AMQP adapter client can be used to simulate a device which receives commands and sends responses back to the application. The command line client is used to simulate an application sending commands to devices and receiving command responses from devices.
+The AMQP adapter client can be used to simulate a device which receives commands and sends responses back to the application. 
 
-Start the AMQP adapter client, as follows:
+A subscription to commands for a specific device can be done like this:
 
 ~~~sh
 # in directory: hono/cli/target/
@@ -443,29 +443,7 @@ java -jar hono-cli-*-exec.jar --spring.profiles.active=amqp-command --hono.clien
 
 After successfully starting the client, a message indicating that the device is ready to receive commands will be printed to standard output. The device is now waiting to receive commands from applications. 
 
-To send a command to the device, open a new terminal shell and start the command application, as shown below:
-
-~~~sh
-# in directory: hono/cli/
-java -jar target/hono-cli-*-exec.jar --hono.client.host=localhost --hono.client.username=consumer@HONO --hono.client.password=verysecret --spring.profiles.active=command,ssl
-~~~
-
-{{% note %}}
-Change into the `cli` directory before running the command above to start the command application. If you change into the target directory (i.e `cli/target`), then the client will not be able to locate to certificate needed to connect to the messaging network.
-{{% /note %}}
-
-Once the command application starts successfully, enter a command name, payload and content-type of the command to send to the device.
-
-~~~plaintext
->>>>>>>>> Enter name of command for device [DEFAULT_TENANT:4711] (prefix with 'ow:' to send one-way command):
-setBrightness
->>>>>>>>> Enter command payload:
-some-payload
->>>>>>>>> Enter content type:
-text/plain
-~~~
-
-After sending the command, the device (i.e. AMQP command client) will print out the command name and payload that it receives and automatically sends a command response to the application.
+After a command has arrived, the AMQP adapter client will print out the command name and payload that it receives and automatically send a command response to the application.
 
 ~~~plaintext
 Received Command Message : [Command name: setBrightness, Command payload: some-payload]

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -43,6 +43,11 @@ description = "Information about changes in recent Hono releases. Includes new f
   but only the identifier. This has been fixed.
 * A potential issue processing Command & Control messages from a Kafka cluster while Command Router instances are
   getting stopped or started has been fixed.
+* The default properties of the Hono CLI tool have been updated to match typical Hono installations. It provides now 
+  3 types of profiles that need to be combined: 1. select the "mode": `receiver` or `command`; 2. select the "target":
+  `sandbox` or `local` (aims for deployment in Minikube but works for every deployment of the Helm chart); 3. select the 
+  "messaging-type": `kafka` (if not set, it defaults to AMQP-based messaging). For details refer to the file 
+  `application.yml` of the CLI module.
 
 ### Deprecations
 

--- a/site/homepage/content/sandbox.md
+++ b/site/homepage/content/sandbox.md
@@ -49,7 +49,7 @@ All services are exposed via the same ports as used in the guide.
 
   ~~~sh
   # in directory where the hono-cli-*-exec.jar file has been downloaded to
-  java -jar hono-cli-*-exec.jar --hono.client.host=hono.eclipseprojects.io --hono.client.port=15671 --hono.client.tlsEnabled=true --hono.client.username=consumer@HONO --hono.client.password=verysecret --spring.profiles.active=receiver
+  java -jar hono-cli-*-exec.jar --hono.client.host=hono.eclipseprojects.io --hono.client.port=15671 --hono.client.tlsEnabled=true --hono.client.username=consumer@HONO --hono.client.password=verysecret --tenant.id=DEFAULT_TENANT --spring.profiles.active=receiver
   ~~~
   Note that only the *receiver* profile is activated but not the *ssl* profile.
 


### PR DESCRIPTION
I noticed a couple of properties that are set in the configuration file of the CLI component which set values that do not really match a recommended Hono setup. So, this PR does not resolve the issue #1486 and does not change the logic of the CLI. It is an intermediary step that updates some defaults.

The goal is to improve the comprehensibility of the file `application.yml` and thereby also the usability of the tool.

The main points are:

1. all usage instructions documented within the Hono project should behave as before
1. this PR does only change defaults for the profiles for the usage as a northbound client and not for the profiles `amqp-send` and `amqp-command`
1. one exception to the point above is the hostname. Which changes from localhost to the sandbox address in the southbound profile
1. there are 2 setups for which we should provide defaults: a) the sandbox and b) a deployment with the Helm chart
1. the default setup should be the sandbox (instead of localhost which does not match any recommended setup)
1. default IDs for tenant and device make sense for custom setups but should not be used on the Sandbox
1. the profile `ssl` does not work for any of the setups and should be removed
1. enable TLS for the sandbox, disable for local setups (using TLS locally would require getting the truststore from the deployment in the right version)
1. I could not resist fixing some issues in the documentation that I found while testing the examples

The solution proposed here is having 3 types of profiles. One can use one of each type:

1. select the "mode": `receiver`, `command`
2. select the "target" `sandbox`, `local` (aims for deployment in Minikube but works for every deployment of the Helm chart)
3. select the "messaging-type": `kafka` (if not set, it defaults to AMQP-based messaging)

(A new CLI tool would better use separate parameters for each of those instead of leaking Spring profiles)