### PR TITLE
[#2848] Add Kafka client metrics

### DIFF
--- a/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
+++ b/adapter-base-spring/src/main/java/org/eclipse/hono/adapter/spring/AbstractMessagingClientConfig.java
@@ -25,6 +25,7 @@ import org.eclipse.hono.client.kafka.CachingKafkaProducerFactory;
 import org.eclipse.hono.client.kafka.KafkaProducerConfigProperties;
 import org.eclipse.hono.client.kafka.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
 import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.telemetry.TelemetrySender;
 import org.eclipse.hono.client.telemetry.amqp.ProtonBasedDownstreamSender;
@@ -48,7 +49,6 @@ import io.opentracing.Tracer;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 
-
 /**
  * A base class that provides helper methods for configuring messaging clients.
  */
@@ -64,13 +64,15 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
      * @param tracer The tracer instance.
      * @param vertx The Vert.x instance to use.
      * @param adapterProperties The adapter's configuration properties.
+     * @param kafkaClientMetricsSupport The Kafka metrics support.
      * @return The created messaging clients.
      */
     protected MessagingClientProviders messagingClientProviders(
             final SendMessageSampler.Factory samplerFactory,
             final Tracer tracer,
             final Vertx vertx,
-            final ProtocolAdapterProperties adapterProperties) {
+            final ProtocolAdapterProperties adapterProperties,
+            final KafkaClientMetricsSupport kafkaClientMetricsSupport) {
 
         final MessagingClientProvider<TelemetrySender> telemetrySenderProvider = new MessagingClientProvider<>();
         final MessagingClientProvider<EventSender> eventSenderProvider = new MessagingClientProvider<>();
@@ -80,6 +82,7 @@ public abstract class AbstractMessagingClientConfig implements ComponentNameProv
             log.info("Kafka Producer is configured, adding Kafka messaging clients");
             final KafkaProducerConfigProperties producerConfig = kafkaProducerConfig();
             final KafkaProducerFactory<String, Buffer> factory = CachingKafkaProducerFactory.sharedFactory(vertx);
+            factory.setMetricsSupport(kafkaClientMetricsSupport);
 
             telemetrySenderProvider.setClient(new KafkaBasedTelemetrySender(factory, producerConfig,
                     adapterProperties.isDefaultsEnabled(), tracer));

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -53,7 +53,7 @@
     <kafka.image.name>confluentinc/cp-kafka:6.1.1</kafka.image.name>
     <logback.version>1.2.3</logback.version>
     <mchange-commons.version>0.2.15</mchange-commons.version>
-    <micrometer.version>1.7.3</micrometer.version>
+    <micrometer.version>1.7.4</micrometer.version>
     <mockito.version>3.7.7</mockito.version>
     <mongodb-image.name>mongo:4.2.13</mongodb-image.name>
     <mongodb-driver.version>4.3.1</mongodb-driver.version>

--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -61,6 +61,15 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-kafka-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaProducerFactory.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/KafkaProducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,6 +12,8 @@
  */
 
 package org.eclipse.hono.client.kafka;
+
+import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
 
 import io.vertx.core.Future;
 import io.vertx.kafka.client.producer.KafkaProducer;
@@ -58,5 +60,12 @@ public interface KafkaProducerFactory<K, V> {
      *         existed with the given name.
      */
     Future<Void> closeProducer(String producerName);
+
+    /**
+     * Sets Kafka metrics support with which producers created by this factory will be registered.
+     *
+     * @param metricsSupport The metrics support.
+     */
+    void setMetricsSupport(KafkaClientMetricsSupport metricsSupport);
 
 }

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/KafkaClientMetricsSupport.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/KafkaClientMetricsSupport.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.metrics;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+
+/**
+ * Provides support for registering Kafka clients from which metrics are fetched.
+ */
+public interface KafkaClientMetricsSupport {
+
+    /**
+     * Registers a Kafka producer to fetch metrics from.
+     *
+     * @param producer The producer to register.
+     * @throws NullPointerException if producer is {@code null}.
+     */
+    void registerKafkaProducer(Producer<?, ?> producer);
+
+    /**
+     * Registers a Kafka consumer to fetch metrics from.
+     *
+     * @param consumer The consumer to register.
+     * @throws NullPointerException if consumer is {@code null}.
+     */
+    void registerKafkaConsumer(Consumer<?, ?> consumer);
+
+    /**
+     * Unregisters a Kafka producer so that no metrics are fetched from it anymore.
+     *
+     * @param producer The producer to unregister.
+     * @throws NullPointerException if producer is {@code null}.
+     */
+    void unregisterKafkaProducer(Producer<?, ?> producer);
+
+    /**
+     * Unregisters a Kafka consumer so that no metrics are fetched from it anymore.
+     *
+     * @param consumer The consumer to unregister.
+     * @throws NullPointerException if consumer is {@code null}.
+     */
+    void unregisterKafkaConsumer(Consumer<?, ?> consumer);
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/KafkaMetricsConfig.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/KafkaMetricsConfig.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.metrics;
+
+import java.util.List;
+
+/**
+ * Configuration properties for the Kafka client metrics support.
+ */
+public class KafkaMetricsConfig {
+
+    private boolean enabled = true;
+    private boolean useDefaultMetrics = true;
+    private List<String> metricsPrefixes = MicrometerKafkaClientMetricsSupport.DEFAULT_METRICS_PREFIXES;
+
+    /**
+     * Gets whether metrics support is enabled.
+     *
+     * @return {@code true} if metrics support is enabled.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether metrics support is enabled.
+     *
+     * @param enabled  {@code true} if metrics support is enabled.
+     */
+    public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Gets whether the default set of Kafka client metrics should be used.
+     *
+     * @return {@code true} if default metrics should be used.
+     */
+    public boolean isUseDefaultMetrics() {
+        return useDefaultMetrics;
+    }
+
+    /**
+     * Sets whether the default set of Kafka client metrics should be used.
+     *
+     * @param useDefaultMetrics {@code true} if default metrics should be used.
+     */
+    public void setUseDefaultMetrics(final boolean useDefaultMetrics) {
+        this.useDefaultMetrics = useDefaultMetrics;
+    }
+
+    /**
+     * Gets the list of prefixes of the metrics to be reported for Kafka clients.
+     * <p>
+     * Metric names have the form <em>kafka.[metric group].[metric name]</em>.
+     * The metric group is the name of the Kafka {@link org.apache.kafka.common.MetricName} group minus the
+     * "-metrics" suffix. E.g. for a metric with an MBean name containing "kafka.consumer:type=consumer-fetch-manager-metrics",
+     * the group is "consumer-fetch-manager".
+     * <p>
+     * If {@link #isUseDefaultMetrics()} is {@code true}, the actually reported list of metrics will also
+     * include the default metrics.
+     *
+     * @return The list of metric prefixes.
+     */
+    public List<String> getMetricsPrefixes() {
+        return metricsPrefixes;
+    }
+
+    /**
+     * Sets the list of prefixes of the metrics to be reported for Kafka clients.
+     * <p>
+     * Metric names have the form <em>kafka.[metric group].[metric name]</em>.
+     * The metric group is the name of the Kafka {@link org.apache.kafka.common.MetricName} group minus the
+     * "-metrics" suffix. E.g. for a metric with an MBean name containing "kafka.consumer:type=consumer-fetch-manager-metrics",
+     * the group is "consumer-fetch-manager".
+     *
+     * @param metricsPrefixes The list of metric prefixes.
+     */
+    public void setMetricsPrefixes(final List<String> metricsPrefixes) {
+        this.metricsPrefixes = metricsPrefixes;
+    }
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/KafkaMetricsOptions.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/KafkaMetricsOptions.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.metrics;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Options for configuring the Kafka client metrics support.
+ *
+ */
+@ConfigMapping(prefix = "hono.kafka.metrics", namingStrategy = ConfigMapping.NamingStrategy.VERBATIM)
+public interface KafkaMetricsOptions {
+
+    /**
+     * Gets whether metrics support is enabled.
+     *
+     * @return {@code true} if metrics support is enabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * Gets whether the default set of Kafka client metrics should be used.
+     *
+     * @return {@code true} if default metrics should be used.
+     */
+    @WithDefault("true")
+    boolean useDefaultMetrics();
+
+    /**
+     * Gets the list of prefixes of the metrics to be reported for Kafka clients.
+     * <p>
+     * Metric names have the form <em>kafka.[metric group].[metric name]</em>.
+     * The metric group is the name of the Kafka {@link org.apache.kafka.common.MetricName} group minus the
+     * "-metrics" suffix. E.g. for a metric with an MBean name containing "kafka.consumer:type=consumer-fetch-manager-metrics",
+     * the group is "consumer-fetch-manager".
+     * <p>
+     * If {@link #useDefaultMetrics()} is {@code true}, the actually reported list of metrics will also
+     * include the default metrics.
+     *
+     * @return The list of metric prefixes.
+     */
+    Optional<List<String>> metricsPrefixes();
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/MicrometerKafkaClientMetricsSupport.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/MicrometerKafkaClientMetricsSupport.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.metrics;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
+import io.micrometer.core.instrument.config.MeterFilter;
+
+/**
+ * Micrometer based implementation to provide support for registering Kafka clients from which metrics are fetched.
+ */
+public final class MicrometerKafkaClientMetricsSupport implements KafkaClientMetricsSupport {
+
+    /**
+     * Default list of Kafka client metrics to be reported.
+     */
+    public static final List<String> DEFAULT_METRICS_PREFIXES = List.of(
+            "kafka.producer.topic.record.send.rate",
+            "kafka.producer.topic.record.error.rate",
+            "kafka.producer.node.request.rate",
+            "kafka.producer.node.response.rate",
+            "kafka.producer.node.request.latency.avg",
+            "kafka.producer.node.outgoing.byte.rate",
+            "kafka.producer.io.wait.time.ns.avg",
+            "kafka.producer.batch.size.avg",
+            "kafka.producer.produce.throttle.time.avg",
+            "kafka.producer.produce.throttle.time.max",
+            "kafka.consumer.fetch.manager.records.lag",
+            "kafka.consumer.fetch.manager.records.lag.max",
+            "kafka.consumer.fetch.manager.records.lead.min",
+            "kafka.consumer.fetch.manager.bytes.consumed.rate",
+            "kafka.consumer.fetch.manager.records.consumed.rate",
+            "kafka.consumer.fetch.manager.fetch.rate",
+            "kafka.consumer.fetch.manager.fetch.throttle.time.avg",
+            "kafka.consumer.fetch.manager.fetch.throttle.time.max",
+            "kafka.consumer.coordinator.rebalance.total",
+            "kafka.consumer.coordinator.failed.rebalance.total",
+            "kafka.consumer.coordinator.rebalance.latency.avg"
+    );
+
+    private static final Logger LOG = LoggerFactory.getLogger(MicrometerKafkaClientMetricsSupport.class);
+
+    private final MeterRegistry meterRegistry;
+    private final Map<Producer<?, ?>, KafkaClientMetrics> producerMetricsMap = new HashMap<>();
+    private final Map<Consumer<?, ?>, KafkaClientMetrics> consumerMetricsMap = new HashMap<>();
+    private final boolean producerMetricsEnabled;
+    private final boolean consumerMetricsEnabled;
+
+    /**
+     * Creates a new MicrometerKafkaClientMetricsSupport.
+     *
+     * @param meterRegistry The meter registry to use.
+     * @param useDefaultMetrics {@code true} if the default metrics should be used.
+     * @param metricsPrefixes The list of prefixes for matching the metrics to be reported.
+     *                        If useDefaultMetrics is {@code true}, the actually reported list of metrics will also
+     *                        include the default metrics.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public MicrometerKafkaClientMetricsSupport(final MeterRegistry meterRegistry, final boolean useDefaultMetrics,
+            final List<String> metricsPrefixes) {
+        this.meterRegistry = Objects.requireNonNull(meterRegistry);
+        Objects.requireNonNull(metricsPrefixes);
+
+        final List<String> metricsPrefixesToUse = new ArrayList<>(useDefaultMetrics ? DEFAULT_METRICS_PREFIXES : List.of());
+        metricsPrefixes.stream()
+                .map(String::trim)
+                .filter(p -> p.startsWith("kafka.")) // sanity check - only entries with kafka prefix are relevant here
+                .forEach(metricsPrefixesToUse::add);
+        final boolean reportAllMetrics = metricsPrefixesToUse.contains("kafka") || metricsPrefixesToUse.contains("kafka.");
+        this.producerMetricsEnabled = reportAllMetrics || metricsPrefixesToUse.stream().anyMatch(
+                prefix -> "kafka.producer".startsWith(prefix) || prefix.startsWith("kafka.producer"));
+        this.consumerMetricsEnabled = reportAllMetrics || metricsPrefixesToUse.stream().anyMatch(
+                prefix -> "kafka.consumer".startsWith(prefix) || prefix.startsWith("kafka.consumer"));
+
+        if (!this.producerMetricsEnabled && !this.consumerMetricsEnabled) {
+            LOG.info("disabling Kafka client metrics (defaults not used and metrics list empty or without matching entries); given metrics prefixes: {}",
+                    metricsPrefixes);
+        } else if (!reportAllMetrics) {
+            LOG.info("activating Kafka client metrics support; used metrics prefixes: {}", metricsPrefixesToUse);
+            this.meterRegistry.config().meterFilter(MeterFilter
+                    .accept(id -> metricsPrefixesToUse.stream().anyMatch(prefix -> id.getName().startsWith(prefix))));
+            // deny all kafka metrics not previously accepted
+            this.meterRegistry.config().meterFilter(MeterFilter.denyNameStartsWith("kafka."));
+        } else {
+            LOG.info("activating Kafka client metrics support; all metrics will be reported "
+                    + "- consider configuring individual metrics to reduce the number of reported metrics");
+        }
+    }
+
+    /**
+     * Checks if producer metrics are enabled either by using the default metrics or via a provided metrics
+     * list matching any kind of producer metric.
+     *
+     * @return {@code true} if producer metrics are enabled.
+     */
+    public boolean isProducerMetricsEnabled() {
+        return producerMetricsEnabled;
+    }
+
+    /**
+     * Checks if consumer metrics are enabled either by using the default metrics or via a provided metrics
+     * list matching any kind of consumer metric.
+     *
+     * @return {@code true} if consumer metrics are enabled.
+     */
+    public boolean isConsumerMetricsEnabled() {
+        return consumerMetricsEnabled;
+    }
+
+    @Override
+    public void registerKafkaProducer(final Producer<?, ?> producer) {
+        Objects.requireNonNull(producer);
+        if (producerMetricsEnabled && !producerMetricsMap.containsKey(producer)) {
+            final KafkaClientMetrics kafkaClientMetrics = new KafkaClientMetrics(producer);
+            producerMetricsMap.put(producer, kafkaClientMetrics);
+            kafkaClientMetrics.bindTo(meterRegistry);
+            LOG.debug("registered producer ({} producers total)", producerMetricsMap.size());
+        }
+    }
+
+    @Override
+    public void registerKafkaConsumer(final Consumer<?, ?> consumer) {
+        Objects.requireNonNull(consumer);
+        if (consumerMetricsEnabled && !consumerMetricsMap.containsKey(consumer)) {
+            final KafkaClientMetrics kafkaClientMetrics = new KafkaClientMetrics(consumer);
+            consumerMetricsMap.put(consumer, kafkaClientMetrics);
+            kafkaClientMetrics.bindTo(meterRegistry);
+            LOG.debug("registered consumer ({} consumers total)", consumerMetricsMap.size());
+        }
+    }
+
+    @Override
+    public void unregisterKafkaProducer(final Producer<?, ?> producer) {
+        Objects.requireNonNull(producer);
+        Optional.ofNullable(producerMetricsMap.remove(producer)).ifPresent(metrics -> metrics.close());
+    }
+
+    @Override
+    public void unregisterKafkaConsumer(final Consumer<?, ?> consumer) {
+        Objects.requireNonNull(consumer);
+        Optional.ofNullable(consumerMetricsMap.remove(consumer)).ifPresent(metrics -> metrics.close());
+    }
+}

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/NoopKafkaClientMetricsSupport.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/NoopKafkaClientMetricsSupport.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.metrics;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+
+/**
+ * A no-op implementation for the Kafka client metrics support.
+ */
+public class NoopKafkaClientMetricsSupport implements KafkaClientMetricsSupport {
+
+    public static NoopKafkaClientMetricsSupport INSTANCE = new NoopKafkaClientMetricsSupport();
+
+    private NoopKafkaClientMetricsSupport() {
+    }
+
+    @Override
+    public void registerKafkaProducer(final Producer<?, ?> producer) {
+    }
+
+    @Override
+    public void registerKafkaConsumer(final Consumer<?, ?> consumer) {
+    }
+
+    @Override
+    public void unregisterKafkaProducer(final Producer<?, ?> producer) {
+    }
+
+    @Override
+    public void unregisterKafkaConsumer(final Consumer<?, ?> consumer) {
+    }
+}

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/metrics/MicrometerKafkaClientMetricsSupportTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/metrics/MicrometerKafkaClientMetricsSupportTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.client.kafka.metrics;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Verifies the behavior of {@link MicrometerKafkaClientMetricsSupport}.
+ */
+public class MicrometerKafkaClientMetricsSupportTest {
+
+    private MeterRegistry meterRegistry;
+
+    /**
+     * Sets up fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+        this.meterRegistry = mock(MeterRegistry.class);
+        final MeterRegistry.Config meterRegistryConfig = mock(MeterRegistry.Config.class);
+        when(meterRegistry.config()).thenReturn(meterRegistryConfig);
+    }
+
+    /**
+     * Verifies that metrics are disabled if given metrics list is empty.
+     */
+    @Test
+    public void testMetricsDisabledOnEmptyMetricsList() {
+        final List<String> metricsPrefixes = List.of();
+        final MicrometerKafkaClientMetricsSupport metricsSupport = new MicrometerKafkaClientMetricsSupport(
+                meterRegistry, false, metricsPrefixes);
+        assertThat(metricsSupport.isProducerMetricsEnabled()).isFalse();
+        assertThat(metricsSupport.isConsumerMetricsEnabled()).isFalse();
+    }
+
+    /**
+     * Verifies that producer and consumer metrics are enabled if the default metrics are used.
+     */
+    @Test
+    public void testProducerConsumerMetricsEnabledWhenUsingDefaultMetrics() {
+        final MicrometerKafkaClientMetricsSupport metricsSupport = new MicrometerKafkaClientMetricsSupport(
+                meterRegistry, true, List.of());
+        assertThat(metricsSupport.isProducerMetricsEnabled()).isTrue();
+        assertThat(metricsSupport.isConsumerMetricsEnabled()).isTrue();
+    }
+
+    /**
+     * Verifies that consumer metrics are disabled if given metrics list doesn't contain matching entries
+     * and default metrics aren't used.
+     */
+    @Test
+    public void testConsumerMetricsDisabledOnMetricsPrefixesListWithoutConsumerMetricPrefix() {
+        final List<String> metricsPrefixes = List.of("kafka.prod");
+        final MicrometerKafkaClientMetricsSupport metricsSupport = new MicrometerKafkaClientMetricsSupport(
+                meterRegistry, false, metricsPrefixes);
+        assertThat(metricsSupport.isProducerMetricsEnabled()).isTrue();
+        assertThat(metricsSupport.isConsumerMetricsEnabled()).isFalse();
+    }
+
+    /**
+     * Verifies that producer metrics are disabled if given metrics list doesn't contain matching entries
+     * and default metrics aren't used.
+     */
+    @Test
+    public void testProducerMetricsDisabledOnMetricsPrefixesListWithoutProducerMetricPrefix() {
+        final List<String> metricsPrefixes = List.of("kafka.con");
+        final MicrometerKafkaClientMetricsSupport metricsSupport = new MicrometerKafkaClientMetricsSupport(
+                meterRegistry, false, metricsPrefixes);
+        assertThat(metricsSupport.isProducerMetricsEnabled()).isFalse();
+        assertThat(metricsSupport.isConsumerMetricsEnabled()).isTrue();
+    }
+}

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -86,6 +86,13 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-micrometer-metrics</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- preventing version conflict with micrometer-core, newer version used there -->
+          <groupId>org.hdrhistogram</groupId>
+          <artifactId>HdrHistogram</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -141,6 +141,19 @@ The properties must be prefixed with `HONO_KAFKA_COMMONCLIENTCONFIG_` and `hono.
 A property with the same name defined in the configuration of one of the specific client types above will have precedence
 over the common property.
 
+## Kafka client metrics configuration
+
+Protocol adapters and the Command Router component by default report a set of metrics concerning the Kafka clients used for sending and receiving messages.
+
+The metrics support can be configured using the following environment variables or corresponding command line options:
+
+| Environment Variable<br>Command Line Option | Mandatory | Default | Description                                                             |
+| :------------------------------------------ | :-------: | :------ | :-----------------------------------------------------------------------|
+| `HONO_KAFKA_METRICS_ENABLED`<br>`--hono.kafka.metrics.enabled` | no | `true` | If set to `false`, no Kafka client metrics will be reported.  |
+| `HONO_KAFKA_METRICS_USEDEFAULTMETRICS`<br>`--hono.kafka.metrics.useDefaultMetrics` | no | `true` | If set to `true`, a set of Kafka consumer and producer related default metrics will be reported. Additional metrics can be added via the `HONO_KAFKA_METRICS_METRICSPREFIXES` property described below. |
+| `HONO_KAFKA_METRICS_METRICSPREFIXES`<br>`--hono.kafka.metrics.metricsPrefixes`| no | - | A comma separated list of prefixes of the metrics to be reported for the Kafka clients (in addition to the default metrics if these are used). The complete list of metrics can be viewed in the [Kafka documentation](https://kafka.apache.org/documentation.html#selector_monitoring). The metric names to be used here have the form `kafka.[metric group].[metric name]`. The metric group can be obtained from the *type* value in the *MBean name*, omitting the `-metrics` suffix. E.g. for an MBean name containing `kafka.consumer:type=consumer-fetch-manager-metrics`, the group is `consumer.fetch.manager` (all dashes are to be replaced by dots in metric group and name). An example of a corresponding metric name would be `kafka.consumer.fetch.manager.bytes.consumed.total` <br>To include all metrics, the property value can be set to the `kafka` prefix. |
+
+
 ## Required Kafka Version
 
 Hono's protocol adapters (and other components) use the Kafka clients in version 2.6. It is recommended to provide a 

--- a/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/commandrouter/KafkaBasedCommandConsumerFactoryImplIT.java
@@ -38,6 +38,7 @@ import org.eclipse.hono.client.kafka.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.consumer.HonoKafkaConsumer;
 import org.eclipse.hono.client.kafka.consumer.KafkaConsumerConfigProperties;
+import org.eclipse.hono.client.kafka.metrics.NoopKafkaClientMetricsSupport;
 import org.eclipse.hono.client.registry.TenantClient;
 import org.eclipse.hono.commandrouter.CommandRouterMetrics;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
@@ -424,7 +425,7 @@ public class KafkaBasedCommandConsumerFactoryImplIT {
         final CommandRouterMetrics metrics = mock(CommandRouterMetrics.class);
         final var kafkaBasedCommandConsumerFactoryImpl = new KafkaBasedCommandConsumerFactoryImpl(vertx, tenantClient,
                 commandTargetMapper, producerFactory, IntegrationTestSupport.getKafkaProducerConfig(),
-                kafkaConsumerConfig, metrics, tracer);
+                kafkaConsumerConfig, metrics, NoopKafkaClientMetricsSupport.INSTANCE, tracer);
         kafkaBasedCommandConsumerFactoryImpl.setGroupId(commandRouterGroupId);
         componentsToStopAfterTest.add(kafkaBasedCommandConsumerFactoryImpl);
         return kafkaBasedCommandConsumerFactoryImpl;


### PR DESCRIPTION
This fixes #2848.

Kafka client metrics are now reported for the Kafka consumers and producers in the Hono protocol adapters and the Command Router.

Also includes an update of the micrometer version - in version 1.7.4 there are some fixes regarding Kafka metrics.