### PR TITLE
Skip error command response if partition revoked

### DIFF
--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
@@ -24,6 +24,7 @@ import org.eclipse.hono.client.command.CommandAlreadyProcessedException;
 import org.eclipse.hono.client.command.CommandContext;
 import org.eclipse.hono.client.command.CommandResponse;
 import org.eclipse.hono.client.command.CommandResponseSender;
+import org.eclipse.hono.client.command.CommandToBeReprocessedException;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
@@ -98,7 +99,8 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
         final ServiceInvocationException mappedError = StatusCodeMapper.toServerError(error);
         final int status = mappedError.getErrorCode();
         Tags.HTTP_STATUS.set(span, status);
-        if (isRequestResponseCommand() && !(error instanceof CommandAlreadyProcessedException)) {
+        if (isRequestResponseCommand() && !(error instanceof CommandAlreadyProcessedException)
+                && !(error instanceof CommandToBeReprocessedException)) {
             final String errorMessage = Optional.ofNullable(ServiceInvocationException.getErrorMessageForExternalClient(mappedError))
                     .orElse("Temporarily unavailable");
             sendDeliveryFailureCommandResponseMessage(status, errorMessage, span)

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandToBeReprocessedException.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandToBeReprocessedException.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.client.command;
+
+import java.net.HttpURLConnection;
+
+import org.eclipse.hono.client.ServerErrorException;
+
+/**
+ * A {@link ServerErrorException} indicating that command processing has been cancelled and that the exact
+ * same command message is expected to be processed by another consumer at a later point in time.
+ */
+public class CommandToBeReprocessedException extends ServerErrorException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new CommandToBeReprocessedException.
+     * <p>
+     * The exception will have a <em>503: Service Unavailable</em> status code.
+     */
+    public CommandToBeReprocessedException() {
+        super(HttpURLConnection.HTTP_UNAVAILABLE);
+    }
+}

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueue.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueue.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.hono.commandrouter.impl.kafka;
 
-import java.net.HttpURLConnection;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
@@ -25,6 +24,7 @@ import java.util.function.Supplier;
 
 import org.apache.kafka.common.TopicPartition;
 import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.command.CommandToBeReprocessedException;
 import org.eclipse.hono.client.command.kafka.KafkaBasedCommandContext;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Pair;
@@ -116,7 +116,7 @@ public class KafkaCommandProcessingQueue {
             TracingHelper.logError(commandContext.getTracingSpan(), String.format(
                     "command won't be sent - commands received from partition [%s] aren't handled by this consumer anymore",
                     topicPartition));
-            final ServerErrorException error = new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE);
+            final ServerErrorException error = new CommandToBeReprocessedException();
             commandContext.release(error);
             return Future.failedFuture(error);
         }
@@ -214,7 +214,7 @@ public class KafkaCommandProcessingQueue {
                     // command is ready to be sent but waiting for the processing of an earlier entry
                     LOG.info("command won't be sent - its partition isn't being handled anymore [{}]", commandContext.getCommand());
                     TracingHelper.logError(commandContext.getTracingSpan(), "command won't be sent - its partition isn't being handled anymore");
-                    final ServerErrorException error = new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE);
+                    final ServerErrorException error = new CommandToBeReprocessedException();
                     commandContext.release(error);
                     actionAppliedPair.two().fail(error);
                 } // in the else case let the applySendCommandAction() method release the command eventually
@@ -245,7 +245,7 @@ public class KafkaCommandProcessingQueue {
                 // might happen if the invoking the sendAction takes place after the partition got unassigned and then reassigned again
                 LOG.info("command won't be sent - not in queue [{}]", commandContext.getCommand());
                 TracingHelper.logError(commandContext.getTracingSpan(), "command won't be sent - not in queue");
-                final ServerErrorException error = new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE);
+                final ServerErrorException error = new CommandToBeReprocessedException();
                 commandContext.release(error);
                 resultPromise.fail(error);
             } else {


### PR DESCRIPTION
Related to  #2751:
Skips sending an error command response message in case command handling got cancelled because the topic partition assignment got revoked. In this case the command will be handled again by the other consumer that the topic partition got newly assigned to.