### PR TITLE
Use specific tracing span names when publishing Kafka records

### DIFF
--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandSender.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandSender.java
@@ -72,6 +72,7 @@ public class KafkaBasedInternalCommandSender extends AbstractKafkaBasedMessageSe
                 command.getDeviceId(),
                 command.getPayload(),
                 getHeaders((KafkaBasedCommand) command),
+                "delegate Command request",
                 commandContext.getTracingContext())
                         .onSuccess(v -> commandContext.accept())
                         .onFailure(thr -> commandContext.release(new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE,

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/tracing/KafkaTracingHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/tracing/KafkaTracingHelper.java
@@ -67,19 +67,21 @@ public final class KafkaTracingHelper {
      * </ul>
      *
      * @param tracer The Tracer to use.
+     * @param operationName The operation name to set for the span.
      * @param topic The topic to which the message is sent.
      * @param referenceType The type of reference towards the span context.
      * @param parent The span context to set as parent and to derive the sampling priority from (may be null).
      * @return The new span.
-     * @throws NullPointerException if tracer or topic is {@code null}.
+     * @throws NullPointerException if tracer, operationName or topic is {@code null}.
      */
-    public static Span newProducerSpan(final Tracer tracer, final String topic, final String referenceType,
-            final SpanContext parent) {
+    public static Span newProducerSpan(final Tracer tracer, final String operationName, final String topic,
+            final String referenceType, final SpanContext parent) {
         Objects.requireNonNull(tracer);
+        Objects.requireNonNull(operationName);
         Objects.requireNonNull(topic);
         Objects.requireNonNull(referenceType);
 
-        return TracingHelper.buildSpan(tracer, parent, "send message", referenceType)
+        return TracingHelper.buildSpan(tracer, parent, operationName, referenceType)
                 .ignoreActiveSpan()
                 .withTag(Tags.COMPONENT.getKey(), "hono-client-kafka")
                 .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSender.java
@@ -82,6 +82,8 @@ public abstract class AbstractKafkaBasedDownstreamSender extends AbstractKafkaBa
      *            </ol>
      * @param payload The data to send.
      * @param properties Additional meta data that should be included in the downstream message.
+     * @param spanOperationName The operation name to set for the span created in this method.
+     *                          If {@code null}, "send message" will be used.
      * @param context The currently active OpenTracing span (may be {@code null}). An implementation should use this as
      *            the parent for any span it creates for tracing the execution of this operation.
      * @return A future indicating the outcome of the operation.
@@ -94,7 +96,7 @@ public abstract class AbstractKafkaBasedDownstreamSender extends AbstractKafkaBa
      */
     protected Future<Void> send(final HonoTopic topic, final TenantObject tenant, final RegistrationAssertion device,
             final QoS qos, final String contentType, final Buffer payload, final Map<String, Object> properties,
-            final SpanContext context) {
+            final String spanOperationName, final SpanContext context) {
 
         Objects.requireNonNull(topic);
         Objects.requireNonNull(tenant);
@@ -108,9 +110,10 @@ public abstract class AbstractKafkaBasedDownstreamSender extends AbstractKafkaBa
         final Map<String, Object> propsWithDefaults = addDefaults(tenant, device, qos, contentType, properties);
 
         if (QoS.AT_LEAST_ONCE.equals(qos)) {
-            return sendAndWaitForOutcome(topic.toString(), tenantId, deviceId, payload, propsWithDefaults, context);
+            return sendAndWaitForOutcome(topic.toString(), tenantId, deviceId, payload, propsWithDefaults,
+                    spanOperationName, context);
         } else {
-            send(topic.toString(), tenantId, deviceId, payload, propsWithDefaults, context);
+            send(topic.toString(), tenantId, deviceId, payload, propsWithDefaults, spanOperationName, context);
             return Future.succeededFuture();
         }
     }

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedEventSender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedEventSender.java
@@ -53,9 +53,6 @@ public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender im
         super(producerFactory, EventConstants.EVENT_ENDPOINT, kafkaProducerConfig, includeDefaults, tracer);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<Void> sendEvent(final TenantObject tenant, final RegistrationAssertion device,
             final String contentType, final Buffer payload, final Map<String, Object> properties,
@@ -68,12 +65,9 @@ public class KafkaBasedEventSender extends AbstractKafkaBasedDownstreamSender im
                 device.getDeviceId(), contentType, properties);
 
         final HonoTopic topic = new HonoTopic(HonoTopic.Type.EVENT, tenant.getTenantId());
-        return send(topic, tenant, device, QoS.AT_LEAST_ONCE, contentType, payload, properties, context);
+        return send(topic, tenant, device, QoS.AT_LEAST_ONCE, contentType, payload, properties, "forward Event", context);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return KafkaBasedEventSender.class.getName() + " via Kafka";

--- a/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedTelemetrySender.java
+++ b/clients/telemetry-kafka/src/main/java/org/eclipse/hono/client/telemetry/kafka/KafkaBasedTelemetrySender.java
@@ -53,9 +53,6 @@ public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSende
         super(producerFactory, TelemetryConstants.TELEMETRY_ENDPOINT, kafkaProducerConfig, includeDefaults, tracer);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Future<Void> sendTelemetry(final TenantObject tenant, final RegistrationAssertion device, final QoS qos,
             final String contentType, final Buffer payload, final Map<String, Object> properties,
@@ -69,12 +66,10 @@ public class KafkaBasedTelemetrySender extends AbstractKafkaBasedDownstreamSende
                 tenant.getTenantId(), device.getDeviceId(), qos, contentType, properties);
 
         final HonoTopic topic = new HonoTopic(HonoTopic.Type.TELEMETRY, tenant.getTenantId());
-        return send(topic, tenant, device, qos, contentType, payload, properties, context);
+
+        return send(topic, tenant, device, qos, contentType, payload, properties, "forward Telemetry data", context);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return KafkaBasedTelemetrySender.class.getName() + " via Kafka";

--- a/clients/telemetry-kafka/src/test/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
+++ b/clients/telemetry-kafka/src/test/java/org/eclipse/hono/client/telemetry/kafka/AbstractKafkaBasedDownstreamSenderTest.java
@@ -106,7 +106,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         final AbstractKafkaBasedDownstreamSender sender = newSender(mockProducer);
 
         // WHEN sending a message
-        sender.send(topic, tenant, device, qos, CONTENT_TYPE, Buffer.buffer(payload), properties, null)
+        sender.send(topic, tenant, device, qos, CONTENT_TYPE, Buffer.buffer(payload), properties, null, null)
                 .onComplete(ctx.succeeding(v -> {
 
                     final ProducerRecord<String, Buffer> actual = mockProducer.history().get(0);
@@ -137,7 +137,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(false);
         final AbstractKafkaBasedDownstreamSender sender = newSender(mockProducer);
 
-        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null)
+        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null, null)
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {
                         // THEN it fails with the expected error
@@ -166,7 +166,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         // GIVEN a sender sending a message
         final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(false);
         final CachingKafkaProducerFactory<String, Buffer> factory = newProducerFactory(mockProducer);
-        newSender(factory).send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null)
+        newSender(factory).send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null, null)
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {
                         // THEN the producer is removed and closed
@@ -194,7 +194,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         // GIVEN a sender sending a message
         final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(false);
         final CachingKafkaProducerFactory<String, Buffer> factory = newProducerFactory(mockProducer);
-        newSender(factory).send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null)
+        newSender(factory).send(topic, tenant, device, qos, CONTENT_TYPE, null, null, null, null)
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {
                         // THEN the producer is present and still open
@@ -290,7 +290,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
 
         final MockProducer<String, Buffer> mockProducer = KafkaClientUnitTestHelper.newMockProducer(true);
         newSender(mockProducer)
-                .send(topic, tenant, device, qos, contentTypeParameter, null, properties, null)
+                .send(topic, tenant, device, qos, contentTypeParameter, null, properties, null, null)
                 .onComplete(ctx.succeeding(v -> {
                     ctx.verify(() -> {
                         final Headers actual = mockProducer.history().get(0).headers();
@@ -318,7 +318,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         properties.put("ttd", ttd);
 
         // WHEN sending the message
-        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, properties, null)
+        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, properties, null, null)
                 .onComplete(ctx.succeeding(t -> {
                     ctx.verify(() -> {
                         // THEN the producer record contains a creation time
@@ -349,7 +349,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         properties.put("ttl", ttl);
 
         // WHEN sending the message
-        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, properties, null)
+        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, properties, null, null)
                 .onComplete(ctx.succeeding(t -> {
                     ctx.verify(() -> {
                         // THEN the producer record contains a creation time
@@ -381,7 +381,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         properties.put("creation-time", creationTime);
 
         // WHEN sending the message
-        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, properties, null)
+        sender.send(topic, tenant, device, qos, CONTENT_TYPE, null, properties, null, null)
                 .onComplete(ctx.succeeding(t -> {
                     ctx.verify(() -> {
                         // THEN the creation time is preserved
@@ -422,7 +422,7 @@ public class AbstractKafkaBasedDownstreamSenderTest {
 
     /**
      * Verifies that
-     * {@link AbstractKafkaBasedDownstreamSender#send(HonoTopic, org.eclipse.hono.util.TenantObject, org.eclipse.hono.util.RegistrationAssertion, QoS, String, Buffer, Map, io.opentracing.SpanContext)}
+     * {@link AbstractKafkaBasedDownstreamSender#send(HonoTopic, org.eclipse.hono.util.TenantObject, org.eclipse.hono.util.RegistrationAssertion, QoS, String, Buffer, Map, String, io.opentracing.SpanContext)}
      * throws a nullpointer exception if a mandatory parameter is {@code null}.
      */
     @Test
@@ -431,16 +431,16 @@ public class AbstractKafkaBasedDownstreamSenderTest {
         final AbstractKafkaBasedDownstreamSender sender = newSender(mockProducer);
 
         assertThrows(NullPointerException.class,
-                () -> sender.send(null, tenant, device, qos, CONTENT_TYPE, null, null, null));
+                () -> sender.send(null, tenant, device, qos, CONTENT_TYPE, null, null, null, null));
 
         assertThrows(NullPointerException.class,
-                () -> sender.send(topic, null, device, qos, CONTENT_TYPE, null, null, null));
+                () -> sender.send(topic, null, device, qos, CONTENT_TYPE, null, null, null, null));
 
         assertThrows(NullPointerException.class,
-                () -> sender.send(topic, tenant, null, qos, CONTENT_TYPE, null, null, null));
+                () -> sender.send(topic, tenant, null, qos, CONTENT_TYPE, null, null, null, null));
 
         assertThrows(NullPointerException.class,
-                () -> sender.send(topic, tenant, device, null, CONTENT_TYPE, null, null, null));
+                () -> sender.send(topic, tenant, device, null, CONTENT_TYPE, null, null, null, null));
 
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/GenericKafkaSender.java
@@ -20,6 +20,7 @@ import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
 
+import io.opentracing.SpanContext;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -54,7 +55,7 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
      */
     public void send(final String topic, final String tenantId, final String deviceId, final Buffer payload,
             final Map<String, Object> properties) {
-        super.send(topic, tenantId, deviceId, payload, properties, null);
+        super.send(topic, tenantId, deviceId, payload, properties, null, (SpanContext) null);
     }
 
     /**
@@ -69,7 +70,7 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
      */
     public void send(final String topic, final String tenantId, final String deviceId, final Buffer payload,
             final List<KafkaHeader> headers) {
-        super.send(topic, tenantId, deviceId, payload, headers, null);
+        super.send(topic, tenantId, deviceId, payload, headers, null, (SpanContext) null);
     }
 
     /**
@@ -90,7 +91,7 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
      */
     public Future<Void> sendAndWaitForOutcome(final String topic, final String tenantId, final String deviceId,
             final Buffer payload, final Map<String, Object> properties) {
-        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, properties, null);
+        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, properties, null, (SpanContext) null);
     }
 
     /**
@@ -111,7 +112,7 @@ public class GenericKafkaSender extends AbstractKafkaBasedMessageSender {
      */
     public Future<Void> sendAndWaitForOutcome(final String topic, final String tenantId, final String deviceId,
             final Buffer payload, final List<KafkaHeader> headers) {
-        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, headers, null);
+        return super.sendAndWaitForOutcome(topic, tenantId, deviceId, payload, headers, null, (SpanContext) null);
     }
 
 }


### PR DESCRIPTION
Span names for sending messages downstream using Kafka are now the same as when using AMQP (not always "send message" anymore).