### PR TITLE
Allow multiple tenants to have empty CA array

### DIFF
--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/tenant/AbstractTenantServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/tenant/AbstractTenantServiceTest.java
@@ -564,6 +564,51 @@ public interface AbstractTenantServiceTest {
     }
 
     /**
+     * Verifies that multiple tenants can contain an empty collection of trusted CAs.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    default void testUpdateTenantAllowsEmptyCaArray(final VertxTestContext ctx) {
+
+        final var trustedCaOne = new TrustedCertificateAuthority();
+        trustedCaOne.setSubjectDn("CN=one");
+        trustedCaOne.setPublicKey("NOTAKEY".getBytes(StandardCharsets.UTF_8));
+
+        final var trustedCaTwo = new TrustedCertificateAuthority();
+        trustedCaTwo.setSubjectDn("CN=two");
+        trustedCaTwo.setPublicKey("NOTAKEY".getBytes(StandardCharsets.UTF_8));
+
+        // GIVEN two tenants with one CA configured each
+        addTenant("tenantOne", new Tenant().setTrustedCertificateAuthorities(List.of(trustedCaOne)))
+            .onFailure(ctx::failNow)
+            .compose(ok -> addTenant("tenantTwo", new Tenant().setTrustedCertificateAuthorities(List.of(trustedCaTwo))))
+            .onFailure(ctx::failNow)
+            .compose(ok -> {
+                // WHEN removing the CA from the first tenant
+                final var updatedTenantOne = new Tenant().setTrustedCertificateAuthorities(List.of());
+                return getTenantManagementService().updateTenant(
+                        "tenantOne",
+                        updatedTenantOne,
+                        Optional.empty(),
+                        NoopSpan.INSTANCE);
+            })
+            // THEN the update succeeds
+            .onFailure(ctx::failNow)
+            .compose(ok -> {
+                // and WHEN removing the CA from the second tenant
+                final var updatedTenantTwo = new Tenant().setTrustedCertificateAuthorities(List.of());
+                return getTenantManagementService().updateTenant(
+                        "tenantTwo",
+                        updatedTenantTwo,
+                        Optional.empty(),
+                        NoopSpan.INSTANCE);
+            })
+            // THEN the update succeeds as well
+            .onComplete(ctx.completing());
+    }
+
+    /**
      * Verifies that a tenant is registered.
      *
      * @param svc The service to probe.

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantServiceTest.java
@@ -42,6 +42,7 @@ import io.vertx.junit5.VertxTestContext;
 @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
 class MongoDbBasedTenantServiceTest implements AbstractTenantServiceTest {
 
+    private static final String DB_NAME_TENANTS_TEST = "hono-tenants-test";
     private static final Logger LOG = LoggerFactory.getLogger(MongoDbBasedTenantServiceTest.class);
 
     private final MongoDbBasedTenantsConfigProperties config = new MongoDbBasedTenantsConfigProperties();
@@ -59,7 +60,7 @@ class MongoDbBasedTenantServiceTest implements AbstractTenantServiceTest {
     public void startService(final VertxTestContext testContext) {
 
         vertx = Vertx.vertx();
-        dao = MongoDbTestUtils.getTenantDao(vertx, "hono-tenants-test");
+        dao = MongoDbTestUtils.getTenantDao(vertx, DB_NAME_TENANTS_TEST);
         tenantService = new MongoDbBasedTenantService(dao, config);
         tenantManagementService = new MongoDbBasedTenantManagementService(dao, config);
         dao.createIndices().onComplete(testContext.completing());

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -25,6 +25,9 @@ description = "Information about changes in recent Hono releases. Includes new f
   matching credentials against a given *client context*.
 * The device registry implementations did not return a JSON object in a response to a failed request as specified
   in the Device Registry Management API. This has been fixed.
+* The MongoDB based registry erroneously rejected requests that would result in multiple tenants having an empty
+  set of trusted CAs. This was due to an erroneous index definition on the *tenants* collection. The index will
+  be dropped and re-created when the registry starts up.
 
 ## 1.9.0
 

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
@@ -427,6 +427,38 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
     }
 
     /**
+     * Verifies that multiple tenants can contain an empty collection of trusted CAs.
+     *
+     * @param context The Vert.x test context.
+     */
+    @Test
+    public void testUpdateTenantAllowsEmptyCaCollection(final VertxTestContext context) {
+
+        final var tenantTwoId = getHelper().getRandomTenantId();
+        final PublicKey publicKey = TenantApiTests.getRandomPublicKey();
+        final TrustedCertificateAuthority trustAnchor1 = Tenants
+                .createTrustAnchor("test-ca", "CN=test-dn-1", publicKey.getEncoded(), publicKey.getAlgorithm(),
+                        Instant.now(), Instant.now().plus(365, ChronoUnit.DAYS));
+        final TrustedCertificateAuthority trustAnchor2 = Tenants
+                .createTrustAnchor(null, "CN=test-dn-2", publicKey.getEncoded(), publicKey.getAlgorithm(),
+                        Instant.now(), Instant.now().plus(365, ChronoUnit.DAYS));
+
+        getHelper().registry.addTenant(tenantId, new Tenant().setTrustedCertificateAuthorities(List.of(trustAnchor1)))
+            .compose(ok -> getHelper().registry.addTenant(
+                    tenantTwoId,
+                    new Tenant().setTrustedCertificateAuthorities(List.of(trustAnchor2))))
+            .compose(ok -> getHelper().registry.updateTenant(
+                    tenantId,
+                    new Tenant().setTrustedCertificateAuthorities(List.of()),
+                    HttpURLConnection.HTTP_NO_CONTENT))
+            .compose(ok -> getHelper().registry.updateTenant(
+                    tenantTwoId,
+                    new Tenant().setTrustedCertificateAuthorities(List.of()),
+                    HttpURLConnection.HTTP_NO_CONTENT))
+            .onComplete(context.completing());
+    }
+
+    /**
      * Verifies that the service rejects an update request for a non-existing tenant.
      *
      * @param context The vert.x test context.

--- a/tests/src/test/resources/mongodb/init_db/2_erroneous-subject-dn-index.js
+++ b/tests/src/test/resources/mongodb/init_db/2_erroneous-subject-dn-index.js
@@ -1,0 +1,11 @@
+db.tenants.createIndex(
+  {
+    "tenant.trusted-ca.subject-dn": 1
+  },
+  {
+    unique: true,
+    partialFilterExpression: {
+      "tenant.trusted-ca": { $exists: true }
+    }
+  }
+);


### PR DESCRIPTION
The (partial) unique index defined on the tenant's trusted-ca array had
been defined using an $exists expression on the trusted-ca property.
This caused tenants with an empty trusted-ca array to also be indexed.

The partial index now uses an $exists expression on
trusted-ca.subject-dn instead which means that only documents will be
indexed that have a non-empty trusted-ca array.

Fixes #2819