### PR TITLE
Add hono user to docker images

### DIFF
--- a/adapters/base-quarkus/pom.xml
+++ b/adapters/base-quarkus/pom.xml
@@ -152,6 +152,10 @@
                   <image>
                     <name>${docker.repository}/%a:%v</name>
                     <build>
+                      <runCmds>
+                        <runCmd>adduser --system --disabled-password -u 1000 hono</runCmd>
+                      </runCmds>
+                      <user>hono</user>
                       <env>
                         <JAVA_MAJOR_VERSION>${maven.compiler.release}</JAVA_MAJOR_VERSION>
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
@@ -242,6 +246,10 @@
                       </tags>
                       <imagePullPolicy>Always</imagePullPolicy>
                       <from>registry.access.redhat.com/ubi8/ubi-minimal:8.1</from>
+                      <runCmds>
+                        <runCmd>adduser --system --disabled-password -u 1000 hono</runCmd>
+                      </runCmds>
+                      <user>hono</user>
                       <workdir>/opt/hono</workdir>
                       <entryPoint>
                         <arg>/opt/hono/${project.artifactId}-${project.version}-runner</arg>

--- a/adapters/base-spring/pom.xml
+++ b/adapters/base-spring/pom.xml
@@ -95,6 +95,10 @@
                 <images>
                   <image>
                     <build>
+                      <runCmds>
+                        <runCmd>adduser --system --disabled-password -u 1000 hono</runCmd>
+                      </runCmds>
+                      <user>hono</user>
                       <env>
                         <JAVA_MAJOR_VERSION>${maven.compiler.release}</JAVA_MAJOR_VERSION>
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>

--- a/services/base-quarkus/pom.xml
+++ b/services/base-quarkus/pom.xml
@@ -143,6 +143,10 @@
                   <image>
                     <name>${docker.repository}/%a:%v</name>
                     <build>
+                      <runCmds>
+                        <runCmd>adduser --system --disabled-password -u 1000 hono</runCmd>
+                      </runCmds>
+                      <user>hono</user>
                       <env>
                         <JAVA_MAJOR_VERSION>${maven.compiler.release}</JAVA_MAJOR_VERSION>
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
@@ -233,6 +237,10 @@
                       </tags>
                       <imagePullPolicy>Always</imagePullPolicy>
                       <from>registry.access.redhat.com/ubi8/ubi-minimal:8.1</from>
+                      <runCmds>
+                        <runCmd>adduser --system --disabled-password -u 1000 hono</runCmd>
+                      </runCmds>
+                      <user>hono</user>
                       <workdir>/opt/hono</workdir>
                       <entryPoint>
                         <arg>/opt/hono/${project.artifactId}-${project.version}-runner</arg>
@@ -299,4 +307,3 @@
     </profile>
   </profiles>
 </project>
-

--- a/services/base-spring/pom.xml
+++ b/services/base-spring/pom.xml
@@ -96,6 +96,10 @@
                 <images>
                   <image>
                     <build>
+                      <runCmds>
+                        <runCmd>adduser --system --disabled-password -u 1000 hono</runCmd>
+                      </runCmds>
+                      <user>hono</user>
                       <env>
                         <JAVA_MAJOR_VERSION>${maven.compiler.release}</JAVA_MAJOR_VERSION>
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
@@ -147,4 +151,3 @@
 
   </profiles>
 </project>
-


### PR DESCRIPTION
This adds a user `hono` to the docker images of services and adapters, and uses it to run the application.
This provides additional security, because currently all applications run as root.