### PR TITLE
Return proper error detail in devices resource responses

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
@@ -51,7 +51,8 @@ public interface DeviceManagementService {
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded with a result containing the created device's identifier if the device
-     *         has been created successfully. The result's <em>status</em> property will have a value as specified
+     *         has been created successfully. Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/createDeviceRegistration">
@@ -60,7 +61,7 @@ public interface DeviceManagementService {
     Future<OperationResult<Id>> createDevice(String tenantId, Optional<String> deviceId, Device device, Span span);
 
     /**
-     * Gets device registration data by device ID.
+     * Gets device registration data for a device identifier.
      *
      * @param tenantId The tenant that the device belongs to.
      * @param deviceId The identifier of the device to get registration data for.
@@ -72,7 +73,8 @@ public interface DeviceManagementService {
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded with a result containing the retrieved device information if a device
-     *         with the given identifier exists. The result's <em>status</em> property will have a value as specified
+     *         with the given identifier exists. Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/getRegistration">
@@ -102,8 +104,9 @@ public interface DeviceManagementService {
      *             as the parent for additional spans created as part of this method's execution.
      * @return A future indicating the outcome of the operation.
      *         <p>
-     *         The future will be succeeded with a result containing the matching devices. The result's <em>status</em>
-     *         property will have a value as specified in the Device Registry Management API.
+     *         The future will be succeeded with a result containing the matching devices. Otherwise, the future will
+     *         be failed with a {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code
+     *         as specified in the Device Registry Management API.
      * @throws NullPointerException if any of filters, sort options or tracing span are {@code null}.
      * @throws IllegalArgumentException if page size is &lt;= 0 or page offset is &lt; 0.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/searchDevicesForTenant"> Device Registry
@@ -139,7 +142,8 @@ public interface DeviceManagementService {
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded with a result containing the updated device's identifier if the device
-     *         has been updated successfully. The result's <em>status</em> property will have a value as specified
+     *         has been updated successfully. Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/updateRegistration">
@@ -166,7 +170,9 @@ public interface DeviceManagementService {
      *             as the parent for additional spans created as part of this method's execution.
      * @return A future indicating the outcome of the operation.
      *         <p>
-     *         The result's <em>status</em> property will have a value as specified
+     *         The future will be succeeded if a device matching the criteria exists and has been deleted successfully.
+     *         Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/deleteRegistration">

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/util/Assertions.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/util/Assertions.java
@@ -25,7 +25,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 public final class Assertions {
 
     private Assertions() {
-        // TODO prevent instantiation
+        // prevent instantiation
     }
 
     /**

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/util/Assertions.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/util/Assertions.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceregistry.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.eclipse.hono.client.ServiceInvocationException;
+
+/**
+ * A collection of assertions usefult for testing device registry implementations.
+ *
+ */
+public final class Assertions {
+
+    private Assertions() {
+        // TODO prevent instantiation
+    }
+
+    /**
+     * Asserts that an error is a {@link ServiceInvocationException} with a status code.
+     *
+     * @param error The error to assert.
+     * @param expectedStatusCode The expected status code.
+     * @throws AssertionError if any of the assertions fail.
+     */
+    public static void assertServiceInvocationException(
+            final Throwable error,
+            final int expectedStatusCode) {
+        assertThat(error).isInstanceOf(ServiceInvocationException.class);
+        assertThat(((ServiceInvocationException) error).getErrorCode()).isEqualTo(expectedStatusCode);
+    }
+
+}

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
@@ -343,6 +343,7 @@ public interface AbstractRegistrationServiceTest {
         final String deviceId = randomDeviceId();
 
         createDevice(deviceId, new Device())
+            .onFailure(ctx::failNow)
             .compose(ok -> getDeviceManagementService().createDevice(
                     TENANT,
                     Optional.of(deviceId),

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
@@ -19,10 +19,13 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.deviceregistry.util.Assertions;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
@@ -340,26 +343,23 @@ public interface AbstractRegistrationServiceTest {
         final String deviceId = randomDeviceId();
 
         createDevice(deviceId, new Device())
-            .onComplete(ctx.succeeding(ok -> {}))
             .compose(ok -> getDeviceManagementService().createDevice(
                     TENANT,
                     Optional.of(deviceId),
                     new Device(),
                     NoopSpan.INSTANCE))
-            .onComplete(ctx.succeeding(response -> {
+            .onComplete(ctx.failing(t -> {
                 ctx.verify(() -> {
                     // THEN the request fails with a conflict
-                    assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_CONFLICT);
+                    ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT));
                 });
             }))
             // but the original device still exists
-            .compose(ok -> getDeviceManagementService().readDevice(TENANT, deviceId, NoopSpan.INSTANCE))
-            .onComplete(ctx.succeeding(response -> {
-                ctx.verify(() -> {
-                    assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_OK);
-                });
-                ctx.completeNow();
-            }));
+            .onFailure(t -> getDeviceManagementService().readDevice(TENANT, deviceId, NoopSpan.INSTANCE)
+                    .onComplete(ctx.succeeding(response -> {
+                        ctx.verify(() -> assertThat(response.getPayload()).isNotNull());
+                        ctx.completeNow();
+                    })));
     }
 
     /**
@@ -413,10 +413,10 @@ public interface AbstractRegistrationServiceTest {
     default void testReadDeviceFailsForNonExistingDevice(final VertxTestContext ctx) {
 
         getDeviceManagementService().readDevice(TENANT, "non-existing-device-id", NoopSpan.INSTANCE)
-            .onComplete(ctx.succeeding(response -> ctx.verify(() -> {
-                assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_NOT_FOUND));
                 ctx.completeNow();
-            })));
+            }));
     }
 
     /**
@@ -494,18 +494,22 @@ public interface AbstractRegistrationServiceTest {
     default void testReadDeviceFailsForDeletedDevice(final VertxTestContext ctx) {
 
         final String deviceId = randomDeviceId();
-        final Checkpoint get = ctx.checkpoint(2);
 
         createDevice(deviceId, new Device())
-            .compose(response -> getDeviceManagementService()
-                        .deleteDevice(TENANT, deviceId, Optional.empty(), NoopSpan.INSTANCE))
+            .onComplete(ctx.succeeding())
+            .compose(response -> getDeviceManagementService().deleteDevice(
+                    TENANT,
+                    deviceId,
+                    Optional.empty(),
+                    NoopSpan.INSTANCE))
+            .onComplete(ctx.succeeding())
             .compose(response -> {
                 ctx.verify(() -> assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT));
-                get.flag();
                 return getDeviceManagementService().readDevice(TENANT, deviceId, NoopSpan.INSTANCE);
-            }).onComplete(ctx.succeeding(response -> {
-                ctx.verify(() -> assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND));
-                get.flag();
+            })
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_NOT_FOUND));
+                ctx.completeNow();
             }));
     }
 
@@ -521,8 +525,8 @@ public interface AbstractRegistrationServiceTest {
 
         getDeviceManagementService()
                 .deleteDevice(TENANT, "non-existing-device", Optional.empty(), NoopSpan.INSTANCE)
-                .onComplete(ctx.succeeding(response -> {
-                    ctx.verify(() -> assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND));
+                .onComplete(ctx.failing(t -> {
+                    ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_NOT_FOUND));
                     ctx.completeNow();
                 }));
     }
@@ -537,23 +541,22 @@ public interface AbstractRegistrationServiceTest {
     default void testDeleteDeviceFailsForNonMatchingResourceVersion(final VertxTestContext ctx) {
 
         final String deviceId = randomDeviceId();
-        final Checkpoint register = ctx.checkpoint(2);
 
         getDeviceManagementService().createDevice(TENANT, Optional.of(deviceId), new Device(), NoopSpan.INSTANCE)
-                .map(response -> {
-                    ctx.verify(() -> assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_CREATED));
-                    register.flag();
-                    return response;
-                }).compose(rr -> {
-                    final String resourceVersion = rr.getResourceVersion().orElse(null);
-                    return getDeviceManagementService().deleteDevice(
-                            TENANT, deviceId, Optional.of("not-" + resourceVersion), NoopSpan.INSTANCE);
-                }).onComplete(ctx.succeeding(response -> {
-                    ctx.verify(() -> {
-                        assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
-                    });
-                    register.flag();
-                }));
+            .onComplete(ctx.succeeding())
+            .compose(response -> {
+                ctx.verify(() -> assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_CREATED));
+                final String resourceVersion = response.getResourceVersion().orElse(null);
+                return getDeviceManagementService().deleteDevice(
+                        TENANT,
+                        deviceId,
+                        Optional.of("not-" + resourceVersion),
+                        NoopSpan.INSTANCE);
+            })
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_PRECON_FAILED));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -634,10 +637,9 @@ public interface AbstractRegistrationServiceTest {
                             new Device().putExtension("customKey", "customValue"),
                             Optional.of("not- " + resourceVersion),
                             NoopSpan.INSTANCE);
-                }).onComplete(ctx.succeeding(response -> {
-                    ctx.verify(() -> {
-                        assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
-                    });
+                })
+                .onComplete(ctx.failing(t -> {
+                    ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_PRECON_FAILED));
                     ctx.completeNow();
                 }));
     }
@@ -792,7 +794,10 @@ public interface AbstractRegistrationServiceTest {
      * @return A new future that will succeed when the read/get operations succeed and the assertions are valid.
      *         Otherwise the future must fail.
      */
-    default Future<?> assertDevice(final String tenant, final String deviceId, final Optional<String> gatewayId,
+    default Future<?> assertDevice(
+            final String tenant,
+            final String deviceId,
+            final Optional<String> gatewayId,
             final Handler<OperationResult<Device>> managementAssertions,
             final Handler<RegistrationResult> adapterAssertions) {
 
@@ -807,10 +812,11 @@ public interface AbstractRegistrationServiceTest {
                 .map(id -> getRegistrationService().assertRegistration(tenant, deviceId, id))
                 .orElseGet(() -> getRegistrationService().assertRegistration(tenant, deviceId));
         return CompositeFuture.all(
-                f1.map(r -> {
-                    managementAssertions.handle(r);
-                    return null;
-                }),
+                f1.otherwise(t -> OperationResult.empty(ServiceInvocationException.extractStatusCode(t)))
+                    .map(r -> {
+                        managementAssertions.handle(r);
+                        return null;
+                    }),
                 f2.map(r -> {
                     adapterAssertions.handle(r);
                     return null;
@@ -818,17 +824,17 @@ public interface AbstractRegistrationServiceTest {
     }
 
     /**
-     * Assert devices, expecting them to be "not found".
+     * Verifies that none of a set of devices exist in tenant {@value #TENANT}.
      *
-     * @param devices The map of devices to assert.
-     * @return A future, reporting the assertion status.
+     * @param devices The device identifiers to check.
+     * @return A succeeded future if none of the devices exist.
      */
-    default Future<?> assertDevicesNotFound(final Map<String, Device> devices) {
+    default Future<?> assertDevicesNotFound(final Set<String> devices) {
 
         Future<?> current = Future.succeededFuture();
 
-        for (final Map.Entry<String, Device> entry : devices.entrySet()) {
-            current = current.compose(ok -> assertDevice(TENANT, entry.getKey(), Optional.empty(),
+        for (final String deviceId : devices) {
+            current = current.compose(ok -> assertDevice(TENANT, deviceId, Optional.empty(),
                     r -> {
                         assertThat(r.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
                     },

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/tenant/AbstractTenantServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/tenant/AbstractTenantServiceTest.java
@@ -28,6 +28,7 @@ import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.StatusCodeMapper;
+import org.eclipse.hono.deviceregistry.util.Assertions;
 import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
 import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
@@ -84,7 +85,7 @@ public interface AbstractTenantServiceTest {
                         buildTenantPayload(),
                         NoopSpan.INSTANCE))
                 .onComplete(ctx.failing(t -> {
-                    ctx.verify(() -> assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT));
+                    ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT));
                     ctx.completeNow();
                 }));
     }
@@ -112,7 +113,7 @@ public interface AbstractTenantServiceTest {
                     tenant,
                     NoopSpan.INSTANCE))
             .onComplete(ctx.failing(t -> {
-                ctx.verify(() -> assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT));
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT));
                 ctx.completeNow();
             }));
     }
@@ -227,7 +228,7 @@ public interface AbstractTenantServiceTest {
                         NoopSpan.INSTANCE);
             })
             .onComplete(ctx.failing(t -> {
-                ctx.verify(() -> assertServiceInvocationException(t, HttpURLConnection.HTTP_PRECON_FAILED));
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_PRECON_FAILED));
                 ctx.completeNow();
             }));
     }
@@ -250,7 +251,7 @@ public interface AbstractTenantServiceTest {
                         NoopSpan.INSTANCE);
             })
             .onComplete(ctx.failing(t -> {
-                ctx.verify(() -> assertServiceInvocationException(t, HttpURLConnection.HTTP_PRECON_FAILED));
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_PRECON_FAILED));
                 ctx.completeNow();
             }));
     }
@@ -488,7 +489,7 @@ public interface AbstractTenantServiceTest {
             .onComplete(ctx.succeeding())
             .compose(ok -> getTenantManagementService().readTenant("tenant", NoopSpan.INSTANCE))
             .onComplete(ctx.failing(t -> {
-                ctx.verify(() -> assertServiceInvocationException(t, HttpURLConnection.HTTP_NOT_FOUND));
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_NOT_FOUND));
                 ctx.completeNow();
             }));
     }
@@ -556,7 +557,7 @@ public interface AbstractTenantServiceTest {
             .onComplete(ctx.failing(t -> {
                 ctx.verify(() -> {
                     // THEN the update fails with a 409
-                    assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT);
+                    Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT);
                 });
                 ctx.completeNow();
             }));
@@ -596,20 +597,6 @@ public interface AbstractTenantServiceTest {
                         return Future.failedFuture(t);
                     }
                 });
-    }
-
-    /**
-     * Asserts that an error is a {@link ServiceInvocationException} with a status code.
-     *
-     * @param error The error to assert.
-     * @param expectedStatusCode The expected status code.
-     * @throws AssertionError if any of the assertions fail.
-     */
-    default void assertServiceInvocationException(
-            final Throwable error,
-            final int expectedStatusCode) {
-        assertThat(error).isInstanceOf(ServiceInvocationException.class);
-        assertThat(((ServiceInvocationException) error).getErrorCode()).isEqualTo(expectedStatusCode);
     }
 
     /**

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
@@ -287,7 +287,8 @@ public class FileBasedDeviceBackend implements DeviceBackend, RegistrationServic
                                     } else {
                                         return r;
                                     }
-                                });
+                                })
+                                .otherwise(t -> OperationResult.empty(ServiceInvocationException.extractStatusCode(t)));
                     } else {
                         return Future.succeededFuture(r);
                     }

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationServiceTest.java
@@ -443,7 +443,7 @@ public class FileBasedRegistrationServiceTest implements AbstractRegistrationSer
                 registrationService.readDevice(TENANT, "newDevice", NoopSpan.INSTANCE)
                     .onComplete(ctx.failing(error -> {
                         // and the device has not been added to the registry
-                        ctx.verify(() -> org.eclipse.hono.deviceregistry.util.Assertions.assertServiceInvocationException(
+                        ctx.verify(() -> Assertions.assertServiceInvocationException(
                                 error, HttpURLConnection.HTTP_NOT_FOUND));
                         ctx.completeNow();
                     }));

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedTenantServiceTest.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.deviceregistry.DeviceRegistryTestUtils;
+import org.eclipse.hono.deviceregistry.util.Assertions;
 import org.eclipse.hono.service.management.tenant.Tenant;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
 import org.eclipse.hono.service.management.tenant.TrustedCertificateAuthority;
@@ -348,7 +349,7 @@ public class FileBasedTenantServiceTest implements AbstractTenantServiceTest {
             .onComplete(ctx.failing(t -> {
                 ctx.verify(() -> {
                     // THEN the update fails
-                    assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN);
+                    Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN);
                 });
                 ctx.completeNow();
             }));
@@ -375,7 +376,7 @@ public class FileBasedTenantServiceTest implements AbstractTenantServiceTest {
             .onComplete(ctx.failing(t -> {
                 ctx.verify(() -> {
                     // THEN the update fails
-                    assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN);
+                    Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN);
                 });
                 ctx.completeNow();
             }));

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/DeviceManagementServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/DeviceManagementServiceImpl.java
@@ -17,6 +17,7 @@ import java.net.HttpURLConnection;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.deviceregistry.jdbc.config.DeviceServiceProperties;
 import org.eclipse.hono.deviceregistry.service.device.AbstractDeviceManagementService;
 import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
@@ -77,7 +78,10 @@ public class DeviceManagementServiceImpl extends AbstractDeviceManagementService
                                 result.getDevice(),
                                 this.ttl,
                                 result.getResourceVersion()))
-                        .orElseGet(() -> OperationResult.empty(HttpURLConnection.HTTP_NOT_FOUND)));
+                        .orElseThrow(() -> new ClientErrorException(
+                                key.getTenantId(),
+                                HttpURLConnection.HTTP_NOT_FOUND,
+                                "no such device")));
 
     }
 
@@ -103,7 +107,10 @@ public class DeviceManagementServiceImpl extends AbstractDeviceManagementService
                 .deleteDevice(key, resourceVersion, span.context())
                 .map(r -> {
                     if (r.getUpdated() <= 0) {
-                        return Result.<Void>from(HttpURLConnection.HTTP_NOT_FOUND);
+                        throw new ClientErrorException(
+                                key.getTenantId(),
+                                HttpURLConnection.HTTP_NOT_FOUND,
+                                "no such device");
                     } else {
                         return Result.<Void>from(HttpURLConnection.HTTP_NO_CONTENT);
                     }

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/RegistryServiceTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/RegistryServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,6 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
+import org.eclipse.hono.deviceregistry.util.Assertions;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.PskCredential;
 import org.eclipse.hono.service.management.credentials.PskSecret;
@@ -91,36 +92,36 @@ class RegistryServiceTest extends AbstractJdbcRegistryTest {
                 .flatMap(x -> {
                     final var device = new Device();
                     return this.registrationManagement
-                            .createDevice(DEFAULT_TENANT, Optional.of("d1"), device, SPAN)
-                            .onComplete(context.succeeding(result -> {
-
-                                context.verify(() -> {
-
-                                    assertThat(result.getStatus())
-                                            .isEqualTo(HttpURLConnection.HTTP_CREATED);
-
-                                });
-
-                            }));
+                            .createDevice(DEFAULT_TENANT, Optional.of("d1"), device, SPAN);
                 })
+
+                .onComplete(context.succeeding(result -> {
+
+                    context.verify(() -> {
+
+                        assertThat(result.getStatus())
+                                .isEqualTo(HttpURLConnection.HTTP_CREATED);
+
+                    });
+
+                }))
 
                 .flatMap(x -> {
                     final var device = new Device();
                     return this.registrationManagement
-                            .createDevice(DEFAULT_TENANT, Optional.of("d1"), device, SPAN)
-                            .onComplete(context.succeeding(result -> {
-
-                                context.verify(() -> {
-
-                                    assertThat(result.getStatus())
-                                            .isEqualTo(HttpURLConnection.HTTP_CONFLICT);
-
-                                });
-
-                            }));
+                            .createDevice(DEFAULT_TENANT, Optional.of("d1"), device, SPAN);
                 })
 
-                .onComplete(context.succeeding(x -> context.completeNow()));
+                .onComplete(context.failing(t -> {
+
+                    context.verify(() -> {
+
+                        Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT);
+
+                    });
+
+                    context.completeNow();
+                }));
 
     }
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDeviceDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/MongoDbBasedDeviceDao.java
@@ -417,6 +417,9 @@ public final class MongoDbBasedDeviceDao extends MongoDbBasedDao implements Devi
                 .start();
         resourceVersion.ifPresent(v -> TracingHelper.TAG_RESOURCE_VERSION.set(span, v));
 
+        LOG.trace("deleting device [tenant-id: {}, device-id: {}, version: {}]",
+                tenantId, deviceId, resourceVersion.orElse(null));
+
         final JsonObject deleteDeviceQuery = MongoDbDocumentBuilder.builder()
                 .withVersion(resourceVersion)
                 .withTenantId(tenantId)

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
@@ -16,7 +16,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.Optional;
@@ -31,6 +30,7 @@ import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigPrope
 import org.eclipse.hono.deviceregistry.service.device.EdgeDeviceAutoProvisioner;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
+import org.eclipse.hono.deviceregistry.util.Assertions;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.device.Device;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
@@ -183,10 +183,8 @@ public class MongoDbBasedRegistrationServiceTest implements AbstractRegistration
         getDeviceManagementService().createDevice(TENANT, Optional.empty(), new Device(), NoopSpan.INSTANCE)
             .onComplete(ok -> ctx.succeeding())
             .compose(ok -> getDeviceManagementService().createDevice(TENANT, Optional.empty(), new Device(), NoopSpan.INSTANCE))
-            .onComplete(ctx.succeeding(response -> {
-                ctx.verify(() -> {
-                    assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
-                });
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN));
                 ctx.completeNow();
             }));
     }
@@ -206,10 +204,8 @@ public class MongoDbBasedRegistrationServiceTest implements AbstractRegistration
         getDeviceManagementService().createDevice(TENANT, Optional.empty(), new Device(), NoopSpan.INSTANCE)
             .onComplete(ok -> ctx.succeeding())
             .compose(ok -> getDeviceManagementService().createDevice(TENANT, Optional.empty(), new Device(), NoopSpan.INSTANCE))
-            .onComplete(ctx.succeeding(response -> {
-                ctx.verify(() -> {
-                    assertThat(response.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
-                });
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN));
                 ctx.completeNow();
             }));
     }

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
@@ -33,6 +33,7 @@ import org.eclipse.hono.service.management.device.DeviceStatus;
 import org.eclipse.hono.service.management.device.DeviceWithId;
 import org.eclipse.hono.tests.CrudHttpClient;
 import org.eclipse.hono.tests.DeviceRegistryHttpClient;
+import org.eclipse.hono.tests.IntegrationTestSupport;
 import org.eclipse.hono.util.RegistrationConstants;
 import org.eclipse.hono.util.RegistryManagementConstants;
 import org.junit.jupiter.api.BeforeEach;
@@ -141,7 +142,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
                     device,
                     CrudHttpClient.CONTENT_TYPE_JSON,
                     HttpURLConnection.HTTP_NOT_FOUND))
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -159,7 +163,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
             // now try to add the device again
             return registry.registerDevice(tenantId, deviceId, device, HttpURLConnection.HTTP_CONFLICT);
         })
-        .onComplete(ctx.completing());
+        .onComplete(ctx.succeeding(response -> {
+            ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+            ctx.completeNow();
+        }));
     }
 
     /**
@@ -177,7 +184,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
                 .registerDevice(
                         tenantId, deviceId, device, null,
                         HttpURLConnection.HTTP_BAD_REQUEST)
-                .onComplete(ctx.completing());
+                .onComplete(ctx.succeeding(response -> {
+                    ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                    ctx.completeNow();
+                }));
     }
 
     /**
@@ -198,7 +208,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
                 requestBody,
                 "application/json",
                 HttpURLConnection.HTTP_BAD_REQUEST)
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -210,7 +223,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
     public void testAddDeviceFailsForInvalidDeviceId(final VertxTestContext ctx) {
 
         registry.registerDevice(tenantId, "device ID With spaces and $pecial chars!", null, HttpURLConnection.HTTP_BAD_REQUEST)
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -222,17 +238,20 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
     public void testAddDeviceFailsForInvalidTenantId(final VertxTestContext ctx) {
 
         registry.registerDevice("tenant ID With spaces and $pecial chars!", deviceId, null, HttpURLConnection.HTTP_BAD_REQUEST)
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
      * Verifies that a request to register a device with a body that exceeds the registry's max payload limit
      * fails with a {@link HttpURLConnection#HTTP_ENTITY_TOO_LARGE} status code.
      *
-     * @param context The vert.x test context.
+     * @param ctx The vert.x test context.
      */
     @Test
-    public void testAddDeviceFailsForRequestPayloadExceedingLimit(final VertxTestContext context)  {
+    public void testAddDeviceFailsForRequestPayloadExceedingLimit(final VertxTestContext ctx)  {
 
         final Device device = new Device();
         final var data = new char[3000];
@@ -240,7 +259,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
         device.setExtensions(Map.of("data", new String(data)));
 
         registry.registerDevice(tenantId, deviceId, device, HttpURLConnection.HTTP_ENTITY_TOO_LARGE)
-            .onComplete(context.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -301,7 +323,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
     public void testGetDeviceFailsForNonExistingTenant(final VertxTestContext ctx) {
 
         registry.getRegistrationInfo("non-existing-tenant", deviceId, HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -314,7 +339,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
     public void testGetDeviceFailsForNonExistingDevice(final VertxTestContext ctx) {
 
         registry.getRegistrationInfo(tenantId, "non-existing-device", HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -406,7 +434,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
                 new JsonObject().put("ext", new JsonObject().put("test", "test")),
                 CrudHttpClient.CONTENT_TYPE_JSON,
                 HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -423,7 +454,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
                 new JsonObject().put("ext", new JsonObject().put("test", "test")),
                 CrudHttpClient.CONTENT_TYPE_JSON,
                 HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -441,10 +475,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
     /**
      * Verifies that an update request fails if it contains no content type.
      *
-     * @param context The vert.x test context.
+     * @param ctx The vert.x test context.
      */
     @Test
-    public void testUpdateDeviceFailsForMissingContentType(final VertxTestContext context) {
+    public void testUpdateDeviceFailsForMissingContentType(final VertxTestContext ctx) {
 
         registry.registerDevice(tenantId, deviceId, new Device())
             .compose(ok -> {
@@ -454,17 +488,21 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
                                 .put("test", "testUpdateDeviceFailsForMissingContentType")
                                 .put("newKey1", "newValue1"));
                 return registry.updateDevice(tenantId, deviceId, requestBody, null, HttpURLConnection.HTTP_BAD_REQUEST);
-            }).onComplete(context.completing());
+            })
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
      * Verifies that a request to update a device with a body that exceeds the registry's max payload limit
      * fails with a {@link HttpURLConnection#HTTP_ENTITY_TOO_LARGE} status code.
      *
-     * @param context The vert.x test context.
+     * @param ctx The vert.x test context.
      */
     @Test
-    public void testUpdateDeviceFailsForRequestPayloadExceedingLimit(final VertxTestContext context)  {
+    public void testUpdateDeviceFailsForRequestPayloadExceedingLimit(final VertxTestContext ctx)  {
 
         registry.registerDevice(tenantId, deviceId, new Device())
             .compose(ok -> {
@@ -480,7 +518,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
                         "application/json",
                         HttpURLConnection.HTTP_ENTITY_TOO_LARGE);
             })
-            .onComplete(context.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
 
@@ -521,7 +562,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
     public void testDeregisterDeviceFailsForNonExistingTenant(final VertxTestContext ctx) {
 
         registry.deregisterDevice("non-existing-tenant", deviceId, HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -533,7 +577,10 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
     public void testDeregisterDeviceFailsForNonExistingDevice(final VertxTestContext ctx) {
 
         registry.deregisterDevice(tenantId, "non-existing-device", HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(ctx.completing());
+            .onComplete(ctx.succeeding(response -> {
+                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                ctx.completeNow();
+            }));
     }
 
     /**


### PR DESCRIPTION
This is step 2 in a series of PR to fix #2471 

The registry implementations have been changed to return a JSON object
with an "error" property in response bodies for failed requests to the
"devices" resources.