### PR TITLE
Support matching credentials against client context in JDBC based registry

### DIFF
--- a/services/device-registry-jdbc/pom.xml
+++ b/services/device-registry-jdbc/pom.xml
@@ -88,6 +88,15 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>
+    <!--
+      use BC for creating self-signed certs instead of sun.security.x509
+      which has been removed in OpenJDK 15
+    -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/CredentialsServiceImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.deviceregistry.jdbc.config.DeviceServiceProperties;
 import org.eclipse.hono.deviceregistry.service.credentials.AbstractCredentialsService;
 import org.eclipse.hono.deviceregistry.service.credentials.CredentialKey;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.service.base.jdbc.store.device.TableAdapterStore;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
@@ -77,6 +78,7 @@ public class CredentialsServiceImpl extends AbstractCredentialsService {
                             .stream()
                             .map(JsonObject::mapFrom)
                             .filter(filter(key.getType(), key.getAuthId()))
+                            .filter(credential -> DeviceRegistryUtils.matchesWithClientContext(credential, clientContext))
                             .flatMap(c -> c.getJsonArray(CredentialsConstants.FIELD_SECRETS)
                                     .stream()
                                     .filter(JsonObject.class::isInstance)
@@ -147,11 +149,11 @@ public class CredentialsServiceImpl extends AbstractCredentialsService {
             }
 
             if (!type.equals(c.getString(CredentialsConstants.FIELD_TYPE))) {
-                return true;
+                return false;
             }
 
             if (!authId.equals(c.getString(CredentialsConstants.FIELD_AUTH_ID))) {
-                return true;
+                return false;
             }
 
             return true;

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -15,6 +15,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   register a new device using the existing device's identifier. This has been fixed.
 * The Mongo DB based registry implementation now uses a proper DB index to find credentials by type and authentication
   ID. This will speed up query execution significantly when there are a lot of devices registered for a tenant.
+* The JDBC based device registry's *get Credentials* operation used by the protocol adapters now also supports
+  matching credentials against a given *client context*.
 
 ## 1.9.0
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -105,9 +105,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <!--
       Device Registry related properties - The MongoDB based device registry is used as the default one.
     -->
-    <!-- should be set to false if testing against a registry that doesn't support comparing client context
-         when retrieving credentials -->
-    <hono.deviceregistry.credentials.supportsClientContext>true</hono.deviceregistry.credentials.supportsClientContext>
     <!-- should be set to false if testing against a registry that doesn't support GW mode -->
     <hono.deviceregistry.supportsGatewayMode>true</hono.deviceregistry.supportsGatewayMode>
     <!-- should be set to false if testing against a registry that doesn't support the "search Devices" operation -->
@@ -469,7 +466,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
         <hono.deviceregistry.image>hono-service-device-registry-jdbc</hono.deviceregistry.image>
         <hono.deviceregistry.resources.folder>deviceregistry-jdbc-h2</hono.deviceregistry.resources.folder>
         <hono.deviceregistry.spring.profiles>registry-adapter,registry-management,tenant-service,create-schema,${logging.profile}</hono.deviceregistry.spring.profiles>
-        <hono.deviceregistry.credentials.supportsClientContext>false</hono.deviceregistry.credentials.supportsClientContext>
         <hono.deviceregistry.supportsSearchDevices>false</hono.deviceregistry.supportsSearchDevices>
         <hono.deviceregistry.supportsSearchTenants>false</hono.deviceregistry.supportsSearchTenants>
         <!-- increase memory limit of the device registry container to 400MB in order to accommodate for embedded H2 DB -->
@@ -491,7 +487,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
         <hono.deviceregistry.image>hono-service-device-registry-jdbc</hono.deviceregistry.image>
         <hono.deviceregistry.resources.folder>deviceregistry-jdbc-postgres</hono.deviceregistry.resources.folder>
         <hono.deviceregistry.spring.profiles>registry-adapter,registry-management,tenant-service,create-schema,${logging.profile}</hono.deviceregistry.spring.profiles>
-        <hono.deviceregistry.credentials.supportsClientContext>false</hono.deviceregistry.credentials.supportsClientContext>
         <hono.deviceregistry.supportsSearchDevices>false</hono.deviceregistry.supportsSearchDevices>
         <hono.deviceregistry.supportsSearchTenants>false</hono.deviceregistry.supportsSearchTenants>
         <hono.jdbc.db.url>jdbc:postgresql://hono-jdbc-db.hono:5432/</hono.jdbc.db.url>
@@ -1662,7 +1657,6 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                 <deviceregistry.amqp.port>${deviceregistry.amqp.port}</deviceregistry.amqp.port>
                 <deviceregistry.http.port>${deviceregistry.http.port}</deviceregistry.http.port>
                 <deviceregistry.supportsGatewayMode>${hono.deviceregistry.supportsGatewayMode}</deviceregistry.supportsGatewayMode>
-                <deviceregistry.credentials.supportsClientContext>${hono.deviceregistry.credentials.supportsClientContext}</deviceregistry.credentials.supportsClientContext>
                 <deviceregistry.supportsSearchDevices>${hono.deviceregistry.supportsSearchDevices}</deviceregistry.supportsSearchDevices>
                 <deviceregistry.supportsSearchTenants>${hono.deviceregistry.supportsSearchTenants}</deviceregistry.supportsSearchTenants>
                 <adapter.coap.host>${coap.ip}</adapter.coap.host>

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
@@ -51,7 +51,6 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.RegistryManagementConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -441,7 +440,6 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
      * @param ctx The vert.x test context.
      */
     @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
-    @EnabledIfSystemProperty(named = "deviceregistry.credentials.supportsClientContext", matches = "true")
     @Test
     public void testGetCredentialsFailsForNonMatchingClientContext(final VertxTestContext ctx) {
 


### PR DESCRIPTION
The (optional) client context provided by protocol adapters when
invoking the Credentials service's "get Credentials" operation is now
also being considered by the JDBC based service implementation.

Fixes #2310