### PR TITLE
[#2661] Pass CommandResponseSender to KafkaBasedCommandContext

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/MessagingClients.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/MessagingClients.java
@@ -33,9 +33,9 @@ import io.vertx.ext.healthchecks.HealthCheckHandler;
  */
 public final class MessagingClients implements Lifecycle {
 
-    private MessagingClient<TelemetrySender> telemetrySenders;
-    private MessagingClient<EventSender> eventSenders;
-    private MessagingClient<CommandResponseSender> commandResponseSenders;
+    private final MessagingClient<TelemetrySender> telemetrySenders;
+    private final MessagingClient<EventSender> eventSenders;
+    private final MessagingClient<CommandResponseSender> commandResponseSenders;
 
     /**
      * Creates a new instance.
@@ -97,6 +97,33 @@ public final class MessagingClients implements Lifecycle {
      */
     public CommandResponseSender getCommandResponseSender(final TenantObject tenant) {
         return commandResponseSenders.getClient(tenant);
+    }
+
+    /**
+     * Gets the clients for sending telemetry messages downstream.
+     *
+     * @return The clients.
+     */
+    public MessagingClient<TelemetrySender> getTelemetrySenders() {
+        return telemetrySenders;
+    }
+
+    /**
+     * Gets the clients for sending event messages downstream.
+     *
+     * @return The clients.
+     */
+    public MessagingClient<EventSender> getEventSenders() {
+        return eventSenders;
+    }
+
+    /**
+     * Gets the clients for sending command response messages downstream.
+     *
+     * @return The clients.
+     */
+    public MessagingClient<CommandResponseSender> getCommandResponseSenders() {
+        return commandResponseSenders;
     }
 
     @Override

--- a/clients/client-common/src/main/java/org/eclipse/hono/client/util/MessagingClient.java
+++ b/clients/client-common/src/main/java/org/eclipse/hono/client/util/MessagingClient.java
@@ -94,21 +94,20 @@ public final class MessagingClient<T extends Lifecycle> implements Lifecycle, Se
 
         return Optional.ofNullable(tenant.getProperty(TenantConstants.FIELD_EXT, JsonObject.class))
             .map(ext -> ext.getString(TenantConstants.FIELD_EXT_MESSAGING_TYPE))
-            .map(type -> {
-                return clientImplementations.get(MessagingType.valueOf(type));
-            })
+            .map(type -> clientImplementations.get(MessagingType.valueOf(type)))
             .orElseGet(this::getDefaultImplementation);
     }
 
     /**
-     * Gets an messaging client implementation for the given messaging type.
+     * Gets a messaging client implementation for the given messaging type or the default client.
      *
-     * @param messagingType The messaging type. If {@code null}, then a messaging client of 
-     *                      type defined in {@link #DEFAULT_MESSAGING_TYPE} is returned.
-     * @return The messaging client for the given type.
+     * @param messagingType The messaging type. If {@code null} or no messaging client of
+     *                      the given type is set, a messaging client of the type defined
+     *                      in {@link #DEFAULT_MESSAGING_TYPE} is returned.
+     * @return The messaging client for the given type or the default client.
      * @throws IllegalStateException if no client implementations are set.
      */
-    public T getClient(final String messagingType) {
+    public T getClientOrDefault(final String messagingType) {
 
         requireClientsConfigured();
 
@@ -116,6 +115,21 @@ public final class MessagingClient<T extends Lifecycle> implements Lifecycle, Se
                 .map(MessagingType::valueOf)
                 .map(clientImplementations::get)
                 .orElseGet(this::getDefaultImplementation);
+    }
+
+    /**
+     * Gets a messaging client implementation for the given messaging type.
+     *
+     * @param messagingType The messaging type.
+     * @return The messaging client for the given type or {@code null} if not set.
+     * @throws NullPointerException if messagingType is {@code null}.
+     * @throws IllegalStateException if no client implementations are set.
+     */
+    public T getClient(final MessagingType messagingType) {
+        Objects.requireNonNull(messagingType);
+        requireClientsConfigured();
+
+        return clientImplementations.get(messagingType);
     }
 
     private T getDefaultImplementation() {

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.command.CommandContext;
+import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.MapBasedExecutionContext;
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBasedCommandContext.class);
 
     private final KafkaBasedCommand command;
+    private final CommandResponseSender commandResponseSender;
     private String completedOutcome;
 
     /**
@@ -41,11 +43,14 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
      *
      * @param command The command to be processed.
      * @param span The OpenTracing span to use for tracking the processing of the command.
+     * @param commandResponseSender The sender used to send a command response.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    public KafkaBasedCommandContext(final KafkaBasedCommand command, final Span span) {
+    public KafkaBasedCommandContext(final KafkaBasedCommand command, final Span span,
+            final CommandResponseSender commandResponseSender) {
         super(span);
         this.command = Objects.requireNonNull(command);
+        this.commandResponseSender = Objects.requireNonNull(commandResponseSender);
     }
 
     @Override

--- a/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumerTest.java
+++ b/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumerTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import org.apache.kafka.clients.admin.Admin;
 import org.eclipse.hono.client.command.CommandContext;
 import org.eclipse.hono.client.command.CommandHandlers;
-import org.eclipse.hono.client.command.kafka.KafkaBasedInternalCommandConsumer;
+import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.test.TracingMockSupport;
@@ -71,10 +71,12 @@ public class KafkaBasedInternalCommandConsumerTest {
         final Tracer tracer = TracingMockSupport.mockTracer(span);
         context = VertxMockSupport.mockContext(mock(Vertx.class));
         commandHandlers = new CommandHandlers();
+        final CommandResponseSender commandResponseSender = mock(CommandResponseSender.class);
         internalCommandConsumer = new KafkaBasedInternalCommandConsumer(
                 context,
                 kafkaAdminClient,
                 kafkaConsumer,
+                commandResponseSender,
                 adapterInstanceId,
                 commandHandlers,
                 tracer);

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.eclipse.hono.client.command.kafka.KafkaBasedCommandResponseSender;
 import org.eclipse.hono.client.command.kafka.KafkaBasedInternalCommandSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
@@ -63,6 +64,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
     private final KafkaConsumerConfigProperties kafkaConsumerConfig;
     private final Tracer tracer;
     private final KafkaBasedInternalCommandSender internalCommandSender;
+    private final KafkaBasedCommandResponseSender kafkaBasedCommandResponseSender;
 
     private KafkaBasedMappingAndDelegatingCommandHandler commandHandler;
     private AsyncHandlingAutoCommitKafkaConsumer kafkaConsumer;
@@ -99,6 +101,8 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         this.tracer = Objects.requireNonNull(tracer);
 
         internalCommandSender = new KafkaBasedInternalCommandSender(kafkaProducerFactory, kafkaProducerConfig, tracer);
+        kafkaBasedCommandResponseSender = new KafkaBasedCommandResponseSender(kafkaProducerFactory, kafkaProducerConfig,
+                tracer);
     }
 
     @Override
@@ -109,7 +113,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         }
         final KafkaCommandProcessingQueue commandQueue = new KafkaCommandProcessingQueue(context);
         commandHandler = new KafkaBasedMappingAndDelegatingCommandHandler(tenantClient, commandQueue,
-                commandTargetMapper, internalCommandSender, tracer);
+                commandTargetMapper, internalCommandSender, kafkaBasedCommandResponseSender, tracer);
 
         final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig("consumer");
         consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "cmd-router-group");

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.command.CommandContext;
 import org.eclipse.hono.client.command.kafka.KafkaBasedCommandContext;
+import org.eclipse.hono.client.command.kafka.KafkaBasedCommandResponseSender;
 import org.eclipse.hono.client.command.kafka.KafkaBasedInternalCommandSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.registry.TenantClient;
@@ -69,6 +70,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
     private CommandTargetMapper commandTargetMapper;
     private KafkaBasedMappingAndDelegatingCommandHandler cmdHandler;
     private KafkaBasedInternalCommandSender internalCommandSender;
+    private KafkaBasedCommandResponseSender kafkaBasedCommandResponseSender;
     private String tenantId;
     private String deviceId;
     private String adapterInstanceId;
@@ -92,10 +94,12 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
         internalCommandSender = mock(KafkaBasedInternalCommandSender.class);
         when(internalCommandSender.sendCommand(any(), any())).thenReturn(Future.succeededFuture());
 
+        kafkaBasedCommandResponseSender = mock(KafkaBasedCommandResponseSender.class);
+
         final Context context = VertxMockSupport.mockContext(mock(Vertx.class));
         final KafkaCommandProcessingQueue commandQueue = new KafkaCommandProcessingQueue(context);
         cmdHandler = new KafkaBasedMappingAndDelegatingCommandHandler(tenantClient, commandQueue, commandTargetMapper,
-                internalCommandSender, TracingMockSupport.mockTracer(TracingMockSupport.mockSpan()));
+                internalCommandSender, kafkaBasedCommandResponseSender, TracingMockSupport.mockTracer(TracingMockSupport.mockSpan()));
     }
 
     /**

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueueTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueueTest.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 
 import org.apache.kafka.common.TopicPartition;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.client.command.kafka.KafkaBasedCommand;
 import org.eclipse.hono.client.command.kafka.KafkaBasedCommandContext;
 import org.eclipse.hono.client.kafka.HonoTopic;
@@ -151,7 +152,7 @@ public class KafkaCommandProcessingQueueTest {
         when(consumerRecord.partition()).thenReturn(0);
 
         final KafkaBasedCommand cmd = KafkaBasedCommand.from(consumerRecord);
-        return new KafkaBasedCommandContext(cmd, mock(Span.class)) {
+        return new KafkaBasedCommandContext(cmd, mock(Span.class), mock(CommandResponseSender.class)) {
             @Override
             public String toString() {
                 return "Command " + offset;


### PR DESCRIPTION
This is a preparation for #2661, passing a `CommandResponseSender` to the `KafkaBasedCommandContext` constructor.

In a followup commit, the sender will then get used in the release/modify/reject methods to send delivery error command response messages.