### PR TITLE
[#2831] Fix Quarkus native 'No Converter registered' exception

### DIFF
--- a/service-base-quarkus/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-base-quarkus/reflection-config.json
+++ b/service-base-quarkus/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-base-quarkus/reflection-config.json
@@ -121,5 +121,14 @@
     "methods": [
       { "name": "<init>", "parameterTypes": [] }
     ]
+  },
+  {
+    "name" : "org.eclipse.hono.config.FileFormat",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]


### PR DESCRIPTION
Relates to changes made in #2856:
When deploying the IoT packages Hono helm chart using the 1.10 SNAPSHOT images, the Hono components don't start.
There is this exception in the logs:
```
java.lang.IllegalArgumentException: SRCFG00013: No Converter registered for class org.eclipse.hono.config.FileFormat
	at io.smallrye.config.SmallRyeConfig.requireConverter(SmallRyeConfig.java:466)
	at io.smallrye.config.ConfigMappingContext.getConverter(ConfigMappingContext.java:113)
	at io.smallrye.config.ConfigMappingContext.lambda$getValueConverter$4(ConfigMappingContext.java:92)
	at java.util.HashMap.computeIfAbsent(HashMap.java:1133)
	at io.smallrye.config.ConfigMappingContext.getValueConverter(ConfigMappingContext.java:89)
	at org.eclipse.hono.config.quarkus.GenericOptions-1742833832Impl.<init>(Unknown Source)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at io.smallrye.config.ConfigMappingLoader.configMappingObject(ConfigMappingLoader.java:59)
	at io.smallrye.config.ConfigMappingContext.constructGroup(ConfigMappingContext.java:80)
	at org.eclipse.hono.config.quarkus.ServerOptions654566698Impl.<init>(Unknown Source)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at io.smallrye.config.ConfigMappingLoader.configMappingObject(ConfigMappingLoader.java:59)
	at io.smallrye.config.ConfigMappingContext.constructGroup(ConfigMappingContext.java:80)
	at io.smallrye.config.ConfigMappingContext.constructRoot(ConfigMappingContext.java:76)
	at io.smallrye.config.ConfigMappingProvider.mapConfiguration(ConfigMappingProvider.java:811)
	at io.smallrye.config.ConfigMappingProvider.mapConfiguration(ConfigMappingProvider.java:794)
	at io.smallrye.config.ConfigMappings.mapConfiguration(ConfigMappings.java:54)
	at io.smallrye.config.ConfigMappings.registerConfigMappings(ConfigMappings.java:36)
	at io.quarkus.arc.runtime.ConfigRecorder.registerConfigMappings(ConfigRecorder.java:81)
	at io.quarkus.deployment.steps.ConfigBuildStep$registerConfigClasses-2116437784.deploy_0(ConfigBuildStep$registerConfigClasses-2116437784.zig:492)
	at io.quarkus.deployment.steps.ConfigBuildStep$registerConfigClasses-2116437784.deploy(ConfigBuildStep$registerConfigClasses-2116437784.zig:40)
	at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:502)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:101)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:66)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:42)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:119)
	at io.quarkus.runner.GeneratedMain.main(GeneratedMain.zig:29)
```