### PR TITLE
[#2903] Ensure out-of-range position gets reset

### DIFF
--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumer.java
@@ -328,7 +328,7 @@ public class AsyncHandlingAutoCommitKafkaConsumer extends HonoKafkaConsumer {
             lastKnownCommittedOffsets.entrySet()
                     .removeIf(entry -> !subscribedTopicPatternTopics.contains(entry.getKey().topic()));
         }
-        if (!"earliest".equals(consumerConfig.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)) && !partitionsSet.isEmpty()) {
+        if (!partitionsSet.isEmpty() && isAutoOffsetResetConfigLatest()) {
             // for each partition ensure an offset gets committed on the next commit if there possibly has never been a commit before;
             // otherwise records published during an upcoming rebalance might be skipped if the partition gets assigned
             // to another consumer which then just begins reading on the latest offset, not the offset from before the rebalance

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumerTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/AsyncHandlingAutoCommitKafkaConsumerTest.java
@@ -140,7 +140,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
 
         consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
         consumer.start().onComplete(ctx.succeedingThenComplete());
@@ -159,7 +160,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
 
         consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, TOPIC_PATTERN, handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
         consumer.start().onComplete(ctx.succeedingThenComplete());
@@ -205,7 +207,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
 
         consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), recordHandler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
         consumer.start().onComplete(ctx.succeeding(v2 -> {
@@ -262,7 +265,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
 
         consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
         consumer.start().onComplete(ctx.succeeding(v2 -> {
@@ -378,7 +382,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
             }
         };
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
         final Context consumerVertxContext = vertx.getOrCreateContext();
@@ -427,7 +432,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
             });
         });
         mockConsumer.setRevokeAllOnRebalance(true);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC2_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC2_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC2_PARTITION, 0L));
         mockConsumer.setNextPollRebalancePartitionAssignment(List.of(TOPIC_PARTITION, TOPIC2_PARTITION));
     }
 
@@ -458,7 +464,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
 
         consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
         consumer.start().onComplete(ctx.succeeding(v2 -> {
@@ -516,7 +523,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
 
         consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
 
@@ -573,7 +581,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
 
         consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
 
@@ -602,7 +611,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
             rebalance1Done.countDown();
         });
         // now force a rebalance which should trigger the above onPartitionsAssignedHandler
-        mockConsumer.updateEndOffsets(Map.of(TOPIC2_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC2_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC2_PARTITION, 0L));
         mockConsumer.rebalance(List.of(TOPIC2_PARTITION));
         if (!rebalance1Done.await(5, TimeUnit.SECONDS)) {
             ctx.failNow(new IllegalStateException("partitionsAssigned handler not invoked"));
@@ -623,7 +633,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
         });
         // now again force a rebalance which should trigger the above onPartitionsAssignedHandler
         // - this time again with the first partition
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.rebalance(List.of(TOPIC_PARTITION));
         if (!rebalance2Done.await(5, TimeUnit.SECONDS)) {
             ctx.failNow(new IllegalStateException("partitionsAssigned handler not invoked"));
@@ -668,7 +679,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
 
         consumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
         consumer.start().onComplete(ctx.succeeding(v2 -> {
@@ -688,7 +700,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
         }
         // records received, but their handling isn't completed yet
         // do a rebalance with the currently assigned partition not being assigned anymore after it
-        mockConsumer.updateEndOffsets(Map.of(TOPIC2_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC2_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC2_PARTITION, 0L));
         mockConsumer.rebalance(List.of(TOPIC2_PARTITION));
         // mark the handling of some records as completed
         recordsHandlingPromiseMap.get(0L).complete();
@@ -740,7 +753,8 @@ public class AsyncHandlingAutoCommitKafkaConsumerTest {
             }
         };
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(TOPIC_PARTITION, 0L));
+        mockConsumer.updateEndOffsets(Map.of(TOPIC_PARTITION, 0L));
         mockConsumer.updatePartitions(TOPIC_PARTITION, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(TOPIC_PARTITION));
         final Context consumerVertxContext = vertx.getOrCreateContext();

--- a/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerTest.java
+++ b/clients/kafka-common/src/test/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumerTest.java
@@ -127,7 +127,8 @@ public class HonoKafkaConsumerTest {
 
         consumer = new HonoKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(topicPartition, 0L));
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, 0L));
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(topicPartition));
         consumer.start().onComplete(ctx.succeedingThenComplete());
     }
@@ -145,7 +146,8 @@ public class HonoKafkaConsumerTest {
 
         consumer = new HonoKafkaConsumer(vertx, TOPIC_PATTERN, handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(topicPartition, (long) 0, topic2Partition, (long) 0));
+        mockConsumer.updateBeginningOffsets(Map.of(topicPartition, 0L, topic2Partition, 0L));
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, 0L, topic2Partition, 0L));
         mockConsumer.updatePartitions(topicPartition, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.updatePartitions(topic2Partition, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(topicPartition, topic2Partition));
@@ -175,7 +177,8 @@ public class HonoKafkaConsumerTest {
 
         consumer = new HonoKafkaConsumer(vertx, TOPIC_PATTERN, handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(topicPartition, (long) 0, topic2Partition, (long) 0));
+        mockConsumer.updateBeginningOffsets(Map.of(topicPartition, 0L, topic2Partition, 0L));
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, 0L, topic2Partition, 0L));
         mockConsumer.updatePartitions(topicPartition, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.updatePartitions(topic2Partition, KafkaMockConsumer.DEFAULT_NODE);
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(topicPartition, topic2Partition));
@@ -186,7 +189,8 @@ public class HonoKafkaConsumerTest {
             // now update partitions with the one for topic3
             mockConsumer.updatePartitions(topic3Partition, KafkaMockConsumer.DEFAULT_NODE);
             mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(topicPartition, topic2Partition, topic3Partition));
-            mockConsumer.updateEndOffsets(Map.of(topic3Partition, (long) 0));
+            mockConsumer.updateBeginningOffsets(Map.of(topic3Partition, 0L));
+            mockConsumer.updateEndOffsets(Map.of(topic3Partition, 0L));
 
             consumer.ensureTopicIsAmongSubscribedTopicPatternTopics(TOPIC3).onComplete(ctx.succeeding(v3 -> {
                 ctx.verify(() -> {
@@ -214,7 +218,8 @@ public class HonoKafkaConsumerTest {
 
         consumer = new HonoKafkaConsumer(vertx, Set.of(TOPIC), handler, consumerConfig);
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(topicPartition, 0L));
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, 0L));
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(topicPartition));
         consumer.start().onComplete(ctx.succeeding(v2 -> {
             mockConsumer.schedulePollTask(() -> {
@@ -248,7 +253,8 @@ public class HonoKafkaConsumerTest {
             }
         };
         consumer.setKafkaConsumerSupplier(() -> mockConsumer);
-        mockConsumer.updateEndOffsets(Map.of(topicPartition, ((long) 0)));
+        mockConsumer.updateBeginningOffsets(Map.of(topicPartition, 0L));
+        mockConsumer.updateEndOffsets(Map.of(topicPartition, 0L));
         mockConsumer.setRebalancePartitionAssignmentAfterSubscribe(List.of(topicPartition));
         consumer.start().onComplete(ctx.succeeding(v2 -> {
             mockConsumer.schedulePollTask(() -> {

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1087,6 +1087,8 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <KAFKA_TRANSACTION_STATE_LOG_MIN_ISR>1</KAFKA_TRANSACTION_STATE_LOG_MIN_ISR>
                       <KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR>1</KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR>
                       <KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS>0</KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS>
+                      <!-- increase log cleaner check frequency (default is 5min) for test where records shall be removed -->
+                      <KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS>1100</KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS>
                       <!-- log level for kafka.server.KafkaServer needs to stay on INFO so that docker-maven-plugin can wait for container startup -->
                       <KAFKA_LOG4J_LOGGERS>kafka.cluster=${hono.kafka.log-level},kafka.controller=${hono.kafka.log-level},kafka.coordinator=${hono.kafka.log-level},kafka.log=${hono.kafka.log-level},kafka.authorizer=${hono.kafka.log-level},kafka.zk=${hono.kafka.log-level},state.change.logger=${hono.kafka.log-level},kafka.server=${hono.kafka.log-level},kafka.server.KafkaServer=INFO</KAFKA_LOG4J_LOGGERS>
                     </env>


### PR DESCRIPTION
This is for #2903:
For Kafka consumers with auto offset reset config "latest", the consumer position for a newly assigned partition will be reset to the latest offset if the committed offset refers to an already deleted record. This makes position handling after start/rebalance more consistent, ensuring that records sent just after consumer.start() completed or during a rebalance are actually getting received.