### PR TITLE
[#2736][#2592] Support receiving commands via both AMQP and Kafka

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -50,6 +50,7 @@ import org.eclipse.hono.service.util.ServiceBaseUtils;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.Lifecycle;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.ResourceIdentifier;
@@ -189,8 +190,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
     }
 
     @Override
-    public final CommandResponseSender getCommandResponseSender(final TenantObject tenant) {
-        return messagingClientProviders.getCommandResponseSender(tenant);
+    public final CommandResponseSender getCommandResponseSender(final MessagingType messagingType, final TenantObject tenant) {
+        return messagingClientProviders.getCommandResponseSender(messagingType, tenant);
     }
 
     /**
@@ -704,7 +705,8 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         Objects.requireNonNull(response);
         Objects.requireNonNull(tenant);
 
-        final CommandResponseSender sender = messagingClientProviders.getCommandResponseSender(tenant);
+        final CommandResponseSender sender = messagingClientProviders
+                .getCommandResponseSender(response.getMessagingType(), tenant);
         return sender.sendCommandResponse(response, context);
     }
 

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/ProtocolAdapter.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/ProtocolAdapter.java
@@ -23,6 +23,7 @@ import org.eclipse.hono.client.registry.CredentialsClient;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.telemetry.TelemetrySender;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.TelemetryExecutionContext;
 import org.eclipse.hono.util.TenantObject;
@@ -98,11 +99,16 @@ public interface ProtocolAdapter {
 
     /**
      * Gets the client being used for sending command response messages downstream.
+     * <p>
+     * Per default, the client using the given messaging type will be chosen. Only if
+     * no such client is available, the client will be determined using the messaging
+     * type configured for the given tenant (if set) or using the overall default type.
      *
+     * @param messagingType The type of messaging system to use.
      * @param tenant The tenant for which to send messages.
      * @return The sender.
      */
-    CommandResponseSender getCommandResponseSender(TenantObject tenant);
+    CommandResponseSender getCommandResponseSender(MessagingType messagingType, TenantObject tenant);
 
         /**
      * Gets an assertion of a device's registration status.

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapter.java
@@ -995,7 +995,7 @@ public final class VertxBasedAmqpProtocolAdapter extends AbstractProtocolAdapter
                 msg.setReplyTo(String.format("%s/%s/%s",
                         CommandConstants.COMMAND_RESPONSE_ENDPOINT,
                         command.getTenant(),
-                        Commands.getDeviceFacingReplyToId(command.getReplyToId(), command.getDeviceId())));
+                        Commands.getDeviceFacingReplyToId(command.getReplyToId(), command.getDeviceId(), command.getMessagingType())));
             }
 
             final Long timerId = getConfig().getSendMessageToDeviceTimeout() < 1 ? null

--- a/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
@@ -73,6 +73,7 @@ import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TelemetryConstants;
@@ -669,7 +670,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
 
         // WHEN an unauthenticated device publishes a command response
         final String replyToAddress = String.format("%s/%s/%s", getCommandResponseEndpoint(), TEST_TENANT_ID,
-                Commands.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE));
+                Commands.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE, MessagingType.amqp));
 
         final Map<String, Object> propertyMap = new HashMap<>();
         propertyMap.put(MessageHelper.APP_PROPERTY_STATUS, 200);
@@ -715,7 +716,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
 
         // WHEN an unauthenticated device publishes a command response
         final String replyToAddress = String.format("%s/%s/%s", getCommandResponseEndpoint(), TEST_TENANT_ID,
-                Commands.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE));
+                Commands.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE, MessagingType.amqp));
 
         final Map<String, Object> propertyMap = new HashMap<>();
         propertyMap.put(MessageHelper.APP_PROPERTY_STATUS, 200);
@@ -1021,7 +1022,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
     public void testMessageLimitExceededForACommandResponseMessage(final VertxTestContext ctx) {
 
         final String replyToAddress = String.format("%s/%s/%s", getCommandResponseEndpoint(), TEST_TENANT_ID,
-                Commands.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE));
+                Commands.getDeviceFacingReplyToId("test-reply-id", TEST_DEVICE, MessagingType.amqp));
         final Buffer payload = Buffer.buffer("payload");
         final Message message = getFakeMessage(replyToAddress, payload);
         message.setCorrelationId("correlation-id");

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CommandResponseResource.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CommandResponseResource.java
@@ -162,7 +162,8 @@ public class CommandResponseResource extends AbstractHonoResource {
 
                     return CompositeFuture.all(tenantValidationTracker, deviceRegistrationTracker);
                 })
-                .compose(ok -> getAdapter().getCommandResponseSender(tenantTracker.result())
+                .compose(ok -> getAdapter()
+                        .getCommandResponseSender(commandResponseTracker.result().getMessagingType(), tenantTracker.result())
                         .sendCommandResponse(commandResponseTracker.result(), currentSpan.context()))
                 .onSuccess(ok -> {
                     LOG.trace("forwarded command response [command-request-id: {}] to downstream application",

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/CommandResponseResourceTest.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/CommandResponseResourceTest.java
@@ -41,6 +41,7 @@ import org.eclipse.hono.service.metric.MetricsTags.Direction;
 import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.TenantObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,7 +88,8 @@ public class CommandResponseResourceTest extends ResourceTestBase {
             .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_FORBIDDEN)));
 
         // WHEN a device publishes an command response
-        final String reqId = Commands.getRequestId("correlation", "replyToId", "device");
+        final String reqId = Commands.encodeRequestIdParameters("correlation", "replyToId", "device",
+                MessagingType.amqp);
         final Buffer payload = Buffer.buffer("some payload");
         final OptionSet options = new OptionSet();
         options.addUriPath(CommandConstants.COMMAND_RESPONSE_ENDPOINT).addUriPath(reqId);
@@ -135,7 +137,8 @@ public class CommandResponseResourceTest extends ResourceTestBase {
         final CommandResponseSender sender = givenACommandResponseSenderForAnyTenant(outcome);
 
         // WHEN a device publishes an command response
-        final String reqId = Commands.getRequestId("correlation", "replyToId", "device");
+        final String reqId = Commands.encodeRequestIdParameters("correlation", "replyToId", "device",
+                MessagingType.amqp);
         final Buffer payload = Buffer.buffer("some payload");
         final OptionSet options = new OptionSet();
         options.addUriPath(CommandConstants.COMMAND_RESPONSE_ENDPOINT).addUriPath(reqId);
@@ -184,7 +187,8 @@ public class CommandResponseResourceTest extends ResourceTestBase {
         final CommandResponseSender sender = givenACommandResponseSenderForAnyTenant(outcome);
 
         // WHEN a device publishes an command response
-        final String reqId = Commands.getRequestId("correlation", "replyToId", "device");
+        final String reqId = Commands.encodeRequestIdParameters("correlation", "replyToId", "device",
+                MessagingType.amqp);
         final Buffer payload = Buffer.buffer("some payload");
         final OptionSet options = new OptionSet();
         options.addUriPath(CommandConstants.COMMAND_RESPONSE_ENDPOINT).addUriPath(reqId);

--- a/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/ResourceTestBase.java
+++ b/adapters/coap-vertx-base/src/test/java/org/eclipse/hono/adapter/coap/ResourceTestBase.java
@@ -34,6 +34,7 @@ import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.TelemetryExecutionContext;
 import org.eclipse.hono.util.TenantObject;
@@ -85,7 +86,7 @@ abstract class ResourceTestBase extends CoapProtocolAdapterMockSupport<CoapProto
         adapter = mock(CoapProtocolAdapter.class);
         when(adapter.checkMessageLimit(any(TenantObject.class), anyLong(), any())).thenReturn(Future.succeededFuture());
         when(adapter.getCommandConsumerFactory()).thenReturn(commandConsumerFactory);
-        when(adapter.getCommandResponseSender(any(TenantObject.class))).thenReturn(commandResponseSender);
+        when(adapter.getCommandResponseSender(any(MessagingType.class), any(TenantObject.class))).thenReturn(commandResponseSender);
         when(adapter.getConfig()).thenReturn(configuration);
         when(adapter.getDownstreamMessageProperties(any(TelemetryExecutionContext.class))).thenReturn(new HashMap<>());
         when(adapter.getEventSender(any(TenantObject.class))).thenReturn(eventSender);

--- a/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
+++ b/adapters/http-vertx-base/src/test/java/org/eclipse/hono/adapter/http/impl/VertxBasedHttpProtocolAdapterTest.java
@@ -40,6 +40,7 @@ import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 import org.eclipse.hono.util.JsonHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.QoS;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -424,7 +425,7 @@ public class VertxBasedHttpProtocolAdapterTest extends ProtocolAdapterTestSuppor
         givenATelemetrySenderForAnyTenant();
         mockSuccessfulAuthentication("DEFAULT_TENANT", "device_1");
         final CommandContext commandContext = givenARequestResponseCommandContext(
-                "DEFAULT_TENANT", "device_1", "doThis", "reply-to-id", null, null);
+                "DEFAULT_TENANT", "device_1", "doThis", "reply-to-id", null, null, MessagingType.amqp);
         final CommandConsumer commandConsumer = mock(CommandConsumer.class);
         when(commandConsumer.close(any())).thenReturn(Future.succeededFuture());
         when(commandConsumerFactory.createCommandConsumer(eq("DEFAULT_TENANT"), eq("device_1"), VertxMockSupport.anyHandler(), any(), any()))

--- a/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx-base/src/test/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapterTest.java
@@ -56,6 +56,7 @@ import org.eclipse.hono.util.Adapter;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.QoS;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.TenantObject;
@@ -1297,7 +1298,7 @@ public class AbstractVertxBasedMqttProtocolAdapterTest extends
 
         adapter.uploadMessage(newMqttContext(msg, mockEndpoint(), span),
                 ResourceIdentifier.fromString(String.format("%s/tenant/device/res/%s/200", getCommandEndpoint(),
-                        Commands.getRequestId("cmd123", "to", "deviceId"))),
+                        Commands.encodeRequestIdParameters("cmd123", "to", "deviceId", MessagingType.amqp))),
                 msg)
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommand.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommand.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.client.command.Commands;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.Strings;
 
@@ -67,7 +68,7 @@ public final class ProtonBasedCommand implements Command {
         this.deviceId = Objects.requireNonNull(deviceId);
         this.correlationId = correlationId;
         this.replyToId = replyToId;
-        requestId = Commands.getRequestId(correlationId, replyToId, deviceId);
+        requestId = Commands.encodeRequestIdParameters(correlationId, replyToId, deviceId, MessagingType.amqp);
     }
 
     /**
@@ -181,6 +182,11 @@ public final class ProtonBasedCommand implements Command {
      */
     Message getMessage() {
         return message;
+    }
+
+    @Override
+    public MessagingType getMessagingType() {
+        return MessagingType.amqp;
     }
 
     @Override
@@ -312,7 +318,7 @@ public final class ProtonBasedCommand implements Command {
         if (isValid()) {
             TracingHelper.TAG_CORRELATION_ID.set(span, getCorrelationId());
             final Map<String, String> items = new HashMap<>(5);
-            items.put(Fields.EVENT, "received command message");
+            items.put(Fields.EVENT, "received command message via AMQP");
             items.put("to", message.getAddress());
             items.put("reply-to", message.getReplyTo());
             items.put("name", getName());

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedLegacyCommandWrapper.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedLegacyCommandWrapper.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 
 import org.eclipse.hono.client.command.Command;
 import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +49,11 @@ public final class ProtonBasedLegacyCommandWrapper implements Command {
         if (Strings.isNullOrEmpty(command.getTenant()) || Strings.isNullOrEmpty(command.getOriginalDeviceId())) {
             LOG.warn("given command expected to have a valid tenant/device id: {}", command);
         }
+    }
+
+    @Override
+    public MessagingType getMessagingType() {
+        return MessagingType.amqp;
     }
 
     @Override

--- a/clients/command-amqp/src/test/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandResponseSenderTest.java
+++ b/clients/command-amqp/src/test/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandResponseSenderTest.java
@@ -29,9 +29,9 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.amqp.test.AmqpClientUnitTestHelper;
 import org.eclipse.hono.client.command.CommandResponse;
 import org.eclipse.hono.client.command.Commands;
-import org.eclipse.hono.client.command.amqp.ProtonBasedCommandResponseSender;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.util.MessagingType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -99,7 +99,7 @@ public class ProtonBasedCommandResponseSenderTest {
 
         // WHEN sending a command response message
         final CommandResponse commandResponse = CommandResponse.fromRequestId(
-                Commands.getRequestId(CORRELATION_ID, REPLY_TO_ID, DEVICE_ID),
+                Commands.encodeRequestIdParameters(CORRELATION_ID, REPLY_TO_ID, DEVICE_ID, MessagingType.amqp),
                 TENANT_ID,
                 DEVICE_ID,
                 null,

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommand.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommand.java
@@ -25,6 +25,7 @@ import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.Strings;
 
 import io.opentracing.Span;
@@ -71,7 +72,7 @@ public final class KafkaBasedCommand implements Command {
         this.subject = subject;
         this.contentType = contentType;
         this.responseRequired = responseRequired;
-        requestId = Commands.getRequestId(correlationId);
+        requestId = Commands.encodeRequestIdParameters(correlationId, MessagingType.kafka);
     }
 
     /**
@@ -184,6 +185,11 @@ public final class KafkaBasedCommand implements Command {
                 subject,
                 contentType,
                 responseRequired);
+    }
+
+    @Override
+    public MessagingType getMessagingType() {
+        return MessagingType.kafka;
     }
 
     @Override
@@ -325,7 +331,7 @@ public final class KafkaBasedCommand implements Command {
         if (isValid()) {
             TracingHelper.TAG_CORRELATION_ID.set(span, correlationId);
             final Map<String, Object> items = new HashMap<>(3);
-            items.put(Fields.EVENT, "received command message");
+            items.put(Fields.EVENT, "received command message via Kafka");
             items.put("subject", subject);
             items.put("content-type", contentType);
             span.log(items);

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
@@ -29,6 +29,7 @@ import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MapBasedExecutionContext;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -179,7 +180,8 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
                 CommandConstants.CONTENT_TYPE_DELIVERY_FAILURE_NOTIFICATION,
                 status,
                 correlationId,
-                "");
+                "",
+                MessagingType.kafka);
         return commandResponseSender.sendCommandResponse(commandResponse, span.context())
                 .onFailure(thr -> {
                     LOG.debug("failed to publish command response [{}]", commandResponse, thr);

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
@@ -60,6 +60,9 @@ public class KafkaBasedCommandResponseSender extends AbstractKafkaBasedMessageSe
 
         final HonoTopic topic = new HonoTopic(HonoTopic.Type.COMMAND_RESPONSE, response.getTenantId());
         log.trace("publish command response [{}]", response);
+        if (response.getMessagingType() != getMessagingType()) {
+            // TODO log to span
+        }
 
         return sendAndWaitForOutcome(topic.toString(), response.getTenantId(), response.getDeviceId(),
                 response.getPayload(), getHeaders(response), context);

--- a/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
+++ b/clients/command-kafka/src/test/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSenderTest.java
@@ -23,13 +23,13 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.eclipse.hono.client.command.CommandResponse;
 import org.eclipse.hono.client.command.Commands;
-import org.eclipse.hono.client.command.kafka.KafkaBasedCommandResponseSender;
 import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.kafka.test.KafkaClientUnitTestHelper;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.MessagingType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,7 +70,7 @@ public class KafkaBasedCommandResponseSenderTest {
         final int status = 200;
         final CommandResponse commandResponse = CommandResponse.fromAddressAndCorrelationId(
                 String.format("%s/%s/%s", CommandConstants.COMMAND_RESPONSE_ENDPOINT, tenantId,
-                        Commands.getDeviceFacingReplyToId("", deviceId)),
+                        Commands.getDeviceFacingReplyToId("", deviceId, MessagingType.kafka)),
                 correlationId,
                 Buffer.buffer(payload),
                 contentType,

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/Command.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/Command.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.client.command;
 
+import org.eclipse.hono.util.MessagingType;
+
 import io.opentracing.Span;
 import io.vertx.core.buffer.Buffer;
 
@@ -148,7 +150,9 @@ public interface Command {
      * Gets this command's reply-to-id as given in the incoming command message.
      * <p>
      * Note that an outgoing command message targeted at the device will contain an
-     * adapted reply-to address containing the device id.
+     * adapted reply-to address containing the device id and the type of messaging
+     * infrastructure over which the command was received (see
+     * {@link Commands#getDeviceFacingReplyToId(String, String, MessagingType)}).
      * <p>
      * For certain command &amp; control implementations (e.g. using Kafka), the command
      * message doesn't contain such an id, so that this method will always return
@@ -166,6 +170,13 @@ public interface Command {
      * @throws IllegalStateException if this command is invalid.
      */
     String getCorrelationId();
+
+    /**
+     * Gets the type of the messaging system on which the command was received.
+     *
+     * @return The messaging type.
+     */
+    MessagingType getMessagingType();
 
     /**
      * Logs information about the command.

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRequestIdParameters.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRequestIdParameters.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.command;
+
+import java.util.Objects;
+
+import org.eclipse.hono.util.MessagingType;
+
+/**
+ * Contains the information encoded in the request identifier when forwarding a Command &amp; Control messages to a
+ * device.
+ */
+public final class CommandRequestIdParameters {
+
+    private final String correlationId;
+    private final String replyToId;
+    private final MessagingType messagingType;
+
+    /**
+     * Creates a new CommandRequestParams object.
+     *
+     * @param correlationId The identifier to use for correlating the response with the request.
+     * @param replyToId An arbitrary identifier encoded into the request ID.
+     * @param messagingType The used messagingType.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public CommandRequestIdParameters(final String correlationId, final String replyToId, final MessagingType messagingType) {
+        this.correlationId = Objects.requireNonNull(correlationId);
+        this.replyToId = Objects.requireNonNull(replyToId);
+        this.messagingType = Objects.requireNonNull(messagingType);
+    }
+
+    /**
+     * Gets the correlation identifier.
+     *
+     * @return The correlation identifier.
+     */
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    /**
+     * Gets the reply-to identifier.
+     * <p>
+     * This may or may not start with the device identifier, depending on whether that was the case for the reply-to
+     * identifier in the original command.
+     *
+     * @return The reply-to identifier.
+     */
+    public String getReplyToId() {
+        return replyToId;
+    }
+
+    /**
+     * Gets the used messaging type.
+     *
+     * @return The messaging type.
+     */
+    public MessagingType getMessagingType() {
+        return messagingType;
+    }
+}

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
@@ -17,6 +17,7 @@ package org.eclipse.hono.client.command;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.Pair;
 
 /**
@@ -26,27 +27,35 @@ import org.eclipse.hono.util.Pair;
 public final class Commands {
 
     /**
-     * Bit flag value for the boolean option that defines whether the original reply-to address of the command message
+     * Bit flag index for the boolean option that defines whether the original reply-to address of the command message
      * contained the device id.
      */
-    private static final byte FLAG_REPLY_TO_CONTAINED_DEVICE_ID = 1;
+    private static final byte BITFLAG_INDEX_REPLY_TO_CONTAINED_DEVICE_ID = 0;
+    /**
+     * Bit flag index for the index of the messaging type used for sending a command message.
+     * <p>The messaging type is encoded in one bit for now.
+     */
+    private static final byte BITFLAG_INDEX_MESSAGING_TYPE = 1;
 
     private Commands() {
         // prevent instantiation
     }
 
     /**
-     * Creates a request ID for a command.
-     * <p>
-     * Incorporates the given correlationId and replyToId (minus deviceId if contained in the replyToId).
+     * Encodes the given correlationId and replyToId (minus deviceId if contained in the replyToId)
+     * into a request ID for a command.
      *
      * @param correlationId The identifier to use for correlating the response with the request.
      * @param replyToId An arbitrary identifier to encode into the request ID.
      * @param deviceId The target of the command.
+     * @param messagingType The type of messaging system to use.
      * @return The request identifier or {@code null} if correlationId or deviceId is {@code null}.
-     * @see #getCorrelationAndReplyToId(String, String) getCorrelationAndReplyId() as the reverse operation.
+     * @throws NullPointerException If messagingType is {@code null}.
+     * @see #decodeRequestIdParameters(String, String) getCorrelationAndReplyId() as the reverse operation.
      */
-    public static String getRequestId(final String correlationId, final String replyToId, final String deviceId) {
+    public static String encodeRequestIdParameters(final String correlationId, final String replyToId, final String deviceId,
+            final MessagingType messagingType) {
+        Objects.requireNonNull(messagingType);
         if (correlationId == null || deviceId == null) {
             return null;
         }
@@ -55,33 +64,35 @@ public final class Commands {
         if (replyToContainedDeviceId) {
             replyToIdWithoutDeviceOrEmpty = replyToIdWithoutDeviceOrEmpty.substring(deviceId.length() + 1);
         }
-        return String.format("%s%02x%s%s", encodeReplyToOptions(replyToContainedDeviceId),
+        return String.format("%s%02x%s%s", encodeReplyToOptions(replyToContainedDeviceId, messagingType),
                 correlationId.length(), correlationId, replyToIdWithoutDeviceOrEmpty);
     }
 
     /**
      * Creates a request ID for a command, in case no replyToId is used.
      * <p>
-     * Use {@link #getRequestId(String, String, String)} if a replyToId is available.
+     * Use {@link #encodeRequestIdParameters(String, String, String, MessagingType)} if a replyToId is available.
      *
      * @param correlationId The identifier to use for correlating the response with the request.
+     * @param messagingType The type of messaging system to use.
      * @return The request identifier or {@code null} if correlationId is {@code null}.
+     * @throws NullPointerException If messagingType is {@code null}.
      */
-    public static String getRequestId(final String correlationId) {
-        return getRequestId(correlationId, null, "");
+    public static String encodeRequestIdParameters(final String correlationId, final MessagingType messagingType) {
+        return encodeRequestIdParameters(correlationId, null, "", messagingType);
     }
 
     /**
-     * Gets the correlation id and reply-to id from a given request id.
+     * Decodes the given request identifier.
      *
      * @param requestId The request id to extract the values from.
      * @param deviceId The device identifier.
-     * @return a pair with correlation id as first and replyToId as second value.
+     * @return The object containing the parameters decoded from the request identifier.
      * @throws NullPointerException if any of the parameters is {@code null}.
      * @throws IllegalArgumentException if the given requestId is invalid.
-     * @see #getRequestId(String, String, String) getRequestId() as the reverse operation.
+     * @see #encodeRequestIdParameters(String, String, String, MessagingType) getRequestId() as the reverse operation.
      */
-    public static Pair<String, String> getCorrelationAndReplyToId(final String requestId, final String deviceId) {
+    public static CommandRequestIdParameters decodeRequestIdParameters(final String requestId, final String deviceId) {
         Objects.requireNonNull(requestId);
         Objects.requireNonNull(deviceId);
 
@@ -93,7 +104,9 @@ public final class Commands {
 
             final String correlationId = requestId.substring(3, 3 + lengthStringOne);
             final String replyToId = addDeviceIdToReply ? deviceId + "/" + replyIdWithoutDevice : replyIdWithoutDevice;
-            return Pair.of(correlationId, replyToId);
+
+            final MessagingType messagingType = getMessagingTypeFromBitFlag(replyToOptionsBitFlag);
+            return new CommandRequestIdParameters(correlationId, replyToId, messagingType);
         } catch (final IndexOutOfBoundsException e) {
             throw new IllegalArgumentException("invalid requestId", e);
         }
@@ -107,50 +120,36 @@ public final class Commands {
      * @param replyToId The reply-to-id as extracted from the 'reply-to' property of the command message.
      *            May be {@code null} in which case an empty string will be used.
      * @param deviceId The device id.
+     * @param messagingType The used messagingType.
      * @return The reply-to-id, starting with the device id.
-     * @throws NullPointerException if deviceId is {@code null}.
-     * @see #getOriginalReplyToId(String, String) getOriginalReplyToId() as the reverse operation.
+     * @throws NullPointerException if deviceId or messagingType is {@code null}.
+     * @see #getOriginalReplyToIdAndMessagingType(String, String) getOriginalReplyToIdAndMessagingType() as the reverse operation.
      */
-    public static String getDeviceFacingReplyToId(final String replyToId, final String deviceId) {
+    public static String getDeviceFacingReplyToId(final String replyToId, final String deviceId, final MessagingType messagingType) {
         Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(messagingType);
 
         final boolean replyToContainedDeviceId = replyToId != null && replyToId.startsWith(deviceId + "/");
         final String replyToIdWithoutDeviceId = replyToContainedDeviceId ? replyToId.substring(deviceId.length() + 1)
                 : Optional.ofNullable(replyToId).orElse("");
-        final String bitFlagString = encodeReplyToOptions(replyToContainedDeviceId);
+        final String bitFlagString = encodeReplyToOptions(replyToContainedDeviceId, messagingType);
         return String.format("%s/%s%s", deviceId, bitFlagString, replyToIdWithoutDeviceId);
-    }
-
-    /**
-     * Encodes the given boolean parameters related to the original reply-to address of the command message as a single
-     * digit string.
-     *
-     * @param replyToContainedDeviceId Whether the original reply-to address of the command message contained the device
-     *            id.
-     * @return The encoded options as a single digit string.
-     */
-    private static String encodeReplyToOptions(final boolean replyToContainedDeviceId) {
-        int bitFlag = 0;
-        if (replyToContainedDeviceId) {
-            bitFlag |= FLAG_REPLY_TO_CONTAINED_DEVICE_ID;
-        }
-        return String.valueOf(bitFlag);
     }
 
     /**
      * Gets the reply-to-id that was set in the original command message.
      * <p>
-     * The input is the id returned by {@link #getDeviceFacingReplyToId(String, String)}, which is
+     * The input is the id returned by {@link #getDeviceFacingReplyToId(String, String, MessagingType)}, which is
      * used in the command message forwarded to the device.
      *
-     * @param deviceFacingReplyToId The reply-to-id as returned by {@link #getDeviceFacingReplyToId(String, String)}.
+     * @param deviceFacingReplyToId The reply-to-id as returned by {@link #getDeviceFacingReplyToId(String, String, MessagingType)}.
      * @param deviceId The device id.
-     * @return The reply-to-id.
+     * @return The pair of reply-to-id and messaging type.
      * @throws NullPointerException if deviceFacingReplyToId or deviceId is {@code null}.
      * @throws IllegalArgumentException if the given deviceFacingReplyToId is invalid.
-     * @see #getDeviceFacingReplyToId(String, String) getDeviceFacingReplyToId() as the reverse operation.
+     * @see #getDeviceFacingReplyToId(String, String, MessagingType) getDeviceFacingReplyToId() as the reverse operation.
      */
-    public static String getOriginalReplyToId(final String deviceFacingReplyToId, final String deviceId) {
+    public static Pair<String, MessagingType> getOriginalReplyToIdAndMessagingType(final String deviceFacingReplyToId, final String deviceId) {
         Objects.requireNonNull(deviceFacingReplyToId);
         Objects.requireNonNull(deviceId);
 
@@ -158,25 +157,75 @@ public final class Commands {
             // deviceFacingReplyToId starts with deviceId/[bit flag]
             final String replyToOptionsBitFlag = deviceFacingReplyToId.substring(deviceId.length() + 1, deviceId.length() + 2);
             final boolean replyToContainedDeviceId = isReplyToContainedDeviceIdOptionSet(replyToOptionsBitFlag);
-            return deviceFacingReplyToId.replaceFirst(deviceId + "/" + replyToOptionsBitFlag,
+            final MessagingType messagingType = getMessagingTypeFromBitFlag(replyToOptionsBitFlag);
+            final String originalReplyToId = deviceFacingReplyToId.replaceFirst(deviceId + "/" + replyToOptionsBitFlag,
                     replyToContainedDeviceId ? deviceId + "/" : "");
+            return Pair.of(originalReplyToId, messagingType);
         } catch (final IndexOutOfBoundsException e) {
             throw new IllegalArgumentException("invalid deviceFacingReplyToId", e);
         }
     }
 
+
+    /**
+     * Encodes the given boolean parameters related to the original reply-to address of the command message as a single
+     * digit string.
+     *
+     * @param replyToContainedDeviceId Whether the original reply-to address of the command message contained the device
+     *            id.
+     * @param messagingType The used messaging type.
+     * @return The encoded options as a single digit string.
+     */
+    private static String encodeReplyToOptions(final boolean replyToContainedDeviceId, final MessagingType messagingType) {
+        int bitFlag = 0;
+        if (replyToContainedDeviceId) {
+            bitFlag |= (1 << BITFLAG_INDEX_REPLY_TO_CONTAINED_DEVICE_ID);
+        }
+        final int messagingTypeIndex = getMessagingTypeIndex(messagingType);
+        bitFlag |= ((messagingTypeIndex << BITFLAG_INDEX_MESSAGING_TYPE) & getMessagingTypeBitmask());
+
+        return String.valueOf(bitFlag);
+    }
+
     /**
      * Checks if the original reply-to address of the command message contained the device id.
      *
-     * @param replyToOptionsBitFlag The bit flag returned by {@link #encodeReplyToOptions(boolean)}.
+     * @param replyToOptionsBitFlag The bit flag returned by {@link #encodeReplyToOptions(boolean, MessagingType)}.
      * @return {@code true} if the original reply-to address of the command message contained the device id.
      * @throws NumberFormatException If the given replyToOptionsBitFlag can't be parsed as an integer.
      */
     private static boolean isReplyToContainedDeviceIdOptionSet(final String replyToOptionsBitFlag) {
-        return decodeReplyToOption(replyToOptionsBitFlag, FLAG_REPLY_TO_CONTAINED_DEVICE_ID);
+        return decodeReplyToOption(replyToOptionsBitFlag, (1 << BITFLAG_INDEX_REPLY_TO_CONTAINED_DEVICE_ID));
     }
 
-    private static boolean decodeReplyToOption(final String replyToOptionsBitFlag, final byte optionBitConstant) {
-        return (Integer.parseInt(replyToOptionsBitFlag) & optionBitConstant) == optionBitConstant;
+    private static boolean decodeReplyToOption(final String replyToOptionsBitFlag, final int bitmask) {
+        return (Integer.parseInt(replyToOptionsBitFlag) & bitmask) == bitmask;
+    }
+
+    /**
+     * Gets the type of messaging system encoded in the given bit flag.
+     *
+     * @param replyToOptionsBitFlag The bit flag returned by {@link #encodeReplyToOptions(boolean, MessagingType)}.
+     * @return The type of messaging system encoded in the bit flag.
+     * @throws NumberFormatException If the given replyToOptionsBitFlag can't be parsed as an integer.
+     */
+    private static MessagingType getMessagingTypeFromBitFlag(final String replyToOptionsBitFlag) {
+        final int messagingTypeIndex = (Integer.parseInt(replyToOptionsBitFlag) & getMessagingTypeBitmask()) >>> BITFLAG_INDEX_MESSAGING_TYPE;
+        return getMessagingTypeFromIndex(messagingTypeIndex);
+    }
+
+    private static int getMessagingTypeBitmask() {
+        // currently only encoding 2 messaging types here (BITFLAG_WIDTH_MESSAGING_TYPE is 1)
+//        return IntStream.range(BITFLAG_INDEX_MESSAGING_TYPE, BITFLAG_INDEX_MESSAGING_TYPE + BITFLAG_WIDTH_MESSAGING_TYPE)
+//                .reduce(0, (mask, index) -> mask | (1 << index));
+        return 1 << BITFLAG_INDEX_MESSAGING_TYPE;
+    }
+
+    private static int getMessagingTypeIndex(final MessagingType messagingType) {
+        return messagingType.equals(MessagingType.kafka) ? 1 : 0;
+    }
+
+    private static MessagingType getMessagingTypeFromIndex(final int messagingTypeIndex) {
+        return messagingTypeIndex == 1 ? MessagingType.kafka : MessagingType.amqp;
     }
 }

--- a/clients/command/src/test/java/org/eclipse/hono/client/command/CommandResponseTest.java
+++ b/clients/command/src/test/java/org/eclipse/hono/client/command/CommandResponseTest.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.HttpURLConnection;
+
+import org.eclipse.hono.util.MessagingType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies behavior of {@link CommandResponse}.
+ *
+ */
+public class CommandResponseTest {
+
+    private static final String CORRELATION_ID = "the-correlation-id";
+    private static final String TENANT_ID = "tenant";
+    private static final String DEVICE_ID = "4711";
+    private static final String REPLY_TO_ID = "the-reply-to-id";
+    private static final String REPLY_TO_ID_WITH_DEVICE = DEVICE_ID + "/" + REPLY_TO_ID;
+
+    /**
+     * Verifies that a response can be created from a request ID.
+     */
+    @Test
+    public void testFromRequestIdSucceeds() {
+
+        final CommandResponse resp = CommandResponse.fromRequestId(
+                Commands.encodeRequestIdParameters(CORRELATION_ID, REPLY_TO_ID, DEVICE_ID, MessagingType.kafka),
+                TENANT_ID,
+                DEVICE_ID,
+                null,
+                null,
+                HttpURLConnection.HTTP_OK);
+        assertThat(resp).isNotNull();
+        assertThat(resp.getDeviceId()).isEqualTo(DEVICE_ID);
+        assertThat(resp.getTenantId()).isEqualTo(TENANT_ID);
+        assertThat(resp.getCorrelationId()).isEqualTo(CORRELATION_ID);
+        assertThat(resp.getReplyToId()).isEqualTo(REPLY_TO_ID);
+        assertThat(resp.getMessagingType()).isEqualTo(MessagingType.kafka);
+    }
+
+    /**
+     * Verifies that creating a response from a request ID which does not contain a hex encoded byte
+     * at the second position fails.
+     */
+    @Test
+    public void testFromFailsForRequestIdWithMalformedLengthPart() {
+
+        // make sure we succeed with a valid length string
+        final CommandResponse resp = CommandResponse.fromRequestId(
+                "003anyString",
+                TENANT_ID,
+                DEVICE_ID,
+                null,
+                null,
+                HttpURLConnection.HTTP_OK);
+        assertThat(resp).isNotNull();
+        assertThat(resp.getCorrelationId()).isEqualTo("any");
+        assertThat(resp.getReplyToId()).isEqualTo("String");
+
+        assertThat(CommandResponse.fromRequestId("0ZZanyString", TENANT_ID, DEVICE_ID, null, null, HttpURLConnection.HTTP_OK))
+                .isNull();
+    }
+
+    /**
+     * Verifies that creating a response from a request ID which does not contain a single digit
+     * at the start position fails.
+     */
+    @Test
+    public void testFromFailsForRequestIdWithMalformedReplyIdOptionBitsPart() {
+
+        // make sure we succeed with a valid length string
+        final CommandResponse resp = CommandResponse.fromRequestId(
+                "003anyString",
+                TENANT_ID,
+                DEVICE_ID,
+                null,
+                null,
+                HttpURLConnection.HTTP_OK);
+        assertThat(resp).isNotNull();
+        assertThat(resp.getCorrelationId()).isEqualTo("any");
+        assertThat(resp.getReplyToId()).isEqualTo("String");
+
+        assertThat(CommandResponse.fromRequestId("Z03anyString", TENANT_ID, DEVICE_ID, null, null, HttpURLConnection.HTTP_OK))
+                .isNull();
+    }
+
+    /**
+     * Verifies that creating a response for an invalid status code fails.
+     */
+    @Test
+    public void testFromFailsForInvalidStatusCode() {
+
+        // make sure we succeed with a valid status code
+        final CommandResponse resp = CommandResponse.fromRequestId(
+                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 200);
+        assertThat(resp).isNotNull();
+        assertThat(resp.getCorrelationId()).isEqualTo("one");
+        assertThat(resp.getReplyToId()).isEqualTo(DEVICE_ID + "/Two");
+
+        assertThat(CommandResponse.fromRequestId(
+                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 100)).isNull();
+        assertThat(CommandResponse.fromRequestId(
+                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 310)).isNull();
+        assertThat(CommandResponse.fromRequestId(
+                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, 600)).isNull();
+        assertThat(CommandResponse.fromRequestId(
+                "103oneTwo", TENANT_ID, DEVICE_ID, null, null, null)).isNull();
+    }
+
+    /**
+     * Verifies that creating a response from a request ID which contains less characters as indicated
+     * by the hex encoded byte at the start position fails.
+     */
+    @Test
+    public void testFromFailsForIncorrectCorrelationIdLength() {
+
+        final String id = "thisIsLessThan255Characters";
+        // make sure we succeed with valid length
+        final CommandResponse resp = CommandResponse.fromRequestId(
+                String.format("0%02x%s", 4, id), TENANT_ID, DEVICE_ID, null, null, 200);
+        assertThat(resp).isNotNull();
+        assertThat(resp.getCorrelationId()).isEqualTo("this");
+        assertThat(resp.getReplyToId()).isEqualTo("IsLessThan255Characters");
+
+        assertThat(CommandResponse.fromRequestId(
+                "1FFthisIsLessThan255Characters",
+                TENANT_ID,
+                DEVICE_ID,
+                null,
+                null,
+                HttpURLConnection.HTTP_OK)).isNull();
+    }
+
+    /**
+     * Verifies that the reply-to id of a command, containing the device id, is adopted as is for the command response.
+     */
+    @Test
+    public void testDeviceIdInReplyTo() {
+        final String requestId = Commands
+                .encodeRequestIdParameters(CORRELATION_ID, REPLY_TO_ID_WITH_DEVICE, DEVICE_ID, MessagingType.amqp);
+        assertThat(requestId).isNotNull();
+        assertThat(requestId.indexOf(DEVICE_ID)).isNotNull();
+        assertThat(requestId.indexOf(DEVICE_ID) == requestId.lastIndexOf(DEVICE_ID))
+                .as("device id only contained once in request id").isTrue();
+        final CommandResponse resp = CommandResponse.fromRequestId(
+                requestId,
+                TENANT_ID,
+                DEVICE_ID,
+                null,
+                null,
+                HttpURLConnection.HTTP_OK);
+        assertThat(resp).isNotNull();
+        assertThat(resp.getReplyToId()).isEqualTo(REPLY_TO_ID_WITH_DEVICE);
+        assertThat(resp.getMessagingType()).isEqualTo(MessagingType.amqp);
+    }
+
+    /**
+     * Verifies that the reply-to id of a command, not containing the device id, is adopted as is for the command
+     * response.
+     */
+    @Test
+    public void testDeviceIdNotInReplyTo() {
+        final CommandResponse resp = CommandResponse.fromRequestId(
+                Commands.encodeRequestIdParameters(CORRELATION_ID, REPLY_TO_ID, DEVICE_ID, MessagingType.amqp),
+                TENANT_ID,
+                DEVICE_ID,
+                null,
+                null,
+                HttpURLConnection.HTTP_OK);
+        assertThat(resp).isNotNull();
+        assertThat(resp.getReplyToId()).isEqualTo(REPLY_TO_ID);
+        assertThat(resp.getMessagingType()).isEqualTo(MessagingType.amqp);
+    }
+
+}

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedMappingAndDelegatingCommandHandler.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedMappingAndDelegatingCommandHandler.java
@@ -29,6 +29,7 @@ import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.commandrouter.impl.AbstractMappingAndDelegatingCommandHandler;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.Strings;
 
@@ -57,6 +58,11 @@ public class ProtonBasedMappingAndDelegatingCommandHandler extends AbstractMappi
             final CommandTargetMapper commandTargetMapper) {
         super(tenantClient, commandTargetMapper, new ProtonBasedInternalCommandSender(connection));
         this.tracer = connection.getTracer();
+    }
+
+    @Override
+    protected final MessagingType getMessagingType() {
+        return MessagingType.amqp;
     }
 
     /**

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.client.kafka.tracing.KafkaTracingHelper;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.commandrouter.impl.AbstractMappingAndDelegatingCommandHandler;
+import org.eclipse.hono.util.MessagingType;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -63,6 +64,11 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
         this.commandQueue = Objects.requireNonNull(commandQueue);
         this.kafkaBasedCommandResponseSender = Objects.requireNonNull(kafkaBasedCommandResponseSender);
         this.tracer = Objects.requireNonNull(tracer);
+    }
+
+    @Override
+    protected final MessagingType getMessagingType() {
+        return MessagingType.kafka;
     }
 
     /**

--- a/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterMockSupport.java
+++ b/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterMockSupport.java
@@ -217,6 +217,7 @@ public abstract class ProtocolAdapterMockSupport {
      * @param contentType The type of the payload or {@code null} if the command has no payload.
      * @param payload The command's payload.
      * @param replyToId The reply-to-id to use.
+     * @param messagingType The type of messaging system to use.
      * @return The mocked context.
      */
     protected CommandContext givenARequestResponseCommandContext(
@@ -225,9 +226,10 @@ public abstract class ProtocolAdapterMockSupport {
             final String name,
             final String replyToId,
             final String contentType,
-            final Buffer payload) {
+            final Buffer payload,
+            final MessagingType messagingType) {
 
-        final Command command = newRequestResponseCommand(tenantId, deviceId, name, replyToId, contentType, payload);
+        final Command command = newRequestResponseCommand(tenantId, deviceId, name, replyToId, contentType, payload, messagingType);
 
         final CommandContext context = mock(CommandContext.class);
         when(context.getCommand()).thenReturn(command);
@@ -261,11 +263,13 @@ public abstract class ProtocolAdapterMockSupport {
             final String name,
             final String replyToId,
             final String contentType,
-            final Buffer payload) {
+            final Buffer payload,
+            final MessagingType messagingType) {
 
         final Command command = newOneWayCommand(tenantId, deviceId, name, contentType, payload);
         when(command.isOneWay()).thenReturn(false);
-        when(command.getRequestId()).thenReturn(Commands.getRequestId("correlation-id", replyToId, deviceId));
+        when(command.getRequestId())
+                .thenReturn(Commands.encodeRequestIdParameters("correlation-id", replyToId, deviceId, messagingType));
         return command;
     }
 


### PR DESCRIPTION
This fixes #2736 and #2592:
If both AMQP and Kafka messaging systems are configured, then the command router will receive command messages via both
systems.
The used messaging system is encoded in the command message forwarded to the device (as part of the request id or the command address in case of an AMQP device).
A command response message will then be forwarded using the messaging system that the command was received in. If that system isn't configured any more, the (tenant/global) default messaging system will be used.
