### PR TITLE
[#2846] Add support for defining failure-notification headers

### DIFF
--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
@@ -14,6 +14,7 @@
 package org.eclipse.hono.client.command.kafka;
 
 import java.net.HttpURLConnection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -184,6 +185,7 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
                 correlationId,
                 "",
                 MessagingType.kafka);
+        commandResponse.setAdditionalProperties(Collections.unmodifiableMap(command.getDeliveryFailureNotificationProperties()));
         return commandResponseSender.sendCommandResponse(commandResponse, span.context())
                 .onFailure(thr -> {
                     LOG.debug("failed to publish command response [{}]", commandResponse, thr);

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandResponseSender.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.hono.client.command.kafka;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -68,16 +69,18 @@ public class KafkaBasedCommandResponseSender extends AbstractKafkaBasedMessageSe
                     getMessagingType(), response.getMessagingType()));
         }
         return sendAndWaitForOutcome(topic, response.getTenantId(), response.getDeviceId(), response.getPayload(),
-                getHeaders(response), span);
+                getHeaders(response, span), span);
     }
 
-    private List<KafkaHeader> getHeaders(final CommandResponse response) {
-        return List.of(KafkaRecordHelper.createKafkaHeader(MessageHelper.SYS_PROPERTY_CORRELATION_ID,
-                response.getCorrelationId()),
-                KafkaRecordHelper.createKafkaHeader(MessageHelper.APP_PROPERTY_DEVICE_ID, response.getDeviceId()),
-                KafkaRecordHelper.createKafkaHeader(MessageHelper.APP_PROPERTY_STATUS, response.getStatus()),
-                KafkaRecordHelper.createKafkaHeader(MessageHelper.SYS_PROPERTY_CONTENT_TYPE,
-                        Objects.nonNull(response.getContentType()) ? response.getContentType()
-                                : MessageHelper.CONTENT_TYPE_OCTET_STREAM));
+    private List<KafkaHeader> getHeaders(final CommandResponse response, final Span span) {
+
+        final List<KafkaHeader> headers = new ArrayList<>(encodePropertiesAsKafkaHeaders(response.getAdditionalProperties(), span));
+        headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.SYS_PROPERTY_CORRELATION_ID, response.getCorrelationId()));
+        headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.APP_PROPERTY_DEVICE_ID, response.getDeviceId()));
+        headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.APP_PROPERTY_STATUS, response.getStatus()));
+        headers.add(KafkaRecordHelper.createKafkaHeader(MessageHelper.SYS_PROPERTY_CONTENT_TYPE,
+                Objects.nonNull(response.getContentType()) ? response.getContentType()
+                        : MessageHelper.CONTENT_TYPE_OCTET_STREAM));
+        return headers;
     }
 }

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandResponse.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandResponse.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.hono.client.command;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.eclipse.hono.util.MessagingType;
@@ -44,6 +46,8 @@ public final class CommandResponse {
     private final String correlationId;
     private final String replyToId;
     private final MessagingType messagingType;
+
+    private Map<String, Object> additionalProperties;
 
     /**
      * Creates a command response.
@@ -248,6 +252,24 @@ public final class CommandResponse {
      */
     public MessagingType getMessagingType() {
         return messagingType;
+    }
+
+    /**
+     * Gets additional properties set for this command response.
+     *
+     * @return The properties.
+     */
+    public Map<String, Object> getAdditionalProperties() {
+        return Optional.ofNullable(additionalProperties).orElseGet(Map::of);
+    }
+
+    /**
+     * Sets additional properties for this command response.
+     *
+     * @param additionalProperties The properties to set.
+     */
+    public void setAdditionalProperties(final Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
     }
 
     @Override

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/producer/AbstractKafkaBasedMessageSender.java
@@ -289,7 +289,14 @@ public abstract class AbstractKafkaBasedMessageSender implements MessagingClient
         return producerFactory.getOrCreateProducer(producerName, config);
     }
 
-    private List<KafkaHeader> encodePropertiesAsKafkaHeaders(final Map<String, Object> properties, final Span span) {
+    /**
+     * Encodes the given properties as a list of Kafka record headers.
+     *
+     * @param properties The properties to encode.
+     * @param span The span to log to if there are exceptions encoding the properties.
+     * @return The created header list.
+     */
+    protected final List<KafkaHeader> encodePropertiesAsKafkaHeaders(final Map<String, Object> properties, final Span span) {
         final List<KafkaHeader> headers = new ArrayList<>();
 
             properties.forEach((k, v) -> {

--- a/site/documentation/content/api/command-and-control-kafka/index.md
+++ b/site/documentation/content/api/command-and-control-kafka/index.md
@@ -88,6 +88,7 @@ The following table provides an overview of the headers the *Business Applicatio
 | *response-required* | yes       | *boolean* | MUST be set with a value of `true`, meaning that the device is required to send a response for the command. |
 | *subject*           | yes       | *string*  | The name of the command to be executed by the device. |
 | *content-type*      | no        | *string*  | If present, MUST contain a *Media Type* as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046) which describes the semantics and format of the command's input data contained in the message payload. However, not all protocol adapters will support this property as not all transport protocols provide means to convey this information, e.g. MQTT 3.1.1 has no notion of message headers. |
+| *delivery-failure-notification-metadata[*]* | no | *string* | Headers with the *delivery-failure-notification-metadata* prefix are adopted for the error command response that is sent in case delivering the command to the device failed. In case of a successful command delivery, these headers are ignored. |
 
 The command message MAY contain arbitrary payload, set as message value, to be sent to the device. The value of the message's *subject* header may provide a hint to the device regarding the format, encoding and semantics of the payload data.
 
@@ -106,6 +107,7 @@ The following table provides an overview of the headers set on a message sent in
 | *device_id*        | yes       | *string*  | The identifier of the device that sent the response. |
 | *status*           | yes       | *integer* | MUST indicate the status of the execution. See table below for possible values. |
 | *content-type*     | no        | *string*  | If present, MUST contain a *Media Type* as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046) which describes the semantics and format of the command's input data contained in the message payload. However, not all protocol adapters will support this property as not all transport protocols provide means to convey this information, e.g. MQTT 3.1.1 has no notion of message headers.<br>If the response is an error message sent by the Hono protocol adapter or Command Router component, the content type MUST be *application/vnd.eclipse-hono-delivery-failure-notification+json*. |
+| *delivery-failure-notification-metadata[*]* | no | *string* | MUST be adopted from the command message headers with the same names *if* the response is an error message sent by the Hono protocol adapter or Command Router component. |
 
 The *status* header must contain an [HTTP 1.1 response status code](https://tools.ietf.org/html/rfc7231#section-6). 
 


### PR DESCRIPTION
This fixes #2846:
Kafka command message headers with the `delivery-failure-notification-metadata` prefix are now adopted for the corresponding command response message sent in case of a command delivery failure.