### PR TITLE
[#2854] Fix: TTL header in downstream messages with Kafka

### DIFF
--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaRecordHelper.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaRecordHelper.java
@@ -115,7 +115,7 @@ public final class KafkaRecordHelper {
         return getHeaderValue(headers, MessageHelper.SYS_HEADER_PROPERTY_TTL, Long.class)
                 .map(ttl -> {
                     final Instant now = Instant.now();
-                    final Instant elapseTime = getCreationTime(headers).orElse(now).plus(Duration.ofSeconds(ttl));
+                    final Instant elapseTime = getCreationTime(headers).orElse(now).plus(Duration.ofMillis(ttl));
                     return elapseTime.isBefore(now);
                 })
                 .orElse(Boolean.FALSE);

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaRecordHelperTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/KafkaRecordHelperTest.java
@@ -166,10 +166,9 @@ public class KafkaRecordHelperTest {
      */
     @Test
     public void testThatTtlIsNotElapsed() {
-        final long createTime = Instant.now().toEpochMilli();
 
-        headers.add(KafkaRecordHelper.createKafkaHeader("ttl", 5));
-        headers.add(KafkaRecordHelper.createKafkaHeader("creation-time", createTime));
+        headers.add(KafkaRecordHelper.createKafkaHeader("ttl", 5000L));
+        headers.add(KafkaRecordHelper.createKafkaHeader("creation-time", Instant.now().toEpochMilli()));
 
         assertThat(KafkaRecordHelper.isTtlElapsed(headers)).isFalse();
     }
@@ -179,10 +178,9 @@ public class KafkaRecordHelperTest {
      */
     @Test
     public void testIsTtlElapsed() {
-        final long createTime = Instant.now().minusSeconds(6).toEpochMilli();
 
-        headers.add(KafkaRecordHelper.createKafkaHeader("ttl", 5));
-        headers.add(KafkaRecordHelper.createKafkaHeader("creation-time", createTime));
+        headers.add(KafkaRecordHelper.createKafkaHeader("ttl", 5000L));
+        headers.add(KafkaRecordHelper.createKafkaHeader("creation-time", Instant.now().minusSeconds(6).toEpochMilli()));
 
         assertThat(KafkaRecordHelper.isTtlElapsed(headers)).isTrue();
     }

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -35,6 +35,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   in the Device Registry Management API. This has been fixed.
 * The MongoDB based registry erroneously rejected requests that would result in multiple tenants having an empty
   set of trusted CAs. This has been fixed.
+* The _ttl_ header in downstream messages with Kafka had been set in seconds instead of milliseconds, as defined
+  by the [API specification]({{% doclink "/api/telemetry-kafka" %}}). This has been fixed.
 
 ## 1.9.1
 


### PR DESCRIPTION
Fixes #2854.

Set a given "TTL" property (in seconds) in the Kafka-based downstream senders in the Kafka header in milliseconds. When evaluating if a consumed message is expired, interpret the TTL header as milliseconds.