### PR TITLE
Fix wrong wildfly elytron version used in NOTICE file

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -96,7 +96,6 @@
     <!-- when updating Vert.x, check if the Kafka clients need to be updated as well -->
     <vertx.version>3.9.7</vertx.version>
     <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
-    <wildfly-elytron.version>1.14.1.Final</wildfly-elytron.version>
     <zookeeper.image.name>confluentinc/cp-zookeeper:6.1.1</zookeeper.image.name>
 
     <!-- The port at which the Prometheus scraping endpoint is exposed -->

--- a/legal/src/main/resources/legal/NOTICE.md
+++ b/legal/src/main/resources/legal/NOTICE.md
@@ -687,7 +687,7 @@ is also available at http://www.apache.org/licenses/LICENSE-2.0.html.
 
 The source code is available from [GitHub](https://github.com/wildfly/wildfly-common/tree/${wildfly-common.version})
 
-### WildFly Elytron ${wildfly-elytron.version}
+### WildFly Elytron
 
 This product includes software developed by the [WildFly project](https://www.wildfly.org/).
 
@@ -696,7 +696,7 @@ of the Apache Software License 2.0.
 A copy of the Apache Software License 2.0 is contained in the file [LICENSE-2.0.txt](LICENSE-2.0.txt) and
 is also available at http://www.apache.org/licenses/LICENSE-2.0.html.
 
-The source code is available from [GitHub](https://github.com/wildfly-security/wildfly-elytron/tree/${wildfly-elytron.version}).
+The source code is available from [GitHub](https://github.com/wildfly-security/wildfly-elytron/).
 
 ### Zstd-jni
 


### PR DESCRIPTION
The actual wildfly elytron version used is `1.15.1.Final`.