### PR TITLE
Return proper error detail in credentials resource responses

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/util/DeviceRegistryUtils.java
@@ -32,8 +32,6 @@ import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.ServiceInvocationException;
-import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.PasswordCredential;
 import org.eclipse.hono.service.management.credentials.PasswordSecret;
@@ -62,34 +60,6 @@ public final class DeviceRegistryUtils {
 
     private DeviceRegistryUtils() {
         // prevent instantiation
-    }
-
-    /**
-     * Maps an error to an empty operation result containing an HTTP status code
-     * that matches the given error.
-     *
-     * @param error The error.
-     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
-     *             implementation should log (error) events on this span and it may set tags and use this span as the
-     *             parent for any spans created in this method.
-     *
-     * @param <T> The type of payload expected in the result.
-     *
-     * @return The (empty) result.
-     * @throws NullPointerException if error is {@code null}.
-     */
-    public static <T> OperationResult<T> mapErrorToResult(final Throwable error, final Span span) {
-
-        Objects.requireNonNull(error);
-
-        LOG.debug(error.getMessage(), error);
-        TracingHelper.logError(span, error.getMessage(), error);
-
-        if (error instanceof IllegalArgumentException) {
-            return OperationResult.empty(HttpURLConnection.HTTP_BAD_REQUEST);
-        }
-
-        return OperationResult.empty(ServiceInvocationException.extractStatusCode(error));
     }
 
     /**

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/CredentialsManagementService.java
@@ -45,7 +45,9 @@ public interface CredentialsManagementService {
      *             as the parent for additional spans created as part of this method's execution.
      * @return A future indicating the outcome of the operation.
      *         <p>
-     *         The result's <em>status</em> property will have a value as specified
+     *         The future will be succeeded if the credentials have been created/updated successfully.
+     *         Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/credentials/setAllCredentials">
@@ -71,7 +73,8 @@ public interface CredentialsManagementService {
      * @return A future indicating the outcome of the operation.
      *         <p>
      *         The future will be succeeded with a result containing the retrieved credentials if a device
-     *         with the given identifier exists. The result's <em>status</em> property will have a value as specified
+     *         with the given identifier exists. Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
      *         in the Device Registry Management API.
      * @throws NullPointerException if any of the parameters are {@code null}.
      * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/credentials/getAllCredentials">

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
@@ -34,9 +34,9 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.client.ClientErrorException;
-import org.eclipse.hono.client.DownstreamSenderFactory;
 import org.eclipse.hono.deviceregistry.DeviceRegistryTestUtils;
 import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
+import org.eclipse.hono.deviceregistry.util.Assertions;
 import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
@@ -123,8 +123,6 @@ public class FileBasedCredentialsServiceTest implements AbstractCredentialsServi
         this.credentialsConfig = new FileBasedCredentialsConfigProperties();
         this.credentialsConfig.setCacheMaxAge(30);
 
-        final DownstreamSenderFactory downstreamSenderFactoryMock = mock(DownstreamSenderFactory.class);
-        when(downstreamSenderFactoryMock.connect()).thenReturn(Future.succeededFuture());
         this.registrationService = new FileBasedRegistrationService(vertx);
         this.registrationService.setConfig(registrationConfig);
 
@@ -486,19 +484,20 @@ public class FileBasedCredentialsServiceTest implements AbstractCredentialsServi
 
         // containing a set of credentials
         setCredentials(getCredentialsManagementService(), "tenant", "device", List.of(secret))
-                .compose(ok -> {
-                    // WHEN trying to update the existing credentials
-                    final PasswordCredential newSecret = Credentials.createPasswordCredential("myId", "baz", OptionalInt.empty());
-                    return getCredentialsManagementService().updateCredentials("tenant", "device",
-                            List.of(newSecret),
-                            Optional.empty(),
-                            NoopSpan.INSTANCE);
-                })
-                .onComplete(ctx.succeeding(s -> ctx.verify(() -> {
-                    // THEN the update fails with a 403
-                    assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
-                    ctx.completeNow();
-                })));
+            .onComplete(ctx.succeeding())
+            .compose(ok -> {
+                // WHEN trying to update the existing credentials
+                final PasswordCredential newSecret = Credentials.createPasswordCredential("myId", "baz", OptionalInt.empty());
+                return getCredentialsManagementService().updateCredentials("tenant", "device",
+                        List.of(newSecret),
+                        Optional.empty(),
+                        NoopSpan.INSTANCE);
+            })
+            .onComplete(ctx.failing(t -> {
+                // THEN the update fails with a 403
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN));
+                ctx.completeNow();
+            }));
     }
 
     /**
@@ -517,20 +516,17 @@ public class FileBasedCredentialsServiceTest implements AbstractCredentialsServi
         // WHEN trying to add credentials using the bcrypt hash-function
         final PasswordCredential passwordCredential = Credentials.createPasswordCredential("bumlux", "thepwd");
 
-        getCredentialsManagementService()
-            .updateCredentials(
+        getCredentialsManagementService().updateCredentials(
                 "tenant",
                 "device",
                 List.of(passwordCredential),
                 Optional.empty(),
                 NoopSpan.INSTANCE)
-            .onComplete(ctx.succeeding(s -> ctx.verify(() -> {
 
-                // THEN the update fails with a 400 BAD REQUEST
-                assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_BAD_REQUEST));
                 ctx.completeNow();
-            }))
-        );
+            }));
     }
 
     /**
@@ -545,6 +541,7 @@ public class FileBasedCredentialsServiceTest implements AbstractCredentialsServi
         // GIVEN a device with a set of credentials
         final PasswordCredential passwordCredential = Credentials.createPasswordCredential("taken-auth-id", "thepwd");
         setCredentials(getCredentialsManagementService(), "tenant", "existing-device", List.of(passwordCredential))
+            .onComplete(ctx.succeeding())
             .compose(result -> {
                 ctx.verify(() -> assertThat(result.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT));
                 // WHEN trying to add credentials of the same type for another device using the same authentication identifier
@@ -556,14 +553,10 @@ public class FileBasedCredentialsServiceTest implements AbstractCredentialsServi
                         Optional.empty(),
                         NoopSpan.INSTANCE);
             })
-            .onComplete(ctx.succeeding(s -> {
-                ctx.verify(() -> {
-                    // THEN the update fails with a 409 CONFLICT
-                    assertThat(s.getStatus()).isEqualTo(HttpURLConnection.HTTP_CONFLICT);
-                });
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_CONFLICT));
                 ctx.completeNow();
-            })
-        );
+            }));
     }
 
     /**

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
-import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.deviceregistry.DeviceRegistryTestUtils;
 import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
 import org.eclipse.hono.deviceregistry.util.Assertions;
@@ -325,14 +324,7 @@ public class FileBasedCredentialsServiceTest implements AbstractCredentialsServi
                         Constants.DEFAULT_TENANT, "sensor1",
                         CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD))
                 .compose(s -> getCredentialsManagementService()
-                        .readCredentials(Constants.DEFAULT_TENANT, "4711", NoopSpan.INSTANCE)
-                        .map(r -> {
-                            if (r.getStatus() == HttpURLConnection.HTTP_OK) {
-                                return null;
-                            } else {
-                                throw new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED);
-                            }
-                        }))
+                        .readCredentials(Constants.DEFAULT_TENANT, "4711", NoopSpan.INSTANCE))
                 .onComplete(ctx.completing());
 
         start(startTracker);

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
@@ -34,6 +34,7 @@ import org.eclipse.hono.deviceregistry.mongodb.model.MongoDbBasedDeviceDao;
 import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDocumentBuilder;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
+import org.eclipse.hono.deviceregistry.util.Assertions;
 import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
 import org.eclipse.hono.service.credentials.CredentialsService;
 import org.eclipse.hono.service.management.OperationResult;
@@ -208,10 +209,10 @@ public class MongoDbBasedCredentialServiceTest implements AbstractCredentialsSer
                         Credentials.createPasswordCredential("device2", "secret")),
                 Optional.empty(),
                 NoopSpan.INSTANCE)
-            .onComplete(ctx.succeeding(r -> {
+            .onComplete(ctx.failing(t -> {
                 ctx.verify(() -> {
                     verify(tenantInformationService).getTenant(eq(tenantId), any(Span.class));
-                    assertThat(r.getStatus()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
+                    Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN);
                 });
                 ctx.completeNow();
             }));

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -17,6 +17,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   ID. This will speed up query execution significantly when there are a lot of devices registered for a tenant.
 * The JDBC based device registry's *get Credentials* operation used by the protocol adapters now also supports
   matching credentials against a given *client context*.
+* The device registry implementations did not return a JSON object in a response to a failed request as specified
+  in the Device Registry Management API. This has been fixed.
 
 ## 1.9.0
 

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/CredentialsManagementIT.java
@@ -395,7 +395,10 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
                 Optional.ofNullable(payload).map(JsonArray::toBuffer).orElse(null),
                 CrudHttpClient.CONTENT_TYPE_JSON,
                 expectedStatus)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -480,6 +483,7 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
                 deviceId,
                 List.of(hashedPasswordCredential),
                 HttpURLConnection.HTTP_NO_CONTENT)
+            .onComplete(context.succeeding())
             .compose(httpResponse -> {
                 context.verify(() -> assertResourceVersionHasChanged(resourceVersion, httpResponse.headers()));
                 // now try to update credentials with other version
@@ -490,7 +494,10 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
                         resourceVersion.get() + "_other",
                         HttpURLConnection.HTTP_PRECON_FAILED);
             })
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -510,7 +517,10 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
                     .setExtensions(Map.of("data", data)));
 
         registry.updateCredentials(tenantId, deviceId, credentials, HttpURLConnection.HTTP_ENTITY_TOO_LARGE)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -525,7 +535,10 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
                 Credentials.createPasswordCredential("auth-id", "password", OptionalInt.of(4)));
 
         registry.updateCredentials("non-existing-tenant", deviceId, credentials, HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     /**
@@ -612,7 +625,10 @@ public class CredentialsManagementIT extends DeviceRegistryTestBase {
     public void testGetCredentialsFailsForNonExistingTenant(final VertxTestContext context)  {
 
         registry.getCredentials("non-existing-tenant", "deviceId", HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(context.completing());
+            .onComplete(context.succeeding(response -> {
+                context.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
+                context.completeNow();
+            }));
     }
 
     private static void assertResponseBodyContainsAllCredentials(final JsonArray responseBody, final List<CommonCredential> expected) {


### PR DESCRIPTION
The registry implementations have been changed to return a JSON object
with an "error" property in response bodies for failed requests to the
"credentials" resources.

Fixes #2471
