### PR TITLE
Documentation: Add the JDBC device registry to page "Device Registries".

### DIFF
--- a/site/documentation/content/user-guide/device-registry.md
+++ b/site/documentation/content/user-guide/device-registry.md
@@ -9,3 +9,5 @@ Eclipse Hono&trade; provides these device registry implementations:
 [File Based Device Registry]({{< relref "/user-guide/file-based-device-registry" >}})
 
 [MongoDB Based Device Registry]({{< relref "/user-guide/mongodb-based-device-registry" >}}).
+
+[JDBC Based Device Registry]({{< relref "/user-guide/jdbc-based-device-registry" >}}).


### PR DESCRIPTION
The page "Device Registries" maintains the URL path that the file based registry used to have when it was the only supported implementation. It links to the current implementations but the JDBC based one was missing. This adds it.