### PR TITLE
Fix Kafka configuration on Sandbox

### DIFF
--- a/deploy/src/main/sandbox/hono-values.yml
+++ b/deploy/src/main/sandbox/hono-values.yml
@@ -228,10 +228,15 @@ kafka:
   externalAccess:
     service:
       type: "LoadBalancer"
+      port: 9092
+      loadBalancerIPs:
+        - "hono.eclipseprojects.io"
     autoDiscovery:
-      resources:
-        requests:
-          cpu: 100m
+      enabled: false
+  serviceAccount:
+    create: false
+  rbac:
+    create: false
   resources:
     requests:
       cpu: 150m


### PR DESCRIPTION
The Kafka server had returned a wrong IP address of the broker to clients. To fix this, the domain name of the sandbox is now explicitly set as the "loadBalancerIP" at the external service for Kafka. The "auto-discovery" of the load balancer IP at the Bitnami Helm chart is now disabled.