### PR TITLE
Prevent tenants from having empty CA array

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/Tenant.java
@@ -78,11 +78,12 @@ public class Tenant {
     private ResourceLimits resourceLimits;
 
     @JsonProperty(RegistryManagementConstants.FIELD_TRACING)
-    @JsonInclude(Include.NON_EMPTY)
+    @JsonInclude(Include.NON_NULL)
     private TenantTracingConfig tracing;
 
     @JsonProperty(RegistryManagementConstants.FIELD_PAYLOAD_TRUSTED_CA)
-    private List<TrustedCertificateAuthority> trustedCertificateAuthorities;
+    @JsonInclude(Include.NON_EMPTY)
+    private List<TrustedCertificateAuthority> trustedCertificateAuthorities = List.of();
 
     @JsonProperty(RegistryManagementConstants.FIELD_REGISTRATION_LIMITS)
     @JsonInclude(Include.NON_DEFAULT)
@@ -118,7 +119,7 @@ public class Tenant {
         this.registrationLimits = other.registrationLimits;
         this.tracing = other.tracing;
         if (Objects.nonNull(other.trustedCertificateAuthorities)) {
-            this.trustedCertificateAuthorities = new ArrayList<>(other.trustedCertificateAuthorities);
+            this.trustedCertificateAuthorities = List.copyOf(other.trustedCertificateAuthorities);
         }
     }
 
@@ -399,7 +400,7 @@ public class Tenant {
      */
     public Tenant setTrustedCertificateAuthorities(final List<TrustedCertificateAuthority> trustedCertificateAuthorities) {
         if (trustedCertificateAuthorities != null) {
-            this.trustedCertificateAuthorities = Collections.unmodifiableList(trustedCertificateAuthorities);
+            this.trustedCertificateAuthorities = List.copyOf(trustedCertificateAuthorities);
         }
         return this;
     }

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -25,6 +25,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   matching credentials against a given *client context*.
 * The device registry implementations did not return a JSON object in a response to a failed request as specified
   in the Device Registry Management API. This has been fixed.
+* The MongoDB based registry erroneously rejected requests that would result in multiple tenants having an empty
+  set of trusted CAs. This has been fixed.
 
 ## 1.9.0
 

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
@@ -427,6 +427,39 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
     }
 
     /**
+     * Verifies that setting an empty list of trusted CAs on multiple tenants does not result in a unique key
+     * violation.
+     *
+     * @param context The Vert.x test context.
+     */
+    @Test
+    public void testUpdateTenantPreventsEmptyCaArray(final VertxTestContext context) {
+
+        final var tenantTwoId = getHelper().getRandomTenantId();
+        final PublicKey publicKey = TenantApiTests.getRandomPublicKey();
+        final TrustedCertificateAuthority trustAnchor1 = Tenants
+                .createTrustAnchor("test-ca", "CN=test-dn-1", publicKey.getEncoded(), publicKey.getAlgorithm(),
+                        Instant.now(), Instant.now().plus(365, ChronoUnit.DAYS));
+        final TrustedCertificateAuthority trustAnchor2 = Tenants
+                .createTrustAnchor(null, "CN=test-dn-2", publicKey.getEncoded(), publicKey.getAlgorithm(),
+                        Instant.now(), Instant.now().plus(365, ChronoUnit.DAYS));
+
+        getHelper().registry.addTenant(tenantId, new Tenant().setTrustedCertificateAuthorities(List.of(trustAnchor1)))
+            .compose(ok -> getHelper().registry.addTenant(
+                    tenantTwoId,
+                    new Tenant().setTrustedCertificateAuthorities(List.of(trustAnchor2))))
+            .compose(ok -> getHelper().registry.updateTenant(
+                    tenantId,
+                    new Tenant().setTrustedCertificateAuthorities(List.of()),
+                    HttpURLConnection.HTTP_NO_CONTENT))
+            .compose(ok -> getHelper().registry.updateTenant(
+                    tenantTwoId,
+                    new Tenant().setTrustedCertificateAuthorities(List.of()),
+                    HttpURLConnection.HTTP_NO_CONTENT))
+            .onComplete(context.completing());
+    }
+
+    /**
      * Verifies that the service rejects an update request for a non-existing tenant.
      *
      * @param context The vert.x test context.


### PR DESCRIPTION
The (partial) unique index defined on the tenant's trusted-ca array is
defined using an $exists expression on the trusted-ca property.
This causes tenants with an empty trusted-ca array to also be indexed.

The Tenant class' trustedCertificateAuthorities field has been annotated
to only be included in its JSON representation when the collection is
not empty.

Fixes #2819