### PR TITLE
Make ServiceInvocationException abstract

### DIFF
--- a/client/src/main/java/org/eclipse/hono/client/ServiceInvocationException.java
+++ b/client/src/main/java/org/eclipse/hono/client/ServiceInvocationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * Indicates an unexpected outcome of a (remote) service invocation.
  *
  */
-public class ServiceInvocationException extends RuntimeException {
+public abstract class ServiceInvocationException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(ServiceInvocationException.class);
@@ -46,19 +46,8 @@ public class ServiceInvocationException extends RuntimeException {
      * @param errorCode The code representing the erroneous outcome.
      * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
      */
-    public ServiceInvocationException(final int errorCode) {
+    protected ServiceInvocationException(final int errorCode) {
         this(null, errorCode, null, null);
-    }
-
-    /**
-     * Creates a new exception for a tenant and error code.
-     *
-     * @param tenant The tenant that the exception occurred in the scope of or {@code null} if unknown.
-     * @param errorCode The code representing the erroneous outcome.
-     * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
-     */
-    public ServiceInvocationException(final String tenant, final int errorCode) {
-        this(tenant, errorCode, null, null);
     }
 
     /**
@@ -68,20 +57,8 @@ public class ServiceInvocationException extends RuntimeException {
      * @param msg The detail message.
      * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
      */
-    public ServiceInvocationException(final int errorCode, final String msg) {
+    protected ServiceInvocationException(final int errorCode, final String msg) {
         this(null, errorCode, msg, null);
-    }
-
-    /**
-     * Creates a new exception for a tenant, an error code and a detail message.
-     *
-     * @param tenant The tenant that the exception occurred in the scope of or {@code null} if unknown.
-     * @param errorCode The code representing the erroneous outcome.
-     * @param msg The detail message.
-     * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
-     */
-    public ServiceInvocationException(final String tenant, final int errorCode, final String msg) {
-        this(tenant, errorCode, msg, null);
     }
 
     /**
@@ -91,20 +68,8 @@ public class ServiceInvocationException extends RuntimeException {
      * @param cause The root cause.
      * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
      */
-    public ServiceInvocationException(final int errorCode, final Throwable cause) {
+    protected ServiceInvocationException(final int errorCode, final Throwable cause) {
         this(null, errorCode, null, cause);
-    }
-
-    /**
-     * Creates a new exception for a tenant, an error code and a root cause.
-     *
-     * @param tenant The tenant that the exception occurred in the scope of or {@code null} if unknown.
-     * @param errorCode The code representing the erroneous outcome.
-     * @param cause The root cause.
-     * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
-     */
-    public ServiceInvocationException(final String tenant, final int errorCode, final Throwable cause) {
-        this(tenant, errorCode, null, cause);
     }
 
     /**
@@ -116,7 +81,7 @@ public class ServiceInvocationException extends RuntimeException {
      * @param cause The root cause.
      * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
      */
-    public ServiceInvocationException(final String tenant, final int errorCode, final String msg, final Throwable cause) {
+    protected ServiceInvocationException(final String tenant, final int errorCode, final String msg, final Throwable cause) {
         super(providedOrDefaultMessage(errorCode, msg), cause);
         if (errorCode < 400 || errorCode >= 600) {
             throw new IllegalArgumentException(String.format("illegal error code [%d], must be >= 400 and < 600", errorCode));
@@ -124,6 +89,63 @@ public class ServiceInvocationException extends RuntimeException {
             this.errorCode = errorCode;
         }
         this.tenant = tenant;
+    }
+
+    /**
+     * Creates a new exception for an error code.
+     *
+     * @param errorCode The code representing the erroneous outcome.
+     * @return The new exception.
+     * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
+     */
+    public static ServiceInvocationException create(final int errorCode) {
+        return create(null, errorCode, null, null);
+    }
+
+    /**
+     * Creates a new exception for an error code and a detail message.
+     *
+     * @param errorCode The code representing the erroneous outcome.
+     * @param msg The detail message.
+     * @return The new exception.
+     * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
+     */
+    public static ServiceInvocationException create(final int errorCode, final String msg) {
+        return create(null, errorCode, msg, null);
+    }
+
+    /**
+     * Creates a new exception for an error code, a detail message and a root cause.
+     *
+     * @param errorCode The code representing the erroneous outcome.
+     * @param msg The detail message.
+     * @param cause The root cause.
+     * @return The new exception.
+     * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
+     */
+    public static ServiceInvocationException create(final int errorCode, final String msg, final Throwable cause) {
+        return create(null, errorCode, msg, cause);
+    }
+
+    /**
+     * Creates a new exception for a tenant, an error code, a detail message and a root cause.
+     *
+     * @param tenant The tenant that the exception occurred in the scope of or {@code null} if unknown.
+     * @param errorCode The code representing the erroneous outcome.
+     * @param msg The detail message.
+     * @param cause The root cause.
+     * @return The new exception.
+     * @throws IllegalArgumentException if the code is not &ge; 400 and &lt; 600.
+     */
+    public static ServiceInvocationException create(final String tenant, final int errorCode, final String msg,
+            final Throwable cause) {
+        if (errorCode >= 400 && errorCode < 500) {
+            return new ClientErrorException(tenant, errorCode, msg, cause);
+        } else if (errorCode >= 500 && errorCode < 600) {
+            return new ServerErrorException(tenant, errorCode, msg, cause);
+        } else {
+            throw new IllegalArgumentException(String.format("illegal error code [%d], must be >= 400 and < 600", errorCode));
+        }
     }
 
     /**

--- a/client/src/test/java/org/eclipse/hono/client/ServiceInvocationExceptionTest.java
+++ b/client/src/test/java/org/eclipse/hono/client/ServiceInvocationExceptionTest.java
@@ -44,7 +44,7 @@ public class ServiceInvocationExceptionTest {
     public void testExtractStatusCodeFromServiceInvocationException() {
 
         final ServiceInvocationException exception = new ServiceInvocationException(
-                HttpURLConnection.HTTP_NOT_FOUND);
+                HttpURLConnection.HTTP_NOT_FOUND) { };
         assertThat(ServiceInvocationException.extractStatusCode(exception)).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
     }
 

--- a/examples/hono-client-examples/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
+++ b/examples/hono-client-examples/src/main/java/org/eclipse/hono/devices/HonoHttpDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-O * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+O * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -204,7 +204,7 @@ public class HonoHttpDevice {
                             });
                         }
                     } else {
-                        result.completeExceptionally(new ServiceInvocationException(response.statusCode()));
+                        result.completeExceptionally(ServiceInvocationException.create(response.statusCode()));
                     }
                 }).exceptionHandler(t -> result.completeExceptionally(t));
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceAndGatewayAutoProvisioner.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceAndGatewayAutoProvisioner.java
@@ -190,7 +190,7 @@ public final class DeviceAndGatewayAutoProvisioner extends AbstractAutoProvision
                                                 .recover(error -> Future.succeededFuture())))
                                 .orElseGet(Future::succeededFuture);
                     } else {
-                        return Future.failedFuture(new ServiceInvocationException(deviceResult.getStatus(),
+                        return Future.failedFuture(ServiceInvocationException.create(deviceResult.getStatus(),
                                 "error retrieving device registration information"));
                     }
                 });

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/DeviceAndGatewayAutoProvisionerTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/DeviceAndGatewayAutoProvisionerTest.java
@@ -443,7 +443,7 @@ public class DeviceAndGatewayAutoProvisionerTest {
                 any(),
                 any(Map.class),
                 any()))
-                        .thenReturn(Future.failedFuture(new ServiceInvocationException(
+                        .thenReturn(Future.failedFuture(ServiceInvocationException.create(
                                 HttpURLConnection.HTTP_INTERNAL_ERROR, "error sending event")));
 
         // WHEN provisioning a device/gateway from a certificate

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/CoapTestBase.java
@@ -954,7 +954,7 @@ public abstract class CoapTestBase {
                                             // not the preceding telemetry/event message
                                             final String msg = "Error sending command response: " + thr.getMessage();
                                             return Future.failedFuture(thr instanceof ServiceInvocationException
-                                                    ? new ServiceInvocationException(tenantId, ((ServiceInvocationException) thr).getErrorCode(), msg, thr)
+                                                    ? ServiceInvocationException.create(tenantId, ((ServiceInvocationException) thr).getErrorCode(), msg, thr)
                                                     : new RuntimeException(msg, thr));
                                         });
                             });

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedCredentialsClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedCredentialsClient.java
@@ -169,7 +169,7 @@ public class JmsBasedCredentialsClient extends JmsBasedRequestResponseServiceCli
                             return CredentialsResult.from(getStatus(message), credentials, getCacheDirective(message));
                         } catch (DecodeException e) {
                             LOG.warn("Credentials service returned malformed payload", e);
-                            throw new ServiceInvocationException(
+                            throw ServiceInvocationException.create(
                                     HttpURLConnection.HTTP_INTERNAL_ERROR,
                                     "Credentials service returned malformed payload");
                         }

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedDeviceConnectionClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedDeviceConnectionClient.java
@@ -239,7 +239,7 @@ public class JmsBasedDeviceConnectionClient extends JmsBasedRequestResponseServi
                             return new RequestResponseResult<>(getStatus(message), json, null, null);
                         } catch (final DecodeException e) {
                             LOG.warn("Device Connection service returned malformed payload", e);
-                            throw new ServiceInvocationException(
+                            throw ServiceInvocationException.create(
                                     HttpURLConnection.HTTP_INTERNAL_ERROR,
                                     "Device Connection service returned malformed payload");
                         }

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedRegistrationClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedRegistrationClient.java
@@ -159,7 +159,7 @@ public class JmsBasedRegistrationClient extends JmsBasedRequestResponseServiceCl
                             return RegistrationResult.from(getStatus(message), json, getCacheDirective(message));
                         } catch (DecodeException e) {
                             LOG.warn("Device Registration service returned malformed payload", e);
-                            throw new ServiceInvocationException(
+                            throw ServiceInvocationException.create(
                                     HttpURLConnection.HTTP_INTERNAL_ERROR,
                                     "Device Registration service returned malformed payload");
                         }

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedRequestResponseClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedRequestResponseClient.java
@@ -289,15 +289,15 @@ public class JmsBasedRequestResponseClient<R extends RequestResponseResult<?>> {
         try {
             final ServiceInvocationException error;
             if (message instanceof TextMessage) {
-                error = new ServiceInvocationException(status, ((TextMessage) message).getText());
+                error = ServiceInvocationException.create(status, ((TextMessage) message).getText());
             } else if (message instanceof BytesMessage) {
                 final BytesMessage byteMessage = (BytesMessage) message;
                 error = Optional.ofNullable(byteMessage.getBody(byte[].class))
-                        .map(b -> new ServiceInvocationException(status, new String(b, StandardCharsets.UTF_8)))
-                        .orElseGet(() -> new ServiceInvocationException(status));
+                        .map(b -> ServiceInvocationException.create(status, new String(b, StandardCharsets.UTF_8)))
+                        .orElseGet(() -> ServiceInvocationException.create(status));
             } else {
                 // ignore body
-                error = new ServiceInvocationException(status);
+                error = ServiceInvocationException.create(status);
             }
             resultHandler.handle(Future.failedFuture(error));
         } catch (JMSException e) {

--- a/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedTenantClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/jms/JmsBasedTenantClient.java
@@ -145,7 +145,7 @@ public class JmsBasedTenantClient extends JmsBasedRequestResponseServiceClient<T
                         return TenantResult.from(getStatus(message), tenant, getCacheDirective(message));
                     } catch (DecodeException e) {
                         LOG.warn("Tenant service returned malformed payload", e);
-                        throw new ServiceInvocationException(
+                        throw ServiceInvocationException.create(
                                 HttpURLConnection.HTTP_INTERNAL_ERROR,
                                 "Tenant service returned malformed payload");
                     }


### PR DESCRIPTION
We have many `exception instanceof ServerErrorException` and `exception instanceof ClientErrorException` conditions in the code.
These wouldn't match for plain `ServiceInvocationException` instances. Therefore, this PR makes `ServiceInvocationException` abstract.

I've also removed 3 constructors with tenant param in order to reduce the overall number of constructors.