### PR TITLE
[#2028] Change adapter instance id format

### DIFF
--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactory.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactory.java
@@ -19,13 +19,16 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ConnectionLifecycle;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.util.KubernetesContainerUtil;
 import org.eclipse.hono.util.Lifecycle;
 import org.eclipse.hono.util.Strings;
 import org.eclipse.hono.util.TenantConstants;
@@ -46,7 +49,10 @@ import io.vertx.core.Vertx;
  */
 public class CommandRouterCommandConsumerFactory implements CommandConsumerFactory {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG = LoggerFactory.getLogger(CommandRouterCommandConsumerFactory.class);
+
+    private static final AtomicInteger ADAPTER_INSTANCE_ID_COUNTER = new AtomicInteger();
+
     /**
      * Identifier that has to be unique to this factory instance.
      * Will be used to represent the protocol adapter (verticle) instance that this factory instance is used in,
@@ -96,10 +102,25 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
     }
 
     private static String getNewAdapterInstanceId(final String adapterName) {
+        final String k8sContainerId = KubernetesContainerUtil.getContainerId();
+        if (k8sContainerId == null || k8sContainerId.length() < 12) {
+            LOG.info("container id could not be identified, using random ID as adapterInstanceId");
+            final String prefix = Strings.isNullOrEmpty(adapterName) ? ""
+                    : adapterName.replaceAll("[^a-zA-Z0-9._-]", "") + "-";
+            return prefix + UUID.randomUUID();
+        }
+        // prefer HOSTNAME env var containing the pod name if running in Kubernetes
+        String adapterInstanceIdPrefix = System.getenv("HOSTNAME");
+        if (Strings.isNullOrEmpty(adapterInstanceIdPrefix)) {
+            adapterInstanceIdPrefix = adapterName;
+        }
         // replace special characters so that the id can be used in a Kafka topic name
-        final String prefix = Strings.isNullOrEmpty(adapterName) ? ""
-                : adapterName.replaceAll("[^a-zA-Z0-9._-]", "") + "-";
-        return prefix + UUID.randomUUID();
+        adapterInstanceIdPrefix = Optional.ofNullable(adapterInstanceIdPrefix)
+                .map(prefix -> prefix.replaceAll("[^a-zA-Z0-9._-]", "")).orElse("");
+        return String.format("%s_%s_%d",
+                adapterInstanceIdPrefix,
+                k8sContainerId.substring(0, 12),
+                ADAPTER_INSTANCE_ID_COUNTER.getAndIncrement());
     }
 
     /**
@@ -116,7 +137,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
     public void registerInternalCommandConsumer(
             final BiFunction<String, CommandHandlers, Lifecycle> internalCommandConsumerSupplier) {
         final Lifecycle consumer = internalCommandConsumerSupplier.apply(adapterInstanceId, commandHandlers);
-        log.info("register internal command consumer {}", consumer.getClass().getSimpleName());
+        LOG.info("register internal command consumer {}", consumer.getClass().getSimpleName());
         internalCommandConsumers.add(consumer);
     }
 
@@ -191,7 +212,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
         // lifespan greater than what can be expressed in nanoseconds (i.e. 292 years) is considered unlimited, preventing ArithmeticExceptions down the road
         final Duration sanitizedLifespan = lifespan == null || lifespan.isNegative()
                 || lifespan.getSeconds() > (Long.MAX_VALUE / 1000_000_000L) ? Duration.ofSeconds(-1) : lifespan;
-        log.trace("create command consumer [tenant-id: {}, device-id: {}, gateway-id: {}]", tenantId, deviceId, gatewayId);
+        LOG.trace("create command consumer [tenant-id: {}, device-id: {}, gateway-id: {}]", tenantId, deviceId, gatewayId);
 
         // register the command handler
         // for short-lived command consumers, let the consumer creation span context be used as reference in the command span
@@ -205,7 +226,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
         return commandRouterClient
                 .registerCommandConsumer(tenantId, deviceId, adapterInstanceId, sanitizedLifespan, context)
                 .onFailure(thr -> {
-                    log.info("error registering consumer with the command router service [tenant: {}, device: {}]",
+                    LOG.info("error registering consumer with the command router service [tenant: {}, device: {}]",
                             tenantId, deviceId, thr);
                     // handler association failed - unregister the handler
                     commandHandlers.removeCommandHandler(tenantId, deviceId);
@@ -230,7 +251,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
         final String tenantId = commandHandlerWrapper.getTenantId();
         final String deviceId = commandHandlerWrapper.getDeviceId();
 
-        log.trace("remove command consumer [tenant-id: {}, device-id: {}]", tenantId, deviceId);
+        LOG.trace("remove command consumer [tenant-id: {}, device-id: {}]", tenantId, deviceId);
         if (!commandHandlers.removeCommandHandler(commandHandlerWrapper)) {
             // This case happens when trying to remove a command consumer which has been overwritten since its creation
             // via a 2nd invocation of 'createCommandConsumer' with the same device/tenant id. Since the 2nd 'createCommandConsumer'
@@ -241,7 +262,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
             // reached the *same* adapter instance and verticle, using this CommandConsumerFactory. Invoking 'removeCommandConsumer'
             // on the 1st (obsolete and overwritten) command subscription shall have no impact. Throwing an explicit exception
             // here will enable the protocol adapter to detect this case and skip an (incorrect) "disconnectedTtd" event message.
-            log.debug("command consumer not removed - handler already replaced or removed [tenant: {}, device: {}]",
+            LOG.debug("command consumer not removed - handler already replaced or removed [tenant: {}, device: {}]",
                     tenantId, deviceId);
             return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
                     "local command handler already replaced or removed"));
@@ -255,7 +276,7 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
                     if (ServiceInvocationException.extractStatusCode(thr) == HttpURLConnection.HTTP_PRECON_FAILED) {
                         final boolean entryMayHaveExpired = !lifespan.isNegative() && Instant.now().isAfter(lifespanStart.plus(lifespan));
                         if (entryMayHaveExpired) {
-                            log.trace("ignoring 412 error when unregistering consumer with the command router service; entry may have already expired [tenant: {}, device: {}]",
+                            LOG.trace("ignoring 412 error when unregistering consumer with the command router service; entry may have already expired [tenant: {}, device: {}]",
                                     tenantId, deviceId);
                             return Future.succeededFuture();
                         } else {
@@ -266,13 +287,13 @@ public class CommandRouterCommandConsumerFactory implements CommandConsumerFacto
                             // on the 1st subscription fails because of the non-matching adapterInstanceId parameter.
                             // Throwing an explicit exception here will enable the protocol adapter to detect this case
                             // and skip sending an (incorrect) "disconnectedTtd" event message.
-                            log.debug("consumer not unregistered - not matched or already removed [tenant: {}, device: {}]",
+                            LOG.debug("consumer not unregistered - not matched or already removed [tenant: {}, device: {}]",
                                     tenantId, deviceId);
                             return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED,
                                     "no matching command consumer mapping found to be removed"));
                         }
                     } else {
-                        log.info("error unregistering consumer with the command router service [tenant: {}, device: {}]", tenantId,
+                        LOG.info("error unregistering consumer with the command router service [tenant: {}, device: {}]", tenantId,
                                 deviceId, thr);
                         return Future.failedFuture(thr);
                     }

--- a/core/src/main/java/org/eclipse/hono/util/KubernetesContainerUtil.java
+++ b/core/src/main/java/org/eclipse/hono/util/KubernetesContainerUtil.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.eclipse.hono.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Locate the current docker container.
+ * <p>
+ * This class has been copied from <em>org.apache.logging.log4j.kubernetes.ContainerUtil</em> from the
+ * <em>log4j-kubernetes</em> module of the <a href="https://github.com/apache/logging-log4j2">Apache Log4j 2</a>
+ * project (commit a50abb9). Adaptations have been done concerning the used logger and the Hono code style.
+ */
+public class KubernetesContainerUtil {
+    private static final int MAXLENGTH = 65;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesContainerUtil.class);
+
+    private KubernetesContainerUtil() {
+    }
+
+    /**
+     * Returns the container id when running in a Docker container.
+     *
+     * This inspects /proc/self/cgroup looking for a Kubernetes Control Group. Once it finds one it attempts
+     * to isolate just the docker container id. There doesn't appear to be a standard way to do this, but
+     * it seems to be the only way to determine what the current container is in a multi-container pod. It would have
+     * been much nicer if Kubernetes would just put the container id in a standard environment variable.
+     *
+     * @see <a href="http://stackoverflow.com/a/25729598/12916">Stackoverflow</a> for a discussion on retrieving the containerId.
+     * @see <a href="https://github.com/jenkinsci/docker-workflow-plugin/blob/master/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java">ControlGroup</a>
+     * for the original version of this. Not much is actually left but it provided good inspiration.
+     * @return The container id.
+     */
+    public static String getContainerId() {
+        try {
+            final File file = new File("/proc/self/cgroup");
+            if (file.exists()) {
+                final Path path = file.toPath();
+                final String id = Files.lines(path).map(KubernetesContainerUtil::getContainerId).filter(Objects::nonNull)
+                        .findFirst().orElse(null);
+                LOGGER.debug("Found container id {}", id);
+                return id;
+            } else {
+                LOGGER.warn("Unable to access container information");
+            }
+        } catch (final IOException ioe) {
+            LOGGER.warn("Error obtaining container id: {}", ioe.getMessage());
+        }
+        return null;
+    }
+
+    private static String getContainerId(final String cgroupLine) {
+        String line = cgroupLine;
+        // Every control group in Kubernetes will use
+        if (line.contains("/kubepods")) {
+            // Strip off everything up to the last slash.
+            int i = line.lastIndexOf('/');
+            if (i < 0) {
+                return null;
+            }
+            // If the remainder has a period then take everything up to it.
+            line = line.substring(i + 1);
+            i = line.lastIndexOf('.');
+            if (i > 0) {
+                line = line.substring(0, i);
+            }
+            // Everything ending with a '/' has already been stripped but the remainder might start with "docker-"
+            if (line.contains("docker-")) {
+                // 8:cpuset:/kubepods.slice/kubepods-pod9c26dfb6_b9c9_11e7_bfb9_02c6c1fc4861.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
+                i = line.lastIndexOf("docker-");
+                line = line.substring(i + 7);
+            }
+            return line.length() <= MAXLENGTH ? line : line.substring(0, MAXLENGTH);
+        }
+
+        return null;
+    }
+}

--- a/legal/src/main/resources/legal/NOTICE.md
+++ b/legal/src/main/resources/legal/NOTICE.md
@@ -54,6 +54,16 @@ http://www.apache.org/licenses/LICENSE-2.0.html.
 
 The source code is available from [Maven Central](http://search.maven.org/remotecontent?filepath=commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar).
 
+### Apache Log4j 2
+
+This product includes software developed by the [Apache Software Foundation](http://www.apache.org/).
+
+Your use of *Apache Log4j 2* is subject to the terms and conditions of the Apache Software License 2.0.
+A copy of the license is contained in the file [LICENSE-2.0.txt](LICENSE-2.0.txt) and is also available at
+http://www.apache.org/licenses/LICENSE-2.0.html.
+
+The source code is available from [GitHub](https://github.com/apache/logging-log4j2).
+
 ### Apache SSHD
 
 This product includes software developed by the [Apache Software Foundation](https://mina.apache.org/sshd-project/).


### PR DESCRIPTION
For #2028:
With this PR, the adapter instance id format gets changed to `[pod_name]_[container_id]_[counter]` if running in Kubernetes.
