### PR TITLE
Make AMQP C&C connection non-mandatory in Quarkus adapters

### DIFF
--- a/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
+++ b/adapter-base-quarkus/src/main/java/org/eclipse/hono/adapter/quarkus/AbstractProtocolAdapterApplication.java
@@ -301,8 +301,10 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
             final CommandRouterClient commandRouterClient = commandRouterClient();
             adapter.setCommandRouterClient(commandRouterClient);
             final CommandRouterCommandConsumerFactory commandConsumerFactory = commandConsumerFactory(commandRouterClient);
-            commandConsumerFactory.registerInternalCommandConsumer(
-                    (id, handlers) -> new ProtonBasedInternalCommandConsumer(commandConsumerConnection(), id, handlers));
+            if (commandConsumerConfig.isHostConfigured()) {
+                commandConsumerFactory.registerInternalCommandConsumer(
+                        (id, handlers) -> new ProtonBasedInternalCommandConsumer(commandConsumerConnection(), id, handlers));
+            }
 
             final CommandResponseSender kafkaCommandResponseSender = messagingClientProviders
                     .getCommandResponseSenderProvider().getClient(MessagingType.kafka);


### PR DESCRIPTION
This prevents Quarkus based protocol adapters from trying to open a Command&Control AMQP connection if no AMQP host is configured.

This reinstates the condition that had already been added before (https://github.com/eclipse/hono/commit/5d9c260a3b06696bfd125dc4575b09c78c01e7c8#diff-78913dd9e44ad0737fd756b03052f8a270ab429aef504cb61c6511947acf830aR235)
but got erroneously removed afterwards (https://github.com/eclipse/hono/commit/1daffd5f01d765de7b2c4589454c5b2e71bfbda0),