### PR TITLE
Include reasonable detail message in exceptions

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AdapterDisabledException.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AdapterDisabledException.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.hono.adapter;
 
+import java.net.HttpURLConnection;
+
 import org.eclipse.hono.client.ClientErrorException;
 
 /**
@@ -27,12 +29,11 @@ public class AdapterDisabledException extends ClientErrorException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Creates a new exception for a tenant and an error code.
+     * Creates a new exception for a tenant using status code 403.
      *
      * @param tenant The tenant that the device belongs to or {@code null} if unknown.
-     * @param errorCode The code representing the erroneous outcome.
      */
-    public AdapterDisabledException(final String tenant, final int errorCode) {
-        super(tenant, errorCode, getLocalizedMessage(MESSAGE_KEY));
+    public AdapterDisabledException(final String tenant) {
+        super(tenant, HttpURLConnection.HTTP_FORBIDDEN, getLocalizedMessage(MESSAGE_KEY));
     }
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/ConnectionDurationExceededException.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/ConnectionDurationExceededException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,16 +21,20 @@ package org.eclipse.hono.adapter;
  */
 public class ConnectionDurationExceededException extends AuthorizationException {
 
+    /**
+     * Resource key for the error message.
+     */
+    public static final String MESSAGE_KEY = "CLIENT_ERROR_CONNECTION_DURATION_EXCEEDED";
+
     private static final long serialVersionUID = 1L;
 
     /**
-     * Creates a new exception for a tenant, a detail message and a root cause.
+     * Creates a new exception for a tenant and a root cause using a default detail message.
      *
      * @param tenant The tenant that the device belongs to or {@code null} if unknown.
-     * @param msg The detail message or {@code null}.
      * @param cause The root cause or {@code null}.
      */
-    public ConnectionDurationExceededException(final String tenant, final String msg, final Throwable cause) {
-        super(tenant, msg, cause);
+    public ConnectionDurationExceededException(final String tenant, final Throwable cause) {
+        super(tenant, getLocalizedMessage(MESSAGE_KEY), cause);
     }
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/DataVolumeExceededException.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/DataVolumeExceededException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,16 +21,20 @@ package org.eclipse.hono.adapter;
  */
 public class DataVolumeExceededException extends AuthorizationException {
 
+    /**
+     * Resource key for the error message.
+     */
+    public static final String MESSAGE_KEY = "CLIENT_ERROR_DATA_VOLUME_EXCEEDED";
+
     private static final long serialVersionUID = 1L;
 
     /**
-     * Creates a new exception for a tenant, a detail message and a root cause.
+     * Creates a new exception for a tenant and a root cause, using a default detail message.
      *
      * @param tenant The tenant that the device belongs to or {@code null} if unknown.
-     * @param msg The detail message or {@code null}.
      * @param cause The root cause or {@code null}.
      */
-    public DataVolumeExceededException(final String tenant, final String msg, final Throwable cause) {
-        super(tenant, msg, cause);
+    public DataVolumeExceededException(final String tenant, final Throwable cause) {
+        super(tenant, getLocalizedMessage(MESSAGE_KEY), cause);
     }
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/TenantConnectionsExceededException.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/TenantConnectionsExceededException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,16 +21,20 @@ package org.eclipse.hono.adapter;
  */
 public class TenantConnectionsExceededException extends AuthorizationException {
 
+    /**
+     * Resource key for the error message.
+     */
+    public static final String MESSAGE_KEY = "CLIENT_ERROR_TENANT_CONNECTIONS_EXCEEDED";
+
     private static final long serialVersionUID = 1L;
 
     /**
-     * Creates a new exception for a tenant, a detail message and a root cause.
+     * Creates a new exception for a tenant and a root cause using a default detail message.
      *
      * @param tenant The tenant that the device belongs to or {@code null} if unknown.
-     * @param msg The detail message or {@code null}.
      * @param cause The root cause or {@code null}.
      */
-    public TenantConnectionsExceededException(final String tenant, final String msg, final Throwable cause) {
-        super(tenant, msg, cause);
+    public TenantConnectionsExceededException(final String tenant, final Throwable cause) {
+        super(tenant, getLocalizedMessage(MESSAGE_KEY), cause);
     }
 }

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBaseTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBaseTest.java
@@ -13,9 +13,6 @@
 
 package org.eclipse.hono.adapter;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.net.HttpURLConnection;
 import java.util.HashMap;
@@ -252,7 +250,7 @@ public class AbstractProtocolAdapterBaseTest {
         when(context.getDownstreamMessageProperties()).thenReturn(new HashMap<>());
 
         final Map<String, Object> props = adapter.getDownstreamMessageProperties(context);
-        assertThat(props.get(MessageHelper.APP_PROPERTY_ORIG_ADAPTER), is(ADAPTER_NAME));
+        assertThat(props.get(MessageHelper.APP_PROPERTY_ORIG_ADAPTER)).isEqualTo(ADAPTER_NAME);
     }
 
     /**
@@ -275,7 +273,7 @@ public class AbstractProtocolAdapterBaseTest {
                 .onComplete(ctx.succeeding(result -> {
                     ctx.verify(() -> {
                         // THEN the result contains the registration assertion
-                        assertThat(result.getDeviceId(), is("device"));
+                        assertThat(result.getDeviceId()).isEqualTo("device");
                         // and the last known gateway has been updated
                         verify(commandRouterClient).setLastKnownGatewayForDevice(
                                 eq("tenant"),
@@ -480,7 +478,11 @@ public class AbstractProtocolAdapterBaseTest {
         // WHEN a device tries to connect
         adapter.checkConnectionLimit(tenant, mock(SpanContext.class)).onComplete(ctx.failing(t -> {
             // THEN the connection limit check fails
-            ctx.verify(() -> assertThat(t, instanceOf(TenantConnectionsExceededException.class)));
+            ctx.verify(() -> {
+                assertThat(t).isInstanceOf(TenantConnectionsExceededException.class);
+                assertThat(t).hasMessageThat().isEqualTo(ServiceInvocationException.getLocalizedMessage(
+                        TenantConnectionsExceededException.MESSAGE_KEY));
+            });
             ctx.completeNow();
         }));
     }
@@ -516,8 +518,8 @@ public class AbstractProtocolAdapterBaseTest {
             // In this case it should be 8kb
             assertEquals(8 * 1024, payloadSizeCaptor.getValue());
             // THEN the message limit check fails
-            ctx.verify(
-                    () -> assertThat(((ClientErrorException) t).getErrorCode(), is(HttpUtils.HTTP_TOO_MANY_REQUESTS)));
+            ctx.verify(() -> assertThat(ServiceInvocationException.extractStatusCode(t))
+                    .isEqualTo(HttpUtils.HTTP_TOO_MANY_REQUESTS));
             ctx.completeNow();
         }));
     }
@@ -544,7 +546,11 @@ public class AbstractProtocolAdapterBaseTest {
         // WHEN a device tries to connect
         adapter.checkConnectionLimit(tenant, mock(SpanContext.class)).onComplete(ctx.failing(t -> {
             // THEN the connection limit check fails
-            ctx.verify(() -> assertThat(t, instanceOf(DataVolumeExceededException.class)));
+            ctx.verify(() -> {
+                assertThat(t).isInstanceOf(DataVolumeExceededException.class);
+                assertThat(t).hasMessageThat().isEqualTo(ServiceInvocationException.getLocalizedMessage(
+                        DataVolumeExceededException.MESSAGE_KEY));
+            });
             ctx.completeNow();
         }));
     }
@@ -571,8 +577,11 @@ public class AbstractProtocolAdapterBaseTest {
         // WHEN a device tries to connect
         adapter.checkConnectionLimit(tenant, mock(SpanContext.class)).onComplete(ctx.failing(t -> {
             // THEN the connection limit check fails
-            ctx.verify(
-                    () -> assertThat(t, instanceOf(ConnectionDurationExceededException.class)));
+            ctx.verify(() -> {
+                assertThat(t).isInstanceOf(ConnectionDurationExceededException.class);
+                assertThat(t).hasMessageThat().isEqualTo(ServiceInvocationException.getLocalizedMessage(
+                        ConnectionDurationExceededException.MESSAGE_KEY));
+            });
             ctx.completeNow();
         }));
     }
@@ -597,7 +606,11 @@ public class AbstractProtocolAdapterBaseTest {
         adapter.checkConnectionDurationLimit(tenant, mock(SpanContext.class))
                 .onComplete(ctx.failing(t -> {
                     //Then the connection duration limit check fails
-                    ctx.verify(() -> assertThat(t, instanceOf(ConnectionDurationExceededException.class)));
+                    ctx.verify(() -> {
+                        assertThat(t).isInstanceOf(ConnectionDurationExceededException.class);
+                        assertThat(t).hasMessageThat().isEqualTo(ServiceInvocationException.getLocalizedMessage(
+                                ConnectionDurationExceededException.MESSAGE_KEY));
+                    });
                     ctx.completeNow();
                 }));
     }

--- a/client/src/main/resources/org/eclipse/hono/client/ServiceInvocationException_messages.properties
+++ b/client/src/main/resources/org/eclipse/hono/client/ServiceInvocationException_messages.properties
@@ -15,9 +15,12 @@
 
 # ClientErrorException
 CLIENT_ERROR_ADAPTER_DISABLED=adapter is disabled
+CLIENT_ERROR_CONNECTION_DURATION_EXCEEDED=tenant's accumulated device connection time exceeds configured maximum
+CLIENT_ERROR_DATA_VOLUME_EXCEEDED=tenant's accumulated message data volume exceeds configured maximum value
 CLIENT_ERROR_DEVICE_DISABLED_OR_NOT_REGISTERED=device is disabled or not registered
 CLIENT_ERROR_GATEWAY_DISABLED_OR_NOT_REGISTERED=gateway is disabled or not registered
 CLIENT_ERROR_MESSAGE_UNDELIVERABLE=consumer declared message as undeliverable, it should not be redelivered
+CLIENT_ERROR_TENANT_CONNECTIONS_EXCEEDED=tenant's configured maximum number of simultaneously connected devices has been reached
 CLIENT_ERROR_TENANT_DISABLED_OR_NOT_REGISTERED=tenant is disabled or not registered
 
 # ServerErrorException

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -24,6 +24,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   altogether.
 * All downstream messages that can be consumed via Hono's north bound APIs now include a `creation-time` header
   which indicates the point in time at which the message has been created.
+* The error messages returned by protocol adapters when sending commands received via Kafka now include a reasonable
+  error description.
 
 ## 1.10.0
 


### PR DESCRIPTION
The exceptions thrown in the context of resource limit violations have
been changed to include a reasonable, localizable detail message.

Fixes #2900