### PR TITLE
Use SpanContext param in ConnectionEventProducer methods

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -947,29 +947,32 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      *
      * @param remoteId The remote ID.
      * @param authenticatedDevice The (optional) authenticated device.
+     * @param context The currently active OpenTracing span context or @{code null}.
      * @return A failed future if an event producer is set but the event could not be published. Otherwise, a succeeded
      *         event.
-     * @see ConnectionEventProducer#connected(ConnectionEventProducer.Context, String, String, Device, JsonObject)
+     * @see ConnectionEventProducer#connected(ConnectionEventProducer.Context, String, String, Device, JsonObject, SpanContext)
      */
-    protected Future<?> sendConnectedEvent(final String remoteId, final Device authenticatedDevice) {
+    protected Future<?> sendConnectedEvent(final String remoteId, final Device authenticatedDevice, final SpanContext context) {
         if (this.connectionEventProducer != null) {
-            return getTenantClient().get(authenticatedDevice.getTenantId(),
-                    null)
+            return getTenantClient().get(authenticatedDevice.getTenantId(), context)
                     .map(this::getEventSender)
-                    .compose(es -> this.connectionEventProducer.connected(new ConnectionEventProducer.Context() {
+                    .compose(es -> this.connectionEventProducer.connected(
+                            new ConnectionEventProducer.Context() {
+                                @Override
+                                public EventSender getMessageSenderClient() {
+                                    return es;
+                                }
 
-                        @Override
-                        public EventSender getMessageSenderClient() {
-                            return es;
-                        }
-
-                        @Override
-                        public TenantClient getTenantClient() {
-                            return AbstractProtocolAdapterBase.this.getTenantClient();
-                        }
-
-                    }, remoteId, getTypeName(),
-                            authenticatedDevice, null));
+                                @Override
+                                public TenantClient getTenantClient() {
+                                    return AbstractProtocolAdapterBase.this.getTenantClient();
+                                }
+                            },
+                            remoteId, 
+                            getTypeName(), 
+                            authenticatedDevice, 
+                            null,
+                            context));
         } else {
             return Future.succeededFuture();
         }
@@ -980,28 +983,32 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      *
      * @param remoteId The remote ID.
      * @param authenticatedDevice The (optional) authenticated device.
+     * @param context The currently active OpenTracing span context or @{code null}.
      * @return A failed future if an event producer is set but the event could not be published. Otherwise, a succeeded
      *         event.
-     * @see ConnectionEventProducer#disconnected(ConnectionEventProducer.Context, String, String, Device, JsonObject)
+     * @see ConnectionEventProducer#disconnected(ConnectionEventProducer.Context, String, String, Device, JsonObject, SpanContext)
      */
-    protected Future<?> sendDisconnectedEvent(final String remoteId, final Device authenticatedDevice) {
+    protected Future<?> sendDisconnectedEvent(final String remoteId, final Device authenticatedDevice, final SpanContext context) {
         if (this.connectionEventProducer != null) {
-            return getTenantClient().get(authenticatedDevice.getTenantId(), null)
+            return getTenantClient().get(authenticatedDevice.getTenantId(), context)
                     .map(this::getEventSender)
-                    .compose(es -> this.connectionEventProducer.disconnected(new ConnectionEventProducer.Context() {
+                    .compose(es -> this.connectionEventProducer.disconnected(
+                            new ConnectionEventProducer.Context() {
+                                @Override
+                                public EventSender getMessageSenderClient() {
+                                    return es;
+                                }
 
-                        @Override
-                        public EventSender getMessageSenderClient() {
-                            return es;
-                        }
-
-                        @Override
-                        public TenantClient getTenantClient() {
-                            return AbstractProtocolAdapterBase.this.getTenantClient();
-                        }
-
-                    }, remoteId, getTypeName(),
-                            authenticatedDevice, null));
+                                @Override
+                                public TenantClient getTenantClient() {
+                                    return AbstractProtocolAdapterBase.this.getTenantClient();
+                                }
+                            },
+                            remoteId,
+                            getTypeName(),
+                            authenticatedDevice,
+                            null,
+                            context));
         } else {
             return Future.succeededFuture();
         }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/AbstractMessageSenderConnectionEventProducer.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/AbstractMessageSenderConnectionEventProducer.java
@@ -16,6 +16,7 @@ import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.RegistrationAssertion;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
@@ -36,9 +37,10 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
             final String remoteId,
             final String protocolAdapter,
             final Device authenticatedDevice,
-            final JsonObject data) {
+            final JsonObject data,
+            final SpanContext spanContext) {
 
-        return sendNotificationEvent(context, authenticatedDevice, protocolAdapter, remoteId, "connected", data);
+        return sendNotificationEvent(context, authenticatedDevice, protocolAdapter, remoteId, "connected", data, spanContext);
     }
 
     @Override
@@ -47,9 +49,10 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
             final String remoteId,
             final String protocolAdapter,
             final Device authenticatedDevice,
-            final JsonObject data) {
+            final JsonObject data,
+            final SpanContext spanContext) {
 
-        return sendNotificationEvent(context, authenticatedDevice, protocolAdapter, remoteId, "disconnected", data);
+        return sendNotificationEvent(context, authenticatedDevice, protocolAdapter, remoteId, "disconnected", data, spanContext);
     }
 
     private Future<?> sendNotificationEvent(
@@ -58,7 +61,8 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
             final String protocolAdapter,
             final String remoteId,
             final String cause,
-            final JsonObject data) {
+            final JsonObject data,
+            final SpanContext spanContext) {
 
         if (authenticatedDevice == null) {
             // we only handle authenticated devices
@@ -68,7 +72,7 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
         final String tenantId = authenticatedDevice.getTenantId();
         final String deviceId = authenticatedDevice.getDeviceId();
 
-        return context.getTenantClient().get(tenantId, null)
+        return context.getTenantClient().get(tenantId, spanContext)
                 .compose(tenant -> {
 
                     final JsonObject payload = new JsonObject();
@@ -86,7 +90,7 @@ public abstract class AbstractMessageSenderConnectionEventProducer implements Co
                             EventConstants.EVENT_CONNECTION_NOTIFICATION_CONTENT_TYPE,
                             payload.toBuffer(),
                             null,
-                            null);
+                            spanContext);
                 });
     }
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/ConnectionEventProducer.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/ConnectionEventProducer.java
@@ -17,6 +17,7 @@ import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.client.telemetry.EventSender;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
@@ -26,15 +27,15 @@ import io.vertx.core.json.JsonObject;
  * The interface is intended to be implemented by setups which are interested in receiving technical connection events.
  * Which might not make sense for all protocols adapters. But mostly for connection oriented ones like MQTT or AMQP 1.0.
  * <p>
- * The protocol adapters may call {@link #connected(Context, String, String, Device, JsonObject)} and
- * {@link #disconnected(Context, String, String, Device, JsonObject)} as they see fit. The whole process is a "best
+ * The protocol adapters may call {@link #connected(Context, String, String, Device, JsonObject, SpanContext)} and
+ * {@link #disconnected(Context, String, String, Device, JsonObject, SpanContext)} as they see fit. The whole process is a "best
  * effort" process and intended to be used for monitoring/debugging.
  * <p>
  * When a protocol adapter calls into this producer it must provide some kind of connection ID, which might have a
  * different meaning for different protocol adapters. This should be as identifiable as possible but there is no
  * requirement for this to be unique. However for each connection the protocol adapter must call
- * {@link #disconnected(Context, String, String, Device, JsonObject)} with the same information as it called
- * {@link #connected(Context, String, String, Device, JsonObject)}.
+ * {@link #disconnected(Context, String, String, Device, JsonObject, SpanContext)} with the same information as it called
+ * {@link #connected(Context, String, String, Device, JsonObject, SpanContext)}.
  */
 public interface ConnectionEventProducer {
 
@@ -70,26 +71,28 @@ public interface ConnectionEventProducer {
      * @param protocolAdapter The name of the protocol adapter sending this event. Must not be {@code null}.
      * @param authenticatedDevice The optional authenticated device associated with the connection. May be {@code null}
      *            if the connection is from an unauthenticated device.
-     * @param data Additional, protocol adapter specific data
-     * @return A future which indicates the result of the event production
+     * @param data Additional, protocol adapter specific data.
+     * @param spanContext The currently active OpenTracing span context or @{code null}.
+     * @return A future which indicates the result of the event production.
      * @throws NullPointerException If either the remote ID or the protocol adapter argument are {@code null}.
      */
     Future<?> connected(Context context, String remoteId, String protocolAdapter, Device authenticatedDevice,
-            JsonObject data);
+            JsonObject data, SpanContext spanContext);
 
     /**
      * Produce an event for a closed connection.
      *
      * @param context Protocol adapter context.
      * @param remoteId The ID of the remote endpoint which disconnected. The same ID used in the call to
-     *            {@link #connected(Context, String, String, Device, JsonObject)}
+     *            {@link #connected(Context, String, String, Device, JsonObject, SpanContext)}
      * @param protocolAdapter The name of the protocol adapter sending this event. Must not be {@code null}.
      * @param authenticatedDevice The optional authenticated device associated with the connection. May be {@code null}
      *            if the connection is from an unauthenticated device.
-     * @param data Additional, protocol adapter specific data
-     * @return A future which indicates the result of the event production
+     * @param data Additional, protocol adapter specific data.
+     * @param spanContext The currently active OpenTracing span context or @{code null}.
+     * @return A future which indicates the result of the event production.
      * @throws NullPointerException If either the remote ID or the protocol adapter argument are {@code null}.
      */
     Future<?> disconnected(Context context, String remoteId, String protocolAdapter, Device authenticatedDevice,
-            JsonObject data);
+            JsonObject data, SpanContext spanContext);
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/LoggingConnectionEventProducer.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/monitoring/LoggingConnectionEventProducer.java
@@ -18,6 +18,7 @@ import org.eclipse.hono.auth.Device;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.opentracing.SpanContext;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
@@ -48,7 +49,8 @@ public final class LoggingConnectionEventProducer implements ConnectionEventProd
             final String remoteId,
             final String protocolAdapter,
             final Device authenticatedDevice,
-            final JsonObject data) {
+            final JsonObject data,
+            final SpanContext spanContext) {
 
         return log(String.format("   Connected - ID: %s, Protocol Adapter: %s, Device: %s, Data: %s",
                 remoteId, protocolAdapter, authenticatedDevice, data));
@@ -60,7 +62,8 @@ public final class LoggingConnectionEventProducer implements ConnectionEventProd
             final String remoteId,
             final String protocolAdapter,
             final Device authenticatedDevice,
-            final JsonObject data) {
+            final JsonObject data,
+            final SpanContext spanContext) {
 
         return log(String.format("Disconnected - ID: %s, Protocol Adapter: %s, Device: %s, Data: %s",
                 remoteId, protocolAdapter, authenticatedDevice, data));

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBaseTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBaseTest.java
@@ -628,7 +628,7 @@ public class AbstractProtocolAdapterBaseTest {
         when(tenantClient.get(eq(Constants.DEFAULT_TENANT), any())).thenReturn(Future.succeededFuture(tenantObject));
 
         // THEN the adapter forwards the connection event message downstream
-        adapter.sendConnectedEvent("remote-id", authenticatedDevice)
+        adapter.sendConnectedEvent("remote-id", authenticatedDevice, null)
             .onComplete(ctx.succeeding(result -> {
                 ctx.verify(() -> {
                         verify(amqpEventSender).sendEvent(
@@ -671,7 +671,7 @@ public class AbstractProtocolAdapterBaseTest {
         when(tenantClient.get(eq(Constants.DEFAULT_TENANT), any())).thenReturn(Future.succeededFuture(tenantObject));
 
         // THEN the adapter forwards the connection event message downstream
-        adapter.sendConnectedEvent("remote-id", authenticatedDevice)
+        adapter.sendConnectedEvent("remote-id", authenticatedDevice, null)
                 .onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
                         verify(kafkaEventSender).sendEvent(

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/monitoring/HonoEventConnectionEventProducerTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/monitoring/HonoEventConnectionEventProducerTest.java
@@ -82,7 +82,7 @@ class HonoEventConnectionEventProducerTest {
                 .setResourceLimits(new ResourceLimits().setMaxTtl(500));
         when(tenantClient.get(anyString(), any())).thenReturn(Future.succeededFuture(tenant));
 
-        producer.connected(context, "device-internal-id", "custom-adapter", authenticatedDevice, new JsonObject())
+        producer.connected(context, "device-internal-id", "custom-adapter", authenticatedDevice, new JsonObject(), null)
             .onComplete(ctx.succeeding(ok -> {
                 ctx.verify(() -> {
                     verify(sender).sendEvent(

--- a/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
+++ b/adapters/amqp-vertx-base/src/test/java/org/eclipse/hono/adapter/amqp/VertxBasedAmqpProtocolAdapterTest.java
@@ -853,11 +853,13 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
                 anyString(),
                 anyString(),
                 any(),
+                any(),
                 any())).thenReturn(Future.succeededFuture());
         when(connectionEventProducer.disconnected(
                 any(ConnectionEventProducer.Context.class),
                 anyString(),
                 anyString(),
+                any(),
                 any(),
                 any())).thenReturn(Future.succeededFuture());
         givenAnAdapter(properties);
@@ -886,6 +888,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
                 anyString(),
                 eq(adapter.getTypeName()),
                 eq(authenticatedDevice),
+                any(),
                 any());
 
         // WHEN the connection to the device is lost
@@ -901,6 +904,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
                 eq("deviceContainer"),
                 eq(adapter.getTypeName()),
                 eq(authenticatedDevice),
+                any(),
                 any());
 
         // WHEN the device closes its connection to the adapter
@@ -916,6 +920,7 @@ public class VertxBasedAmqpProtocolAdapterTest extends ProtocolAdapterTestSuppor
                 eq("deviceContainer"),
                 eq(adapter.getTypeName()),
                 eq(authenticatedDevice),
+                any(),
                 any());
     }
 

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/AbstractVertxBasedMqttProtocolAdapter.java
@@ -481,7 +481,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             currentSpan.log("abort connection request processing, connection already closed");
             result.fail("connection already closed");
         } else {
-            sendConnectedEvent(endpoint.clientIdentifier(), authenticatedDevice)
+            sendConnectedEvent(endpoint.clientIdentifier(), authenticatedDevice, currentSpan.context())
                 .map(authenticatedDevice)
                 .recover(t -> {
                     log.warn("failed to send connection event for client [clientId: {}]",
@@ -1706,7 +1706,7 @@ public abstract class AbstractVertxBasedMqttProtocolAdapter<T extends MqttProtoc
             final Span span = newSpan("CLOSE");
             AbstractVertxBasedMqttProtocolAdapter.this.onClose(endpoint);
             final CompositeFuture removalDoneFuture = removeAllCommandSubscriptions(span);
-            sendDisconnectedEvent(endpoint.clientIdentifier(), authenticatedDevice);
+            sendDisconnectedEvent(endpoint.clientIdentifier(), authenticatedDevice, span.context());
             if (authenticatedDevice == null) {
                 log.debug("connection to anonymous device [clientId: {}] closed", endpoint.clientIdentifier());
                 metrics.decrementUnauthenticatedConnections();


### PR DESCRIPTION
This adds a `SpanContext` parameter to the methods of the `ConnectionEventProducer` interface.

This prevents `get Tenant by ID` spans in the AMQP/MQTT adapter with no parent span, where it is unclear just by looking at the tracing span to which overall operation/request this belongs to.