### PR TITLE
[#2777] Use Truth assertThat() instead of AssertJ in 'tests' module

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -92,6 +92,7 @@
     <spring-boot.version>2.4.8</spring-boot.version>
     <spring-security-crypto.version>5.4.7</spring-security-crypto.version>
     <testcontainers.version>1.15.2</testcontainers.version>
+    <truth.version>1.1.3</truth.version>
     <!-- when updating Vert.x, check if the Kafka clients need to be updated as well -->
     <vertx.version>3.9.7</vertx.version>
     <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
@@ -1021,6 +1022,19 @@
         <artifactId>assertj-core</artifactId>
         <version>${assertj-core.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.truth</groupId>
+        <artifactId>truth</artifactId>
+        <version>${truth.version}</version>
+        <scope>test</scope>
+        <!-- exclude JUnit 4, see https://github.com/google/truth/issues/333 -->
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/legal/src/main/resources/checkstyle/default.xml
+++ b/legal/src/main/resources/checkstyle/default.xml
@@ -72,7 +72,9 @@
     <module name="AvoidStaticImport">
       <property
         name="excludes"
-        value="org.assertj.core.api.Assertions.assertThat,
+        value="com.google.common.truth.Truth.assertThat,
+               com.google.common.truth.Truth.assertWithMessage,
+               org.assertj.core.api.Assertions.assertThat,
                org.assertj.core.api.Assertions.assertThatThrownBy,
                org.hamcrest.CoreMatchers.*,
                org.hamcrest.Matchers.*,

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -9,9 +9,12 @@ maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.12.3
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.12.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.ben-manes.caffeine/caffeine/2.8.8, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.luben/zstd-jni/1.4.4-7, BSD-2-Clause, approved, CQ22420
+maven/mavencentral/com.google.auto.value/auto-value-annotations/1.8.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.code.gson/gson/2.8.6, Apache-2.0, approved, CQ23102
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/30.1-jre, Apache-2.0 AND CC0-1.0 AND LicenseRef-Public-Domain, approved, CQ23244
 maven/mavencentral/com.google.protobuf/protobuf-java/3.12.2, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.truth/truth/1.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.h2database/h2/1.4.200, EPL-1.0, approved, CQ14966
 maven/mavencentral/com.mchange/c3p0/0.9.5.4, LGPL-2.1-only OR EPL-1.0, approved, clearlydefined
 maven/mavencentral/com.mchange/mchange-commons-java/0.2.15, LGPL-2.1-only OR EPL-1.0, approved, clearlydefined
@@ -161,6 +164,7 @@ maven/mavencentral/org.objenesis/objenesis/3.1, Apache-2.0, approved, clearlydef
 maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.osgi/org.osgi.compendium/4.3.1, Apache-2.0, approved, CQ10111
 maven/mavencentral/org.osgi/org.osgi.core/4.3.1, Apache-2.0, approved, CQ10111
+maven/mavencentral/org.ow2.asm/asm/9.1, BSD-3-Clause, approved, CQ23029
 maven/mavencentral/org.postgresql/postgresql/42.2.18, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/org.reactivestreams/reactive-streams/1.0.3, CC0-1.0, approved, CQ16332
 maven/mavencentral/org.slf4j/jul-to-slf4j/1.7.28, MIT, approved, CQ12842

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -9,9 +9,12 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.12.3
 com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.12.3
 com.github.ben-manes.caffeine:caffeine:jar:2.8.8
 com.github.luben:zstd-jni:jar:1.4.4-7
+com.google.auto.value:auto-value-annotations:jar:1.8.1
 com.google.code.gson:gson:jar:2.8.6
+com.google.errorprone:error_prone_annotations:jar:2.2.0
 com.google.guava:guava:jar:30.1-jre
 com.google.protobuf:protobuf-java:jar:3.12.2
+com.google.truth:truth:jar:1.1.3
 com.h2database:h2:jar:1.4.200
 com.mchange:c3p0:jar:0.9.5.4
 com.mchange:mchange-commons-java:jar:0.2.15
@@ -161,6 +164,7 @@ org.objenesis:objenesis:jar:3.1
 org.opentest4j:opentest4j:jar:1.2.0
 org.osgi:org.osgi.compendium:jar:4.3.1
 org.osgi:org.osgi.core:jar:4.3.1
+org.ow2.asm:asm:jar:9.1
 org.postgresql:postgresql:jar:42.2.18
 org.reactivestreams:reactive-streams:jar:1.0.3
 org.slf4j:jul-to-slf4j:jar:1.7.28

--- a/test-utils/adapter-base-test-utils/pom.xml
+++ b/test-utils/adapter-base-test-utils/pom.xml
@@ -40,5 +40,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterMockSupport.java
+++ b/test-utils/adapter-base-test-utils/src/main/java/org/eclipse/hono/adapter/test/ProtocolAdapterMockSupport.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.hono.adapter.test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -23,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Map;
 import java.util.Objects;
@@ -406,7 +406,7 @@ public abstract class ProtocolAdapterMockSupport {
             });
         Optional.ofNullable(contentType)
             .ifPresent(v -> {
-                assertThat(contentTypeCaptor.getValue()).isEqualToIgnoringCase(v);
+                assertThat(contentTypeCaptor.getValue()).ignoringCase().isEqualTo(v);
             });
     }
 
@@ -525,11 +525,11 @@ public abstract class ProtocolAdapterMockSupport {
             });
         Optional.ofNullable(contentType)
             .ifPresent(v -> {
-                assertThat(contentTypeCaptor.getValue()).isEqualToIgnoringCase(v);
+                assertThat(contentTypeCaptor.getValue()).ignoringCase().isEqualTo(v);
             });
         Optional.ofNullable(ttl)
             .ifPresent(v -> {
-                assertThat(propsCaptor.getValue()).contains(Map.entry(MessageHelper.SYS_HEADER_PROPERTY_TTL, v));
+                assertThat(propsCaptor.getValue()).containsAtLeastEntriesIn(Map.of(MessageHelper.SYS_HEADER_PROPERTY_TTL, v));
             });
     }
 

--- a/test-utils/kafka-test-utils/pom.xml
+++ b/test-utils/kafka-test-utils/pom.xml
@@ -41,5 +41,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/KafkaClientUnitTestHelper.java
+++ b/test-utils/kafka-test-utils/src/main/java/org/eclipse/hono/kafka/test/KafkaClientUnitTestHelper.java
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.kafka.test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -77,11 +77,14 @@ public class KafkaClientUnitTestHelper {
     public static void assertStandardHeaders(final ProducerRecord<String, Buffer> actual, final String deviceId,
             final String contentType, final int qos) {
 
-        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("content-type", contentType.getBytes()));
+        assertThat(actual.headers().headers("content-type")).hasSize(1);
+        assertThat(actual.headers()).contains(new RecordHeader("content-type", contentType.getBytes()));
 
-        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("device_id", deviceId.getBytes()));
+        assertThat(actual.headers().headers("device_id")).hasSize(1);
+        assertThat(actual.headers()).contains(new RecordHeader("device_id", deviceId.getBytes()));
 
-        assertThat(actual.headers()).containsOnlyOnce(new RecordHeader("qos", Json.encode(qos).getBytes()));
+        assertThat(actual.headers().headers("qos")).hasSize(1);
+        assertThat(actual.headers()).contains(new RecordHeader("qos", Json.encode(qos).getBytes()));
     }
 
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -262,6 +262,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-command-amqp</artifactId>
       <scope>test</scope>

--- a/tests/src/test/java/org/eclipse/hono/tests/AmqpMessageContextConditionalVerifier.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/AmqpMessageContextConditionalVerifier.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.hono.tests;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageContext;

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -13,7 +13,8 @@
 
 package org.eclipse.hono.tests;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
@@ -920,12 +921,10 @@ public final class IntegrationTestSupport {
                 // complete, and check if we successfully deleted the devices
                 .onComplete(ctx.succeeding(tenantsInRegistry -> {
                     ctx.verify(() -> {
-                        assertThat(devicesDeleted.get())
-                            .as("successfully deleted devices")
-                            .isTrue();
-                        assertThat(tenantsInRegistry)
-                            .as("registry contains no other tenants after successful deletion of temporary tenants")
-                            .isEqualTo(0);
+                        assertWithMessage("devices successfully deleted").that(devicesDeleted.get()).isTrue();
+                        assertWithMessage("no. of tenants in registry after successful deletion of temporary tenants")
+                                .that(tenantsInRegistry)
+                                .isEqualTo(0);
                     });
                     ctx.completeNow();
                 }));
@@ -1456,12 +1455,12 @@ public final class IntegrationTestSupport {
             final DownstreamMessage<? extends MessageContext> msg,
             final String expectedTenantId) {
 
-        assertThat(msg.getTenantId()).as("message includes matching tenant ID").isEqualTo(expectedTenantId);
-        assertThat(msg.getDeviceId()).as("message includes non-null device ID").isNotNull();
+        assertWithMessage("message tenant ID").that(msg.getTenantId()).isEqualTo(expectedTenantId);
+        assertWithMessage("message tenant ID").that(msg.getDeviceId()).isNotNull();
         final var ttdValue = msg.getTimeTillDisconnect();
         if (ttdValue != null) {
-            assertThat(ttdValue).as("ttd property contains an integer >= -1").isGreaterThanOrEqualTo(-1);
-            assertThat(msg.getCreationTime()).as("message contains a non-null creation time").isNotNull();
+            assertWithMessage("ttd property value").that(ttdValue).isAtLeast(-1);
+            assertWithMessage("message creation time").that(msg.getCreationTime()).isNotNull();
         }
     }
 
@@ -1476,15 +1475,16 @@ public final class IntegrationTestSupport {
             final JsonObject deviceStatus,
             final boolean expectedAutoProvisionedStatus) {
 
-        assertThat(deviceStatus).as("device registration info contains status").isNotNull();
+        assertWithMessage("status in device registration info").that(deviceStatus).isNotNull();
         if (expectedAutoProvisionedStatus) {
-            assertThat(deviceStatus.getBoolean(RegistryManagementConstants.FIELD_AUTO_PROVISIONED))
-                .as("auto-provisioned property has value true")
-                .isTrue();
+            assertWithMessage("auto-provisioned property")
+                    .that(deviceStatus.getBoolean(RegistryManagementConstants.FIELD_AUTO_PROVISIONED))
+                    .isTrue();
         } else {
-            assertThat(deviceStatus.getBoolean(RegistryManagementConstants.FIELD_AUTO_PROVISIONED))
-            .as("auto-provisioned property is either missing or has value false")
-            .matches(b -> b == null || !b.booleanValue());
+            final Boolean autoProvisioned = deviceStatus.getBoolean(RegistryManagementConstants.FIELD_AUTO_PROVISIONED);
+            assertWithMessage("auto-provisioned property is missing or has value 'false'")
+                    .that(autoProvisioned == null || !autoProvisioned)
+                    .isTrue();
         }
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpAdapterTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpAdapterTestBase.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.tests.amqp;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Optional;
 import java.util.Set;
@@ -276,7 +276,8 @@ public abstract class AmqpAdapterTestBase {
 
         return result.future()
                 .map(con -> {
-                    assertThat(unopenedConnection.getRemoteOfferedCapabilities()).contains(Constants.CAP_ANONYMOUS_RELAY);
+                    assertThat(unopenedConnection.getRemoteOfferedCapabilities()).asList()
+                            .contains(Constants.CAP_ANONYMOUS_RELAY);
                     this.context = Vertx.currentContext();
                     this.connection = unopenedConnection;
                     log.info("AMQPS connection to adapter [{}:{}] established",

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpConnectionIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.amqp;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.security.GeneralSecurityException;

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/AmqpUploadTestBase.java
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package org.eclipse.hono.tests.amqp;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.net.HttpURLConnection;
 import java.util.Collections;
@@ -136,8 +137,9 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
             .map(s -> {
                 setup.verify(() -> {
                     final UnsignedLong maxMessageSize = s.getRemoteMaxMessageSize();
-                    assertThat(maxMessageSize).as("check adapter's attach frame includes max-message-size").isNotNull();
-                    assertThat(maxMessageSize.longValue()).as("check message size is limited").isGreaterThan(0);
+                    assertWithMessage("max-message-size included in adapter's attach frame")
+                            .that(maxMessageSize).isNotNull();
+                    assertWithMessage("max-message-size").that(maxMessageSize.longValue()).isGreaterThan(0);
                 });
                 sender = s;
                 return s;
@@ -201,8 +203,9 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
             log.info("AMQP adapter uses max-message-size {}", maxMessageSize);
 
             ctx.verify(() -> {
-                assertThat(maxMessageSize).as("check adapter's attach frame includes max-message-size").isNotNull();
-                assertThat(maxMessageSize.longValue()).as("check message size is limited").isGreaterThan(0);
+                assertWithMessage("max-message-size included in adapter's attach frame")
+                        .that(maxMessageSize).isNotNull();
+                assertWithMessage("max-message-size").that(maxMessageSize.longValue()).isGreaterThan(0);
             });
 
             final Message msg = ProtonHelper.message();
@@ -316,17 +319,18 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
             .onComplete(setup.succeeding(s -> {
                 setup.verify(() -> {
                     final UnsignedLong maxMessageSize = s.getRemoteMaxMessageSize();
-                    assertThat(maxMessageSize).as("check adapter's attach frame includes max-message-size").isNotNull();
-                    assertThat(maxMessageSize.longValue()).as("check message size is limited").isGreaterThan(0);
+                    assertWithMessage("max-message-size included in adapter's attach frame")
+                            .that(maxMessageSize).isNotNull();
+                    assertWithMessage("max-message-size").that(maxMessageSize.longValue()).isGreaterThan(0);
                 });
                 sender = s;
                 setup.completeNow();
             }));
 
         assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
-        assertThat(setup.failed())
-            .as("successfully connect to adapter")
-            .isFalse();
+        assertWithMessage("adapter connection failure occurred")
+                .that(setup.failed())
+                .isFalse();
 
         testUploadMessages(tenantId, senderQos);
     }
@@ -359,17 +363,18 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
             .onComplete(setup.succeeding(s -> {
                 setup.verify(() -> {
                     final UnsignedLong maxMessageSize = s.getRemoteMaxMessageSize();
-                    assertThat(maxMessageSize).as("check adapter's attach frame includes max-message-size").isNotNull();
-                    assertThat(maxMessageSize.longValue()).as("check message size is limited").isGreaterThan(0);
+                    assertWithMessage("max-message-size included in adapter's attach frame")
+                            .that(maxMessageSize).isNotNull();
+                    assertWithMessage("max-message-size").that(maxMessageSize.longValue()).isGreaterThan(0);
                 });
                 sender = s;
                 setup.completeNow();
             }));
 
         assertThat(setup.awaitCompletion(5, TimeUnit.SECONDS)).isTrue();
-        assertThat(setup.failed())
-            .as("successfully connect to adapter")
-            .isFalse();
+        assertWithMessage("adapter connection failure occurred")
+                .that(setup.failed())
+                .isFalse();
 
         testUploadMessages(tenantId, senderQos);
     }
@@ -507,9 +512,9 @@ public abstract class AmqpUploadTestBase extends AmqpAdapterTestBase {
         if (messageSending.failed()) {
             Assertions.fail("failed to upload messages", messageSending.causeOfFailure());
         }
-        assertThat(messagesReceived.get())
-            .as(String.format("assert all %d expected messages are received", IntegrationTestSupport.MSG_COUNT))
-            .isGreaterThanOrEqualTo(IntegrationTestSupport.MSG_COUNT);
+        assertWithMessage("number of received messages")
+                .that(messagesReceived.get())
+                .isAtLeast(IntegrationTestSupport.MSG_COUNT);
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/CommandAndControlAmqpIT.java
@@ -13,7 +13,8 @@
 
 package org.eclipse.hono.tests.amqp;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.net.HttpURLConnection;
 import java.util.Map;
@@ -168,8 +169,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             }))
         .onComplete(setup.succeeding(v -> setupDone.flag()));
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("connect and subscribe finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("connect and subscribe finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
@@ -335,8 +336,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
 
         asyncResponseConsumer.onComplete(setup.completing());
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("setup of command response consumer finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("setup of command response consumer finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
@@ -523,7 +524,6 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         connectToAdapter(tenantId, deviceId, password, () -> createEventConsumer(tenantId, msg -> {
             // expect empty notification with TTD -1
             setup.verify(() -> assertThat(msg.getContentType())
-                    .as("receive TTD notification")
                     .isEqualTo(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION));
             final TimeUntilDisconnectNotification notification = msg.getTimeUntilDisconnectNotification().orElse(null);
             log.debug("received notification [{}]", notification);
@@ -547,9 +547,9 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             })
             .onComplete(setup.succeeding(v -> setupDone.flag()));
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-            .as("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
-            .isTrue();
+        assertWithMessage("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
+                .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
             return;
@@ -616,7 +616,6 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         connectToAdapter(tenantId, deviceId, password, () -> createEventConsumer(tenantId, msg -> {
             // expect empty notification with TTD -1
             setup.verify(() -> assertThat(msg.getContentType())
-                    .as("receive TTD notification")
                     .isEqualTo(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION));
             final TimeUntilDisconnectNotification notification = msg.getTimeUntilDisconnectNotification().orElse(null);
             log.debug("received notification [{}]", notification);
@@ -635,8 +634,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                 .compose(v -> kafkaAsyncErrorResponseConsumer)
                 .onComplete(setup.succeeding(v -> setupDone.flag()));
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
@@ -709,7 +708,6 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
         connectToAdapter(tenantId, deviceId, password, () -> createEventConsumer(tenantId, msg -> {
             // expect empty notification with TTD -1
             setup.verify(() -> assertThat(msg.getContentType())
-                    .as("receive TTD notification")
                     .isEqualTo(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION));
             final TimeUntilDisconnectNotification notification = msg.getTimeUntilDisconnectNotification().orElse(null);
             log.debug("received notification [{}]", notification);
@@ -735,9 +733,9 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
             }))
         .onComplete(setup.succeeding(v -> setupDone.flag()));
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-            .as("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
-            .isTrue();
+        assertWithMessage("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
+                .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
             return;
@@ -764,7 +762,7 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                 .onComplete(ctx.failing(t -> {
                     ctx.verify(() -> {
                         // relevant for Kafka case: assert first command was actually received
-                        assertThat(firstCommandReceived.getPlain()).as("first command was received").isTrue();
+                        assertWithMessage("first command received").that(firstCommandReceived.getPlain()).isTrue();
                         assertThat(t).isInstanceOf(ServerErrorException.class);
                         assertThat(((ServerErrorException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_UNAVAILABLE);
                         // with no explicit credit check, the AMQP adapter would just run into the "waiting for delivery update" timeout (after 1s)
@@ -814,8 +812,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                         }))
                 .onComplete(setup.succeeding(v -> setupDone.flag()));
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
@@ -888,8 +886,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                         REJECTED_COMMAND_ERROR_MESSAGE::equals)
                 : Future.succeededFuture(null);
         kafkaAsyncErrorResponseConsumer.onComplete(setup.completing());
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("setup of command response consumer finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("setup of command response consumer finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
@@ -996,8 +994,8 @@ public class CommandAndControlAmqpIT extends AmqpAdapterTestBase {
                         null)
                 : Future.succeededFuture(null);
         kafkaAsyncErrorResponseConsumer.onComplete(setup.completing());
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("setup of command response consumer finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("setup of command response consumer finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());

--- a/tests/src/test/java/org/eclipse/hono/tests/amqp/EventAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/amqp/EventAmqpIT.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.tests.amqp;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;

--- a/tests/src/test/java/org/eclipse/hono/tests/auth/AuthServerAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/auth/AuthServerAmqpIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.auth;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 

--- a/tests/src/test/java/org/eclipse/hono/tests/client/ApplicationClientIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/client/ApplicationClientIT.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.tests.client;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.List;
@@ -71,8 +71,8 @@ public class ApplicationClientIT {
         client.connect().onComplete(ctx.failing(t -> {
             // THEN the connection attempt fails due to lack of authorization
             ctx.verify(() -> {
-                assertThat(t).isInstanceOfSatisfying(ClientErrorException.class,
-                        error -> assertThat(error.getErrorCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED));
+                assertThat(t).isInstanceOf(ClientErrorException.class);
+                assertThat(((ClientErrorException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
             });
             ctx.completeNow();
         }));
@@ -101,8 +101,8 @@ public class ApplicationClientIT {
         client.connect().onComplete(ctx.failing(t -> {
             // THEN the connection attempt fails due to lack of authorization
             ctx.verify(() -> {
-                assertThat(t).isInstanceOfSatisfying(ClientErrorException.class,
-                        error -> assertThat(error.getErrorCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST));
+                assertThat(t).isInstanceOf(ClientErrorException.class);
+                assertThat(((ClientErrorException) t).getErrorCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
             });
             ctx.completeNow();
         }));

--- a/tests/src/test/java/org/eclipse/hono/tests/client/HonoKafkaConsumerIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/client/HonoKafkaConsumerIT.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.tests.client;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/EventCoapIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.coap;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;

--- a/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/coap/TelemetryCoapIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.coap;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;

--- a/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.tests.commandrouter;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/tests/src/test/java/org/eclipse/hono/tests/http/CorsIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/CorsIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.http;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.Optional;

--- a/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/EventHttpIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.http;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.UUID;

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -13,7 +13,8 @@
 
 package org.eclipse.hono.tests.http;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
@@ -1200,8 +1201,9 @@ import io.vertx.junit5.VertxTestContext;
 
                                 ctx.verify(() -> {
                                     // assert that the response contains a command
-                                    assertThat(httpResponse.getHeader(Constants.HEADER_COMMAND))
-                                            .as("response #" + count + " doesn't contain command").isNotNull();
+                                    assertWithMessage("response no. %s '%s' header", count, Constants.HEADER_COMMAND)
+                                            .that(httpResponse.getHeader(Constants.HEADER_COMMAND))
+                                            .isNotNull();
                                     assertThat(httpResponse.getHeader(Constants.HEADER_COMMAND)).isEqualTo(COMMAND_TO_SEND);
                                     assertThat(httpResponse.getHeader(HttpHeaders.CONTENT_TYPE.toString())).isEqualTo("application/json");
                                     assertThat(requestId).isNotNull();
@@ -1303,8 +1305,9 @@ import io.vertx.junit5.VertxTestContext;
                         .map(httpResponse -> {
                             ctx.verify(() -> {
                                 // assert that the response contains a one-way command
-                                assertThat(httpResponse.getHeader(Constants.HEADER_COMMAND))
-                                        .as("response #" + count + " doesn't contain command").isNotNull();
+                                assertWithMessage("response no. %s '%s' header", count, Constants.HEADER_COMMAND)
+                                        .that(httpResponse.getHeader(Constants.HEADER_COMMAND))
+                                        .isNotNull();
                                 assertThat(httpResponse.getHeader(Constants.HEADER_COMMAND)).isEqualTo(COMMAND_TO_SEND);
                                 assertThat(httpResponse.getHeader(HttpHeaders.CONTENT_TYPE.toString())).isEqualTo("application/json");
                                 assertThat(httpResponse.getHeader(Constants.HEADER_COMMAND_REQUEST_ID)).isNull();

--- a/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/TelemetryHttpIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.http;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.concurrent.TimeUnit;

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/CommandAndControlMqttIT.java
@@ -13,7 +13,8 @@
 
 package org.eclipse.hono.tests.mqtt;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
@@ -297,8 +298,8 @@ public class CommandAndControlMqttIT extends MqttTestBase {
         .compose(conAck -> subscribeToCommands(commandTargetDeviceId, commandConsumer, endpointConfig, subscribeQos))
         .onComplete(setup.succeeding(ok -> ready.flag()));
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
@@ -404,8 +405,8 @@ public class CommandAndControlMqttIT extends MqttTestBase {
             ready.flag();
         }));
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
@@ -488,8 +489,8 @@ public class CommandAndControlMqttIT extends MqttTestBase {
                 .compose(ok -> kafkaAsyncErrorResponseConsumer)
                 .onComplete(setup.succeeding(v -> ready.flag()));
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());
@@ -594,8 +595,8 @@ public class CommandAndControlMqttIT extends MqttTestBase {
                 .compose(conAck -> subscribeToCommands(commandTargetDeviceId, commandConsumer, endpointConfig, subscribeQos))
                 .onComplete(setup.succeeding(ok -> ready.flag()));
 
-        assertThat(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
-                .as("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+        assertWithMessage("setup of adapter finished within %s seconds", IntegrationTestSupport.getTestSetupTimeout())
+                .that(setup.awaitCompletion(IntegrationTestSupport.getTestSetupTimeout(), TimeUnit.SECONDS))
                 .isTrue();
         if (setup.failed()) {
             ctx.failNow(setup.causeOfFailure());

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/EventMqttIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.mqtt;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Map;
 import java.util.UUID;

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttCommandEndpointConfiguration.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttCommandEndpointConfiguration.java
@@ -14,7 +14,8 @@
 
 package org.eclipse.hono.tests.mqtt;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import org.eclipse.hono.tests.CommandEndpointConfiguration;
 import org.eclipse.hono.util.ResourceIdentifier;
@@ -98,13 +99,13 @@ public class MqttCommandEndpointConfiguration extends CommandEndpointConfigurati
 
         assertThat(topic).isNotNull();
 
-        assertThat(topic.getEndpoint())
-        .as("command topic contains correct endpoint")
-        .isEqualTo(getSouthboundEndpoint());
+        assertWithMessage("command topic endpoint")
+                .that(topic.getEndpoint())
+                .isEqualTo(getSouthboundEndpoint());
 
-        assertThat(topic.getTenantId())
-        .as("command topic does not contain tenant ID")
-        .isNull();
+        assertWithMessage("command topic tenant ID")
+                .that(topic.getTenantId())
+                .isNull();
 
 
         switch (getSubscriberRole()) {
@@ -112,32 +113,31 @@ public class MqttCommandEndpointConfiguration extends CommandEndpointConfigurati
             // TODO: anything to assert in this case?
             break;
         case DEVICE:
-            assertThat(topic.getResourceId())
-            .as("command topic does not contain device ID")
-            .isNull();
+            assertWithMessage("command topic device ID")
+                    .that(topic.getResourceId())
+                    .isNull();
             break;
         case GATEWAY_FOR_ALL_DEVICES:
             // fall through
         case GATEWAY_FOR_SINGLE_DEVICE:
-            assertThat(topic.getResourceId())
-            .as("command topic contains device ID")
-            .isEqualTo(expectedCommandTarget);
+            assertWithMessage("command topic device ID")
+                    .that(topic.getResourceId())
+                    .isEqualTo(expectedCommandTarget);
             break;
         }
 
         if (isOneWayCommand) {
-            assertThat(topic.elementAt(4))
-            .as("one-way command topic does not contain request ID")
-            .isNull();
+            assertWithMessage("request ID part of one-way command topic")
+                    .that(topic.elementAt(4))
+                    .isNull();
         } else {
-            assertThat(topic.elementAt(4))
-            .as("command topic contains request ID")
-            .isNotNull();
+            assertWithMessage("request ID part of command topic")
+                    .that(topic.elementAt(4))
+                    .isNotNull();
         }
 
-        assertThat(topic.elementAt(5))
-        .as("command topic contains command name")
-        .isEqualTo(expectedCommandName);
-
+        assertWithMessage("command name in command topic")
+                .that(topic.elementAt(5))
+                .isEqualTo(expectedCommandName);
     }
 }

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttConnectionIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.mqtt;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Collections;
 import java.util.List;

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.mqtt;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.HashMap;

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/TelemetryMqttQoS1IT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.mqtt;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.Map;

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsApiTests.java
@@ -14,7 +14,8 @@
 
 package org.eclipse.hono.tests.registry;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -342,12 +343,12 @@ abstract class CredentialsApiTests extends DeviceRegistryTestBase {
                     final DeviceStatus deviceStatus = resultBody
                             .getJsonObject(RegistryManagementConstants.FIELD_STATUS)
                             .mapTo(DeviceStatus.class);
-                    assertThat(deviceStatus.isAutoProvisioned())
-                        .as("device is marked as auto-provisioned")
-                        .isTrue();
-                    assertThat(deviceStatus.isAutoProvisioningNotificationSent())
-                        .as("auto-provisioning notification for device has been sent")
-                        .isTrue();
+                    assertWithMessage("device auto-provisioned")
+                            .that(deviceStatus.isAutoProvisioned())
+                            .isTrue();
+                    assertWithMessage("auto-provisioning notification for device sent")
+                            .that(deviceStatus.isAutoProvisioningNotificationSent())
+                            .isTrue();
                 });
                 autoProvisioningCompleted.flag();
             }));

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.tests.registry;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.time.Instant;
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.eclipse.hono.service.http.HttpUtils;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
@@ -153,7 +154,7 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
             .onComplete(context.succeeding(httpResponse -> {
                 context.verify(() -> {
                     final CommonCredential[] credsOnRecord = httpResponse.bodyAsJson(CommonCredential[].class);
-                    assertThat(credsOnRecord).hasSize(3);
+                    assertThat(credsOnRecord).hasLength(3);
                     Arrays.stream(credsOnRecord)
                         .forEach(creds -> {
                             assertThat(creds.getExtensions().get("device-id")).isNull();
@@ -662,7 +663,7 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
                 .withIgnoredFields("secrets.id", "secrets.key", "secrets.passwordHash", "secrets.passwordPlain", "secrets.hashFunction", "secrets.salt")
                 .build();
 
-        assertThat(returnedCreds)
+        Assertions.assertThat(returnedCreds)
             .usingRecursiveFieldByFieldElementComparator(config)
             .containsExactlyInAnyOrderElementsOf(expected);
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceConnectionApiTests.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.hono.tests.registry;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.time.Duration;

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistrationApiTests.java
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.tests.registry;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.Collections;
@@ -92,7 +92,7 @@ abstract class DeviceRegistrationApiTests extends DeviceRegistryTestBase {
                 .onComplete(ctx.succeeding(resp -> {
                     ctx.verify(() -> {
                         assertThat(resp.getDeviceId()).isEqualTo(deviceId);
-                        assertThat(resp.getDefaults()).containsAllEntriesOf(defaults.getMap());
+                        assertThat(resp.getDefaults()).containsExactlyEntriesIn(defaults.getMap());
                     });
                     ctx.completeNow();
                 }));
@@ -124,7 +124,7 @@ abstract class DeviceRegistrationApiTests extends DeviceRegistryTestBase {
                 .onComplete(ctx.succeeding(resp -> {
                     ctx.verify(() -> {
                         assertThat(resp.getDeviceId()).isEqualTo(deviceId);
-                        assertThat(resp.getAuthorizedGateways()).containsExactlyElementsOf(via);
+                        assertThat(resp.getAuthorizedGateways()).containsExactlyElementsIn(via);
                     });
                     ctx.completeNow();
                 }));

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistryTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistryTestBase.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.registry;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Objects;
 

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantApiTests.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantApiTests.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.registry;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.security.KeyPair;
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.security.auth.x500.X500Principal;
 
+import org.assertj.core.api.Assertions;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.tests.IntegrationTestSupport;
@@ -121,7 +122,7 @@ abstract class TenantApiTests extends DeviceRegistryTestBase {
         .onComplete(ctx.succeeding(tenantObject -> {
             ctx.verify(() -> {
                 assertThat(tenantObject.getDefaults()).isEqualTo(expectedTenantObject.getDefaults());
-                assertThat(tenantObject.getAdapters())
+                Assertions.assertThat(tenantObject.getAdapters())
                     .usingRecursiveFieldByFieldElementComparator()
                     .containsAll(expectedTenantObject.getAdapters());
                 assertThat(tenantObject.getResourceLimits().getMaxConnections())
@@ -208,7 +209,7 @@ abstract class TenantApiTests extends DeviceRegistryTestBase {
         .onComplete(ctx.succeeding(tenantObject -> {
             ctx.verify(() -> {
                 assertThat(tenantObject.getTenantId()).isEqualTo(tenantId);
-                assertThat(tenantObject.getTrustAnchors()).size().isEqualTo(1);
+                assertThat(tenantObject.getTrustAnchors()).hasSize(1);
                 final TrustAnchor trustAnchor = tenantObject.getTrustAnchors().iterator().next();
                 assertThat(trustAnchor.getCA()).isEqualTo(subjectDn);
                 assertThat(trustAnchor.getCAPublicKey()).isEqualTo(publicKey);

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantJmsIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantJmsIT.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.tests.registry;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.concurrent.TimeUnit;

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
@@ -13,10 +13,10 @@
 
 package org.eclipse.hono.tests.registry;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.security.PublicKey;


### PR DESCRIPTION
For #2777:
This makes compilation of the 'tests' module up to 5x faster.

I've kept a few AssertJ `assertThat()` invocations where objects get compared recursively.

The adaptations made here are either related to
- the differences in the assertion methods (e.g. `containsAllEntriesOf` vs. `containsExactlyEntriesIn`) 
- or the different way of handling an `assertThat` description message - `assertThat(...).as("message")` vs. `assertWithMessage("message").that(...)`

Concerning these `assertThat` messages, I've rephrased them in most cases, so that they fit the format of the AssertionError output, which is e.g.:
```
myAssertThatMessage
expected to be true
---
myAssertThatMessage
expected to be greater than: 7
but was                    : 5
---
myAssertThatMessage
expected not to be: null
---
myAssertThatMessage
expected to contain: sdss
but was            : test
```

Complete example:
AssertJ:
```
final UnsignedLong maxMessageSize = s.getRemoteMaxMessageSize();
assertThat(maxMessageSize).as("check adapter's attach frame includes max-message-size").isNotNull();
```
produces:
```
java.lang.AssertionError: 
java.lang.AssertionError: [check adapter's attach frame includes max-message-size] 
Expecting actual not to be null
Caused by: java.lang.AssertionError: 
[check adapter's attach frame includes max-message-size] 
Expecting actual not to be null
```

Truth:
```
final UnsignedLong maxMessageSize = s.getRemoteMaxMessageSize();
assertWithMessage("max-message-size included in adapter's attach frame")
        .that(maxMessageSize).isNotNull();
```
produces:
```
java.lang.AssertionError: 
max-message-size included in adapter's attach frame
value of          : getRemoteMaxMessageSize()
expected not to be: null
Caused by: com.google.common.truth.AssertionErrorWithFacts: 
max-message-size included in adapter's attach frame
value of          : getRemoteMaxMessageSize()
expected not to be: null
```

