### PR TITLE
Add support for configuring a trust and key store in Device Connection Client

### DIFF
--- a/client-device-connection-infinispan-quarkus/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/quarkus/InfinispanRemoteConfigurationProperties.java
+++ b/client-device-connection-infinispan-quarkus/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/quarkus/InfinispanRemoteConfigurationProperties.java
@@ -49,6 +49,15 @@ public class InfinispanRemoteConfigurationProperties extends org.eclipse.hono.de
     private Optional<String> saslMechanism;
     private Optional<Integer> socketTimeout;
     private Optional<Integer> connectTimeout;
+    private Optional<String> trustStorePath;
+    private Optional<String> trustStoreFileName;
+    private Optional<String> trustStoreType;
+    private Optional<String> trustStorePassword;
+    private Optional<String> keyStoreFileName;
+    private Optional<String> keyStoreType;
+    private Optional<String> keyStorePassword;
+    private Optional<String> keyAlias;
+    private Optional<String> keyStoreCertificatePassword;
 
     /**
      * @param serverList The server list.
@@ -127,6 +136,86 @@ public class InfinispanRemoteConfigurationProperties extends org.eclipse.hono.de
         value.ifPresent(s -> {
             LOG.trace("setting connectTimeout: {}", s);
             super.setConnectTimeout(s);
+        });
+    }
+
+    /**
+     * @param value The value to set.
+     */
+    public void setTrustStorePath(final Optional<String> value) {
+        value.ifPresent(s -> {
+            LOG.trace("setting trustStorePath: {}", s);
+            super.setTrustStorePath(s);
+        });
+    }
+
+    /**
+     * @param value The value to set.
+     */
+    public void setTrustStoreFileName(final Optional<String> value) {
+        value.ifPresent(s -> {
+            LOG.trace("setting trustStoreFileName: {}", s);
+            super.setTrustStoreFileName(s);
+        });
+    }
+
+    /**
+     * @param value The value to set.
+     */
+    public void setTrustStoreType(final Optional<String> value) {
+        value.ifPresent(s -> {
+            LOG.trace("setting trustStoreType: {}", s);
+            super.setTrustStoreType(s);
+        });
+    }
+
+    /**
+     * @param value The value to set.
+     */
+    public void setKeyStoreFileName(final Optional<String> value) {
+        value.ifPresent(s -> {
+            LOG.trace("setting keyStoreFileName: {}", s);
+            super.setKeyStoreFileName(s);
+        });
+    }
+
+    /**
+     * @param value The value to set.
+     */
+    public void setKeyStoreType(final Optional<String> value) {
+        value.ifPresent(s -> {
+            LOG.trace("setting keyStoreType: {}", s);
+            super.setKeyStoreType(s);
+        });
+    }
+
+    /**
+     * @param value The value to set.
+     */
+    public void setKeyStorePassword(final Optional<String> value) {
+        value.ifPresent(s -> {
+            LOG.trace("setting keyStorePassword: *****");
+            super.setKeyStorePassword(s);
+        });
+    }
+
+    /**
+     * @param value The value to set.
+     */
+    public void setKeyAlias(final Optional<String> value) {
+        value.ifPresent(s -> {
+            LOG.trace("setting keyAlias: {}", s);
+            super.setKeyAlias(s);
+        });
+    }
+
+    /**
+     * @param value The value to set.
+     */
+    public void setKeyStoreCertificatePassword(final Optional<String> value) {
+        value.ifPresent(s -> {
+            LOG.trace("setting keyStoreCertificatePassword: *****");
+            super.setKeyStoreCertificatePassword(s);
         });
     }
 }

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -4,6 +4,14 @@ title = "What is new & noteworthy in Hono?"
 description = "Information about changes in recent Hono releases. Includes new features, fixes, enhancements and API changes."
 +++
 
+## 1.10.0
+
+### Fixes & Enhancements
+
+* The Quarkus based variants of Hono's components now support configuring the Hot Rod client with a key and/or
+  trust store in order to enable TLS secured connections to Infinispan servers and to authenticate using a
+  client certificate.
+
 ## 1.9.0
 
 ### New Features

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -84,15 +84,15 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
     <hono.command-router.config-src>clustered-cache</hono.command-router.config-src>
     <hono.command-router.disabled>false</hono.command-router.disabled>
     <hono.command-router.image>hono-service-command-router</hono.command-router.image>
-    <hono.command-router.max-mem>256000000</hono.command-router.max-mem>
+    <hono.command-router.max-mem>300000000</hono.command-router.max-mem>
 
     <hono.device-connection.disabled>true</hono.device-connection.disabled>
 
     <hono.infinispan.disabled>false</hono.infinispan.disabled>
     <hono.infinispan.host>hono-infinispan.hono</hono.infinispan.host>
     <hono.infinispan.port>11222</hono.infinispan.port>
-    <hono.infinispan.username>device-registry@HONO</hono.infinispan.username>
-    <hono.infinispan.password>device-registry-secret</hono.infinispan.password>
+    <hono.infinispan.username>hono</hono.infinispan.username>
+    <hono.infinispan.password>hono-secret</hono.infinispan.password>
 
     <!--
       Messaging related properties - AMQP is used as the default one.
@@ -366,7 +366,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       <properties>
         <hono.infinispan.disabled>true</hono.infinispan.disabled>
         <hono.command-router.config-src>embedded-cache</hono.command-router.config-src>
-        <hono.command-router.max-mem>314572800</hono.command-router.max-mem>
+        <hono.command-router.max-mem>350000000</hono.command-router.max-mem>
       </properties>
     </profile>
     <profile>
@@ -646,12 +646,11 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <arg>/opt/infinispan/bin/server.sh</arg>
                     </entrypoint>
                     <cmd>
-                      <arg>-b</arg>
-                      <arg>SITE_LOCAL</arg>
                       <arg>-c</arg>
                       <arg>hono-data-grid.xml</arg>
                       <arg>-Dquarkus.log.category."org.infinispan.CONFIG".level=INFO</arg>
                       <arg>-Dquarkus.log.category."org.infinispan.CONTAINER".level=INFO</arg>
+                      <arg>-Dquarkus.log.category."org.infinispan.SECURITY".level=INFO</arg>
                       <arg>-Dquarkus.log.category."org.infinispan.SERVER".level=INFO</arg>
                     </cmd>
                     <ports>
@@ -673,11 +672,7 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                     </log>
                     <wait>
                       <time>${service.startup.timeout}</time>
-                      <http>
-                        <method>GET</method>
-                        <url>http://${infinispan.ip}:${infinispan.port}/rest/v2/cache-managers/routing-info/health/status</url>
-                        <status>200..299</status>
-                      </http>
+                      <log>.*(Infinispan Server .* started).*</log>
                     </wait>
                   </run>
                 </image>

--- a/tests/src/test/resources/commandrouter/clustered-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/clustered-cache/application.yml
@@ -26,6 +26,8 @@ hono:
         saslMechanism: "SCRAM-SHA-512"
         socketTimeout: 5000
         connectTimeout: 5000
+        trustStorePath: "/etc/hono/certs/trusted-certs.pem"
+        useSsl: true
   registration:
     name: 'Hono Command Router'
     host: ${hono.registration.host}

--- a/tests/src/test/resources/infinispan/hono-data-grid.xml
+++ b/tests/src/test/resources/infinispan/hono-data-grid.xml
@@ -39,14 +39,14 @@
       <interface name="public">
         <non-loopback />
       </interface>
-      <interface name="admin">
+      <interface name="local">
         <loopback />
       </interface>
     </interfaces>
 
-    <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
-      <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
-      <socket-binding name="admin" port="9990" interface="admin"/>
+    <socket-bindings default-interface="local" port-offset="${infinispan.socket.binding.port-offset:0}">
+      <socket-binding name="external" port="${hono.infinispan.port}" interface="public"/>
+      <socket-binding name="admin" port="9990"/>
     </socket-bindings>
 
     <security>
@@ -81,16 +81,16 @@
       </security-realms>
     </security>
 
-    <endpoints socket-binding="default">
+    <endpoints socket-binding="external" security-realm="ApplicationRealm">
       <hotrod-connector name="hotrod">
-        <authentication security-realm="ApplicationRealm">
-          <sasl mechanisms="SCRAM-SHA-512 SCRAM-SHA-384 DIGEST-SHA-512 DIGEST-SHA-384 DIGEST-MD5"
+        <authentication>
+          <sasl mechanisms="SCRAM-SHA-512 SCRAM-SHA-384 DIGEST-SHA-512 DIGEST-SHA-384"
                 server-name="${hono.infinispan.host}"
-                qop="auth" />
+                qop="auth-conf" />
         </authentication>
       </hotrod-connector>
       <rest-connector name="rest">
-        <authentication security-realm="ApplicationRealm" mechanisms="DIGEST BASIC" />
+        <authentication mechanisms="DIGEST BASIC" />
       </rest-connector>
     </endpoints>
 


### PR DESCRIPTION
The Quarkus based variants of Hono's components now support configuring
the Hot Rod client with a key and/or trust store in order to enable TLS
connections and to authenticate using a client certificate.

Fixes #2789