### PR TITLE
Remove support for exporting metrics to Graphite or InfluxDB

### DIFF
--- a/adapter-base/pom.xml
+++ b/adapter-base/pom.xml
@@ -114,11 +114,6 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-graphite</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/metric/MicrometerBasedMetricsTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/metric/MicrometerBasedMetricsTest.java
@@ -41,12 +41,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
-import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer.Sample;
-import io.micrometer.graphite.GraphiteConfig;
-import io.micrometer.graphite.GraphiteMeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.core.Handler;
@@ -68,8 +65,7 @@ public class MicrometerBasedMetricsTest {
      */
     public static Stream<MeterRegistry> registries() {
         return Stream.of(new MeterRegistry[] {
-                                new PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
-                                new GraphiteMeterRegistry(GraphiteConfig.DEFAULT, Clock.SYSTEM)
+                                new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
                                 });
     }
 

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -135,26 +135,6 @@
       </dependencies>
     </profile>
 
-   <profile>
-      <id>metrics-graphite</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.micrometer</groupId>
-          <artifactId>micrometer-registry-graphite</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>metrics-influxdb</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.micrometer</groupId>
-          <artifactId>micrometer-registry-influx</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-
     <profile>
       <id>metrics-prometheus</id>
       <dependencies>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -297,18 +297,6 @@
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-registry-graphite</artifactId>
-        <version>${micrometer.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-registry-influx</artifactId>
-        <version>${micrometer.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-prometheus</artifactId>
         <version>${micrometer.version}</version>
         <scope>runtime</scope>

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -15,12 +15,9 @@ maven/mavencentral/com.h2database/h2/1.4.200, EPL-1.0, approved, CQ14966
 maven/mavencentral/com.mchange/c3p0/0.9.5.4, LGPL-2.1-only OR EPL-1.0, approved, clearlydefined
 maven/mavencentral/com.mchange/mchange-commons-java/0.2.15, LGPL-2.1-only OR EPL-1.0, approved, clearlydefined
 maven/mavencentral/commons-cli/commons-cli/1.4, Apache-2.0, approved, CQ13132
-maven/mavencentral/com.rabbitmq/amqp-client/5.5.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.okio/okio/2.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup/protoparser/4.0.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.dropwizard.metrics/metrics-core/4.1.14, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.dropwizard.metrics/metrics-graphite/4.1.14, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jaegertracing/jaeger-client/1.6.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jaegertracing/jaeger-core/1.6.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jaegertracing/jaeger-micrometer/1.6.0, Apache-2.0, approved, clearlydefined
@@ -30,7 +27,6 @@ maven/mavencentral/io.jsonwebtoken/jjwt-api/0.11.2, Apache-2.0, approved, clearl
 maven/mavencentral/io.jsonwebtoken/jjwt-impl/0.11.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.jsonwebtoken/jjwt-jackson/0.11.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.micrometer/micrometer-core/1.6.7, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.micrometer/micrometer-registry-graphite/1.6.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.micrometer/micrometer-registry-prometheus/1.6.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.netty/netty-buffer/4.1.58.Final, Apache-2.0, approved, CQ21842
 maven/mavencentral/io.netty/netty-codec/4.1.58.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
@@ -123,7 +119,6 @@ maven/mavencentral/javax.annotation/javax.annotation-api/1.3.2, CDDL-1.1 OR GPL-
 maven/mavencentral/javax.xml.bind/jaxb-api/2.2.12, CDDL-1.0, approved, CQ8374
 maven/mavencentral/net.bytebuddy/byte-buddy/1.10.19, , approved, CQ22491
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.10.19, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.i2p.crypto/eddsa/0.3.0, CC0, approved, CQ17804
 maven/mavencentral/org.apache.kafka/kafka-clients/2.6.0, Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND EPL-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.13.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.13.3, Apache-2.0, approved, clearlydefined

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -15,12 +15,9 @@ com.h2database:h2:jar:1.4.200
 com.mchange:c3p0:jar:0.9.5.4
 com.mchange:mchange-commons-java:jar:0.2.15
 commons-cli:commons-cli:jar:1.4
-com.rabbitmq:amqp-client:jar:5.5.3
 com.squareup.okhttp3:okhttp:jar:4.9.0
 com.squareup.okio:okio:jar:2.8.0
 com.squareup:protoparser:jar:4.0.3
-io.dropwizard.metrics:metrics-core:jar:4.1.14
-io.dropwizard.metrics:metrics-graphite:jar:4.1.14
 io.jaegertracing:jaeger-client:jar:1.6.0
 io.jaegertracing:jaeger-core:jar:1.6.0
 io.jaegertracing:jaeger-micrometer:jar:1.6.0
@@ -30,7 +27,6 @@ io.jsonwebtoken:jjwt-api:jar:0.11.2
 io.jsonwebtoken:jjwt-impl:jar:0.11.2
 io.jsonwebtoken:jjwt-jackson:jar:0.11.2
 io.micrometer:micrometer-core:jar:1.6.7
-io.micrometer:micrometer-registry-graphite:jar:1.6.7
 io.micrometer:micrometer-registry-prometheus:jar:1.6.7
 io.netty:netty-buffer:jar:4.1.58.Final
 io.netty:netty-codec-dns:jar:4.1.58.Final
@@ -123,7 +119,6 @@ javax.annotation:javax.annotation-api:jar:1.3.2
 javax.xml.bind:jaxb-api:jar:2.2.12
 net.bytebuddy:byte-buddy-agent:jar:1.10.19
 net.bytebuddy:byte-buddy:jar:1.10.19
-net.i2p.crypto:eddsa:jar:0.3.0
 org.apache.kafka:kafka-clients:jar:2.6.0
 org.apache.logging.log4j:log4j-api:jar:2.13.3
 org.apache.logging.log4j:log4j-to-slf4j:jar:2.13.3

--- a/service-base/src/main/resources/org/eclipse/hono/service/metric/legacy.properties
+++ b/service-base/src/main/resources/org/eclipse/hono/service/metric/legacy.properties
@@ -1,3 +1,0 @@
-management.metrics.export.graphite.protocol=plaintext
-management.metrics.export.graphite.tagsAsPrefix=host
-management.metrics.export.graphite.step=1s

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -119,26 +119,6 @@
     </profile>
 
     <profile>
-      <id>metrics-graphite</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.micrometer</groupId>
-          <artifactId>micrometer-registry-graphite</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>metrics-influxdb</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.micrometer</groupId>
-          <artifactId>micrometer-registry-influx</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
       <id>metrics-prometheus</id>
       <dependencies>
         <dependency>

--- a/site/documentation/content/admin-guide/monitoring-tracing-config.md
+++ b/site/documentation/content/admin-guide/monitoring-tracing-config.md
@@ -3,16 +3,32 @@ title = "Monitoring & Tracing"
 weight = 355
 +++
 
-The individual components of an Eclipse Hono&trade; installation need to work together in order to provide their functionality to devices and applications. Under normal circumstances these interactions work flawlessly. However, due to the nature of distributed systems, any one (or more) of the components may crash or become otherwise unavailable due to arbitrary reasons. This page describes how Hono supports operations teams by providing insights into the individual service components and their interactions with each other by means of reporting metrics and tracing the processing of individual messages through the system.
+The individual components of an Eclipse Hono&trade; installation need to work together in order to provide their
+functionality to devices and applications. Under normal circumstances these interactions work flawlessly.
+However, due to the nature of distributed systems, any one (or more) of the components may crash or become otherwise
+unavailable due to arbitrary reasons. This page describes how Hono supports operations teams by providing insights
+into the individual service components and their interactions with each other by means of reporting metrics and
+tracing the processing of individual messages through the system.
 <!--more-->
 
-When a device uploads telemetry data to the HTTP adapter, the adapter invokes operations on the Device Registration, Credentials and the Tenant services in order to authenticate and authorize the device before sending the telemetry data downstream to the AMQP 1.0 Messaging Network. The overall success of this process and the latency involved before the message reaches the consumer is determined by the individual interactions between the service components.
+When a device uploads telemetry data to the HTTP adapter, the adapter invokes operations on the Device Registration,
+Credentials and the Tenant services in order to authenticate and authorize the device before sending the telemetry
+data downstream to the AMQP 1.0 Messaging Network. The overall success of this process and the latency involved before
+the message reaches the consumer is determined by the individual interactions between the service components.
 
 ## Monitoring
 
-In a production environment, an operations team will usually want to keep track of some *key performance indicators* (KPI) which allow the team to determine the overall *health* of the system, e.g. memory and CPU consumption etc. Hono supports the tracking of such KPIs by means of metrics it can be configured to report. The metrics are usually collected in a time series database like *InfluxDB* or *Prometheus* and then visualized on a monitoring dash-board built using frameworks like *Grafana*. Such a dash-board can usually also be configured to send alarms when certain thresholds are exceeded.
+In a production environment, an operations team will usually want to keep track of some *key performance indicators* (KPI)
+which allow the team to determine the overall *health* of the system, e.g. memory and CPU consumption etc.
+Hono supports the tracking of such KPIs by means of metrics it can be configured to report. The metrics are usually
+collected in a time series database like *InfluxDB* or *Prometheus* and then visualized on a monitoring dash-board built
+using frameworks like *Grafana*. Such a dash-board can usually also be configured to send alarms when certain
+thresholds are exceeded.
 
-Metrics usually provide insights into the past and current status of an individual component. The values can be aggregated to provide a picture of the overall system's status. As such, metrics provide a great way to *monitor* system health and, in particular, to anticipate resource shortages and use such knowledge to pro-actively prevent system failure.
+Metrics usually provide insights into the past and current status of an individual component. The values can be
+aggregated to provide a picture of the overall system's status. As such, metrics provide a great way to *monitor*
+system health and, in particular, to anticipate resource shortages and use such knowledge to pro-actively prevent
+system failure.
 
 ### Configuring a Metrics Back End
 
@@ -23,22 +39,18 @@ Micrometer integration with Spring Boot and Vert.x.
 Please refer to the [Micrometer documentation](http://micrometer.io/docs)
 for details regarding the configuration of a specific Micrometer back end.
 In most cases, you only need to add the back end specific jar files to the class path and
-add back end specific configuration to the `application.yml` file.
+add back end specific configuration properties to the `application.yml` file.
 
-The Hono build supports configuration of a specific metrics back end by means
-of Maven profiles. The following build profiles are currently supported:
+The Hono build supports configuration of the Prometheus metrics back end by means
+of the `metrics-prometheus` Maven profile.
 
-* `metrics-prometheus` – Enables the Prometheus backend.
-* `metrics-graphite` – Enables the Graphite backend.
-* `metrics-influxdb` – Enables the InfluxDB backend.
+Note that the profile is not active by default, i.e. you need to
+explicitly activate it when starting the build using Maven's `-P`
+command line parameter:
 
-Additionally, to selecting a metrics back end, you may need to configure the
-back end using Spring configuration options. See the documentation mentioned
-above for more information.
-
-Note that none of the above profiles are active by default, i.e. you need to
-explicitly activate one of them when starting the build using Maven's `-p`
-command line parameter.
+```sh
+mvn clean install -Pmetrics-prometheus ...
+```
 
 ### Using Prometheus
 
@@ -61,11 +73,13 @@ All of Hono's service components and protocol adapters contain a *Health Check* 
 expose several HTTP endpoints for determining the component's status.
 In particular, the server exposes a `/readiness`, a `/liveness` and an optional `/prometheus` URI endpoint.
 
-The former two endpoints are supposed to be used by container orchestration platforms like Kubernetes to monitor the runtime status of the containers
-that it manages. These endpoints are *always* exposed when the health check server is started.
+The former two endpoints are supposed to be used by container orchestration platforms like Kubernetes to monitor the
+runtime status of the containers that it manages. These endpoints are *always* exposed when the health check server is
+started.
 
-The `/prometheus` endpoint can be used by a Prometheus server to retrieve collected meter data from the component. It is *only* exposed if Prometheus has
-been configured as the metrics back end as described [above]({{< relref "#configuring-a-metrics-back-end" >}}).
+The `/prometheus` endpoint can be used by a Prometheus server to retrieve collected meter data from the component.
+It is *only* exposed if Prometheus has been configured as the metrics back end as described
+[above]({{< relref "#configuring-a-metrics-back-end" >}}).
 
 The health check server can be configured by means of the following environment variables:
 
@@ -87,65 +101,69 @@ The component/service will fail to start if neither the secure not the insecure 
 
 ## Tracing
 
-In normal operation the vast majority of messages should be flowing through the system without any noteworthy delays or problems. In fact, that is the whole purpose of Hono. However, that doesn't mean that nothing can go wrong. For example, when a tenant's device administrator changes the credentials of a device in the Credentials service but has not yet updated the credentials on the device yet, then the device will start to fail in uploading any data to the protocol adapter it connects to. After a while, a back end application's administrator might notice, that there hasn't been any data being received from that particular device for quite some time. The application administrator therefore calls up the Hono operations team and complains about the data *being lost somewhere*.
+In normal operation the vast majority of messages should be flowing through the system without any noteworthy delays
+or problems. In fact, that is the whole purpose of Hono. However, that doesn't mean that nothing can go wrong.
+For example, when a tenant's device administrator changes the credentials of a device in the Credentials service but
+has not yet updated the credentials on the device yet, then the device will start to fail in uploading any data to the
+protocol adapter it connects to. After a while, a back end application's administrator might notice, that there hasn't
+been any data being received from that particular device for quite some time. The application administrator therefore
+calls up the Hono operations team and complains about the data *being lost somewhere*.
 
-The operations team will have a hard time determining what is happening, because it will need to figure out which components have been involved in the processing of the device and why the data hasn't been processed as usual. The metrics alone usually do not help much here because metrics are usually not scoped to individual devices. The logs written by the individual components, on the other hand, might contain enough information to correlate individual entries in the log with each other and thus *trace* the processing of the message throughout the system. However, this is usually a very tedious (and error prone) process and the relevant information is often only logged at a level (e.g. *DEBUG*) that is not used in production (often *INFO* or above).
+The operations team will have a hard time determining what is happening, because it will need to figure out which
+components have been involved in the processing of the device and why the data hasn't been processed as usual.
+The metrics alone usually do not help much here because metrics are usually not scoped to individual devices.
+The logs written by the individual components, on the other hand, might contain enough information to correlate
+individual entries in the log with each other and thus *trace* the processing of the message throughout the system.
+However, this is usually a very tedious (and error prone) process and the relevant information is often only logged at
+a level (e.g. *DEBUG*) that is not used in production (often *INFO* or above).
 
-In order to address this problem, Hono's service components are instrumented using [OpenTracing](https://opentracing.io/). OpenTracing provides *Vendor-neutral APIs and instrumentation for distributed tracing*. The OpenTracing web page provides a [list of supported tracer implementations](https://opentracing.io/docs/supported-tracers/) from which users can choose in order to collect (and examine) the tracing information generated by Hono's individual components.
+In order to address this problem, Hono's service components are instrumented using [OpenTracing](https://opentracing.io/).
+OpenTracing provides *Vendor-neutral APIs and instrumentation for distributed tracing*. The OpenTracing web page provides
+a [list of supported tracer implementations](https://opentracing.io/docs/supported-tracers/) from which users can choose
+in order to collect (and examine) the tracing information generated by Hono's individual components.
 
 ### Configuring a Tracer
 
-**Hint**: The description in this chapter applies to any compatible OpenTracing implementation. For an easier approach to configure usage of [Jaeger tracing](https://www.jaegertracing.io/), see the next chapter.
+**Hint**: The description in this chapter applies to any compatible OpenTracing implementation. For an easier approach
+to configure usage of [Jaeger tracing](https://www.jaegertracing.io/), see the next chapter.
 
-Hono's components use the [OpenTracing Tracer Resolver](https://github.com/opentracing-contrib/java-tracerresolver) mechanism to find and initialize a concrete OpenTracing implementation during startup of the component. The discovery mechanism is using Java's [ServiceLoader](https://docs.oracle.com/javase/9/docs/api/java/util/ServiceLoader.html) and as such relies on the required resources to be available on the class path.
+Hono's components use the [OpenTracing Tracer Resolver](https://github.com/opentracing-contrib/java-tracerresolver)
+mechanism to find and initialize a concrete OpenTracing implementation during startup of the component.
+The discovery mechanism is using Java's [ServiceLoader](https://docs.oracle.com/javase/9/docs/api/java/util/ServiceLoader.html)
+and as such relies on the required resources to be available on the class path.
 
-When starting up any of Hono's Docker images as a container, the JVM will look for additional jar files to include in its class path in the container's `/opt/hono/extensions` folder. Thus, using a specific implementation of OpenTracing is just a matter of configuring the container to mount a volume or binding a host folder at that location and putting the implementation's jar files and resources into the corresponding volume or host folder.
+When starting up any of Hono's Docker images as a container, the JVM will look for additional jar files to include in
+its class path in the container's `/opt/hono/extensions` folder. Thus, using a specific implementation of OpenTracing is
+just a matter of configuring the container to mount a volume or binding a host folder at that location and putting the
+implementation's jar files and resources into the corresponding volume or host folder.
 
 {{% note %}}
-This also means that (currently) only Tracer implementations can be used with Hono that also implement the Tracer Resolver mechanism.
+This also means that (currently) only Tracer implementations can be used with Hono that also implement the Tracer
+Resolver mechanism.
 {{% /note %}}
-
-Assuming that the HTTP adapter should be configured to use [Jaeger tracing](https://www.jaegertracing.io/), the following steps are necessary:
-
-1. Download [Jaeger's Java Tracer Resolver](https://github.com/jaegertracing/jaeger-client-java/tree/master/jaeger-tracerresolver) implementation and its dependencies (see the hint at the end).
-2. Put the jars to a folder on the Docker host, e.g. `/tmp/jaeger`.
-3. Start the HTTP adapter Docker image mounting the host folder:
-
-    ```sh
-    docker run --name hono-adapter-http-vertx \
-    --mount type=bind,src=/tmp/jaeger,dst=/opt/hono/extensions,ro \
-    ... \
-    eclipse/hono-adapter-http-vertx
-    ```
-
-**Note**: the command given above does not contain the environment variables and secrets that are required to configure the service properly. The environment variables for configuring the Jaeger client are also missing. Please refer to the [Jaeger documentation](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/README.md) for details.
-
-When the HTTP adapter starts up, it will look for a working implementation of the Tracer Resolver on its classpath and (if found) initialize and use it for publishing traces. The adapter's log file will indicate the name of the Tracer implementation being used.
-
-Using a Docker *volume* instead of a *bind mount* works the same way but requires the use of `volume` as the *type* of the `--mount` parameter. Please refer to the [Docker reference documentation](https://docs.docker.com/engine/reference/commandline/service_create/#add-bind-mounts-volumes-or-memory-filesystems) for details.
-
-**Hint**: to resolve all dependencies for `jaeger-tracerresolver` in order to provide them to `/opt/hono/extensions`, you may want to rely on Maven's dependency plugin. To obtain all jar files you can invoke the following command in a simple Maven project that contains only the dependency to `jaeger-tracerresolver`:
-
-~~~sh
-mvn dependency:copy-dependencies
-~~~
-    
-All jar files can then be found in the directory `target/dependency`.    
 
 ## Configuring usage of Jaeger tracing (included in Docker images)
 
-In case [Jaeger tracing](https://www.jaegertracing.io/) shall be used, there is an alternative to putting the jar files in the container's `/opt/hono/extensions` folder as described above.
-This is to have the Jaeger tracing jar files be included in the Hono Docker images by using the `jaeger` Maven profile when building Hono.
-
-For example, building the HTTP adapter image with the Jaeger client included:
+In case [Jaeger tracing](https://www.jaegertracing.io/) shall be used, there is an alternative to putting the jar files
+in the container's `/opt/hono/extensions` folder as described above.
+This is to have the Jaeger tracing jar files be included in the Hono Docker images by using the `jaeger` Maven profile
+when building Hono. For example, building the HTTP adapter image with the Jaeger client included:
 
 ~~~sh
 # in directory: hono/adapters/http-vertx/
 mvn clean install -Pbuild-docker-image,jaeger
 ~~~
 
-Note that when running the created docker image, the environment variables for configuring the Jaeger client still need to be set. Please refer to the [Jaeger documentation](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/README.md) for details.
+Note that when running the created docker image, the environment variables for configuring the Jaeger client still
+need to be set. Please refer to the
+[Jaeger documentation](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/README.md) for details.
 
 ## Enforcing the recording of traces for a tenant
 
-Typically, in production systems, the tracing components will be configured to not store *all* trace spans in the tracing backend, in order to reduce the performance impact. For debugging purposes it can however be beneficial to enforce the recording of certain traces. Hono allows this by providing a configuration option in the Tenant information with which all traces concerning the processing of telemetry, event and command messages for that specific tenant will be recorded. Furthermore, this enforced trace sampling can be restricted to only apply to messages sent in the context of a specific authentication identifier. Please refer to the [description of the `tracing` object]({{< ref "/api/tenant#tracing-format" >}}) in the Tenant Information for details.
+Typically, in production systems, the tracing components will be configured to not store *all* trace spans in the tracing
+backend, in order to reduce the performance impact. For debugging purposes it can however be beneficial to enforce the
+recording of certain traces. Hono allows this by providing a configuration option in the Tenant information with which
+all traces concerning the processing of telemetry, event and command messages for that specific tenant will be recorded.
+Furthermore, this enforced trace sampling can be restricted to only apply to messages sent in the context of a specific
+authentication identifier. Please refer to the [description of the `tracing` object]({{< ref "/api/tenant#tracing-format" >}})
+in the Tenant Information for details.

--- a/site/documentation/content/api/Metrics.md
+++ b/site/documentation/content/api/Metrics.md
@@ -12,12 +12,12 @@ and how to interpret actual values.
 
 ## Reported Metrics
 
-Hono uses [Micrometer](https://micrometer.io/) in combination with Spring Boot
-to internally collect metrics. Those metrics can be exported to different
+Hono uses [Micrometer](https://micrometer.io/) for collecting metrics. Those metrics can be exported to different
 back ends. Please refer to [Configuring Metrics]({{< relref "/admin-guide/monitoring-tracing-config#configuring-a-metrics-back-end" >}})
 for details.
 
-The example deployment by default uses [Prometheus](https://prometheus.io/) as the metrics back end.
+The container images published on Docker Hub have been compiled with support for [Prometheus](https://prometheus.io/)
+as the metrics back end.
 
 When deploying to Kubernetes/OpenShift, the metrics reported by Hono may contain
 environment specific tags (like the *pod* name) which are added by the Prometheus
@@ -27,28 +27,28 @@ Hono applications may report other metrics in addition to the ones defined here.
 In particular, all components report metrics regarding the JVM's internal state, e.g.
 memory consumption and garbage collection status. Those metrics are not considered
 part of Hono's *official* metrics definition. However, all those metrics
-will still contain tags as described below.
+will still contain the common tags described below.
 
 ### Common Metrics
 
 Tags for common metrics are:
 
-| Tag              | Value                              | Description |
-| ---------------- | ---------------------------------- | ----------- |
-| *host*           | *string*                           | The name of the host that the component reporting the metric is running on |
-| *component-type* | `adapter`, `service`             | The type of component reporting the metric |
-| *component-name* | *string*                           | The name of the component reporting the metric. |
+| Tag              | Value              | Description |
+| ---------------- | ------------------ | ----------- |
+| *host*           | *string*           | The name of the host that the component reporting the metric is running on |
+| *component-type* | `adapter`, `service` | The type of component reporting the metric |
+| *component-name* | *string*           | The name of the component reporting the metric. |
 
 The names of Hono's standard components are as follows:
 
-| Component         | *component-name*      |
-| ----------------- | --------------------- |
+| Component         | *component-name*   |
+| ----------------- | ------------------ |
 | Auth Server       | `hono-auth`         |
 | Device Registry   | `hono-registry`     |
 | AMQP adapter      | `hono-amqp`         |
 | CoAP adapter      | `hono-coap`         |
 | HTTP adapter      | `hono-http`         |
-| Kura adapter      | `hono-kura-mqtt`   |
+| Kura adapter      | `hono-kura-mqtt`    |
 | MQTT adapter      | `hono-mqtt`         |
 | Lora adapter      | `hono-lora`         |
 | Sigfox adapter    | `hono-sigfox`       |

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -46,6 +46,10 @@ description = "Information about changes in recent Hono releases. Includes new f
   *telemetry-kafka*. This allows Hono's components to define more specific dependencies on client classes
   that they require. This change should have no effect on application clients.
 
+## End of life
+
+* The Maven profiles for compiling in support for exporting metrics to Graphite and InfluxDB have been removed.
+
 ## 1.8.0
 
 ### New Features


### PR DESCRIPTION
The Maven profiles for compiling in support for exporting collected
metrics to a Graphite or InfluxDB back end have been removed as there
doesn't seem to be any demand for it.

Fixes #2695