### PR TITLE
Improve Command Router C&C tracing

### DIFF
--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedInternalCommandConsumer.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedInternalCommandConsumer.java
@@ -134,7 +134,10 @@ public class ProtonBasedInternalCommandConsumer extends AbstractServiceClient im
         }
 
         final SpanContext spanContext = TracingHelper.extractSpanContext(tracer, msg);
-        final Span currentSpan = CommandContext.createSpan(tracer, command, spanContext);
+        final SpanContext followsFromSpanContext = commandHandler != null
+                ? commandHandler.getConsumerCreationSpanContext()
+                : null;
+        final Span currentSpan = CommandContext.createSpan(tracer, command, spanContext, followsFromSpanContext);
         currentSpan.setTag(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId);
 
         final CommandContext commandContext = new ProtonBasedCommandContext(command, delivery, currentSpan);

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -284,7 +284,10 @@ public class KafkaBasedInternalCommandConsumer implements Lifecycle {
         }
 
         final SpanContext spanContext = KafkaTracingHelper.extractSpanContext(tracer, record);
-        final Span currentSpan = CommandContext.createSpan(tracer, command, spanContext);
+        final SpanContext followsFromSpanContext = commandHandler != null
+                ? commandHandler.getConsumerCreationSpanContext()
+                : null;
+        final Span currentSpan = CommandContext.createSpan(tracer, command, spanContext, followsFromSpanContext);
         currentSpan.setTag(MessageHelper.APP_PROPERTY_ADAPTER_INSTANCE_ID, adapterInstanceId);
 
         final CommandContext commandContext = new KafkaBasedCommandContext(command, currentSpan, commandResponseSender);

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandHandlerWrapper.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandHandlerWrapper.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.command;
 
 import java.util.Objects;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -29,6 +30,7 @@ public final class CommandHandlerWrapper {
     private final String gatewayId;
     private final Handler<CommandContext> commandHandler;
     private final Context context;
+    private final SpanContext consumerCreationSpanContext;
 
     /**
      * Creates a new CommandHandlerWrapper.
@@ -42,15 +44,24 @@ public final class CommandHandlerWrapper {
      *                  parameter.)
      * @param commandHandler The command handler.
      * @param context The vert.x context to run the handler on or {@code null} to invoke the handler directly.
+     * @param consumerCreationSpanContext The context of the span for tracking the creation of the command consumer
+     *                                    that this command handler belongs to. If not {@code null}, the given context
+     *                                    is intended to be used by that command consumer for creating a
+     *                                    <em>follows-from</em> reference in the span created for the processing of a
+     *                                    command request message. Note that providing a span context here only makes
+     *                                    sense for short-lived command consumers as created by the HTTP and CoAP
+     *                                    adapters for example.
      * @throws NullPointerException If tenantId, deviceId or commandHandler is {@code null}.
      */
     public CommandHandlerWrapper(final String tenantId, final String deviceId, final String gatewayId,
-            final Handler<CommandContext> commandHandler, final Context context) {
+            final Handler<CommandContext> commandHandler, final Context context,
+            final SpanContext consumerCreationSpanContext) {
         this.tenantId = Objects.requireNonNull(tenantId);
         this.deviceId = Objects.requireNonNull(deviceId);
         this.gatewayId = gatewayId;
         this.commandHandler = Objects.requireNonNull(commandHandler);
         this.context = context;
+        this.consumerCreationSpanContext = consumerCreationSpanContext;
     }
 
     /**
@@ -79,6 +90,16 @@ public final class CommandHandlerWrapper {
      */
     public String getGatewayId() {
         return gatewayId;
+    }
+
+    /**
+     * The span context of the command consumer creation operation or {@code null} if
+     * that context isn't available or shouldn't be used.
+     *
+     * @return The span context or {@code null}.
+     */
+    public SpanContext getConsumerCreationSpanContext() {
+        return consumerCreationSpanContext;
     }
 
     /**

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandHandlers.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandHandlers.java
@@ -56,7 +56,7 @@ public class CommandHandlers {
         Objects.requireNonNull(deviceId);
         Objects.requireNonNull(commandHandler);
 
-        return putCommandHandler(new CommandHandlerWrapper(tenantId, deviceId, gatewayId, commandHandler, context));
+        return putCommandHandler(new CommandHandlerWrapper(tenantId, deviceId, gatewayId, commandHandler, context, null));
     }
 
     /**


### PR DESCRIPTION
This adds a `FOLLOWS_FROM` span reference from the "handle command" span in the command handling trace started in the Command Router to the span in the preceding trace where the command consumer was created in the protocol adapter.
This is only enabled for short-lived command consumers, i.e. those that get created in the HTTP/CoAP adapters for ttd requests.

![CommandRouter_http_coap_spanRef](https://user-images.githubusercontent.com/891931/124116096-daf9e500-da6e-11eb-9d41-c137793e8308.png)

Compared with the span reference added in  #2755, this is the link in the other direction.