### PR TITLE
[#2661] Send Kafka command response message on delivery error

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/CommandResponse.java
+++ b/client/src/main/java/org/eclipse/hono/client/CommandResponse.java
@@ -163,18 +163,18 @@ public final class CommandResponse {
     }
 
     /**
-     * Gets the reply-to identifier that has been extracted from the request ID.
+     * Gets the reply-to identifier that is either part of the request ID or the response address.
      *
-     * @return The identifier or {@code null} if the request ID could not be parsed.
+     * @return The identifier.
      */
     public String getReplyToId() {
         return replyToId;
     }
 
     /**
-     * Gets the correlation identifier that has bee extracted from the request ID.
+     * Gets the correlation identifier.
      *
-     * @return The identifier or {@code null} if the request ID could not be parsed.
+     * @return The identifier or {@code null} if no correlation id is set.
      */
     public String getCorrelationId() {
         return (String) message.getCorrelationId();

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
@@ -15,19 +15,27 @@ package org.eclipse.hono.client.command.kafka;
 
 import java.net.HttpURLConnection;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.client.command.CommandAlreadyProcessedException;
 import org.eclipse.hono.client.command.CommandContext;
+import org.eclipse.hono.client.command.CommandResponse;
 import org.eclipse.hono.client.command.CommandResponseSender;
+import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MapBasedExecutionContext;
+import org.eclipse.hono.util.MessageHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 
 /**
  * A context for passing around parameters relevant for processing a {@code Command} used in a Kafka based
@@ -89,7 +97,14 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
         final ServiceInvocationException mappedError = StatusCodeMapper.toServerError(error);
         final int status = mappedError.getErrorCode();
         Tags.HTTP_STATUS.set(span, status);
-        span.finish();
+        if (isRequestResponseCommand() && !(error instanceof CommandAlreadyProcessedException)) {
+            final String errorMessage = Optional.ofNullable(ServiceInvocationException.getErrorMessageForExternalClient(mappedError))
+                    .orElse("Temporarily unavailable");
+            sendDeliveryFailureCommandResponseMessage(status, errorMessage, span)
+                    .onComplete(v -> span.finish());
+        } else {
+            span.finish();
+        }
     }
 
     @Override
@@ -104,7 +119,15 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
         final int status = undeliverableHere ? HttpURLConnection.HTTP_NOT_FOUND
                 : HttpURLConnection.HTTP_UNAVAILABLE;
         Tags.HTTP_STATUS.set(span, status);
-        span.finish();
+        if (isRequestResponseCommand()) {
+            final String error = "command not processed"
+                    + (deliveryFailed ? "; delivery failed" : "")
+                    + (undeliverableHere ? "; undeliverable here" : "");
+            sendDeliveryFailureCommandResponseMessage(status, error, span)
+                    .onComplete(v -> span.finish());
+        } else {
+            span.finish();
+        }
     }
 
     @Override
@@ -128,7 +151,45 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
         }
         final Span span = getTracingSpan();
         Tags.HTTP_STATUS.set(span, status);
-        span.finish();
+        if (isRequestResponseCommand()) {
+            final String nonNullCause = Optional.ofNullable(cause).orElse("Command message rejected");
+            sendDeliveryFailureCommandResponseMessage(status, nonNullCause, span)
+                    .onComplete(v -> span.finish());
+        } else {
+            span.finish();
+        }
+    }
+
+    private boolean isRequestResponseCommand() {
+        return !command.isOneWay();
+    }
+
+    private Future<Void> sendDeliveryFailureCommandResponseMessage(final int status, final String error, final Span span) {
+        final JsonObject payloadJson = new JsonObject();
+        payloadJson.put("error", error != null ? error : "");
+        final String correlationId = getCorrelationId();
+        if (correlationId == null) {
+            TracingHelper.logError(span, "can't send command response message - no correlation id set");
+            return Future.failedFuture("missing correlation id");
+        }
+        final CommandResponse commandResponse = new CommandResponse(
+                command.getTenant(),
+                command.getDeviceId(),
+                payloadJson.toBuffer(),
+                CommandConstants.CONTENT_TYPE_DELIVERY_FAILURE_NOTIFICATION,
+                status,
+                correlationId,
+                "");
+        return commandResponseSender.sendCommandResponse(commandResponse, span.context())
+                .onFailure(thr -> TracingHelper.logError(span, "failed to publish command response message", thr))
+                .onSuccess(v -> span.log("published error command response"));
+    }
+
+    private String getCorrelationId() {
+        // extract correlation id from headers; command could be invalid in which case command.getCorrelationId() throws an exception
+        return KafkaRecordHelper
+                .getHeaderValue(command.getRecord().headers(), MessageHelper.SYS_PROPERTY_CORRELATION_ID, String.class)
+                .orElse(null);
     }
 
     private boolean setCompleted(final String outcome) {

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.eclipse.hono.client.NoConsumerException;
+import org.eclipse.hono.client.command.CommandAlreadyProcessedException;
 import org.eclipse.hono.client.command.CommandContext;
 import org.eclipse.hono.client.command.CommandHandlerWrapper;
 import org.eclipse.hono.client.command.CommandHandlers;
@@ -298,7 +299,7 @@ public class KafkaBasedInternalCommandConsumer implements Lifecycle {
                 LOG.debug("ignoring command - record partition offset {} <= last handled offset {} [{}]", commandOffset,
                         lastHandledOffset, command);
                 TracingHelper.logError(currentSpan, "command record already handled before");
-                commandContext.release();
+                commandContext.release(new CommandAlreadyProcessedException());
             } else {
                 lastHandledPartitionOffsets.put(commandPartition, commandOffset);
                 LOG.trace("using [{}] for received command [{}]", commandHandler, command);

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandAlreadyProcessedException.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandAlreadyProcessedException.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.command;
+
+import java.net.HttpURLConnection;
+
+import org.eclipse.hono.client.ServerErrorException;
+
+/**
+ * A {@link ServerErrorException} indicating that the exact same command message was already
+ * handled before.
+ */
+public class CommandAlreadyProcessedException extends ServerErrorException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new CommandAlreadyProcessedException.
+     * <p>
+     * The exception will have a <em>500: Internal Server Error</em> status code.
+     */
+    public CommandAlreadyProcessedException() {
+        super(HttpURLConnection.HTTP_INTERNAL_ERROR);
+    }
+}

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandResponse.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandResponse.java
@@ -43,7 +43,19 @@ public final class CommandResponse {
     private final String correlationId;
     private final String replyToId;
 
-    private CommandResponse(
+    /**
+     * Creates a command response.
+     *
+     * @param tenantId The tenant that the device sending the response belongs to.
+     * @param deviceId The ID of the device that the response originates from.
+     * @param payload The payload of the response or {@code null} if the response has no payload.
+     * @param contentType The contentType of the response or {@code null} if the response has no payload.
+     * @param status The HTTP status code indicating the outcome of the command.
+     * @param correlationId The correlation ID of the command that this is the response for.
+     * @param replyToId The replyTo ID of the command message.
+     * @throws NullPointerException if tenantId, deviceId, correlationId or replyToId is {@code null}.
+     */
+    public CommandResponse(
             final String tenantId,
             final String deviceId,
             final Buffer payload,
@@ -52,13 +64,13 @@ public final class CommandResponse {
             final String correlationId,
             final String replyToId) {
 
-        this.tenantId = tenantId;
-        this.deviceId = deviceId;
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.deviceId = Objects.requireNonNull(deviceId);
         this.payload = payload;
         this.contentType = contentType;
         this.status = status;
-        this.correlationId = correlationId;
-        this.replyToId = replyToId;
+        this.correlationId = Objects.requireNonNull(correlationId);
+        this.replyToId = Objects.requireNonNull(replyToId);
     }
 
     /**
@@ -91,22 +103,21 @@ public final class CommandResponse {
         } else if (INVALID_STATUS_CODE.test(status)) {
             LOG.debug("cannot create CommandResponse: status is invalid: {}", status);
             return null;
-        } else {
-            try {
-                final Pair<String, String> correlationAndReplyToId = Commands
-                        .getCorrelationAndReplyToId(requestId, deviceId);
-                return new CommandResponse(
-                        tenantId,
-                        deviceId,
-                        payload,
-                        contentType,
-                        status,
-                        correlationAndReplyToId.one(),
-                        correlationAndReplyToId.two());
-            } catch (final IllegalArgumentException e) {
-                LOG.debug("error creating CommandResponse", e);
-                return null;
-            }
+        }
+        try {
+            final Pair<String, String> correlationAndReplyToId = Commands
+                    .getCorrelationAndReplyToId(requestId, deviceId);
+            return new CommandResponse(
+                    tenantId,
+                    deviceId,
+                    payload,
+                    contentType,
+                    status,
+                    correlationAndReplyToId.one(),
+                    correlationAndReplyToId.two());
+        } catch (final IllegalArgumentException e) {
+            LOG.debug("error creating CommandResponse", e);
+            return null;
         }
     }
 
@@ -193,18 +204,18 @@ public final class CommandResponse {
     }
 
     /**
-     * Gets the reply-to identifier that has been extracted from the request ID.
+     * Gets the reply-to identifier that is either part of the request ID or the response address.
      *
-     * @return The identifier or {@code null} if the request ID could not be parsed.
+     * @return The identifier.
      */
     public String getReplyToId() {
         return replyToId;
     }
 
     /**
-     * Gets the correlation identifier that has bee extracted from the request ID.
+     * Gets the correlation identifier.
      *
-     * @return The identifier or {@code null} if the request ID could not be parsed.
+     * @return The identifier.
      */
     public String getCorrelationId() {
         return correlationId;

--- a/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
@@ -71,6 +71,11 @@ public class CommandConstants {
     public static final String COMMAND_RESPONSE_RESPONSE_PART_SHORT = "s";
 
     /**
+     * The content type that is defined for error command response messages sent by a protocol adapter or Command Router.
+     */
+    public static final String CONTENT_TYPE_DELIVERY_FAILURE_NOTIFICATION = "application/vnd.eclipse-hono-delivery-failure-notification+json";
+
+    /**
      * Position of the status code in the MQTT command response topic.
      * {@code command/[tenant]/[device-id]/res/<req-id>/<status>}
      */

--- a/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.tests;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
+import org.eclipse.hono.client.kafka.KafkaProducerFactory;
+import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
+
+import io.opentracing.noop.NoopTracerFactory;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.producer.KafkaHeader;
+
+/**
+ * A generic Kafka sender.
+ */
+public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
+
+    /**
+     * Creates a new generic Kafka sender.
+     *
+     * @param producerFactory The factory to use for creating Kafka producers.
+     * @param producerConfig The Kafka producer configuration.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public GenericKafkaSender(final KafkaProducerFactory<String, Buffer> producerFactory,
+            final KafkaProducerConfigProperties producerConfig) {
+        super(producerFactory, "generic-sender", producerConfig, NoopTracerFactory.create());
+    }
+
+    /**
+     * Sends a message to a kafka cluster and doesn't wait for an outcome.
+     *
+     * @param topic      The topic to send the message to.
+     * @param tenantId   The tenant that the device belongs to.
+     * @param deviceId   The device identifier.
+     * @param payload    The data to send.
+     * @param properties Additional meta data that should be included in the message.
+     * @throws NullPointerException if topic, tenantId, deviceId or properties are {@code null}.
+     */
+    public void send(final String topic, final String tenantId, final String deviceId, final Buffer payload,
+            final Map<String, Object> properties) {
+        super.send(topic, tenantId, deviceId, payload, properties, null);
+    }
+
+    /**
+     * Sends a message to a kafka cluster and doesn't wait for an outcome.
+     *
+     * @param topic    The topic to send the message to.
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device identifier.
+     * @param payload  The data to send.
+     * @param headers  Additional meta data that should be included in the message.
+     * @throws NullPointerException if topic, tenantId, deviceId or headers are {@code null}.
+     */
+    public void send(final String topic, final String tenantId, final String deviceId, final Buffer payload,
+            final List<KafkaHeader> headers) {
+        super.send(topic, tenantId, deviceId, payload, headers, null);
+    }
+
+    /**
+     * Sends a message to a kafka cluster and waits for the outcome.
+     *
+     * @param topic      The topic to send the message to.
+     * @param tenantId   The tenant that the device belongs to.
+     * @param deviceId   The device identifier.
+     * @param payload    The data to send.
+     * @param properties Additional meta data that should be included in the message.
+     * @return A future indicating the outcome of the operation.
+     * <p>
+     * The future will be succeeded if the message has been sent.
+     * <p>
+     * The future will be failed with a {@link ServerErrorException} if the data could
+     * not be sent. The error code contained in the exception indicates the cause of the failure.
+     * @throws NullPointerException if topic, tenantId, deviceId or properties are {@code null}.
+     */
+    public Future<Void> sendAndWaitForOutcome(final String topic, final String tenantId, final String deviceId,
+            final Buffer payload, final Map<String, Object> properties) {
+        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, properties, null);
+    }
+
+    /**
+     * Sends a message to a kafka cluster and waits for the outcome.
+     *
+     * @param topic    The topic to send the message to.
+     * @param tenantId The tenant that the device belongs to.
+     * @param deviceId The device identifier.
+     * @param payload  The data to send.
+     * @param headers  Additional meta data that should be included in the message.
+     * @return A future indicating the outcome of the operation.
+     * <p>
+     * The future will be succeeded if the message has been sent.
+     * <p>
+     * The future will be failed with a {@link ServerErrorException} if the data could
+     * not be sent. The error code contained in the exception indicates the cause of the failure.
+     * @throws NullPointerException if topic, tenantId, deviceId or headers are {@code null}.
+     */
+    public Future<Void> sendAndWaitForOutcome(final String topic, final String tenantId, final String deviceId,
+            final Buffer payload, final List<KafkaHeader> headers) {
+        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, headers, null);
+    }
+
+}


### PR DESCRIPTION
This is for #2661.

In the release/modify/reject methods of the `KafkaBasedCommandContext`, a Kafka error command response message will be published now, provided the original command is a request/response command with a correlation id.