### PR TITLE
Report 'hono.commands.*' metrics in Command Router

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/ConnectedDevicesAsyncCacheLoader.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/ConnectedDevicesAsyncCacheLoader.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import org.eclipse.hono.adapter.metric.MicrometerBasedMetrics;
+import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.TenantConstants;
 import org.slf4j.Logger;

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/ConnectionDurationAsyncCacheLoader.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/ConnectionDurationAsyncCacheLoader.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import org.eclipse.hono.adapter.metric.MicrometerBasedMetrics;
+import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.TenantConstants;
 import org.slf4j.Logger;

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/DataVolumeAsyncCacheLoader.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/DataVolumeAsyncCacheLoader.java
@@ -20,8 +20,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import org.eclipse.hono.adapter.metric.MicrometerBasedMetrics;
 import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.TenantConstants;
 import org.slf4j.Logger;

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterMetrics.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/AmqpAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.adapter.amqp;
 
-import org.eclipse.hono.adapter.metric.Metrics;
-import org.eclipse.hono.adapter.metric.NoopBasedMetrics;
+import org.eclipse.hono.service.metric.Metrics;
+import org.eclipse.hono.service.metric.NoopBasedMetrics;
 
 /**
  * Metrics for the AMQP adapter.

--- a/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/MicrometerBasedAmqpAdapterMetrics.java
+++ b/adapters/amqp-vertx-base/src/main/java/org/eclipse/hono/adapter/amqp/MicrometerBasedAmqpAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.adapter.amqp;
 
-import org.eclipse.hono.adapter.metric.MicrometerBasedMetrics;
+import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterMetrics.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/CoapAdapterMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.adapter.coap;
 
-import org.eclipse.hono.adapter.metric.Metrics;
-import org.eclipse.hono.adapter.metric.NoopBasedMetrics;
+import org.eclipse.hono.service.metric.Metrics;
+import org.eclipse.hono.service.metric.NoopBasedMetrics;
 
 /**
  * Metrics for the COAP based adapters.

--- a/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/MicrometerBasedCoapAdapterMetrics.java
+++ b/adapters/coap-vertx-base/src/main/java/org/eclipse/hono/adapter/coap/MicrometerBasedCoapAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.adapter.coap;
 
-import org.eclipse.hono.adapter.metric.MicrometerBasedMetrics;
+import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/HttpAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.adapter.http;
 
-import org.eclipse.hono.adapter.metric.Metrics;
-import org.eclipse.hono.adapter.metric.NoopBasedMetrics;
+import org.eclipse.hono.service.metric.Metrics;
+import org.eclipse.hono.service.metric.NoopBasedMetrics;
 
 /**
  * Metrics for the HTTP based adapters.

--- a/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/MicrometerBasedHttpAdapterMetrics.java
+++ b/adapters/http-vertx-base/src/main/java/org/eclipse/hono/adapter/http/MicrometerBasedHttpAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.adapter.http;
 
-import org.eclipse.hono.adapter.metric.MicrometerBasedMetrics;
+import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MicrometerBasedMqttAdapterMetrics.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MicrometerBasedMqttAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.adapter.mqtt;
 
-import org.eclipse.hono.adapter.metric.MicrometerBasedMetrics;
+import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.vertx.core.Vertx;

--- a/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
+++ b/adapters/mqtt-vertx-base/src/main/java/org/eclipse/hono/adapter/mqtt/MqttAdapterMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,8 +13,8 @@
 
 package org.eclipse.hono.adapter.mqtt;
 
-import org.eclipse.hono.adapter.metric.Metrics;
-import org.eclipse.hono.adapter.metric.NoopBasedMetrics;
+import org.eclipse.hono.service.metric.Metrics;
+import org.eclipse.hono.service.metric.NoopBasedMetrics;
 
 /**
  * Metrics for the MQTT adapter.

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/InternalCommandSender.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/InternalCommandSender.java
@@ -36,6 +36,10 @@ public interface InternalCommandSender extends Lifecycle {
      * @param adapterInstanceId The protocol adapter instance id to send the command to.
      * @return A future that will be succeeded once the outcome of the send operation has been applied to
      *         the command context.
+     *         <p>
+     *         The future will be failed with a {@link org.eclipse.hono.client.ServerErrorException} if the message
+     *         could not be sent or if no acknowledgement was received from the peer in time (if the
+     *         transport protocol supports this).
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     Future<Void> sendCommand(CommandContext commandContext, String adapterInstanceId);

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/DeviceConnectionDurationTracker.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/DeviceConnectionDurationTracker.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.eclipse.hono.adapter.metric;
+package org.eclipse.hono.service.metric;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/Metrics.java
@@ -11,9 +11,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.adapter.metric;
+package org.eclipse.hono.service.metric;
 
-import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.TenantObject;
 
 import io.micrometer.core.instrument.Timer.Sample;

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.adapter.metric;
+package org.eclipse.hono.service.metric;
 
 import java.util.Map;
 import java.util.Objects;
@@ -24,7 +24,6 @@ import java.util.function.Supplier;
 
 import org.eclipse.hono.client.SendMessageSampler;
 import org.eclipse.hono.config.ProtocolAdapterProperties;
-import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
 import org.eclipse.hono.service.metric.MetricsTags.ProcessingOutcome;
 import org.eclipse.hono.service.util.ServiceBaseUtils;

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/NoopBasedMetrics.java
@@ -11,11 +11,10 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 
-package org.eclipse.hono.adapter.metric;
+package org.eclipse.hono.service.metric;
 
 import java.util.Objects;
 
-import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.metric.MetricsTags.ConnectionAttemptOutcome;
 import org.eclipse.hono.service.metric.MetricsTags.Direction;
 import org.eclipse.hono.service.metric.MetricsTags.EndpointType;

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/DeviceConnectionDurationTrackerTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/DeviceConnectionDurationTrackerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.hono.adapter.metric;
+package org.eclipse.hono.service.metric;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import org.eclipse.hono.adapter.metric.DeviceConnectionDurationTracker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/metric/MicrometerBasedMetricsTest.java
@@ -12,7 +12,7 @@
  */
 
 
-package org.eclipse.hono.adapter.metric;
+package org.eclipse.hono.service.metric;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.eclipse.hono.config.ProtocolAdapterProperties;
-import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.service.metric.MetricsTags.EndpointType;
 import org.eclipse.hono.service.metric.MetricsTags.QoS;
 import org.eclipse.hono.service.metric.MetricsTags.TtdStatus;

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/CommandRouterMetrics.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/CommandRouterMetrics.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.commandrouter;
+
+import org.eclipse.hono.service.metric.Metrics;
+import org.eclipse.hono.service.metric.NoopBasedMetrics;
+
+/**
+ * Metrics for the Command Router.
+ */
+public interface CommandRouterMetrics extends Metrics {
+
+    /**
+     * A no-op implementation this specific metrics type.
+     */
+    final class Noop extends NoopBasedMetrics implements CommandRouterMetrics {
+
+        private Noop() {
+        }
+    }
+
+    /**
+     * The no-op implementation.
+     */
+    CommandRouterMetrics NOOP = new Noop();
+
+    // empty for now
+}

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/MicrometerBasedCommandRouterMetrics.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/MicrometerBasedCommandRouterMetrics.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.commandrouter;
+
+import org.eclipse.hono.service.metric.MicrometerBasedMetrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.Vertx;
+
+/**
+ * Metrics for the Command Router.
+ */
+public class MicrometerBasedCommandRouterMetrics extends MicrometerBasedMetrics implements CommandRouterMetrics {
+
+    /**
+     * Create a new metrics instance for the Command Router service.
+     *
+     * @param registry The meter registry to use.
+     * @param vertx The Vert.x instance to use.
+     *
+     * @throws NullPointerException if either parameter is {@code null}.
+     */
+    public MicrometerBasedCommandRouterMetrics(final MeterRegistry registry, final Vertx vertx) {
+        super(registry, vertx);
+    }
+}

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.client.command.CommandConsumer;
 import org.eclipse.hono.client.impl.CachingClientFactory;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.commandrouter.CommandConsumerFactory;
+import org.eclipse.hono.commandrouter.CommandRouterMetrics;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.util.AddressHelper;
 import org.eclipse.hono.util.CommandConstants;
@@ -74,6 +75,7 @@ public class ProtonBasedCommandConsumerFactoryImpl extends AbstractServiceClient
      * @param commandTargetMapper The component for mapping an incoming command to the gateway (if applicable) and
      *            protocol adapter instance that can handle it. Note that no initialization of this factory will be done
      *            here, that is supposed to be done by the calling method.
+     * @param metrics The component to use for reporting metrics.
      * @param samplerFactory The sampler factory to use.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
@@ -81,13 +83,14 @@ public class ProtonBasedCommandConsumerFactoryImpl extends AbstractServiceClient
             final HonoConnection connection,
             final TenantClient tenantClient,
             final CommandTargetMapper commandTargetMapper,
+            final CommandRouterMetrics metrics,
             final SendMessageSampler.Factory samplerFactory) {
         super(connection, samplerFactory);
         Objects.requireNonNull(tenantClient);
         Objects.requireNonNull(commandTargetMapper);
 
         mappingAndDelegatingCommandHandler = new ProtonBasedMappingAndDelegatingCommandHandler(tenantClient, connection,
-                commandTargetMapper);
+                commandTargetMapper, metrics);
         mappingAndDelegatingCommandConsumerFactory = new CachingClientFactory<>(connection.getVertx(), c -> true);
     }
 

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedMappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedMappingAndDelegatingCommandHandlerTest.java
@@ -38,6 +38,7 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.HonoConnection;
 import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.commandrouter.CommandRouterMetrics;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.eclipse.hono.test.VertxMockSupport;
@@ -105,8 +106,9 @@ public class ProtonBasedMappingAndDelegatingCommandHandlerTest {
         when(tenantClient.get(eq(tenantId), any())).thenReturn(Future.succeededFuture(TenantObject.from(tenantId)));
         commandTargetMapper = mock(CommandTargetMapper.class);
 
+        final CommandRouterMetrics metrics = mock(CommandRouterMetrics.class);
         mappingAndDelegatingCommandHandler = new ProtonBasedMappingAndDelegatingCommandHandler(tenantClient,
-                connection, commandTargetMapper);
+                connection, commandTargetMapper, metrics);
     }
 
     /**

--- a/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router-base/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
@@ -38,6 +38,7 @@ import org.eclipse.hono.client.command.kafka.KafkaBasedCommandResponseSender;
 import org.eclipse.hono.client.command.kafka.KafkaBasedInternalCommandSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
 import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.commandrouter.CommandRouterMetrics;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.test.VertxMockSupport;
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
+import io.opentracing.Tracer;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -98,8 +100,10 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
 
         final Context context = VertxMockSupport.mockContext(mock(Vertx.class));
         final KafkaCommandProcessingQueue commandQueue = new KafkaCommandProcessingQueue(context);
+        final CommandRouterMetrics metrics = mock(CommandRouterMetrics.class);
+        final Tracer tracer = TracingMockSupport.mockTracer(TracingMockSupport.mockSpan());
         cmdHandler = new KafkaBasedMappingAndDelegatingCommandHandler(tenantClient, commandQueue, commandTargetMapper,
-                internalCommandSender, kafkaBasedCommandResponseSender, TracingMockSupport.mockTracer(TracingMockSupport.mockSpan()));
+                internalCommandSender, kafkaBasedCommandResponseSender, metrics, tracer);
     }
 
     /**

--- a/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/MetricsFactory.java
+++ b/services/command-router-quarkus/src/main/java/org/eclipse/hono/commandrouter/quarkus/MetricsFactory.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.commandrouter.quarkus;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.eclipse.hono.commandrouter.MicrometerBasedCommandRouterMetrics;
+import org.eclipse.hono.service.metric.MetricsTags;
+import org.eclipse.hono.util.Constants;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.Vertx;
+
+/**
+ * A factory class that creates Command Router specific metrics.
+ */
+@ApplicationScoped
+public class MetricsFactory {
+
+    @Singleton
+    @Produces
+    MicrometerBasedCommandRouterMetrics metrics(
+            final Vertx vertx,
+            final MeterRegistry registry) {
+        registry.config().commonTags(MetricsTags.forService(Constants.SERVICE_NAME_COMMAND_ROUTER));
+        return new MicrometerBasedCommandRouterMetrics(registry, vertx);
+    }
+}

--- a/site/documentation/content/api/Metrics.md
+++ b/site/documentation/content/api/Metrics.md
@@ -45,6 +45,7 @@ The names of Hono's standard components are as follows:
 | ----------------- | ------------------ |
 | Auth Server       | `hono-auth`         |
 | Device Registry   | `hono-registry`     |
+| Command Router    | `hono-command-router` |
 | AMQP adapter      | `hono-amqp`         |
 | CoAP adapter      | `hono-coap`         |
 | HTTP adapter      | `hono-http`         |
@@ -108,4 +109,4 @@ For an incoming message of size 10KB, it is reported as 12KB.
 
 ### Service Metrics
 
-Hono's service components do not report any metrics at the moment.
+Hono's service components do not report own metrics at the moment. The Command Router service component reports the *hono.commands.received* and *hono.commands.payload* metrics for command messages that could not be forwarded to a protocol adapter.

--- a/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.hono.tests.commandrouter;
 
+import static org.mockito.Mockito.mock;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
 import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.commandrouter.CommandRouterMetrics;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
 import org.eclipse.hono.commandrouter.impl.kafka.KafkaBasedCommandConsumerFactoryImpl;
 import org.eclipse.hono.test.TracingMockSupport;
@@ -418,9 +420,10 @@ public class KafkaBasedCommandConsumerFactoryImplIT {
         final KafkaConsumerConfigProperties kafkaConsumerConfig = new KafkaConsumerConfigProperties();
         kafkaConsumerConfig.setConsumerConfig(Map.of(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS));
+        final CommandRouterMetrics metrics = mock(CommandRouterMetrics.class);
         final var kafkaBasedCommandConsumerFactoryImpl = new KafkaBasedCommandConsumerFactoryImpl(vertx, tenantClient,
                 commandTargetMapper, producerFactory, IntegrationTestSupport.getKafkaProducerConfig(),
-                kafkaConsumerConfig, tracer);
+                kafkaConsumerConfig, metrics, tracer);
         kafkaBasedCommandConsumerFactoryImpl.setGroupId(commandRouterGroupId);
         componentsToStopAfterTest.add(kafkaBasedCommandConsumerFactoryImpl);
         return kafkaBasedCommandConsumerFactoryImpl;


### PR DESCRIPTION
This is for #2827.

First commit moves metrics classes into the service-base module. This is so that they can be used from the command router component.

Second commit lets the 'hono.commands.received' and 'hono.commands.payload' metrics be reported in the Command Router for commands that could not be forwarded.