### PR TITLE
Return proper error detail in tenants resource responses

### DIFF
--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/AbstractStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/AbstractStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import io.opentracing.log.Fields;
 import io.vertx.core.Future;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.healthchecks.Status;
@@ -131,7 +132,7 @@ public abstract class AbstractStore implements HealthCheckProvider, AutoCloseabl
 
                     // if we updated something ...
                     if (r.getUpdated() != 0) {
-                        // ... then we optimistic lock held
+                        // ... then the optimistic lock held
                         return Future.succeededFuture(r);
                     }
 
@@ -144,7 +145,7 @@ public abstract class AbstractStore implements HealthCheckProvider, AutoCloseabl
                             .flatMap(readResult -> {
 
                                 span.log(Map.of(
-                                        "event", "check read result",
+                                        Fields.EVENT, "check read result",
                                         "read_count", readResult.getNumRows()));
 
                                 // ... having read the current state, without the version ...

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
@@ -93,6 +93,21 @@ public final class DeviceRegistryUtils {
     }
 
     /**
+     * Maps an error.
+     *
+     * @param <T> The type of result.
+     * @param error The error to map.
+     * @param tenantId The tenant that the error occurred for.
+     * @return A future failed with the mapped error.
+     */
+    public static <T> Future<T> mapError(final Throwable error, final String tenantId) {
+        if (error instanceof IllegalArgumentException) {
+            return Future.failedFuture(new ClientErrorException(tenantId, HttpURLConnection.HTTP_BAD_REQUEST, error.getMessage()));
+        }
+        return Future.failedFuture(error);
+    }
+
+    /**
      * Converts tenant object of type {@link Tenant} to an object of type {@link TenantObject}.
      *
      * @param tenantId The identifier of the tenant.

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/TenantManagementService.java
@@ -50,7 +50,8 @@ public interface TenantManagementService {
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded with a result containing the created tenant's identifier if the tenant
-     *         has been created successfully. The result's <em>status</em> property will have a value as specified
+     *         has been created successfully. Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/createTenant">
@@ -70,7 +71,8 @@ public interface TenantManagementService {
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded with a result containing the retrieved tenant information if a tenant
-     *         with the given identifier exists. The result's <em>status</em> property will have a value as specified
+     *         with the given identifier exists. Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/getTenant">
@@ -99,8 +101,9 @@ public interface TenantManagementService {
      *             as the parent for additional spans created as part of this method's execution.
      * @return A future indicating the outcome of the operation.
      *         <p>
-     *         The future will be succeeded with a result containing the matching tenants. The result's <em>status</em>
-     *         property will have a value as specified in the Device Registry Management API.
+     *         The future will be succeeded with a result containing the matching tenants. Otherwise, the future will
+     *         be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code
+     *         as specified in the Device Registry Management API.
      * @throws NullPointerException if any of filters, sort options or tracing span are {@code null}.
      * @throws IllegalArgumentException if page size is &lt;= 0 or page offset is &lt; 0.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/searchTenants"> Device Registry
@@ -132,7 +135,9 @@ public interface TenantManagementService {
      *             as the parent for additional spans created as part of this method's execution.
      * @return A future indicating the outcome of the operation.
      *         <p>
-     *         The result's <em>status</em> property will have a value as specified
+     *         The future will be succeeded if a tenant matching the criteria exists and has been updated successfully.
+     *         Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/updateTenant">
@@ -157,7 +162,9 @@ public interface TenantManagementService {
      *             as the parent for additional spans created as part of this method's execution.
      * @return A future indicating the outcome of the operation.
      *         <p>
-     *         The result's <em>status</em> property will have a value as specified
+     *         The future will be succeeded if a tenant matching the criteria exists and has been deleted successfully.
+     *         Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/tenants/deleteTenant">

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantServiceTest.java
@@ -281,7 +281,7 @@ public class FileBasedTenantServiceTest implements AbstractTenantServiceTest {
                 return svc.saveToFile();
             })
             .compose(ok -> {
-                verify(fileSystem).writeFile(eq(FILE_NAME), buffer.capture(), any(Handler.class));
+                ctx.verify(() -> verify(fileSystem).writeFile(eq(FILE_NAME), buffer.capture(), any(Handler.class)));
                 // and clearing the tenant registry
                 svc.clear();
                 return assertTenantDoesNotExist(svc, Constants.DEFAULT_TENANT);
@@ -345,13 +345,13 @@ public class FileBasedTenantServiceTest implements AbstractTenantServiceTest {
                 "tenant",
                 Optional.empty(),
                 NoopSpan.INSTANCE)
-                .onComplete(ctx.succeeding(s -> {
-                    ctx.verify(() -> {
-                        // THEN the update fails
-                        assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
-                    });
-                    ctx.completeNow();
-                }));
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> {
+                    // THEN the update fails
+                    assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN);
+                });
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -372,12 +372,12 @@ public class FileBasedTenantServiceTest implements AbstractTenantServiceTest {
                 new Tenant(),
                 Optional.empty(),
                 NoopSpan.INSTANCE)
-                .onComplete(ctx.succeeding(s -> {
-                    ctx.verify(() -> {
-                        // THEN the update fails
-                        assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
-                    });
-                    ctx.completeNow();
-                }));
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> {
+                    // THEN the update fails
+                    assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN);
+                });
+                ctx.completeNow();
+            }));
     }
 }

--- a/services/device-registry-jdbc/src/test/resources/logback-test.xml
+++ b/services/device-registry-jdbc/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020 Contributors to the Eclipse Foundation
+    Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -29,8 +29,12 @@
 
   <logger name="org.eclipse.hono" level="INFO"/>
   <logger name="org.eclipse.hono.deviceregistry.jdbc" level="INFO"/>
+  <logger name="org.eclipse.hono.deviceregistry.jdbc.impl" level="INFO"/>
+  <logger name="org.eclipse.hono.deviceregistry.service.tenant" level="INFO"/>
+  <logger name="org.eclipse.hono.deviceregistry.util" level="INFO"/>
   <logger name="org.eclipse.hono.service.base.jdbc" level="INFO"/>
   <logger name="org.eclipse.hono.service.base.jdbc.store.device" level="INFO"/>
   <logger name="org.eclipse.hono.service.base.jdbc.store.model" level="INFO"/>
+  <logger name="org.eclipse.hono.service.base.jdbc.store.tenant" level="INFO"/>
 
 </configuration>

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDao.java
@@ -330,16 +330,17 @@ public abstract class MongoDbBasedDao {
                     .compose(foundResource -> {
                         if (!foundResource.getVersion().equals(versionFromRequest.get())) {
                             return Future.failedFuture(
-                                    new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
-                                            "Resource version mismatch"));
+                                    new ClientErrorException(
+                                            HttpURLConnection.HTTP_PRECON_FAILED,
+                                            "resource version mismatch"));
                         }
                         return Future.failedFuture(
-                                new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR,
-                                        String.format("Error modifying resource [%s].", resourceId)));
+                                new ServerErrorException(
+                                        HttpURLConnection.HTTP_INTERNAL_ERROR,
+                                        "error modifying resource"));
                     });
         } else {
-            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND,
-                    String.format("Resource [%s] not found.", resourceId)));
+            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND, "no such object"));
         }
     }
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedTenantDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedTenantDao.java
@@ -166,7 +166,8 @@ public final class MongoDbBasedTenantDao extends MongoDbBasedDao implements Tena
 
         return createTenantPromise.future()
                 .map(tenantObjectIdResult -> {
-                    LOG.debug("successfully created tenant [tenant-id: {}]", tenantConfig.getTenantId());
+                    LOG.debug("successfully created tenant [tenant-id: {}, version: {}]",
+                            tenantConfig.getTenantId(), tenantConfig.getVersion());
                     span.log("successfully created tenant");
                     return tenantConfig.getVersion();
                 })
@@ -214,7 +215,7 @@ public final class MongoDbBasedTenantDao extends MongoDbBasedDao implements Tena
         return findTenantPromise.future()
                 .map(tenantJsonResult -> {
                     if (tenantJsonResult == null) {
-                        throw new ClientErrorException(tenantId, HttpURLConnection.HTTP_NOT_FOUND, "tenant not found");
+                        throw new ClientErrorException(tenantId, HttpURLConnection.HTTP_NOT_FOUND, "no such tenant");
                     } else {
                         if (LOG.isTraceEnabled()) {
                             LOG.trace("tenant from collection:{}{}", System.lineSeparator(), tenantJsonResult.encodePrettily());
@@ -257,7 +258,9 @@ public final class MongoDbBasedTenantDao extends MongoDbBasedDao implements Tena
                 .map(tenantJsonResult -> {
                     if (tenantJsonResult == null) {
                         LOG.debug("could not find tenant [subject DN: {}]", dn);
-                        throw new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND);
+                        throw new ClientErrorException(
+                                HttpURLConnection.HTTP_NOT_FOUND,
+                                "no such tenant");
                     } else {
                         return TenantDto.forRead(tenantJsonResult.getString(Constants.JSON_FIELD_TENANT_ID),
                                 tenantJsonResult.getJsonObject(TenantDto.FIELD_TENANT).mapTo(Tenant.class),
@@ -358,14 +361,16 @@ public final class MongoDbBasedTenantDao extends MongoDbBasedDao implements Tena
         final Promise<JsonObject> deleteTenantPromise = Promise.promise();
         mongoClient.findOneAndDelete(collectionName, deleteTenantQuery, deleteTenantPromise);
         return deleteTenantPromise.future()
-                .compose(tenantDtoResult -> Optional.ofNullable(tenantDtoResult)
-                        .map(deleted -> {
-                            LOG.debug("successfully deleted tenant [tenant-id: {}]", tenantId);
-                            span.log("successfully deleted tenant");
-                            return Future.succeededFuture((Void) null);
-                        })
-                        .orElseGet(() -> MongoDbBasedDao.checkForVersionMismatchAndFail(tenantId,
-                                resourceVersion, getById(tenantId, span))))
+                .compose(deleteResult -> {
+                    if (deleteResult == null) {
+                        return MongoDbBasedDao.checkForVersionMismatchAndFail(tenantId,
+                                resourceVersion, getById(tenantId, span));
+                    } else {
+                        LOG.debug("successfully deleted tenant [tenant-id: {}]", tenantId);
+                        span.log("successfully deleted tenant");
+                        return Future.succeededFuture((Void) null);
+                    }
+                })
                 .onFailure(t -> TracingHelper.logError(span, "error deleting tenant", t))
                 .recover(this::mapError)
                 .onComplete(r -> span.finish());

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -81,6 +81,7 @@ import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.Pair;
 import org.eclipse.hono.util.RegistryManagementConstants;
+import org.eclipse.hono.util.RequestResponseApiConstants;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TimeUntilDisconnectNotification;
@@ -97,6 +98,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.kafka.admin.KafkaAdminClient;
@@ -1486,6 +1488,18 @@ public final class IntegrationTestSupport {
                     .that(autoProvisioned == null || !autoProvisioned)
                     .isTrue();
         }
+    }
+
+    /**
+     * Verifies that a response body contains a JSON object with a non-null <em>error</em> property.
+     *
+     * @param response The response to check.
+     * @throws AssertionError if any of the checks fails.
+     */
+    public static void assertErrorPayload(final HttpResponse<Buffer> response) {
+        assertThat(response).isNotNull();
+        final JsonObject payload = response.bodyAsJsonObject();
+        assertThat(payload.getString(RequestResponseApiConstants.FIELD_ERROR)).isNotNull();
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
@@ -142,7 +142,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
         payload.setExtensions(Map.of("data", new String(data)));
 
         getHelper().registry.addTenant(tenantId, payload, HttpURLConnection.HTTP_ENTITY_TOO_LARGE)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -160,7 +163,11 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
             .compose(ar -> {
                 // now try to add the tenant again
                 return getHelper().registry.addTenant(tenantId, payload, HttpURLConnection.HTTP_CONFLICT);
-            }).onComplete(context.completing());
+            })
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -177,7 +184,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
                 buildTenantPayload(),
                 "application/x-www-form-urlencoded",
                 HttpURLConnection.HTTP_BAD_REQUEST)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -239,7 +249,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
     public void testAddTenantFailsForInvalidTenantId(final VertxTestContext context) {
 
         getHelper().registry.addTenant("invalid tenantid$", null, HttpURLConnection.HTTP_BAD_REQUEST)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -258,7 +271,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
                 requestBody,
                 "application/json",
                 HttpURLConnection.HTTP_BAD_REQUEST)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -284,7 +300,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
                 tenant,
                 "application/json",
                 HttpURLConnection.HTTP_BAD_REQUEST)
-                .onComplete(context.completing());
+                .onComplete(context.succeeding(response -> {
+                    context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                    context.completeNow();
+                }));
     }
 
     /**
@@ -306,7 +325,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
                 requestBody,
                 "application/json",
                 HttpURLConnection.HTTP_BAD_REQUEST)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -326,7 +348,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
                 requestBody,
                 "application/json",
                 HttpURLConnection.HTTP_BAD_REQUEST)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -411,7 +436,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
         final Tenant altered = buildTenantPayload();
 
         getHelper().registry.updateTenant("non-existing-tenant", altered, HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -435,7 +463,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
         getHelper().registry.addTenant(tenantId, new Tenant())
                 .compose(ok -> getHelper().registry.updateTenant(tenantId, tenantForUpdate,
                         HttpURLConnection.HTTP_BAD_REQUEST))
-                .onComplete(context.completing());
+                .onComplete(context.succeeding(response -> {
+                    context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                    context.completeNow();
+                }));
     }
 
     /**
@@ -456,7 +487,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
 
                 return getHelper().registry.updateTenant(tenantId, payload, HttpURLConnection.HTTP_ENTITY_TOO_LARGE);
             })
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -482,7 +516,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
     public void testRemoveTenantFailsForNonExistingTenant(final VertxTestContext context) {
 
         getHelper().registry.removeTenant("non-existing-tenant", HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -526,7 +563,10 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
     public void testGetTenantFailsForNonExistingTenant(final VertxTestContext context) {
 
         getHelper().registry.getTenant("non-existing-tenant", HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**


### PR DESCRIPTION
This is the first PR in a series to fix #2471

The registry implementations have been changed to return a JSON object
with an "error" property in response bodies for failed requests to the
"tenants" resources.
