### PR TITLE
Use Eclipse Temurin based Java 17 base image

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@
     <jackson.version>2.12.4</jackson.version>
     <jaeger.image.name>jaegertracing/all-in-one:1.26</jaeger.image.name>
     <jaeger.version>1.6.0</jaeger.version>
-    <java-base-image.name>docker.io/openjdk:11-jre-slim</java-base-image.name>
+    <java-base-image.name>docker.io/eclipse-temurin:17-focal</java-base-image.name>
     <jaxb.api.version>2.2.12</jaxb.api.version>
     <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
     <jjwt.version>0.11.2</jjwt.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -889,7 +889,17 @@ Test cases are run against Docker images of Hono server + (Apache Qpid Dispatch 
                       <LOGGING_CONFIG>file:///etc/hono/logback-spring.xml</LOGGING_CONFIG>
                       <SPRING_CONFIG_LOCATION>file:///etc/hono/</SPRING_CONFIG_LOCATION>
                       <SPRING_PROFILES_ACTIVE>authentication-impl,${logging.profile}</SPRING_PROFILES_ACTIVE>
-                      <JDK_JAVA_OPTIONS>${default.java.options}</JDK_JAVA_OPTIONS>
+                      <!--
+                        We disable the consumption of the "server_name" TLS extension which clients use to
+                        indicate the name of the host they want to connect to. The Qpid Dispatch Router sets
+                        a value which includes the port that the client wants to connect to. This is clearly not
+                        allowed by RFC 6066 and OpenJDK 17 will fail the TLS handshake with the Dispatch Router if
+                        the "server_name" extension is not disabled altogether.
+                        See https://docs.oracle.com/en/java/javase/17/security/java-secure-socket-extension-jsse-reference-guide.html#GUID-527BAE97-3B78-4390-A479-623BD998C4EE
+                       -->
+                      <JDK_JAVA_OPTIONS>
+                        ${default.java.options} -Djdk.tls.server.disableExtensions=server_name
+                      </JDK_JAVA_OPTIONS>
                       <PN_TRACE_FRM>0</PN_TRACE_FRM>
                     </env>
                     <log>


### PR DESCRIPTION
addresses #2909

Eclipse Temurin is the (sub-)project of Eclipse Adoptium which produces the JDK binaries and corresponding Docker images (see https://adoptium.net/faq.html#temurinName).