### PR TITLE
Fix error-handling when getting credentials

### DIFF
--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/credentials/AbstractCredentialsServiceTest.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.service.credentials;
+
+import static org.mockito.Mockito.mock;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.HttpURLConnection;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.client.util.MessagingClientProvider;
+import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
+import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
+import org.eclipse.hono.service.management.device.DeviceAndGatewayAutoProvisioner;
+import org.eclipse.hono.service.management.device.DeviceManagementService;
+import org.eclipse.hono.util.CacheDirective;
+import org.eclipse.hono.util.CredentialsConstants;
+import org.eclipse.hono.util.CredentialsResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.opentracing.Span;
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests verifying the behavior of {@link AbstractCredentialsService}.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class AbstractCredentialsServiceTest {
+
+    /**
+     * Verifies that when the <em>processGet</em> method returns an error result, its status
+     * is adopted for the <em>get</em> method result.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testGetCredentialsPreservesOriginalErrorStatus(final VertxTestContext ctx) {
+
+        final AbstractCredentialsService credentialsService = new AbstractCredentialsService() {
+            @Override
+            protected Future<CredentialsResult<JsonObject>> processGet(final TenantKey tenant, final CredentialKey key,
+                    final JsonObject clientContext, final Span span) {
+                return Future.succeededFuture(CredentialsResult.from(HttpURLConnection.HTTP_BAD_GATEWAY));
+            }
+        };
+
+        final String tenantId = "tenant";
+        final String type = CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD;
+        final String authId = UUID.randomUUID().toString();
+        final NoopSpan span = NoopSpan.INSTANCE;
+
+        credentialsService.get(tenantId, type, authId, span)
+                .onComplete(ctx.succeeding(getCredentialsResult -> {
+                    ctx.verify(() -> {
+                        assertThat(getCredentialsResult.getCacheDirective()).isNotNull();
+                        assertThat(getCredentialsResult.getCacheDirective()).isEqualTo(CacheDirective.noCacheDirective());
+                        assertThat(getCredentialsResult.getStatus()).isEqualTo(HttpURLConnection.HTTP_BAD_GATEWAY);
+                    });
+
+                    // another test with auto-provisioning enabled
+                    credentialsService.setDeviceAndGatewayAutoProvisioner(getDeviceAndGatewayAutoProvisionerMock());
+                    credentialsService.get(tenantId, type, authId, span)
+                            .onComplete(ctx.succeeding(getCredentialsResult2 -> {
+                                ctx.verify(() -> {
+                                    assertThat(getCredentialsResult2.getCacheDirective()).isNotNull();
+                                    assertThat(getCredentialsResult2.getCacheDirective()).isEqualTo(CacheDirective.noCacheDirective());
+                                    assertThat(getCredentialsResult2.getStatus()).isEqualTo(HttpURLConnection.HTTP_BAD_GATEWAY);
+                                });
+                                ctx.completeNow();
+                            }));
+                }));
+    }
+
+    private DeviceAndGatewayAutoProvisioner getDeviceAndGatewayAutoProvisionerMock() {
+        return new DeviceAndGatewayAutoProvisioner(
+                mock(Vertx.class),
+                mock(DeviceManagementService.class),
+                mock(CredentialsManagementService.class),
+                new MessagingClientProvider<>());
+    }
+}

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/CredentialsServiceTestBase.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/credentials/CredentialsServiceTestBase.java
@@ -77,9 +77,9 @@ import io.vertx.junit5.VertxTestContext.ExecutionBlock;
  * {@link CredentialsManagementService} in device registry implementations.
  *
  */
-public interface AbstractCredentialsServiceTest {
+public interface CredentialsServiceTestBase {
 
-    Logger log = LoggerFactory.getLogger(AbstractCredentialsServiceTest.class);
+    Logger log = LoggerFactory.getLogger(CredentialsServiceTestBase.class);
     JsonObject CLIENT_CONTEXT = new JsonObject()
             .put("client-id", "some-client-identifier");
 

--- a/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
+++ b/services/device-registry-file/src/test/java/org/eclipse/hono/deviceregistry/file/FileBasedCredentialsServiceTest.java
@@ -36,8 +36,8 @@ import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.deviceregistry.DeviceRegistryTestUtils;
 import org.eclipse.hono.deviceregistry.service.tenant.NoopTenantInformationService;
 import org.eclipse.hono.deviceregistry.util.Assertions;
-import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
 import org.eclipse.hono.service.credentials.CredentialsService;
+import org.eclipse.hono.service.credentials.CredentialsServiceTestBase;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.Credentials;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
@@ -76,7 +76,7 @@ import io.vertx.junit5.VertxTestContext;
  */
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
-public class FileBasedCredentialsServiceTest implements AbstractCredentialsServiceTest {
+public class FileBasedCredentialsServiceTest implements CredentialsServiceTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileBasedCredentialsServiceTest.class);
 

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/JdbcBasedCredentialsServiceTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/JdbcBasedCredentialsServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.deviceregistry.jdbc.impl;
 
-import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
+import org.eclipse.hono.service.credentials.CredentialsServiceTestBase;
 
-class JdbcBasedCredentialsServiceTest extends AbstractJdbcRegistryTest implements AbstractCredentialsServiceTest {
+class JdbcBasedCredentialsServiceTest extends AbstractJdbcRegistryTest implements CredentialsServiceTestBase {
 }

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
@@ -35,8 +35,8 @@ import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDocumentBuilder;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantKey;
 import org.eclipse.hono.deviceregistry.util.Assertions;
-import org.eclipse.hono.service.credentials.AbstractCredentialsServiceTest;
 import org.eclipse.hono.service.credentials.CredentialsService;
+import org.eclipse.hono.service.credentials.CredentialsServiceTestBase;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.credentials.Credentials;
 import org.eclipse.hono.service.management.credentials.CredentialsDto;
@@ -76,7 +76,7 @@ import io.vertx.junit5.VertxTestContext;
 @ExtendWith(VertxExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-public class MongoDbBasedCredentialServiceTest implements AbstractCredentialsServiceTest {
+public class MongoDbBasedCredentialServiceTest implements CredentialsServiceTestBase {
 
     private static final String DB_NAME_CREDENTIALS_TEST = "hono-credentials-test";
     private static final Logger LOG = LoggerFactory.getLogger(MongoDbBasedCredentialServiceTest.class);


### PR DESCRIPTION
An error getting/parsing credentials in the device registry is currently not handled correctly, leading to an NPE like:

```
[vert.x-eventloop-thread-3] DEBUG o.e.h.d.s.c.AbstractCredentialsService - converting error to response
java.lang.NullPointerException: null
at org.eclipse.hono.deviceregistry.service.credentials.AbstractCredentialsService.lambda$get$1(AbstractCredentialsService.java:170)
at io.vertx.core.Future.lambda$compose$3(Future.java:368)
at io.vertx.core.impl.FutureImpl.dispatch(FutureImpl.java:105)
at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:150)
at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:111)
at io.vertx.core.Future.lambda$otherwise$7(Future.java:540)
at io.vertx.core.impl.FutureImpl.tryFail(FutureImpl.java:195)
at io.vertx.core.impl.FutureImpl.fail(FutureImpl.java:125)
at io.vertx.core.Future.lambda$map$4(Future.java:418)
at io.vertx.core.impl.FutureImpl$Handlers.handle(FutureImpl.java:228)
at io.vertx.core.impl.FutureImpl$Handlers.handle(FutureImpl.java:224)
at io.vertx.core.impl.FutureImpl.tryFail(FutureImpl.java:195)
at io.vertx.core.impl.FutureImpl.fail(FutureImpl.java:125)
at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:178)
at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:21)
at io.vertx.core.impl.FailedFuture.onComplete(FailedFuture.java:49)
at io.vertx.core.Future.lambda$recover$6(Future.java:504)
at io.vertx.core.impl.FutureImpl.tryFail(FutureImpl.java:195)
at io.vertx.core.impl.FutureImpl.fail(FutureImpl.java:125)
at io.vertx.core.Future.lambda$map$4(Future.java:413)
at io.vertx.core.impl.FutureImpl.dispatch(FutureImpl.java:105)
at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:150)
at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:111)
at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:176)
at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:21)
at io.vertx.ext.mongo.impl.MongoClientImpl.lambda$null$12(MongoClientImpl.java:795)
at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:366)
at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
at java.base/java.lang.Thread.run(Unknown Source)
```