### PR TITLE
Improve error tracing in MongoDB classes

### DIFF
--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedCredentialsDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedCredentialsDao.java
@@ -182,12 +182,12 @@ public final class MongoDbBasedCredentialsDao extends MongoDbBasedDao implements
                             credentials.getTenantId(), credentials.getDeviceId(), credentials.getVersion());
                     return credentials.getVersion();
                 })
-                .recover(this::mapError)
                 .onFailure(t -> {
                     LOG.debug("error adding credentials for device [tenant: {}, device-id: {}]",
                             credentials.getTenantId(), credentials.getDeviceId(), t);
                     TracingHelper.logError(span, "error adding credentials", t);
                 })
+                .recover(this::mapError)
                 .onComplete(r -> span.finish());
     }
 
@@ -210,11 +210,11 @@ public final class MongoDbBasedCredentialsDao extends MongoDbBasedDao implements
                 .start();
 
         return getByDeviceId(tenantId, deviceId)
-                .recover(this::mapError)
                 .onFailure(t -> {
                     LOG.debug("error retrieving credentials by device ID", t);
                     TracingHelper.logError(span, "error retrieving credentials by device ID", t);
                 })
+                .recover(this::mapError)
                 .onComplete(r -> span.finish());
     }
 
@@ -310,11 +310,11 @@ public final class MongoDbBasedCredentialsDao extends MongoDbBasedDao implements
                         return dto;
                     }
                 })
-                .recover(this::mapError)
                 .onFailure(t -> {
                     LOG.debug("error retrieving credentials by auth-id and type", t);
                     TracingHelper.logError(span, "error retrieving credentials by auth-id and type", t);
                 })
+                .recover(this::mapError)
                 .onComplete(r -> span.finish());
     }
 
@@ -389,11 +389,11 @@ public final class MongoDbBasedCredentialsDao extends MongoDbBasedDao implements
                         return Future.failedFuture(error);
                     }
                 })
-                .recover(this::mapError)
                 .onFailure(error -> {
                     LOG.debug("error updating credentials", error);
                     TracingHelper.logError(span, "error updating credentials", error);
                 })
+                .recover(this::mapError)
                 .onComplete(r -> span.finish());
     }
 
@@ -441,11 +441,11 @@ public final class MongoDbBasedCredentialsDao extends MongoDbBasedDao implements
                         return Future.succeededFuture((Void) null);
                     }
                 })
-                .recover(this::mapError)
                 .onFailure(error -> {
                     LOG.debug("error deleting credentials", error);
                     TracingHelper.logError(span, "error deleting credentials", error);
                 })
+                .recover(this::mapError)
                 .onComplete(r -> span.finish());
     }
 }


### PR DESCRIPTION
A MongoDB error will now be traced before mapping it to a ServerErrorException, so that the 'error.object' in the trace contains more info than just "org.eclipse.hono.client.ServerErrorException: Error Code: 500".