### PR TITLE
[#2842] Log errors sending event messages on INFO level again

### DIFF
--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericSenderLink.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/GenericSenderLink.java
@@ -78,6 +78,8 @@ public class GenericSenderLink extends AbstractHonoClient {
     private final String targetAddress;
     private final SendMessageSampler sampler;
 
+    private boolean errorInfoLoggingEnabled;
+
     /**
      * Creates a new sender.
      *
@@ -293,6 +295,15 @@ public class GenericSenderLink extends AbstractHonoClient {
 
         return checkForCreditAndSend(message, currentSpan,
                 () -> sendMessageAndWaitForOutcome(message, currentSpan, false));
+    }
+
+    /**
+     * Sets whether message sending errors should be logged on INFO level.
+     *
+     * @param errorInfoLoggingEnabled {@code true} if errors should be logged on INFO level.
+     */
+    public void setErrorInfoLoggingEnabled(final boolean errorInfoLoggingEnabled) {
+        this.errorInfoLoggingEnabled = errorInfoLoggingEnabled;
     }
 
     private Future<ProtonDelivery> checkForCreditAndSend(
@@ -609,16 +620,11 @@ public class GenericSenderLink extends AbstractHonoClient {
         return Optional.ofNullable(message.getAddress()).orElse(targetAddress);
     }
 
-    /**
-     * Logs an error that occurred when sending a message.
-     * <p>
-     * This method logs on DEBUG level by default. Subclasses may override this
-     * method to use a different log level.
-     *
-     * @param format The log format string.
-     * @param arguments The arguments of the format string.
-     */
     private void logMessageSendingError(final String format, final Object... arguments) {
-        log.debug(format, arguments);
+        if (errorInfoLoggingEnabled) {
+            log.info(format, arguments);
+        } else {
+            log.debug(format, arguments);
+        }
     }
 }

--- a/clients/telemetry-amqp/src/main/java/org/eclipse/hono/client/telemetry/amqp/ProtonBasedDownstreamSender.java
+++ b/clients/telemetry-amqp/src/main/java/org/eclipse/hono/client/telemetry/amqp/ProtonBasedDownstreamSender.java
@@ -122,6 +122,7 @@ public class ProtonBasedDownstreamSender extends SenderCachingServiceClient impl
                     final ResourceIdentifier target = ResourceIdentifier.from(EventConstants.EVENT_ENDPOINT, tenant.getTenantId(), device.getDeviceId());
                     final Message message = createMessage(tenant, device, QoS.AT_LEAST_ONCE, target, contentType, payload, properties);
                     message.setDurable(true);
+                    sender.setErrorInfoLoggingEnabled(true); // log on INFO level since events are usually brokered and therefore errors here might indicate issues with the broker
                     return sender.sendAndWaitForOutcome(message, newChildSpan(context, "forward Event"));
                 })
                 .mapEmpty();


### PR DESCRIPTION
This fixes #2842.

The added `GenericSenderLink` field here is admittedly not very pretty. But this way of doing the logging in `GenericSenderLink` itself (as opposed to doing it in the invoking method like `sender.sendAndWaitForOutcome(msg, span).onFailure(t -> log.info("[...]"))`) means that more details  (e.g. delivery states) will be logged, providing more input for error analysis.