### PR TITLE
Fix updating of status properties

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceDto.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceDto.java
@@ -163,10 +163,14 @@ public class DeviceDto extends BaseDto<Device> {
         final T deviceDto = BaseDto.forUpdate(supplier, device.withoutStatus(), version);
         deviceDto.setTenantId(tenantId);
         deviceDto.setDeviceId(deviceId);
+        final Boolean autoProvisioned = Optional.ofNullable(device.getStatus())
+                .map(DeviceStatus::isAutoProvisioned)
+                .orElse(false);
         final Boolean notificationSent = Optional.ofNullable(device.getStatus())
                 .map(DeviceStatus::isAutoProvisioningNotificationSent)
                 .orElse(false);
         deviceDto.setDeviceStatus(new DeviceStatus()
+                .setAutoProvisioned(autoProvisioned)
                 .setAutoProvisioningNotificationSent(notificationSent));
 
         return deviceDto;

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDeviceDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDeviceDao.java
@@ -370,7 +370,7 @@ public final class MongoDbBasedDeviceDao extends MongoDbBasedDao implements Devi
                             deviceConfig.getVersion());
                     // we need to manually copy the device status because the passed in DeviceDto's data
                     // property does not contain any status information (it had been removed by the
-                    // DeviceDto.fromUpdate method used to create it)
+                    // DeviceDto.forUpdate method used to create it)
                     dto.setDeviceStatus(deviceConfig.getDeviceStatus());
                     final JsonObject updateDeviceQuery = MongoDbDocumentBuilder.builder()
                             .withVersion(resourceVersion)

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedCredentialsDaoTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedCredentialsDaoTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceregistry.mongodb.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.service.management.credentials.CredentialsDto;
+import org.eclipse.hono.service.management.device.DeviceDto;
+import org.eclipse.hono.service.management.tenant.TenantDto;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.FindOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.UpdateOptions;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+
+/**
+ * Tests verifying behavior of {@link MongoDbBasedTenantDao}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class MongoDbBasedCredentialsDaoTest {
+
+    private MongoClient mongoClient;
+    private MongoDbBasedCredentialsDao dao;
+
+    /**
+     * Creates the fixture.
+     */
+    @BeforeEach
+    void setUp() {
+        mongoClient = mock(MongoClient.class);
+        dao = new MongoDbBasedCredentialsDao(mongoClient, "credentials", null, null);
+    }
+
+    /**
+     * Verifies that the DAO sets the initial version and creation date when creating a set of credentials.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateSetsCreationDate(final VertxTestContext ctx) {
+
+        when(mongoClient.insert(anyString(), any(JsonObject.class), VertxMockSupport.anyHandler()))
+            .thenAnswer(invocation -> {
+                final Handler<AsyncResult<String>> resultHandler = invocation.getArgument(2);
+                resultHandler.handle(Future.succeededFuture("initial-version"));
+                return mongoClient;
+            });
+
+        final var dto = CredentialsDto.forCreation("tenantId", "deviceId", List.of(), "initial-version");
+
+        dao.create(dto, NoopSpan.INSTANCE.context())
+            .onComplete(ctx.succeeding(version -> {
+                ctx.verify(() -> {
+                    assertThat(version).isEqualTo("initial-version");
+                    final var document = ArgumentCaptor.forClass(JsonObject.class);
+                    verify(mongoClient).insert(eq("credentials"), document.capture(), VertxMockSupport.anyHandler());
+                    assertThat(document.getValue().getString(TenantDto.FIELD_VERSION))
+                        .isEqualTo("initial-version");
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_CREATED))
+                        .isNotNull();
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_UPDATED_ON))
+                        .isNull();
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that the DAO sets the new version and last update time but also keeps the original
+     * creation date when updating credentials.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testUpdateSetsLastUpdate(final VertxTestContext ctx) {
+
+        final var existingRecord = CredentialsDto.forRead(
+                "tenantId",
+                "deviceId",
+                List.of(),
+                Instant.now().minusSeconds(60).truncatedTo(ChronoUnit.SECONDS),
+                null,
+                "initial-version");
+
+        when(mongoClient.findOne(anyString(), any(), any(), VertxMockSupport.anyHandler()))
+            .thenAnswer(invocation -> {
+                final Handler<AsyncResult<JsonObject>> resultHandler = invocation.getArgument(3);
+                resultHandler.handle(Future.succeededFuture(JsonObject.mapFrom(existingRecord)));
+                return mongoClient;
+            });
+
+        when(mongoClient.findOneAndReplaceWithOptions(
+                anyString(),
+                any(JsonObject.class),
+                any(JsonObject.class),
+                any(FindOptions.class),
+                any(UpdateOptions.class),
+                VertxMockSupport.anyHandler()))
+            .thenAnswer(invocation -> {
+                final Handler<AsyncResult<JsonObject>> resultHandler = invocation.getArgument(5);
+                resultHandler.handle(Future.succeededFuture(new JsonObject().put(DeviceDto.FIELD_VERSION, "new-version")));
+                return mongoClient;
+            });
+
+        final var dto = CredentialsDto.forUpdate("tenantId", "deviceId", List.of(), "new-version");
+
+        dao.update(dto, Optional.of(existingRecord.getVersion()), NoopSpan.INSTANCE.context())
+            .onComplete(ctx.succeeding(newVersion -> {
+                ctx.verify(() -> {
+                    final var document = ArgumentCaptor.forClass(JsonObject.class);
+                    verify(mongoClient).findOneAndReplaceWithOptions(
+                            eq("credentials"),
+                            any(JsonObject.class),
+                            document.capture(),
+                            any(FindOptions.class),
+                            any(UpdateOptions.class),
+                            VertxMockSupport.anyHandler());
+                    assertThat(document.getValue().getString(TenantDto.FIELD_VERSION))
+                        .isEqualTo("new-version");
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_CREATED))
+                        .isEqualTo(existingRecord.getCreationTime());
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_UPDATED_ON))
+                        .isAfterOrEqualTo(existingRecord.getCreationTime());
+                });
+                ctx.completeNow();
+            }));
+    }
+
+}

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDeviceDaoTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDeviceDaoTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceregistry.mongodb.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.service.management.device.DeviceDto;
+import org.eclipse.hono.service.management.device.DeviceStatus;
+import org.eclipse.hono.service.management.tenant.TenantDto;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.FindOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.UpdateOptions;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+
+/**
+ * Tests verifying behavior of {@link MongoDbBasedTenantDao}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class MongoDbBasedDeviceDaoTest {
+
+    private MongoClient mongoClient;
+    private MongoDbBasedDeviceDao dao;
+
+    /**
+     * Creates the fixture.
+     */
+    @BeforeEach
+    void setUp() {
+        mongoClient = mock(MongoClient.class);
+        dao = new MongoDbBasedDeviceDao(mongoClient, "devices", null);
+    }
+
+    /**
+     * Verifies that the DAO sets the initial version and creation date when creating a device.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateSetsCreationDate(final VertxTestContext ctx) {
+
+        when(mongoClient.insert(anyString(), any(JsonObject.class), VertxMockSupport.anyHandler()))
+            .thenAnswer(invocation -> {
+                final Handler<AsyncResult<String>> resultHandler = invocation.getArgument(2);
+                resultHandler.handle(Future.succeededFuture("initial-version"));
+                return mongoClient;
+            });
+
+        final var dto = DeviceDto.forCreation(DeviceDto::new, "tenantId", "deviceId", new Device(), "initial-version");
+
+        dao.create(dto, NoopSpan.INSTANCE.context())
+            .onComplete(ctx.succeeding(version -> {
+                ctx.verify(() -> {
+                    assertThat(version).isEqualTo("initial-version");
+                    final var document = ArgumentCaptor.forClass(JsonObject.class);
+                    verify(mongoClient).insert(eq("devices"), document.capture(), VertxMockSupport.anyHandler());
+                    assertThat(document.getValue().getString(TenantDto.FIELD_VERSION))
+                        .isEqualTo("initial-version");
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_CREATED))
+                        .isNotNull();
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_UPDATED_ON))
+                        .isNull();
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that the DAO sets the new version and last update time but also keeps the original
+     * creation date when updating a device.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testUpdateSetsLastUpdate(final VertxTestContext ctx) {
+
+        final var existingRecord = MongoDbBasedDeviceDto.forRead(
+                MongoDbBasedDeviceDto::new,
+                "tenantId",
+                "deviceId",
+                new Device(),
+                new DeviceStatus(),
+                Instant.now().minusSeconds(60).truncatedTo(ChronoUnit.SECONDS),
+                null,
+                "initial-version");
+
+        when(mongoClient.findOne(anyString(), any(), any(), VertxMockSupport.anyHandler()))
+            .thenAnswer(invocation -> {
+                final Handler<AsyncResult<JsonObject>> resultHandler = invocation.getArgument(3);
+                resultHandler.handle(Future.succeededFuture(JsonObject.mapFrom(existingRecord)));
+                return mongoClient;
+            });
+
+        when(mongoClient.findOneAndReplaceWithOptions(
+                anyString(),
+                any(JsonObject.class),
+                any(JsonObject.class),
+                any(FindOptions.class),
+                any(UpdateOptions.class),
+                VertxMockSupport.anyHandler()))
+            .thenAnswer(invocation -> {
+                final Handler<AsyncResult<JsonObject>> resultHandler = invocation.getArgument(5);
+                resultHandler.handle(Future.succeededFuture(new JsonObject().put(DeviceDto.FIELD_VERSION, "new-version")));
+                return mongoClient;
+            });
+
+        final var dto = DeviceDto.forUpdate(DeviceDto::new, "tenantId", "deviceId", new Device(), "new-version");
+
+        dao.update(dto, Optional.of(existingRecord.getVersion()), NoopSpan.INSTANCE.context())
+            .onComplete(ctx.succeeding(newVersion -> {
+                ctx.verify(() -> {
+                    final var document = ArgumentCaptor.forClass(JsonObject.class);
+                    verify(mongoClient).findOneAndReplaceWithOptions(
+                            eq("devices"),
+                            any(JsonObject.class),
+                            document.capture(),
+                            any(FindOptions.class),
+                            any(UpdateOptions.class),
+                            VertxMockSupport.anyHandler());
+                    assertThat(document.getValue().getString(TenantDto.FIELD_VERSION))
+                        .isEqualTo("new-version");
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_CREATED))
+                        .isEqualTo(existingRecord.getCreationTime());
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_UPDATED_ON))
+                        .isAfterOrEqualTo(existingRecord.getCreationTime());
+                });
+                ctx.completeNow();
+            }));
+    }
+
+}

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedTenantDaoTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedTenantDaoTest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceregistry.mongodb.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.service.management.tenant.TenantDto;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.FindOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.UpdateOptions;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+
+/**
+ * Tests verifying behavior of {@link MongoDbBasedTenantDao}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class MongoDbBasedTenantDaoTest {
+
+    private MongoClient mongoClient;
+    private MongoDbBasedTenantDao dao;
+
+    /**
+     * Creates the fixture.
+     */
+    @BeforeEach
+    void setUp() {
+        mongoClient = mock(MongoClient.class);
+        dao = new MongoDbBasedTenantDao(mongoClient, "tenants", null);
+    }
+
+    /**
+     * Verifies that the DAO sets the initial version and creation date when creating a tenant.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateSetsCreationDate(final VertxTestContext ctx) {
+
+        when(mongoClient.insert(anyString(), any(JsonObject.class), VertxMockSupport.anyHandler()))
+            .thenAnswer(invocation -> {
+                final Handler<AsyncResult<String>> resultHandler = invocation.getArgument(2);
+                resultHandler.handle(Future.succeededFuture("initial-version"));
+                return mongoClient;
+            });
+
+        final var dto = TenantDto.forCreation("tenantId", new Tenant(), "initial-version");
+
+        dao.create(dto, NoopSpan.INSTANCE.context())
+            .onComplete(ctx.succeeding(version -> {
+                ctx.verify(() -> {
+                    assertThat(version).isEqualTo("initial-version");
+                    final var document = ArgumentCaptor.forClass(JsonObject.class);
+                    verify(mongoClient).insert(eq("tenants"), document.capture(), VertxMockSupport.anyHandler());
+                    assertThat(document.getValue().getString(TenantDto.FIELD_VERSION))
+                        .isEqualTo("initial-version");
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_CREATED))
+                        .isNotNull();
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_UPDATED_ON))
+                        .isNull();
+                });
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that the DAO sets the new version and last update time but also keeps the original
+     * creation date when updating a tenant.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testUpdateSetsLastUpdate(final VertxTestContext ctx) {
+
+        final var existingRecord = TenantDto.forRead(
+                "tenantId",
+                new Tenant(),
+                Instant.now().minusSeconds(60).truncatedTo(ChronoUnit.SECONDS),
+                null,
+                "initial-version");
+
+        when(mongoClient.findOne(anyString(), any(), any(), VertxMockSupport.anyHandler()))
+            .thenAnswer(invocation -> {
+                final Handler<AsyncResult<JsonObject>> resultHandler = invocation.getArgument(3);
+                resultHandler.handle(Future.succeededFuture(JsonObject.mapFrom(existingRecord)));
+                return mongoClient;
+            });
+
+        when(mongoClient.findOneAndReplaceWithOptions(
+                anyString(),
+                any(JsonObject.class),
+                any(JsonObject.class),
+                any(FindOptions.class),
+                any(UpdateOptions.class),
+                VertxMockSupport.anyHandler()))
+            .thenAnswer(invocation -> {
+                final Handler<AsyncResult<JsonObject>> resultHandler = invocation.getArgument(5);
+                resultHandler.handle(Future.succeededFuture(new JsonObject().put(TenantDto.FIELD_VERSION, "new-version")));
+                return mongoClient;
+            });
+
+        final var dto = TenantDto.forUpdate("tenantId", new Tenant(), "new-version");
+
+        dao.update(dto, Optional.of(existingRecord.getVersion()), NoopSpan.INSTANCE.context())
+            .onComplete(ctx.succeeding(newVersion -> {
+                ctx.verify(() -> {
+                    assertThat(newVersion).isEqualTo("new-version");
+                    final var document = ArgumentCaptor.forClass(JsonObject.class);
+                    verify(mongoClient).findOneAndReplaceWithOptions(
+                            eq("tenants"),
+                            any(JsonObject.class),
+                            document.capture(),
+                            any(FindOptions.class),
+                            any(UpdateOptions.class),
+                            VertxMockSupport.anyHandler());
+                    assertThat(document.getValue().getString(TenantDto.FIELD_VERSION))
+                        .isEqualTo("new-version");
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_CREATED))
+                        .isEqualTo(existingRecord.getCreationTime());
+                    assertThat(document.getValue().getInstant(TenantDto.FIELD_UPDATED_ON))
+                        .isAfterOrEqualTo(existingRecord.getCreationTime());
+                });
+                ctx.completeNow();
+            }));
+    }
+
+}


### PR DESCRIPTION
The DAOs have been changed to keep an instance's original creation time
when updating the instance.

Fixes #2774