### PR TITLE
Include Spring Boot Command Router in Github Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,22 +26,19 @@ jobs:
       matrix:
         device-registry: [file,jdbc,mongodb]
         include:
-          # let the file based registry test-run use the command router, Quarkus based components (running on JVM)
-          # and AMQP 1.0 messaging network.
+          # Use quarkus-jvm images: file registry, kafka messaging, spring-boot-command-router with embedded cache
           - device-registry: file
-            commandrouting-mode: command-router
+            commandrouting-mode: spring-boot-command-router
             commandrouting-cache: embedded
             component-type: quarkus-jvm
             messaging-type: kafka
-          # let the jdbc test-run use the device connection service component (instead of the command router),
-          # Spring Boot based components and AMQP 1.0 messaging network.
+          # Use spring-boot images: jdbc registry, amqp messaging, dev-con-service with embedded cache
           - device-registry: jdbc
             commandrouting-mode: dev-con-service
             commandrouting-cache: embedded
             component-type: spring-boot
             messaging-type: amqp
-          # let the mongodb test-run use the command router, Spring Boot based components and Kafka
-          # as the messaging system.
+          # Use quarkus-jvm images: mongodb registry, amqp messaging, command-router with server cache
           - device-registry: mongodb
             commandrouting-mode: command-router
             commandrouting-cache: server

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -575,6 +575,20 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
       </properties>
     </profile>
     <profile>
+      <!-- overriding the above "components-quarkus-jvm"/"components-quarkus-native" profiles in terms of the command-router properties -->
+      <id>command-router-spring-boot</id>
+      <activation>
+        <property>
+          <name>hono.commandrouting.mode</name>
+          <value>spring-boot-command-router</value>
+        </property>
+      </activation>
+      <properties>
+        <hono.command-router.config-dir>etc/hono</hono.command-router.config-dir>
+        <hono.command-router.image>hono-service-command-router</hono.command-router.image>
+      </properties>
+    </profile>
+    <profile>
       <id>run-tests</id>
       <build>
         <plugins>

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -158,6 +158,7 @@ Connection service component instead, the `device-connection-service` maven prof
 ```sh
 mvn verify -Prun-tests -Dhono.commandrouting.mode=dev-con-service
 ```
+Note that the Quarkus based component images cannot be used in this case.
 
 ### Running the Tests with Kafka as the Messaging Infrastructure
 


### PR DESCRIPTION
The Spring Boot based Command Router component hasn't been tested in the GitHub Actions integration tests recently.

This PR changes the workflow to do that again.
In order to still use only 3 test runs and still test both AMQP and Kafka messaging using quarkus images (quarkus images being the default now in the IoT packages Hono deployment), I've changed one quarkus test run configuration to use a Spring Boot Command Router.