### PR TITLE
Support deletion of all devices of a tenant

### DIFF
--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
@@ -179,4 +179,25 @@ public interface DeviceManagementService {
      *      Device Registry Management API - Delete Device Registration</a>
      */
     Future<Result<Void>> deleteDevice(String tenantId, String deviceId, Optional<String> resourceVersion, Span span);
+
+    /**
+     * Deletes all devices of a tenant.
+     *
+     * @param tenantId The tenant that the devices to be deleted belong to.
+     * @param span The active OpenTracing span to use for tracking this operation.
+     *             <p>
+     *             Implementations <em>must not</em> invoke the {@link Span#finish()} nor the {@link Span#finish(long)}
+     *             methods. However,implementations may log (error) events on this span, set tags and use this span
+     *             as the parent for additional spans created as part of this method's execution.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if all of the tenant's devices have been deleted successfully.
+     *         Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServiceInvocationException} containing an error code as specified
+     *         in the Device Registry Management API.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/deleteDevicesOfTenant">
+     *      Device Registry Management API - Delete Devices of Tenant</a>
+     */
+    Future<Result<Void>> deleteDevicesOfTenant(String tenantId, Span span);
 }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpointTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpointTest.java
@@ -421,6 +421,34 @@ public class DelegatingDeviceManagementHttpEndpointTest {
                 any(Span.class));
     }
 
+    /**
+     * Verifies that the endpoint uses the tenant ID provided in a request's URI
+     * for deleting all of a tenant's devices.
+     */
+    @Test
+    public void testDeleteDevicesUsesTenantIdFromUriParam() {
+
+        when(service.deleteDevicesOfTenant(anyString(), any(Span.class)))
+            .thenReturn(Future.succeededFuture(OperationResult.from(HttpURLConnection.HTTP_NO_CONTENT)));
+
+        final HttpServerResponse response = newResponse();
+
+        final HttpServerRequest request = newRequest(
+                HttpMethod.DELETE,
+                "/v1/devices/mytenant",
+                requestHeaders,
+                requestParams,
+                response);
+
+        router.handle(request);
+
+        verify(response).setStatusCode(HttpURLConnection.HTTP_NO_CONTENT);
+        verify(service).deleteDevicesOfTenant(
+                eq("mytenant"),
+                any(Span.class));
+    }
+
+
     private HttpServerRequest newRequest(
             final HttpMethod method,
             final String relativeURI,

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
@@ -169,6 +169,12 @@ public class FileBasedDeviceBackend implements DeviceBackend, RegistrationServic
     }
 
     @Override
+    public Future<Result<Void>> deleteDevicesOfTenant(final String tenantId, final Span span) {
+
+        return registrationService.deleteDevicesOfTenant(tenantId, span);
+    }
+
+    @Override
     public Future<OperationResult<Id>> createDevice(
             final String tenantId,
             final Optional<String> deviceId,

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationService.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.deviceregistry.service.device.AbstractRegistrationService;
 import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
@@ -433,6 +434,13 @@ public class FileBasedRegistrationService extends AbstractRegistrationService
         dirty.set(true);
         return Future.succeededFuture(Result.from(HttpURLConnection.HTTP_NO_CONTENT));
 
+    }
+
+    @Override
+    public Future<Result<Void>> deleteDevicesOfTenant(final String tenantId, final Span span) {
+        return Future.failedFuture(new ServerErrorException(
+                HttpURLConnection.HTTP_NOT_IMPLEMENTED,
+                "this registry does not support the delete devices of tenant operation"));
     }
 
     @Override

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/DeviceManagementServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/DeviceManagementServiceImpl.java
@@ -120,6 +120,15 @@ public class DeviceManagementServiceImpl extends AbstractDeviceManagementService
     }
 
     @Override
+    protected Future<Result<Void>> processDeleteDevicesOfTenant(final String tenantId, final Span span) {
+
+        return this.store
+                .dropTenant(tenantId, span.context())
+                .map(r -> Result.<Void>from(HttpURLConnection.HTTP_NO_CONTENT))
+                .recover(e -> Services.recover(e));
+    }
+
+    @Override
     protected String generateDeviceId(final String tenantId) {
         return UUID.randomUUID().toString();
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/CredentialsDao.java
@@ -111,4 +111,19 @@ public interface CredentialsDao {
      * @throws NullPointerException if any of tenant, device ID or resource version are {@code null}.
      */
     Future<Void> delete(String tenantId, String deviceId, Optional<String> resourceVersion, SpanContext tracingContext);
+
+    /**
+     * Deletes all credentials of devices belonging to a tenant.
+     *
+     * @param tenantId The tenant that the devices belong to.
+     * @param tracingContext The context to track the processing of the request in
+     *                       or {@code null} if no such context exists.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if all credentials of devices that belong to the given tenant
+     *         have been deleted.
+     *         Otherwise, the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if tenant ID is {@code null}.
+     */
+    Future<Void> delete(String tenantId, SpanContext tracingContext);
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/DeviceDao.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/DeviceDao.java
@@ -144,6 +144,20 @@ public interface DeviceDao {
     Future<Void> delete(String tenantId, String deviceId, Optional<String> resourceVersion, SpanContext tracingContext);
 
     /**
+     * Deletes all device instances of a tenant.
+     *
+     * @param tenantId The tenant that the devices belong to.
+     * @param tracingContext The context to track the processing of the request in
+     *                       or {@code null} if no such context exists.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if all devices belonging to the given tenant have been deleted.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if tenant ID is {@code null}.
+     */
+    Future<Void> delete(String tenantId, SpanContext tracingContext);
+
+    /**
      * Gets the number of device instances for a tenant.
      *
      * @param tenantId The tenant to get the number of devices for.

--- a/site/documentation/content/api/management/device-registry-v1.yaml
+++ b/site/documentation/content/api/management/device-registry-v1.yaml
@@ -384,6 +384,24 @@ paths:
             404:
                $ref: '#/components/responses/NotFound'
 
+      delete:
+         tags:
+            - devices
+         summary: Delete all devices of a tenant.
+         description: |
+            Clients use this operation to remove all devices of a tenant from the registry.
+
+            When the operation succeeds, none of the registration information and credentials of devices
+            belonging to the tenant must be accessible anymore. These entities should be reported as *not found*.
+         operationId: deleteDevicesOfTenant
+         responses:
+            204:
+               description: All devices of the tenant have been deleted
+            400:
+               $ref: '#/components/responses/MalformedRequest'
+            401:
+               $ref: '#/components/responses/Unauthorized'
+
    /devices/{tenantId}/{deviceId}:
 
       parameters:

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -19,6 +19,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   for details.
 * The authentication provider used to guard access to the Mongo DB based registry implementation's HTTP endpoint
   can now be configured using environment variables. Please refer to the registry's Admin Guide for details.
+* The Registry Management API has been extended with an operation to delete all devices (including credentials) of a
+  tenant. Both the Mongo DB and the JDBC based registry implementations support this operation.
 
 ### Fixes & Enhancements
 

--- a/tests/src/test/java/org/eclipse/hono/tests/DeviceRegistryHttpClient.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/DeviceRegistryHttpClient.java
@@ -679,6 +679,32 @@ public final class DeviceRegistryHttpClient {
     }
 
     /**
+     * Removes registration information for all devices of a tenant.
+     *
+     * @param tenantId The tenant that the devices belong to.
+     * @return A future indicating the outcome of the operation. The future will succeed if the registration information
+     *         has been removed. Otherwise the future will fail.
+     * @throws NullPointerException if tenant ID is {@code null}.
+     */
+    public Future<HttpResponse<Buffer>> deregisterDevicesOfTenant(final String tenantId) {
+
+        Objects.requireNonNull(tenantId);
+        final String requestUri = registrationWithoutIdUri(tenantId);
+        return httpClient.delete(
+                requestUri,
+                getRequestHeaders(),
+                ResponsePredicate.create(response -> {
+            if (response.statusCode() == HttpURLConnection.HTTP_NO_CONTENT ||
+                    response.statusCode() == HttpURLConnection.HTTP_NOT_IMPLEMENTED) {
+                return ResponsePredicateResult.success();
+            } else {
+                return ResponsePredicateResult.failure(
+                        String.format("expected status code 204 or 501 but got %d", response.statusCode()));
+            }
+        }));
+    }
+
+    /**
      * Removes registration information for a device.
      *
      * @param tenantId The tenant that the device belongs to.

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
@@ -554,18 +554,17 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
     }
 
     /**
-     * Verifies that a request to deregister a device fails if the given tenant does not exist.
+     * Verifies that a request to deregister a device succeeds even if the given tenant does not exist (anymore).
      *
      * @param ctx The vert.x test context
      */
     @Test
-    public void testDeregisterDeviceFailsForNonExistingTenant(final VertxTestContext ctx) {
+    public void testDeregisterDeviceSucceedsForNonExistingTenant(final VertxTestContext ctx) {
 
-        registry.deregisterDevice("non-existing-tenant", deviceId, HttpURLConnection.HTTP_NOT_FOUND)
-            .onComplete(ctx.succeeding(response -> {
-                ctx.verify(() -> IntegrationTestSupport.assertErrorPayload(response));
-                ctx.completeNow();
-            }));
+        registry.addDeviceToTenant(tenantId, deviceId, "secret")
+            .compose(ok -> registry.removeTenant(tenantId))
+            .compose(ok -> registry.deregisterDevice(tenantId, deviceId, HttpURLConnection.HTTP_NO_CONTENT))
+            .onComplete(ctx.completing());
     }
 
     /**

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
@@ -568,6 +568,28 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
     }
 
     /**
+     * Verifies that a request to deregister all devices of a tenant succeeds.
+     *
+     * @param ctx The vert.x test context
+     */
+    @Test
+    public void testDeregisterDevicesOfTenantSucceeds(final VertxTestContext ctx) {
+
+        final String otherDeviceId = getHelper().getRandomDeviceId(tenantId);
+
+        registry.addDeviceToTenant(tenantId, deviceId, "secret")
+            .compose(ok -> registry.addDeviceToTenant(tenantId, otherDeviceId, "othersecret"))
+            .onFailure(ctx::failNow)
+            .compose(ok -> registry.deregisterDevicesOfTenant(tenantId))
+            .onFailure(ctx::failNow)
+            .compose(ok -> registry.getRegistrationInfo(tenantId, deviceId, HttpURLConnection.HTTP_NOT_FOUND))
+            .compose(ok -> registry.getCredentials(tenantId, deviceId, HttpURLConnection.HTTP_NOT_FOUND))
+            .compose(ok -> registry.getRegistrationInfo(tenantId, otherDeviceId, HttpURLConnection.HTTP_NOT_FOUND))
+            .compose(ok -> registry.getCredentials(tenantId, otherDeviceId, HttpURLConnection.HTTP_NOT_FOUND))
+            .onComplete(ctx.completing());
+    }
+
+    /**
      * Verifies that a request to deregister a non-existing device fails.
      *
      * @param ctx The vert.x test context.


### PR DESCRIPTION
The Registry Management API has been extended with an operation to
delete all devices (and their credentials) of a tenant.

Both the Mongo DB and the JDBC based registry implementations support
this operation.

Fixes #2793