### PR TITLE
[#2732] Set last known gateway as part of batch request

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/BasicCache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/BasicCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -75,18 +75,12 @@ public abstract class BasicCache<K, V> implements Cache<K, V>, Lifecycle {
      */
     protected abstract boolean isStarted();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<Void> start() {
         LOG.info("starting cache");
         return connectToCache();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<Void> stop() {
         LOG.info("stopping cache");
@@ -153,37 +147,14 @@ public abstract class BasicCache<K, V> implements Cache<K, V>, Lifecycle {
         // nothing done by default
     }
 
-    /**
-     * Puts a value to the cache.
-     *
-     * @param key The key.
-     * @param value The value.
-     * @return A succeeded future containing the previous value or {@code null} if the
-     *         cache didn't contain the key yet.
-     *         A failed future if the value could not be stored in the cache.
-     * @throws NullPointerException if any of the parameters is {@code null}.
-     */
     @Override
     public Future<V> put(final K key, final V value) {
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
 
         return withCache(cache -> cache.putAsync(key, value));
-
     }
 
-    /**
-     * Puts a value to the cache.
-     *
-     * @param key The key.
-     * @param value The value.
-     * @param lifespan The lifespan of the entry. A negative value is interpreted as an unlimited lifespan.
-     * @param lifespanUnit The time unit for the lifespan.
-     * @return A succeeded future containing the previous value or {@code null} if the
-     *         cache didn't contain the key yet.
-     *         A failed future if the value could not be stored in the cache.
-     * @throws NullPointerException if any of the parameters is {@code null}.
-     */
     @Override
     public Future<V> put(final K key, final V value, final long lifespan, final TimeUnit lifespanUnit) {
         Objects.requireNonNull(key);
@@ -191,36 +162,31 @@ public abstract class BasicCache<K, V> implements Cache<K, V>, Lifecycle {
         Objects.requireNonNull(lifespanUnit);
 
         return withCache(cache -> cache.putAsync(key, value, lifespan, lifespanUnit));
-
     }
 
-    /**
-     * Removes a key/value mapping from the cache.
-     *
-     * @param key The key.
-     * @param value The value.
-     * @return {@code true} if the key was mapped to the value, {@code false}
-     *         otherwise.
-     * @throws NullPointerException if any of the parameters is {@code null}.
-     */
+    @Override
+    public Future<Void> putAll(final Map<? extends K, ? extends V> data) {
+        Objects.requireNonNull(data);
+
+        return withCache(cache -> cache.putAllAsync(data));
+    }
+
+    @Override
+    public Future<Void> putAll(final Map<? extends K, ? extends V> data, final long lifespan, final TimeUnit lifespanUnit) {
+        Objects.requireNonNull(data);
+        Objects.requireNonNull(lifespanUnit);
+
+        return withCache(cache -> cache.putAllAsync(data, lifespan, lifespanUnit));
+    }
+
     @Override
     public Future<Boolean> remove(final K key, final V value) {
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
 
         return withCache(cache -> cache.removeAsync(key, value));
-
     }
 
-    /**
-     * Gets a value from the cache.
-     *
-     * @param key The key.
-     * @return A succeeded future containing the value or {@code null} if the
-     *         cache didn't contain the key yet.
-     *         A failed future if the value could not be read from the cache.
-     * @throws NullPointerException if key is {@code null}.
-     */
     @Override
     public Future<V> get(final K key) {
         Objects.requireNonNull(key);
@@ -229,19 +195,11 @@ public abstract class BasicCache<K, V> implements Cache<K, V>, Lifecycle {
 
     }
 
-    /**
-     * Gets the values for the specified keys from the cache.
-     *
-     * @param keys The keys.
-     * @return A succeeded future containing a map with key/value pairs.
-     * @throws NullPointerException if keys is {@code null}.
-     */
     @Override
     public Future<Map<K, V>> getAll(final Set<? extends K> keys) {
         Objects.requireNonNull(keys);
 
         return withCache(cache -> cache.getAllAsync(keys));
-
     }
 
     /**
@@ -254,7 +212,6 @@ public abstract class BasicCache<K, V> implements Cache<K, V>, Lifecycle {
 
         return Future.failedFuture(new ServerErrorException(
                 HttpURLConnection.HTTP_UNAVAILABLE, "no connection to data grid"));
-
     }
 
 }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Cache.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/Cache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -66,6 +66,28 @@ public interface Cache<K, V> {
     Future<V> put(K key, V value, long lifespan, TimeUnit lifespanUnit);
 
     /**
+     * Puts all values of the given map to the cache.
+     *
+     * @param data The map with the entries to add.
+     * @return A succeeded future if the operation succeeded.
+     *         A failed future if there was an error storing the entries in the cache.
+     * @throws NullPointerException if data is {@code null}.
+     */
+    Future<Void> putAll(Map<? extends K, ? extends V> data);
+
+    /**
+     * Puts all values of the given map to the cache.
+     *
+     * @param data The map with the entries to add.
+     * @param lifespan The lifespan of the entries. A negative value is interpreted as an unlimited lifespan.
+     * @param lifespanUnit The time unit for the lifespan.
+     * @return A succeeded future if the operation succeeded.
+     *         A failed future if there was an error storing the entries in the cache.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<Void> putAll(Map<? extends K, ? extends V> data, long lifespan, TimeUnit lifespanUnit);
+
+    /**
      * Gets a value from the cache.
      *
      * @param key The key.
@@ -77,7 +99,7 @@ public interface Cache<K, V> {
     Future<V> get(K key);
 
     /**
-     * Remove a key/value mapping from the cache.
+     * Removes a key/value mapping from the cache.
      *
      * @param key The key.
      * @param value The value.

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionClient.java
@@ -79,9 +79,6 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
         return finishSpan(connectionInfoCache.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, span), span);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<JsonObject> getLastKnownGatewayForDevice(
             final String tenantId,
@@ -94,9 +91,6 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
         return finishSpan(connectionInfoCache.getLastKnownGatewayForDevice(tenantId, deviceId, span), span);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<Void> setCommandHandlingAdapterInstance(
             final String tenantId,
@@ -114,9 +108,6 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
         return finishSpan(connectionInfoCache.setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, lifespan, span), span);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<Void> removeCommandHandlingAdapterInstance(
             final String tenantId,
@@ -174,9 +165,6 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
         });
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<Void> start() {
         if (connectionInfoCache instanceof Lifecycle) {
@@ -186,9 +174,6 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<Void> stop() {
         if (connectionInfoCache instanceof Lifecycle) {
@@ -198,9 +183,6 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
         if (connectionInfoCache instanceof ServiceClient) {
@@ -208,9 +190,6 @@ public final class CacheBasedDeviceConnectionClient implements DeviceConnectionC
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
         if (connectionInfoCache instanceof ServiceClient) {

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,6 +14,7 @@
 package org.eclipse.hono.deviceconnection.infinispan.client;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Set;
 
 import io.opentracing.Span;
@@ -46,6 +47,30 @@ public interface DeviceConnectionInfo {
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     Future<Void> setLastKnownGatewayForDevice(String tenant, String deviceId, String gatewayId, Span span);
+
+    /**
+     * For a given list of device and gateway combinations, sets the gateway as the last gateway that acted on behalf
+     * of the device.
+     * <p>
+     * If a device connects directly instead of through a gateway, the device identifier itself is to be used as
+     * gateway value.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceIdToGatewayIdMap The map containing device identifiers and associated gateway identifiers. The
+     *                               gateway identifier may be the same as the device identifier if the device is
+     *                               (currently) not connected via a gateway but directly to a protocol adapter.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the device connection information has been updated.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     *         The outcome is indeterminate if any of the entries cannot be processed by an implementation.
+     *         In such a case, client code should assume that none of the entries have been updated.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<Void> setLastKnownGatewayForDevice(String tenant, Map<String, String> deviceIdToGatewayIdMap, Span span);
 
     /**
      * Gets the gateway that last acted on behalf of a device.

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandRouterClient.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandRouterClient.java
@@ -14,10 +14,18 @@
 package org.eclipse.hono.client.command.amqp;
 
 import java.net.HttpURLConnection;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.eclipse.hono.client.HonoConnection;
@@ -33,6 +41,7 @@ import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CommandRouterConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.Pair;
 import org.eclipse.hono.util.RequestResponseResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.tag.Tags;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
@@ -52,7 +62,33 @@ import io.vertx.core.json.JsonObject;
  */
 public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServiceClient<JsonObject, RequestResponseResult<JsonObject>> implements CommandRouterClient {
 
+    /**
+     * Interval in "set last known gateway" requests are done.
+     */
+    static final long SET_LAST_KNOWN_GATEWAY_UPDATE_INTERVAL_MILLIS = 400L;
+    /**
+     * Maximum number of entries in a "set last known gateway" batch request.
+     */
+    static final int SET_LAST_KNOWN_GATEWAY_UPDATE_MAX_ENTRIES = 100;
+    /**
+     * The maximum number of "set last known gateway" requests triggered in one go. Subsequent requests will only be
+     * sent after these requests are finished.
+     */
+    static final int SET_LAST_KNOWN_GATEWAY_UPDATE_MAX_PARALLEL_REQ = 50;
+
     private static final Logger LOG = LoggerFactory.getLogger(ProtonBasedCommandRouterClient.class);
+
+    /**
+     * Key is a Pair with tenant and device identifier, value is the gateway identifier.
+     */
+    private final LinkedHashMap<Pair<String, String>, String> lastKnownGatewaysWorkQueue = new LinkedHashMap<>();
+    /**
+     * A non-null value means the "set last known gateways" update is currently in progress.
+     */
+    private Long lastKnownGatewaysUpdateTimerId;
+
+    private boolean stopped = false;
+    private Clock clock = Clock.systemUTC();
 
     /**
      * Creates a new client for a connection.
@@ -74,8 +110,27 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
     }
 
     /**
-     * {@inheritDoc}
+     * Sets a clock to use for determining the current system time.
+     * <p>
+     * The default value of this property is {@link Clock#systemUTC()}.
+     * <p>
+     * This property should only be set for running tests expecting the current
+     * time to be a certain value, e.g. by using {@link Clock#fixed(Instant, java.time.ZoneId)}.
+     *
+     * @param clock The clock to use.
+     * @throws NullPointerException if clock is {@code null}.
      */
+    void setClock(final Clock clock) {
+        this.clock = Objects.requireNonNull(clock);
+    }
+
+    @Override
+    public Future<Void> stop() {
+        stopped = true;
+        Optional.ofNullable(lastKnownGatewaysUpdateTimerId).ifPresent(tid -> connection.getVertx().cancelTimer(tid));
+        return super.stop();
+    }
+
     @Override
     protected String getKey(final String tenantId) {
         return String.format("%s-%s", CommandRouterConstants.COMMAND_ROUTER_ENDPOINT, tenantId);
@@ -123,6 +178,12 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation always returns a succeeded future and strives to set the gateway with a delay of at most
+     * {@value SET_LAST_KNOWN_GATEWAY_UPDATE_INTERVAL_MILLIS} ms as part of a batch request.
+     */
     @Override
     public Future<Void> setLastKnownGatewayForDevice(
             final String tenantId,
@@ -134,22 +195,159 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(gatewayId);
 
-        final Map<String, Object> properties = createDeviceIdProperties(deviceId);
-        properties.put(MessageHelper.APP_PROPERTY_GATEWAY_ID, gatewayId);
+        // last known gateway isn't set immediately here, data is put in a queue to do a batch request later
 
-        // using FollowsFrom instead of ChildOf reference here as invoking methods usually don't depend and wait on the result of this method
-        final Span currentSpan = newFollowingSpan(context, "set last known gateway for device");
-        TracingHelper.setDeviceTags(currentSpan, tenantId, deviceId);
-        currentSpan.setTag(MessageHelper.APP_PROPERTY_GATEWAY_ID, gatewayId);
+        // insertion order used here so that oldest mappings are processed first (entries are removed when requests are prepared)
+        lastKnownGatewaysWorkQueue.put(Pair.of(tenantId, deviceId), gatewayId);
 
-        final Future<RequestResponseResult<JsonObject>> resultTracker = getOrCreateClient(tenantId)
-                .compose(client -> client.createAndSendRequest(
-                        CommandRouterConstants.CommandRouterAction.SET_LAST_KNOWN_GATEWAY.getSubject(),
-                        properties,
-                        null,
-                        null,
-                        this::getRequestResponseResult,
-                        currentSpan));
+        if (lastKnownGatewaysUpdateTimerId == null && !stopped) {
+            lastKnownGatewaysUpdateTimerId = connection.getVertx().setTimer(
+                    SET_LAST_KNOWN_GATEWAY_UPDATE_INTERVAL_MILLIS,
+                    tid -> processLastKnownGatewaysWorkQueue(null, null, null));
+        }
+        return Future.succeededFuture();
+    }
+
+    private void processLastKnownGatewaysWorkQueue(final Instant processingStartParam, final Set<String> tenantsToProcess,
+            final Span spanParam) {
+        log.debug("processLastKnownGatewaysWorkQueue; queue size: {}", lastKnownGatewaysWorkQueue.size());
+        final Instant processingStart = Optional.ofNullable(processingStartParam).orElseGet(() -> Instant.now(clock));
+        final Span currentSpan = Optional.ofNullable(spanParam)
+                .orElseGet(() -> newFollowingSpan(null, "set last known gateways"));
+        if (tenantsToProcess == null) {
+            currentSpan.log(Map.of("no_of_device_entries_to_set", lastKnownGatewaysWorkQueue.size()));
+        }
+
+        final Map<String, Map<String, String>> deviceToGatewayMapPerTenant = new LinkedHashMap<>();
+        final Set<String> tenantsWithRequestLimitReached = new HashSet<>();
+
+        // assemble data for the batch requests triggered in this run
+        // - entries exceeding the request size or count limits will be handled in the next run
+        for (final var iter = lastKnownGatewaysWorkQueue.entrySet().iterator(); iter.hasNext();) {
+            final var tenantDeviceToGatewayEntry = iter.next();
+            final String tenantId = tenantDeviceToGatewayEntry.getKey().one();
+            if (tenantsToProcess == null || tenantsToProcess.contains(tenantId)) {
+                if (!deviceToGatewayMapPerTenant.containsKey(tenantId)
+                        && deviceToGatewayMapPerTenant.size() >= SET_LAST_KNOWN_GATEWAY_UPDATE_MAX_PARALLEL_REQ) {
+                    tenantsWithRequestLimitReached.add(tenantId);
+                } else {
+                    deviceToGatewayMapPerTenant.putIfAbsent(tenantId, new HashMap<>());
+                    final Map<String, String> deviceToGatewayMap = deviceToGatewayMapPerTenant.get(tenantId);
+                    if (deviceToGatewayMap.size() < SET_LAST_KNOWN_GATEWAY_UPDATE_MAX_ENTRIES) {
+                        deviceToGatewayMap.put(tenantDeviceToGatewayEntry.getKey().two(),
+                                tenantDeviceToGatewayEntry.getValue());
+                        iter.remove();
+                    } else {
+                        tenantsWithRequestLimitReached.add(tenantId);
+                    }
+                }
+            }
+        }
+        @SuppressWarnings("rawtypes")
+        final List<Future> resultFutures = new ArrayList<>();
+        deviceToGatewayMapPerTenant.forEach((tenantId, deviceToGatewayMap) -> {
+            resultFutures.add(setLastKnownGateways(tenantId, deviceToGatewayMap, currentSpan.context()));
+        });
+        CompositeFuture.join(resultFutures)
+                .onComplete(ar -> {
+                    if (ar.failed()) {
+                        TracingHelper.logError(currentSpan, ar.cause());
+                    }
+                    if (stopped) {
+                        currentSpan.finish();
+                    } else if (!lastKnownGatewaysWorkQueue.isEmpty()) {
+                        // still work to do
+                        final long millisToWaitForNextInvocation = SET_LAST_KNOWN_GATEWAY_UPDATE_INTERVAL_MILLIS - Duration
+                                .between(processingStart, Instant.now(clock)).toMillis();
+
+                        if (millisToWaitForNextInvocation < 1) {
+                            // processing took longer than the update interval - start a new run right away (not restricted to tenantsWithRequestLimitReached)
+                            if (!tenantsWithRequestLimitReached.isEmpty()) {
+                                currentSpan.log(String.format("still remaining entries to be set for %d tenants - will be handled in next overall run",
+                                        tenantsWithRequestLimitReached.size()));
+                                log.info("processLastKnownGatewaysWorkQueue: not all entries could be set during update interval; current queue size: {}",
+                                        lastKnownGatewaysWorkQueue.size());
+                            }
+                            currentSpan.finish();
+                            processLastKnownGatewaysWorkQueue(null, null, null);
+
+                        } else if (!tenantsWithRequestLimitReached.isEmpty()) {
+                            // not all entries could be handled in this run - start a new run with just these tenants
+                            // (no need to already do the requests for the other tenants, for which entries where added in between)
+                            currentSpan.log(String.format("starting another round of requests for %d tenants (request size/count limit was reached)",
+                                    tenantsWithRequestLimitReached.size()));
+                            processLastKnownGatewaysWorkQueue(processingStart, tenantsWithRequestLimitReached, currentSpan);
+
+                        } else {
+                            log.debug("schedule next processLastKnownGatewaysWorkQueue invocation in {}ms", millisToWaitForNextInvocation);
+                            currentSpan.finish();
+                            lastKnownGatewaysUpdateTimerId = connection.getVertx().setTimer(
+                                    millisToWaitForNextInvocation,
+                                    tid -> processLastKnownGatewaysWorkQueue(null, null, null));
+                        }
+                    } else {
+                        // no work left
+                        currentSpan.finish();
+                        lastKnownGatewaysUpdateTimerId = null;
+                    }
+                });
+    }
+
+    /**
+     * For a given list of device and gateway combinations, sets the gateway as the last gateway that acted on behalf
+     * of the device.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceToGatewayMap The map associating device identifiers with the corresponding last gateway.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            An implementation should use this as the parent for any span it creates for tracing
+     *            the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the entries were successfully set.
+     *         Otherwise the future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException}.
+     *         The outcome is indeterminate if any of the entries cannot be processed by the Command Router service
+     *         implementation. In such a case, client code should assume that none of the entries have been updated.
+     */
+    protected Future<Void> setLastKnownGateways(final String tenantId, final Map<String, String> deviceToGatewayMap,
+            final SpanContext context) {
+        final Span currentSpan;
+        final Future<RequestResponseResult<JsonObject>> resultTracker;
+        if (deviceToGatewayMap.size() == 1) {
+            // use single entry operation so that traces with device and gateway are created
+            final Map.Entry<String, String> entry = deviceToGatewayMap.entrySet().iterator().next();
+            final String deviceId = entry.getKey();
+            final String gatewayId = entry.getValue();
+            final Map<String, Object> properties = createDeviceIdProperties(deviceId);
+            properties.put(MessageHelper.APP_PROPERTY_GATEWAY_ID, gatewayId);
+            currentSpan = newChildSpan(context, "set last known gateway for device");
+            TracingHelper.setDeviceTags(currentSpan, tenantId, deviceId);
+            currentSpan.setTag(MessageHelper.APP_PROPERTY_GATEWAY_ID, gatewayId);
+
+            resultTracker = getOrCreateClient(tenantId)
+                    .compose(client -> client.createAndSendRequest(
+                            CommandRouterConstants.CommandRouterAction.SET_LAST_KNOWN_GATEWAY.getSubject(),
+                            properties,
+                            null,
+                            null,
+                            this::getRequestResponseResult,
+                            currentSpan));
+        } else {
+            currentSpan = newChildSpan(context, "set last known gateways for tenant devices");
+            TracingHelper.setDeviceTags(currentSpan, tenantId, null);
+            currentSpan.log(Map.of("no_of_entries", deviceToGatewayMap.size()));
+
+            final JsonObject payload = new JsonObject();
+            deviceToGatewayMap.forEach(payload::put);
+            resultTracker = getOrCreateClient(tenantId)
+                    .compose(client -> client.createAndSendRequest(
+                            CommandRouterConstants.CommandRouterAction.SET_LAST_KNOWN_GATEWAY.getSubject(),
+                            null,
+                            payload.toBuffer(),
+                            MessageHelper.CONTENT_TYPE_APPLICATION_JSON,
+                            this::getRequestResponseResult,
+                            currentSpan));
+        }
         return mapResultAndFinishSpan(
                 resultTracker,
                 result -> {
@@ -160,7 +358,9 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
                         throw StatusCodeMapper.from(result);
                     }
                 },
-                currentSpan).mapEmpty();
+                currentSpan)
+                .onFailure(thr -> log.debug("failed to set last known gateway(s) for tenant [{}]", tenantId, thr))
+                .mapEmpty();
     }
 
     @Override

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterClient.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterClient.java
@@ -45,6 +45,8 @@ public interface CommandRouterClient extends Lifecycle {
      *         <p>
      *         The future will be succeeded if the entry was successfully set.
      *         Otherwise the future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException}.
+     *         An implementation may also always return a succeeded future and set the gateway at a later point in time
+     *         as part of a batch request.
      * @throws NullPointerException if any of the parameters except context is {@code null}.
      */
     Future<Void> setLastKnownGatewayForDevice(String tenantId, String deviceId, String gatewayId, SpanContext context);

--- a/service-base/src/main/java/org/eclipse/hono/service/commandrouter/CommandRouterService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/commandrouter/CommandRouterService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,6 +15,7 @@ package org.eclipse.hono.service.commandrouter;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
@@ -47,6 +48,27 @@ public interface CommandRouterService {
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     Future<CommandRouterResult> setLastKnownGatewayForDevice(String tenantId, String deviceId, String gatewayId,
+            Span span);
+
+    /**
+     * For a given list of device and gateway combinations, sets the gateway as the last gateway that acted on behalf
+     * of the device.
+     * <p>
+     * If a device connects directly instead of through a gateway, the device identifier itself is to be used as
+     * gateway value.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceIdToGatewayIdMap The map containing device identifiers and associated gateway identifiers. The
+     *                               gateway identifier may be the same as the device identifier if last message came
+     *                               from the device directly.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *             The <em>status</em> will be <em>204 No Content</em> if the operation completed successfully.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<CommandRouterResult> setLastKnownGatewayForDevice(String tenantId, Map<String, String> deviceIdToGatewayIdMap,
             Span span);
 
     /**

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -173,6 +174,13 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
             final String gatewayId, final Span span) {
 
         return deviceConnectionInfo.setLastKnownGatewayForDevice(tenantId, deviceId, gatewayId, span)
+                .map(ok -> CommandRouterResult.from(HttpURLConnection.HTTP_NO_CONTENT));
+    }
+
+    @Override
+    public Future<CommandRouterResult> setLastKnownGatewayForDevice(final String tenantId,
+            final Map<String, String> deviceIdToGatewayIdMap, final Span span) {
+        return deviceConnectionInfo.setLastKnownGatewayForDevice(tenantId, deviceIdToGatewayIdMap, span)
                 .map(ok -> CommandRouterResult.from(HttpURLConnection.HTTP_NO_CONTENT));
     }
 


### PR DESCRIPTION
This fixes #2732.

The last known gateway of a device isn't set right away anymore. Instead, all such device-to-gateway mappings happening in a time frame of 400ms are sent to the Command Router as part of a batch request.
It is ensured that these requests don't exceed a certain size and not too many such requests are made at once.