### PR TITLE
Make regex for validating hashed-password auth-ids configurable

### DIFF
--- a/core/src/main/java/org/eclipse/hono/config/AuthenticatingClientConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/AuthenticatingClientConfigProperties.java
@@ -28,6 +28,9 @@ import org.eclipse.hono.util.Strings;
  */
 public class AuthenticatingClientConfigProperties extends AbstractConfig {
 
+    /**
+     * The <em>unknown</em> server role.
+     */
     public static final String SERVER_ROLE_UNKNOWN = "unknown";
 
     private String credentialsPath = null;

--- a/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ServiceConfigProperties.java
@@ -55,8 +55,8 @@ public class ServiceConfigProperties extends ServerConfig {
     private int receiverLinkCredit = DEFAULT_RECEIVER_LINK_CREDITS;
     private String corsAllowedOrigin = "*";
     private long sendTimeOut = DEFAULT_SEND_TIMEOUT_IN_MS;
-    private Pattern tenantIdPattern = Pattern.compile(RegistryManagementConstants.DEFAULT_TENANT_ID_PATTERN);
-    private Pattern deviceIdPattern = Pattern.compile(RegistryManagementConstants.DEFAULT_DEVICE_ID_PATTERN);
+    private Pattern tenantIdPattern = Pattern.compile(RegistryManagementConstants.DEFAULT_REGEX_TENANT_ID);
+    private Pattern deviceIdPattern = Pattern.compile(RegistryManagementConstants.DEFAULT_REGEX_DEVICE_ID);
 
     /**
      * Sets the maximum size of a message payload this server accepts from clients.
@@ -230,7 +230,7 @@ public class ServiceConfigProperties extends ServerConfig {
     /**
      * Gets the pattern defining valid device identifiers.
      * <p>
-     * The default value of this property is {@value org.eclipse.hono.util.RegistryManagementConstants#DEFAULT_DEVICE_ID_PATTERN}.
+     * The default value of this property is {@value org.eclipse.hono.util.RegistryManagementConstants#DEFAULT_REGEX_DEVICE_ID}.
      *
      * @return The pattern.
      */
@@ -241,7 +241,7 @@ public class ServiceConfigProperties extends ServerConfig {
     /**
      * Sets the regular expression defining valid device identifiers.
      * <p>
-     * The default value of this property is {@value org.eclipse.hono.util.RegistryManagementConstants#DEFAULT_DEVICE_ID_PATTERN}
+     * The default value of this property is {@value org.eclipse.hono.util.RegistryManagementConstants#DEFAULT_REGEX_DEVICE_ID}
      *
      * @param regex The regular expression.
      * @throws NullPointerException if regex is {@code null}.
@@ -254,7 +254,7 @@ public class ServiceConfigProperties extends ServerConfig {
     /**
      * Gets the pattern defining valid tenant identifiers.
      * <p>
-     * The default value of this property is {@value org.eclipse.hono.util.RegistryManagementConstants#DEFAULT_TENANT_ID_PATTERN}.
+     * The default value of this property is {@value org.eclipse.hono.util.RegistryManagementConstants#DEFAULT_REGEX_TENANT_ID}.
      *
      * @return The pattern.
      */
@@ -265,7 +265,7 @@ public class ServiceConfigProperties extends ServerConfig {
     /**
      * Sets the regular expression defining valid tenant identifiers.
      * <p>
-     * The default value of this property is {@link org.eclipse.hono.util.RegistryManagementConstants#DEFAULT_TENANT_ID_PATTERN}
+     * The default value of this property is {@link org.eclipse.hono.util.RegistryManagementConstants#DEFAULT_REGEX_TENANT_ID}
      *
      * @param regex The regular expression.
      * @throws NullPointerException if regex is {@code null}.

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.hono.util;
 
+import java.util.regex.Pattern;
+
 /**
  * Constants &amp; utility methods used throughout the Device Management API.
  */
@@ -39,107 +41,130 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
 
     // FIELD DEFINITIONS
 
-    // DEVICES
+    // GENERIC
 
     /**
-     * The name of the field that contains the identifiers of those gateways that may act on behalf of the device.
+     * The name of the field that contains the extension fields.
      */
-    public static final String FIELD_VIA = RegistrationConstants.FIELD_VIA;
+    public static final String FIELD_EXT = "ext";
 
     /**
-     * The name of the field that contains the identifiers of groups of gateways that may act on behalf of the device.
+     * The name of the field that contains the identifier of an entity.
      */
-    public static final String FIELD_VIA_GROUPS = "viaGroups";
+    public static final String FIELD_ID = "id";
 
     /**
-     * The name of the field that contains the status data for the device.
-     * The status object contains the creation date, the last edit date and the last user.
+     * The name of the field that contains meta information about an entity like creation date and time of last
+     * modification.
+     *
+     * @see #FIELD_STATUS_CREATION_DATE
+     * @see #FIELD_STATUS_LAST_UPDATE
+     * @see #FIELD_STATUS_LAST_USER
      */
     public static final String FIELD_STATUS = "status";
-
     /**
      * The name of the field that contains the creation date of the device.
      */
     public static final String FIELD_STATUS_CREATION_DATE = "created";
-
     /**
      * The name of the field that contains the last update date of the device.
      */
     public static final String FIELD_STATUS_LAST_UPDATE = "updated";
-
     /**
      * The name of the field that contains the last user that edited the device.
      */
     public static final String FIELD_STATUS_LAST_USER = "last-user";
 
     /**
+     * The name of the field that contains the JSON pointer corresponding to the field used for filtering entities.
+     */
+    public static final String FIELD_FILTER_FIELD = "field";
+    /**
+     * The name of the field that contains the operator used for filtering entities.
+     */
+    public static final String FIELD_FILTER_OPERATOR = "op";
+    /**
+     * The name of the field that contains the value used for filtering entities.
+     */
+    public static final String FIELD_FILTER_VALUE = "value";
+    /**
+     * The name of the field that contains the result of a search operation.
+     */
+    public static final String FIELD_RESULT_SET_PAGE = "result";
+    /**
+     * The name of the field that contains the total number of objects in the result set of a search operation.
+     */
+    public static final String FIELD_RESULT_SET_SIZE = "total";
+    /**
+     * The name of the field that contains sort direction used by a search operation to sort the result set.
+     */
+    public static final String FIELD_SORT_DIRECTION = "direction";
+
+    /**
+     * The name of the query parameter that contains the filter JSON object for a search operation.
+     */
+    public static final String PARAM_FILTER_JSON = "filterJson";
+    /**
+     * The name of the query parameter that contains the page offset for a search operation.
+     */
+    public static final String PARAM_PAGE_OFFSET = "pageOffset";
+    /**
+     * The name of the query parameter that contains the page size for a search operation.
+     */
+    public static final String PARAM_PAGE_SIZE = "pageSize";
+    /**
+     * The name of the query parameter that contains the sort JSON object used by a search operation to sort the
+     * result set.
+     */
+    public static final String PARAM_SORT_JSON = "sortJson";
+
+
+    // DEVICES
+
+    /**
+     * The name of the authority which authorizes a gateway to perform auto-provisioning.
+     */
+    public static final String AUTHORITY_AUTO_PROVISIONING_ENABLED = "auto-provisioning-enabled";
+    /**
+     * The name of the property that contains information about the service endpoint to use for sending
+     * commands to a device.
+     */
+    public static final String COMMAND_ENDPOINT = "command-endpoint";
+    /**
+     * The name of the property that contains the authorities of a device.
+     */
+    public static final String FIELD_AUTHORITIES = "authorities";
+    /**
+     * The name of the field that contains a boolean indicating if a device has been auto-provisioned.
+     */
+    public static final String FIELD_AUTO_PROVISIONED   = "auto-provisioned";
+    /**
+     * The name of the field that contains a boolean indicating if a notification for an auto-provisioned device was sent.
+     */
+    public static final String FIELD_AUTO_PROVISIONING_NOTIFICATION_SENT = "auto-provisioning-notification-sent";
+    /**
      * The name of the field that contains the name of a service that can be used to transform downstream messages
      * uploaded by the device before they are forwarded to downstream consumers.
      */
     public static final String FIELD_DOWNSTREAM_MESSAGE_MAPPER = "downstream-message-mapper";
-
+    /**
+     * The name of the field that contains the names of the gateway groups that the (gateway) device is a member of.
+     */
+    public static final String FIELD_MEMBER_OF = "memberOf";
     /**
      * The name of the field that contains the name of a service that can be used to transform upstream commands
      * to be sent to the device.
      */
     public static final String FIELD_UPSTREAM_MESSAGE_MAPPER = "upstream-message-mapper";
-
     /**
-     * The name of the field that contains the names of the gateway groups that the (gateway) device is a member of.
+     * The name of the field that contains the identifiers of those gateways that may act on behalf of the device.
      */
-    public static final String FIELD_MEMBER_OF = "memberOf";
-
+    public static final String FIELD_VIA = RegistrationConstants.FIELD_VIA;
     /**
-     * The name of the field that contains the JSON pointer corresponding to the field used for filtering devices.
+     * The name of the field that contains the identifiers of groups of gateways that may act on behalf of the device.
      */
-    public static final String FIELD_FILTER_FIELD = "field";
+    public static final String FIELD_VIA_GROUPS = "viaGroups";
 
-    /**
-     * The name of the query parameter that contains the filter JSON object for search devices operation.
-     */
-    public static final String PARAM_FILTER_JSON = "filterJson";
-
-    /**
-     * The name of the field that contains the operator used for filtering devices.
-     */
-    public static final String FIELD_FILTER_OPERATOR = "op";
-
-    /**
-     * The name of the field that contains the value used for filtering devices.
-     */
-    public static final String FIELD_FILTER_VALUE = "value";
-
-    /**
-     * The name of the query parameter that contains the page offset for search devices operation.
-     */
-    public static final String PARAM_PAGE_OFFSET = "pageOffset";
-
-    /**
-     * The name of the query parameter that contains the page size for search devices operation.
-     */
-    public static final String PARAM_PAGE_SIZE = "pageSize";
-
-    /**
-     * The name of the field that contains sort direction used by search devices operation to sort the result set.
-     */
-    public static final String FIELD_SORT_DIRECTION = "direction";
-
-    /**
-     * The name of the query parameter that contains the sort JSON object used by search devices operation to sort the
-     * result set.
-     */
-    public static final String PARAM_SORT_JSON = "sortJson";
-
-    /**
-     * The name of the field that contains the total number of objects in the result set of the search devices
-     * operation.
-     */
-    public static final String FIELD_RESULT_SET_SIZE = "total";
-
-    /**
-     * The name of the field that contains the result of the search devices operation.
-     */
-    public static final String FIELD_RESULT_SET_PAGE = "result";
 
     // CREDENTIALS
 
@@ -160,18 +185,10 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_SECRETS                     = "secrets";
     /**
-     * The name of the field that contains the extension fields.
+     * The name of the system property that contains the regular expression to use for validating
+     * authentication IDs of <em>hashed-password</em> secrets.
      */
-    public static final String FIELD_EXT                         = "ext";
-    /**
-     * The name of the property that defines the messaging type to be used for a tenant.
-     */
-    public static final String FIELD_EXT_MESSAGING_TYPE = "messaging-type";
-
-    /**
-     * The name of the field that contains the id of the entity (e.g. secret id).
-     */
-    public static final String FIELD_ID = "id";
+    public static final String SYSTEM_PROPERTY_USERNAME_REGEX = "hono.registry.usernameRegex";
 
     // SECRETS
 
@@ -232,6 +249,7 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String HASH_FUNCTION_SHA256              = "sha-256";
 
+
     // TENANTS
 
     /**
@@ -253,6 +271,21 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String FIELD_ADAPTERS_DEVICE_AUTHENTICATION_REQUIRED = "device-authentication-required";
     /**
+     * The name of the property that indicates whether a unregistered device that authenticates with
+     * a client certificate should be auto-provisioned as a gateway. 
+     */
+    public static final String FIELD_AUTO_PROVISION_AS_GATEWAY = "auto-provision-as-gateway";
+    /**
+     * The name of the property that defines the device identifier template for the devices/gateways
+     * being auto-provisioned.
+     */
+    public static final String FIELD_AUTO_PROVISIONING_DEVICE_ID_TEMPLATE = "auto-provisioning-device-id-template";
+    /**
+     * The name of the property that indicates whether a CA cert can be used to
+     * automatically provision new devices. 
+     */
+    public static final String FIELD_AUTO_PROVISIONING_ENABLED = "auto-provisioning-enabled";
+    /**
      * The name of the property that contains the configuration options to limit 
      * the device connection duration of tenants.
      */
@@ -269,6 +302,10 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      * The name of the property that contains the date on which the data volume limit came into effect.
      */
     public static final String FIELD_EFFECTIVE_SINCE = "effective-since";
+    /**
+     * The name of the property that defines the messaging type to be used for a tenant.
+     */
+    public static final String FIELD_EXT_MESSAGING_TYPE = "messaging-type";
     /**
      * The name of the property that contains the maximum number of bytes to be allowed for a tenant.
      */
@@ -359,39 +396,6 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      * a {@link TracingSamplingMode} value.
      */
     public static final String FIELD_TRACING_SAMPLING_MODE_PER_AUTH_ID = "sampling-mode-per-auth-id";
-
-    /**
-     * The default regular expression to validate tenant IDs supplied when creating tenants are legal.
-     */
-    public static final String DEFAULT_TENANT_ID_PATTERN = "^[a-zA-Z0-9-_\\.]+$";
-
-    /**
-     * The default regular expression to validate device IDs supplied when creating devices are legal.
-     */
-    public static final String DEFAULT_DEVICE_ID_PATTERN = "^[a-zA-Z0-9-_\\.:=]+$";
-
-    /**
-     * The name of the field that contains a boolean indicating if an entity was auto-provisioned.
-     */
-    public static final String FIELD_AUTO_PROVISIONED   = "auto-provisioned";
-
-    /**
-     * The name of the property that indicates whether a CA cert can be used to
-     * automatically provision new devices. 
-     */
-    public static final String FIELD_AUTO_PROVISIONING_ENABLED = "auto-provisioning-enabled";
-
-    /**
-     * The name of the property that indicates whether a unregistered device that authenticates with
-     * a client certificate should be auto-provisioned as a gateway. 
-     */
-    public static final String FIELD_AUTO_PROVISION_AS_GATEWAY = "auto-provision-as-gateway";
-
-    /**
-     * The name of the property that defines the device identifier template for the devices/gateways
-     * being auto-provisioned.
-     */
-    public static final String FIELD_AUTO_PROVISIONING_DEVICE_ID_TEMPLATE = "auto-provisioning-device-id-template";
     /**
      * The name of the place holder for subject DN in the device-id template used during auto-provisioning.
      */
@@ -400,25 +404,30 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      * The name of the place holder for subject DN's Common Name in the device-id template used during auto-provisioning.
      */
     public static final String PLACEHOLDER_SUBJECT_CN = "{{subject-cn}}";
-    /**
-     * The name of the field that contains a boolean indicating if a notification for an auto-provisioned device was sent.
-     */
-    public static final String FIELD_AUTO_PROVISIONING_NOTIFICATION_SENT = "auto-provisioning-notification-sent";
+
+
+    // DEFAULTS
 
     /**
-     * The name of the property that contains the authorities of a device.
+     * The default regular expression to validate device IDs supplied when creating devices are legal.
      */
-    public static final String FIELD_AUTHORITIES = "authorities";
+    public static final String DEFAULT_REGEX_DEVICE_ID = "^[a-zA-Z0-9-_\\.:=]+$";
 
     /**
-     * The name of the authority which authorizes a gateway to perform auto-provisioning.
+     * The default regular expression to validate tenant IDs supplied when creating tenants are legal.
      */
-    public static final String AUTHORITY_AUTO_PROVISIONING_ENABLED = "auto-provisioning-enabled";
+    public static final String DEFAULT_REGEX_TENANT_ID = "^[a-zA-Z0-9-_\\.]+$";
 
     /**
-     * The name of the property that contains command-endpoint of a device.
+     * The default regular expression for validating authentication IDs supplied when creating hashed-password credentials.
      */
-    public static final String COMMAND_ENDPOINT = "command-endpoint";
+    public static final String DEFAULT_REGEX_USERNAME = "^[a-zA-Z0-9-_=\\.]+$";
+    /**
+     * The default pattern for validating authentication IDs supplied when creating hashed-password credentials.
+     * <p>
+     * Based on {@link #DEFAULT_PATTERN_USERNAME}.
+     */
+    public static final Pattern DEFAULT_PATTERN_USERNAME = Pattern.compile(DEFAULT_REGEX_USERNAME);
 
     private RegistryManagementConstants() {
         // prevent instantiation

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -425,7 +425,7 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
     /**
      * The default pattern for validating authentication IDs supplied when creating hashed-password credentials.
      * <p>
-     * Based on {@link #DEFAULT_PATTERN_USERNAME}.
+     * Based on {@link #DEFAULT_REGEX_USERNAME}.
      */
     public static final Pattern DEFAULT_PATTERN_USERNAME = Pattern.compile(DEFAULT_REGEX_USERNAME);
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
@@ -30,6 +30,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * <p>
  * See <a href="https://www.eclipse.org/hono/docs/api/credentials/#pre-shared-key">Pre-Shared Key</a> for an example
  * of the configuration properties for this credential type.
+ * <p>
+ * The <em>auth-id</em> in this case serves as the <em>PSK identity</em>. According to
+ * <a href="https://datatracker.ietf.org/doc/html/rfc4279#section-5.1">RFC 4279, Section 5.1</a>,
+ * the PSK identity can be an arbitrary UTF-8 encoded string of up to 2^16-1 bytes length.
+ * There are nor restrictions regarding the characters being allowed in the identifier.
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class PskCredential extends CommonCredential {

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/PskCredential.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * The <em>auth-id</em> in this case serves as the <em>PSK identity</em>. According to
  * <a href="https://datatracker.ietf.org/doc/html/rfc4279#section-5.1">RFC 4279, Section 5.1</a>,
  * the PSK identity can be an arbitrary UTF-8 encoded string of up to 2^16-1 bytes length.
- * There are nor restrictions regarding the characters being allowed in the identifier.
+ * There are no restrictions regarding the characters being allowed in the identifier.
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class PskCredential extends CommonCredential {

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/config/DeviceServiceProperties.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/config/DeviceServiceProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +19,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.eclipse.hono.util.RegistryManagementConstants;
 
 /**
  * Device service properties.
@@ -39,15 +42,15 @@ public class DeviceServiceProperties {
 
     private final Set<String> hashAlgorithmsAllowList = new HashSet<>();
 
-    public int getTaskExecutorQueueSize() {
+    public final int getTaskExecutorQueueSize() {
         return this.taskExecutorQueueSize;
     }
 
-    public void setTaskExecutorQueueSize(final int taskExecutorQueueSize) {
+    public final void setTaskExecutorQueueSize(final int taskExecutorQueueSize) {
         this.taskExecutorQueueSize = taskExecutorQueueSize;
     }
 
-    public Duration getCredentialsTtl() {
+    public final Duration getCredentialsTtl() {
         return this.credentialsTtl;
     }
 
@@ -58,7 +61,7 @@ public class DeviceServiceProperties {
      * @throws NullPointerException if ttl is {@code null}.
      * @throws IllegalArgumentException if the TTL value is less than one second.
      */
-    public void setCredentialsTtl(final Duration credentialsTtl) {
+    public final void setCredentialsTtl(final Duration credentialsTtl) {
         Objects.requireNonNull(credentialsTtl);
         if (credentialsTtl.toSeconds() <= 0) {
             throw new IllegalArgumentException("'credentialsTtl' must be a positive duration of at least one second");
@@ -66,7 +69,7 @@ public class DeviceServiceProperties {
         this.credentialsTtl = credentialsTtl;
     }
 
-    public Duration getRegistrationTtl() {
+    public final Duration getRegistrationTtl() {
         return this.registrationTtl;
     }
 
@@ -77,7 +80,7 @@ public class DeviceServiceProperties {
      * @throws IllegalArgumentException if the TTL value is less than one second.
      */
 
-    public void setRegistrationTtl(final Duration registrationTtl) {
+    public final void setRegistrationTtl(final Duration registrationTtl) {
         if (registrationTtl.toSeconds() <= 0) {
             throw new IllegalArgumentException("'registrationTtl' must be a positive duration of at least one second");
         }
@@ -105,7 +108,7 @@ public class DeviceServiceProperties {
      * @param costfactor The maximum number.
      * @throws IllegalArgumentException if iterations is &lt; 4 or &gt; 31.
      */
-    public void setMaxBcryptCostfactor(final int costfactor) {
+    public final void setMaxBcryptCostfactor(final int costfactor) {
         if (costfactor < 4 || costfactor > 31) {
             throw new IllegalArgumentException("iterations must be > 3 and < 32");
         } else {
@@ -125,7 +128,7 @@ public class DeviceServiceProperties {
      *
      * @return The supported algorithms.
      */
-    public Set<String> getHashAlgorithmsAllowList() {
+    public final Set<String> getHashAlgorithmsAllowList() {
         return Collections.unmodifiableSet(this.hashAlgorithmsAllowList);
     }
 
@@ -141,9 +144,27 @@ public class DeviceServiceProperties {
      * @param hashAlgorithmsAllowList The algorithms to support.
      * @throws NullPointerException if the list is {@code null}.
      */
-    public void setHashAlgorithmsAllowList(final String[] hashAlgorithmsAllowList) {
+    public final void setHashAlgorithmsAllowList(final String[] hashAlgorithmsAllowList) {
         Objects.requireNonNull(hashAlgorithmsAllowList);
         this.hashAlgorithmsAllowList.clear();
         this.hashAlgorithmsAllowList.addAll(Arrays.asList(hashAlgorithmsAllowList));
+    }
+
+    /**
+     * Sets the regular expression that should be used to validate authentication identifiers (user names) of
+     * hashed-password credentials.
+     * <p>
+     * After successful validation of the expression's syntax, the regex is set as the value
+     * of system property {@value RegistryManagementConstants#SYSTEM_PROPERTY_USERNAME_REGEX}.
+     *
+     * @param regex The regular expression to use.
+     * @throws NullPointerException if regex is {@code null}.
+     * @throws java.util.regex.PatternSyntaxException if regex is not a valid regular expression.
+     */
+    public final void setUsernamePattern(final String regex) {
+        Objects.requireNonNull(regex);
+        // verify regex syntax
+        Pattern.compile(regex);
+        System.setProperty(RegistryManagementConstants.SYSTEM_PROPERTY_USERNAME_REGEX, regex);
     }
 }

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/config/TenantServiceProperties.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/config/TenantServiceProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,7 +25,7 @@ public class TenantServiceProperties {
 
     private Duration tenantTtl = DEFAULT_TENANT_TTL;
 
-    public Duration getTenantTtl() {
+    public final Duration getTenantTtl() {
         return this.tenantTtl;
     }
 
@@ -36,7 +36,7 @@ public class TenantServiceProperties {
      * @throws NullPointerException if ttl is {@code null}.
      * @throws IllegalArgumentException if the duration is less than one second.
      */
-    public void setTenantTtl(final Duration tenantTtl) {
+    public final void setTenantTtl(final Duration tenantTtl) {
         Objects.requireNonNull(tenantTtl);
 
         if (tenantTtl.toSeconds() <= 0) {

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedRegistrationConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedRegistrationConfigProperties.java
@@ -12,6 +12,11 @@
  *******************************************************************************/
 package org.eclipse.hono.deviceregistry.mongodb.config;
 
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import org.eclipse.hono.util.RegistryManagementConstants;
+
 /**
  * Configuration properties for Hono's device registration and management APIs.
  */
@@ -72,5 +77,21 @@ public final class MongoDbBasedRegistrationConfigProperties extends AbstractMong
         return DEFAULT_DEVICE_COLLECTION_NAME;
     }
 
-
+    /**
+     * Sets the regular expression that should be used to validate authentication identifiers (user names) of
+     * hashed-password credentials.
+     * <p>
+     * After successful validation of the expression's syntax, the regex is set as the value
+     * of system property {@value RegistryManagementConstants#SYSTEM_PROPERTY_USERNAME_REGEX}.
+     *
+     * @param regex The regular expression to use.
+     * @throws NullPointerException if regex is {@code null}.
+     * @throws java.util.regex.PatternSyntaxException if regex is not a valid regular expression.
+     */
+    public void setUsernamePattern(final String regex) {
+        Objects.requireNonNull(regex);
+        // verify regex syntax
+        Pattern.compile(regex);
+        System.setProperty(RegistryManagementConstants.SYSTEM_PROPERTY_USERNAME_REGEX, regex);
+    }
 }

--- a/site/documentation/content/admin-guide/jdbc-device-registry-config.md
+++ b/site/documentation/content/admin-guide/jdbc-device-registry-config.md
@@ -47,10 +47,11 @@ and availability.
 | `HONO_REGISTRY_JDBC_MANAGEMENT_PASSWORD`         <br> `--hono.registry.jdbc.management.password`          | no  | -    | The password used to access the database. |
 | `HONO_REGISTRY_JDBC_MANAGEMENT_MAXIMUMPOOLSIZE`  <br> `--hono.registry.jdbc.management.maximumPoolSize`   | no  | Depends on the connection pool implementation. `15` for C3P0. | The maximum size of the connection pool. |
 | `HONO_REGISTRY_JDBC_MANAGEMENT_TABLENAME`        <br> `--hono.registry.jdbc.management`                   | no  | -    | The name of the table the datastore uses. If the datastore requires multiple tables, this is the prefix. |
-| `HONO_REGISTRY_SVC_TASKEXECUTORQUEUESIZE`        <br> `--hono.registry.svc.taskExecutorQueueSize`         | no  | `1024` | The size of the executor queue for hashing passwords. |
 | `HONO_REGISTRY_SVC_CREDENTIALSTTL`               <br> `--hono.registry.svc.credentialsTtl`                | no  | `1m` | The TTL for credentials responses. |
-| `HONO_REGISTRY_SVC_REGISTRATIONTTL`              <br> `--hono.registry.svc.registrationTtl`               | no  | `1m` | The TTL for registrations responses. |
 | `HONO_REGISTRY_SVC_MAXBCRYPTITERATIONS`          <br> `--hono.registry.svc.maxBcryptIterations`           | no  | `10` | The maximum number of allowed bcrypt iterations. |
+| `HONO_REGISTRY_SVC_REGISTRATIONTTL`              <br> `--hono.registry.svc.registrationTtl`               | no  | `1m` | The TTL for registrations responses. |
+| `HONO_REGISTRY_SVC_TASKEXECUTORQUEUESIZE`        <br> `--hono.registry.svc.taskExecutorQueueSize`         | no  | `1024` | The size of the executor queue for hashing passwords. |
+| `HONO_REGISTRY_SVC_USERNAMEPATTERN`              <br> `--hono.registry.svc.usernamePattern`               | no | `^[a-zA-Z0-9-_=\\.]+$` | The regular expression to use for validating authentication identifiers (user names) of hashed-password credentials. |
 | `HONO_TENANT_JDBC_ADAPTER_URL`                   <br> `--hono.tenant.jdbc.adapter.url`                    | yes | -    | The JDBC URL to the database. |
 | `HONO_TENANT_JDBC_ADAPTER_DRIVERCLASS`           <br> `--hono.tenant.jdbc.adapter.driverClass`            | no  | The default driver registered for the JDBC URL. | The class name of the JDBC driver.|
 | `HONO_TENANT_JDBC_ADAPTER_USERNAME`              <br> `--hono.tenant.jdbc.adapter.username`               | no  | -    | The username used to access the database. |

--- a/site/documentation/content/admin-guide/mongodb-device-registry-config.md
+++ b/site/documentation/content/admin-guide/mongodb-device-registry-config.md
@@ -60,6 +60,7 @@ The following table provides an overview of the configuration variables and corr
 | `HONO_REGISTRY_SVC_COLLECTION_NAME`<br>`--hono.registry.svc.collectionName` | no | `devices` | The name of the MongoDB collection where the server stores registered device information.|
 | `HONO_REGISTRY_SVC_MAX_DEVICES_PER_TENANT`<br>`--hono.registry.svc.maxDevicesPerTenant` | no | `-1` | The number of devices that can be registered for each tenant. It is an error to set this property to a value < -1. The value `-1` indicates that no limit is set.|
 | `HONO_REGISTRY_SVC_RECEIVER_LINK_CREDIT`<br>`--hono.registry.svc.receiverLinkCredit` | no | `100` | The number of credits to flow to a client connecting to the Device Registration endpoint. |
+| `HONO_REGISTRY_SVC_USERNAMEPATTERN`<br>`--hono.registry.svc.usernamePattern` | no | `^[a-zA-Z0-9-_=\\.]+$` | The regular expression to use for validating authentication identifiers (user names) of hashed-password credentials. |
 | `HONO_TENANT_SVC_CACHE_MAX_AGE`<br>`--hono.tenant.svc.cacheMaxAge` | no | `180` | The maximum period of time (seconds) that information returned by the service's operations may be cached for. |
 | `HONO_TENANT_SVC_COLLECTION_NAME`<br>`--hono.tenant.svc.collectionName` | no | `tenants` | The name of the MongoDB collection where the server stores tenants information.|
 | `HONO_TENANT_SVC_RECEIVER_LINK_CREDIT`<br>`--hono.tenant.svc.receiverLinkCredit` | no | `100` | The number of credits to flow to a client connecting to the Tenant endpoint. |

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -6,6 +6,12 @@ description = "Information about changes in recent Hono releases. Includes new f
 
 ## 1.10.0 (not yet released)
 
+### New Features
+
+* The JDBC and Mongo DB based registry implementations now support configuration of a regular expression that should
+  be used to validate authentication identifiers (user names) of hashed-password credentials. Please refer to the
+  corresponding Admin Guides for details.
+
 ### Fixes & Enhancements
 
 * The Quarkus based variants of Hono's components now support configuring the Hot Rod client with a key and/or


### PR DESCRIPTION
The MongoDB and JDBC based registries have been changed to allow for the
configuration of a regular expression that is used by the
PasswordCredential class to validate the authentication identifier (user
name). The regular expression is read from a System property by the
PasswordCredential class because it is instantiated by the Jackson
framework when unmarshalling a JSON string and I can currently not think
of any other way of passing it in.

Fixes #2559
