### PR TITLE
Set default Kafka command consumer assignment strategy

### DIFF
--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.metrics.KafkaClientMetricsSupport;
@@ -487,6 +488,18 @@ public class HonoKafkaConsumer implements Lifecycle {
             }
             log.trace("done checking positions for {} newly assigned partitions", assignedPartitions.size());
         }
+    }
+
+    /**
+     * Checks if a partition assignment strategy using cooperative rebalancing is used.
+     *
+     * @return {@code true} if cooperative rebalancing is used.
+     */
+    protected final boolean isCooperativeRebalancingConfigured() {
+        // check if CooperativeStickyAssignor is configured (custom cooperative assignor not supported for now)
+        return Optional.ofNullable(consumerConfig.get(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG))
+                .map(value -> value.equals(CooperativeStickyAssignor.class.getName()))
+                .orElse(false);
     }
 
     /**

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
 import org.eclipse.hono.client.command.kafka.KafkaBasedCommandResponseSender;
 import org.eclipse.hono.client.command.kafka.KafkaBasedInternalCommandSender;
 import org.eclipse.hono.client.kafka.HonoTopic;
@@ -154,6 +155,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
 
         final Map<String, String> consumerConfig = kafkaConsumerConfig.getConsumerConfig("consumer");
         consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        consumerConfig.putIfAbsent(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
         kafkaConsumer = new AsyncHandlingAutoCommitKafkaConsumer(vertx, COMMANDS_TOPIC_PATTERN,
                 commandHandler::mapAndDelegateIncomingCommandMessage, consumerConfig);
         kafkaConsumer.setMetricsSupport(kafkaClientMetricsSupport);

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -161,6 +161,8 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         kafkaConsumer.setMetricsSupport(kafkaClientMetricsSupport);
         kafkaConsumer.setOnRebalanceDoneHandler(
                 partitions -> commandQueue.setCurrentlyHandledPartitions(Helper.to(partitions)));
+        kafkaConsumer.setOnPartitionsLostHandler(
+                partitions -> commandQueue.setRevokedPartitions(Helper.to(partitions)));
 
         return CompositeFuture.all(commandHandler.start(), kafkaConsumer.start())
                 .mapEmpty();


### PR DESCRIPTION
Using ~[StickyAssignor](https://kafka.apache.org/27/javadoc/org/apache/kafka/clients/consumer/StickyAssignor.html)~ [CooperativeStickyAssignor](https://kafka.apache.org/27/javadoc/org/apache/kafka/clients/consumer/CooperativeStickyAssignor.html) as default partition assignment strategy for the command router Kafka consumer.

Compared to the default assignor (RangeAssignor) this produces a more balanced and sticky assignment.