### PR TITLE
Use index when finding credentials by type and auth-id

### DIFF
--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -13,6 +13,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   client certificate.
 * The MongoDB based DeviceManagementService erroneously removed the original device registration when trying to
   register a new device using the existing device's identifier. This has been fixed.
+* The Mongo DB based registry implementation now uses a proper DB index to find credentials by type and authentication
+  ID. This will speed up query execution significantly when there are a lot of devices registered for a tenant.
 
 ## 1.9.0
 


### PR DESCRIPTION
The MongoDB based Credentials service implementation does not use the
existing index for finding credentials by tenant, auth-id and type.
Instead, all documents of the tenant are scanned one by one for matching
auth-id and type.

The credentials DAO has been changed to create another compund index on
the credentials array documents' auth-id and type fields which is then
used by Mongo DB to determine the (small) set of documents matching the
auth-id and type before comparing with the required tenant ID.

Fixes #2792