### PR TITLE
Add support for encrypting PSKs in Mongo DB based registry

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -34,6 +34,7 @@
     <caffeine.version>2.8.8</caffeine.version>
     <californium.version>2.6.2</californium.version>
     <commons-cli.version>1.4</commons-cli.version>
+    <cryptvault.version>1.0.2</cryptvault.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.14.0</dispatch-router.image.name>
     <guava.version>30.1-jre</guava.version>
     <gson.version>2.8.6</gson.version>
@@ -929,6 +930,11 @@
             <artifactId>animal-sniffer-annotations</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.bol</groupId>
+        <artifactId>cryptvault</artifactId>
+        <version>${cryptvault.version}</version>
       </dependency>
 
       <!-- Testing -->

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -1,5 +1,6 @@
 maven/mavencentral/ch.qos.logback/logback-classic/1.2.3, EPL-1.0, approved, CQ13636
 maven/mavencentral/ch.qos.logback/logback-core/1.2.3, EPL-1.0, approved, CQ13635
+maven/mavencentral/com.bol/cryptvault/1.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.12.3, Apache-2.0, approved, CQ23207
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.12.3, Apache-2.0, approved, CQ23202
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.12.3, Apache-2.0, approved, CQ23206

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -1,5 +1,6 @@
 ch.qos.logback:logback-classic:jar:1.2.3
 ch.qos.logback:logback-core:jar:1.2.3
+com.bol:cryptvault:jar:1.0.2
 com.fasterxml.jackson.core:jackson-annotations:jar:2.12.3
 com.fasterxml.jackson.core:jackson-core:jar:2.12.3
 com.fasterxml.jackson.core:jackson-databind:jar:2.12.3

--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>spring-beans</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.bol</groupId>
+      <artifactId>cryptvault</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- testing -->
     <dependency>

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/CryptVaultBasedFieldLevelEncryption.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/CryptVaultBasedFieldLevelEncryption.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceregistry.util;
+
+import java.util.Objects;
+
+import com.bol.crypt.CryptVault;
+
+/**
+ * A {@code CryptVault} based field level encryption helper.
+ */
+public final class CryptVaultBasedFieldLevelEncryption implements FieldLevelEncryption {
+
+    private final CryptVault cryptVault;
+
+    /**
+     * Creates a new encryption helper for a vault.
+     *
+     * @param vault The vault.
+     * @throws NullPointerException if vault is {@code null}.
+     */
+    public CryptVaultBasedFieldLevelEncryption(final CryptVault vault) {
+        this.cryptVault = Objects.requireNonNull(vault);
+    }
+
+    @Override
+    public byte[] encrypt(final byte[] data) {
+        return cryptVault.encrypt(data);
+    }
+
+    @Override
+    public byte[] decrypt(final byte[] data) {
+        return cryptVault.decrypt(data);
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/FieldLevelEncryption.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/FieldLevelEncryption.java
@@ -31,6 +31,7 @@ public interface FieldLevelEncryption {
      *
      * @param data The data to encrypt.
      * @return The encrypted data.
+     * @throws RuntimeException if encryption fails.
      */
     byte[] encrypt(byte[] data);
 
@@ -39,6 +40,7 @@ public interface FieldLevelEncryption {
      *
      * @param data The (encrypted) data to decrypt.
      * @return The decrypted data.
+     * @throws RuntimeException if decryption fails.
      */
     byte[] decrypt(byte[] data);
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/FieldLevelEncryption.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/FieldLevelEncryption.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceregistry.util;
+
+
+/**
+ * A strategy for encrypting/decrypting property values.
+ *
+ */
+public interface FieldLevelEncryption {
+
+    /**
+     * An implementation that does nothing.
+     */
+    FieldLevelEncryption NOOP_ENCRYPTION = new NoopEncryption();
+
+    /**
+     * Encrypts the given data.
+     *
+     * @param data The data to encrypt.
+     * @return The encrypted data.
+     */
+    byte[] encrypt(byte[] data);
+
+    /**
+     * Decrypts the given data.
+     *
+     * @param data The (encrypted) data to decrypt.
+     * @return The decrypted data.
+     */
+    byte[] decrypt(byte[] data);
+
+    /**
+     * An implementation that does nothing.
+     */
+    class NoopEncryption implements FieldLevelEncryption {
+        /**
+         * Returns the data passed in.
+         */
+        @Override
+        public byte[] encrypt(final byte[] data) {
+            return data;
+        }
+
+        /**
+         * Returns the data passed in.
+         */
+        @Override
+        public byte[] decrypt(final byte[] data) {
+            return data;
+        }
+    }
+}

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CommonCredential.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
+import org.eclipse.hono.deviceregistry.util.FieldLevelEncryption;
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -199,6 +200,32 @@ public abstract class CommonCredential {
      * @return This credentials object with all non-public information removed.
      */
     public CommonCredential stripPrivateInfo() {
+        return this;
+    }
+
+    /**
+     * Encrypts fields of these credentials if applicable.
+     * <p>
+     * This default implementation does nothing.
+     *
+     * @param cryptHelper The helper to use for encrypting field values or {@code null} if encryption is
+     *                    not supported.
+     * @return This credentials object.
+     */
+    public CommonCredential encryptFields(final FieldLevelEncryption cryptHelper) {
+        return this;
+    }
+
+    /**
+     * Decrypts fields of these credentials if applicable.
+     * <p>
+     * This default implementation does nothing.
+     *
+     * @param cryptHelper The helper to use for decrypting field values or {@code null} if encryption is
+     *                    not supported.
+     * @return This credentials object.
+     */
+    public CommonCredential decryptFields(final FieldLevelEncryption cryptHelper) {
         return this;
     }
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,7 +16,9 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
+import org.eclipse.hono.deviceregistry.util.FieldLevelEncryption;
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -99,6 +101,32 @@ public class PskCredential extends CommonCredential {
     @Override
     public final PskCredential stripPrivateInfo() {
         getSecrets().forEach(PskSecret::stripPrivateInfo);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Encrypts the shared key of all secrets.
+     */
+    @Override
+    public CommonCredential encryptFields(final FieldLevelEncryption cryptHelper) {
+        Optional.ofNullable(cryptHelper).ifPresent(helper -> {
+            getSecrets().forEach(secret -> secret.encryptFields(helper));
+        });
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Decrypts the shared key of all secrets.
+     */
+    @Override
+    public CommonCredential decryptFields(final FieldLevelEncryption cryptHelper) {
+        Optional.ofNullable(cryptHelper).ifPresent(helper -> {
+            getSecrets().forEach(secret -> secret.decryptFields(helper));
+        });
         return this;
     }
 }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/credentials/PskSecretTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/credentials/PskSecretTest.java
@@ -85,7 +85,7 @@ public class PskSecretTest {
     }
 
     /**
-     * Verifies that the shared key is being encrypted/decrpyted using the given field level encryption helper.
+     * Verifies that the shared key is being encrypted/decrypted using the given field level encryption helper.
      */
     @Test
     public void testEncryptFieldsEncryptsKey() {

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -49,6 +49,15 @@
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-telemetry-kafka</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.bol</groupId>
+      <artifactId>cryptvault</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- testing -->
     <dependency>
@@ -62,6 +71,15 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mongodb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!--
+      use BC for creating self-signed certs instead of sun.security.x509
+      which has been removed in OpenJDK 15
+    -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/AbstractMongoDbBasedRegistryConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/AbstractMongoDbBasedRegistryConfigProperties.java
@@ -33,6 +33,7 @@ public abstract class AbstractMongoDbBasedRegistryConfigProperties {
      * Mongodb collection name for individual device registry service entity type.
      */
     private String collectionName = getDefaultCollectionName();
+    private String encryptionKeyFile;
 
     /**
      * Gets the default name of the Mongo DB collection that the registry's data should be persisted to.
@@ -86,5 +87,24 @@ public abstract class AbstractMongoDbBasedRegistryConfigProperties {
             throw new IllegalArgumentException("max age must be >= 0");
         }
         this.cacheMaxAge = maxAge;
+    }
+
+    /**
+     * Sets the path to the YAML file that encryption keys should be read from.
+     *
+     * @param path The path to the file.
+     * @throws NullPointerException if path is {@code null}.
+     */
+    public final void setEncryptionKeyFile(final String path) {
+        this.encryptionKeyFile = Objects.requireNonNull(path);
+    }
+
+    /**
+     * Gets the path to the YAML file that encryption keys are read from.
+     *
+     * @return The path to the file or {@code null} if not set.
+     */
+    public final String getEncryptionKeyFile() {
+        return this.encryptionKeyFile;
     }
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedCredentialsDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedCredentialsDao.java
@@ -164,7 +164,7 @@ public final class MongoDbBasedCredentialsDao extends MongoDbBasedDao implements
                 .start();
 
         final Promise<String> addCredentialsPromise = Promise.promise();
-        credentials.getCredentials().parallelStream().forEach(cred -> cred.encryptFields(fieldLevelEncryption));
+        credentials.getCredentials().stream().forEach(cred -> cred.encryptFields(fieldLevelEncryption));
         mongoClient.insert(
                 collectionName,
                 JsonObject.mapFrom(credentials),
@@ -240,7 +240,7 @@ public final class MongoDbBasedCredentialsDao extends MongoDbBasedDao implements
                                     System.lineSeparator(), result.encodePrettily());
                         }
                         final var dto = result.mapTo(CredentialsDto.class);
-                        dto.getCredentials().parallelStream().forEach(cred -> cred.decryptFields(fieldLevelEncryption));
+                        dto.getCredentials().stream().forEach(cred -> cred.decryptFields(fieldLevelEncryption));
                         return dto;
                     }
                 });
@@ -301,7 +301,7 @@ public final class MongoDbBasedCredentialsDao extends MongoDbBasedDao implements
                                     System.lineSeparator(), result.encodePrettily());
                         }
                         final var dto = result.mapTo(CredentialsDto.class);
-                        dto.getCredentials().parallelStream().forEach(cred -> cred.decryptFields(fieldLevelEncryption));
+                        dto.getCredentials().stream().forEach(cred -> cred.decryptFields(fieldLevelEncryption));
                         return dto;
                     }
                 })
@@ -331,7 +331,7 @@ public final class MongoDbBasedCredentialsDao extends MongoDbBasedDao implements
                 .withTag(TracingHelper.TAG_DEVICE_ID, credentials.getDeviceId())
                 .start();
         resourceVersion.ifPresent(v -> TracingHelper.TAG_RESOURCE_VERSION.set(span, v));
-        credentials.getCredentials().parallelStream().forEach(cred -> cred.encryptFields(fieldLevelEncryption));
+        credentials.getCredentials().stream().forEach(cred -> cred.encryptFields(fieldLevelEncryption));
 
         final JsonObject replaceCredentialsQuery = MongoDbDocumentBuilder.builder()
                 .withVersion(resourceVersion)

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDao.java
@@ -24,6 +24,7 @@ import javax.annotation.PreDestroy;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.deviceregistry.util.FieldLevelEncryption;
 import org.eclipse.hono.service.management.BaseDto;
 import org.eclipse.hono.service.management.SearchResult;
 import org.eclipse.hono.util.RegistryManagementConstants;
@@ -67,6 +68,10 @@ public abstract class MongoDbBasedDao {
      * The name of the Mongo DB collection that the entity is mapped to.
      */
     protected final String collectionName;
+    /**
+     * The helper to use for encrypting/decrypting property values.
+     */
+    protected final FieldLevelEncryption fieldLevelEncryption;
 
     /**
      * Creates a new DAO.
@@ -74,12 +79,15 @@ public abstract class MongoDbBasedDao {
      * @param mongoClient The client to use for accessing the Mongo DB.
      * @param collectionName The name of the collection that contains the data.
      * @param tracer The tracer to use for tracking the processing of requests.
-     * @throws NullPointerException if any of the parameters other than tracer are {@code null}.
+     * @param fieldLevelEncryption The helper to use for encrypting/decrypting property values or {@code null} if
+     *                             encryption of fields is not supported.
+     * @throws NullPointerException if any of the parameters other than tracer or field level encryption are {@code null}.
      */
     protected MongoDbBasedDao(
             final MongoClient mongoClient,
             final String collectionName,
-            final Tracer tracer) {
+            final Tracer tracer,
+            final FieldLevelEncryption fieldLevelEncryption) {
 
         Objects.requireNonNull(mongoClient);
         Objects.requireNonNull(collectionName);
@@ -87,6 +95,7 @@ public abstract class MongoDbBasedDao {
         this.mongoClient = mongoClient;
         this.collectionName = collectionName;
         this.tracer = Optional.ofNullable(tracer).orElse(NoopTracerFactory.create());
+        this.fieldLevelEncryption = fieldLevelEncryption;
     }
 
     /**

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDeviceDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDeviceDao.java
@@ -75,19 +75,6 @@ public final class MongoDbBasedDeviceDao extends MongoDbBasedDao implements Devi
      *
      * @param mongoClient The client to use for accessing the Mongo DB.
      * @param collectionName The name of the collection that contains the tenant data.
-     * @throws NullPointerException if any of the parameters are {@code null}.
-     */
-    public MongoDbBasedDeviceDao(
-            final MongoClient mongoClient,
-            final String collectionName) {
-        super(mongoClient, collectionName, null);
-    }
-
-    /**
-     * Creates a new DAO.
-     *
-     * @param mongoClient The client to use for accessing the Mongo DB.
-     * @param collectionName The name of the collection that contains the tenant data.
      * @param tracer The tracer to use for tracking the processing of requests.
      * @throws NullPointerException if any of the parameters other than tracer are {@code null}.
      */
@@ -95,7 +82,7 @@ public final class MongoDbBasedDeviceDao extends MongoDbBasedDao implements Devi
             final MongoClient mongoClient,
             final String collectionName,
             final Tracer tracer) {
-        super(mongoClient, collectionName, tracer);
+        super(mongoClient, collectionName, tracer, null);
     }
 
     /**

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedTenantDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedTenantDao.java
@@ -70,19 +70,6 @@ public final class MongoDbBasedTenantDao extends MongoDbBasedDao implements Tena
      *
      * @param mongoClient The client to use for accessing the Mongo DB.
      * @param collectionName The name of the collection that contains the tenant data.
-     * @throws NullPointerException if any of the parameters are {@code null}.
-     */
-    public MongoDbBasedTenantDao(
-            final MongoClient mongoClient,
-            final String collectionName) {
-        super(mongoClient, collectionName, null);
-    }
-
-    /**
-     * Creates a new DAO for a Mongo DB configuration.
-     *
-     * @param mongoClient The client to use for accessing the Mongo DB.
-     * @param collectionName The name of the collection that contains the tenant data.
      * @param tracer The tracer to use for tracking the processing of requests.
      * @throws NullPointerException if any of the parameters other than tracer are {@code null}.
      */
@@ -90,7 +77,7 @@ public final class MongoDbBasedTenantDao extends MongoDbBasedDao implements Tena
             final MongoClient mongoClient,
             final String collectionName,
             final Tracer tracer) {
-        super(mongoClient, collectionName, tracer);
+        super(mongoClient, collectionName, tracer, null);
     }
 
     /**

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbTestUtils.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbTestUtils.java
@@ -71,7 +71,8 @@ public final class MongoDbTestUtils {
 
         return new MongoDbBasedTenantDao(
                 getMongoClient(vertx, dbName),
-                "tenants");
+                "tenants",
+                null);
     }
 
     /**
@@ -86,7 +87,8 @@ public final class MongoDbTestUtils {
 
         return new MongoDbBasedDeviceDao(
                 getMongoClient(vertx, dbName),
-                "devices");
+                "devices",
+                null);
     }
 
     /**
@@ -101,6 +103,8 @@ public final class MongoDbTestUtils {
 
         return new MongoDbBasedCredentialsDao(
                 getMongoClient(vertx, dbName),
-                "credentials");
+                "credentials",
+                null,
+                null);
     }
 }

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -15,6 +15,8 @@ description = "Information about changes in recent Hono releases. Includes new f
 * Northbound applications sending request/response Command & Control messages via Kafka will now receive
   a notification about a failed command delivery via a command response message. See the
   [Command &amp; Control API for Kafka]({{% doclink "/api/command-and-control-kafka/" %}}) for details.
+* The Mongo DB based device registry implementation now supports transparent (symmetric) encryption of Pre-Shared Key
+  secrets. Please refer to the user guide for details regarding configuration.
 
 ### Fixes & Enhancements
 

--- a/tests/src/test/resources/deviceregistry-mongodb/application.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/application.yml
@@ -35,6 +35,7 @@ hono:
     svc:
   credentials:
     svc:
+      encryptionKeyFile: /etc/hono/encryptionKeys.yml
       maxBcryptCostFactor: ${max.bcrypt.costFactor}
   tenant:
     svc:

--- a/tests/src/test/resources/deviceregistry-mongodb/encryptionKeys.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/encryptionKeys.yml
@@ -1,0 +1,6 @@
+defaultKey: 2
+keys:
+- version: 1
+  key: hqHKBLV83LpCqzKpf8OvutbCs+O5wX5BPu3btWpEvXA=
+- version: 2
+  key: ge2L+MA9jLA8UiUJ4z5fUoK+Lgj2yddlL6EzYIBqb1Q=


### PR DESCRIPTION
The Mongo DB based registry has been extended to (transparently)
encrypt/decrypt pre-shared keys when writing/reading credentials to/from
the Mongo DB collection.

Fixes #2717